### PR TITLE
refactor(consensus): move run_consensus out of lib.rs

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/lib.rs
+++ b/crates/sequencing/papyrus_consensus/src/lib.rs
@@ -3,19 +3,6 @@
 // TODO(Matan): fix #[allow(missing_docs)].
 //! A consensus implementation for a [`Starknet`](https://www.starknet.io/) node.
 
-use std::time::Duration;
-
-use futures::channel::{mpsc, oneshot};
-use futures::Stream;
-use manager::MultiHeightManager;
-use papyrus_common::metrics as papyrus_metrics;
-use papyrus_network::network_manager::ReportSender;
-use papyrus_protobuf::consensus::{ConsensusMessage, Proposal};
-use papyrus_protobuf::converters::ProtobufConversionError;
-use starknet_api::block::{BlockHash, BlockNumber};
-use tracing::{debug, info, instrument};
-use types::{ConsensusBlock, ConsensusContext, ConsensusError, ProposalInit, ValidatorId};
-
 pub mod config;
 pub mod manager;
 #[allow(missing_docs)]
@@ -31,44 +18,4 @@ pub(crate) mod test_utils;
 #[allow(missing_docs)]
 pub mod types;
 
-// TODO(dvir): add test for this.
-#[instrument(skip(context, start_height, network_receiver), level = "info")]
-#[allow(missing_docs)]
-pub async fn run_consensus<BlockT, ContextT, NetworkReceiverT>(
-    mut context: ContextT,
-    start_height: BlockNumber,
-    validator_id: ValidatorId,
-    consensus_delay: Duration,
-    mut network_receiver: NetworkReceiverT,
-) -> Result<(), ConsensusError>
-where
-    BlockT: ConsensusBlock,
-    ContextT: ConsensusContext<Block = BlockT>,
-    NetworkReceiverT:
-        Stream<Item = (Result<ConsensusMessage, ProtobufConversionError>, ReportSender)> + Unpin,
-    ProposalWrapper:
-        Into<(ProposalInit, mpsc::Receiver<BlockT::ProposalChunk>, oneshot::Receiver<BlockHash>)>,
-{
-    // Add a short delay to allow peers to connect and avoid "InsufficientPeers" error
-    tokio::time::sleep(consensus_delay).await;
-    let mut current_height = start_height;
-    let mut manager = MultiHeightManager::new();
-    loop {
-        let decision = manager
-            .run_height(&mut context, current_height, validator_id, &mut network_receiver)
-            .await?;
-
-        info!(
-            "Finished consensus for height: {current_height}. Agreed on block with id: {:x}",
-            decision.block.id().0
-        );
-        debug!("Decision: {:?}", decision);
-        metrics::gauge!(papyrus_metrics::PAPYRUS_CONSENSUS_HEIGHT, current_height.0 as f64);
-        current_height = current_height.unchecked_next();
-    }
-}
-
-// `Proposal` is defined in the protobuf crate so we can't implement `Into` for it because of the
-// orphan rule. This wrapper enables us to implement `Into` for the inner `Proposal`.
-#[allow(missing_docs)]
-pub struct ProposalWrapper(Proposal);
+pub use manager::{run_consensus, ProposalWrapper};


### PR DESCRIPTION
this is in preparation for adding more functionality with the sync channel. I prefer not to
have functionality in the lib file as I see its purpose as cataloguing the modules and
public exports of the crate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/386)
<!-- Reviewable:end -->
