### PR TITLE
refactor: use deref in account tx for removal of builerplate

### DIFF
--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -73,9 +73,9 @@ pub enum AccountTransaction {
 impl HasRelatedFeeType for AccountTransaction {
     fn version(&self) -> TransactionVersion {
         match self {
-            Self::Declare(tx) => tx.tx.version(),
-            Self::DeployAccount(tx) => tx.tx.version(),
-            Self::Invoke(tx) => tx.tx.version(),
+            Self::Declare(tx) => tx.version(),
+            Self::DeployAccount(tx) => tx.version(),
+            Self::Invoke(tx) => tx.version(),
         }
     }
 

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -1827,7 +1827,7 @@ fn test_l1_handler(#[values(false, true)] use_kzg_da: bool) {
     let contract_address = test_contract.get_instance_address(0);
     let versioned_constants = &block_context.versioned_constants;
     let tx = L1HandlerTransaction::create_for_testing(Fee(1), contract_address);
-    let calldata = tx.tx.calldata.clone();
+    let calldata = tx.calldata.clone();
     let key = calldata.0[1];
     let value = calldata.0[2];
     let payload_size = tx.payload_size();


### PR DESCRIPTION
I tried searching the code for all instances where the `deref` will be useful and address them.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/236)
<!-- Reviewable:end -->
