### PR TITLE
feat(blockifier): add send_message_to_l1 cairo native syscall

### DIFF
--- a/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
@@ -13,6 +13,10 @@ use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::{trivial_external_entry_point_new, CairoVersion, BALANCE};
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native), 32160; "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 20960; "VM")]
 fn test_send_message_to_l1(test_contract: FeatureContract, expected_gas: u64) {
     let chain_info = &ChainInfo::create_for_testing();


### PR DESCRIPTION
Implements the `send_message_to_l1` syscall for native cairo syscall handler.