### PR TITLE
fix: fix cargo.lock after merge conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9790,7 +9790,7 @@ name = "starknet_consensus_manager_types"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "derive_more",
+ "derive_more 0.99.17",
  "mockall",
  "papyrus_proc_macros",
  "serde",


### PR DESCRIPTION
I think the merge conflict originated from this commit @yair-starkware 

commit e428a6b2db743ad801e11df8063ef25ee78f0c82 (HEAD)
Author: Yair Bakalchuk <yair@starkware.co>
Date:   Mon Sep 9 12:51:53 2024 +0300

    feat(batcher): batcher client trait

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/942)
<!-- Reviewable:end -->
