### PR TITLE
chore(tests-integration): change test tx tips to ensure determinstic order

### DIFF
--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -17,8 +17,8 @@ async fn test_end_to_end(mut tx_generator: MultiAccountTransactionGenerator) {
     let mock_running_system = IntegrationTestSetup::new_from_tx_generator(&tx_generator).await;
 
     let account0_invoke_nonce1 = tx_generator.account_with_id(0).generate_invoke_with_tip(1);
-    let account0_invoke_nonce2 = tx_generator.account_with_id(0).generate_invoke_with_tip(1);
-    let account1_invoke_nonce1 = tx_generator.account_with_id(1).generate_invoke_with_tip(1);
+    let account0_invoke_nonce2 = tx_generator.account_with_id(0).generate_invoke_with_tip(2);
+    let account1_invoke_nonce1 = tx_generator.account_with_id(1).generate_invoke_with_tip(3);
 
     let account0_invoke_nonce1_tx_hash =
         mock_running_system.assert_add_tx_success(&account0_invoke_nonce1).await;
@@ -33,6 +33,10 @@ async fn test_end_to_end(mut tx_generator: MultiAccountTransactionGenerator) {
     let mempool_txs = mock_running_system.get_txs(4).await;
 
     // Assert.
+    // account1_invoke_nonce1 precedes account0_invoke_nonce1 as its nonce is lower, despite the
+    // higher tip of the latter. account1_invoke_nonce1 precedes account0_invoke_nonce1 as it
+    // offers a higher tip, regardless of the nonce. Hence the expected tx order, regardless of
+    // tx hashes, is: account1_invoke_nonce1, account0_invoke_nonce1, and account0_invoke_nonce2.
     let expected_tx_hashes_from_get_txs = [
         account1_invoke_nonce1_tx_hash,
         account0_invoke_nonce1_tx_hash,


### PR DESCRIPTION
**Stack**:
- #1383
- #1392 ⬅
- #1364
- #1363
- #1361
- #1360


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1392)
<!-- Reviewable:end -->
