### PR TITLE
fix(tests-integration): feature account in state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9942,7 +9942,6 @@ dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
  "indexmap 2.2.6",
- "itertools 0.12.1",
  "mempool_test_utils",
  "papyrus_common",
  "papyrus_rpc",

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -281,8 +281,8 @@ impl MultiAccountTransactionGenerator {
         self.register_account(account_contract);
     }
 
-    pub fn accounts(&self) -> Vec<&FeatureAccount> {
-        self.account_tx_generators.iter().map(|tx_gen| &tx_gen.account).collect()
+    pub fn accounts(&self) -> Vec<FeatureAccount> {
+        self.account_tx_generators.iter().map(|tx_gen| &tx_gen.account).copied().collect()
     }
 }
 
@@ -376,7 +376,7 @@ impl AccountTransactionGenerator {
 // Note: feature contracts have their own address generating method, but it a mocked address and is
 // not related to an actual deploy account transaction, which is the way real account addresses are
 // calculated.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct FeatureAccount {
     pub account: FeatureContract,
     pub sender_address: ContractAddress,
@@ -385,6 +385,10 @@ pub struct FeatureAccount {
 impl FeatureAccount {
     pub fn class_hash(&self) -> ClassHash {
         self.account.get_class_hash()
+    }
+
+    pub fn cairo_version(&self) -> CairoVersion {
+        self.account.cairo_version()
     }
 
     fn new(account: FeatureContract, deploy_account_tx: &RpcTransaction) -> Self {

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -13,7 +13,6 @@ axum.workspace = true
 blockifier.workspace = true
 cairo-lang-starknet-classes.workspace = true
 indexmap.workspace = true
-itertools.workspace = true
 mempool_test_utils.workspace = true
 papyrus_common.workspace = true
 papyrus_rpc.workspace = true

--- a/crates/tests-integration/src/integration_test_setup.rs
+++ b/crates/tests-integration/src/integration_test_setup.rs
@@ -35,12 +35,8 @@ impl IntegrationTestSetup {
         // Configure and start tracing.
         configure_tracing();
 
-        // FIXME: will be removed in a subsequent commit, which adds support for `FeatureAccount`
-        // to the state reader.
-        let accounts = tx_generator.accounts().into_iter().map(|account| account.account);
-
         // Spawn a papyrus rpc server for a papyrus storage reader.
-        let rpc_server_addr = spawn_test_rpc_state_reader(accounts).await;
+        let rpc_server_addr = spawn_test_rpc_state_reader(tx_generator.accounts()).await;
 
         // Derive the configuration for the mempool node.
         let config = create_config(rpc_server_addr).await;

--- a/crates/tests-integration/src/state_reader.rs
+++ b/crates/tests-integration/src/state_reader.rs
@@ -15,7 +15,7 @@ use blockifier::test_utils::{
 use blockifier::transaction::objects::FeeType;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use indexmap::{indexmap, IndexMap};
-use itertools::Itertools;
+use mempool_test_utils::starknet_api_test_utils::FeatureAccount;
 use papyrus_common::pending_classes::PendingClasses;
 use papyrus_rpc::{run_server, RpcConfig};
 use papyrus_storage::body::BodyStorageWriter;
@@ -53,46 +53,36 @@ type ContractClassesMap =
 /// Creates a papyrus storage reader and spawns a papyrus rpc server for it.
 /// Returns the address of the rpc server.
 /// A variable number of identical accounts and test contracts are initialized and funded.
-pub async fn spawn_test_rpc_state_reader(
-    accounts: impl IntoIterator<Item = FeatureContract>,
-) -> SocketAddr {
+pub async fn spawn_test_rpc_state_reader(accounts: Vec<FeatureAccount>) -> SocketAddr {
     let block_context = BlockContext::create_for_testing();
 
-    // Map feature contracts to their number of instances inside the account array.
-    let mut account_to_n_instances: IndexMap<FeatureContract, usize> =
-        IndexMap::from_iter(accounts.into_iter().counts());
-
-    // Add essential contracts to contract mapping, if not exist already.
-    // TODO: can this hard-coding be removed?
-    for contract in [
+    let accounts: Vec<FeatureAccount> = [
         FeatureContract::TestContract(CairoVersion::Cairo0),
         FeatureContract::TestContract(CairoVersion::Cairo1),
         FeatureContract::ERC20(CairoVersion::Cairo0),
-    ] {
-        *account_to_n_instances.entry(contract).or_default() += 1;
-    }
+    ]
+    .into_iter()
+    .map(|account| FeatureAccount { account, sender_address: account.get_instance_address(0) })
+    .chain(accounts)
+    .collect();
 
-    let storage_reader =
-        initialize_papyrus_test_state(block_context.chain_info(), account_to_n_instances);
+    let storage_reader = initialize_papyrus_test_state(block_context.chain_info(), accounts);
     run_papyrus_rpc_server(storage_reader).await
 }
 
 fn initialize_papyrus_test_state(
     chain_info: &ChainInfo,
-    contract_instances: IndexMap<FeatureContract, usize>,
+    accounts: Vec<FeatureAccount>,
 ) -> StorageReader {
-    let state_diff = prepare_state_diff(chain_info, &contract_instances);
+    let state_diff = prepare_state_diff(chain_info, &accounts);
 
     let (cairo0_contract_classes, cairo1_contract_classes) =
-        prepare_compiled_contract_classes(contract_instances.into_keys());
+        prepare_compiled_contract_classes(&accounts);
 
     write_state_to_papyrus_storage(state_diff, &cairo0_contract_classes, &cairo1_contract_classes)
 }
 
-fn prepare_state_diff(
-    chain_info: &ChainInfo,
-    contract_instances: &IndexMap<FeatureContract, usize>,
-) -> ThinStateDiff {
+fn prepare_state_diff(chain_info: &ChainInfo, accounts: &[FeatureAccount]) -> ThinStateDiff {
     let erc20 = FeatureContract::ERC20(CairoVersion::Cairo0);
     let erc20_class_hash = erc20.get_class_hash();
 
@@ -105,22 +95,18 @@ fn prepare_state_diff(
 
     let mut storage_diffs = IndexMap::new();
     let mut declared_classes = IndexMap::new();
-    for (contract, &n_instances) in contract_instances {
-        for instance in 0..n_instances {
-            // Declare and deploy the contracts
-            match contract.cairo_version() {
-                CairoVersion::Cairo0 => {
-                    deprecated_declared_classes.push(contract.get_class_hash());
-                }
-                CairoVersion::Cairo1 => {
-                    declared_classes.insert(contract.get_class_hash(), Default::default());
-                }
+    for account in accounts {
+        // Declare and deploy the contracts
+        match account.cairo_version() {
+            CairoVersion::Cairo0 => {
+                deprecated_declared_classes.push(account.class_hash());
             }
-            let instance = u16::try_from(instance).unwrap();
-            deployed_contracts
-                .insert(contract.get_instance_address(instance), contract.get_class_hash());
-            fund_feature_account_contract(&mut storage_diffs, contract, instance, chain_info);
+            CairoVersion::Cairo1 => {
+                declared_classes.insert(account.class_hash(), Default::default());
+            }
         }
+        deployed_contracts.insert(account.sender_address, account.class_hash());
+        fund_feature_account_contract(&mut storage_diffs, account, chain_info);
     }
 
     ThinStateDiff {
@@ -132,23 +118,21 @@ fn prepare_state_diff(
     }
 }
 
-fn prepare_compiled_contract_classes(
-    contract_instances: impl Iterator<Item = FeatureContract>,
-) -> ContractClassesMap {
+fn prepare_compiled_contract_classes(accounts: &[FeatureAccount]) -> ContractClassesMap {
     let mut cairo0_contract_classes = Vec::new();
     let mut cairo1_contract_classes = Vec::new();
-    for contract in contract_instances {
-        match contract.cairo_version() {
+    for account in accounts {
+        match account.cairo_version() {
             CairoVersion::Cairo0 => {
                 cairo0_contract_classes.push((
-                    contract.get_class_hash(),
-                    serde_json::from_str(&contract.get_raw_class()).unwrap(),
+                    account.class_hash(),
+                    serde_json::from_str(&account.account.get_raw_class()).unwrap(),
                 ));
             }
             CairoVersion::Cairo1 => {
                 cairo1_contract_classes.push((
-                    contract.get_class_hash(),
-                    serde_json::from_str(&contract.get_raw_class()).unwrap(),
+                    account.class_hash(),
+                    serde_json::from_str(&account.account.get_raw_class()).unwrap(),
                 ));
             }
         }
@@ -209,15 +193,14 @@ fn test_block_header(block_number: BlockNumber) -> BlockHeader {
 
 fn fund_feature_account_contract(
     storage_diffs: &mut IndexMap<ContractAddress, IndexMap<StorageKey, Felt>>,
-    contract: &FeatureContract,
-    instance: u16,
+    account: &FeatureAccount,
     chain_info: &ChainInfo,
 ) {
-    match contract {
+    match account.account {
         FeatureContract::AccountWithLongValidate(_)
         | FeatureContract::AccountWithoutValidations(_)
         | FeatureContract::FaultyAccount(_) => {
-            fund_account(storage_diffs, &contract.get_instance_address(instance), chain_info);
+            fund_account(storage_diffs, &account.sender_address, chain_info);
         }
         _ => (),
     }


### PR DESCRIPTION
Use `FeatureAccount` in the flow test state reader. This fixes the longstanding bug of relying on
`FeatureContract::get_instance_address`, which generates mocked addresses for accounts, rather than ones derived from deploy account txs, which is how addresses are determined in Feature Acconuts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1061)
<!-- Reviewable:end -->
