### PR TITLE
fix(blockifier): remove the gas word following the resource name in errors

### DIFF
--- a/crates/blockifier/src/transaction/errors.rs
+++ b/crates/blockifier/src/transaction/errors.rs
@@ -24,7 +24,7 @@ pub enum TransactionFeeError {
     #[error("Actual fee ({}) exceeded paid fee on L1 ({}).", actual_fee.0, paid_fee.0)]
     InsufficientFee { paid_fee: Fee, actual_fee: Fee },
     #[error(
-        "Resource {resource} Gas bounds (max amount: {max_amount}, max price: {max_price}) exceed \
+        "Resource {resource} bounds (max amount: {max_amount}, max price: {max_price}) exceed \
          balance ({balance})."
     )]
     GasBoundsExceedBalance {
@@ -38,12 +38,12 @@ pub enum TransactionFeeError {
     #[error("Max fee ({}) is too low. Minimum fee: {}.", max_fee.0, min_fee.0)]
     MaxFeeTooLow { min_fee: Fee, max_fee: Fee },
     #[error(
-        "Resource {resource} max gas price ({max_gas_price}) is lower than the actual gas price: \
+        "Max {resource} price ({max_gas_price}) is lower than the actual gas price: \
          {actual_gas_price}."
     )]
     MaxGasPriceTooLow { resource: Resource, max_gas_price: u128, actual_gas_price: u128 },
     #[error(
-        "Max {resource} gas amount ({max_gas_amount}) is lower than the minimal gas amount: \
+        "Max {resource} amount ({max_gas_amount}) is lower than the minimal gas amount: \
          {minimal_gas_amount}."
     )]
     MaxGasAmountTooLow { resource: Resource, max_gas_amount: u64, minimal_gas_amount: u64 },


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/796)
<!-- Reviewable:end -->
