### PR TITLE
chore(mempool_node): add component replacer for servers

### DIFF
--- a/crates/mempool_infra/src/component_server/definitions.rs
+++ b/crates/mempool_infra/src/component_server/definitions.rs
@@ -1,5 +1,6 @@
 use std::any::type_name;
 
+use thiserror::Error;
 use tokio::sync::mpsc::Receiver;
 use tracing::info;
 
@@ -25,4 +26,14 @@ pub async fn request_response_loop<Request, Response, Component>(
 
         tx.send(res).await.expect("Response connection should be open.");
     }
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum ReplaceComponentError {
+    #[error("Internal error.")]
+    InternalError,
+}
+
+pub trait ComponentReplacer<Component> {
+    fn replace(&mut self, component: Component) -> Result<(), ReplaceComponentError>;
 }

--- a/crates/mempool_infra/src/component_server/empty_component_server.rs
+++ b/crates/mempool_infra/src/component_server/empty_component_server.rs
@@ -3,6 +3,7 @@ use std::any::type_name;
 use async_trait::async_trait;
 use tracing::info;
 
+use crate::component_server::{ComponentReplacer, ReplaceComponentError};
 use crate::errors::{ComponentError, ComponentServerError};
 use crate::starters::Startable;
 
@@ -28,4 +29,11 @@ impl<Component: Startable<ComponentError> + Send + Sync> Startable<ComponentServ
 
 pub fn create_empty_server<Component: Send + Sync>(component: Component) -> EmptyServer<Component> {
     EmptyServer::new(component)
+}
+
+impl<Component> ComponentReplacer<Component> for EmptyServer<Component> {
+    fn replace(&mut self, component: Component) -> Result<(), ReplaceComponentError> {
+        self.component = component;
+        Ok(())
+    }
 }

--- a/crates/mempool_infra/src/component_server/local_component_server.rs
+++ b/crates/mempool_infra/src/component_server/local_component_server.rs
@@ -6,6 +6,7 @@ use tracing::error;
 
 use super::definitions::request_response_loop;
 use crate::component_definitions::{ComponentRequestAndResponseSender, ComponentRequestHandler};
+use crate::component_server::{ComponentReplacer, ReplaceComponentError};
 use crate::errors::{ComponentError, ComponentServerError};
 use crate::starters::Startable;
 
@@ -179,5 +180,18 @@ where
         rx: Receiver<ComponentRequestAndResponseSender<Request, Response>>,
     ) -> Self {
         Self { component, rx, _local_server_type: PhantomData }
+    }
+}
+
+impl<Component, Request, Response, LocalServerType> ComponentReplacer<Component>
+    for BaseLocalComponentServer<Component, Request, Response, LocalServerType>
+where
+    Component: ComponentRequestHandler<Request, Response>,
+    Request: Send + Sync,
+    Response: Send + Sync,
+{
+    fn replace(&mut self, component: Component) -> Result<(), ReplaceComponentError> {
+        self.component = component;
+        Ok(())
     }
 }


### PR DESCRIPTION
**Stack**:
- #1111
- #1110
- #1109
- #1103
- #1102
- #1101
- #1100
- #1099
- #1098
- #1097
- #1096
- #1090
- #1089
- #1088
- #1058 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1058)
<!-- Reviewable:end -->
