### PR TITLE
refactor(mempool): remove test_add_tx_sequential_nonces redudant test

### DIFF
--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -316,7 +316,7 @@ fn test_add_tx(mut mempool: Mempool) {
 }
 
 #[rstest]
-fn test_add_tx_multi_nonce_success(mut mempool: Mempool) {
+fn test_add_tx_correctly_places_txs_in_queue_and_pool(mut mempool: Mempool) {
     // Setup.
     let input_address_0_nonce_0 =
         add_tx_input!(tx_hash: 1, address: "0x0", tx_nonce: 0, account_nonce: 0);
@@ -439,27 +439,6 @@ fn test_add_tx_tip_priority_over_tx_hash(mut mempool: Mempool) {
         [&input_big_tip_small_hash.tx, &input_small_tip_big_hash.tx].map(TransactionReference::new);
     let expected_mempool_content =
         MempoolContentBuilder::new().with_priority_queue(expected_queue_txs).build();
-    expected_mempool_content.assert_eq(&mempool);
-}
-
-#[rstest]
-fn test_add_tx_sequential_nonces(mut mempool: Mempool) {
-    // Setup.
-    let input_nonce_0 = add_tx_input!(tx_hash: 0, tx_nonce: 0, account_nonce: 0);
-    let input_nonce_1 = add_tx_input!(tx_hash: 1, tx_nonce: 1, account_nonce: 0);
-
-    // Test.
-    for input in [&input_nonce_0, &input_nonce_1] {
-        add_tx(&mut mempool, input);
-    }
-
-    // Assert: only eligible transaction appears in the queue.
-    let expected_queue_txs = [TransactionReference::new(&input_nonce_0.tx)];
-    let expected_pool_txs = [input_nonce_0.tx, input_nonce_1.tx];
-    let expected_mempool_content = MempoolContentBuilder::new()
-        .with_pool(expected_pool_txs)
-        .with_priority_queue(expected_queue_txs)
-        .build();
     expected_mempool_content.assert_eq(&mempool);
 }
 


### PR DESCRIPTION
This test is already covered by `test_add_tx_multi_nonce_success`. Both tests verify that adding sequential nonces includes the latter transaction in the pool.