### PR TITLE
chore(mempool_node): remove unused errors

### DIFF
--- a/crates/mempool_infra/src/errors.rs
+++ b/crates/mempool_infra/src/errors.rs
@@ -6,18 +6,14 @@ pub enum ComponentError {
     ComponentConfigError,
     #[error("An internal component error.")]
     InternalComponentError,
-    #[error("Component has already been started.")]
-    AlreadyStarted,
 }
 
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum ComponentServerError {
-    #[error("Server has already been started.")]
-    AlreadyStarted,
-    #[error("Http server has failed: {0}.")]
-    HttpServerStartError(String),
     #[error(transparent)]
     ComponentError(#[from] ComponentError),
+    #[error("Http server has failed: {0}.")]
+    HttpServerStartError(String),
     #[error("Server unexpectedly stopped.")]
     ServerUnexpectedlyStopped,
 }


### PR DESCRIPTION
**Stack**:
- #1111
- #1110
- #1109
- #1103
- #1102
- #1101
- #1100
- #1099
- #1098
- #1097
- #1096
- #1090
- #1089
- #1088 ⬅
- #1058


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*