### PR TITLE
chore(mempool): use transaction queue content in mempool content

### DIFF
--- a/crates/mempool/src/transaction_queue.rs
+++ b/crates/mempool/src/transaction_queue.rs
@@ -12,6 +12,10 @@ use starknet_api::transaction::{
 
 use crate::mempool::TransactionReference;
 
+#[cfg(test)]
+#[path = "transaction_queue_test_utils.rs"]
+pub mod transaction_queue_test_utils;
+
 // A queue holding the transaction that with nonces that match account nonces.
 // Note: the derived comparison functionality considers the order guaranteed by the data structures
 // used.

--- a/crates/mempool/src/transaction_queue_test_utils.rs
+++ b/crates/mempool/src/transaction_queue_test_utils.rs
@@ -18,7 +18,7 @@ pub struct TransactionQueueContent {
 }
 
 impl TransactionQueueContent {
-    pub fn _with_priority_and_pending<Q, P>(priority_txs: Q, pending_txs: P) -> Self
+    pub fn with_priority_and_pending<Q, P>(priority_txs: Q, pending_txs: P) -> Self
     where
         Q: IntoIterator<Item = TransactionReference>,
         P: IntoIterator<Item = TransactionReference>,
@@ -39,7 +39,7 @@ impl TransactionQueueContent {
         Self { priority_queue, pending_queue, address_to_tx }
     }
 
-    pub fn _assert_eq_priority_and_pending_content(&self, tx_queue: &TransactionQueue) {
+    pub fn assert_eq_priority_and_pending_content(&self, tx_queue: &TransactionQueue) {
         assert_eq!(self.priority_queue, tx_queue.priority_queue);
         assert_eq!(self.pending_queue, tx_queue.pending_queue);
         assert_eq!(self.address_to_tx, tx_queue.address_to_tx);

--- a/crates/mempool/src/transaction_queue_test_utils.rs
+++ b/crates/mempool/src/transaction_queue_test_utils.rs
@@ -1,0 +1,62 @@
+use std::collections::{BTreeSet, HashMap};
+
+use pretty_assertions::assert_eq;
+use starknet_api::core::ContractAddress;
+
+use crate::mempool::TransactionReference;
+use crate::transaction_queue::{PendingTransaction, PriorityTransaction, TransactionQueue};
+
+// Utils.
+
+/// Represents the internal content of the transaction queue.
+/// Enables customized (and potentially inconsistent) creation for unit testing.
+#[derive(Debug, Default)]
+pub struct TransactionQueueContent {
+    priority_queue: BTreeSet<PriorityTransaction>,
+    pending_queue: BTreeSet<PendingTransaction>,
+    address_to_tx: HashMap<ContractAddress, TransactionReference>,
+}
+
+impl TransactionQueueContent {
+    pub fn _with_priority_and_pending<Q, P>(priority_txs: Q, pending_txs: P) -> Self
+    where
+        Q: IntoIterator<Item = TransactionReference>,
+        P: IntoIterator<Item = TransactionReference>,
+    {
+        let priority_queue: BTreeSet<PriorityTransaction> =
+            priority_txs.into_iter().map(Into::into).collect();
+
+        let pending_queue: BTreeSet<PendingTransaction> =
+            pending_txs.into_iter().map(Into::into).collect();
+
+        let address_to_tx: HashMap<ContractAddress, TransactionReference> = priority_queue
+            .iter()
+            .map(|tx| &tx.0)
+            .chain(pending_queue.iter().map(|tx| &tx.0))
+            .map(|tx| (tx.sender_address, tx.clone()))
+            .collect();
+
+        Self { priority_queue, pending_queue, address_to_tx }
+    }
+
+    pub fn _assert_eq_priority_and_pending_content(&self, tx_queue: &TransactionQueue) {
+        assert_eq!(self.priority_queue, tx_queue.priority_queue);
+        assert_eq!(self.pending_queue, tx_queue.pending_queue);
+        assert_eq!(self.address_to_tx, tx_queue.address_to_tx);
+    }
+}
+
+impl From<TransactionQueueContent> for TransactionQueue {
+    fn from(tx_queue_content: TransactionQueueContent) -> TransactionQueue {
+        let TransactionQueueContent { priority_queue, pending_queue, address_to_tx } =
+            tx_queue_content;
+        TransactionQueue { priority_queue, pending_queue, address_to_tx, ..Default::default() }
+    }
+}
+
+impl From<TransactionQueue> for TransactionQueueContent {
+    fn from(tx_queue: TransactionQueue) -> TransactionQueueContent {
+        let TransactionQueue { priority_queue, pending_queue, address_to_tx, .. } = tx_queue;
+        TransactionQueueContent { priority_queue, pending_queue, address_to_tx }
+    }
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/785)
<!-- Reviewable:end -->
