### PR TITLE
chore: create execution_resources file to split the starknet api transaction file

### DIFF
--- a/crates/committer_cli/src/tests/utils/objects.rs
+++ b/crates/committer_cli/src/tests/utils/objects.rs
@@ -11,6 +11,7 @@ use starknet_api::core::{
     Nonce,
     PatriciaKey,
 };
+use starknet_api::execution_resources::GasVector;
 use starknet_api::state::{StorageKey, ThinStateDiff};
 use starknet_api::transaction::{
     Event,
@@ -18,7 +19,6 @@ use starknet_api::transaction::{
     EventData,
     EventKey,
     Fee,
-    GasVector,
     L2ToL1Payload,
     MessageToL1,
     RevertedTransactionExecutionStatus,

--- a/crates/papyrus_execution/src/objects.rs
+++ b/crates/papyrus_execution/src/objects.rs
@@ -32,16 +32,13 @@ use starknet_api::core::{
 };
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::deprecated_contract_class::EntryPointType;
-use starknet_api::state::ThinStateDiff;
-use starknet_api::transaction::{
+use starknet_api::execution_resources::{
     Builtin,
-    Calldata,
-    EventContent,
     ExecutionResources,
-    Fee,
     GasVector as StarknetApiGasVector,
-    MessageToL1,
 };
+use starknet_api::state::ThinStateDiff;
+use starknet_api::transaction::{Calldata, EventContent, Fee, MessageToL1};
 use starknet_types_core::felt::Felt;
 
 use crate::{ExecutionError, ExecutionResult, TransactionExecutionOutput};

--- a/crates/papyrus_execution/src/testing_instances.rs
+++ b/crates/papyrus_execution/src/testing_instances.rs
@@ -7,7 +7,8 @@ use papyrus_test_utils::{auto_impl_get_test_instance, get_number_of_variants, Ge
 use starknet_api::block::GasPrice;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, PatriciaKey};
 use starknet_api::deprecated_contract_class::EntryPointType;
-use starknet_api::transaction::{Calldata, EventContent, ExecutionResources, Fee, MessageToL1};
+use starknet_api::execution_resources::ExecutionResources;
+use starknet_api::transaction::{Calldata, EventContent, Fee, MessageToL1};
 use starknet_api::{contract_address, felt, patricia_key};
 use starknet_types_core::felt::Felt;
 

--- a/crates/papyrus_protobuf/src/converters/receipt.rs
+++ b/crates/papyrus_protobuf/src/converters/receipt.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
 
 use starknet_api::core::{ContractAddress, EthAddress, PatriciaKey};
+use starknet_api::execution_resources::{Builtin, ExecutionResources, GasVector};
 use starknet_api::transaction::{
-    Builtin,
     DeclareTransactionOutput,
     DeployAccountTransactionOutput,
     DeployTransactionOutput,
-    ExecutionResources,
     Fee,
-    GasVector,
     InvokeTransactionOutput,
     L1HandlerTransactionOutput,
     L2ToL1Payload,

--- a/crates/papyrus_protobuf/src/converters/transaction_test.rs
+++ b/crates/papyrus_protobuf/src/converters/transaction_test.rs
@@ -1,14 +1,12 @@
 use lazy_static::lazy_static;
 use papyrus_test_utils::{get_rng, GetTestInstance};
+use starknet_api::execution_resources::{Builtin, ExecutionResources, GasVector};
 use starknet_api::transaction::{
-    Builtin,
     DeclareTransaction,
     DeclareTransactionOutput,
     DeployAccountTransaction,
     DeployAccountTransactionOutput,
     DeployTransactionOutput,
-    ExecutionResources,
-    GasVector,
     InvokeTransaction,
     InvokeTransactionOutput,
     L1HandlerTransactionOutput,

--- a/crates/papyrus_rpc/src/v0_6/transaction.rs
+++ b/crates/papyrus_rpc/src/v0_6/transaction.rs
@@ -765,22 +765,22 @@ pub enum Builtin {
     SegmentArena,
 }
 
-impl TryFrom<starknet_api::transaction::Builtin> for Builtin {
+impl TryFrom<starknet_api::execution_resources::Builtin> for Builtin {
     type Error = ();
-    fn try_from(builtin: starknet_api::transaction::Builtin) -> Result<Self, Self::Error> {
+    fn try_from(builtin: starknet_api::execution_resources::Builtin) -> Result<Self, Self::Error> {
         match builtin {
-            starknet_api::transaction::Builtin::RangeCheck => Ok(Builtin::RangeCheck),
-            starknet_api::transaction::Builtin::Pedersen => Ok(Builtin::Pedersen),
-            starknet_api::transaction::Builtin::Poseidon => Ok(Builtin::Poseidon),
-            starknet_api::transaction::Builtin::EcOp => Ok(Builtin::EcOp),
-            starknet_api::transaction::Builtin::Ecdsa => Ok(Builtin::Ecdsa),
-            starknet_api::transaction::Builtin::Bitwise => Ok(Builtin::Bitwise),
-            starknet_api::transaction::Builtin::Keccak => Ok(Builtin::Keccak),
-            starknet_api::transaction::Builtin::SegmentArena => Ok(Builtin::SegmentArena),
+            starknet_api::execution_resources::Builtin::RangeCheck => Ok(Builtin::RangeCheck),
+            starknet_api::execution_resources::Builtin::Pedersen => Ok(Builtin::Pedersen),
+            starknet_api::execution_resources::Builtin::Poseidon => Ok(Builtin::Poseidon),
+            starknet_api::execution_resources::Builtin::EcOp => Ok(Builtin::EcOp),
+            starknet_api::execution_resources::Builtin::Ecdsa => Ok(Builtin::Ecdsa),
+            starknet_api::execution_resources::Builtin::Bitwise => Ok(Builtin::Bitwise),
+            starknet_api::execution_resources::Builtin::Keccak => Ok(Builtin::Keccak),
+            starknet_api::execution_resources::Builtin::SegmentArena => Ok(Builtin::SegmentArena),
             // These builtins are not part of the specs.
-            starknet_api::transaction::Builtin::AddMod
-            | starknet_api::transaction::Builtin::MulMod
-            | starknet_api::transaction::Builtin::RangeCheck96 => Err(()),
+            starknet_api::execution_resources::Builtin::AddMod
+            | starknet_api::execution_resources::Builtin::MulMod
+            | starknet_api::execution_resources::Builtin::RangeCheck96 => Err(()),
         }
     }
 }
@@ -796,8 +796,8 @@ pub struct ExecutionResources {
     pub memory_holes: Option<u64>,
 }
 
-impl From<starknet_api::transaction::ExecutionResources> for ExecutionResources {
-    fn from(value: starknet_api::transaction::ExecutionResources) -> Self {
+impl From<starknet_api::execution_resources::ExecutionResources> for ExecutionResources {
+    fn from(value: starknet_api::execution_resources::ExecutionResources) -> Self {
         Self {
             steps: value.steps,
             builtin_instance_counter: value

--- a/crates/papyrus_rpc/src/v0_7/execution_test.rs
+++ b/crates/papyrus_rpc/src/v0_7/execution_test.rs
@@ -1440,17 +1440,15 @@ impl GetTestInstance for FunctionInvocation {
             calls: Vec::new(),
             events: Vec::<OrderedEvent>::get_test_instance(rng),
             messages: Vec::<OrderedL2ToL1Message>::get_test_instance(rng),
-            execution_resources: starknet_api::transaction::ExecutionResources::get_test_instance(
-                rng,
-            )
-            .into(),
+            execution_resources:
+                starknet_api::execution_resources::ExecutionResources::get_test_instance(rng).into(),
         }
     }
 }
 
 impl GetTestInstance for ExecutionResources {
     fn get_test_instance(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
-        starknet_api::transaction::ExecutionResources::get_test_instance(rng).into()
+        starknet_api::execution_resources::ExecutionResources::get_test_instance(rng).into()
     }
 }
 

--- a/crates/papyrus_rpc/src/v0_7/transaction.rs
+++ b/crates/papyrus_rpc/src/v0_7/transaction.rs
@@ -835,22 +835,22 @@ pub enum Builtin {
     SegmentArena,
 }
 
-impl TryFrom<starknet_api::transaction::Builtin> for Builtin {
+impl TryFrom<starknet_api::execution_resources::Builtin> for Builtin {
     type Error = ();
-    fn try_from(builtin: starknet_api::transaction::Builtin) -> Result<Self, Self::Error> {
+    fn try_from(builtin: starknet_api::execution_resources::Builtin) -> Result<Self, Self::Error> {
         match builtin {
-            starknet_api::transaction::Builtin::RangeCheck => Ok(Builtin::RangeCheck),
-            starknet_api::transaction::Builtin::Pedersen => Ok(Builtin::Pedersen),
-            starknet_api::transaction::Builtin::Poseidon => Ok(Builtin::Poseidon),
-            starknet_api::transaction::Builtin::EcOp => Ok(Builtin::EcOp),
-            starknet_api::transaction::Builtin::Ecdsa => Ok(Builtin::Ecdsa),
-            starknet_api::transaction::Builtin::Bitwise => Ok(Builtin::Bitwise),
-            starknet_api::transaction::Builtin::Keccak => Ok(Builtin::Keccak),
-            starknet_api::transaction::Builtin::SegmentArena => Ok(Builtin::SegmentArena),
+            starknet_api::execution_resources::Builtin::RangeCheck => Ok(Builtin::RangeCheck),
+            starknet_api::execution_resources::Builtin::Pedersen => Ok(Builtin::Pedersen),
+            starknet_api::execution_resources::Builtin::Poseidon => Ok(Builtin::Poseidon),
+            starknet_api::execution_resources::Builtin::EcOp => Ok(Builtin::EcOp),
+            starknet_api::execution_resources::Builtin::Ecdsa => Ok(Builtin::Ecdsa),
+            starknet_api::execution_resources::Builtin::Bitwise => Ok(Builtin::Bitwise),
+            starknet_api::execution_resources::Builtin::Keccak => Ok(Builtin::Keccak),
+            starknet_api::execution_resources::Builtin::SegmentArena => Ok(Builtin::SegmentArena),
             // These builtins are not part of the specs.
-            starknet_api::transaction::Builtin::AddMod
-            | starknet_api::transaction::Builtin::MulMod
-            | starknet_api::transaction::Builtin::RangeCheck96 => Err(()),
+            starknet_api::execution_resources::Builtin::AddMod
+            | starknet_api::execution_resources::Builtin::MulMod
+            | starknet_api::execution_resources::Builtin::RangeCheck96 => Err(()),
         }
     }
 }
@@ -926,8 +926,8 @@ impl Add for ExecutionResources {
     }
 }
 
-impl From<starknet_api::transaction::ExecutionResources> for ExecutionResources {
-    fn from(value: starknet_api::transaction::ExecutionResources) -> Self {
+impl From<starknet_api::execution_resources::ExecutionResources> for ExecutionResources {
+    fn from(value: starknet_api::execution_resources::ExecutionResources) -> Self {
         let l1_gas = value.da_gas_consumed.l1_gas;
         let l1_data_gas = value.da_gas_consumed.l1_data_gas;
         Self {
@@ -937,8 +937,8 @@ impl From<starknet_api::transaction::ExecutionResources> for ExecutionResources 
     }
 }
 
-impl From<starknet_api::transaction::ExecutionResources> for ComputationResources {
-    fn from(value: starknet_api::transaction::ExecutionResources) -> Self {
+impl From<starknet_api::execution_resources::ExecutionResources> for ComputationResources {
+    fn from(value: starknet_api::execution_resources::ExecutionResources) -> Self {
         Self {
             steps: value.steps,
             builtin_instance_counter: value

--- a/crates/papyrus_storage/src/serialization/serializers.rs
+++ b/crates/papyrus_storage/src/serialization/serializers.rs
@@ -64,6 +64,7 @@ use starknet_api::deprecated_contract_class::{
     StructType,
     TypedParameter,
 };
+use starknet_api::execution_resources::{Builtin, ExecutionResources, GasVector};
 use starknet_api::hash::{PoseidonHash, StarkHash};
 use starknet_api::state::{
     ContractClass,
@@ -75,7 +76,6 @@ use starknet_api::state::{
 };
 use starknet_api::transaction::{
     AccountDeploymentData,
-    Builtin,
     Calldata,
     ContractAddressSalt,
     DeclareTransaction,
@@ -94,9 +94,7 @@ use starknet_api::transaction::{
     EventData,
     EventIndexInTransactionOutput,
     EventKey,
-    ExecutionResources,
     Fee,
-    GasVector,
     InvokeTransaction,
     InvokeTransactionOutput,
     InvokeTransactionV0,

--- a/crates/papyrus_test_utils/src/lib.rs
+++ b/crates/papyrus_test_utils/src/lib.rs
@@ -85,6 +85,7 @@ use starknet_api::deprecated_contract_class::{
     StructType,
     TypedParameter,
 };
+use starknet_api::execution_resources::{Builtin, ExecutionResources, GasVector};
 use starknet_api::felt;
 use starknet_api::hash::{PoseidonHash, StarkHash};
 use starknet_api::state::{
@@ -98,7 +99,6 @@ use starknet_api::state::{
 };
 use starknet_api::transaction::{
     AccountDeploymentData,
-    Builtin,
     Calldata,
     ContractAddressSalt,
     DeclareTransaction,
@@ -117,9 +117,7 @@ use starknet_api::transaction::{
     EventData,
     EventIndexInTransactionOutput,
     EventKey,
-    ExecutionResources,
     Fee,
-    GasVector,
     InvokeTransaction,
     InvokeTransactionOutput,
     InvokeTransactionV0,

--- a/crates/starknet_api/src/block_hash/block_hash_calculator.rs
+++ b/crates/starknet_api/src/block_hash/block_hash_calculator.rs
@@ -11,11 +11,11 @@ use crate::block::{BlockHash, BlockHeaderWithoutHash};
 use crate::core::{EventCommitment, ReceiptCommitment, StateDiffCommitment, TransactionCommitment};
 use crate::crypto::utils::HashChain;
 use crate::data_availability::L1DataAvailabilityMode;
+use crate::execution_resources::GasVector;
 use crate::state::ThinStateDiff;
 use crate::transaction::{
     Event,
     Fee,
-    GasVector,
     MessageToL1,
     TransactionExecutionStatus,
     TransactionHash,

--- a/crates/starknet_api/src/block_hash/receipt_commitment.rs
+++ b/crates/starknet_api/src/block_hash/receipt_commitment.rs
@@ -5,8 +5,9 @@ use super::block_hash_calculator::{TransactionHashingData, TransactionOutputForH
 use crate::core::ReceiptCommitment;
 use crate::crypto::patricia_hash::calculate_root;
 use crate::crypto::utils::HashChain;
+use crate::execution_resources::GasVector;
 use crate::hash::starknet_keccak_hash;
-use crate::transaction::{GasVector, MessageToL1, TransactionExecutionStatus, TransactionHash};
+use crate::transaction::{MessageToL1, TransactionExecutionStatus, TransactionHash};
 
 #[cfg(test)]
 #[path = "receipt_commitment_test.rs"]

--- a/crates/starknet_api/src/block_hash/test_utils.rs
+++ b/crates/starknet_api/src/block_hash/test_utils.rs
@@ -4,10 +4,10 @@ use starknet_types_core::felt::Felt;
 
 use super::block_hash_calculator::TransactionOutputForHash;
 use crate::core::{ClassHash, CompiledClassHash, ContractAddress, EthAddress, Nonce};
+use crate::execution_resources::GasVector;
 use crate::state::ThinStateDiff;
 use crate::transaction::{
     Fee,
-    GasVector,
     L2ToL1Payload,
     MessageToL1,
     RevertedTransactionExecutionStatus,

--- a/crates/starknet_api/src/execution_resources.rs
+++ b/crates/starknet_api/src/execution_resources.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
+pub struct GasVector {
+    pub l1_gas: u64,
+    pub l1_data_gas: u64,
+}
+
+/// The execution resources used by a transaction.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
+pub struct ExecutionResources {
+    pub steps: u64,
+    pub builtin_instance_counter: HashMap<Builtin, u64>,
+    pub memory_holes: u64,
+    pub da_gas_consumed: GasVector,
+    pub gas_consumed: GasVector,
+}
+
+#[derive(Clone, Debug, Deserialize, EnumIter, Eq, Hash, PartialEq, Serialize)]
+pub enum Builtin {
+    #[serde(rename = "range_check_builtin_applications")]
+    RangeCheck,
+    #[serde(rename = "pedersen_builtin_applications")]
+    Pedersen,
+    #[serde(rename = "poseidon_builtin_applications")]
+    Poseidon,
+    #[serde(rename = "ec_op_builtin_applications")]
+    EcOp,
+    #[serde(rename = "ecdsa_builtin_applications")]
+    Ecdsa,
+    #[serde(rename = "bitwise_builtin_applications")]
+    Bitwise,
+    #[serde(rename = "keccak_builtin_applications")]
+    Keccak,
+    #[serde(rename = "segment_arena_builtin")]
+    SegmentArena,
+    #[serde(rename = "add_mod_builtin")]
+    AddMod,
+    #[serde(rename = "mul_mod_builtin")]
+    MulMod,
+    #[serde(rename = "range_check96_builtin")]
+    RangeCheck96,
+}
+
+const RANGE_CHACK_BUILTIN_NAME: &str = "range_check";
+const PEDERSEN_BUILTIN_NAME: &str = "pedersen";
+const POSEIDON_BUILTIN_NAME: &str = "poseidon";
+const EC_OP_BUILTIN_NAME: &str = "ec_op";
+const ECDSA_BUILTIN_NAME: &str = "ecdsa";
+const BITWISE_BUILTIN_NAME: &str = "bitwise";
+const KECCAK_BUILTIN_NAME: &str = "keccak";
+const SEGMENT_ARENA_BUILTIN_NAME: &str = "segment_arena";
+const ADD_MOD_BUILTIN_NAME: &str = "add_mod";
+const MUL_MOD_BUILTIN_NAME: &str = "mul_mod";
+const RANGE_CHECK96_BUILTIN_NAME: &str = "range_check96";
+
+impl Builtin {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Builtin::RangeCheck => RANGE_CHACK_BUILTIN_NAME,
+            Builtin::Pedersen => PEDERSEN_BUILTIN_NAME,
+            Builtin::Poseidon => POSEIDON_BUILTIN_NAME,
+            Builtin::EcOp => EC_OP_BUILTIN_NAME,
+            Builtin::Ecdsa => ECDSA_BUILTIN_NAME,
+            Builtin::Bitwise => BITWISE_BUILTIN_NAME,
+            Builtin::Keccak => KECCAK_BUILTIN_NAME,
+            Builtin::SegmentArena => SEGMENT_ARENA_BUILTIN_NAME,
+            Builtin::AddMod => ADD_MOD_BUILTIN_NAME,
+            Builtin::MulMod => MUL_MOD_BUILTIN_NAME,
+            Builtin::RangeCheck96 => RANGE_CHECK96_BUILTIN_NAME,
+        }
+    }
+}

--- a/crates/starknet_api/src/lib.rs
+++ b/crates/starknet_api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod crypto;
 pub mod data_availability;
 pub mod deprecated_contract_class;
 pub mod executable_transaction;
+pub mod execution_resources;
 pub mod hash;
 pub mod rpc_transaction;
 pub mod serde_utils;

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -19,6 +19,7 @@ use crate::core::{
     Nonce,
 };
 use crate::data_availability::DataAvailabilityMode;
+use crate::execution_resources::ExecutionResources;
 use crate::hash::StarkHash;
 use crate::serde_utils::PrefixedBytesAsHex;
 use crate::transaction_hash::{
@@ -948,75 +949,3 @@ pub struct PaymasterData(pub Vec<Felt>);
 /// its class hash, address salt and constructor calldata.
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct AccountDeploymentData(pub Vec<Felt>);
-
-#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
-pub struct GasVector {
-    pub l1_gas: u64,
-    pub l1_data_gas: u64,
-}
-
-/// The execution resources used by a transaction.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
-pub struct ExecutionResources {
-    pub steps: u64,
-    pub builtin_instance_counter: HashMap<Builtin, u64>,
-    pub memory_holes: u64,
-    pub da_gas_consumed: GasVector,
-    pub gas_consumed: GasVector,
-}
-
-#[derive(Clone, Debug, Deserialize, EnumIter, Eq, Hash, PartialEq, Serialize)]
-pub enum Builtin {
-    #[serde(rename = "range_check_builtin_applications")]
-    RangeCheck,
-    #[serde(rename = "pedersen_builtin_applications")]
-    Pedersen,
-    #[serde(rename = "poseidon_builtin_applications")]
-    Poseidon,
-    #[serde(rename = "ec_op_builtin_applications")]
-    EcOp,
-    #[serde(rename = "ecdsa_builtin_applications")]
-    Ecdsa,
-    #[serde(rename = "bitwise_builtin_applications")]
-    Bitwise,
-    #[serde(rename = "keccak_builtin_applications")]
-    Keccak,
-    #[serde(rename = "segment_arena_builtin")]
-    SegmentArena,
-    #[serde(rename = "add_mod_builtin")]
-    AddMod,
-    #[serde(rename = "mul_mod_builtin")]
-    MulMod,
-    #[serde(rename = "range_check96_builtin")]
-    RangeCheck96,
-}
-
-const RANGE_CHACK_BUILTIN_NAME: &str = "range_check";
-const PEDERSEN_BUILTIN_NAME: &str = "pedersen";
-const POSEIDON_BUILTIN_NAME: &str = "poseidon";
-const EC_OP_BUILTIN_NAME: &str = "ec_op";
-const ECDSA_BUILTIN_NAME: &str = "ecdsa";
-const BITWISE_BUILTIN_NAME: &str = "bitwise";
-const KECCAK_BUILTIN_NAME: &str = "keccak";
-const SEGMENT_ARENA_BUILTIN_NAME: &str = "segment_arena";
-const ADD_MOD_BUILTIN_NAME: &str = "add_mod";
-const MUL_MOD_BUILTIN_NAME: &str = "mul_mod";
-const RANGE_CHECK96_BUILTIN_NAME: &str = "range_check96";
-
-impl Builtin {
-    pub fn name(&self) -> &'static str {
-        match self {
-            Builtin::RangeCheck => RANGE_CHACK_BUILTIN_NAME,
-            Builtin::Pedersen => PEDERSEN_BUILTIN_NAME,
-            Builtin::Poseidon => POSEIDON_BUILTIN_NAME,
-            Builtin::EcOp => EC_OP_BUILTIN_NAME,
-            Builtin::Ecdsa => ECDSA_BUILTIN_NAME,
-            Builtin::Bitwise => BITWISE_BUILTIN_NAME,
-            Builtin::Keccak => KECCAK_BUILTIN_NAME,
-            Builtin::SegmentArena => SEGMENT_ARENA_BUILTIN_NAME,
-            Builtin::AddMod => ADD_MOD_BUILTIN_NAME,
-            Builtin::MulMod => MUL_MOD_BUILTIN_NAME,
-            Builtin::RangeCheck96 => RANGE_CHECK96_BUILTIN_NAME,
-        }
-    }
-}

--- a/crates/starknet_client/src/reader/objects/test_utils.rs
+++ b/crates/starknet_client/src/reader/objects/test_utils.rs
@@ -9,6 +9,7 @@ use starknet_api::core::{
     EthAddress,
     Nonce,
 };
+use starknet_api::execution_resources::GasVector;
 use starknet_api::hash::StarkHash;
 use starknet_api::state::{EntryPoint, EntryPointType};
 use starknet_api::transaction::{
@@ -17,7 +18,6 @@ use starknet_api::transaction::{
     ContractAddressSalt,
     Event,
     Fee,
-    GasVector,
     L1ToL2Payload,
     L2ToL1Payload,
     PaymasterData,

--- a/crates/starknet_client/src/reader/objects/transaction.rs
+++ b/crates/starknet_client/src/reader/objects/transaction.rs
@@ -14,6 +14,7 @@ use starknet_api::core::{
     EthAddress,
     Nonce,
 };
+use starknet_api::execution_resources::GasVector;
 use starknet_api::hash::StarkHash;
 use starknet_api::transaction::{
     AccountDeploymentData,
@@ -24,7 +25,6 @@ use starknet_api::transaction::{
     DeployTransactionOutput,
     Event,
     Fee,
-    GasVector,
     InvokeTransactionOutput,
     L1HandlerTransactionOutput,
     L1ToL2Payload,
@@ -664,7 +664,7 @@ pub enum Builtin {
     RangeCheck96,
 }
 
-impl From<ExecutionResources> for starknet_api::transaction::ExecutionResources {
+impl From<ExecutionResources> for starknet_api::execution_resources::ExecutionResources {
     fn from(execution_resources: ExecutionResources) -> Self {
         let da_gas_consumed = execution_resources.data_availability.unwrap_or_default();
         Self {
@@ -674,27 +674,39 @@ impl From<ExecutionResources> for starknet_api::transaction::ExecutionResources 
                 .into_iter()
                 .filter_map(|(builtin, count)| match builtin {
                     Builtin::RangeCheck => {
-                        Some((starknet_api::transaction::Builtin::RangeCheck, count))
+                        Some((starknet_api::execution_resources::Builtin::RangeCheck, count))
                     }
                     Builtin::Pedersen => {
-                        Some((starknet_api::transaction::Builtin::Pedersen, count))
+                        Some((starknet_api::execution_resources::Builtin::Pedersen, count))
                     }
                     Builtin::Poseidon => {
-                        Some((starknet_api::transaction::Builtin::Poseidon, count))
+                        Some((starknet_api::execution_resources::Builtin::Poseidon, count))
                     }
-                    Builtin::EcOp => Some((starknet_api::transaction::Builtin::EcOp, count)),
-                    Builtin::Ecdsa => Some((starknet_api::transaction::Builtin::Ecdsa, count)),
-                    Builtin::Bitwise => Some((starknet_api::transaction::Builtin::Bitwise, count)),
-                    Builtin::Keccak => Some((starknet_api::transaction::Builtin::Keccak, count)),
+                    Builtin::EcOp => {
+                        Some((starknet_api::execution_resources::Builtin::EcOp, count))
+                    }
+                    Builtin::Ecdsa => {
+                        Some((starknet_api::execution_resources::Builtin::Ecdsa, count))
+                    }
+                    Builtin::Bitwise => {
+                        Some((starknet_api::execution_resources::Builtin::Bitwise, count))
+                    }
+                    Builtin::Keccak => {
+                        Some((starknet_api::execution_resources::Builtin::Keccak, count))
+                    }
                     // output builtin should be ignored.
                     Builtin::Output => None,
                     Builtin::SegmentArena => {
-                        Some((starknet_api::transaction::Builtin::SegmentArena, count))
+                        Some((starknet_api::execution_resources::Builtin::SegmentArena, count))
                     }
-                    Builtin::AddMod => Some((starknet_api::transaction::Builtin::AddMod, count)),
-                    Builtin::MulMod => Some((starknet_api::transaction::Builtin::MulMod, count)),
+                    Builtin::AddMod => {
+                        Some((starknet_api::execution_resources::Builtin::AddMod, count))
+                    }
+                    Builtin::MulMod => {
+                        Some((starknet_api::execution_resources::Builtin::MulMod, count))
+                    }
                     Builtin::RangeCheck96 => {
-                        Some((starknet_api::transaction::Builtin::RangeCheck96, count))
+                        Some((starknet_api::execution_resources::Builtin::RangeCheck96, count))
                     }
                 })
                 .collect(),


### PR DESCRIPTION
As part of refactoring the file `transaction.rs`, I noticed this file is too big.
Let us split this file and move some objects into the file `execution_resources.rs`.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/335)
<!-- Reviewable:end -->
