### PR TITLE
chore: move the compiler config into the gateway config

### DIFF
--- a/config/mempool/default_config.json
+++ b/config/mempool/default_config.json
@@ -204,11 +204,6 @@
     "privacy": "TemporaryValue",
     "value": "SN_MAIN"
   },
-  "compiler_config.max_bytecode_size": {
-    "description": "Limitation of contract bytecode size.",
-    "privacy": "Public",
-    "value": 81920
-  },
   "components.batcher.execute": {
     "description": "The component execution flag.",
     "privacy": "Public",
@@ -593,6 +588,11 @@
     "description": "Address of the STRK fee token.",
     "privacy": "Public",
     "value": "0x0"
+  },
+  "gateway_config.compiler_config.max_bytecode_size": {
+    "description": "Limitation of contract bytecode size.",
+    "privacy": "Public",
+    "value": 81920
   },
   "gateway_config.stateful_tx_validator_config.max_nonce_for_validation_skip": {
     "description": "Maximum nonce for which the validation is skipped.",

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -5,6 +5,7 @@ use papyrus_config::dumping::{append_sub_config_name, ser_param, SerializeConfig
 use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
 use starknet_api::core::Nonce;
+use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use starknet_types_core::felt::Felt;
 use validator::Validate;
 
@@ -14,6 +15,7 @@ use crate::compiler_version::VersionId;
 pub struct GatewayConfig {
     pub stateless_tx_validator_config: StatelessTransactionValidatorConfig,
     pub stateful_tx_validator_config: StatefulTransactionValidatorConfig,
+    pub compiler_config: SierraToCasmCompilationConfig,
     pub chain_info: ChainInfo,
 }
 
@@ -28,6 +30,7 @@ impl SerializeConfig for GatewayConfig {
                 self.stateful_tx_validator_config.dump(),
                 "stateful_tx_validator_config",
             ),
+            append_sub_config_name(self.compiler_config.dump(), "compiler_config"),
             append_sub_config_name(self.chain_info.dump(), "chain_info"),
         ]
         .into_iter()

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -10,7 +10,6 @@ use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_mempool_infra::component_definitions::ComponentStarter;
 use starknet_mempool_types::communication::{AddTransactionArgsWrapper, SharedMempoolClient};
 use starknet_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
-use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use tracing::{error, instrument};
 
 use crate::compilation::GatewayCompiler;
@@ -150,11 +149,11 @@ fn process_tx(
 pub fn create_gateway(
     config: GatewayConfig,
     rpc_state_reader_config: RpcStateReaderConfig,
-    compiler_config: SierraToCasmCompilationConfig,
     mempool_client: SharedMempoolClient,
 ) -> Gateway {
     let state_reader_factory = Arc::new(RpcStateReaderFactory { config: rpc_state_reader_config });
-    let gateway_compiler = GatewayCompiler::new_command_line_compiler(compiler_config);
+    let gateway_compiler =
+        GatewayCompiler::new_command_line_compiler(config.compiler_config.clone());
 
     Gateway::new(config, state_reader_factory, gateway_compiler, mempool_client)
 }

--- a/crates/mempool_node/src/components.rs
+++ b/crates/mempool_node/src/components.rs
@@ -48,7 +48,6 @@ pub fn create_node_components(
         Some(create_gateway(
             config.gateway_config.clone(),
             config.rpc_state_reader_config.clone(),
-            config.compiler_config.clone(),
             mempool_client,
         ))
     } else {

--- a/crates/mempool_node/src/config/node_config.rs
+++ b/crates/mempool_node/src/config/node_config.rs
@@ -15,7 +15,6 @@ use starknet_consensus_manager::config::ConsensusManagerConfig;
 use starknet_gateway::config::{GatewayConfig, RpcStateReaderConfig};
 use starknet_http_server::config::HttpServerConfig;
 use starknet_monitoring_endpoint::config::MonitoringEndpointConfig;
-use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
 use validator::Validate;
 
 use crate::config::ComponentConfig;
@@ -57,8 +56,6 @@ pub struct SequencerNodeConfig {
     #[validate]
     pub rpc_state_reader_config: RpcStateReaderConfig,
     #[validate]
-    pub compiler_config: SierraToCasmCompilationConfig,
-    #[validate]
     pub monitoring_endpoint_config: MonitoringEndpointConfig,
 }
 
@@ -75,7 +72,6 @@ impl SerializeConfig for SequencerNodeConfig {
             append_sub_config_name(self.gateway_config.dump(), "gateway_config"),
             append_sub_config_name(self.http_server_config.dump(), "http_server_config"),
             append_sub_config_name(self.rpc_state_reader_config.dump(), "rpc_state_reader_config"),
-            append_sub_config_name(self.compiler_config.dump(), "compiler_config"),
             append_sub_config_name(
                 self.monitoring_endpoint_config.dump(),
                 "monitoring_endpoint_config",
@@ -96,7 +92,6 @@ impl Default for SequencerNodeConfig {
             gateway_config: Default::default(),
             http_server_config: Default::default(),
             rpc_state_reader_config: Default::default(),
-            compiler_config: Default::default(),
             monitoring_endpoint_config: Default::default(),
         }
     }


### PR DESCRIPTION
Per @Itay-Tsabary-Starkware 's request. 
We want to clean up the sequencer node config.