### PR TITLE
refactor(mempool): rename account to account state

### DIFF
--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -8,7 +8,7 @@ use starknet_api::transaction::TransactionHash;
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_infra::component_runner::{ComponentStartError, ComponentStarter};
 use starknet_mempool_types::communication::{MempoolWrapperInput, SharedMempoolClient};
-use starknet_mempool_types::mempool_types::{Account, AccountNonce, MempoolInput};
+use starknet_mempool_types::mempool_types::{AccountNonce, AccountState, MempoolInput};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use tracing::{error, info, instrument};
 
@@ -138,7 +138,7 @@ fn process_tx(
     // TODO(Arni): Add the Sierra and the Casm to the mempool input.
     Ok(MempoolInput {
         tx: executable_tx,
-        account: Account { sender_address, state: AccountNonce { nonce: account_nonce } },
+        account: AccountState { sender_address, state: AccountNonce { nonce: account_nonce } },
     })
 }
 

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -9,7 +9,7 @@ use starknet_api::executable_transaction::{InvokeTransaction, Transaction};
 use starknet_api::rpc_transaction::{RpcDeclareTransaction, RpcTransaction};
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_types::communication::{MempoolWrapperInput, MockMempoolClient};
-use starknet_mempool_types::mempool_types::{Account, AccountNonce, MempoolInput};
+use starknet_mempool_types::mempool_types::{AccountNonce, AccountState, MempoolInput};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 
 use crate::compilation::GatewayCompiler;
