### PR TITLE
fix(mempool_node): don't drop component clients when running servers

### DIFF
--- a/crates/mempool_node/src/main.rs
+++ b/crates/mempool_node/src/main.rs
@@ -24,7 +24,8 @@ async fn main() -> anyhow::Result<()> {
         exit(1);
     }
 
-    let (_, servers) = create_node_modules(&config);
+    // Clients are currently unused, but should not be dropped.
+    let (_clients, servers) = create_node_modules(&config);
 
     info!("Starting components!");
     run_component_servers(&config, servers).await?;

--- a/crates/mempool_node/src/servers.rs
+++ b/crates/mempool_node/src/servers.rs
@@ -168,15 +168,9 @@ pub fn get_server_future(
     execute_flag: bool,
     server: Option<Box<impl ComponentServerStarter + Send + 'static>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), ComponentServerError>> + Send>> {
-    let server_future = match execute_flag {
-        true => {
-            let mut server = match server {
-                Some(server) => server,
-                _ => panic!("{} component is not initialized.", name),
-            };
-            async move { server.start().await }.boxed()
-        }
-        false => pending().boxed(),
-    };
-    server_future
+    if !execute_flag {
+        return pending().boxed();
+    }
+    let mut server = server.unwrap_or_else(|| panic!("{} component is not initialized.", name));
+    async move { server.start().await }.boxed()
 }


### PR DESCRIPTION
Also minor refactor of get_server_future

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1141)
<!-- Reviewable:end -->
