### PR TITLE
feat: add state to FeatureContract via wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5981,6 +5981,7 @@ dependencies = [
 name = "mempool_test_utils"
 version = "0.0.0"
 dependencies = [
+ "assert_matches",
  "blockifier",
  "serde_json",
  "starknet-types-core",

--- a/crates/mempool_test_utils/Cargo.toml
+++ b/crates/mempool_test_utils/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [features]
 
 [dependencies]
+assert_matches.workspace = true
 blockifier = { workspace = true, features = ["testing"] }
 serde_json.workspace = true
 starknet-types-core.workspace = true


### PR DESCRIPTION
Account variants need to keep track of their own address, so that future txs can use that address to generate new txs.

Currently unused, will replace `FeatureContract` in all tests-integration usages, instead of current usage of `get_instance_address`, which generates incorrect addresses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1010)
<!-- Reviewable:end -->
