### PR TITLE
fix(tests-integration): copy gateway storage

### DIFF
--- a/crates/tests-integration/src/integration_test_utils.rs
+++ b/crates/tests-integration/src/integration_test_utils.rs
@@ -1,10 +1,14 @@
 use std::net::SocketAddr;
+use std::path::Path;
 
 use axum::body::Body;
 use mempool_test_utils::starknet_api_test_utils::rpc_tx_to_json;
-use papyrus_storage::test_utils::get_test_config;
+use papyrus_storage::db::DbConfig;
+use papyrus_storage::test_utils::get_mmap_file_test_config;
+use papyrus_storage::StorageConfig;
 use papyrus_storage::StorageScope::StateOnly;
 use reqwest::{Client, Response};
+use starknet_api::core::ChainId;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_batcher::config::BatcherConfig;
@@ -17,7 +21,8 @@ use starknet_gateway::config::{
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_http_server::config::HttpServerConfig;
 use starknet_mempool_node::config::SequencerNodeConfig;
-use tempfile::TempDir;
+use tempfile::{tempdir, TempDir};
+use tokio::fs;
 use tokio::net::TcpListener;
 
 async fn create_gateway_config() -> GatewayConfig {
@@ -38,8 +43,18 @@ async fn create_http_server_config() -> HttpServerConfig {
     HttpServerConfig { ip: socket.ip(), port: socket.port() }
 }
 
-pub async fn create_config(rpc_server_addr: SocketAddr) -> (SequencerNodeConfig, TempDir) {
-    let (batcher_config, storage_file_handle) = create_batcher_config();
+pub async fn create_config(
+    rpc_server_addr: SocketAddr,
+    initialized_storage_path: &TempDir,
+) -> (SequencerNodeConfig, TempDir) {
+    let batcher_storage_path = tempdir().unwrap();
+    fs::copy(
+        initialized_storage_path.path().join("mdbx.dat"),
+        &batcher_storage_path.path().join("mdbx.dat"),
+    )
+    .await
+    .unwrap();
+    let batcher_config = create_batcher_config(batcher_storage_path.path());
     let gateway_config = create_gateway_config().await;
     let http_server_config = create_http_server_config().await;
     let rpc_state_reader_config = test_rpc_state_reader_config(rpc_server_addr);
@@ -51,7 +66,7 @@ pub async fn create_config(rpc_server_addr: SocketAddr) -> (SequencerNodeConfig,
         ..SequencerNodeConfig::default()
     };
 
-    (sequencer_node_config, storage_file_handle)
+    (sequencer_node_config, batcher_storage_path)
 }
 
 /// A test utility client for interacting with an http server.
@@ -101,11 +116,20 @@ fn test_rpc_state_reader_config(rpc_server_addr: SocketAddr) -> RpcStateReaderCo
     }
 }
 
-fn create_batcher_config() -> (BatcherConfig, TempDir) {
-    let storage_scope = Some(StateOnly);
-    // Need to keep the file handle alive to prevent the tempdir from being deleted.
-    let (storage_test_config, tempdir_file_handle) = get_test_config(storage_scope);
-    (BatcherConfig { storage: storage_test_config }, tempdir_file_handle)
+fn create_batcher_config(batcher_storage_path: &Path) -> BatcherConfig {
+    let storage_config = StorageConfig {
+        db_config: DbConfig {
+            path_prefix: batcher_storage_path.to_path_buf(),
+            chain_id: ChainId::Other("".to_owned()),
+            enforce_file_exists: true,
+            min_size: 1 << 20,    // 1MB
+            max_size: 1 << 35,    // 32GB
+            growth_step: 1 << 26, // 64MB
+        },
+        scope: StateOnly,
+        mmap_file_config: get_mmap_file_test_config(),
+    };
+    BatcherConfig { storage: storage_config }
 }
 
 /// Returns a unique IP address and port for testing purposes.


### PR DESCRIPTION
HACK: until we setup state sync between storages, we're going to take the storage generated by the storage_reader generator, copy the file, and feed it to the batcher config.

This is an ugly way of initializing the batcher and GW with the same state.

TODO: Once we have state sync, remove this stuff and replace with initializing the batcher with the updated state, then having the gw state sync from it.

NOTE: also added tempdir file handler to `IntegrationTestSetup` while i'm at it, it's required by papyrus_storage to prevent deallocation of the file (this should be fixed inside papyrus_storage so that this issue is hidden from the users).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1187)
<!-- Reviewable:end -->
