### PR TITLE
refactor(mempool_infra): create an alias to all trait bounds in remote server

### DIFF
--- a/crates/mempool_infra/src/component_server/remote_component_server.rs
+++ b/crates/mempool_infra/src/component_server/remote_component_server.rs
@@ -13,6 +13,21 @@ use super::definitions::ComponentServerStarter;
 use crate::component_client::LocalComponentClient;
 use crate::component_definitions::{ServerError, APPLICATION_OCTET_STREAM};
 
+pub trait ComponentTraitBounds<Request, Response>:
+    ComponentRequestHandler<Request, Response> + Send + 'static
+{
+}
+impl<T, Request, Response> ComponentTraitBounds<Request, Response> for T where
+    T: ComponentRequestHandler<Request, Response> + Send + 'static
+{
+}
+
+pub trait RequestTraitBounds: DeserializeOwned + Send + Sync + 'static {}
+impl<T> RequestTraitBounds for T where T: DeserializeOwned + Send + Sync + 'static {}
+
+pub trait ResponseTraitBounds: Serialize + Send + Sync + 'static {}
+impl<T> ResponseTraitBounds for T where T: Serialize + Send + Sync + 'static {}
+
 /// The `RemoteComponentServer` struct is a generic server that handles requests and responses for a
 /// specified component. It receives requests, processes them using the provided component, and
 /// sends back responses. The server needs to be started using the `start` function, which runs
@@ -150,8 +165,8 @@ where
 #[async_trait]
 impl<Request, Response> ComponentServerStarter for RemoteComponentServer<Request, Response>
 where
-    Request: DeserializeOwned + Send + Sync + 'static,
-    Response: Serialize + Send + Sync + 'static,
+Request: DeserializeOwned + Send + Sync + 'static,
+    Response: Serialize + Send + Sync + 'static,s in remote server
 {
     async fn start(&mut self) {
         let make_svc = make_service_fn(|_conn| {


### PR DESCRIPTION
**Stack**:
- #939
- #938 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/938)
<!-- Reviewable:end -->
