### PR TITLE
refactor(mempool): remove AccountNonce struct

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -4,12 +4,7 @@ use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::transaction::{Tip, TransactionHash, ValidResourceBounds};
 use starknet_mempool_types::errors::MempoolError;
-use starknet_mempool_types::mempool_types::{
-    AccountNonce,
-    AccountState,
-    MempoolInput,
-    MempoolResult,
-};
+use starknet_mempool_types::mempool_types::{AccountState, MempoolInput, MempoolResult};
 
 use crate::transaction_pool::TransactionPool;
 use crate::transaction_queue::TransactionQueue;
@@ -27,8 +22,8 @@ pub struct Mempool {
     tx_pool: TransactionPool,
     // Transactions eligible for sequencing.
     tx_queue: TransactionQueue,
-    // Represents the current state of the mempool during block creation.
-    mempool_state: HashMap<ContractAddress, AccountNonce>,
+    // Represents the state of the mempool during block creation.
+    mempool_state: HashMap<ContractAddress, Nonce>,
     // The most recent account nonces received, for all account in the pool.
     account_nonces: AccountToNonce,
 }
@@ -71,8 +66,8 @@ impl Mempool {
         }
 
         // Update the mempool state with the given transactions' nonces.
-        for tx in &eligible_txs {
-            self.mempool_state.entry(tx.contract_address()).or_default().nonce = tx.nonce();
+        for tx_ref in &eligible_tx_references {
+            self.mempool_state.insert(tx_ref.sender_address, tx_ref.nonce);
         }
 
         Ok(eligible_txs)
@@ -97,9 +92,9 @@ impl Mempool {
     // block.
     pub fn commit_block(
         &mut self,
-        state_changes: HashMap<ContractAddress, AccountNonce>,
+        state_changes: HashMap<ContractAddress, Nonce>,
     ) -> MempoolResult<()> {
-        for (&address, AccountNonce { nonce }) in &state_changes {
+        for (&address, &nonce) in &state_changes {
             let next_nonce = nonce.try_increment().map_err(|_| MempoolError::FeltOutOfRange)?;
             self.align_to_account_state(address, next_nonce);
         }
@@ -138,9 +133,7 @@ impl Mempool {
         // Stateful checks.
 
         // Check nonce against mempool state.
-        if let Some(AccountNonce { nonce: mempool_state_nonce }) =
-            self.mempool_state.get(&sender_address)
-        {
+        if let Some(mempool_state_nonce) = self.mempool_state.get(&sender_address) {
             if mempool_state_nonce >= &tx_nonce {
                 return Err(duplicate_nonce_error);
             }

--- a/crates/mempool_types/src/mempool_types.rs
+++ b/crates/mempool_types/src/mempool_types.rs
@@ -5,12 +5,6 @@ use starknet_api::executable_transaction::Transaction;
 use crate::errors::MempoolError;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct AccountNonce {
-    pub nonce: Nonce,
-    // TODO: add balance field when needed.
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct AccountState {
     // TODO(Ayelet): Consider removing this field as it is duplicated in ThinTransaction.
     pub sender_address: ContractAddress,


### PR DESCRIPTION
Part of a larger refactor.
**Starting point:**
Two separate structs:

- AccountState (contains a nonce field)
- Account (contains sender_address and AccountState)

**Target:**
Merge into one struct, AccountState, containing two fields: sender_address and account_nonce.

**Current state:**
- AccountState (contains sender_address and nonce)

_**Please start by reviewing the mempool_types.rs file first.**_

**Stack of PRs:**

1. refactor(mempool): rename account state to account nonce #957
2. refactor(mempool): rename account to account state #959 
3. refactor(mempool): merge AccountNonce into AccountState #963 
4. refactor(mempool): remove AccountNonce struct #965 **<-- you're here**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/965)
<!-- Reviewable:end -->
