### PR TITLE
fix(tests-integration): disallow nonce=0 invokes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5982,6 +5982,7 @@ name = "mempool_test_utils"
 version = "0.0.0"
 dependencies = [
  "blockifier",
+ "pretty_assertions",
  "serde_json",
  "starknet-types-core",
  "starknet_api",

--- a/crates/mempool_test_utils/Cargo.toml
+++ b/crates/mempool_test_utils/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 blockifier = { workspace = true, features = ["testing"] }
+pretty_assertions.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -8,6 +8,7 @@ use std::sync::OnceLock;
 
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::{create_trivial_calldata, CairoVersion};
+use pretty_assertions::{assert_eq, assert_ne};
 use serde_json::to_string_pretty;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::data_availability::DataAvailabilityMode;
@@ -286,10 +287,17 @@ pub struct AccountTransactionGenerator {
 impl AccountTransactionGenerator {
     /// Generate a valid `RpcTransaction` with default parameters.
     pub fn generate_default_invoke(&mut self) -> RpcTransaction {
+        let nonce = self.next_nonce();
+        assert_ne!(
+            nonce,
+            Nonce(Felt::ZERO),
+            "Only deploy account can nonce 0; to override use the raw invoke tx generator"
+        );
+
         let invoke_args = invoke_tx_args!(
             sender_address: self.sender_address(),
             resource_bounds: test_resource_bounds_mapping(),
-            nonce: self.next_nonce(),
+            nonce,
             calldata: create_trivial_calldata(self.test_contract_address()),
         );
         rpc_invoke_tx(invoke_args)

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -26,7 +26,6 @@ async fn test_end_to_end() {
 
     mock_running_system.assert_add_tx_success(&account0_invoke_nonce1).await;
 
-    // FIXME: invoke with nonce0 shouldn't be possible, fix it, make this FAIL.
     let account1_invoke_nonce0_tx_hash =
         mock_running_system.assert_add_tx_success(&account1_invoke_nonce0).await;
 


### PR DESCRIPTION
Only `DeployAccount` should have nonce=0.
Test is disabled anyway, but would have failed now if it weren't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1004)
<!-- Reviewable:end -->
