### PR TITLE
refactor(mempool): rename account state to account nonce

### DIFF
--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -8,7 +8,7 @@ use starknet_api::transaction::TransactionHash;
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_infra::component_runner::{ComponentStartError, ComponentStarter};
 use starknet_mempool_types::communication::{MempoolWrapperInput, SharedMempoolClient};
-use starknet_mempool_types::mempool_types::{Account, AccountState, MempoolInput};
+use starknet_mempool_types::mempool_types::{Account, AccountNonce, MempoolInput};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use tracing::{error, info, instrument};
 
@@ -138,7 +138,7 @@ fn process_tx(
     // TODO(Arni): Add the Sierra and the Casm to the mempool input.
     Ok(MempoolInput {
         tx: executable_tx,
-        account: Account { sender_address, state: AccountState { nonce: account_nonce } },
+        account: Account { sender_address, state: AccountNonce { nonce: account_nonce } },
     })
 }
 

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -9,7 +9,7 @@ use starknet_api::executable_transaction::{InvokeTransaction, Transaction};
 use starknet_api::rpc_transaction::{RpcDeclareTransaction, RpcTransaction};
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_types::communication::{MempoolWrapperInput, MockMempoolClient};
-use starknet_mempool_types::mempool_types::{Account, AccountState, MempoolInput};
+use starknet_mempool_types::mempool_types::{Account, AccountNonce, MempoolInput};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 
 use crate::compilation::GatewayCompiler;
