### PR TITLE
refactor(node): users pass the prefix for splitting config args

### DIFF
--- a/crates/papyrus_node/src/bin/run_consensus.rs
+++ b/crates/papyrus_node/src/bin/run_consensus.rs
@@ -1,5 +1,9 @@
 //! Run a papyrus node with consensus enabled and the ability to simulate network issues for
 //! consensus.
+//!
+//! Expects to receive 2 groupings of arguments:
+//! 1. TestConfig - these are prefixed with `--test.` in the command.
+//! 2. NodeConfig - any argument lacking the above prefix is assumed to be in NodeConfig.
 use clap::Parser;
 use futures::stream::StreamExt;
 use papyrus_consensus::config::ConsensusConfig;
@@ -97,7 +101,7 @@ fn build_consensus(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let (test_config, node_config) = build_configs::<TestConfig>()?;
+    let (test_config, node_config) = build_configs::<TestConfig>("--test.")?;
 
     let mut resources = PapyrusResources::new(&node_config)?;
 

--- a/crates/papyrus_node/src/bin_utils.rs
+++ b/crates/papyrus_node/src/bin_utils.rs
@@ -5,22 +5,19 @@ use papyrus_config::ConfigError;
 
 use crate::config::NodeConfig;
 
-// Test arguments passed on the command line are prefixed with `test.<ARG_NAME>`.
-const TEST_ARG_PREFIX: &str = "--test.";
-
 /// Split the elements of `input_args` into 2 groups:
-/// 1. Those prefixed with "--test."
+/// 1. Those prefixed with `split_args_prefix`
 /// 2. Other.
 ///
 /// Presumes input is: program_name (--flag_name value)*
-pub fn split_args(input_args: Vec<String>) -> (Vec<String>, Vec<String>) {
+pub fn split_args(input_args: Vec<String>, split_args_prefix: &str) -> (Vec<String>, Vec<String>) {
     input_args[1..].chunks(2).fold(
         (vec![input_args[0].clone()], vec![input_args[0].clone()]),
         |(mut matching_args, mut mismatched_args), input_arg| {
             let (name, value) = (&input_arg[0], &input_arg[1]);
             // String leading `--` for comparison.
-            if &name[..TEST_ARG_PREFIX.len()] == TEST_ARG_PREFIX {
-                matching_args.push(format!("--{}", &name[TEST_ARG_PREFIX.len()..]));
+            if &name[..split_args_prefix.len()] == split_args_prefix {
+                matching_args.push(format!("--{}", &name[split_args_prefix.len()..]));
                 matching_args.push(value.clone());
             } else {
                 mismatched_args.push(name.clone());
@@ -32,9 +29,11 @@ pub fn split_args(input_args: Vec<String>) -> (Vec<String>, Vec<String>) {
 }
 
 /// Build both the node and test configs from the command line arguments.
-pub fn build_configs<T: Parser + Default>() -> Result<(T, NodeConfig), ConfigError> {
+pub fn build_configs<T: Parser + Default>(
+    split_args_prefix: &str,
+) -> Result<(T, NodeConfig), ConfigError> {
     let input_args = args().collect::<Vec<_>>();
-    let (test_input_args, node_input_args) = split_args(input_args);
+    let (test_input_args, node_input_args) = split_args(input_args, split_args_prefix);
 
     let mut test_config = T::default();
     test_config.update_from(test_input_args.iter());


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/925)
<!-- Reviewable:end -->
