### PR TITLE
chore: wrap cairo lang version id for code dedup

### DIFF
--- a/crates/gateway/src/compiler_version.rs
+++ b/crates/gateway/src/compiler_version.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use starknet_sierra_compile::utils::sierra_program_as_felts_to_big_uint_as_hex;
 use starknet_types_core::felt::Felt;
 use thiserror::Error;
-use validator::Validate;
 
 #[derive(Debug, Error)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -19,52 +18,34 @@ pub enum VersionIdError {
     InvalidVersion { message: String },
 }
 
-// TODO(Arni): Share this struct with the Cairo lang crate.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Validate, PartialEq)]
-pub struct VersionId {
-    pub major: usize,
-    pub minor: usize,
-    pub patch: usize,
-}
-
-impl VersionId {
-    pub const MIN: Self = Self { major: 0, minor: 0, patch: 0 };
-    pub const MAX: Self = Self { major: usize::MAX, minor: usize::MAX, patch: usize::MAX };
-}
-
-impl From<VersionId> for CairoLangVersionId {
-    fn from(version: VersionId) -> Self {
-        CairoLangVersionId { major: version.major, minor: version.minor, patch: version.patch }
-    }
-}
-
-impl From<CairoLangVersionId> for VersionId {
-    fn from(version: CairoLangVersionId) -> Self {
-        VersionId { major: version.major, minor: version.minor, patch: version.patch }
-    }
-}
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct VersionId(pub CairoLangVersionId);
 
 impl std::fmt::Display for VersionId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        CairoLangVersionId::from(*self).fmt(f)