@@ -70,7 +70,7 @@ async fn test_add_tx() {
         .with(eq(MempoolWrapperInput {
             mempool_input: MempoolInput {
                 tx: executable_tx,
-                account: Account { sender_address, state: AccountState { nonce: *rpc_tx.nonce() } },
+                account: Account { sender_address, state: AccountNonce { nonce: *rpc_tx.nonce() } },
             },
             message_metadata: None,
         }))

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -12,7 +12,7 @@ use starknet_api::test_utils::invoke::executable_invoke_tx;
 use starknet_api::transaction::{Tip, TransactionHash, ValidResourceBounds};
 use starknet_api::{contract_address, felt, invoke_tx_args, patricia_key};
 use starknet_mempool_types::errors::MempoolError;
-use starknet_mempool_types::mempool_types::{Account, AccountState};
+use starknet_mempool_types::mempool_types::{Account, AccountNonce};
 use starknet_types_core::felt::Felt;
 
 use crate::mempool::{AccountToNonce, Mempool, MempoolInput, TransactionReference};
@@ -147,7 +147,7 @@ fn commit_block(
     state_changes: impl IntoIterator<Item = (&'static str, u8)>,
 ) {
     let state_changes = HashMap::from_iter(state_changes.into_iter().map(|(address, nonce)| {
-        (contract_address!(address), AccountState { nonce: Nonce(felt!(nonce)) })
+        (contract_address!(address), AccountNonce { nonce: Nonce(felt!(nonce)) })
     }));
 
     assert_eq!(mempool.commit_block(state_changes), Ok(()));
@@ -191,7 +191,7 @@ macro_rules! add_tx_input {
         let tx = tx!(tip: $tip, tx_hash: $tx_hash, sender_address: $sender_address, tx_nonce: $tx_nonce, resource_bounds: $resource_bounds);
         let sender_address = contract_address!($sender_address);
         let account_nonce = Nonce(felt!($account_nonce));
-        let account = Account { sender_address, state: AccountState {nonce: account_nonce}};
+        let account = Account { sender_address, state: AccountNonce {nonce: account_nonce}};
 
         MempoolInput { tx, account }
     }};
@@ -876,7 +876,7 @@ fn test_account_nonce_does_not_decrease_in_add_tx() {
 fn test_account_nonces_update_in_commit_block() {
     // Setup.
     let input = add_tx_input!(tx_nonce: 2_u8, account_nonce: 0_u8);
-    let Account { sender_address, state: AccountState { nonce } } = input.account;
+    let Account { sender_address, state: AccountNonce { nonce } } = input.account;
     let pool_txs = [input.tx];
     let mut mempool = MempoolContentBuilder::new()
         .with_pool(pool_txs)
@@ -885,7 +885,7 @@ fn test_account_nonces_update_in_commit_block() {
     let committed_nonce = Nonce(Felt::ZERO);
 
     // Test: update through a commit block.
-    let state_changes = HashMap::from([(sender_address, AccountState { nonce: committed_nonce })]);
+    let state_changes = HashMap::from([(sender_address, AccountNonce { nonce: committed_nonce })]);
     assert_eq!(mempool.commit_block(state_changes), Ok(()));
 
     // Assert.
@@ -899,7 +899,7 @@ fn test_account_nonces_update_in_commit_block() {
 fn test_account_nonce_does_not_decrease_in_commit_block() {
     // Setup.
     let input_account_nonce_2 = add_tx_input!(tx_nonce: 3_u8, account_nonce: 2_u8);
-    let Account { sender_address, state: AccountState { nonce } } = input_account_nonce_2.account;
+    let Account { sender_address, state: AccountNonce { nonce } } = input_account_nonce_2.account;
     let account_nonces = [(sender_address, nonce)];
     let pool_txs = [input_account_nonce_2.tx];
     let mut mempool = MempoolContentBuilder::new()
@@ -909,7 +909,7 @@ fn test_account_nonce_does_not_decrease_in_commit_block() {
 
     // Test: commits state change of a lower account nonce.
     let state_changes =
-        HashMap::from([(sender_address, AccountState { nonce: Nonce(felt!(0_u8)) })]);
+        HashMap::from([(sender_address, AccountNonce { nonce: Nonce(felt!(0_u8)) })]);
     assert_eq!(mempool.commit_block(state_changes), Ok(()));
 
     // Assert: the account nonce is not updated.

--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -4,7 +4,7 @@ use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_mempool_types::errors::MempoolError;
-use starknet_mempool_types::mempool_types::{Account, AccountState, MempoolResult};
+use starknet_mempool_types::mempool_types::{Account, AccountNonce, MempoolResult};
 
 use crate::mempool::TransactionReference;
 
@@ -99,7 +99,7 @@ impl TransactionPool {
         &self,
         current_account_state: Account,
     ) -> MempoolResult<Option<&TransactionReference>> {
-        let Account { sender_address, state: AccountState { nonce } } = current_account_state;
+        let Account { sender_address, state: AccountNonce { nonce } } = current_account_state;
         // TOOD(Ayelet): Change to StarknetApiError.
         let next_nonce = nonce.try_increment().map_err(|_| MempoolError::FeltOutOfRange)?;
         Ok(self.get_by_address_and_nonce(sender_address, next_nonce))

--- a/crates/mempool_types/src/mempool_types.rs
+++ b/crates/mempool_types/src/mempool_types.rs
@@ -5,7 +5,7 @@ use starknet_api::executable_transaction::Transaction;
 use crate::errors::MempoolError;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct AccountState {
+pub struct AccountNonce {
     pub nonce: Nonce,
     // TODO: add balance field when needed.
 }
@@ -14,7 +14,7 @@ pub struct AccountState {
 pub struct Account {
     // TODO(Ayelet): Consider removing this field as it is duplicated in ThinTransaction.
     pub sender_address: ContractAddress,
-    pub state: AccountState,
+    pub state: AccountNonce,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Part of a larger refactor.

**Starting point:** 
Two separate structs:
- AccountState (contains a nonce field)
- Account (contains sender_address and AccountState)

**Target:**
Merge into one struct, AccountState, containing two fields: sender_address and account_nonce.

**Current state:**

- AccountNonce (contains a nonce field)
- Account (contains sender_address and AccountState)

_**Please start by reviewing the mempool_types.rs file first.**_

**Stack of PRs:**

1. refactor(mempool): rename account state to account nonce #957 **<-- you're here**
2. refactor(mempool): rename account to account state #959
3. refactor(mempool): merge AccountNonce into AccountState #963
4. refactor(mempool): remove AccountNonce struct #965

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/957)
<!-- Reviewable:end -->
