### PR TITLE
chore(concurrency): store the state diff instead of the writes

### DIFF
--- a/crates/blockifier/src/concurrency/worker_logic.rs
+++ b/crates/blockifier/src/concurrency/worker_logic.rs
@@ -35,6 +35,7 @@ const EXECUTION_OUTPUTS_UNWRAP_ERROR: &str = "Execution task outputs should not 
 #[derive(Debug)]
 pub struct ExecutionTaskOutput {
     pub reads: StateMaps,
+    // TODO(Yoni): rename to state_diff.
     pub writes: StateMaps,
     pub contract_classes: ContractClassMapping,
     pub visited_pcs: HashMap<ClassHash, HashSet<usize>>,
@@ -138,18 +139,15 @@ impl<'a, S: StateReader> WorkerExecutor<'a, S> {
         let execution_output_inner = match execution_result {
             Ok(_) => {
                 let tx_reads_writes = transactional_state.cache.take();
-                let class_hash_to_class = transactional_state.class_hash_to_class.take();
+                let writes = tx_reads_writes.to_state_diff();
+                let contract_classes = transactional_state.class_hash_to_class.take();
                 let visited_pcs = transactional_state.visited_pcs;
-                tx_versioned_state.apply_writes(
-                    &tx_reads_writes.writes,
-                    &class_hash_to_class,
-                    // The versioned state does not carry the visited PCs.
-                    &HashMap::default(),
-                );
+                // The versioned state does not carry the visited PCs.
+                tx_versioned_state.apply_writes(&writes, &contract_classes, &HashMap::default());
                 ExecutionTaskOutput {
                     reads: tx_reads_writes.initial_reads,
-                    writes: tx_reads_writes.writes,
-                    contract_classes: class_hash_to_class,
+                    writes,
+                    contract_classes,
                     visited_pcs,
                     result: execution_result,
                 }
@@ -229,8 +227,8 @@ impl<'a, S: StateReader> WorkerExecutor<'a, S> {
         // Execution is final.
         let mut execution_output = lock_mutex_in_array(&self.execution_outputs, tx_index);
         let writes = &execution_output.as_ref().expect(EXECUTION_OUTPUTS_UNWRAP_ERROR).writes;
-        let reads = &execution_output.as_ref().expect(EXECUTION_OUTPUTS_UNWRAP_ERROR).reads;
-        let mut tx_state_changes_keys = StateChanges::from(writes.diff(reads)).into_keys();
+        // TODO(Yoni): get rid of this clone.
+        let mut tx_state_changes_keys = StateChanges::from(writes.clone()).into_keys();
         let tx_result =
             &mut execution_output.as_mut().expect(EXECUTION_OUTPUTS_UNWRAP_ERROR).result;
 

--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -386,7 +386,7 @@ fn test_worker_execute(max_resource_bounds: ValidResourceBounds) {
         ..Default::default()
     };
 
-    assert_eq!(execution_output.writes, writes);
+    assert_eq!(execution_output.writes, writes.diff(&reads));
     assert_eq!(execution_output.reads, reads);
     assert_ne!(execution_output.visited_pcs, HashMap::default());
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/800)
<!-- Reviewable:end -->
