### PR TITLE
test: add batcher client to sequencer end_to_end_test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10386,6 +10386,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "starknet_batcher",
+ "starknet_batcher_types",
  "starknet_client",
  "starknet_gateway",
  "starknet_gateway_types",

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -24,6 +24,7 @@ serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_batcher.workspace = true
+starknet_batcher_types.workspace = true
 starknet_client.workspace = true
 starknet_gateway = { workspace = true, features = ["testing"] }
 starknet_gateway_types.workspace = true

--- a/crates/tests-integration/src/integration_test_setup.rs
+++ b/crates/tests-integration/src/integration_test_setup.rs
@@ -4,6 +4,7 @@ use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerato
 use starknet_api::executable_transaction::Transaction;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
+use starknet_batcher_types::communication::SharedBatcherClient;
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_http_server::config::HttpServerConfig;
 use starknet_mempool_infra::trace_util::configure_tracing;
@@ -30,6 +31,7 @@ pub struct IntegrationTestSetup {
 
     // TODO(Arni): Replace with a batcher server handle and a batcher client.
     pub mempool_client: SharedMempoolClient,
+    pub batcher_client: SharedBatcherClient,
 
     // Handle of the sequencer node.
     pub sequencer_node_handle: JoinHandle<Result<(), anyhow::Error>>,
@@ -72,6 +74,7 @@ impl IntegrationTestSetup {
             add_tx_http_client,
             batcher_storage_file_handle: storage_for_test.batcher_storage_handle,
             mempool_client: clients.get_mempool_client().unwrap().clone(),
+            batcher_client: clients.get_batcher_client().unwrap(),
             rpc_storage_file_handle: storage_for_test.rpc_storage_handle,
             sequencer_node_handle,
         }
@@ -85,6 +88,7 @@ impl IntegrationTestSetup {
         self.add_tx_http_client.assert_add_tx_error(tx).await
     }
 
+    // TODO(Arni): consider deleting this function if it is not used in any test.
     pub async fn get_txs(&self, n_txs: usize) -> Vec<Transaction> {
         self.mempool_client.get_txs(n_txs).await.unwrap()
     }

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -3,7 +3,10 @@ use blockifier::test_utils::CairoVersion;
 use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerator;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
+use starknet_api::block::BlockNumber;
 use starknet_api::transaction::TransactionHash;
+use starknet_batcher_types::batcher_types::StartHeightInput;
+use starknet_batcher_types::communication::SharedBatcherClient;
 use starknet_mempool_integration_tests::integration_test_setup::IntegrationTestSetup;
 
 #[fixture]
@@ -40,6 +43,8 @@ async fn test_end_to_end(mut tx_generator: MultiAccountTransactionGenerator) {
     // Test.
     let mempool_txs = mock_running_system.get_txs(4).await;
 
+    run_consensus_for_end_to_end_test(&mock_running_system.batcher_client).await;
+
     // Assert.
     let expected_tx_hashes_from_get_txs = [
         account1_invoke_nonce1_tx_hash,
@@ -49,4 +54,18 @@ async fn test_end_to_end(mut tx_generator: MultiAccountTransactionGenerator) {
     let actual_tx_hashes: Vec<TransactionHash> =
         mempool_txs.iter().map(|tx| tx.tx_hash()).collect();
     assert_eq!(expected_tx_hashes_from_get_txs, *actual_tx_hashes);
+}
+
+/// This function should mirror
+/// [`run_consensus`](papyrus_consensus::manager::run_consensus). It makes requests
+/// from the batcher client and asserts the expected responses were received.
+pub async fn run_consensus_for_end_to_end_test(batcher_client: &SharedBatcherClient) {
+    // Setup. Holds the state of the consensus manager.
+
+    // Set start height.
+    // TODO(Arni): Get the current height from the mock_running_system object.
+    let current_height = BlockNumber(1);
+
+    // Test.
+    batcher_client.start_height(StartHeightInput { height: current_height }).await.unwrap();
 }


### PR DESCRIPTION
This PR conflicts with #1296.

In this PR we do not create a mock consensus manager but add the least amount of code to allow us to add the batcher to the flow test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1352)
<!-- Reviewable:end -->
