### PR TITLE
fix: add protoc to blockifier post merge ci

### DIFF
--- a/.github/workflows/blockifier_post-merge.yml
+++ b/.github/workflows/blockifier_post-merge.yml
@@ -6,6 +6,10 @@ on:
       - closed
     paths:
       - 'crates/blockifier/**'
+
+env:
+  PROTOC_VERSION: v25.1
+
 jobs:
   if_merged:
     if: github.event.pull_request.merged == true
@@ -16,6 +20,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v0-rust-ubuntu-20.04"
+      - uses: Noelware/setup-protoc@1.1.0
+        with:
+          version: ${{env.PROTOC_VERSION}}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

blocker post-merge ci fail as protoc is missing for running `cargo test.`


## What is the new behavior?

- install protoc in the ci.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/30)
<!-- Reviewable:end -->
