### PR TITLE
chore(blockifier): add `Deserialization` for `ContractClass`

### DIFF
--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -46,7 +46,7 @@ pub mod test;
 pub type ContractClassResult<T> = Result<T, ContractClassError>;
 
 /// Represents a runnable Starknet contract class (meaning, the program is runnable by the VM).
-#[derive(Clone, Debug, Eq, PartialEq, derive_more::From)]
+#[derive(Clone, Debug, Eq, PartialEq, derive_more::From, Deserialize)]
 pub enum ContractClass {
     V0(ContractClassV0),
     V1(ContractClassV1),
@@ -173,7 +173,8 @@ impl TryFrom<DeprecatedContractClass> for ContractClassV0 {
 /// Represents a runnable Cario (Cairo 1) Starknet contract class (meaning, the program is runnable
 /// by the VM). We wrap the actual class in an Arc to avoid cloning the program when cloning the
 /// class.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+#[serde(try_from = "CasmContractClass")]
 pub struct ContractClassV1(pub Arc<ContractClassV1Inner>);
 impl Deref for ContractClassV1 {
     type Target = ContractClassV1Inner;

--- a/crates/blockifier/src/execution/contract_class_test.rs
+++ b/crates/blockifier/src/execution/contract_class_test.rs
@@ -1,11 +1,12 @@
 use std::collections::HashSet;
+use std::fs;
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use cairo_lang_starknet_classes::NestedIntList;
 use rstest::rstest;
 
-use crate::execution::contract_class::{ContractClassV1, ContractClassV1Inner};
+use crate::execution::contract_class::{ContractClassV0, ContractClassV1, ContractClassV1Inner};
 use crate::transaction::errors::TransactionExecutionError;
 
 #[rstest]
@@ -41,4 +42,33 @@ fn test_get_visited_segments() {
             .unwrap_err(),
         TransactionExecutionError::InvalidSegmentStructure(907, 807)
     );
+}
+
+#[test]
+fn test_deserialization_of_contract_class_v0() {
+    let contract_class: ContractClassV0 = serde_json::from_slice(
+        &fs::read(
+            "ERC20/ERC20_Cairo0/ERC20_without_some_syscalls/ERC20/\
+             erc20_contract_without_some_syscalls_compiled.json",
+        )
+        .unwrap(),
+    )
+    .expect("failed to deserialize contract class from file");
+
+    assert_eq!(
+        contract_class,
+        ContractClassV0::from_file(
+            "ERC20/ERC20_Cairo0/ERC20_without_some_syscalls/ERC20/\
+             erc20_contract_without_some_syscalls_compiled.json",
+        )
+    );
+}
+
+#[test]
+fn test_deserialization_of_contract_class_v1() {
+    let contract_class: ContractClassV1 =
+        serde_json::from_slice(&fs::read("ERC20/ERC20_Cairo1/erc20.casm.json").unwrap())
+            .expect("failed to deserialize contract class from file");
+
+    assert_eq!(contract_class, ContractClassV1::from_file("ERC20/ERC20_Cairo1/erc20.casm.json"));
 }


### PR DESCRIPTION
## Description
This pull request adds deserialization support for the `ContractClass` struct. The changes include implementing the `Deserialize` trait for `ContractClassV1` and updating the unit tests to verify the correct deserialization of both `ContractClassV0` and `ContractClassV1`.

## Implementation of Deserialize for ContractClassV1:

- The `Deserialize` trait has been implemented for `ContractClassV1` to support deserialization from JSON.
- The deserialization process involves converting the input into a JSON value, then into a JSON string, and finally using the `try_from_json_string` method to deserialize into a `ContractClassV1` object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/702)
<!-- Reviewable:end -->
