### PR TITLE
chore: fix docstring of executable contract class structs

### DIFF
--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -43,13 +43,9 @@ use crate::transaction::errors::TransactionExecutionError;
 #[path = "contract_class_test.rs"]
 pub mod test;
 
-/// Represents a runnable Starknet contract class (meaning, the program is runnable by the VM).
-/// We wrap the actual class in an Arc to avoid cloning the program when cloning the class.
-// Note: when deserializing from a SN API class JSON string, the ABI field is ignored
-// by serde, since it is not required for execution.
-
 pub type ContractClassResult<T> = Result<T, ContractClassError>;
 
+/// Represents a runnable Starknet contract class (meaning, the program is runnable by the VM).
 #[derive(Clone, Debug, Eq, PartialEq, derive_more::From)]
 pub enum ContractClass {
     V0(ContractClassV0),
@@ -103,6 +99,12 @@ impl ContractClass {
 }
 
 // V0.
+
+/// Represents a runnable Cario 0 Starknet contract class (meaning, the program is runnable by the
+/// VM). We wrap the actual class in an Arc to avoid cloning the program when cloning the
+/// class.
+// Note: when deserializing from a SN API class JSON string, the ABI field is ignored
+// by serde, since it is not required for execution.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 pub struct ContractClassV0(pub Arc<ContractClassV0Inner>);
 impl Deref for ContractClassV0 {
@@ -170,6 +172,10 @@ impl TryFrom<DeprecatedContractClass> for ContractClassV0 {
 }
 
 // V1.
+
+/// Represents a runnable Cario (Cairo 1) Starknet contract class (meaning, the program is runnable
+/// by the VM). We wrap the actual class in an Arc to avoid cloning the program when cloning the
+/// class.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractClassV1(pub Arc<ContractClassV1Inner>);
 impl Deref for ContractClassV1 {


### PR DESCRIPTION
In a previous PR: https://reviewable.io/reviews/starkware-libs/blockifier/452, there was a mixup with the docstring of the structs.
This PR fixes this issue.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/491)
<!-- Reviewable:end -->
