### PR TITLE
feat: let StreamHashMap return Ready(None) when channel gets closed

### DIFF
--- a/crates/papyrus_network/src/utils.rs
+++ b/crates/papyrus_network/src/utils.rs
@@ -66,7 +66,7 @@ impl<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> Stream for StreamHashMap<K
         }
         HashMap::retain(&mut unpinned_self.map, |key, _| !finished_streams.contains(key));
         unpinned_self.wakers_waiting_for_new_stream.push(cx.waker().clone());
-        Poll::Pending
+        if finished_streams.is_empty() { Poll::Pending } else { Poll::Ready(None) }
     }
 }
 


### PR DESCRIPTION
StreamHashMap holds a set of open channel receivers. When polled, it returns `Ready(Some(...))` if any of the receivers had a message ready. 
When a channel is closed, it will quietly remove it from the set it holds, and returns `Pending` as if nothing happened. 

I suggest we change this behavior, so when a channel is closed and StreamHashMap is polled it would return `Ready(None)` (which is what the individual channel receivers do when they get closed and then polled). This will allow the user to check which channel was closed (or if multiple channels were closed) and act accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1345)
<!-- Reviewable:end -->
