### PR TITLE
refactor: use snapi class info in process declare tx

### DIFF
--- a/crates/gateway/src/compilation.rs
+++ b/crates/gateway/src/compilation.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use blockifier::execution::contract_class::{ClassInfo, ContractClass, ContractClassV1};
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass as CairoLangContractClass;
+use starknet_api::contract_class::ClassInfo;
 use starknet_api::core::CompiledClassHash;
 use starknet_api::rpc_transaction::RpcDeclareTransaction;
 use starknet_sierra_compile::cairo_lang_compiler::CairoLangSierraToCasmCompiler;
@@ -43,17 +43,10 @@ impl GatewayCompiler {
 
         validate_compiled_class_hash(&casm_contract_class, &tx.compiled_class_hash)?;
 
-        ClassInfo::new(
-            &ContractClass::V1(ContractClassV1::try_from(casm_contract_class).map_err(|e| {
-                error!("Failed to convert CasmContractClass to Blockifier ContractClass: {:?}", e);
-                GatewaySpecError::UnexpectedError { data: "Internal server error.".to_owned() }
-            })?),
-            rpc_contract_class.sierra_program.len(),
-            rpc_contract_class.abi.len(),
-        )
-        .map_err(|e| {
-            error!("Failed to convert Blockifier ContractClass to Blockifier ClassInfo: {:?}", e);
-            GatewaySpecError::UnexpectedError { data: "Internal server error.".to_owned() }
+        Ok(ClassInfo {
+            casm_contract_class,
+            sierra_program_length: rpc_contract_class.sierra_program.len(),
+            abi_length: rpc_contract_class.abi.len(),
         })
     }
 

--- a/crates/gateway/src/compilation_test.rs
+++ b/crates/gateway/src/compilation_test.rs
@@ -1,9 +1,11 @@
 use assert_matches::assert_matches;
-use blockifier::execution::contract_class::ContractClass;
 use cairo_lang_sierra_to_casm::compiler::CompilationError;
 use cairo_lang_starknet_classes::allowed_libfuncs::AllowedLibfuncsError;
 use cairo_lang_starknet_classes::casm_contract_class::StarknetSierraCompilationError;
-use mempool_test_utils::starknet_api_test_utils::declare_tx as rpc_declare_tx;
+use mempool_test_utils::starknet_api_test_utils::{
+    compiled_class_hash as test_contract_compiled_class_hash,
+    declare_tx as rpc_declare_tx,
+};
 use rstest::{fixture, rstest};
 use starknet_api::core::CompiledClassHash;
 use starknet_api::rpc_transaction::{
@@ -103,7 +105,9 @@ fn test_process_declare_tx_success(
     let declare_tx = RpcDeclareTransaction::V3(declare_tx_v3);
 
     let class_info = gateway_compiler.process_declare_tx(&declare_tx).unwrap();
-    assert_matches!(class_info.contract_class(), ContractClass::V1(_));
-    assert_eq!(class_info.sierra_program_length(), sierra_program_length);
-    assert_eq!(class_info.abi_length(), abi_length);
+    let compiled_class_hash =
+        CompiledClassHash(class_info.casm_contract_class.compiled_class_hash());
+    assert_eq!(compiled_class_hash, *test_contract_compiled_class_hash());
+    assert_eq!(class_info.sierra_program_length, sierra_program_length);
+    assert_eq!(class_info.abi_length, abi_length);
 }

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use axum::extract::State;
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use blockifier::execution::contract_class::ClassInfo;
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
@@ -131,9 +132,12 @@ fn process_tx(
 
     // Compile Sierra to Casm.
     let optional_class_info = match &tx {
-        RpcTransaction::Declare(declare_tx) => {
-            Some(gateway_compiler.process_declare_tx(declare_tx)?)
-        }
+        RpcTransaction::Declare(declare_tx) => Some(
+            ClassInfo::try_from(gateway_compiler.process_declare_tx(declare_tx)?).map_err(|e| {
+                error!("Failed to convert Starknet API ClassInfo to Blockifier ClassInfo: {:?}", e);
+                GatewaySpecError::UnexpectedError { data: "Internal server error.".to_owned() }
+            })?,
+        ),
         _ => None,
     };
 

--- a/crates/gateway/src/stateful_transaction_validator_test.rs
+++ b/crates/gateway/src/stateful_transaction_validator_test.rs
@@ -3,6 +3,7 @@ use blockifier::blockifier::stateful_validator::{
     StatefulValidatorResult as BlockifierStatefulValidatorResult,
 };
 use blockifier::context::BlockContext;
+use blockifier::execution::contract_class::ClassInfo;
 use blockifier::test_utils::CairoVersion;
 use blockifier::transaction::errors::{TransactionFeeError, TransactionPreValidationError};
 use mempool_test_utils::invoke_tx_args;
@@ -83,9 +84,12 @@ fn test_stateful_tx_validator(
 ) {
     let optional_class_info = match &external_tx {
         RpcTransaction::Declare(declare_tx) => Some(
-            GatewayCompiler::new_cairo_lang_compiler(SierraToCasmCompilationConfig::default())
-                .process_declare_tx(declare_tx)
-                .unwrap(),
+            ClassInfo::try_from(
+                GatewayCompiler::new_cairo_lang_compiler(SierraToCasmCompilationConfig::default())
+                    .process_declare_tx(declare_tx)
+                    .unwrap(),
+            )
+            .unwrap(),
         ),
         _ => None,
     };

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::fs::File;
 use std::path::Path;
 use std::rc::Rc;
+use std::sync::OnceLock;
 
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::{create_trivial_calldata, CairoVersion, NonceManager};
@@ -127,13 +128,15 @@ pub fn contract_class() -> ContractClass {
 }
 
 /// Get the compiled class hash corresponding to the contract class used for testing.
-pub fn compiled_class_hash() -> CompiledClassHash {
-    CompiledClassHash(felt!(COMPILED_CLASS_HASH_OF_CONTRACT_CLASS))
+pub fn compiled_class_hash() -> &'static CompiledClassHash {
+    static COMPILED_CLASS_HASH: OnceLock<CompiledClassHash> = OnceLock::new();
+    COMPILED_CLASS_HASH
+        .get_or_init(|| CompiledClassHash(felt!(COMPILED_CLASS_HASH_OF_CONTRACT_CLASS)))
 }
 
 pub fn declare_tx() -> RpcTransaction {
     let contract_class = contract_class();
-    let compiled_class_hash = compiled_class_hash();
+    let compiled_class_hash = *compiled_class_hash();
 
     let account_contract = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
     let account_address = account_contract.get_instance_address(0);


### PR DESCRIPTION
During the function process_tx in the gateway, the compilation (sierra to casm) occurs.
In this PR, we change the compilation's return type from `blockifier::execution::contract_class::ClassInfo` to `starknet_api::contract_class::ClassInfo`.

In the following PRs, `MempoolInput` will (indirectly) use `starknet_api::..::ClassInfo`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/516)
<!-- Reviewable:end -->
