### PR TITLE
chore: align the inputs of create_gateway to get only configs

### DIFF
--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -12,6 +12,7 @@ use starknet_api::transaction::TransactionHash;
 use starknet_mempool_infra::component_runner::{ComponentStartError, ComponentStarter};
 use starknet_mempool_types::communication::SharedMempoolClient;
 use starknet_mempool_types::mempool_types::{Account, AccountState, MempoolInput};
+use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use tracing::{error, info, instrument};
 
 use crate::compilation::GatewayCompiler;
@@ -154,10 +155,11 @@ fn process_tx(
 pub fn create_gateway(
     config: GatewayConfig,
     rpc_state_reader_config: RpcStateReaderConfig,
-    gateway_compiler: GatewayCompiler,
+    compiler_config: SierraToCasmCompilationConfig,
     mempool_client: SharedMempoolClient,
 ) -> Gateway {
     let state_reader_factory = Arc::new(RpcStateReaderFactory { config: rpc_state_reader_config });
+    let gateway_compiler = GatewayCompiler::new_cairo_lang_compiler(compiler_config);
 
     Gateway::new(config, state_reader_factory, gateway_compiler, mempool_client)
 }

--- a/crates/mempool_node/src/components.rs
+++ b/crates/mempool_node/src/components.rs
@@ -1,6 +1,5 @@
 use starknet_batcher::batcher::{create_batcher, Batcher};
 use starknet_consensus_manager::consensus_manager::ConsensusManager;
-use starknet_gateway::compilation::GatewayCompiler;
 use starknet_gateway::gateway::{create_gateway, Gateway};
 use starknet_mempool::mempool::Mempool;
 
@@ -34,12 +33,11 @@ pub fn create_components(config: &MempoolNodeConfig, clients: &MempoolNodeClient
     let gateway = if config.components.gateway.execute {
         let mempool_client =
             clients.get_mempool_client().expect("Mempool Client should be available");
-        let gateway_compiler = GatewayCompiler::new_cairo_lang_compiler(config.compiler_config);
 
         Some(create_gateway(
             config.gateway_config.clone(),
             config.rpc_state_reader_config.clone(),
-            gateway_compiler,
+            config.compiler_config.clone(),
             mempool_client,
         ))
     } else {

--- a/crates/starknet_sierra_compile/src/config.rs
+++ b/crates/starknet_sierra_compile/src/config.rs
@@ -5,7 +5,7 @@ use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Validate, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
 pub struct SierraToCasmCompilationConfig {
     pub max_bytecode_size: usize,
 }


### PR DESCRIPTION
Per @lev-starkware's suggestion.
We align the inputs of `create_gateway` so that it only gets configs.
This does not collide with our needs for creating the gateway with dependency injection as we can always use the gateway's `new` constructor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/545)
<!-- Reviewable:end -->
