### PR TITLE
fix(gateway): change gateway types to use the correct message metadata struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10301,6 +10301,7 @@ dependencies = [
  "axum",
  "enum-assoc",
  "mockall",
+ "papyrus_network_types",
  "papyrus_rpc",
  "serde",
  "serde_json",

--- a/crates/gateway_types/Cargo.toml
+++ b/crates/gateway_types/Cargo.toml
@@ -13,6 +13,7 @@ async-trait.workspace = true
 axum.workspace = true
 enum-assoc.workspace = true
 mockall.workspace = true
+papyrus_network_types.workspace = true
 papyrus_rpc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/gateway_types/src/gateway_types.rs
+++ b/crates/gateway_types/src/gateway_types.rs
@@ -1,15 +1,13 @@
+use papyrus_network_types::network_types::BroadcastedMessageMetadata;
 use serde::{Deserialize, Serialize};
 use starknet_api::rpc_transaction::RpcTransaction;
 
 use crate::errors::GatewayError;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct MessageMetadata {}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GatewayInput {
     pub rpc_tx: RpcTransaction,
-    pub message_metadata: Option<MessageMetadata>,
+    pub message_metadata: Option<BroadcastedMessageMetadata>,
 }
 
 pub type GatewayResult<T> = Result<T, GatewayError>;


### PR DESCRIPTION
- refactor(network): rename BroadcastedMessageManager to BroadcastedMessageMetadata
- fix(gateway): change gateway types to use the correct message metadata struct

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1357)
<!-- Reviewable:end -->
