### PR TITLE
test(blockifier): l1 bounds -> all bounds (or parametrize) in account transaction test

### DIFF
--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -98,7 +98,7 @@ use crate::transaction::transactions::{DeclareTransaction, ExecutableTransaction
 use crate::utils::u64_from_usize;
 
 #[rstest]
-fn test_circuit(block_context: BlockContext, default_l1_resource_bounds: ValidResourceBounds) {
+fn test_circuit(block_context: BlockContext, default_all_resource_bounds: ValidResourceBounds) {
     let test_contract = FeatureContract::TestContract(CairoVersion::Cairo1);
     let account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
     let chain_info = &block_context.chain_info;
@@ -121,7 +121,7 @@ fn test_circuit(block_context: BlockContext, default_l1_resource_bounds: ValidRe
         state,
         &block_context,
         invoke_tx_args! {
-            resource_bounds: default_l1_resource_bounds,
+            resource_bounds: default_all_resource_bounds,
             ..tx_args
         },
     )
@@ -131,7 +131,7 @@ fn test_circuit(block_context: BlockContext, default_l1_resource_bounds: ValidRe
 }
 
 #[rstest]
-fn test_rc96_holes(block_context: BlockContext, default_l1_resource_bounds: ValidResourceBounds) {
+fn test_rc96_holes(block_context: BlockContext, default_all_resource_bounds: ValidResourceBounds) {
     let test_contract = FeatureContract::TestContract(CairoVersion::Cairo1);
     let account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
     let chain_info = &block_context.chain_info;
@@ -154,7 +154,7 @@ fn test_rc96_holes(block_context: BlockContext, default_l1_resource_bounds: Vali
         state,
         &block_context,
         invoke_tx_args! {
-            resource_bounds: default_l1_resource_bounds,
+            resource_bounds: default_all_resource_bounds,
             ..tx_args
         },
     )
@@ -284,12 +284,15 @@ fn test_assert_actual_fee_in_bounds(
 
 // TODO(Dori, 15/9/2023): Convert version variance to attribute macro.
 #[rstest]
+#[case::v0(TransactionVersion::ZERO, default_all_resource_bounds())]
+#[case::v1(TransactionVersion::ONE, default_all_resource_bounds())]
+#[case::l1_bounds(TransactionVersion::THREE, default_l1_resource_bounds())]
+#[case::all_bounds(TransactionVersion::THREE, default_all_resource_bounds())]
 fn test_account_flow_test(
     block_context: BlockContext,
     max_fee: Fee,
-    default_l1_resource_bounds: ValidResourceBounds,
-    #[values(TransactionVersion::ZERO, TransactionVersion::ONE, TransactionVersion::THREE)]
-    tx_version: TransactionVersion,
+    #[case] tx_version: TransactionVersion,
+    #[case] resource_bounds: ValidResourceBounds,
     #[values(true, false)] only_query: bool,
 ) {
     let TestInitData { mut state, account_address, contract_address, mut nonce_manager } =
@@ -304,7 +307,7 @@ fn test_account_flow_test(
             sender_address: account_address,
             calldata: create_trivial_calldata(contract_address),
             version: tx_version,
-            resource_bounds: default_l1_resource_bounds,
+            resource_bounds,
             nonce: nonce_manager.next(account_address),
             only_query,
         },
@@ -319,7 +322,7 @@ fn test_account_flow_test(
 fn test_invoke_tx_from_non_deployed_account(
     block_context: BlockContext,
     max_fee: Fee,
-    default_l1_resource_bounds: ValidResourceBounds,
+    default_all_resource_bounds: ValidResourceBounds,
     #[case] tx_version: TransactionVersion,
 ) {
     let TestInitData { mut state, account_address, contract_address: _, mut nonce_manager } =
@@ -341,7 +344,7 @@ fn test_invoke_tx_from_non_deployed_account(
                 felt!(1_u8),         // Calldata length.
                 felt!(2_u8)          // Calldata: num.
             ],
-            resource_bounds: default_l1_resource_bounds,
+            resource_bounds: default_all_resource_bounds,
             version: tx_version,
             nonce: nonce_manager.next(account_address),
         },
@@ -368,7 +371,8 @@ fn test_infinite_recursion(
     #[values(true, false)] success: bool,
     #[values(true, false)] normal_recurse: bool,
     mut block_context: BlockContext,
-    default_l1_resource_bounds: ValidResourceBounds,
+    #[values(default_l1_resource_bounds(), default_all_resource_bounds())]
+    resource_bounds: ValidResourceBounds,
 ) {
     // Limit the number of execution steps (so we quickly hit the limit).
     block_context.versioned_constants.invoke_tx_max_n_steps = 4200;
@@ -396,7 +400,7 @@ fn test_infinite_recursion(
         &mut state,
         &block_context,
         invoke_tx_args! {
-            resource_bounds: default_l1_resource_bounds,
+            resource_bounds,
             sender_address: account_address,
             calldata: execute_calldata,
             nonce: nonce_manager.next(account_address),
@@ -553,14 +557,15 @@ fn test_max_fee_limit_validate(
 }
 
 #[rstest]
-#[case(TransactionVersion::ONE)]
-#[case(TransactionVersion::THREE)]
+#[case::v1(TransactionVersion::ONE, default_all_resource_bounds())]
+#[case::l1_bounds(TransactionVersion::THREE, default_l1_resource_bounds())]
+#[case::all_bounds(TransactionVersion::THREE, default_all_resource_bounds())]
 fn test_recursion_depth_exceeded(
     #[case] tx_version: TransactionVersion,
     #[values(CairoVersion::Cairo0, CairoVersion::Cairo1)] cairo_version: CairoVersion,
     block_context: BlockContext,
     max_fee: Fee,
-    default_l1_resource_bounds: ValidResourceBounds,
+    #[case] resource_bounds: ValidResourceBounds,
 ) {
     let TestInitData { mut state, account_address, contract_address, mut nonce_manager } =
         create_test_init_data(&block_context.chain_info, cairo_version);
@@ -594,7 +599,7 @@ fn test_recursion_depth_exceeded(
         calldata,
         version: tx_version,
         nonce: nonce_manager.next(account_address),
-        resource_bounds: default_l1_resource_bounds,
+        resource_bounds,
     };
     let tx_execution_info = run_invoke_tx(&mut state, &block_context, invoke_args.clone());
 
@@ -628,6 +633,7 @@ fn test_recursion_depth_exceeded(
 fn test_revert_invoke(
     block_context: BlockContext,
     max_fee: Fee,
+    default_all_resource_bounds: ValidResourceBounds,
     #[case] transaction_version: TransactionVersion,
     #[case] fee_type: FeeType,
 ) {
@@ -646,6 +652,7 @@ fn test_revert_invoke(
         &block_context,
         invoke_tx_args! {
             max_fee,
+            resource_bounds: default_all_resource_bounds,
             sender_address: account_address,
             calldata: create_calldata(
                 test_contract_address,
@@ -798,13 +805,14 @@ fn recursive_function_calldata(
 /// Tests that reverted transactions are charged more fee and steps than their (recursive) prefix
 /// successful counterparts.
 /// In this test reverted transactions are valid function calls that got insufficient steps limit.
-#[case(TransactionVersion::ONE)]
-#[case(TransactionVersion::THREE)]
+#[case::v1(TransactionVersion::ONE, default_all_resource_bounds())]
+#[case::l1_bounds(TransactionVersion::THREE, default_l1_resource_bounds())]
+#[case::all_bounds(TransactionVersion::THREE, default_all_resource_bounds())]
 fn test_reverted_reach_steps_limit(
     max_fee: Fee,
-    default_l1_resource_bounds: ValidResourceBounds,
     mut block_context: BlockContext,
     #[case] version: TransactionVersion,
+    #[case] resource_bounds: ValidResourceBounds,
     #[values(CairoVersion::Cairo0, CairoVersion::Cairo1)] cairo_version: CairoVersion,
 ) {
     let TestInitData { mut state, account_address, contract_address, mut nonce_manager } =
@@ -814,7 +822,7 @@ fn test_reverted_reach_steps_limit(
     block_context.versioned_constants.invoke_tx_max_n_steps = 6000;
     let recursion_base_args = invoke_tx_args! {
         max_fee,
-        resource_bounds: default_l1_resource_bounds,
+        resource_bounds,
         sender_address: account_address,
         version,
     };
@@ -912,13 +920,14 @@ fn test_reverted_reach_steps_limit(
 /// asserts false. We test deltas between consecutive depths, and further depths.
 fn test_n_reverted_steps(
     block_context: BlockContext,
-    default_l1_resource_bounds: ValidResourceBounds,
+    #[values(default_l1_resource_bounds(), default_all_resource_bounds())]
+    resource_bounds: ValidResourceBounds,
     #[values(CairoVersion::Cairo0, CairoVersion::Cairo1)] cairo_version: CairoVersion,
 ) {
     let TestInitData { mut state, account_address, contract_address, mut nonce_manager } =
         create_test_init_data(&block_context.chain_info, cairo_version);
     let recursion_base_args = invoke_tx_args! {
-        resource_bounds: default_l1_resource_bounds,
+        resource_bounds,
         sender_address: account_address,
     };
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1312)
<!-- Reviewable:end -->
