### PR TITLE
fix(tests-integration) use feature account

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::path::Path;
@@ -190,9 +189,9 @@ pub fn invoke_tx(cairo_version: CairoVersion) -> RpcTransaction {
 pub fn executable_invoke_tx(cairo_version: CairoVersion) -> Transaction {
     let default_account = FeatureContract::AccountWithoutValidations(cairo_version);
 
-    MultiAccountTransactionGenerator::new_for_account_contracts([default_account])
-        .account_with_id(0)
-        .generate_default_executable_invoke()
+    let mut tx_generator = MultiAccountTransactionGenerator::new();
+    tx_generator.register_account(default_account);
+    tx_generator.account_with_id(0).generate_default_executable_invoke()
 }
 
 pub fn generate_default_deploy_account_with_salt(
@@ -211,7 +210,6 @@ pub fn generate_default_deploy_account_with_salt(
 // TODO: when moving this to Starknet API crate, move this const into a module alongside
 // MultiAcconutTransactionGenerator.
 type AccountId = usize;
-type ContractInstanceId = u16;
 
 type SharedNonceManager = Rc<RefCell<NonceManager>>;
 
@@ -225,48 +223,50 @@ type SharedNonceManager = Rc<RefCell<NonceManager>>;
 /// # Example
 ///
 /// ```
+/// use blockifier::test_utils::contracts::FeatureContract;
+/// use blockifier::test_utils::CairoVersion;
 /// use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerator;
 ///
-/// let mut tx_generator = MultiAccountTransactionGenerator::new(2); // Initialize with 2 accounts.
+/// let mut tx_generator = MultiAccountTransactionGenerator::new();
+/// let some_account_type = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
+/// // Initialize multiple accounts, these can be any account type in `FeatureContract`.
+/// tx_generator.register_account_for_flow_test(some_account_type.clone());
+/// tx_generator.register_account_for_flow_test(some_account_type);
+///
 /// let account_0_tx_with_nonce_0 = tx_generator.account_with_id(0).generate_default_invoke();
 /// let account_1_tx_with_nonce_0 = tx_generator.account_with_id(1).generate_default_invoke();
 /// let account_0_tx_with_nonce_1 = tx_generator.account_with_id(0).generate_default_invoke();
 /// ```
 // Note: when moving this to starknet api crate, see if blockifier's
 // [blockifier::transaction::test_utils::FaultyAccountTxCreatorArgs] can be made to use this.
+#[derive(Default)]
 pub struct MultiAccountTransactionGenerator {
     // Invariant: coupled with the nonce manager.
     account_tx_generators: Vec<AccountTransactionGenerator>,
     // Invariant: nonces managed internally thorugh `generate` API of the account transaction
     // generator.
-    // Only used by single account transaction generators, but owning it here is preferable over
-    // only distributing the ownership among the account generators.
-    _nonce_manager: SharedNonceManager,
+    nonce_manager: SharedNonceManager,
 }
 
 impl MultiAccountTransactionGenerator {
-    pub fn new(n_accounts: usize) -> Self {
-        let default_account_contract =
-            FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
-        let accounts = std::iter::repeat(default_account_contract).take(n_accounts);
-        Self::new_for_account_contracts(accounts)
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    pub fn new_for_account_contracts(accounts: impl IntoIterator<Item = FeatureContract>) -> Self {
-        let mut account_tx_generators = vec![];
-        let mut account_type_to_n_instances = HashMap::new();
-        let nonce_manager = SharedNonceManager::default();
-        for account in accounts {
-            let n_current_contract = account_type_to_n_instances.entry(account).or_insert(0);
-            account_tx_generators.push(AccountTransactionGenerator {
-                account,
-                contract_instance_id: *n_current_contract,
-                nonce_manager: nonce_manager.clone(),
-            });
-            *n_current_contract += 1;
-        }
+    pub fn register_account(
+        &mut self,
+        account_contract: FeatureContract,
+    ) -> (FeatureAccount, RpcTransaction) {
+        let new_account_id = self.account_tx_generators.len();
+        let (account_tx_generator, default_deploy_account_tx) = AccountTransactionGenerator::new(
+            new_account_id,
+            account_contract,
+            self.nonce_manager.clone(),
+        );
+        self.account_tx_generators.push(account_tx_generator);
+        let account_tx_generator = self.account_with_id(new_account_id);
 
-        Self { account_tx_generators, _nonce_manager: nonce_manager }
+        (account_tx_generator.account.clone(), default_deploy_account_tx)
     }
 
     pub fn account_with_id(&mut self, account_id: AccountId) -> &mut AccountTransactionGenerator {
@@ -277,6 +277,16 @@ impl MultiAccountTransactionGenerator {
             )
         })
     }
+
+    // TODO(deploy_account_support): once we support deploy account in tests, remove this method and
+    // only use new_account_default in tests. In particular, deploy account txs must be then sent to
+    // the GW via the add tx endpoint just like other txs.
+    pub fn register_account_for_flow_test(
+        &mut self,
+        account_contract: FeatureContract,
+    ) -> FeatureAccount {
+        self.register_account(account_contract).0
+    }
 }
 
 /// Manages transaction generation for a single account.
@@ -286,9 +296,9 @@ impl MultiAccountTransactionGenerator {
 /// with room for future extensions.
 ///
 /// TODO: add more transaction generation methods as needed.
+#[derive(Debug)]
 pub struct AccountTransactionGenerator {
-    account: FeatureContract,
-    contract_instance_id: ContractInstanceId,
+    account: FeatureAccount,
     nonce_manager: SharedNonceManager,
 }
 
@@ -299,7 +309,7 @@ impl AccountTransactionGenerator {
             sender_address: self.sender_address(),
             resource_bounds: test_resource_bounds_mapping(),
             nonce: self.next_nonce(),
-            calldata: create_trivial_calldata(self.test_contract_address()),
+            calldata: create_trivial_calldata(self.sender_address()),
         );
         rpc_invoke_tx(invoke_args)
     }
@@ -309,16 +319,10 @@ impl AccountTransactionGenerator {
             sender_address: self.sender_address(),
             resource_bounds: test_valid_resource_bounds(),
             nonce: self.next_nonce(),
-            calldata: create_trivial_calldata(self.test_contract_address()),
+            calldata: create_trivial_calldata(self.sender_address()),
         );
 
         Transaction::Invoke(starknet_api::test_utils::invoke::executable_invoke_tx(invoke_args))
-    }
-
-    // TODO: support more contracts, instead of this hardcoded type.
-    pub fn test_contract_address(&mut self) -> ContractAddress {
-        let cairo_version = self.account.cairo_version();
-        FeatureContract::TestContract(cairo_version).get_instance_address(0)
     }
 
     /// Generates an `RpcTransaction` with fully custom parameters.
@@ -335,13 +339,35 @@ impl AccountTransactionGenerator {
     }
 
     pub fn sender_address(&mut self) -> ContractAddress {
-        self.account.get_instance_address(self.contract_instance_id)
+        self.account.sender_address
     }
 
     /// Retrieves the nonce for the current account, and __increments__ it internally.
     pub fn next_nonce(&mut self) -> Nonce {
         let sender_address = self.sender_address();
         self.nonce_manager.borrow_mut().next(sender_address)
+    }
+
+    /// Private constructor, since only the multi-account transaction generator should create this
+    /// struct.
+    // TODO: add a version that doesn't rely on the default deploy account constructor, but takes
+    // deploy account args.
+    fn new(
+        account_id: usize,
+        account: FeatureContract,
+        nonce_manager: SharedNonceManager,
+    ) -> (Self, RpcTransaction) {
+        let contract_address_salt = ContractAddressSalt(account_id.into());
+        // A DeployAccount tx must be created now in order to affix an address to it.
+        // If this doesn't happen now it'll be difficult to fund the account during test setup.
+        let default_deploy_account_tx =
+            generate_default_deploy_account(&account, contract_address_salt);
+
+        let tx_generator = Self {
+            account: FeatureAccount::new(account, &default_deploy_account_tx),
+            nonce_manager,
+        };
+        (tx_generator, default_deploy_account_tx)
     }
 }
 
@@ -361,7 +387,7 @@ impl FeatureAccount {
         self.account.get_class_hash()
     }
 
-    fn _new(account: FeatureContract, deploy_account_tx: &RpcTransaction) -> Self {
+    fn new(account: FeatureContract, deploy_account_tx: &RpcTransaction) -> Self {
         assert_matches!(
             deploy_account_tx,
             RpcTransaction::DeployAccount(_),

--- a/crates/starknet_api/src/test_utils.rs
+++ b/crates/starknet_api/src/test_utils.rs
@@ -11,7 +11,7 @@ pub mod declare;
 pub mod deploy_account;
 pub mod invoke;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct NonceManager {
     next_nonce: HashMap<ContractAddress, Felt>,
 }

--- a/crates/tests-integration/src/integration_test_setup.rs
+++ b/crates/tests-integration/src/integration_test_setup.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 
-use blockifier::test_utils::contracts::FeatureContract;
-use blockifier::test_utils::CairoVersion;
+use mempool_test_utils::starknet_api_test_utils::FeatureAccount;
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
@@ -29,21 +28,16 @@ pub struct IntegrationTestSetup {
 }
 
 impl IntegrationTestSetup {
-    pub async fn new(n_accounts: usize) -> Self {
-        let default_account_contract =
-            FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
-        let accounts = std::iter::repeat(default_account_contract).take(n_accounts);
-        Self::new_for_account_contracts(accounts).await
-    }
-
-    pub async fn new_for_account_contracts(
-        accounts: impl IntoIterator<Item = FeatureContract>,
-    ) -> Self {
+    pub async fn new_for_accounts(accounts: &[FeatureAccount]) -> Self {
         let handle = Handle::current();
         let task_executor = TokioExecutor::new(handle);
 
-        // Configure and start tracing
+        // Configure and start tracing.
         configure_tracing();
+
+        // FIXME: will be removed in a subsequent commit, which adds support for `FeatureAccount`
+        // to the state reader.
+        let accounts = accounts.iter().map(|account| account.account);
 
         // Spawn a papyrus rpc server for a papyrus storage reader.
         let rpc_server_addr = spawn_test_rpc_state_reader(accounts).await;

--- a/crates/tests-integration/src/integration_test_utils.rs
+++ b/crates/tests-integration/src/integration_test_utils.rs
@@ -1,11 +1,7 @@
 use std::net::SocketAddr;
 
 use axum::body::Body;
-use blockifier::test_utils::contracts::FeatureContract;
-use mempool_test_utils::starknet_api_test_utils::{
-    rpc_tx_to_json,
-    MultiAccountTransactionGenerator,
-};
+use mempool_test_utils::starknet_api_test_utils::rpc_tx_to_json;
 use reqwest::{Client, Response};
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
@@ -19,8 +15,6 @@ use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_http_server::config::HttpServerConfig;
 use starknet_mempool_node::config::MempoolNodeConfig;
 use tokio::net::TcpListener;
-
-use crate::integration_test_setup::IntegrationTestSetup;
 
 async fn create_gateway_config() -> GatewayConfig {
     let stateless_tx_validator_config = StatelessTransactionValidatorConfig {
@@ -112,16 +106,4 @@ pub async fn get_available_socket() -> SocketAddr {
         // Then, resolve to the actual selected port.
         .local_addr()
         .expect("Failed to get local address")
-}
-
-/// Use to create a tx generator with _pre-funded_ accounts, alongside a mocked test setup.
-pub async fn setup_with_tx_generation(
-    accounts: &[FeatureContract],
-) -> (IntegrationTestSetup, MultiAccountTransactionGenerator) {
-    let integration_test_setup =
-        IntegrationTestSetup::new_for_account_contracts(accounts.iter().copied()).await;
-    let tx_generator =
-        MultiAccountTransactionGenerator::new_for_account_contracts(accounts.iter().copied());
-
-    (integration_test_setup, tx_generator)
 }

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -1,28 +1,36 @@
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::CairoVersion;
+use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerator;
+use rstest::{fixture, rstest};
 use starknet_api::transaction::TransactionHash;
-use starknet_mempool_integration_tests::integration_test_utils::setup_with_tx_generation;
+use starknet_mempool_integration_tests::integration_test_setup::IntegrationTestSetup;
 
+#[fixture]
+fn tx_generator() -> MultiAccountTransactionGenerator {
+    MultiAccountTransactionGenerator::new()
+}
+
+#[rstest]
 #[ignore = "Gilad: There are structural issues with funding new accounts and this need surgery.
             Will fix soon. Once fixed, the test logic also need work, it's stale by now."]
 #[tokio::test]
-async fn test_end_to_end() {
+async fn test_end_to_end(mut tx_generator: MultiAccountTransactionGenerator) {
     // Setup.
-    let accounts = [
+    let accounts: Vec<_> = [
         FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1),
         FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0),
-    ];
-    let (mock_running_system, mut tx_generator) = setup_with_tx_generation(&accounts).await;
+    ]
+    .into_iter()
+    .map(|account| tx_generator.register_account_for_flow_test(account))
+    .collect();
 
-    let account0_deploy_nonce0 = &tx_generator.account_with_id(0).generate_default_deploy_account();
+    let mock_running_system = IntegrationTestSetup::new_for_accounts(&accounts).await;
+
     let account0_invoke_nonce1 = tx_generator.account_with_id(0).generate_default_invoke();
     let account1_invoke_nonce0 = tx_generator.account_with_id(1).generate_default_invoke();
     let account0_invoke_nonce2 = tx_generator.account_with_id(0).generate_default_invoke();
 
     // Test.
-
-    let account0_deploy_nonce0_tx_hash =
-        mock_running_system.assert_add_tx_success(account0_deploy_nonce0).await;
 
     mock_running_system.assert_add_tx_success(&account0_invoke_nonce1).await;
 
@@ -38,8 +46,7 @@ async fn test_end_to_end() {
 
     // Only the transactions with nonce 0 should be returned from the mempool,
     // because we haven't merged queue-replenishment yet.
-    let expected_tx_hashes_from_get_txs =
-        [account1_invoke_nonce0_tx_hash, account0_deploy_nonce0_tx_hash];
+    let expected_tx_hashes_from_get_txs = [account1_invoke_nonce0_tx_hash];
 
     // This assert should be replaced with 4 once queue-replenishment is merged, also add a tx hole
     // at that point, and ensure the assert doesn't change due to that.


### PR DESCRIPTION
Fix bug in tx generator where txs used `FeatureContract` mock addresses, rather than a consistent `sender_address` per deployed account, as derived from its deploy account tx.

Changes:
- Main part is in `starknet_api_test_utils.rs`, the rest is mostly getting things to compile, in particular, the code in end_to_end_test.rs and integration_test_setup.rs is disabled at the moment anyway.

There are two main changes (in `starknet_api_test_utils.rs`)
- Loading accounts to the generator must be done one at a time, this is for very-near-future-proofing for when we start supporting deploy account txs, where every account loaded to the tx generator will
 generate a deploy-account tx that has to accepted before invokes can
 pass validation.
 - Once accounts are loaded to the system, we use FeatureAccount instead of FeatureContract directly, which makes sure that every account is matched with exactly one sender_address, as determined by a unique deploy_account tx.