### PR TITLE
refactor: share the chain info as a config for the gateway

### DIFF
--- a/config/mempool/default_config.json
+++ b/config/mempool/default_config.json
@@ -304,17 +304,17 @@
     "privacy": "Public",
     "value": 1
   },
-  "gateway_config.stateful_tx_validator_config.chain_info.chain_id": {
+  "gateway_config.chain_info.chain_id": {
     "description": "The chain ID of the StarkNet chain.",
     "privacy": "Public",
     "value": "0x0"
   },
-  "gateway_config.stateful_tx_validator_config.chain_info.fee_token_addresses.eth_fee_token_address": {
+  "gateway_config.chain_info.fee_token_addresses.eth_fee_token_address": {
     "description": "Address of the ETH fee token.",
     "privacy": "Public",
     "value": "0x0"
   },
-  "gateway_config.stateful_tx_validator_config.chain_info.fee_token_addresses.strk_fee_token_address": {
+  "gateway_config.chain_info.fee_token_addresses.strk_fee_token_address": {
     "description": "Address of the STRK fee token.",
     "privacy": "Public",
     "value": "0x0"

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
+use blockifier::context::ChainInfo;
 use blockifier::test_utils::CairoVersion;
 use mempool_test_utils::starknet_api_test_utils::{declare_tx, invoke_tx};
 use mockall::predicate::eq;
@@ -28,13 +29,14 @@ pub fn app_state(
             config: StatelessTransactionValidatorConfig::default(),
         },
         stateful_tx_validator: Arc::new(StatefulTransactionValidator {
-            config: StatefulTransactionValidatorConfig::create_for_testing(),
+            config: StatefulTransactionValidatorConfig::default(),
         }),
         gateway_compiler: GatewayCompiler::new_command_line_compiler(
             SierraToCasmCompilationConfig::default(),
         ),
         state_reader_factory: Arc::new(state_reader_factory),
         mempool_client,
+        chain_info: ChainInfo::create_for_testing(),
     }
 }
 

--- a/crates/gateway/src/stateful_transaction_validator.rs
+++ b/crates/gateway/src/stateful_transaction_validator.rs
@@ -4,7 +4,7 @@ use blockifier::blockifier::stateful_validator::{
     StatefulValidatorResult as BlockifierStatefulValidatorResult,
 };
 use blockifier::bouncer::BouncerConfig;
-use blockifier::context::BlockContext;
+use blockifier::context::{BlockContext, ChainInfo};
 use blockifier::state::cached_state::CachedState;
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::versioned_constants::VersionedConstants;
@@ -88,6 +88,7 @@ impl StatefulTransactionValidator {
     pub fn instantiate_validator(
         &self,
         state_reader_factory: &dyn StateReaderFactory,
+        chain_info: &ChainInfo,
     ) -> StatefulTransactionValidatorResult<BlockifierStatefulValidator> {
         // TODO(yael 6/5/2024): consider storing the block_info as part of the
         // StatefulTransactionValidator and update it only once a new block is created.
@@ -104,7 +105,7 @@ impl StatefulTransactionValidator {
         // able to read the block_hash of 10 blocks ago from papyrus.
         let block_context = BlockContext::new(
             block_info,
-            self.config.chain_info.clone(),
+            chain_info.clone(),
             versioned_constants,
             BouncerConfig::max(),
         );

--- a/crates/gateway/src/stateful_transaction_validator_test.rs
+++ b/crates/gateway/src/stateful_transaction_validator_test.rs
@@ -2,7 +2,7 @@ use blockifier::blockifier::stateful_validator::{
     StatefulValidatorError as BlockifierStatefulValidatorError,
     StatefulValidatorResult as BlockifierStatefulValidatorResult,
 };
-use blockifier::context::BlockContext;
+use blockifier::context::ChainInfo;
 use blockifier::test_utils::CairoVersion;
 use blockifier::transaction::errors::{TransactionFeeError, TransactionPreValidationError};
 use mempool_test_utils::starknet_api_test_utils::{
@@ -44,20 +44,8 @@ pub const STATEFUL_VALIDATOR_FEE_ERROR: BlockifierStatefulValidatorError =
     );
 
 #[fixture]
-fn block_context() -> BlockContext {
-    BlockContext::create_for_testing()
-}
-
-#[fixture]
-fn stateful_validator(block_context: BlockContext) -> StatefulTransactionValidator {
-    StatefulTransactionValidator {
-        config: StatefulTransactionValidatorConfig {
-            max_nonce_for_validation_skip: Default::default(),
-            validate_max_n_steps: block_context.versioned_constants().validate_max_n_steps,
-            max_recursion_depth: block_context.versioned_constants().max_recursion_depth,
-            chain_info: block_context.chain_info().clone(),
-        },
-    }
+fn stateful_validator() -> StatefulTransactionValidator {
+    StatefulTransactionValidator { config: StatefulTransactionValidatorConfig::default() }
 }
 
 // TODO(Arni): consider testing declare and deploy account.
@@ -90,8 +78,8 @@ fn test_stateful_tx_validator(
     assert_eq!(result, expected_result_as_stateful_transaction_result);
 }
 
-#[test]
-fn test_instantiate_validator() {
+#[rstest]
+fn test_instantiate_validator(stateful_validator: StatefulTransactionValidator) {
     let state_reader_factory = local_test_state_reader_factory(CairoVersion::Cairo1, false);
 
     let mut mock_state_reader_factory = MockStateReaderFactory::new();
@@ -111,16 +99,8 @@ fn test_instantiate_validator() {
         .with(eq(latest_block))
         .return_once(move |_| state_reader);
 
-    let block_context = &BlockContext::create_for_testing();
-    let stateful_validator = StatefulTransactionValidator {
-        config: StatefulTransactionValidatorConfig {
-            max_nonce_for_validation_skip: Default::default(),
-            validate_max_n_steps: block_context.versioned_constants().validate_max_n_steps,
-            max_recursion_depth: block_context.versioned_constants().max_recursion_depth,
-            chain_info: block_context.chain_info().clone(),
-        },
-    };
-    let blockifier_validator = stateful_validator.instantiate_validator(&mock_state_reader_factory);
+    let blockifier_validator = stateful_validator
+        .instantiate_validator(&mock_state_reader_factory, &ChainInfo::create_for_testing());
     assert!(blockifier_validator.is_ok());
 }
 

--- a/crates/tests-integration/src/integration_test_utils.rs
+++ b/crates/tests-integration/src/integration_test_utils.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use axum::body::Body;
+use blockifier::context::ChainInfo;
 use mempool_test_utils::starknet_api_test_utils::rpc_tx_to_json;
 use papyrus_storage::StorageConfig;
 use reqwest::{Client, Response};
@@ -25,10 +26,10 @@ async fn create_gateway_config() -> GatewayConfig {
         max_signature_length: 2,
         ..Default::default()
     };
+    let stateful_tx_validator_config = StatefulTransactionValidatorConfig::default();
+    let chain_info = ChainInfo::create_for_testing();
 
-    let stateful_tx_validator_config = StatefulTransactionValidatorConfig::create_for_testing();
-
-    GatewayConfig { stateless_tx_validator_config, stateful_tx_validator_config }
+    GatewayConfig { stateless_tx_validator_config, stateful_tx_validator_config, chain_info }
 }
 
 async fn create_http_server_config() -> HttpServerConfig {


### PR DESCRIPTION
The `ChainInfo` is a part of the config that is relevant not only to the stateful validator but also to the conversion `RpcTransaction` -> `ExecutableTransaction`. In this PR we move this config to be a part of the `GatewayConfig`. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/520)
<!-- Reviewable:end -->
