### PR TITLE
chore(mempool_infra): use generics for component server starter

### DIFF
--- a/crates/mempool_infra/src/component_server/definitions.rs
+++ b/crates/mempool_infra/src/component_server/definitions.rs
@@ -1,16 +1,9 @@
 use std::any::type_name;
 
-use async_trait::async_trait;
 use tokio::sync::mpsc::Receiver;
 use tracing::info;
 
 use crate::component_definitions::{ComponentRequestAndResponseSender, ComponentRequestHandler};
-use crate::errors::ComponentServerError;
-
-#[async_trait]
-pub trait ComponentServerStarter: Send + Sync {
-    async fn start(&mut self) -> Result<(), ComponentServerError>;
-}
 
 pub async fn request_response_loop<Request, Response, Component>(
     rx: &mut Receiver<ComponentRequestAndResponseSender<Request, Response>>,

--- a/crates/mempool_infra/src/component_server/empty_component_server.rs
+++ b/crates/mempool_infra/src/component_server/empty_component_server.rs
@@ -3,7 +3,6 @@ use std::any::type_name;
 use async_trait::async_trait;
 use tracing::info;
 
-use super::definitions::ComponentServerStarter;
 use crate::errors::{ComponentError, ComponentServerError};
 use crate::starters::Startable;
 
@@ -18,7 +17,7 @@ impl<Component: Send + Sync> EmptyServer<Component> {
 }
 
 #[async_trait]
-impl<Component: Startable<ComponentError> + Send + Sync> ComponentServerStarter
+impl<Component: Startable<ComponentError> + Send + Sync> Startable<ComponentServerError>
     for EmptyServer<Component>
 {
     async fn start(&mut self) -> Result<(), ComponentServerError> {

--- a/crates/mempool_infra/src/component_server/local_component_server.rs
+++ b/crates/mempool_infra/src/component_server/local_component_server.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use tokio::sync::mpsc::Receiver;
 use tracing::error;
 
-use super::definitions::{request_response_loop, ComponentServerStarter};
+use super::definitions::request_response_loop;
 use crate::component_definitions::{ComponentRequestAndResponseSender, ComponentRequestHandler};
 use crate::errors::{ComponentError, ComponentServerError};
 use crate::starters::Startable;
@@ -37,18 +37,15 @@ use crate::starters::Startable;
 /// use std::sync::mpsc::{channel, Receiver};
 ///
 /// use async_trait::async_trait;
-/// use starknet_mempool_infra::errors::ComponentError;
-/// use starknet_mempool_infra::starters::DefaultComponentStarter;
+/// use starknet_mempool_infra::errors::{ComponentError, ComponentServerError};
+/// use starknet_mempool_infra::starters::{DefaultComponentStarter, Startable};
 /// use tokio::task;
 ///
 /// use crate::starknet_mempool_infra::component_definitions::{
 ///     ComponentRequestAndResponseSender,
 ///     ComponentRequestHandler,
 /// };
-/// use crate::starknet_mempool_infra::component_server::{
-///     ComponentServerStarter,
-///     LocalComponentServer,
-/// };
+/// use crate::starknet_mempool_infra::component_server::LocalComponentServer;
 ///
 /// // Define your component
 /// struct MyComponent {}
@@ -111,7 +108,7 @@ pub type LocalComponentServer<Component, Request, Response> =
 pub struct BlockingLocalServerType {}
 
 #[async_trait]
-impl<Component, Request, Response> ComponentServerStarter
+impl<Component, Request, Response> Startable<ComponentServerError>
     for LocalComponentServer<Component, Request, Response>
 where
     Component: ComponentRequestHandler<Request, Response> + Send + Sync + Startable<ComponentError>,
@@ -130,7 +127,7 @@ pub type LocalActiveComponentServer<Component, Request, Response> =
 pub struct NonBlockingLocalServerType {}
 
 #[async_trait]
-impl<Component, Request, Response> ComponentServerStarter
+impl<Component, Request, Response> Startable<ComponentServerError>
     for LocalActiveComponentServer<Component, Request, Response>
 where
     Component: ComponentRequestHandler<Request, Response>

--- a/crates/mempool_infra/src/component_server/remote_component_server.rs
+++ b/crates/mempool_infra/src/component_server/remote_component_server.rs
@@ -10,11 +10,11 @@ use hyper::{Body, Request as HyperRequest, Response as HyperResponse, Server, St
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use super::definitions::ComponentServerStarter;
 use crate::component_client::{ClientError, LocalComponentClient};
 use crate::component_definitions::{ServerError, APPLICATION_OCTET_STREAM};
 use crate::errors::ComponentServerError;
 use crate::serde_utils::BincodeSerdeWrapper;
+use crate::starters::Startable;
 
 /// The `RemoteComponentServer` struct is a generic server that handles requests and responses for a
 /// specified component. It receives requests, processes them using the provided component, and
@@ -47,10 +47,8 @@ use crate::serde_utils::BincodeSerdeWrapper;
 ///
 /// use crate::starknet_mempool_infra::component_client::LocalComponentClient;
 /// use crate::starknet_mempool_infra::component_definitions::ComponentRequestHandler;
-/// use crate::starknet_mempool_infra::component_server::{
-///     ComponentServerStarter,
-///     RemoteComponentServer,
-/// };
+/// use crate::starknet_mempool_infra::component_server::RemoteComponentServer;
+/// use crate::starknet_mempool_infra::starters::Startable;
 ///
 /// // Define your component
 /// struct MyComponent {}
@@ -154,7 +152,7 @@ where
 }
 
 #[async_trait]
-impl<Request, Response> ComponentServerStarter for RemoteComponentServer<Request, Response>
+impl<Request, Response> Startable<ComponentServerError> for RemoteComponentServer<Request, Response>
 where
     Request: Serialize + DeserializeOwned + Send + Sync + Debug + 'static,
     Response: Serialize + DeserializeOwned + Send + Sync + Debug + 'static,

--- a/crates/mempool_infra/src/starters.rs
+++ b/crates/mempool_infra/src/starters.rs
@@ -13,12 +13,12 @@ pub trait Startable<StartError> {
 pub trait DefaultComponentStarter {}
 
 #[async_trait]
-impl<T: Send + Sync> Startable<ComponentError> for T
+impl<Component: Send + Sync> Startable<ComponentError> for Component
 where
-    T: DefaultComponentStarter,
+    Component: DefaultComponentStarter,
 {
     async fn start(&mut self) -> Result<(), ComponentError> {
-        info!("Starting component {}.", type_name::<T>());
+        info!("Starting component {}.", type_name::<Component>());
         Ok(())
     }
 }

--- a/crates/mempool_infra/tests/active_local_component_client_server_test.rs
+++ b/crates/mempool_infra/tests/active_local_component_client_server_test.rs
@@ -8,11 +8,7 @@ use starknet_mempool_infra::component_definitions::{
     ComponentRequestAndResponseSender,
     ComponentRequestHandler,
 };
-use starknet_mempool_infra::component_server::{
-    ComponentServerStarter,
-    EmptyServer,
-    LocalActiveComponentServer,
-};
+use starknet_mempool_infra::component_server::{EmptyServer, LocalActiveComponentServer};
 use starknet_mempool_infra::errors::ComponentError;
 use starknet_mempool_infra::starters::Startable;
 use tokio::sync::mpsc::{channel, Sender};

--- a/crates/mempool_infra/tests/local_component_client_server_test.rs
+++ b/crates/mempool_infra/tests/local_component_client_server_test.rs
@@ -16,7 +16,8 @@ use starknet_mempool_infra::component_definitions::{
     ComponentRequestAndResponseSender,
     ComponentRequestHandler,
 };
-use starknet_mempool_infra::component_server::{ComponentServerStarter, LocalComponentServer};
+use starknet_mempool_infra::component_server::LocalComponentServer;
+use starknet_mempool_infra::starters::Startable;
 use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::channel;
 use tokio::task;

--- a/crates/mempool_infra/tests/remote_component_client_server_test.rs
+++ b/crates/mempool_infra/tests/remote_component_client_server_test.rs
@@ -35,12 +35,9 @@ use starknet_mempool_infra::component_definitions::{
     ServerError,
     APPLICATION_OCTET_STREAM,
 };
-use starknet_mempool_infra::component_server::{
-    ComponentServerStarter,
-    LocalComponentServer,
-    RemoteComponentServer,
-};
+use starknet_mempool_infra::component_server::{LocalComponentServer, RemoteComponentServer};
 use starknet_mempool_infra::serde_utils::BincodeSerdeWrapper;
+use starknet_mempool_infra::starters::Startable;
 use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::channel;
 use tokio::sync::Mutex;

--- a/crates/mempool_node/src/servers.rs
+++ b/crates/mempool_node/src/servers.rs
@@ -10,8 +10,8 @@ use starknet_consensus_manager::communication::{
 use starknet_gateway::communication::{create_gateway_server, GatewayServer};
 use starknet_http_server::communication::{create_http_server, HttpServer};
 use starknet_mempool::communication::{create_mempool_server, MempoolServer};
-use starknet_mempool_infra::component_server::ComponentServerStarter;
 use starknet_mempool_infra::errors::ComponentServerError;
+use starknet_mempool_infra::starters::Startable;
 use tracing::error;
 
 use crate::communication::MempoolNodeCommunication;
@@ -144,7 +144,7 @@ pub async fn run_component_servers(
 pub fn get_server_future(
     name: &str,
     execute_flag: bool,
-    server: Option<Box<impl ComponentServerStarter + 'static>>,
+    server: Option<Box<impl Startable<ComponentServerError> + Send + 'static>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), ComponentServerError>> + Send>> {
     let server_future = match execute_flag {
         true => {


### PR DESCRIPTION
**Stack**:
- #1111
- #1110
- #1109
- #1103
- #1102
- #1101
- #1100
- #1099
- #1098
- #1097
- #1096
- #1090
- #1089
- #1088
- #1058
- #1057
- #1056
- #1027 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1027)
<!-- Reviewable:end -->
