### PR TITLE
fix(tests-integration): remove deploy from e2e

### DIFF
--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -14,15 +14,11 @@ async fn test_end_to_end() {
     ];
     let (mock_running_system, mut tx_generator) = setup_with_tx_generation(&accounts).await;
 
-    let account0_deploy_nonce0 = &tx_generator.account_with_id(0).generate_default_deploy_account();
     let account0_invoke_nonce1 = tx_generator.account_with_id(0).generate_default_invoke();
     let account1_invoke_nonce0 = tx_generator.account_with_id(1).generate_default_invoke();
     let account0_invoke_nonce2 = tx_generator.account_with_id(0).generate_default_invoke();
 
     // Test.
-
-    let account0_deploy_nonce0_tx_hash =
-        mock_running_system.assert_add_tx_success(account0_deploy_nonce0).await;
 
     mock_running_system.assert_add_tx_success(&account0_invoke_nonce1).await;
 
@@ -38,8 +34,7 @@ async fn test_end_to_end() {
 
     // Only the transactions with nonce 0 should be returned from the mempool,
     // because we haven't merged queue-replenishment yet.
-    let expected_tx_hashes_from_get_txs =
-        [account1_invoke_nonce0_tx_hash, account0_deploy_nonce0_tx_hash];
+    let expected_tx_hashes_from_get_txs = [account1_invoke_nonce0_tx_hash];
 
     // This assert should be replaced with 4 once queue-replenishment is merged, also add a tx hole
     // at that point, and ensure the assert doesn't change due to that.


### PR DESCRIPTION
Not supported yet, we need to be able to execute in batcher and close blocks before we can do anything interesting here.

Specifically, invokes won't pass the GW until an account is deployed, so until we can expicitely close blocks we can't use deploys and invokes inside the same test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1050)
<!-- Reviewable:end -->