+        self.0.fmt(f)
     }
 }
 
 impl VersionId {
-    pub fn from_sierra_program(sierra_program: &[Felt]) -> Result<Self, VersionIdError> {
-        let sierra_program_length = sierra_program.len();
+    pub const MIN: Self = Self(CairoLangVersionId { major: 0, minor: 0, patch: 0 });
+    pub const MAX: Self =
+        Self(CairoLangVersionId { major: usize::MAX, minor: usize::MAX, patch: usize::MAX });
 
-        if sierra_program_length < 6 {
-            return Err(VersionIdError::InvalidVersion {
+    pub fn new(major: usize, minor: usize, patch: usize) -> Self {
+        Self(CairoLangVersionId { major, minor, patch })
+    }
+
+    pub fn from_sierra_program(sierra_program: &[Felt]) -> Result<Self, VersionIdError> {
+        let sierra_program_for_compiler = sierra_program_as_felts_to_big_uint_as_hex(
+            sierra_program.get(..6).ok_or(VersionIdError::InvalidVersion {
                 message: format!(
-                    "Sierra program is too short. Got program of length {}, which is not long \
-                     enough for Sierra program's headers.",
-                    sierra_program_length
+                    "Failed to retrieve version from the program: insufficient length. Expected \
+                     at least 6 felts (got {}).",
+                    sierra_program.len()
                 ),
-            });
-        }
-        let sierra_program_for_compiler =
-            sierra_program_as_felts_to_big_uint_as_hex(&sierra_program[..6]);
+            })?,
+        );
 
         let (version_id, _compiler_version_id) = version_id_from_serialized_sierra_program(
             &sierra_program_for_compiler,
@@ -73,19 +54,27 @@ impl VersionId {
             message: format!("Error extracting version ID from Sierra program: {err}"),
         })?;
 
-        Ok(version_id.into())
+        Ok(VersionId(version_id))
     }
 }
 
 impl PartialOrd for VersionId {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.major != other.major {
-            return Some(self.major.cmp(&other.major));
+        // An implementation of partial_cmp for VersionId.
+        fn partial_cmp(
+            lhs: &CairoLangVersionId,
+            rhs: &CairoLangVersionId,
+        ) -> Option<std::cmp::Ordering> {
+            if lhs.major != rhs.major {
+                return Some(lhs.major.cmp(&rhs.major));
+            }
+            if lhs.minor != rhs.minor {
+                return Some(lhs.minor.cmp(&rhs.minor));
+            }
+            lhs.patch.partial_cmp(&rhs.patch)
         }
-        if self.minor != other.minor {
-            return Some(self.minor.cmp(&other.minor));
-        }
-        self.patch.partial_cmp(&other.patch)
+
+        partial_cmp(&self.0, &other.0)
     }
 }
 
@@ -94,19 +83,19 @@ impl SerializeConfig for VersionId {
         BTreeMap::from_iter([
             ser_param(
                 "major",
-                &self.major,
+                &self.0.major,
                 "The major version of the configuration.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(
                 "minor",
-                &self.minor,
+                &self.0.minor,
                 "The minor version of the configuration.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(
                 "patch",
-                &self.patch,
+                &self.0.patch,
                 "The patch version of the configuration.",
                 ParamPrivacyInput::Public,
             ),

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -86,8 +86,8 @@ impl Default for StatelessTransactionValidatorConfig {
             max_calldata_length: 4000,
             max_signature_length: 4000,
             max_contract_class_object_size: 4089446,
-            min_sierra_version: VersionId { major: 1, minor: 1, patch: 0 },
-            max_sierra_version: VersionId { major: 1, minor: 5, patch: usize::MAX },
+            min_sierra_version: VersionId::new(1, 1, 0),
+            max_sierra_version: VersionId::new(1, 5, usize::MAX),
         }
     }
 }

--- a/crates/gateway/src/stateless_transaction_validator.rs
+++ b/crates/gateway/src/stateless_transaction_validator.rs
@@ -123,7 +123,8 @@ impl StatelessTransactionValidator {
     ) -> StatelessTransactionValidatorResult<()> {
         // Any patch version is valid. (i.e. when check version for upper bound, we ignore the Z
         // part in a version X.Y.Z).
-        let max_sierra_version = VersionId { patch: usize::MAX, ..self.config.max_sierra_version };
+        let mut max_sierra_version = self.config.max_sierra_version;
+        max_sierra_version.0.patch = usize::MAX;
 
         let sierra_version = VersionId::from_sierra_program(sierra_program)?;
         if self.config.min_sierra_version <= sierra_version && sierra_version <= max_sierra_version

--- a/crates/gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/gateway/src/stateless_transaction_validator_test.rs
@@ -1,3 +1,4 @@
+use std::sync::OnceLock;
 use std::vec;
 
 use assert_matches::assert_matches;
@@ -27,26 +28,34 @@ use crate::stateless_transaction_validator::{
 };
 use crate::test_utils::create_sierra_program;
 
-const MIN_SIERRA_VERSION: VersionId = VersionId { major: 1, minor: 1, patch: 0 };
-const MAX_SIERRA_VERSION: VersionId = VersionId { major: 1, minor: 5, patch: usize::MAX };
-
-const DEFAULT_VALIDATOR_CONFIG_FOR_TESTING: StatelessTransactionValidatorConfig =
-    StatelessTransactionValidatorConfig {
+fn min_sierra_version() -> &'static VersionId {
+    static MIN_SIERRA_VERSION: OnceLock<VersionId> = OnceLock::new();
+    MIN_SIERRA_VERSION.get_or_init(|| VersionId::new(1, 1, 0))
+}
+fn max_sierra_version() -> &'static VersionId {
+    static MAX_SIERRA_VERSION: OnceLock<VersionId> = OnceLock::new();
+    MAX_SIERRA_VERSION.get_or_init(|| VersionId::new(1, 5, usize::MAX))
+}
+fn default_validator_config_for_testing() -> &'static StatelessTransactionValidatorConfig {
+    static DEFAULT_VALIDATOR_CONFIG_FOR_TESTING: OnceLock<StatelessTransactionValidatorConfig> =
+        OnceLock::new();
+    DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.get_or_init(|| StatelessTransactionValidatorConfig {
         validate_non_zero_l1_gas_fee: false,
         validate_non_zero_l2_gas_fee: false,
         max_calldata_length: 1,
         max_signature_length: 1,
         max_contract_class_object_size: 100000,
-        min_sierra_version: MIN_SIERRA_VERSION,
-        max_sierra_version: MAX_SIERRA_VERSION,
-    };
+        min_sierra_version: *min_sierra_version(),
+        max_sierra_version: *max_sierra_version(),
+    })
+}
 
 #[rstest]
 #[case::ignore_resource_bounds(
     StatelessTransactionValidatorConfig{
         validate_non_zero_l1_gas_fee: false,
         validate_non_zero_l2_gas_fee: false,
-        ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+        ..default_validator_config_for_testing().clone()
     },
     zero_resource_bounds_mapping(),
     calldata![],
