### PR TITLE
chore: add build file to mempool_node to allow usage of starknet_sierra_compile crate

### DIFF
--- a/crates/mempool_node/build.rs
+++ b/crates/mempool_node/build.rs
@@ -1,0 +1,3 @@
+// Sets up the environment variable OUT_DIR, which holds the cairo compiler binary.
+// The binary is dowloaded to OUT_DIR by the starknet_sierra_compile crate.
+fn main() {}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1126)
<!-- Reviewable:end -->
