### PR TITLE
refactor(mempool): add mempool p2p sender client to mempool wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9881,10 +9881,7 @@ dependencies = [
  "starknet_api",
  "starknet_mempool_infra",
  "starknet_mempool_p2p",
-<<<<<<< HEAD
-=======
- "starknet_mempool_p2p_sender_types",
->>>>>>> 6d52a6b54 (refactor(mempool): add mempool p2p sender client to mempool wrapper)
+ "starknet_mempool_p2p_types",
  "starknet_mempool_types",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9874,11 +9874,13 @@ dependencies = [
  "derive_more 0.99.17",
  "itertools 0.12.1",
  "mempool_test_utils",
+ "papyrus_network",
  "pretty_assertions",
  "rstest",
  "starknet-types-core",
  "starknet_api",
  "starknet_mempool_infra",
+ "starknet_mempool_p2p",
  "starknet_mempool_types",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9881,6 +9881,10 @@ dependencies = [
  "starknet_api",
  "starknet_mempool_infra",
  "starknet_mempool_p2p",
+<<<<<<< HEAD
+=======
+ "starknet_mempool_p2p_sender_types",
+>>>>>>> 6d52a6b54 (refactor(mempool): add mempool p2p sender client to mempool wrapper)
  "starknet_mempool_types",
  "tokio",
 ]
@@ -9975,6 +9979,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "papyrus_network",
+ "starknet_api",
  "starknet_mempool_infra",
  "starknet_mempool_p2p_types",
 ]

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -68,17 +68,9 @@ async fn test_add_tx() {
         .expect_add_tx()
         .once()
         .with(eq(MempoolWrapperInput {
-            // TODO(Arni): Use external_to_executable_tx instead of `create_executable_tx`. Consider
-            // creating a `convertor for testing` that does not do the compilation.
             mempool_input: MempoolInput {
-                tx: create_executable_tx(
-                    sender_address,
-                    tx_hash,
-                    *tx.tip(),
-                    *tx.nonce(),
-                    ValidResourceBounds::AllResources(tx.resource_bounds().clone()),
-                ),
-                account: Account { sender_address, state: AccountState { nonce: *tx.nonce() } },
+                tx: executable_tx,
+                account: Account { sender_address, state: AccountState { nonce: *rpc_tx.nonce() } },
             },
             message_metadata: None,
         }))

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -68,9 +68,17 @@ async fn test_add_tx() {
         .expect_add_tx()
         .once()
         .with(eq(MempoolWrapperInput {
+            // TODO(Arni): Use external_to_executable_tx instead of `create_executable_tx`. Consider
+            // creating a `convertor for testing` that does not do the compilation.
             mempool_input: MempoolInput {
-                tx: executable_tx,
-                account: Account { sender_address, state: AccountState { nonce: *rpc_tx.nonce() } },
+                tx: create_executable_tx(
+                    sender_address,
+                    tx_hash,
+                    *tx.tip(),
+                    *tx.nonce(),
+                    ValidResourceBounds::AllResources(*tx.resource_bounds()),
+                ),
+                account: Account { sender_address, state: AccountState { nonce: *tx.nonce() } },
             },
             message_metadata: None,
         }))

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -76,7 +76,7 @@ async fn test_add_tx() {
                     tx_hash,
                     *tx.tip(),
                     *tx.nonce(),
-                    ValidResourceBounds::AllResources(*tx.resource_bounds()),
+                    ValidResourceBounds::AllResources(tx.resource_bounds().clone()),
                 ),
                 account: Account { sender_address, state: AccountState { nonce: *tx.nonce() } },
             },

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 derive_more.workspace = true
+starknet_mempool_p2p_sender_types.workspace = true
 papyrus_network.workspace = true
 starknet_api.workspace = true
 starknet_mempool_infra.workspace = true

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -11,11 +11,11 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 derive_more.workspace = true
-starknet_mempool_p2p_sender_types.workspace = true
 papyrus_network.workspace = true
 starknet_api.workspace = true
 starknet_mempool_infra.workspace = true
 starknet_mempool_p2p.workspace = true
+starknet_mempool_p2p_types.workspace = true
 starknet_mempool_types.workspace = true
 tokio.workspace = true
 

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -11,8 +11,10 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 derive_more.workspace = true
+papyrus_network.workspace = true
 starknet_api.workspace = true
 starknet_mempool_infra.workspace = true
+starknet_mempool_p2p.workspace = true
 starknet_mempool_types.workspace = true
 tokio.workspace = true
 

--- a/crates/mempool/src/communication.rs
+++ b/crates/mempool/src/communication.rs
@@ -8,7 +8,7 @@ use starknet_mempool_infra::component_definitions::ComponentRequestHandler;
 use starknet_mempool_infra::component_runner::ComponentStarter;
 use starknet_mempool_infra::component_server::{LocalComponentServer, RemoteComponentServer};
 use starknet_mempool_p2p::sender::EmptyMempoolP2pSenderClient;
-use starknet_mempool_p2p_sender_types::communication::SharedMempoolP2pSenderClient;
+use starknet_mempool_p2p_types::communication::SharedMempoolP2pSenderClient;
 use starknet_mempool_types::communication::{
     MempoolRequest,
     MempoolRequestAndResponseSender,

--- a/crates/mempool/src/communication.rs
+++ b/crates/mempool/src/communication.rs
@@ -1,10 +1,13 @@
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use papyrus_network::network_manager::BroadcastedMessageManager;
 use starknet_api::executable_transaction::Transaction;
 use starknet_mempool_infra::component_definitions::ComponentRequestHandler;
 use starknet_mempool_infra::component_runner::ComponentStarter;
 use starknet_mempool_infra::component_server::{LocalComponentServer, RemoteComponentServer};
+use starknet_mempool_p2p::sender::{EmptyMempoolP2pSenderClient, SharedMempoolP2pSenderClient};
 use starknet_mempool_types::communication::{
     MempoolRequest,
     MempoolRequestAndResponseSender,
@@ -26,7 +29,8 @@ pub fn create_mempool_server(
     mempool: Mempool,
     rx_mempool: Receiver<MempoolRequestAndResponseSender>,
 ) -> MempoolServer {
-    let communication_wrapper = MempoolCommunicationWrapper::new(mempool);
+    let communication_wrapper =
+        MempoolCommunicationWrapper::new(mempool, Arc::new(EmptyMempoolP2pSenderClient));
     LocalComponentServer::new(communication_wrapper, rx_mempool)
 }
 
@@ -35,22 +39,48 @@ pub fn create_remote_mempool_server(
     ip_address: IpAddr,
     port: u16,
 ) -> RemoteMempoolServer {
-    let communication_wrapper = MempoolCommunicationWrapper::new(mempool);
+    let communication_wrapper =
+        MempoolCommunicationWrapper::new(mempool, Arc::new(EmptyMempoolP2pSenderClient));
     RemoteComponentServer::new(communication_wrapper, ip_address, port)
 }
 
 /// Wraps the mempool to enable inbound async communication from other components.
 pub struct MempoolCommunicationWrapper {
     mempool: Mempool,
+    mempool_p2p_sender_client: SharedMempoolP2pSenderClient,
 }
 
 impl MempoolCommunicationWrapper {
-    pub fn new(mempool: Mempool) -> Self {
-        MempoolCommunicationWrapper { mempool }
+    pub fn new(mempool: Mempool, mempool_p2p_sender_client: SharedMempoolP2pSenderClient) -> Self {
+        MempoolCommunicationWrapper { mempool, mempool_p2p_sender_client }
     }
 
-    fn add_tx(&mut self, mempool_wrapper_input: MempoolWrapperInput) -> MempoolResult<()> {
-        self.mempool.add_tx(mempool_wrapper_input.mempool_input)
+    async fn send_tx_to_p2p(
+        &self,
+        message_metadata: Option<BroadcastedMessageManager>,
+        tx: Transaction,
+    ) {
+        match message_metadata {
+            Some(message_metadata) => {
+                self.mempool_p2p_sender_client
+                    .continue_propagation(message_metadata)
+                    .await
+                    .unwrap();
+            }
+            None => {
+                self.mempool_p2p_sender_client.add_transaction(tx.into()).await.unwrap();
+            }
+        }
+    }
+
+    async fn add_tx(&mut self, mempool_wrapper_input: MempoolWrapperInput) -> MempoolResult<()> {
+        let result = self.mempool.add_tx(mempool_wrapper_input.mempool_input.clone());
+        self.send_tx_to_p2p(
+            mempool_wrapper_input.message_metadata,
+            mempool_wrapper_input.mempool_input.tx,
+        )
+        .await;
+        result
     }
 
     fn get_txs(&mut self, n_txs: usize) -> MempoolResult<Vec<Transaction>> {
@@ -63,7 +93,7 @@ impl ComponentRequestHandler<MempoolRequest, MempoolResponse> for MempoolCommuni
     async fn handle_request(&mut self, request: MempoolRequest) -> MempoolResponse {
         match request {
             MempoolRequest::AddTransaction(mempool_wrapper_input) => {
-                MempoolResponse::AddTransaction(self.add_tx(mempool_wrapper_input))
+                MempoolResponse::AddTransaction(self.add_tx(mempool_wrapper_input).await)
             }
             MempoolRequest::GetTransactions(n_txs) => {
                 MempoolResponse::GetTransactions(self.get_txs(n_txs))

--- a/crates/mempool/src/communication.rs
+++ b/crates/mempool/src/communication.rs
@@ -7,7 +7,8 @@ use starknet_api::executable_transaction::Transaction;
 use starknet_mempool_infra::component_definitions::ComponentRequestHandler;
 use starknet_mempool_infra::component_runner::ComponentStarter;
 use starknet_mempool_infra::component_server::{LocalComponentServer, RemoteComponentServer};
-use starknet_mempool_p2p::sender::{EmptyMempoolP2pSenderClient, SharedMempoolP2pSenderClient};
+use starknet_mempool_p2p::sender::EmptyMempoolP2pSenderClient;
+use starknet_mempool_p2p_sender_types::communication::SharedMempoolP2pSenderClient;
 use starknet_mempool_types::communication::{
     MempoolRequest,
     MempoolRequestAndResponseSender,

--- a/crates/mempool_p2p/Cargo.toml
+++ b/crates/mempool_p2p/Cargo.toml
@@ -11,5 +11,6 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 papyrus_network.workspace = true
+starknet_api.workspace = true
 starknet_mempool_infra.workspace = true
 starknet_mempool_p2p_types.workspace = true

--- a/crates/mempool_p2p/src/sender/mod.rs
+++ b/crates/mempool_p2p/src/sender/mod.rs
@@ -18,3 +18,22 @@ impl ComponentRequestHandler<MempoolP2pSenderRequest, MempoolP2pSenderResponse>
         unimplemented!()
     }
 }
+
+pub struct EmptyMempoolP2pSenderClient;
+
+#[async_trait]
+impl MempoolP2pSenderClient for EmptyMempoolP2pSenderClient {
+    async fn add_transaction(
+        &self,
+        _transaction: RpcTransaction,
+    ) -> MempoolP2pSenderClientResult<()> {
+        Ok(())
+    }
+
+    async fn continue_propagation(
+        &self,
+        _propagation_manager: BroadcastedMessageManager,
+    ) -> MempoolP2pSenderClientResult<()> {
+        Ok(())
+    }
+}

--- a/crates/mempool_p2p/src/sender/mod.rs
+++ b/crates/mempool_p2p/src/sender/mod.rs
@@ -1,6 +1,10 @@
 use async_trait::async_trait;
+use papyrus_network::network_manager::BroadcastedMessageManager;
+use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_mempool_infra::component_definitions::ComponentRequestHandler;
 use starknet_mempool_p2p_types::communication::{
+    MempoolP2pSenderClient,
+    MempoolP2pSenderClientResult,
     MempoolP2pSenderRequest,
     MempoolP2pSenderResponse,
 };

--- a/crates/mempool_p2p_sender_types/Cargo.toml
+++ b/crates/mempool_p2p_sender_types/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "starknet_mempool_p2p_sender_types"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait.workspace = true
+papyrus_network.workspace = true
+papyrus_proc_macros.workspace = true
+serde = { workspace = true, features = ["derive"] }
+starknet_api.workspace = true
+starknet_mempool_infra.workspace = true
+thiserror.workspace = true

--- a/crates/mempool_p2p_sender_types/src/communication.rs
+++ b/crates/mempool_p2p_sender_types/src/communication.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+// TODO(Shahak): Create a papyrus_network_types crate and move BroadcastedMessageManager to
+// there.
+use papyrus_network::network_manager::BroadcastedMessageManager;
+use papyrus_proc_macros::handle_response_variants;
+use serde::{Deserialize, Serialize};
+use starknet_api::rpc_transaction::RpcTransaction;
+use starknet_mempool_infra::component_client::{ClientError, LocalComponentClient};
+use thiserror::Error;
+
+use crate::errors::MempoolP2pSenderError;
+use crate::mempool_p2p_types::MempoolP2pSenderResult;
+
+#[async_trait]
+pub trait MempoolP2pSenderClient: Send + Sync {
+    /// Adds a transaction to be propagated to other peers. This should only be called on a new
+    /// transaction coming from the user and not from another peer. To handle transactions coming
+    /// from other peers, use `continue_propagation`.
+    async fn add_transaction(
+        &self,
+        transaction: RpcTransaction,
+    ) -> MempoolP2pSenderClientResult<()>;
+
+    /// Continues the propagation of a transaction we've received from another peer.
+    async fn continue_propagation(
+        &self,
+        propagation_manager: BroadcastedMessageManager,
+    ) -> MempoolP2pSenderClientResult<()>;
+}
+
+// TODO: Implement remote MempoolP2pSenderClient.
+pub type LocalMempoolP2pSenderClientImpl =
+    LocalComponentClient<MempoolP2pSenderRequest, MempoolP2pSenderResponse>;
+pub type SharedMempoolP2pSenderClient = Arc<dyn MempoolP2pSenderClient>;
+pub type MempoolP2pSenderClientResult<T> = Result<T, MempoolP2pSenderClientError>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum MempoolP2pSenderRequest {
+    AddTransaction(RpcTransaction),
+    ContinuePropagation(BroadcastedMessageManager),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum MempoolP2pSenderResponse {
+    AddTransaction(MempoolP2pSenderResult<()>),
+    ContinuePropagation(MempoolP2pSenderResult<()>),
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum MempoolP2pSenderClientError {
+    #[error(transparent)]
+    ClientError(#[from] ClientError),
+    #[error(transparent)]
+    MempoolP2pSenderError(#[from] MempoolP2pSenderError),
+}
+
+#[async_trait]
+impl MempoolP2pSenderClient for LocalMempoolP2pSenderClientImpl {
+    async fn add_transaction(
+        &self,
+        transaction: RpcTransaction,
+    ) -> MempoolP2pSenderClientResult<()> {
+        let request = MempoolP2pSenderRequest::AddTransaction(transaction);
+        let response = self.send(request).await;
+        handle_response_variants!(
+            MempoolP2pSenderResponse,
+            AddTransaction,
+            MempoolP2pSenderClientError,
+            MempoolP2pSenderError
+        )
+    }
+
+    async fn continue_propagation(
+        &self,
+        propagation_manager: BroadcastedMessageManager,
+    ) -> MempoolP2pSenderClientResult<()> {
+        let request = MempoolP2pSenderRequest::ContinuePropagation(propagation_manager);
+        let response = self.send(request).await;
+        handle_response_variants!(
+            MempoolP2pSenderResponse,
+            ContinuePropagation,
+            MempoolP2pSenderClientError,
+            MempoolP2pSenderError
+        )
+    }
+}

--- a/crates/mempool_p2p_sender_types/src/errors.rs
+++ b/crates/mempool_p2p_sender_types/src/errors.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// This error is defined even though it's empty to be compatible with the other components.
+#[derive(Debug, Error, Serialize, Deserialize, Clone)]
+pub enum MempoolP2pSenderError {}

--- a/crates/mempool_p2p_sender_types/src/lib.rs
+++ b/crates/mempool_p2p_sender_types/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod communication;
+pub mod errors;
+pub mod mempool_p2p_types;

--- a/crates/mempool_p2p_sender_types/src/mempool_p2p_types.rs
+++ b/crates/mempool_p2p_sender_types/src/mempool_p2p_types.rs
@@ -1,0 +1,3 @@
+use crate::errors::MempoolP2pSenderError;
+
+pub type MempoolP2pSenderResult<T> = Result<T, MempoolP2pSenderError>;

--- a/crates/starknet_api/src/executable_transaction.rs
+++ b/crates/starknet_api/src/executable_transaction.rs
@@ -10,9 +10,15 @@ use crate::core::{
     Nonce,
 };
 use crate::data_availability::DataAvailabilityMode;
-use crate::rpc_transaction::{RpcDeployAccountTransaction, RpcInvokeTransaction, RpcTransaction};
+use crate::rpc_transaction::{
+    RpcDeployAccountTransaction,
+    RpcInvokeTransaction,
+    RpcInvokeTransactionV3,
+    RpcTransaction,
+};
 use crate::transaction::{
     AccountDeploymentData,
+    AllResourceBounds,
     Calldata,
     ContractAddressSalt,
     PaymasterData,
@@ -138,6 +144,29 @@ impl Transaction {
             ),
             tx_hash,
         })
+    }
+}
+
+// TODO: replace with proper implementation.
+impl From<Transaction> for RpcTransaction {
+    fn from(tx: Transaction) -> Self {
+        Self::Invoke(RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
+            sender_address: tx.contract_address(),
+            tip: tx.tip().unwrap_or_default(),
+            nonce: Nonce::default(),
+            resource_bounds: match tx.resource_bounds() {
+                Some(ValidResourceBounds::AllResources(all_resource_bounds)) => {
+                    all_resource_bounds.clone()
+                }
+                _ => AllResourceBounds::default(),
+            },
+            signature: TransactionSignature::default(),
+            calldata: Calldata::default(),
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+            paymaster_data: PaymasterData::default(),
+            account_deployment_data: AccountDeploymentData::default(),
+        }))
     }
 }
 


### PR DESCRIPTION
- refactor(mempool): split mempool_p2p crate to types and business logic crates
- cr comments draft
- refactor(mempool): wrap mempool_input with optional broadcasted message metadata
- refactor(mempool): add mempool p2p sender client to mempool wrapper

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/858)
<!-- Reviewable:end -->
