### PR TITLE
chore: use cairo lang util to extract sierra program version id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9025,7 +9025,6 @@ dependencies = [
  "mockall",
  "mockito 1.4.0",
  "num-bigint 0.4.5",
- "num-traits 0.2.19",
  "papyrus_config",
  "papyrus_rpc",
  "pretty_assertions",

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -20,7 +20,6 @@ cairo-vm.workspace = true
 enum-assoc.workspace = true
 hyper.workspace = true
 mempool_test_utils.workspace = true
-num-traits.workspace = true
 papyrus_config.workspace = true
 papyrus_rpc.workspace = true
 reqwest.workspace = true

--- a/crates/gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/gateway/src/stateless_transaction_validator_test.rs
@@ -205,8 +205,8 @@ fn test_signature_too_long(
     vec![],
     StatelessTransactionValidatorError::InvalidSierraVersion (
         VersionIdError::InvalidVersion {
-            message: "Sierra program is too short. got program of length 0 which is not long enough \
-                     to hold the version field.".into()
+            message: "Sierra program is too short. Got program of length 0, which is not \
+                     long enough for Sierra program's headers.".into()
         }
     )
 )]
@@ -214,17 +214,26 @@ fn test_signature_too_long(
     vec![felt!(1_u128)],
     StatelessTransactionValidatorError::InvalidSierraVersion (
         VersionIdError::InvalidVersion {
-            message: "Sierra program is too short. got program of length 1 which is not long enough \
-                     to hold the version field.".into()
+            message: "Sierra program is too short. Got program of length 1, which is not \
+                     long enough for Sierra program's headers.".into()
         }
     )
 )]
-#[case::sierra_program_length_two(
-    vec![felt!(1_u128), felt!(3_u128)],
+#[case::sierra_program_length_three(
+    vec![felt!(1_u128), felt!(3_u128), felt!(0_u128)],
     StatelessTransactionValidatorError::InvalidSierraVersion (
         VersionIdError::InvalidVersion {
-            message: "Sierra program is too short. got program of length 2 which is not long enough \
-                     to hold the version field.".into()
+            message: "Sierra program is too short. Got program of length 3, which is not \
+                     long enough for Sierra program's headers.".into()
+        }
+    )
+)]
+#[case::sierra_program_length_four(
+    vec![felt!(1_u128), felt!(3_u128), felt!(0_u128), felt!(0_u128)],
+    StatelessTransactionValidatorError::InvalidSierraVersion (
+        VersionIdError::InvalidVersion {
+            message: "Sierra program is too short. Got program of length 4, which is not \
+                     long enough for Sierra program's headers.".into()
         }
     )
 )]
@@ -233,11 +242,14 @@ fn test_signature_too_long(
             felt!(1_u128),
             felt!(3_u128),
             felt!(0x10000000000000000_u128), // Does not fit into a usize.
+            felt!(0_u128),
+            felt!(0_u128),
+            felt!(0_u128),
     ],
     StatelessTransactionValidatorError::InvalidSierraVersion (
             VersionIdError::InvalidVersion {
-                message: "version contains a value that is out of range: \
-                 0x10000000000000000".into()
+                message: "Error extracting version ID from Sierra program: \
+                         Invalid input for deserialization.".into()
             }
         )
     )
@@ -296,8 +308,10 @@ fn test_declare_contract_class_size_too_long() {
             ..DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
         },
     };
-    let contract_class =
-        ContractClass { sierra_program: vec![felt!(1_u128); 3], ..Default::default() };
+    let contract_class = ContractClass {
+        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
+        ..Default::default()
+    };
     let contract_class_length = serde_json::to_string(&contract_class).unwrap().len();
     let tx = external_declare_tx(declare_tx_args!(contract_class));
 
@@ -359,7 +373,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
         StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING };
 
     let contract_class = ContractClass {
-        sierra_program: vec![felt!(1_u128); 3],
+        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
         entry_points_by_type: EntryPointByType {
             constructor: entry_points.clone(),
             external: vec![],
@@ -372,7 +386,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
     assert_eq!(tx_validator.validate(&tx), expected);
 
     let contract_class = ContractClass {
-        sierra_program: vec![felt!(1_u128); 3],
+        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
         entry_points_by_type: EntryPointByType {
             constructor: vec![],
             external: entry_points.clone(),
@@ -385,7 +399,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
     assert_eq!(tx_validator.validate(&tx), expected);
 
     let contract_class = ContractClass {
-        sierra_program: vec![felt!(1_u128); 3],
+        sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
         entry_points_by_type: EntryPointByType {
             constructor: vec![],
             external: vec![],

--- a/crates/gateway/src/test_utils.rs
+++ b/crates/gateway/src/test_utils.rs
@@ -4,8 +4,13 @@ use crate::compiler_version::VersionId;
 
 pub fn create_sierra_program(version_id: &VersionId) -> Vec<Felt> {
     vec![
+        // Sierra Version ID.
         Felt::from(u64::try_from(version_id.major).unwrap()),
         Felt::from(u64::try_from(version_id.minor).unwrap()),
         Felt::from(u64::try_from(version_id.patch).unwrap()),
+        // Compiler Version ID.
+        Felt::from(u64::try_from(0).unwrap()),
+        Felt::from(u64::try_from(0).unwrap()),
+        Felt::from(u64::try_from(0).unwrap()),
     ]
 }

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -62,7 +62,16 @@ pub fn external_tx_for_testing(
         TransactionType::Declare => {
             // Minimal contract class.
             let contract_class = ContractClass {
-                sierra_program: vec![felt!(1_u32), felt!(3_u32), felt!(0_u32)],
+                sierra_program: vec![
+                    // Sierra Version ID.
+                    felt!(1_u32),
+                    felt!(3_u32),
+                    felt!(0_u32),
+                    // Compiler version ID.
+                    felt!(1_u32),
+                    felt!(3_u32),
+                    felt!(0_u32),
+                ],
                 ..Default::default()
             };
             external_declare_tx(declare_tx_args!(resource_bounds, signature, contract_class))

--- a/crates/starknet_sierra_compile/src/utils.rs
+++ b/crates/starknet_sierra_compile/src/utils.rs
@@ -19,7 +19,7 @@ pub fn into_contract_class_for_compilation(
     rpc_contract_class: &RpcContractClass,
 ) -> CairoLangContractClass {
     let sierra_program =
-        rpc_contract_class.sierra_program.iter().map(felt_to_big_uint_as_hex).collect();
+        sierra_program_as_felts_to_big_uint_as_hex(&rpc_contract_class.sierra_program);
     let entry_points_by_type =
         into_cairo_lang_contract_entry_points(&rpc_contract_class.entry_points_by_type);
 
@@ -56,6 +56,10 @@ fn into_cairo_lang_contract_entry_point(
         selector: entry_point.selector.0.to_biguint(),
         function_idx: entry_point.function_idx.0,
     }
+}
+
+pub fn sierra_program_as_felts_to_big_uint_as_hex(sierra_program: &[Felt]) -> Vec<BigUintAsHex> {
+    sierra_program.iter().map(felt_to_big_uint_as_hex).collect()
 }
 
 fn felt_to_big_uint_as_hex(felt: &Felt) -> BigUintAsHex {


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The validation for version ID is currently only validating the version is in range. It does not validate the compiler version is included in the contract.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Use the Cairo lang deserializer to deserialize the version ID.
- The gateway now validates the compiler version is included in the program.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/84)
<!-- Reviewable:end -->
