### PR TITLE
chore(mempool): implement explicit `Default` for mempool

### DIFF
--- a/crates/mempool/src/communication.rs
+++ b/crates/mempool/src/communication.rs
@@ -29,7 +29,7 @@ pub fn create_mempool_server(
 pub fn create_mempool(
     mempool_p2p_propagator_client: SharedMempoolP2pPropagatorClient,
 ) -> MempoolCommunicationWrapper {
-    MempoolCommunicationWrapper::new(Mempool::empty(), mempool_p2p_propagator_client)
+    MempoolCommunicationWrapper::new(Mempool::default(), mempool_p2p_propagator_client)
 }
 
 /// Wraps the mempool to enable inbound async communication from other components.

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -21,7 +21,7 @@ pub mod mempool_test;
 
 type AccountToNonce = HashMap<ContractAddress, Nonce>;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Mempool {
     _config: MempoolConfig,
     // TODO: add docstring explaining visibility and coupling of the fields.
@@ -39,10 +39,6 @@ pub struct Mempool {
 }
 
 impl Mempool {
-    pub fn empty() -> Self {
-        Mempool::default()
-    }
-
     /// Returns an iterator of the current eligible transactions for sequencing, ordered by their
     /// priority.
     pub fn iter(&self) -> impl Iterator<Item = &TransactionReference> {
@@ -291,6 +287,19 @@ impl Mempool {
         };
 
         incoming_value >= escalation_qualified_value
+    }
+}
+
+impl Default for Mempool {
+    fn default() -> Self {
+        Mempool {
+            _config: MempoolConfig::default(),
+            tx_pool: TransactionPool::default(),
+            tx_queue: TransactionQueue::default(),
+            mempool_state: HashMap::new(),
+            account_nonces: HashMap::new(),
+            fee_escalation_percentage: 10,
+        }
     }
 }
 

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -176,7 +176,7 @@ fn add_txs_and_verify_no_replacement(
 
 #[fixture]
 fn mempool() -> Mempool {
-    Mempool::empty()
+    Mempool::default()
 }
 
 // Tests.

--- a/crates/mempool/tests/flow_test.rs
+++ b/crates/mempool/tests/flow_test.rs
@@ -15,7 +15,7 @@ use starknet_mempool_types::errors::MempoolError;
 
 #[fixture]
 fn mempool() -> Mempool {
-    Mempool::empty()
+    Mempool::default()
 }
 
 // Tests.


### PR DESCRIPTION
Also, remove `Mempool::empty` c-tor; so that constructing a default mempool is explicit.