### PR TITLE
feat(consensus): add decision fn to consensus context API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6282,7 +6282,6 @@ dependencies = [
  "assert_matches",
  "async-stream",
  "bytes",
- "clap",
  "deadqueue",
  "defaultmap",
  "derive_more",

--- a/crates/sequencing/papyrus_consensus/src/manager.rs
+++ b/crates/sequencing/papyrus_consensus/src/manager.rs
@@ -9,12 +9,11 @@ use std::time::Duration;
 
 use futures::channel::{mpsc, oneshot};
 use futures::{Stream, StreamExt};
-use papyrus_common::metrics as papyrus_metrics;
 use papyrus_network::network_manager::ReportSender;
 use papyrus_protobuf::consensus::{ConsensusMessage, Proposal};
 use papyrus_protobuf::converters::ProtobufConversionError;
 use starknet_api::block::{BlockHash, BlockNumber};
-use tracing::{debug, info, instrument};
+use tracing::{debug, instrument};
 
 use crate::single_height_consensus::SingleHeightConsensus;
 use crate::types::{
@@ -52,13 +51,7 @@ where
         let decision = manager
             .run_height(&mut context, current_height, validator_id, &mut network_receiver)
             .await?;
-
-        info!(
-            "Finished consensus for height: {current_height}. Agreed on block with id: {:x}",
-            decision.block.id().0
-        );
-        debug!("Decision: {:?}", decision);
-        metrics::gauge!(papyrus_metrics::PAPYRUS_CONSENSUS_HEIGHT, current_height.0 as f64);
+        context.notify_decision(decision.block, decision.precommits).await?;
         current_height = current_height.unchecked_next();
     }
 }

--- a/crates/sequencing/papyrus_consensus/src/manager_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/manager_test.rs
@@ -71,6 +71,12 @@ mock! {
             content_receiver: mpsc::Receiver<Transaction>,
             fin_receiver: oneshot::Receiver<BlockHash>,
         ) -> Result<(), ConsensusError>;
+
+        async fn notify_decision(
+            &self,
+            block: TestBlock,
+            precommits: Vec<Vote>,
+        ) -> Result<(), ConsensusError>;
     }
 }
 

--- a/crates/sequencing/papyrus_consensus/src/test_utils.rs
+++ b/crates/sequencing/papyrus_consensus/src/test_utils.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use mockall::mock;
-use papyrus_protobuf::consensus::ConsensusMessage;
+use papyrus_protobuf::consensus::{ConsensusMessage, Vote};
 use starknet_api::block::{BlockHash, BlockNumber};
 
 use crate::types::{ConsensusBlock, ConsensusContext, ConsensusError, ProposalInit, ValidatorId};
@@ -56,6 +56,12 @@ mock! {
             init: ProposalInit,
             content_receiver: mpsc::Receiver<u32>,
             fin_receiver: oneshot::Receiver<BlockHash>,
+        ) -> Result<(), ConsensusError>;
+
+        async fn notify_decision(
+            &self,
+            block: TestBlock,
+            precommits: Vec<Vote>,
         ) -> Result<(), ConsensusError>;
     }
 }

--- a/crates/sequencing/papyrus_consensus/src/types.rs
+++ b/crates/sequencing/papyrus_consensus/src/types.rs
@@ -135,6 +135,16 @@ pub trait ConsensusContext {
         content_receiver: mpsc::Receiver<<Self::Block as ConsensusBlock>::ProposalChunk>,
         fin_receiver: oneshot::Receiver<BlockHash>,
     ) -> Result<(), ConsensusError>;
+
+    /// Update the context that a decision has been reached for a given height.
+    /// - `block` identifies the decision.
+    /// - `precommits` - All precommits must be for the same `(block.id(), height, round)` and form
+    ///   a quorum (>2/3 of the voting power) for this height.
+    async fn notify_decision(
+        &self,
+        block: Self::Block,
+        precommits: Vec<Vote>,
+    ) -> Result<(), ConsensusError>;
 }
 
 #[derive(PartialEq)]


### PR DESCRIPTION
This is how consensus updates the rest of the node when a new block has been decided.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/387)
<!-- Reviewable:end -->
