### PR TITLE
refactor: move the panic catch into the compile sierra to casm method

### DIFF
--- a/crates/gateway/src/compilation.rs
+++ b/crates/gateway/src/compilation.rs
@@ -1,12 +1,9 @@
-use std::panic;
-
 use blockifier::execution::contract_class::{ClassInfo, ContractClass, ContractClassV1};
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass as CairoLangContractClass;
 use starknet_api::core::CompiledClassHash;
 use starknet_api::rpc_transaction::RpcDeclareTransaction;
 use starknet_sierra_compile::compile::SierraToCasmCompiler;
-use starknet_sierra_compile::errors::CompilationUtilError;
 use starknet_sierra_compile::utils::into_contract_class_for_compilation;
 
 use crate::errors::{GatewayError, GatewayResult};
@@ -48,12 +45,7 @@ impl GatewayCompiler {
         &self,
         cairo_lang_contract_class: CairoLangContractClass,
     ) -> Result<CasmContractClass, GatewayError> {
-        let catch_unwind_result =
-            panic::catch_unwind(|| self.sierra_to_casm_compiler.compile(cairo_lang_contract_class));
-        let casm_contract_class =
-            catch_unwind_result.map_err(|_| CompilationUtilError::CompilationPanic)??;
-
-        Ok(casm_contract_class)
+        Ok(self.sierra_to_casm_compiler.compile(cairo_lang_contract_class)?)
     }
 }
 

--- a/crates/starknet_sierra_compile/src/compile.rs
+++ b/crates/starknet_sierra_compile/src/compile.rs
@@ -1,3 +1,5 @@
+use std::panic;
+
 use cairo_lang_starknet_classes::allowed_libfuncs::ListSelector;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
@@ -16,6 +18,17 @@ pub struct SierraToCasmCompiler {
 
 impl SierraToCasmCompiler {
     pub fn compile(
+        &self,
+        contract_class: ContractClass,
+    ) -> Result<CasmContractClass, CompilationUtilError> {
+        let catch_unwind_result = panic::catch_unwind(|| self.compile_inner(contract_class));
+        let casm_contract_class =
+            catch_unwind_result.map_err(|_| CompilationUtilError::CompilationPanic)??;
+
+        Ok(casm_contract_class)
+    }
+
+    fn compile_inner(
         &self,
         contract_class: ContractClass,
     ) -> Result<CasmContractClass, CompilationUtilError> {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/318)
<!-- Reviewable:end -->
