### PR TITLE
refactor(mempool): rename MempoolInput to AddTransactionArgs

### DIFF
--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -6,8 +6,8 @@ use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_infra::component_definitions::ComponentStarter;
-use starknet_mempool_types::communication::{MempoolWrapperInput, SharedMempoolClient};
-use starknet_mempool_types::mempool_types::{AccountState, MempoolInput};
+use starknet_mempool_types::communication::{AddTransactionArgsWrapper, SharedMempoolClient};
+use starknet_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use tracing::{error, instrument};
 
@@ -74,7 +74,7 @@ async fn internal_add_tx(
     app_state: AppState,
     tx: RpcTransaction,
 ) -> GatewayResult<TransactionHash> {
-    let mempool_input = tokio::task::spawn_blocking(move || {
+    let add_tx_args = tokio::task::spawn_blocking(move || {
         process_tx(
             app_state.stateless_tx_validator,
             app_state.stateful_tx_validator.as_ref(),
@@ -89,10 +89,10 @@ async fn internal_add_tx(
         GatewaySpecError::UnexpectedError { data: "Internal server error".to_owned() }
     })??;
 
-    let tx_hash = mempool_input.tx.tx_hash();
+    let tx_hash = add_tx_args.tx.tx_hash();
 
-    let mempool_wrapper_input = MempoolWrapperInput { mempool_input, message_metadata: None };
-    app_state.mempool_client.add_tx(mempool_wrapper_input).await.map_err(|e| {
+    let add_tx_args = AddTransactionArgsWrapper { args: add_tx_args, p2p_message_metadata: None };
+    app_state.mempool_client.add_tx(add_tx_args).await.map_err(|e| {
         error!("Failed to send tx to mempool: {}", e);
         GatewaySpecError::UnexpectedError { data: "Internal server error".to_owned() }
     })?;
@@ -106,7 +106,7 @@ fn process_tx(
     state_reader_factory: &dyn StateReaderFactory,
     gateway_compiler: GatewayCompiler,
     tx: RpcTransaction,
-) -> GatewayResult<MempoolInput> {
+) -> GatewayResult<AddTransactionArgs> {
     // TODO(Arni, 1/5/2024): Perform congestion control.
 
     // Perform stateless validations.
@@ -135,7 +135,7 @@ fn process_tx(
     stateful_tx_validator.run_validate(&executable_tx, nonce, validator)?;
 
     // TODO(Arni): Add the Sierra and the Casm to the mempool input.
-    Ok(MempoolInput { tx: executable_tx, account_state: AccountState { address, nonce } })
+    Ok(AddTransactionArgs { tx: executable_tx, account_state: AccountState { address, nonce } })
 }
 
 pub fn create_gateway(

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -8,8 +8,8 @@ use starknet_api::core::{ChainId, CompiledClassHash, ContractAddress};
 use starknet_api::executable_transaction::{InvokeTransaction, Transaction};
 use starknet_api::rpc_transaction::{RpcDeclareTransaction, RpcTransaction};
 use starknet_gateway_types::errors::GatewaySpecError;
-use starknet_mempool_types::communication::{MempoolWrapperInput, MockMempoolClient};
-use starknet_mempool_types::mempool_types::{AccountState, MempoolInput};
+use starknet_mempool_types::communication::{AddTransactionArgsWrapper, MockMempoolClient};
+use starknet_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 
 use crate::compilation::GatewayCompiler;
@@ -64,16 +64,14 @@ async fn test_add_tx() {
     let tx_hash = executable_tx.tx_hash();
 
     let mut mock_mempool_client = MockMempoolClient::new();
+    let add_tx_args = AddTransactionArgs {
+        tx: executable_tx,
+        account_state: AccountState { address, nonce: *rpc_tx.nonce() },
+    };
     mock_mempool_client
         .expect_add_tx()
         .once()
-        .with(eq(MempoolWrapperInput {
-            mempool_input: MempoolInput {
-                tx: executable_tx,
-                account_state: AccountState { address, nonce: *rpc_tx.nonce() },
-            },
-            message_metadata: None,
-        }))
+        .with(eq(AddTransactionArgsWrapper { args: add_tx_args, p2p_message_metadata: None }))
         .return_once(|_| Ok(()));
     let state_reader_factory = local_test_state_reader_factory(CairoVersion::Cairo1, false);
     let app_state = app_state(Arc::new(mock_mempool_client), state_reader_factory);

--- a/crates/mempool/src/communication.rs
+++ b/crates/mempool/src/communication.rs
@@ -3,10 +3,10 @@ use starknet_api::executable_transaction::Transaction;
 use starknet_mempool_infra::component_definitions::{ComponentRequestHandler, ComponentStarter};
 use starknet_mempool_infra::component_server::LocalComponentServer;
 use starknet_mempool_types::communication::{
+    AddTransactionArgsWrapper,
     MempoolRequest,
     MempoolRequestAndResponseSender,
     MempoolResponse,
-    MempoolWrapperInput,
 };
 use starknet_mempool_types::mempool_types::{CommitBlockArgs, MempoolResult};
 use tokio::sync::mpsc::Receiver;
@@ -34,8 +34,8 @@ impl MempoolCommunicationWrapper {
         MempoolCommunicationWrapper { mempool }
     }
 
-    fn add_tx(&mut self, mempool_wrapper_input: MempoolWrapperInput) -> MempoolResult<()> {
-        self.mempool.add_tx(mempool_wrapper_input.mempool_input)
+    fn add_tx(&mut self, args_wrapper: AddTransactionArgsWrapper) -> MempoolResult<()> {
+        self.mempool.add_tx(args_wrapper.args)
     }
 
     fn commit_block(&mut self, args: CommitBlockArgs) -> MempoolResult<()> {
@@ -51,8 +51,8 @@ impl MempoolCommunicationWrapper {
 impl ComponentRequestHandler<MempoolRequest, MempoolResponse> for MempoolCommunicationWrapper {
     async fn handle_request(&mut self, request: MempoolRequest) -> MempoolResponse {
         match request {
-            MempoolRequest::AddTransaction(mempool_wrapper_input) => {
-                MempoolResponse::AddTransaction(self.add_tx(mempool_wrapper_input))
+            MempoolRequest::AddTransaction(args) => {
+                MempoolResponse::AddTransaction(self.add_tx(args))
             }
             MempoolRequest::CommitBlock(args) => {
                 MempoolResponse::CommitBlock(self.commit_block(args))

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -14,7 +14,7 @@ use starknet_api::{contract_address, felt, invoke_tx_args, nonce, patricia_key};
 use starknet_mempool_types::errors::MempoolError;
 use starknet_mempool_types::mempool_types::{AccountState, CommitBlockArgs};
 
-use crate::mempool::{AccountToNonce, Mempool, MempoolInput, TransactionReference};
+use crate::mempool::{AccountToNonce, AddTransactionArgs, Mempool, TransactionReference};
 use crate::transaction_pool::TransactionPool;
 use crate::transaction_queue::transaction_queue_test_utils::{
     TransactionQueueContent,
@@ -154,12 +154,16 @@ impl FromIterator<TransactionReference> for TransactionQueue {
 }
 
 #[track_caller]
-fn add_tx(mempool: &mut Mempool, input: &MempoolInput) {
+fn add_tx(mempool: &mut Mempool, input: &AddTransactionArgs) {
     assert_eq!(mempool.add_tx(input.clone()), Ok(()));
 }
 
 #[track_caller]
-fn add_tx_expect_error(mempool: &mut Mempool, input: &MempoolInput, expected_error: MempoolError) {
+fn add_tx_expect_error(
+    mempool: &mut Mempool,
+    input: &AddTransactionArgs,
+    expected_error: MempoolError,
+) {
     assert_eq!(mempool.add_tx(input.clone()), Err(expected_error));
 }
 
@@ -219,7 +223,7 @@ macro_rules! add_tx_input {
         let account_nonce = nonce!($account_nonce);
         let account_state = AccountState { address, nonce: account_nonce};
 
-        MempoolInput { tx, account_state }
+        AddTransactionArgs { tx, account_state }
     }};
     (tip: $tip:expr, tx_hash: $tx_hash:expr, sender_address: $sender_address:expr,
         tx_nonce: $tx_nonce:expr, account_nonce: $account_nonce:expr) => {{
@@ -516,7 +520,7 @@ fn test_add_tx_lower_than_queued_nonce() {
     let lower_nonce_input =
         add_tx_input!(tx_hash: 2, sender_address: "0x0", tx_nonce: 0, account_nonce: 0);
 
-    let MempoolInput { tx: valid_input_tx, .. } = valid_input;
+    let AddTransactionArgs { tx: valid_input_tx, .. } = valid_input;
     let queue_txs = [TransactionReference::new(&valid_input_tx)];
     let pool_txs = [valid_input_tx];
     let account_nonces = [("0x0", 1)];

--- a/crates/mempool_types/src/mempool_types.rs
+++ b/crates/mempool_types/src/mempool_types.rs
@@ -14,7 +14,7 @@ pub struct AccountState {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct MempoolInput {
+pub struct AddTransactionArgs {
     pub tx: Transaction,
     pub account_state: AccountState,
 }


### PR DESCRIPTION
For consistency with CommitBlockArgs;
MempoolInput is a stale name (was given back when it was the single input to the mempool).

This PR is a rename only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1147)
<!-- Reviewable:end -->
