### PR TITLE
test: move nonce storage_key and compiled_class_hash macros to starknet api test utils

### DIFF
--- a/crates/blockifier/src/blockifier/transaction_executor_test.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor_test.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::{Fee, TransactionVersion};
-use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args};
+use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args, nonce};
 use starknet_types_core::felt::Felt;
 
 use crate::blockifier::config::TransactionExecutorConfig;
@@ -14,7 +14,6 @@ use crate::blockifier::transaction_executor::{
 };
 use crate::bouncer::{Bouncer, BouncerWeights};
 use crate::context::BlockContext;
-use crate::nonce;
 use crate::state::cached_state::CachedState;
 use crate::state::state_api::StateReader;
 use crate::test_utils::contracts::FeatureContract;

--- a/crates/blockifier/src/bouncer_test.rs
+++ b/crates/blockifier/src/bouncer_test.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use cairo_vm::types::builtin_name::BuiltinName;
 use rstest::rstest;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
-use starknet_api::{class_hash, contract_address, felt, patricia_key};
+use starknet_api::{class_hash, contract_address, felt, patricia_key, storage_key};
 
 use super::BouncerConfig;
 use crate::blockifier::transaction_executor::{
@@ -14,7 +14,6 @@ use crate::bouncer::{verify_tx_weights_in_bounds, Bouncer, BouncerWeights, Built
 use crate::context::BlockContext;
 use crate::execution::call_info::ExecutionSummary;
 use crate::state::cached_state::{StateChangesKeys, TransactionalState};
-use crate::storage_key;
 use crate::test_utils::initial_test_state::test_state;
 use crate::transaction::errors::TransactionExecutionError;
 

--- a/crates/blockifier/src/concurrency/flow_test.rs
+++ b/crates/blockifier/src/concurrency/flow_test.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use rstest::rstest;
 use starknet_api::core::{ContractAddress, PatriciaKey};
-use starknet_api::{contract_address, felt, patricia_key};
+use starknet_api::{contract_address, felt, patricia_key, storage_key};
 
 use crate::abi::sierra_types::{SierraType, SierraU128};
 use crate::concurrency::scheduler::{Scheduler, Task, TransactionStatus};
@@ -12,7 +12,6 @@ use crate::concurrency::test_utils::{safe_versioned_state_for_testing, DEFAULT_C
 use crate::concurrency::versioned_state::ThreadSafeVersionedState;
 use crate::state::cached_state::{CachedState, ContractClassMapping, StateMaps};
 use crate::state::state_api::UpdatableState;
-use crate::storage_key;
 use crate::test_utils::dict_state_reader::DictStateReader;
 
 const CONTRACT_ADDRESS: &str = "0x18031991";

--- a/crates/blockifier/src/concurrency/versioned_state_test.rs
+++ b/crates/blockifier/src/concurrency/versioned_state_test.rs
@@ -16,10 +16,13 @@ use starknet_api::transaction::{Calldata, ContractAddressSalt, ValidResourceBoun
 use starknet_api::{
     calldata,
     class_hash,
+    compiled_class_hash,
     contract_address,
     deploy_account_tx_args,
     felt,
+    nonce,
     patricia_key,
+    storage_key,
 };
 
 use crate::abi::abi_utils::{get_fee_token_var_address, get_storage_var_address};
@@ -52,7 +55,6 @@ use crate::transaction::account_transaction::AccountTransaction;
 use crate::transaction::objects::{HasRelatedFeeType, TransactionInfoCreator};
 use crate::transaction::test_utils::{l1_resource_bounds, max_resource_bounds};
 use crate::transaction::transactions::ExecutableTransaction;
-use crate::{compiled_class_hash, nonce, storage_key};
 
 #[fixture]
 pub fn safe_versioned_state(

--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -10,7 +10,15 @@ use starknet_api::transaction::{
     TransactionVersion,
     ValidResourceBounds,
 };
-use starknet_api::{contract_address, declare_tx_args, felt, invoke_tx_args, patricia_key};
+use starknet_api::{
+    contract_address,
+    declare_tx_args,
+    felt,
+    invoke_tx_args,
+    nonce,
+    patricia_key,
+    storage_key,
+};
 use starknet_types_core::felt::Felt;
 
 use super::WorkerExecutor;
@@ -47,7 +55,6 @@ use crate::transaction::test_utils::{
     max_resource_bounds,
 };
 use crate::transaction::transaction_execution::Transaction;
-use crate::{nonce, storage_key};
 
 fn trivial_calldata_invoke_tx(
     account_address: ContractAddress,

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -17,7 +17,7 @@ use starknet_api::transaction::{
     TransactionHash,
     TransactionVersion,
 };
-use starknet_api::{calldata, felt};
+use starknet_api::{calldata, felt, nonce, storage_key};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
@@ -50,7 +50,7 @@ use crate::transaction::objects::{
     TransactionInfo,
 };
 use crate::versioned_constants::VersionedConstants;
-use crate::{check_entry_point_execution_error_for_custom_hint, nonce, retdata, storage_key};
+use crate::{check_entry_point_execution_error_for_custom_hint, retdata};
 
 #[test]
 fn test_storage_read_write() {

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -5,19 +5,19 @@ use num_bigint::BigInt;
 use pretty_assertions::assert_eq;
 use starknet_api::core::{EntryPointSelector, PatriciaKey};
 use starknet_api::transaction::Calldata;
-use starknet_api::{calldata, felt};
+use starknet_api::{calldata, felt, storage_key};
 
 use crate::abi::abi_utils::{get_storage_var_address, selector_from_name};
 use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::entry_point::CallEntryPoint;
+use crate::retdata;
 use crate::state::cached_state::CachedState;
 use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::dict_state_reader::DictStateReader;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::{trivial_external_entry_point_new, CairoVersion, BALANCE};
 use crate::versioned_constants::VersionedConstants;
-use crate::{retdata, storage_key};
 
 #[test]
 fn test_call_info_iteration() {

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -2,7 +2,6 @@ use cairo_vm::Felt252;
 use num_traits::Pow;
 use starknet_api::core::ChainId;
 use starknet_api::data_availability::DataAvailabilityMode;
-use starknet_api::felt;
 use starknet_api::transaction::{
     AccountDeploymentData,
     Calldata,
@@ -14,6 +13,7 @@ use starknet_api::transaction::{
     TransactionVersion,
     ValidResourceBounds,
 };
+use starknet_api::{felt, nonce};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
@@ -22,7 +22,6 @@ use crate::context::ChainInfo;
 use crate::execution::common_hints::ExecutionMode;
 use crate::execution::entry_point::CallEntryPoint;
 use crate::execution::syscalls::hint_processor::{L1_DATA, L1_GAS, L2_GAS};
-use crate::nonce;
 use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::{

--- a/crates/blockifier/src/fee/actual_cost_test.rs
+++ b/crates/blockifier/src/fee/actual_cost_test.rs
@@ -1,6 +1,6 @@
 use rstest::{fixture, rstest};
-use starknet_api::invoke_tx_args;
 use starknet_api::transaction::{L2ToL1Payload, ValidResourceBounds};
+use starknet_api::{invoke_tx_args, nonce};
 use starknet_types_core::felt::Felt;
 
 use crate::context::BlockContext;
@@ -11,7 +11,6 @@ use crate::fee::gas_usage::{
     get_log_message_to_l1_emissions_cost,
     get_message_segment_length,
 };
-use crate::nonce;
 use crate::state::cached_state::StateChangesCount;
 use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::initial_test_state::test_state;

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -5,7 +5,15 @@ use indexmap::indexmap;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::core::PatriciaKey;
-use starknet_api::{class_hash, contract_address, felt, patricia_key};
+use starknet_api::{
+    class_hash,
+    compiled_class_hash,
+    contract_address,
+    felt,
+    nonce,
+    patricia_key,
+    storage_key,
+};
 
 use crate::context::{BlockContext, ChainInfo};
 use crate::state::cached_state::*;
@@ -13,7 +21,6 @@ use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::dict_state_reader::DictStateReader;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::CairoVersion;
-use crate::{compiled_class_hash, nonce, storage_key};
 const CONTRACT_ADDRESS: &str = "0x100";
 
 fn set_initial_state_values(

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -114,35 +114,6 @@ pub const CURRENT_BLOCK_NUMBER_FOR_VALIDATE: u64 = 2000;
 pub const CURRENT_BLOCK_TIMESTAMP: u64 = 1072023;
 pub const CURRENT_BLOCK_TIMESTAMP_FOR_VALIDATE: u64 = 1069200;
 
-// TODO(Yoni, 1/1/2025): move to SN API.
-/// A utility macro to create a [`Nonce`](starknet_api::core::Nonce) from a hex string / unsigned
-/// integer representation.
-#[macro_export]
-macro_rules! nonce {
-    ($s:expr) => {
-        starknet_api::core::Nonce(starknet_types_core::felt::Felt::from($s))
-    };
-}
-
-// TODO(Yoni, 1/1/2025): move to SN API.
-/// A utility macro to create a [`StorageKey`] from a hex string / unsigned integer representation.
-#[macro_export]
-macro_rules! storage_key {
-    ($s:expr) => {
-        starknet_api::state::StorageKey(starknet_api::patricia_key!($s))
-    };
-}
-
-// TODO(Yoni, 1/1/2025): move to SN API.
-/// A utility macro to create a [`starknet_api::core::CompiledClassHash`] from a hex string /
-/// unsigned integer representation.
-#[macro_export]
-macro_rules! compiled_class_hash {
-    ($s:expr) => {
-        starknet_api::core::CompiledClassHash(starknet_types_core::felt::Felt::from($s))
-    };
-}
-
 #[derive(Default)]
 pub struct SaltManager {
     next_salt: u8,

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -28,7 +28,9 @@ use starknet_api::{
     deploy_account_tx_args,
     felt,
     invoke_tx_args,
+    nonce,
     patricia_key,
+    storage_key,
 };
 use starknet_types_core::felt::Felt;
 
@@ -37,6 +39,7 @@ use crate::abi::abi_utils::{
     get_storage_var_address,
     selector_from_name,
 };
+use crate::check_transaction_execution_error_for_invalid_scenario;
 use crate::context::BlockContext;
 use crate::execution::contract_class::{ContractClass, ContractClassV1};
 use crate::execution::entry_point::EntryPointExecutionContext;
@@ -86,7 +89,6 @@ use crate::transaction::test_utils::{
 };
 use crate::transaction::transaction_types::TransactionType;
 use crate::transaction::transactions::{DeclareTransaction, ExecutableTransaction, ExecutionFlags};
-use crate::{check_transaction_execution_error_for_invalid_scenario, nonce, storage_key};
 
 #[rstest]
 fn test_circuit(block_context: BlockContext, max_resource_bounds: ValidResourceBounds) {

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -11,13 +11,12 @@ use starknet_api::transaction::{
     TransactionVersion,
     ValidResourceBounds,
 };
-use starknet_api::{felt, invoke_tx_args};
+use starknet_api::{felt, invoke_tx_args, nonce};
 use starknet_types_core::felt::Felt;
 
 use crate::context::{BlockContext, ChainInfo};
 use crate::execution::syscalls::SyscallSelector;
 use crate::fee::fee_utils::get_fee_by_gas_vector;
-use crate::nonce;
 use crate::state::cached_state::CachedState;
 use crate::state::state_api::StateReader;
 use crate::test_utils::contracts::FeatureContract;

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -32,6 +32,7 @@ use starknet_api::{
     deploy_account_tx_args,
     felt,
     invoke_tx_args,
+    nonce,
     patricia_key,
 };
 use starknet_types_core::felt::Felt;
@@ -133,7 +134,6 @@ use crate::versioned_constants::VersionedConstants;
 use crate::{
     check_transaction_execution_error_for_custom_hint,
     check_transaction_execution_error_for_invalid_scenario,
-    nonce,
     retdata,
 };
 

--- a/crates/starknet_api/src/test_utils.rs
+++ b/crates/starknet_api/src/test_utils.rs
@@ -28,3 +28,30 @@ impl NonceManager {
         }
     }
 }
+
+/// A utility macro to create a [`Nonce`] from a hex string / unsigned integer
+/// representation.
+#[macro_export]
+macro_rules! nonce {
+    ($s:expr) => {
+        $crate::core::Nonce(starknet_types_core::felt::Felt::from($s))
+    };
+}
+
+/// A utility macro to create a [`StorageKey`](crate::state::StorageKey) from a hex string /
+/// unsigned integer representation.
+#[macro_export]
+macro_rules! storage_key {
+    ($s:expr) => {
+        $crate::state::StorageKey(starknet_api::patricia_key!($s))
+    };
+}
+
+/// A utility macro to create a [`CompiledClassHash`](crate::core::CompiledClassHash) from a hex
+/// string / unsigned integer representation.
+#[macro_export]
+macro_rules! compiled_class_hash {
+    ($s:expr) => {
+        $crate::core::CompiledClassHash(starknet_types_core::felt::Felt::from($s))
+    };
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/760)
<!-- Reviewable:end -->
