### PR TITLE
fix: remove unusued dependency from papyrus network

### DIFF
--- a/crates/papyrus_network/src/bin_utils/mod.rs
+++ b/crates/papyrus_network/src/bin_utils/mod.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use libp2p::identity::Keypair;
-use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{noise, yamux, Multiaddr, Swarm, SwarmBuilder};
 use tracing::debug;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/210)
<!-- Reviewable:end -->
