### PR TITLE
feat(mempool): impl MempoolConfig

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -21,9 +21,9 @@ pub mod mempool_test;
 
 type AccountToNonce = HashMap<ContractAddress, Nonce>;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Mempool {
-    _config: MempoolConfig,
+    config: MempoolConfig,
     // TODO: add docstring explaining visibility and coupling of the fields.
     // All transactions currently held in the mempool.
     tx_pool: TransactionPool,
@@ -33,9 +33,6 @@ pub struct Mempool {
     mempool_state: HashMap<ContractAddress, Nonce>,
     // The most recent account nonces received, for all account in the pool.
     account_nonces: AccountToNonce,
-    // TODO(Elin): make configurable; should be bounded?
-    // Percentage increase for tip and max gas price to enable transaction replacement.
-    fee_escalation_percentage: u8, // E.g., 10 for a 10% increase.
 }
 
 impl Mempool {
@@ -234,6 +231,10 @@ impl Mempool {
 
     #[tracing::instrument(level = "debug", skip(self, incoming_tx), err)]
     fn handle_fee_escalation(&mut self, incoming_tx: &Transaction) -> MempoolResult<()> {
+        if !self.config.enable_fee_escalation {
+            return Ok(());
+        }
+
         let incoming_tx_ref = TransactionReference::new(incoming_tx);
         let TransactionReference { address, nonce, .. } = incoming_tx_ref;
         let Some(existing_tx_ref) = self.tx_pool.get_by_address_and_nonce(address, nonce) else {
@@ -244,7 +245,7 @@ impl Mempool {
         if !self.should_replace_tx(existing_tx_ref, &incoming_tx_ref) {
             tracing::debug!(
                 "{existing_tx_ref} was not replaced by {incoming_tx_ref} due to insufficient
-                fee escalation."
+            fee escalation."
             );
             // TODO(Elin): consider adding a more specific error type / message.
             return Err(MempoolError::DuplicateNonce { address, nonce });
@@ -275,7 +276,7 @@ impl Mempool {
     }
 
     fn increased_enough(&self, existing_value: u128, incoming_value: u128) -> bool {
-        let percentage = u128::from(self.fee_escalation_percentage);
+        let percentage = u128::from(self.config.fee_escalation_percentage);
 
         let Some(escalation_qualified_value) = existing_value
             .checked_mul(percentage)
@@ -290,22 +291,18 @@ impl Mempool {
     }
 }
 
-impl Default for Mempool {
-    fn default() -> Self {
-        Mempool {
-            _config: MempoolConfig::default(),
-            tx_pool: TransactionPool::default(),
-            tx_queue: TransactionQueue::default(),
-            mempool_state: HashMap::new(),
-            account_nonces: HashMap::new(),
-            fee_escalation_percentage: 10,
-        }
-    }
+#[derive(Debug)]
+pub struct MempoolConfig {
+    enable_fee_escalation: bool,
+    // Percentage increase for tip and max gas price to enable transaction replacement.
+    fee_escalation_percentage: u8, // E.g., 10 for a 10% increase.
 }
 
-// TODO(Ayelet): Add custom Default implementation for MempoolConfig when fields are added.
-#[derive(Debug, Default)]
-pub struct MempoolConfig {}
+impl Default for MempoolConfig {
+    fn default() -> Self {
+        MempoolConfig { enable_fee_escalation: true, fee_escalation_percentage: 10 }
+    }
+}
 
 // TODO(Elin): move to a shared location with other next-gen node crates.
 fn tip(tx: &Transaction) -> Tip {

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -6,7 +6,7 @@ use starknet_api::{contract_address, invoke_tx_args, nonce, patricia_key};
 use starknet_mempool_types::errors::MempoolError;
 use starknet_mempool_types::mempool_types::AddTransactionArgs;
 
-use crate::mempool::{tip, Mempool, TransactionReference};
+use crate::mempool::{tip, Mempool, MempoolConfig, TransactionReference};
 use crate::test_utils::{add_tx, add_tx_expect_error, commit_block, get_txs_and_assert_expected};
 use crate::transaction_pool::TransactionPool;
 use crate::transaction_queue::transaction_queue_test_utils::{
@@ -22,9 +22,9 @@ use crate::{add_tx_input, tx};
 /// Enables customized (and potentially inconsistent) creation for unit testing.
 #[derive(Debug, Default)]
 struct MempoolContent {
+    config: MempoolConfig,
     tx_pool: Option<TransactionPool>,
     tx_queue_content: Option<TransactionQueueContent>,
-    fee_escalation_percentage: u8,
 }
 
 impl MempoolContent {
@@ -41,32 +41,34 @@ impl MempoolContent {
 
 impl From<MempoolContent> for Mempool {
     fn from(mempool_content: MempoolContent) -> Mempool {
-        let MempoolContent { tx_pool, tx_queue_content, fee_escalation_percentage } =
-            mempool_content;
+        let MempoolContent { tx_pool, tx_queue_content, config } = mempool_content;
         Mempool {
+            config,
             tx_pool: tx_pool.unwrap_or_default(),
             tx_queue: tx_queue_content
                 .map(|content| content.complete_to_tx_queue())
                 .unwrap_or_default(),
-            fee_escalation_percentage,
             // TODO: Add implementation when needed.
             mempool_state: Default::default(),
             account_nonces: Default::default(),
-            _config: Default::default(),
         }
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct MempoolContentBuilder {
+    config: MempoolConfig,
     tx_pool: Option<TransactionPool>,
     tx_queue_content_builder: TransactionQueueContentBuilder,
-    fee_escalation_percentage: u8,
 }
 
 impl MempoolContentBuilder {
     fn new() -> Self {
-        Self::default()
+        Self {
+            config: MempoolConfig { enable_fee_escalation: false, ..Default::default() },
+            tx_pool: None,
+            tx_queue_content_builder: Default::default(),
+        }
     }
 
     fn with_pool<P>(mut self, pool_txs: P) -> Self
@@ -100,15 +102,16 @@ impl MempoolContentBuilder {
     }
 
     fn with_fee_escalation_percentage(mut self, fee_escalation_percentage: u8) -> Self {
-        self.fee_escalation_percentage = fee_escalation_percentage;
+        self.config.enable_fee_escalation = true;
+        self.config.fee_escalation_percentage = fee_escalation_percentage;
         self
     }
 
     fn build(self) -> MempoolContent {
         MempoolContent {
+            config: self.config,
             tx_pool: self.tx_pool,
             tx_queue_content: self.tx_queue_content_builder.build(),
-            fee_escalation_percentage: self.fee_escalation_percentage,
         }
     }
 


### PR DESCRIPTION
Moving `fee_escalation_percentage` into `MempoolConfig` and adding an `enable_fee_escalation` field to control when escalation applies. Updating test util's config to be non-optional, with fee escalation disabled by default.