### PR TITLE
refactor(mempool): merge AccountNonce into AccountState

### DIFF
--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -8,7 +8,7 @@ use starknet_api::transaction::TransactionHash;
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_infra::component_runner::{ComponentStartError, ComponentStarter};
 use starknet_mempool_types::communication::{MempoolWrapperInput, SharedMempoolClient};
-use starknet_mempool_types::mempool_types::{AccountNonce, AccountState, MempoolInput};
+use starknet_mempool_types::mempool_types::{AccountState, MempoolInput};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use tracing::{error, info, instrument};
 
@@ -128,18 +128,15 @@ fn process_tx(
 
     let mut validator = stateful_tx_validator.instantiate_validator(state_reader_factory)?;
     let sender_address = executable_tx.contract_address();
-    let account_nonce = validator.get_nonce(sender_address).map_err(|e| {
+    let nonce = validator.get_nonce(sender_address).map_err(|e| {
         error!("Failed to get nonce for sender address {}: {}", sender_address, e);
         GatewaySpecError::UnexpectedError { data: "Internal server error.".to_owned() }
     })?;
 
-    stateful_tx_validator.run_validate(&executable_tx, account_nonce, validator)?;
+    stateful_tx_validator.run_validate(&executable_tx, nonce, validator)?;
 
     // TODO(Arni): Add the Sierra and the Casm to the mempool input.
-    Ok(MempoolInput {
-        tx: executable_tx,
-        account: AccountState { sender_address, state: AccountNonce { nonce: account_nonce } },
-    })
+    Ok(MempoolInput { tx: executable_tx, account: AccountState { sender_address, nonce } })
 }
 
 pub fn create_gateway(

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -9,7 +9,7 @@ use starknet_api::executable_transaction::{InvokeTransaction, Transaction};
 use starknet_api::rpc_transaction::{RpcDeclareTransaction, RpcTransaction};
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_types::communication::{MempoolWrapperInput, MockMempoolClient};
-use starknet_mempool_types::mempool_types::{AccountNonce, AccountState, MempoolInput};
+use starknet_mempool_types::mempool_types::{AccountState, MempoolInput};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 
 use crate::compilation::GatewayCompiler;
@@ -70,10 +70,7 @@ async fn test_add_tx() {
         .with(eq(MempoolWrapperInput {
             mempool_input: MempoolInput {
                 tx: executable_tx,
-                account: AccountState {
-                    sender_address,
-                    state: AccountNonce { nonce: *rpc_tx.nonce() },
-                },
+                account: AccountState { sender_address, nonce: *rpc_tx.nonce() },
             },
             message_metadata: None,
         }))

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -83,10 +83,7 @@ impl Mempool {
     /// TODO: check Account nonce and balance.
     pub fn add_tx(&mut self, input: MempoolInput) -> MempoolResult<()> {
         self.validate_input(&input)?;
-        let MempoolInput {
-            tx,
-            account: AccountState { sender_address, state: AccountNonce { nonce } },
-        } = input;
+        let MempoolInput { tx, account: AccountState { sender_address, nonce } } = input;
         self.tx_pool.insert(tx)?;
         self.align_to_account_state(sender_address, nonce);
         Ok(())
@@ -133,7 +130,7 @@ impl Mempool {
         // Stateless checks.
 
         // Check the input: transaction nonce against given account state.
-        let account_nonce = input.account.state.nonce;
+        let account_nonce = input.account.nonce;
         if account_nonce > tx_nonce {
             return Err(duplicate_nonce_error);
         }
@@ -163,10 +160,8 @@ impl Mempool {
 
     fn enqueue_next_eligible_txs(&mut self, txs: &[TransactionReference]) -> MempoolResult<()> {
         for tx in txs {
-            let current_account_state = AccountState {
-                sender_address: tx.sender_address,
-                state: AccountNonce { nonce: tx.nonce },
-            };
+            let current_account_state =
+                AccountState { sender_address: tx.sender_address, nonce: tx.nonce };
 
             if let Some(next_tx_reference) =
                 self.tx_pool.get_next_eligible_tx(current_account_state)?

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -209,7 +209,7 @@ macro_rules! add_tx_input {
         let tx = tx!(tip: $tip, tx_hash: $tx_hash, sender_address: $sender_address, tx_nonce: $tx_nonce, resource_bounds: $resource_bounds);
         let sender_address = contract_address!($sender_address);
         let account_nonce = Nonce(felt!($account_nonce));
-        let account = AccountState { sender_address, state: AccountNonce {nonce: account_nonce}};
+        let account = AccountState { sender_address, nonce: account_nonce};
 
         MempoolInput { tx, account }
     }};
@@ -561,10 +561,8 @@ fn test_add_tx_lower_than_queued_nonce() {
     let lower_nonce_input =
         add_tx_input!(tx_hash: 2, sender_address: "0x0", tx_nonce: 0_u8, account_nonce: 0_u8);
 
-    let MempoolInput {
-        tx: valid_input_tx,
-        account: AccountState { sender_address, state: AccountNonce { nonce } },
-    } = valid_input;
+    let MempoolInput { tx: valid_input_tx, account: AccountState { sender_address, nonce } } =
+        valid_input;
     let queue_txs = [TransactionReference::new(&valid_input_tx)];
     let account_nonces = [(sender_address, nonce)];
     let expected_mempool_content = MempoolContentBuilder::new()
@@ -879,9 +877,9 @@ fn test_account_nonces_update_in_add_tx(mut mempool: Mempool) {
     add_tx(&mut mempool, &input);
 
     // Assert.
-    let expected_mempool_content = MempoolContentBuilder::new()
-        .with_account_nonces([(input.account.sender_address, input.account.state.nonce)])
-        .build();
+    let AccountState { sender_address, nonce } = input.account;
+    let expected_mempool_content =
+        MempoolContentBuilder::new().with_account_nonces([(sender_address, nonce)]).build();
     expected_mempool_content.assert_eq_account_nonces(&mempool);
 }
 
@@ -907,7 +905,7 @@ fn test_account_nonce_does_not_decrease_in_add_tx() {
 fn test_account_nonces_update_in_commit_block() {
     // Setup.
     let input = add_tx_input!(tx_nonce: 2_u8, account_nonce: 0_u8);
-    let AccountState { sender_address, state: AccountNonce { nonce } } = input.account;
+    let AccountState { sender_address, nonce } = input.account;
     let pool_txs = [input.tx];
     let mut mempool = MempoolContentBuilder::new()
         .with_pool(pool_txs)
@@ -930,8 +928,7 @@ fn test_account_nonces_update_in_commit_block() {
 fn test_account_nonce_does_not_decrease_in_commit_block() {
     // Setup.
     let input_account_nonce_2 = add_tx_input!(tx_nonce: 3_u8, account_nonce: 2_u8);
-    let AccountState { sender_address, state: AccountNonce { nonce } } =
-        input_account_nonce_2.account;
+    let AccountState { sender_address, nonce } = input_account_nonce_2.account;
     let account_nonces = [(sender_address, nonce)];
     let pool_txs = [input_account_nonce_2.tx];
     let mut mempool = MempoolContentBuilder::new()

--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -4,7 +4,7 @@ use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_mempool_types::errors::MempoolError;
-use starknet_mempool_types::mempool_types::{AccountNonce, AccountState, MempoolResult};
+use starknet_mempool_types::mempool_types::{AccountState, MempoolResult};
 
 use crate::mempool::TransactionReference;
 
@@ -99,7 +99,7 @@ impl TransactionPool {
         &self,
         current_account_state: AccountState,
     ) -> MempoolResult<Option<&TransactionReference>> {
-        let AccountState { sender_address, state: AccountNonce { nonce } } = current_account_state;
+        let AccountState { sender_address, nonce } = current_account_state;
         // TOOD(Ayelet): Change to StarknetApiError.
         let next_nonce = nonce.try_increment().map_err(|_| MempoolError::FeltOutOfRange)?;
         Ok(self.get_by_address_and_nonce(sender_address, next_nonce))

--- a/crates/mempool_types/src/mempool_types.rs
+++ b/crates/mempool_types/src/mempool_types.rs
@@ -14,7 +14,7 @@ pub struct AccountNonce {
 pub struct AccountState {
     // TODO(Ayelet): Consider removing this field as it is duplicated in ThinTransaction.
     pub sender_address: ContractAddress,
-    pub state: AccountNonce,
+    pub nonce: Nonce,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Part of a larger refactor.
**Starting point:**
Two separate structs:

- AccountState (contains a nonce field)
- Account (contains sender_address and AccountState)

**Target:**
Merge into one struct, AccountState, containing two fields: sender_address and account_nonce.

**Current state:**
- AccountState (contains sender_address and nonce)
- AccountNonce (contains nonce)

_**Please start by reviewing the mempool_types.rs file first.**_

**Stack of PRs:**

1. refactor(mempool): rename account state to account nonce #957
2. refactor(mempool): rename account to account state #959 
3. refactor(mempool): merge AccountNonce into AccountState #963 **<-- you're here**
4. refactor(mempool): remove AccountNonce struct #965
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/963)
<!-- Reviewable:end -->
