### PR TITLE
fix: undo invoke_tx usage of transaction generator

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -170,14 +170,21 @@ pub fn declare_tx() -> RpcTransaction {
     ))
 }
 
-// Convenience method for generating a single invoke transaction with trivial fields.
-// For multiple, nonce-incrementing transactions, use the transaction generator directly.
+/// Convenience method for generating a single invoke transaction with trivial fields.
+/// For multiple, nonce-incrementing transactions under a single account address, use the
+/// transaction generator..
 pub fn invoke_tx(cairo_version: CairoVersion) -> RpcTransaction {
-    let default_account = FeatureContract::AccountWithoutValidations(cairo_version);
+    let test_contract = FeatureContract::TestContract(cairo_version);
+    let account_contract = FeatureContract::AccountWithoutValidations(cairo_version);
+    let sender_address = account_contract.get_instance_address(0);
+    let mut nonce_manager = NonceManager::default();
 
-    MultiAccountTransactionGenerator::new_for_account_contracts([default_account])
-        .account_with_id(0)
-        .generate_default_invoke()
+    rpc_invoke_tx(invoke_tx_args!(
+        resource_bounds: test_resource_bounds_mapping(),
+        nonce : nonce_manager.next(sender_address),
+        sender_address,
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0))
+    ))
 }
 
 pub fn executable_invoke_tx(cairo_version: CairoVersion) -> Transaction {


### PR DESCRIPTION
Revert Transaction Generator Changes in `invoke_tx` Function

This PR reverts changes made to the one-shot `invoke_tx` function in commit 09efafe449e23f8c5c8b0fbd240bce6d29e4190b.

Reason for Reversion:
The `invoke_tx` function is currently only used in `gateway_test`, which relies on a local state setup with a specific funding scheme. This scheme is incompatible with the `MultiAccountTransactionGenerator`.

Technical Details:
1. The current implementation in `gateway_test` depends on each transaction using a generated address through `FeatureContract`.
2. This address is specifically funded for each transaction.
3. The `MultiAccountTransactionGenerator` requires multiple transactions from the same account to have a consistent address.
4. The `FeatureContract` addressing system does not support this consistent addressing across multiple transactions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1029)
<!-- Reviewable:end -->