@@ -56,7 +65,7 @@ const DEFAULT_VALIDATOR_CONFIG_FOR_TESTING: StatelessTransactionValidatorConfig 
     StatelessTransactionValidatorConfig{
         validate_non_zero_l1_gas_fee: true,
         validate_non_zero_l2_gas_fee: false,
-        ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+        ..default_validator_config_for_testing().clone()
     },
     create_resource_bounds_mapping(NON_EMPTY_RESOURCE_BOUNDS, ResourceBounds::default()),
     calldata![],
@@ -66,7 +75,7 @@ const DEFAULT_VALIDATOR_CONFIG_FOR_TESTING: StatelessTransactionValidatorConfig 
     StatelessTransactionValidatorConfig{
         validate_non_zero_l1_gas_fee: false,
         validate_non_zero_l2_gas_fee: true,
-        ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+        ..default_validator_config_for_testing().clone()
     },
     create_resource_bounds_mapping(ResourceBounds::default(), NON_EMPTY_RESOURCE_BOUNDS),
     calldata![],
@@ -76,26 +85,26 @@ const DEFAULT_VALIDATOR_CONFIG_FOR_TESTING: StatelessTransactionValidatorConfig 
     StatelessTransactionValidatorConfig{
         validate_non_zero_l1_gas_fee: true,
         validate_non_zero_l2_gas_fee: true,
-        ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+        ..default_validator_config_for_testing().clone()
     },
     create_resource_bounds_mapping(NON_EMPTY_RESOURCE_BOUNDS, NON_EMPTY_RESOURCE_BOUNDS),
     calldata![],
     TransactionSignature::default()
 )]
 #[case::non_empty_valid_calldata(
-    DEFAULT_VALIDATOR_CONFIG_FOR_TESTING,
+    default_validator_config_for_testing().clone(),
     zero_resource_bounds_mapping(),
     calldata![Felt::ONE],
     TransactionSignature::default()
 )]
 #[case::non_empty_valid_signature(
-    DEFAULT_VALIDATOR_CONFIG_FOR_TESTING,
+    default_validator_config_for_testing().clone(),
     zero_resource_bounds_mapping(),
     calldata![],
     TransactionSignature(vec![Felt::ONE])
 )]
 #[case::valid_tx(
-    DEFAULT_VALIDATOR_CONFIG_FOR_TESTING,
+    default_validator_config_for_testing().clone(),
     zero_resource_bounds_mapping(),
     calldata![],
     TransactionSignature::default()