@@ -70,7 +70,10 @@ async fn test_add_tx() {
         .with(eq(MempoolWrapperInput {
             mempool_input: MempoolInput {
                 tx: executable_tx,
-                account: Account { sender_address, state: AccountNonce { nonce: *rpc_tx.nonce() } },
+                account: AccountState {
+                    sender_address,
+                    state: AccountNonce { nonce: *rpc_tx.nonce() },
+                },
             },
             message_metadata: None,
         }))

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -4,7 +4,7 @@ use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::transaction::{Tip, TransactionHash, ValidResourceBounds};
 use starknet_mempool_types::errors::MempoolError;
-use starknet_mempool_types::mempool_types::{Account, AccountNonce, MempoolInput, MempoolResult};
+use starknet_mempool_types::mempool_types::{AccountState, AccountNonce, MempoolInput, MempoolResult};
 
 use crate::transaction_pool::TransactionPool;
 use crate::transaction_queue::TransactionQueue;
@@ -78,7 +78,7 @@ impl Mempool {
     /// TODO: check Account nonce and balance.
     pub fn add_tx(&mut self, input: MempoolInput) -> MempoolResult<()> {
         self.validate_input(&input)?;
-        let MempoolInput { tx, account: Account { sender_address, state: AccountNonce { nonce } } } =
+        let MempoolInput { tx, account: AccountState { sender_address, state: AccountNonce { nonce } } } =
             input;
         self.tx_pool.insert(tx)?;
         self.align_to_account_state(sender_address, nonce);
@@ -156,7 +156,7 @@ impl Mempool {
 
     fn enqueue_next_eligible_txs(&mut self, txs: &[TransactionReference]) -> MempoolResult<()> {
         for tx in txs {
-            let current_account_state = Account {
+            let current_account_state = AccountState {
                 sender_address: tx.sender_address,
                 state: AccountNonce { nonce: tx.nonce },
             };

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -12,7 +12,7 @@ use starknet_api::test_utils::invoke::executable_invoke_tx;
 use starknet_api::transaction::{Tip, TransactionHash, ValidResourceBounds};
 use starknet_api::{contract_address, felt, invoke_tx_args, patricia_key};
 use starknet_mempool_types::errors::MempoolError;
-use starknet_mempool_types::mempool_types::{Account, AccountNonce};
+use starknet_mempool_types::mempool_types::{AccountNonce, AccountState};
 use starknet_types_core::felt::Felt;
 
 use crate::mempool::{AccountToNonce, Mempool, MempoolInput, TransactionReference};
@@ -191,7 +191,7 @@ macro_rules! add_tx_input {
         let tx = tx!(tip: $tip, tx_hash: $tx_hash, sender_address: $sender_address, tx_nonce: $tx_nonce, resource_bounds: $resource_bounds);
         let sender_address = contract_address!($sender_address);
         let account_nonce = Nonce(felt!($account_nonce));
-        let account = Account { sender_address, state: AccountNonce {nonce: account_nonce}};
+        let account = AccountState { sender_address, state: AccountNonce {nonce: account_nonce}};
 
         MempoolInput { tx, account }
     }};
@@ -876,7 +876,7 @@ fn test_account_nonce_does_not_decrease_in_add_tx() {
 fn test_account_nonces_update_in_commit_block() {
     // Setup.
     let input = add_tx_input!(tx_nonce: 2_u8, account_nonce: 0_u8);
-    let Account { sender_address, state: AccountNonce { nonce } } = input.account;
+    let AccountState { sender_address, state: AccountNonce { nonce } } = input.account;
     let pool_txs = [input.tx];
     let mut mempool = MempoolContentBuilder::new()
         .with_pool(pool_txs)
@@ -899,7 +899,8 @@ fn test_account_nonces_update_in_commit_block() {
 fn test_account_nonce_does_not_decrease_in_commit_block() {
     // Setup.
     let input_account_nonce_2 = add_tx_input!(tx_nonce: 3_u8, account_nonce: 2_u8);
-    let Account { sender_address, state: AccountNonce { nonce } } = input_account_nonce_2.account;
+    let AccountState { sender_address, state: AccountNonce { nonce } } =
+        input_account_nonce_2.account;
     let account_nonces = [(sender_address, nonce)];
     let pool_txs = [input_account_nonce_2.tx];
     let mut mempool = MempoolContentBuilder::new()

--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -4,7 +4,7 @@ use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_mempool_types::errors::MempoolError;
-use starknet_mempool_types::mempool_types::{Account, AccountNonce, MempoolResult};
+use starknet_mempool_types::mempool_types::{AccountState, AccountNonce, MempoolResult};
 
 use crate::mempool::TransactionReference;
 
@@ -97,9 +97,9 @@ impl TransactionPool {
 
     pub fn get_next_eligible_tx(
         &self,
-        current_account_state: Account,
+        current_account_state: AccountState,
     ) -> MempoolResult<Option<&TransactionReference>> {
-        let Account { sender_address, state: AccountNonce { nonce } } = current_account_state;
+        let AccountState { sender_address, state: AccountNonce { nonce } } = current_account_state;
         // TOOD(Ayelet): Change to StarknetApiError.
         let next_nonce = nonce.try_increment().map_err(|_| MempoolError::FeltOutOfRange)?;
         Ok(self.get_by_address_and_nonce(sender_address, next_nonce))

--- a/crates/mempool_types/src/mempool_types.rs
+++ b/crates/mempool_types/src/mempool_types.rs
@@ -11,7 +11,7 @@ pub struct AccountNonce {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct Account {
+pub struct AccountState {
     // TODO(Ayelet): Consider removing this field as it is duplicated in ThinTransaction.
     pub sender_address: ContractAddress,
     pub state: AccountNonce,
@@ -20,7 +20,7 @@ pub struct Account {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MempoolInput {
     pub tx: Transaction,
-    pub account: Account,
+    pub account: AccountState,
 }
 
 pub type MempoolResult<T> = Result<T, MempoolError>;


### PR DESCRIPTION
Part of a larger refactor.
Starting point:
Two separate structs:

- AccountState (contains a nonce field)
- Account (contains sender_address and AccountState)

Current state:
- AccountNonce (contains a nonce field)
- AccountState (contains sender_address and AccountState)

Target:
Merge into one struct, AccountState, containing two fields: sender_address and account_nonce.