### PR TITLE
feat(blockifier): add replace_class cairo native syscall

### DIFF
--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -29,6 +29,7 @@ use crate::execution::call_info::{
     Retdata,
 };
 use crate::execution::common_hints::ExecutionMode;
+use crate::execution::contract_class::RunnableContractClass;
 use crate::execution::entry_point::{
     CallEntryPoint,
     ConstructorContext,
@@ -359,8 +360,28 @@ impl<'state> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
 
         Ok((Felt::from(deployed_contract_address), constructor_retdata))
     }
-    fn replace_class(&mut self, _class_hash: Felt, _remaining_gas: &mut u128) -> SyscallResult<()> {
-        todo!("Implement replace_class syscall.");
+    fn replace_class(&mut self, class_hash: Felt, remaining_gas: &mut u128) -> SyscallResult<()> {
+        self.pre_execute_syscall(remaining_gas, self.context.gas_costs().replace_class_gas_cost)?;
+
+        let class_hash = ClassHash(class_hash);
+        let contract_class = self
+            .state
+            .get_compiled_contract_class(class_hash)
+            .map_err(|e| self.handle_error(remaining_gas, e.into()))?;
+
+        match contract_class {
+            RunnableContractClass::V0(_) => Err(self.handle_error(
+                remaining_gas,
+                SyscallExecutionError::ForbiddenClassReplacement { class_hash },
+            )),
+            RunnableContractClass::V1(_) | RunnableContractClass::V1Native(_) => {
+                self.state
+                    .set_class_hash_at(self.call.storage_address, class_hash)
+                    .map_err(|e| self.handle_error(remaining_gas, e.into()))?;
+
+                Ok(())
+            }
+        }
     }
 
     fn library_call(

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
@@ -1,3 +1,4 @@
+use pretty_assertions::assert_eq;
 use starknet_api::{calldata, felt};
 use test_case::test_case;
 
@@ -10,6 +11,10 @@ use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::{trivial_external_entry_point_new, CairoVersion, BALANCE};
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native); "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
 fn undeclared_class_hash(test_contract: FeatureContract) {
     let mut state = test_state(&ChainInfo::create_for_testing(), BALANCE, &[(test_contract, 1)]);
@@ -19,10 +24,15 @@ fn undeclared_class_hash(test_contract: FeatureContract) {
         entry_point_selector: selector_from_name("test_replace_class"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
-    assert!(error.contains("is not declared"));
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err();
+
+    assert!(error.to_string().contains("is not declared"));
 }
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native); "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
 fn cairo0_class_hash(test_contract: FeatureContract) {
     let empty_contract_cairo0 = FeatureContract::Empty(CairoVersion::Cairo0);
@@ -40,10 +50,15 @@ fn cairo0_class_hash(test_contract: FeatureContract) {
         entry_point_selector: selector_from_name("test_replace_class"),
         ..trivial_external_entry_point_new(test_contract)
     };
-    let error = entry_point_call.execute_directly(&mut state).unwrap_err().to_string();
-    assert!(error.contains("Cannot replace V1 class hash with V0 class hash"));
+    let error = entry_point_call.execute_directly(&mut state).unwrap_err();
+
+    assert!(error.to_string().contains("Cannot replace V1 class hash with V0 class hash"));
 }
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native), 13850; "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 5220; "VM")]
 fn positive_flow(test_contract: FeatureContract, gas_consumed: u64) {
     let empty_contract = FeatureContract::Empty(CairoVersion::Cairo1);


### PR DESCRIPTION
Implements the`replace_class` syscall for native cairo syscall handler.