### PR TITLE
feat(consensus): add sync sender to context to broadcast on decision

### DIFF
--- a/crates/papyrus_node/src/main.rs
+++ b/crates/papyrus_node/src/main.rs
@@ -110,6 +110,7 @@ fn run_consensus(
         storage_reader.clone(),
         network_channels.messages_to_broadcast_sender,
         config.num_validators,
+        None,
     );
     // TODO(matan): connect this to an actual channel.
     if let Some(test_config) = config.test.as_ref() {

--- a/crates/papyrus_protobuf/src/consensus.rs
+++ b/crates/papyrus_protobuf/src/consensus.rs
@@ -11,13 +11,14 @@ pub struct Proposal {
     pub block_hash: BlockHash,
 }
 
-#[derive(Debug, Hash, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
 pub enum VoteType {
     Prevote,
+    #[default]
     Precommit,
 }
 
-#[derive(Debug, Hash, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
 pub struct Vote {
     pub vote_type: VoteType,
     pub height: u64,

--- a/crates/papyrus_protobuf/src/converters/consensus.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus.rs
@@ -105,6 +105,8 @@ impl From<Vote> for protobuf::Vote {
     }
 }
 
+auto_impl_into_and_try_from_vec_u8!(Vote, protobuf::Vote);
+
 impl TryFrom<protobuf::ConsensusMessage> for ConsensusMessage {
     type Error = ProtobufConversionError;
 

--- a/crates/sequencing/papyrus_consensus/src/manager_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/manager_test.rs
@@ -75,7 +75,7 @@ mock! {
         ) -> Result<(), ConsensusError>;
 
         async fn notify_decision(
-            &self,
+            &mut self,
             block: TestBlock,
             precommits: Vec<Vote>,
         ) -> Result<(), ConsensusError>;

--- a/crates/sequencing/papyrus_consensus/src/papyrus_consensus_context.rs
+++ b/crates/sequencing/papyrus_consensus/src/papyrus_consensus_context.rs
@@ -24,7 +24,7 @@ use crate::ProposalWrapper;
 
 // TODO: add debug messages and span to the tasks.
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct PapyrusConsensusBlock {
     content: Vec<Transaction>,
     id: BlockHash,
@@ -45,8 +45,9 @@ impl ConsensusBlock for PapyrusConsensusBlock {
 
 pub struct PapyrusConsensusContext {
     storage_reader: StorageReader,
-    broadcast_sender: BroadcastSubscriberSender<ConsensusMessage>,
+    network_broadcast_sender: BroadcastSubscriberSender<ConsensusMessage>,
     validators: Vec<ValidatorId>,
+    sync_broadcast_sender: Option<BroadcastSubscriberSender<Vote>>,
 }
 
 impl PapyrusConsensusContext {
@@ -54,13 +55,15 @@ impl PapyrusConsensusContext {
     #[allow(dead_code)]
     pub fn new(
         storage_reader: StorageReader,
-        broadcast_sender: BroadcastSubscriberSender<ConsensusMessage>,
+        network_broadcast_sender: BroadcastSubscriberSender<ConsensusMessage>,
         num_validators: u64,
+        sync_broadcast_sender: Option<BroadcastSubscriberSender<Vote>>,
     ) -> Self {
         Self {
             storage_reader,
-            broadcast_sender,
+            network_broadcast_sender,
             validators: (0..num_validators).map(ContractAddress::from).collect(),
+            sync_broadcast_sender,
         }
     }
 }
@@ -160,9 +163,13 @@ impl ConsensusContext for PapyrusConsensusContext {
                         panic!("Block in {height} was not found in storage despite waiting for it")
                     })
                     .block_hash;
+
+                // This can happen as a result of sync interrupting `run_height`.
                 fin_sender
                     .send(PapyrusConsensusBlock { content: transactions, id: block_hash })
-                    .expect("Send should succeed");
+                    .unwrap_or_else(|_| {
+                        warn!("Failed to send block to consensus. height={height}");
+                    })
             }
             .instrument(debug_span!("consensus_validate_proposal")),
         );
@@ -180,7 +187,7 @@ impl ConsensusContext for PapyrusConsensusContext {
 
     async fn broadcast(&mut self, message: ConsensusMessage) -> Result<(), ConsensusError> {
         debug!("Broadcasting message: {message:?}");
-        self.broadcast_sender.send(message).await?;
+        self.network_broadcast_sender.send(message).await?;
         Ok(())
     }
 
@@ -190,7 +197,7 @@ impl ConsensusContext for PapyrusConsensusContext {
         mut content_receiver: mpsc::Receiver<Transaction>,
         fin_receiver: oneshot::Receiver<BlockHash>,
     ) -> Result<(), ConsensusError> {
-        let mut broadcast_sender = self.broadcast_sender.clone();
+        let mut network_broadcast_sender = self.network_broadcast_sender.clone();
 
         tokio::spawn(
             async move {
@@ -219,7 +226,7 @@ impl ConsensusContext for PapyrusConsensusContext {
                     proposal.block_hash
                 );
 
-                broadcast_sender
+                network_broadcast_sender
                     .send(ConsensusMessage::Proposal(proposal))
                     .await
                     .expect("Failed to send proposal");
@@ -230,7 +237,7 @@ impl ConsensusContext for PapyrusConsensusContext {
     }
 
     async fn notify_decision(
-        &self,
+        &mut self,
         block: Self::Block,
         precommits: Vec<Vote>,
     ) -> Result<(), ConsensusError> {
@@ -239,6 +246,10 @@ impl ConsensusContext for PapyrusConsensusContext {
             "Finished consensus for height: {height}. Agreed on block with id: {:x}",
             block.id().0
         );
+        if let Some(sender) = &mut self.sync_broadcast_sender {
+            sender.send(precommits[0].clone()).await?;
+        }
+
         Ok(())
     }
 }

--- a/crates/sequencing/papyrus_consensus/src/test_utils.rs
+++ b/crates/sequencing/papyrus_consensus/src/test_utils.rs
@@ -59,7 +59,7 @@ mock! {
         ) -> Result<(), ConsensusError>;
 
         async fn notify_decision(
-            &self,
+            &mut self,
             block: TestBlock,
             precommits: Vec<Vote>,
         ) -> Result<(), ConsensusError>;

--- a/crates/sequencing/papyrus_consensus/src/types.rs
+++ b/crates/sequencing/papyrus_consensus/src/types.rs
@@ -141,7 +141,7 @@ pub trait ConsensusContext {
     /// - `precommits` - All precommits must be for the same `(block.id(), height, round)` and form
     ///   a quorum (>2/3 of the voting power) for this height.
     async fn notify_decision(
-        &self,
+        &mut self,
         block: Self::Block,
         precommits: Vec<Vote>,
     ) -> Result<(), ConsensusError>;


### PR DESCRIPTION
This is optional since outside of testing mode sync should be its own component of the node.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/413)
<!-- Reviewable:end -->
