### PR TITLE
refactor(tests-integration): refactor state reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9940,7 +9940,6 @@ dependencies = [
  "starknet_mempool_types",
  "starknet_task_executor",
  "strum 0.25.0",
- "tempfile",
  "tokio",
 ]
 

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -17,7 +17,7 @@ itertools.workspace = true
 mempool_test_utils.workspace = true
 papyrus_common.workspace = true
 papyrus_rpc.workspace = true
-papyrus_storage.workspace = true
+papyrus_storage = { workspace = true, features = ["testing"] }
 reqwest.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true
@@ -31,7 +31,6 @@ starknet_mempool_node.workspace = true
 starknet_mempool_types.workspace = true
 starknet_task_executor.workspace = true
 strum.workspace = true
-tempfile.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Changes:
- use papyrus test util to create storage
- hoist cairo0 var definition away from the storage stuff

style:
- use annotation instead of fish in the cairo0 var
- deref coercion over `as_slice`, more succinct

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1014)
<!-- Reviewable:end -->
