### PR TITLE
feat(consensus): redefine consensus height metric to working height

### DIFF
--- a/crates/papyrus_common/src/metrics.rs
+++ b/crates/papyrus_common/src/metrics.rs
@@ -38,5 +38,5 @@ pub const PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "papyrus_num_active_outbo
 /// Global variable set by the main config to enable collecting profiling metrics.
 pub static COLLECT_PROFILING_METRICS: OnceLock<bool> = OnceLock::new();
 
-/// The height most recently decided by consensus.
+/// The height consensus is currently working on.
 pub const PAPYRUS_CONSENSUS_HEIGHT: &str = "papyrus_consensus_height";

--- a/crates/sequencing/papyrus_consensus/run_consensus.py
+++ b/crates/sequencing/papyrus_consensus/run_consensus.py
@@ -35,7 +35,7 @@ class Node:
         port = self.monitoring_gateway_server_port
         command = f"curl -s -X GET http://localhost:{port}/monitoring/metrics | grep -oP 'papyrus_consensus_height \\K\\d+'"
         result = subprocess.run(command, shell=True, capture_output=True, text=True)
-        # returns the latest decided height, or None if node isn't ready or no height reached.
+        # returns the latest decided height, or None if consensus has not yet started.
         return int(result.stdout) if result.stdout else None
 
     def check_height(self):

--- a/crates/sequencing/papyrus_consensus/src/manager.rs
+++ b/crates/sequencing/papyrus_consensus/src/manager.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use futures::channel::{mpsc, oneshot};
 use futures::{Stream, StreamExt};
+use papyrus_common::metrics::PAPYRUS_CONSENSUS_HEIGHT;
 use papyrus_network::network_manager::ReportSender;
 use papyrus_protobuf::consensus::{ConsensusMessage, Proposal};
 use papyrus_protobuf::converters::ProtobufConversionError;
@@ -50,6 +51,8 @@ where
     let mut current_height = start_height;
     let mut manager = MultiHeightManager::new();
     loop {
+        metrics::gauge!(PAPYRUS_CONSENSUS_HEIGHT, current_height.0 as f64);
+
         let run_height =
             manager.run_height(&mut context, current_height, validator_id, &mut network_receiver);
 

--- a/crates/sequencing/papyrus_consensus/src/papyrus_consensus_context.rs
+++ b/crates/sequencing/papyrus_consensus/src/papyrus_consensus_context.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use futures::sink::SinkExt;
 use futures::StreamExt;
-use papyrus_common::metrics::PAPYRUS_CONSENSUS_HEIGHT;
 use papyrus_network::network_manager::BroadcastSubscriberSender;
 use papyrus_protobuf::consensus::{ConsensusMessage, Proposal, Vote};
 use papyrus_storage::body::BodyStorageReader;
@@ -237,7 +236,6 @@ impl ConsensusContext for PapyrusConsensusContext {
             "Finished consensus for height: {height}. Agreed on block with id: {:x}",
             block.id().0
         );
-        metrics::gauge!(PAPYRUS_CONSENSUS_HEIGHT, height as f64);
         Ok(())
     }
 }


### PR DESCRIPTION
This will be more useful than stating the most recent decision when we are stuck on block 0.
Also moved out of Context::decision due to sync

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/404)
<!-- Reviewable:end -->
