### PR TITLE
refactor(mempool_test_utils): rename constructor

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -377,8 +377,10 @@ impl AccountTransactionGenerator {
         let default_deploy_account_tx =
             generate_deploy_account_with_salt(&account, contract_address_salt);
 
-        let mut account_tx_generator =
-            Self { account: Contract::new(account, &default_deploy_account_tx), nonce_manager };
+        let mut account_tx_generator = Self {
+            account: Contract::new_for_account(account, &default_deploy_account_tx),
+            nonce_manager,
+        };
         // Bump the account nonce after transaction creation.
         account_tx_generator.next_nonce();
 
@@ -410,7 +412,7 @@ impl Contract {
         self.contract.get_raw_class()
     }
 
-    fn new(account: FeatureContract, deploy_account_tx: &RpcTransaction) -> Self {
+    fn new_for_account(account: FeatureContract, deploy_account_tx: &RpcTransaction) -> Self {
         assert_matches!(
             deploy_account_tx,
             RpcTransaction::DeployAccount(_),


### PR DESCRIPTION
This constructor name hints better that its only useful for accounts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1123)
<!-- Reviewable:end -->
