### PR TITLE
refactor: remove most fields from statful validator output

### DIFF
--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -130,12 +130,13 @@ fn process_tx(
     // TODO(Yael 31/7/24): refactor after IntrnalTransaction is ready, delete validate_info and
     // compute all the info outside of run_validate.
     let validate_info = stateful_tx_validator.run_validate(&executable_tx, validator)?;
+    let sender_address = executable_tx.contract_address();
 
     // TODO(Arni): Add the Sierra and the Casm to the mempool input.
     Ok(MempoolInput {
         tx: executable_tx,
         account: Account {
-            sender_address: validate_info.sender_address,
+            sender_address,
             state: AccountState { nonce: validate_info.account_nonce },
         },
     })

--- a/crates/gateway/src/stateful_transaction_validator_test.rs
+++ b/crates/gateway/src/stateful_transaction_validator_test.rs
@@ -15,12 +15,12 @@ use mockall::predicate::eq;
 use num_bigint::BigUint;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
-use starknet_api::core::{ContractAddress, Nonce, PatriciaKey};
+use starknet_api::core::Nonce;
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::test_utils::deploy_account::executable_deploy_account_tx;
 use starknet_api::test_utils::invoke::executable_invoke_tx;
-use starknet_api::transaction::{Resource, TransactionHash};
-use starknet_api::{contract_address, deploy_account_tx_args, felt, invoke_tx_args, patricia_key};
+use starknet_api::transaction::Resource;
+use starknet_api::{deploy_account_tx_args, invoke_tx_args};
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_types_core::felt::Felt;
 
@@ -66,11 +66,7 @@ fn stateful_validator(block_context: BlockContext) -> StatefulTransactionValidat
 #[rstest]
 #[case::valid_tx(
     create_executable_invoke_tx(CairoVersion::Cairo1),
-    Ok(ValidateInfo{
-        tx_hash: TransactionHash::default(),
-        sender_address: contract_address!("0xc0020000"),
-        account_nonce: Nonce::default()
-    })
+    Ok(ValidateInfo{account_nonce: Nonce::default()})
 )]
 #[case::invalid_tx(
     create_executable_invoke_tx(CairoVersion::Cairo1),

--- a/crates/starknet_api/src/executable_transaction.rs
+++ b/crates/starknet_api/src/executable_transaction.rs
@@ -58,6 +58,10 @@ impl Transaction {
         }
     }
 
+    pub fn sender_address(&self) -> ContractAddress {
+        self.contract_address()
+    }
+
     pub fn nonce(&self) -> Nonce {
         match self {
             Transaction::Declare(tx_data) => tx_data.tx.nonce(),


### PR DESCRIPTION
The struct `ValidateInfo` holds all the information relevant to the rest of the transaction's lifecycle from the run of the validate. Most of its members are no longer needed as they can be obtained from the `ExecutableTransaction`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/521)
<!-- Reviewable:end -->
