### PR TITLE
refactor(node): create run_consensus binary

### DIFF
--- a/crates/papyrus_node/src/bin/run_consensus.rs
+++ b/crates/papyrus_node/src/bin/run_consensus.rs
@@ -1,0 +1,111 @@
+use clap::Parser;
+use futures::stream::StreamExt;
+use papyrus_consensus::config::ConsensusConfig;
+use papyrus_consensus::simulation_network_receiver::NetworkReceiver;
+use papyrus_consensus_orchestrator::papyrus_consensus_context::PapyrusConsensusContext;
+use papyrus_network::gossipsub_impl::Topic;
+use papyrus_network::network_manager::{BroadcastTopicChannels, NetworkManager};
+use papyrus_node::run::{run, PapyrusResources, PapyrusTaskHandles};
+use papyrus_node::test_utils::build_configs;
+use papyrus_p2p_sync::BUFFER_SIZE;
+use papyrus_storage::StorageReader;
+use starknet_api::block::BlockNumber;
+use tokio::task::JoinHandle;
+
+/// Test configuration for consensus.
+#[derive(Parser, Debug, Clone, PartialEq)]
+pub struct TestConfig {
+    #[arg(long = "cache_size", help = "The cache size for the test network receiver.")]
+    pub cache_size: usize,
+    #[arg(
+        long = "random_seed",
+        help = "The random seed for the test simulation to ensure repeatable test results."
+    )]
+    pub random_seed: u64,
+    #[arg(long = "drop_probability", help = "The probability of dropping a message.")]
+    pub drop_probability: f64,
+    #[arg(long = "invalid_probability", help = "The probability of sending an invalid message.")]
+    pub invalid_probability: f64,
+    #[arg(long = "sync_topic", help = "The network topic for sync messages.")]
+    pub sync_topic: String,
+}
+
+impl Default for TestConfig {
+    fn default() -> Self {
+        Self {
+            cache_size: 1000,
+            random_seed: 0,
+            drop_probability: 0.0,
+            invalid_probability: 0.0,
+            sync_topic: "consensus_test_sync".to_string(),
+        }
+    }
+}
+
+fn build_consensus(
+    consensus_config: ConsensusConfig,
+    test_config: TestConfig,
+    storage_reader: StorageReader,
+    network_manager: &mut NetworkManager,
+) -> anyhow::Result<Option<JoinHandle<anyhow::Result<()>>>> {
+    let network_channels = network_manager.register_broadcast_topic(
+        Topic::new(consensus_config.network_topic.clone()),
+        BUFFER_SIZE,
+    )?;
+    // TODO(matan): connect this to an actual channel.
+    let sync_channels = network_manager
+        .register_broadcast_topic(Topic::new(test_config.sync_topic.clone()), BUFFER_SIZE)?;
+    let context = PapyrusConsensusContext::new(
+        storage_reader.clone(),
+        network_channels.messages_to_broadcast_sender.clone(),
+        consensus_config.num_validators,
+        Some(sync_channels.messages_to_broadcast_sender),
+    );
+    let sync_receiver =
+        sync_channels.broadcasted_messages_receiver.map(|(vote, _report_sender)| {
+            BlockNumber(vote.expect("Sync channel should never have errors").height)
+        });
+    let network_receiver = NetworkReceiver::new(
+        network_channels.broadcasted_messages_receiver,
+        test_config.cache_size,
+        test_config.random_seed,
+        test_config.drop_probability,
+        test_config.invalid_probability,
+    );
+    let broadcast_channels = BroadcastTopicChannels {
+        messages_to_broadcast_sender: network_channels.messages_to_broadcast_sender,
+        broadcasted_messages_receiver: Box::new(network_receiver),
+        reported_messages_sender: network_channels.reported_messages_sender,
+        continue_propagation_sender: network_channels.continue_propagation_sender,
+    };
+
+    Ok(Some(tokio::spawn(async move {
+        Ok(papyrus_consensus::run_consensus(
+            context,
+            consensus_config.start_height,
+            consensus_config.validator_id,
+            consensus_config.consensus_delay,
+            consensus_config.timeouts.clone(),
+            broadcast_channels,
+            sync_receiver,
+        )
+        .await?)
+    })))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let (test_config, node_config) = build_configs::<TestConfig>()?;
+
+    let mut resources = PapyrusResources::new(&node_config)?;
+
+    let consensus_handle = build_consensus(
+        node_config.consensus.clone().unwrap(),
+        test_config,
+        resources.storage_reader.clone(),
+        resources.maybe_network_manager.as_mut().unwrap(),
+    )?;
+    let tasks = PapyrusTaskHandles { consensus_handle, ..Default::default() };
+
+    run(node_config, resources, tasks).await
+}

--- a/crates/papyrus_node/src/lib.rs
+++ b/crates/papyrus_node/src/lib.rs
@@ -7,4 +7,6 @@ pub mod config;
 #[cfg(test)]
 mod precision_test;
 pub mod run;
+/// Not cfg(test) because it's used for component tests which compile normally.
+pub mod test_utils;
 pub mod version;

--- a/crates/papyrus_node/src/test_utils.rs
+++ b/crates/papyrus_node/src/test_utils.rs
@@ -1,0 +1,48 @@
+use std::env::args;
+
+use clap::Parser;
+use papyrus_config::ConfigError;
+
+use crate::config::NodeConfig;
+
+// Test arguments passed on the command line are prefixed with `test.<ARG_NAME>`.
+const TEST_ARG_PREFIX: &str = "--test.";
+
+/// Split the elements of `input_args` into 2 groups:
+/// 1. Those prefixed with "--test."
+/// 2. Other.
+///
+/// Presumes input is: program_name (--flag_name value)*
+pub fn split_args(input_args: Vec<String>) -> (Vec<String>, Vec<String>) {
+    input_args[1..].chunks(2).fold(
+        (vec![input_args[0].clone()], vec![input_args[0].clone()]),
+        |(mut matching_args, mut mismatched_args), input_arg| {
+            let (name, value) = (&input_arg[0], &input_arg[1]);
+            // String leading `--` for comparison.
+            if &name[..TEST_ARG_PREFIX.len()] == TEST_ARG_PREFIX {
+                matching_args.push(format!("--{}", name[TEST_ARG_PREFIX.len()..].to_string()));
+                matching_args.push(value.clone());
+            } else {
+                mismatched_args.push(name.clone());
+                mismatched_args.push(value.clone());
+            }
+            (matching_args, mismatched_args)
+        },
+    )
+}
+
+/// Build both the node and test configs from the command line arguments.
+pub fn build_configs<T: Parser + Default>() -> Result<(T, NodeConfig), ConfigError> {
+    let input_args = args().collect::<Vec<_>>();
+    let (test_input_args, node_input_args) = split_args(input_args);
+
+    let mut test_config = T::default();
+    test_config.update_from(test_input_args.iter());
+
+    let node_config = NodeConfig::load_and_process(node_input_args);
+    if let Err(ConfigError::CommandInput(clap_err)) = node_config {
+        clap_err.exit();
+    }
+    let node_config = node_config?;
+    Ok((test_config, node_config))
+}


### PR DESCRIPTION
This overrides the default by adding a network receiver to simulate a faulty network