### PR TITLE
chore(ci): delete unused lints

### DIFF
--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -6,5 +6,3 @@ cargo clippy --workspace --all-targets --all-features -- \
     -D nonstandard-style \
     -D rust-2018-idioms \
     -D unused \
-    -A clippy::unwrap_used \
-    -A clippy::blocks_in_conditions  # This is because of a bug in tracing: https://github.com/tokio-rs/tracing/issues/2876


### PR DESCRIPTION
- `unwrap_used` is already allowed by default and not denied explicitly in any crate.
- the tracing bug in question has been fixed last month.