### PR TITLE
refactor: use fully-qualified std::fmt::Display trait

### DIFF
--- a/crates/gateway_types/src/errors.rs
+++ b/crates/gateway_types/src/errors.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use enum_assoc::Assoc;
@@ -80,7 +78,7 @@ impl IntoResponse for GatewaySpecError {
     }
 }
 
-impl Display for GatewaySpecError {
+impl std::fmt::Display for GatewaySpecError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let as_rpc = self.clone().into_rpc();
         write!(

--- a/crates/monitoring_endpoint/src/config.rs
+++ b/crates/monitoring_endpoint/src/config.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fmt::Display;
 use std::net::IpAddr;
 
 use papyrus_config::dumping::{ser_param, SerializeConfig};
@@ -38,7 +37,7 @@ impl SerializeConfig for MonitoringEndpointConfig {
     }
 }
 
-impl Display for MonitoringEndpointConfig {
+impl std::fmt::Display for MonitoringEndpointConfig {
     #[cfg_attr(coverage_nightly, coverage_attribute)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")

--- a/crates/papyrus_config/src/validators.rs
+++ b/crates/papyrus_config/src/validators.rs
@@ -1,6 +1,5 @@
 //! Utils for config validations.
 
-use std::fmt::Display;
 use std::path::Path;
 
 use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
@@ -60,7 +59,7 @@ impl From<ValidationErrors> for ParsedValidationErrors {
     }
 }
 
-impl Display for ParsedValidationErrors {
+impl std::fmt::Display for ParsedValidationErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut error_string = String::new();
         for error in &self.0 {

--- a/crates/papyrus_monitoring_gateway/src/lib.rs
+++ b/crates/papyrus_monitoring_gateway/src/lib.rs
@@ -6,7 +6,6 @@
 mod gateway_test;
 
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Display;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -103,7 +102,7 @@ impl SerializeConfig for MonitoringGatewayConfig {
     }
 }
 
-impl Display for MonitoringGatewayConfig {
+impl std::fmt::Display for MonitoringGatewayConfig {
     #[cfg_attr(coverage_nightly, coverage_attribute)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")

--- a/crates/papyrus_rpc/src/lib.rs
+++ b/crates/papyrus_rpc/src/lib.rs
@@ -16,7 +16,6 @@ mod v0_8;
 mod version_config;
 
 use std::collections::BTreeMap;
-use std::fmt::Display;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -160,12 +159,12 @@ impl SerializeConfig for RpcConfig {
     }
 }
 
-fn internal_server_error(err: impl Display) -> ErrorObjectOwned {
+fn internal_server_error(err: impl std::fmt::Display) -> ErrorObjectOwned {
     error!("{}: {}", INTERNAL_ERROR_MSG, err);
     ErrorObjectOwned::owned(InternalError.code(), INTERNAL_ERROR_MSG, None::<()>)
 }
 
-fn internal_server_error_with_msg(err: impl Display) -> ErrorObjectOwned {
+fn internal_server_error_with_msg(err: impl std::fmt::Display) -> ErrorObjectOwned {
     error!("{}: {}", INTERNAL_ERROR_MSG, err);
     ErrorObjectOwned::owned(InternalError.code(), err.to_string(), None::<()>)
 }

--- a/crates/papyrus_rpc/src/v0_8/transaction.rs
+++ b/crates/papyrus_rpc/src/v0_8/transaction.rs
@@ -3,7 +3,6 @@
 mod transaction_test;
 
 use std::collections::BTreeMap;
-use std::fmt::Display;
 use std::num::NonZeroU64;
 use std::ops::Add;
 use std::sync::Arc;
@@ -1171,7 +1170,7 @@ pub fn get_block_tx_hashes_by_number<Mode: TransactionKind>(
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct L1L2MsgHash(pub [u8; 32]);
 
-impl Display for L1L2MsgHash {
+impl std::fmt::Display for L1L2MsgHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "0x{}", hex::encode(self.0))
     }

--- a/crates/papyrus_rpc/src/version_config.rs
+++ b/crates/papyrus_rpc/src/version_config.rs
@@ -2,8 +2,6 @@
 #[path = "version_config_test.rs"]
 mod version_config_test;
 
-use std::fmt;
-
 pub const VERSION_PATTERN: &str = "[Vv][0-9]+_[0-9]+(_[0-9]+)?";
 
 #[derive(Eq, PartialEq, Hash)]
@@ -25,8 +23,8 @@ pub struct VersionId {
     pub patch: u8,
 }
 
-impl fmt::Display for VersionId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for VersionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}_{}", self.name, self.patch)
     }
 }

--- a/crates/papyrus_storage/src/version.rs
+++ b/crates/papyrus_storage/src/version.rs
@@ -2,8 +2,6 @@
 #[path = "version_test.rs"]
 mod version_test;
 
-use std::fmt::Display;
-
 use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
 use crate::{StorageError, StorageResult, StorageTxn};
@@ -126,7 +124,7 @@ impl<'env> VersionStorageWriter for StorageTxn<'env, RW> {
     }
 }
 
-impl Display for Version {
+impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let major = self.major.to_string();
         let minor = self.minor.to_string();

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -2,8 +2,6 @@
 #[path = "block_test.rs"]
 mod block_test;
 
-use std::fmt::Display;
-
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
@@ -111,7 +109,7 @@ impl From<StarknetVersion> for Vec<u8> {
     }
 }
 
-impl Display for StarknetVersion {
+impl std::fmt::Display for StarknetVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", Vec::<u8>::from(self).iter().map(|x| x.to_string()).join("."))
     }

--- a/crates/starknet_api/src/crypto/utils.rs
+++ b/crates/starknet_api/src/crypto/utils.rs
@@ -5,9 +5,6 @@
 #[allow(clippy::explicit_auto_deref)]
 mod crypto_test;
 
-use std::fmt;
-use std::fmt::LowerHex;
-
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash as CoreStarkHash};
@@ -34,9 +31,9 @@ pub enum CryptoError {
 )]
 pub struct PublicKey(pub Felt);
 
-impl LowerHex for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.0, f)
+impl std::fmt::LowerHex for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::LowerHex::fmt(&self.0, f)
     }
 }
 

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fmt::Display;
 use std::sync::Arc;
 
 use num_bigint::BigUint;
@@ -814,7 +813,7 @@ impl From<Fee> for Felt {
 )]
 pub struct TransactionHash(pub StarkHash);
 
-impl Display for TransactionHash {
+impl std::fmt::Display for TransactionHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/crates/starknet_client/src/starknet_error.rs
+++ b/crates/starknet_client/src/starknet_error.rs
@@ -2,8 +2,6 @@
 #[path = "starknet_error_test.rs"]
 mod starknet_error_test;
 
-use std::fmt::{self, Display, Formatter};
-
 #[cfg(any(feature = "testing", test))]
 use enum_iterator::Sequence;
 use serde::de::Error;
@@ -70,8 +68,8 @@ pub struct StarknetError {
     pub message: String,
 }
 
-impl Display for StarknetError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for StarknetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")
     }
 }

--- a/crates/starknet_patricia/src/felt.rs
+++ b/crates/starknet_patricia/src/felt.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use ethnum::U256;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::{Felt as StarknetTypesFelt, FromStrError};
@@ -67,8 +65,8 @@ impl std::ops::Mul for Felt {
     }
 }
 
-impl fmt::Debug for Felt {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Debug for Felt {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", U256::from(self))
     }
 }


### PR DESCRIPTION
To disambiguate from derive_more::Display.