### PR TITLE
test(blockifier): estimate_minimal_gas_vector depends on GasVectorComputationMode

### DIFF
--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -485,6 +485,7 @@ pub struct TransactionResources {
     pub n_reverted_steps: usize,
 }
 
+#[derive(Debug, PartialEq)]
 pub enum GasVectorComputationMode {
     All,
     NoL2Gas,

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -825,6 +825,39 @@ fn assert_failure_if_resource_bounds_exceed_balance(
 }
 
 #[rstest]
+fn test_estimate_minimal_gas_vector(
+    mut block_context: BlockContext,
+    #[values(true, false)] use_kzg_da: bool,
+    #[values(GasVectorComputationMode::NoL2Gas, GasVectorComputationMode::All)]
+    gas_vector_computation_mode: GasVectorComputationMode,
+    #[values(CairoVersion::Cairo0, CairoVersion::Cairo1)] account_cairo_version: CairoVersion,
+) {
+    block_context.block_info.use_kzg_da = use_kzg_da;
+    let block_context = &block_context;
+    let account_contract = FeatureContract::AccountWithoutValidations(account_cairo_version);
+    let test_contract = FeatureContract::TestContract(CairoVersion::Cairo0);
+
+    let valid_invoke_tx_args = invoke_tx_args! {
+        sender_address: account_contract.get_instance_address(0),
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        max_fee: Fee(MAX_FEE)
+    };
+
+    // The minimal gas estimate does not depend on tx version.
+    let tx = &account_invoke_tx(valid_invoke_tx_args);
+    let minimal_gas_vector =
+        estimate_minimal_gas_vector(block_context, tx, &gas_vector_computation_mode).unwrap();
+    let minimal_l1_gas = minimal_gas_vector.l1_gas;
+    let minimal_l2_gas = minimal_gas_vector.l2_gas;
+    let minimal_l1_data_gas = minimal_gas_vector.l1_data_gas;
+    if gas_vector_computation_mode == GasVectorComputationMode::NoL2Gas || !use_kzg_da {
+        assert!(minimal_l1_gas > 0);
+    }
+    assert_eq!(minimal_l2_gas > 0, gas_vector_computation_mode == GasVectorComputationMode::All);
+    assert_eq!(minimal_l1_data_gas > 0, use_kzg_da);
+}
+
+#[rstest]
 fn test_max_fee_exceeds_balance(
     block_context: BlockContext,
     max_resource_bounds: ValidResourceBounds,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/776)
<!-- Reviewable:end -->
