### PR TITLE
fix: revert event test

### DIFF
--- a/crates/papyrus_protobuf/src/converters/event_test.rs
+++ b/crates/papyrus_protobuf/src/converters/event_test.rs
@@ -11,7 +11,8 @@ fn convert_event_to_vec_u8_and_back() {
     let transaction_hash = TransactionHash::get_test_instance(&mut rng);
 
     let data = DataOrFin(Some((event, transaction_hash)));
-    let res_data = DataOrFin::try_from(data.clone()).unwrap();
+    let bytes_data = Vec::<u8>::from(data.clone());
+    let res_data = DataOrFin::try_from(bytes_data).unwrap();
     assert_eq!(data, res_data);
 }
 


### PR DESCRIPTION
This fixes a couple of lines in `papyrus_protobuf/src/converters/event_test.rs` that I accidentally changed in a previous PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/847)
<!-- Reviewable:end -->
