### PR TITLE
feat: add select to StreamHandler::run() function

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/stream_handler.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler.rs
@@ -78,9 +78,12 @@ impl<T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError
     /// Guarantees that messages are sent in order.
     pub async fn run(&mut self) {
         loop {
-            if let Some(message) = self.inbound_receiver.next().await {
-                self.handle_message(message);
-            }
+            // TODO(guyn): this select is here to allow us to add the outbound flow.
+            tokio::select!(
+                Some(message) = self.inbound_receiver.next() => {
+                    self.handle_message(message);
+                }
+            );
         }
     }
 


### PR DESCRIPTION
We change the loop in the `run()` function to use a `select` instead of an `await` so that we can later add the outbound flow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/sequencer/1417)
<!-- Reviewable:end -->
