### PR TITLE
feat(blockifier): add get_block_hash cairo native syscall

### DIFF
--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -21,6 +21,7 @@ use starknet_api::transaction::fields::{Calldata, ContractAddressSalt};
 use starknet_api::transaction::L2ToL1Payload;
 use starknet_types_core::felt::Felt;
 
+use crate::abi::constants;
 use crate::execution::call_info::{
     CallInfo,
     MessageToL1,
@@ -39,6 +40,7 @@ use crate::execution::execution_utils::execute_deployment;
 use crate::execution::native::utils::{calculate_resource_bounds, default_tx_v2_info};
 use crate::execution::syscalls::hint_processor::{
     SyscallExecutionError,
+    BLOCK_NUMBER_OUT_OF_RANGE_ERROR,
     INVALID_INPUT_LENGTH_ERROR,
     OUT_OF_GAS_ERROR,
 };
@@ -254,10 +256,42 @@ impl<'state> NativeSyscallHandler<'state> {
 impl<'state> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
     fn get_block_hash(
         &mut self,
-        _block_number: u64,
-        _remaining_gas: &mut u128,
+        block_number: u64,
+        remaining_gas: &mut u128,
     ) -> SyscallResult<Felt> {
-        todo!("Implement get_block_hash syscall.");
+        self.pre_execute_syscall(remaining_gas, self.context.gas_costs().get_block_hash_gas_cost)?;
+
+        if self.context.execution_mode == ExecutionMode::Validate {
+            let err = SyscallExecutionError::InvalidSyscallInExecutionMode {
+                syscall_name: "get_block_hash".to_string(),
+                execution_mode: ExecutionMode::Validate,
+            };
+            return Err(self.handle_error(remaining_gas, err));
+        }
+
+        let current_block_number =
+            self.context.tx_context.block_context.block_info().block_number.0;
+        if current_block_number < constants::STORED_BLOCK_HASH_BUFFER
+            || block_number > current_block_number - constants::STORED_BLOCK_HASH_BUFFER
+        {
+            // `panic` is unreachable in this case, also this is covered by tests so we can safely
+            // unwrap
+            let out_of_range_felt = Felt::from_hex(BLOCK_NUMBER_OUT_OF_RANGE_ERROR)
+                .expect("Converting BLOCK_NUMBER_OUT_OF_RANGE_ERROR to Felt should not fail.");
+            let error = SyscallExecutionError::SyscallError { error_data: vec![out_of_range_felt] };
+            return Err(self.handle_error(remaining_gas, error));
+        }
+
+        let key = StorageKey::try_from(Felt::from(block_number))
+            .map_err(|e| self.handle_error(remaining_gas, e.into()))?;
+        let block_hash_contract_address =
+            ContractAddress::try_from(Felt::from(constants::BLOCK_HASH_CONTRACT_ADDRESS))
+                .map_err(|e| self.handle_error(remaining_gas, e.into()))?;
+
+        match self.state.get_storage_at(block_hash_contract_address, key) {
+            Ok(value) => Ok(value),
+            Err(e) => Err(self.handle_error(remaining_gas, e.into())),
+        }
     }
 
     fn get_execution_info(&mut self, remaining_gas: &mut u128) -> SyscallResult<ExecutionInfo> {

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
@@ -40,6 +40,10 @@ fn initialize_state(test_contract: FeatureContract) -> (CachedState<DictStateRea
     (state, block_number, block_hash)
 }
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native), 13850; "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1), 5220; "VM")]
 fn positive_flow(test_contract: FeatureContract, expected_gas: u64) {
     let (mut state, block_number, block_hash) = initialize_state(test_contract);
@@ -60,6 +64,10 @@ fn positive_flow(test_contract: FeatureContract, expected_gas: u64) {
     );
 }
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native); "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
 fn negative_flow_execution_mode_validate(test_contract: FeatureContract) {
     let (mut state, block_number, _) = initialize_state(test_contract);
@@ -72,13 +80,30 @@ fn negative_flow_execution_mode_validate(test_contract: FeatureContract) {
     };
 
     let error = entry_point_call.execute_directly_in_validate_mode(&mut state).unwrap_err();
-
+    #[cfg(feature = "cairo_native")]
+    if matches!(test_contract, FeatureContract::TestContract(CairoVersion::Native)) {
+        assert!(
+            error
+                .to_string()
+                .contains("Unauthorized syscall get_block_hash in execution mode Validate.")
+        );
+    } else {
+        check_entry_point_execution_error_for_custom_hint!(
+            &error,
+            "Unauthorized syscall get_block_hash in execution mode Validate.",
+        );
+    }
+    #[cfg(not(feature = "cairo_native"))]
     check_entry_point_execution_error_for_custom_hint!(
         &error,
         "Unauthorized syscall get_block_hash in execution mode Validate.",
     );
 }
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native); "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
 fn negative_flow_block_number_out_of_range(test_contract: FeatureContract) {
     let (mut state, _, _) = initialize_state(test_contract);
@@ -92,10 +117,11 @@ fn negative_flow_block_number_out_of_range(test_contract: FeatureContract) {
         ..trivial_external_entry_point_new(test_contract)
     };
 
-    let call_info = entry_point_call.execute_directly(&mut state).unwrap();
-    assert!(call_info.execution.failed);
-    assert_eq!(
-        format_panic_data(&call_info.execution.retdata.0),
-        "0x426c6f636b206e756d626572206f7574206f662072616e6765 ('Block number out of range')"
+    let call_result = entry_point_call.execute_directly(&mut state);
+    let (actual_error_msg, expected_error_msg) = (
+        format_panic_data(&call_result.unwrap().execution.retdata.0),
+        "0x426c6f636b206e756d626572206f7574206f662072616e6765 ('Block number out of range')",
     );
+
+    assert_eq!(actual_error_msg, expected_error_msg);
 }


### PR DESCRIPTION
Implements the `get_block_hash` syscall for native cairo syscall handler.