### PR TITLE
feat(mempool): add account_txs API to TransactionPool

### DIFF
--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -83,6 +83,13 @@ impl TransactionPool {
         }
     }
 
+    pub fn _account_txs_sorted_by_nonce(
+        &self,
+        address: ContractAddress,
+    ) -> impl Iterator<Item = &TransactionReference> {
+        self.txs_by_account._account_txs_sorted_by_nonce(address)
+    }
+
     pub fn _get_by_tx_hash(&self, tx_hash: TransactionHash) -> MempoolResult<&Transaction> {
         self.tx_pool.get(&tx_hash).ok_or(MempoolError::TransactionNotFound { tx_hash })
     }
@@ -134,6 +141,13 @@ impl AccountTransactionIndex {
 
     fn get(&self, address: ContractAddress, nonce: Nonce) -> Option<&TransactionReference> {
         self.0.get(&address)?.get(&nonce)
+    }
+
+    fn _account_txs_sorted_by_nonce(
+        &self,
+        address: ContractAddress,
+    ) -> impl Iterator<Item = &TransactionReference> {
+        self.0.get(&address).into_iter().flat_map(|nonce_to_tx_ref| nonce_to_tx_ref.values())
     }
 
     fn remove_up_to_nonce(


### PR DESCRIPTION
To be used in `commit_block` to restore non-included transactions in queue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1257)
<!-- Reviewable:end -->