@@ -119,7 +128,7 @@ fn test_positive_flow(
     StatelessTransactionValidatorConfig{
         validate_non_zero_l1_gas_fee: true,
         validate_non_zero_l2_gas_fee: false,
-        ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+        ..default_validator_config_for_testing().clone()
     },
     zero_resource_bounds_mapping(),
     StatelessTransactionValidatorError::ZeroResourceBounds{
@@ -130,7 +139,7 @@ fn test_positive_flow(
     StatelessTransactionValidatorConfig{
         validate_non_zero_l1_gas_fee: false,
         validate_non_zero_l2_gas_fee: true,
-        ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+        ..default_validator_config_for_testing().clone()
     },
     create_resource_bounds_mapping(NON_EMPTY_RESOURCE_BOUNDS, ResourceBounds::default()),
     StatelessTransactionValidatorError::ZeroResourceBounds{
@@ -160,7 +169,7 @@ fn test_calldata_too_long(
     #[values(TransactionType::DeployAccount, TransactionType::Invoke)] tx_type: TransactionType,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING };
+        StatelessTransactionValidator { config: default_validator_config_for_testing().clone() };
     let tx = external_tx_for_testing(
         tx_type,
         zero_resource_bounds_mapping(),
@@ -183,7 +192,7 @@ fn test_signature_too_long(
     tx_type: TransactionType,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING };
+        StatelessTransactionValidator { config: default_validator_config_for_testing().clone() };
     let tx = external_tx_for_testing(
         tx_type,
         zero_resource_bounds_mapping(),
@@ -205,8 +214,8 @@ fn test_signature_too_long(
     vec![],
     StatelessTransactionValidatorError::InvalidSierraVersion (
         VersionIdError::InvalidVersion {
-            message: "Sierra program is too short. Got program of length 0, which is not \
-                     long enough for Sierra program's headers.".into()
+            message: "Failed to retrieve version from the program: insufficient length. Expected \
+                     at least 6 felts (got 0).".into()
         }
     )
 )]
@@ -214,8 +223,8 @@ fn test_signature_too_long(
     vec![felt!(1_u128)],
     StatelessTransactionValidatorError::InvalidSierraVersion (
         VersionIdError::InvalidVersion {
-            message: "Sierra program is too short. Got program of length 1, which is not \
-                     long enough for Sierra program's headers.".into()
+            message: "Failed to retrieve version from the program: insufficient length. Expected \
+                     at least 6 felts (got 1).".into()
         }
     )
 )]
@@ -223,8 +232,8 @@ fn test_signature_too_long(
     vec![felt!(1_u128), felt!(3_u128), felt!(0_u128)],
     StatelessTransactionValidatorError::InvalidSierraVersion (
         VersionIdError::InvalidVersion {
-            message: "Sierra program is too short. Got program of length 3, which is not \
-                     long enough for Sierra program's headers.".into()
+            message: "Failed to retrieve version from the program: insufficient length. Expected \
+                     at least 6 felts (got 3).".into()
         }
     )
 )]
@@ -232,8 +241,8 @@ fn test_signature_too_long(
     vec![felt!(1_u128), felt!(3_u128), felt!(0_u128), felt!(0_u128)],
     StatelessTransactionValidatorError::InvalidSierraVersion (
         VersionIdError::InvalidVersion {
-            message: "Sierra program is too short. Got program of length 4, which is not \
-                     long enough for Sierra program's headers.".into()
+            message: "Failed to retrieve version from the program: insufficient length. Expected \
+                     at least 6 felts (got 4).".into()
         }
     )
 )]
@@ -255,19 +264,19 @@ fn test_signature_too_long(
     )
 ]
 #[case::sierra_version_too_low(
-    create_sierra_program(&VersionId { major: 0, minor: 3, patch: 0 }),
+    create_sierra_program(&VersionId::new(0,3,0)),
     StatelessTransactionValidatorError::UnsupportedSierraVersion {
-            version: VersionId{major: 0, minor: 3, patch: 0},
-            min_version: MIN_SIERRA_VERSION,
-            max_version: MAX_SIERRA_VERSION,
+            version: VersionId::new(0,3,0),
+            min_version: *min_sierra_version(),
+            max_version: *max_sierra_version(),
     })
 ]
 #[case::sierra_version_too_high(
