### PR TITLE
feat(consensus): make the fields of BroadcastTopicClient public, used for test construction

### DIFF
--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -244,11 +244,11 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
 
         Ok(BroadcastTopicChannels {
             broadcasted_messages_receiver,
-            broadcast_topic_client: BroadcastTopicClient {
+            broadcast_topic_client: BroadcastTopicClient::new(
                 messages_to_broadcast_sender,
                 reported_messages_sender,
                 continue_propagation_sender,
-            },
+            ),
         })
     }
 
@@ -879,6 +879,21 @@ pub struct BroadcastTopicClient<T: TryFrom<Bytes>> {
     messages_to_broadcast_sender: BroadcastTopicSender<T, Bytes>,
     reported_messages_sender: BroadcastTopicSender<BroadcastedMessageManager, PeerId>,
     continue_propagation_sender: Sender<BroadcastedMessageManager>,
+}
+
+impl<T: TryFrom<Bytes>> BroadcastTopicClient<T> {
+    // TODO(matan): Remove once consensus_manager no longer needs to build fake channels.
+    pub fn new(
+        messages_to_broadcast_sender: BroadcastTopicSender<T, Bytes>,
+        reported_messages_sender: BroadcastTopicSender<BroadcastedMessageManager, PeerId>,
+        continue_propagation_sender: Sender<BroadcastedMessageManager>,
+    ) -> Self {
+        BroadcastTopicClient {
+            messages_to_broadcast_sender,
+            reported_messages_sender,
+            continue_propagation_sender,
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/papyrus_network/src/network_manager/test_utils.rs
+++ b/crates/papyrus_network/src/network_manager/test_utils.rs
@@ -108,11 +108,11 @@ where
 
     let subscriber_channels = BroadcastTopicChannels {
         broadcasted_messages_receiver,
-        broadcast_topic_client: BroadcastTopicClient {
+        broadcast_topic_client: BroadcastTopicClient::new(
             messages_to_broadcast_sender,
             reported_messages_sender,
             continue_propagation_sender,
-        },
+        ),
     };
 
     let mock_broadcasted_messages_fn: MockBroadcastedMessagesFn<T> =


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1198)
<!-- Reviewable:end -->
