### PR TITLE
refactor(mempool): rename TransactionReference field sender_address -> address

### DIFF
--- a/crates/mempool/src/suspended_transaction_pool.rs
+++ b/crates/mempool/src/suspended_transaction_pool.rs
@@ -18,13 +18,13 @@ impl _SuspendedTransactionPool {
 
     pub fn _insert(&mut self, tx: TransactionReference) {
         assert_eq!(
-            self.suspended_tx_pool.insert((tx.sender_address, tx.nonce), tx),
+            self.suspended_tx_pool.insert((tx.address, tx.nonce), tx),
             None,
             "Keys should be unique; duplicates are checked prior."
         );
     }
 
     pub fn _remove(&mut self, tx: &TransactionReference) -> bool {
-        self.suspended_tx_pool.remove(&(tx.sender_address, tx.nonce)).is_some()
+        self.suspended_tx_pool.remove(&(tx.address, tx.nonce)).is_some()
     }
 }

--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -123,17 +123,17 @@ struct AccountTransactionIndex(HashMap<ContractAddress, BTreeMap<Nonce, Transact
 impl AccountTransactionIndex {
     /// If the transaction already exists in the mapping, the old value is returned.
     fn insert(&mut self, tx: TransactionReference) -> Option<TransactionReference> {
-        self.0.entry(tx.sender_address).or_default().insert(tx.nonce, tx)
+        self.0.entry(tx.address).or_default().insert(tx.nonce, tx)
     }
 
     fn remove(&mut self, tx: TransactionReference) -> Option<TransactionReference> {
-        let TransactionReference { sender_address, nonce, .. } = tx;
-        let account_txs = self.0.get_mut(&sender_address)?;
+        let TransactionReference { address, nonce, .. } = tx;
+        let account_txs = self.0.get_mut(&address)?;
 
         let removed_tx = account_txs.remove(&nonce);
 
         if removed_tx.is_some() && account_txs.is_empty() {
-            self.0.remove(&sender_address);
+            self.0.remove(&address);
         }
 
         removed_tx

--- a/crates/mempool/src/transaction_queue.rs
+++ b/crates/mempool/src/transaction_queue.rs
@@ -37,7 +37,7 @@ impl TransactionQueue {
     /// Panics: if given a duplicate tx.
     pub fn insert(&mut self, tx_reference: TransactionReference) {
         assert_eq!(
-            self.address_to_tx.insert(tx_reference.sender_address, tx_reference),
+            self.address_to_tx.insert(tx_reference.address, tx_reference),
             None,
             "Only a single transaction from the same contract class can be in the mempool at a \
              time."
@@ -60,7 +60,7 @@ impl TransactionQueue {
         let txs: Vec<TransactionReference> =
             (0..n_txs).filter_map(|_| self.priority_queue.pop_last().map(|tx| tx.0)).collect();
         for tx in &txs {
-            self.address_to_tx.remove(&tx.sender_address);
+            self.address_to_tx.remove(&tx.address);
         }
 
         txs
@@ -107,7 +107,7 @@ impl TransactionQueue {
                 l2_gas: ResourceBounds { max_amount: GasAmount(0), max_price_per_unit: threshold },
                 ..Default::default()
             }),
-            sender_address: ContractAddress::default(),
+            address: ContractAddress::default(),
             nonce: Nonce::default(),
             tx_hash: TransactionHash::default(),
             tip: Tip::default(),

--- a/crates/mempool/src/transaction_queue_test_utils.rs
+++ b/crates/mempool/src/transaction_queue_test_utils.rs
@@ -36,7 +36,7 @@ impl TransactionQueueContent {
             .chain(priority_queue.iter().map(|priority_tx| priority_tx.0));
         let mut address_to_tx = HashMap::new();
         for tx_ref in tx_references {
-            let address = tx_ref.sender_address;
+            let address = tx_ref.address;
             if address_to_tx.insert(address, tx_ref).is_some() {
                 panic!("Duplicate address: {address}; queues must be mutually exclusive.");
             }


### PR DESCRIPTION
Shorter name is preferable, and equivalently understandable; rename only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1413)
<!-- Reviewable:end -->
