### PR TITLE
fix(network): update package Cargo.toml's with lint configuration to ignore coverage_nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,8 +79,8 @@ jobs:
 
   doc:
     runs-on: ubuntu-latest
-    # env:
-    #   RUSTDOCFLAGS: "-D warnings"
+    env:
+      RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/papyrus_config/Cargo.toml
+++ b/crates/papyrus_config/Cargo.toml
@@ -24,3 +24,8 @@ itertools.workspace = true
 lazy_static.workspace = true
 papyrus_test_utils = { path = "../papyrus_test_utils" }
 tempfile.workspace = true
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/papyrus_load_test/Cargo.toml
+++ b/crates/papyrus_load_test/Cargo.toml
@@ -22,3 +22,8 @@ tokio.workspace = true
 [dev-dependencies]
 lazy_static.workspace = true
 pretty_assertions.workspace = true
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/papyrus_monitoring_gateway/Cargo.toml
+++ b/crates/papyrus_monitoring_gateway/Cargo.toml
@@ -28,3 +28,8 @@ papyrus_storage = { path = "../papyrus_storage", features = ["testing"] }
 pretty_assertions.workspace = true
 starknet_client = { path = "../starknet_client", features = ["testing"] }
 tower = { workspace = true, features = ["util"] }
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/papyrus_node/Cargo.toml
+++ b/crates/papyrus_node/Cargo.toml
@@ -60,3 +60,8 @@ metrics-exporter-prometheus.workspace = true
 papyrus_test_utils = { path = "../papyrus_test_utils" }
 pretty_assertions.workspace = true
 tempfile.workspace = true
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/papyrus_rpc/Cargo.toml
+++ b/crates/papyrus_rpc/Cargo.toml
@@ -61,3 +61,8 @@ starknet_api = { path = "../starknet_api", version = "0.13.0-rc.0", features = [
 starknet_client = { path = "../starknet_client", features = ["testing"] }
 strum.workspace = true
 strum_macros.workspace = true
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/papyrus_storage/Cargo.toml
+++ b/crates/papyrus_storage/Cargo.toml
@@ -73,3 +73,8 @@ tempfile = { workspace = true }
 test-case.workspace = true
 test-log.workspace = true
 tokio = { workspace = true, features = ["full", "sync"] }
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/papyrus_sync/Cargo.toml
+++ b/crates/papyrus_sync/Cargo.toml
@@ -40,3 +40,8 @@ simple_logger.workspace = true
 starknet_api = { path = "../starknet_api", version = "0.13.0-rc.0", features = ["testing"] }
 starknet_client = { path = "../starknet_client", features = ["testing"] }
 tokio-stream.workspace = true
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/starknet_client/Cargo.toml
+++ b/crates/starknet_client/Cargo.toml
@@ -52,3 +52,8 @@ papyrus_test_utils = { path = "../papyrus_test_utils" }
 # The `rand` and `rand_chacha` crates are used in the `testing` feature, which is optional.
 # `strum` is used by `EnumIter` which is used in this crate.
 ignored = ["rand", "rand_chacha", "strum"]
+
+[lints.rust]
+# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
+# needed (from rust 1.80).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }


### PR DESCRIPTION
Having this just at the workspace level doesn't seem to suppress the warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/287)
<!-- Reviewable:end -->