-    create_sierra_program(&VersionId { major: 1, minor: 6, patch: 0 }),
+    create_sierra_program(&VersionId::new(1,6,0)),
     StatelessTransactionValidatorError::UnsupportedSierraVersion {
-            version: VersionId { major: 1, minor: 6, patch: 0 },
-            min_version: MIN_SIERRA_VERSION,
-            max_version: MAX_SIERRA_VERSION,
+            version: VersionId::new(1,6,0),
+            min_version: *min_sierra_version(),
+            max_version: *max_sierra_version(),
     })
 ]
 fn test_declare_sierra_version_failure(
@@ -275,7 +284,7 @@ fn test_declare_sierra_version_failure(
     #[case] expected_error: StatelessTransactionValidatorError,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING };
+        StatelessTransactionValidator { config: default_validator_config_for_testing().clone() };
 
     let contract_class = ContractClass { sierra_program, ..Default::default() };
     let tx = external_declare_tx(declare_tx_args!(contract_class));
@@ -284,14 +293,18 @@ fn test_declare_sierra_version_failure(
 }
 
 #[rstest]
-#[case::min_sierra_version(create_sierra_program(&MIN_SIERRA_VERSION))]
-#[case::valid_sierra_version(create_sierra_program(&VersionId { major: 1, minor: 3, patch: 0 }))]
-#[case::max_sierra_version_patch_zero(create_sierra_program(&VersionId { patch: 0, ..MAX_SIERRA_VERSION }))]
-#[case::max_sierra_version_patch_non_trivial(create_sierra_program(&VersionId { patch: 1, ..MAX_SIERRA_VERSION }))]
-#[case::max_sierra_version(create_sierra_program(&MAX_SIERRA_VERSION))]
+#[case::min_sierra_version(create_sierra_program(min_sierra_version()))]
+#[case::valid_sierra_version(create_sierra_program(&VersionId::new( 1, 3, 0 )))]
+#[case::max_sierra_version_patch_zero(create_sierra_program(
+    &VersionId::new( max_sierra_version().0.major, max_sierra_version().0.minor, 0)
+))]
+#[case::max_sierra_version_patch_non_trivial(create_sierra_program(
+    &VersionId::new(max_sierra_version().0.major, max_sierra_version().0.minor, 1)
+))]
+#[case::max_sierra_version(create_sierra_program(max_sierra_version()))]
 fn test_declare_sierra_version_sucsses(#[case] sierra_program: Vec<Felt>) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING };
+        StatelessTransactionValidator { config: default_validator_config_for_testing().clone() };
 
     let contract_class = ContractClass { sierra_program, ..Default::default() };
     let tx = external_declare_tx(declare_tx_args!(contract_class));
@@ -305,11 +318,11 @@ fn test_declare_contract_class_size_too_long() {
     let tx_validator = StatelessTransactionValidator {
         config: StatelessTransactionValidatorConfig {
             max_contract_class_object_size: config_max_contract_class_object_size,
-            ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+            ..default_validator_config_for_testing().clone()
         },
     };
     let contract_class = ContractClass {
-        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
+        sierra_program: create_sierra_program(min_sierra_version()),
         ..Default::default()
     };
     let contract_class_length = serde_json::to_string(&contract_class).unwrap().len();
@@ -370,10 +383,10 @@ fn test_declare_entry_points_not_sorted_by_selector(
     #[case] expected: StatelessTransactionValidatorResult<()>,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING };
+        StatelessTransactionValidator { config: default_validator_config_for_testing().clone() };
 
     let contract_class = ContractClass {
-        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
+        sierra_program: create_sierra_program(min_sierra_version()),
         entry_points_by_type: EntryPointByType {
             constructor: entry_points.clone(),
             external: vec![],
@@ -386,7 +399,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
     assert_eq!(tx_validator.validate(&tx), expected);
 
     let contract_class = ContractClass {
-        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
+        sierra_program: create_sierra_program(min_sierra_version()),
         entry_points_by_type: EntryPointByType {
             constructor: vec![],
             external: entry_points.clone(),
@@ -399,7 +412,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
     assert_eq!(tx_validator.validate(&tx), expected);
 
     let contract_class = ContractClass {
-        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
+        sierra_program: create_sierra_program(min_sierra_version()),
         entry_points_by_type: EntryPointByType {
             constructor: vec![],
             external: vec![],

--- a/crates/gateway/src/test_utils.rs
+++ b/crates/gateway/src/test_utils.rs
@@ -3,6 +3,7 @@ use starknet_types_core::felt::Felt;
 use crate::compiler_version::VersionId;
 
 pub fn create_sierra_program(version_id: &VersionId) -> Vec<Felt> {
+    let version_id = version_id.0;
     vec![
         // Sierra Version ID.
         Felt::from(u64::try_from(version_id.major).unwrap()),


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is code duplication between Cairo-Lang's version ID and the gateway's version ID.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Refactor the Gateway's version ID as a wrapper.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/83)
<!-- Reviewable:end -->
