### PR TITLE
fix(tests-integration): disallow nonce=0 invokes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5983,6 +5983,7 @@ version = "0.0.0"
 dependencies = [
  "assert_matches",
  "blockifier",
+ "pretty_assertions",
  "serde_json",
  "starknet-types-core",
  "starknet_api",

--- a/crates/mempool_test_utils/Cargo.toml
+++ b/crates/mempool_test_utils/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [dependencies]
 assert_matches.workspace = true
 blockifier = { workspace = true, features = ["testing"] }
+pretty_assertions.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -26,7 +26,6 @@ async fn test_end_to_end() {
 
     mock_running_system.assert_add_tx_success(&account0_invoke_nonce1).await;
 
-    // FIXME: invoke with nonce0 shouldn't be possible, fix it, make this FAIL.
     let account1_invoke_nonce0_tx_hash =
         mock_running_system.assert_add_tx_success(&account1_invoke_nonce0).await;
 


### PR DESCRIPTION
Only `DeployAccount` txs should have nonce=0.
Test is disabled anyway, but would have failed now if it weren't.

One can use generate_raw if they want to create a faulty tx with nonce=0, but in typical usage with default constructors this situation shouldn't happen, and is a bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1008)
<!-- Reviewable:end -->
