### PR TITLE
feat: integrate streaming with consensus proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7420,6 +7420,7 @@ dependencies = [
  "papyrus_monitoring_gateway",
  "papyrus_network",
  "papyrus_p2p_sync",
+ "papyrus_protobuf",
  "papyrus_rpc",
  "papyrus_storage",
  "papyrus_sync",

--- a/crates/papyrus_node/Cargo.toml
+++ b/crates/papyrus_node/Cargo.toml
@@ -39,6 +39,7 @@ papyrus_consensus_orchestrator.workspace = true
 papyrus_monitoring_gateway.workspace = true
 papyrus_network.workspace = true
 papyrus_p2p_sync.workspace = true
+papyrus_protobuf.workspace = true
 papyrus_rpc = { workspace = true, optional = true }
 papyrus_storage.workspace = true
 papyrus_sync.workspace = true

--- a/crates/papyrus_node/src/run.rs
+++ b/crates/papyrus_node/src/run.rs
@@ -13,14 +13,16 @@ use papyrus_common::pending_classes::PendingClasses;
 use papyrus_config::presentation::get_config_presentation;
 use papyrus_config::validators::config_validate;
 use papyrus_consensus::config::ConsensusConfig;
+use papyrus_consensus::stream_handler::StreamHandler;
 use papyrus_consensus_orchestrator::papyrus_consensus_context::PapyrusConsensusContext;
 use papyrus_monitoring_gateway::MonitoringServer;
 use papyrus_network::gossipsub_impl::Topic;
-use papyrus_network::network_manager::NetworkManager;
+use papyrus_network::network_manager::{BroadcastTopicChannels, NetworkManager};
 use papyrus_network::{network_manager, NetworkConfig};
 use papyrus_p2p_sync::client::{P2PSyncClient, P2PSyncClientChannels};
 use papyrus_p2p_sync::server::{P2PSyncServer, P2PSyncServerChannels};
 use papyrus_p2p_sync::{Protocol, BUFFER_SIZE};
+use papyrus_protobuf::consensus::{ProposalPart, StreamMessage};
 #[cfg(feature = "rpc")]
 use papyrus_rpc::run_server;
 use papyrus_storage::{open_storage, update_storage_metrics, StorageReader, StorageWriter};
@@ -49,6 +51,7 @@ const DEFAULT_LEVEL: LevelFilter = LevelFilter::INFO;
 // different genesis hash.
 // TODO: Consider moving to a more general place.
 const GENESIS_HASH: &str = "0x0";
+pub const NETWORK_TOPIC: &str = "consensus_proposals";
 
 // TODO(dvir): add this to config.
 // Duration between updates to the storage metrics (those in the collect_storage_metrics function).
@@ -185,12 +188,25 @@ fn spawn_consensus(
 
     let network_channels = network_manager
         .register_broadcast_topic(Topic::new(config.network_topic.clone()), BUFFER_SIZE)?;
+    let proposal_network_channels: BroadcastTopicChannels<StreamMessage<ProposalPart>> =
+        network_manager.register_broadcast_topic(Topic::new(NETWORK_TOPIC), BUFFER_SIZE)?;
+    let BroadcastTopicChannels {
+        broadcasted_messages_receiver: inbound_network_receiver,
+        broadcast_topic_client: outbound_network_sender,
+    } = proposal_network_channels;
+
+    let (outbound_internal_sender, inbound_internal_receiver) =
+        StreamHandler::get_channels(inbound_network_receiver, outbound_network_sender);
+
     let context = PapyrusConsensusContext::new(
         storage_reader.clone(),
         network_channels.broadcast_topic_client.clone(),
+        // outbound_network_sender.clone(),
+        outbound_internal_sender,
         config.num_validators,
         None,
     );
+
     Ok(tokio::spawn(async move {
         Ok(papyrus_consensus::run_consensus(
             context,
@@ -199,6 +215,7 @@ fn spawn_consensus(
             config.consensus_delay,
             config.timeouts.clone(),
             network_channels.into(),
+            inbound_internal_receiver,
             futures::stream::pending(),
         )
         .await?)

--- a/crates/papyrus_protobuf/src/converters/mod.rs
+++ b/crates/papyrus_protobuf/src/converters/mod.rs
@@ -22,6 +22,13 @@ pub enum ProtobufConversionError {
     MissingField { field_description: &'static str },
     #[error("Type `{type_description}` should be {num_expected} bytes but it got {value:?}.")]
     BytesDataLengthMismatch { type_description: &'static str, num_expected: usize, value: Vec<u8> },
+    #[error("Type `{type_description}` got unexpected enum variant {value_as_str}")]
+    WrongEnumVariant {
+        type_description: &'static str,
+        value_as_str: String,
+        expected: &'static str,
+        got: &'static str,
+    },
     #[error(transparent)]
     DecodeError(#[from] DecodeError),
     /// For CompressionError and serde_json::Error we put the string of the error instead of the

--- a/crates/papyrus_protobuf/src/converters/test_instances.rs
+++ b/crates/papyrus_protobuf/src/converters/test_instances.rs
@@ -2,7 +2,7 @@ use papyrus_test_utils::{auto_impl_get_test_instance, get_number_of_variants, Ge
 use rand::Rng;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ContractAddress;
-use starknet_api::transaction::Transaction;
+use starknet_api::transaction::{Transaction, TransactionHash};
 
 use crate::consensus::{
     ConsensusMessage,
@@ -52,6 +52,7 @@ auto_impl_get_test_instance! {
     }
     pub struct TransactionBatch {
         pub transactions: Vec<Transaction>,
+        pub tx_hashes: Vec<TransactionHash>,
     }
     pub enum ProposalPart {
         Init(ProposalInit) = 0,

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/consensus.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/consensus.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 import "p2p/proto/transaction.proto";
 import "p2p/proto/common.proto";
 
+// To be deprecated
 message Proposal {
     uint64               height       = 1;
     uint32               round        = 2;
@@ -54,6 +55,8 @@ message ProposalInit {
 
 message TransactionBatch {
     repeated Transaction transactions = 1;
+    // TODO(guyn): remove this once we know how to calculate hashes
+    repeated Felt252 tx_hashes = 2;
 }
 
 message ProposalFin {

--- a/crates/sequencing/papyrus_consensus/src/stream_handler.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler.rs
@@ -30,7 +30,9 @@ type StreamKey = (PeerId, StreamId);
 const CHANNEL_BUFFER_LENGTH: usize = 100;
 
 #[derive(Debug, Clone)]
-struct StreamData<T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>> {
+struct StreamData<
+    T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + 'static,
+> {
     next_message_id: MessageId,
     // Last message ID. If None, it means we have not yet gotten to it.
     fin_message_id: Option<MessageId>,
@@ -56,7 +58,7 @@ impl<T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError
 /// - Buffering inbound messages and reporting them to the application in order.
 /// - Sending outbound messages to the network, wrapped in StreamMessage.
 pub struct StreamHandler<
-    T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
+    T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + 'static,
 > {
     // For each stream ID from the network, send the application a Receiver
     // that will receive the messages in order. This allows sending such Receivers.
@@ -98,6 +100,41 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
             outbound_stream_receivers: StreamHashMap::new(HashMap::new()),
             outbound_stream_number: HashMap::new(),
         }
+    }
+
+    /// Create a new StreamHandler and start it running in a new task.
+    /// Gets network input/output channels and returns application input/output channels.
+    pub fn get_channels(
+        inbound_network_receiver: BroadcastTopicServer<StreamMessage<T>>,
+        outbound_network_sender: BroadcastTopicClient<StreamMessage<T>>,
+    ) -> (mpsc::Sender<(StreamId, mpsc::Receiver<T>)>, mpsc::Receiver<mpsc::Receiver<T>>) {
+        // The inbound messages come into StreamHandler via inbound_network_receiver,
+        // and are forwarded to the consensus via inbound_internal_receiver
+        // (the StreamHandler keeps the inbound_internal_sender to pass messsage).
+        let (inbound_internal_sender, inbound_internal_receiver): (
+            mpsc::Sender<mpsc::Receiver<T>>,
+            mpsc::Receiver<mpsc::Receiver<T>>,
+        ) = mpsc::channel(CHANNEL_BUFFER_LENGTH);
+        // The outbound messages that an application would like to send are:
+        //  1. Sent into outbound_internal_sender as tuples of (StreamId, Receiver)
+        //  2. Ingested by StreamHandler by its outbound_internal_receiver.
+        //  3. Broadcast by the StreamHandler using its outbound_network_sender.
+        let (outbound_internal_sender, outbound_internal_receiver): (
+            mpsc::Sender<(StreamId, mpsc::Receiver<T>)>,
+            mpsc::Receiver<(StreamId, mpsc::Receiver<T>)>,
+        ) = mpsc::channel(CHANNEL_BUFFER_LENGTH);
+
+        let mut stream_handler = StreamHandler::<T>::new(
+            inbound_internal_sender,    // Sender<Receiver<T>>,
+            inbound_network_receiver,   // BroadcastTopicServer<StreamMessage<T>>,
+            outbound_internal_receiver, // Receiver<(StreamId, Receiver<T>)>,
+            outbound_network_sender,    // BroadcastTopicClient<StreamMessage<T>>
+        );
+        tokio::spawn(async move {
+            stream_handler.run().await;
+        });
+
+        (outbound_internal_sender, inbound_internal_receiver)
     }
 
     /// Listen for messages coming from the network and from the application.

--- a/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
@@ -83,7 +83,7 @@ mod tests {
             mock_register_broadcast_topic().unwrap();
         let network_sender_to_inbound = mock_network.broadcasted_messages_sender;
 
-        // The inbound_receiver is given to StreamHandler to inbound to mock network messages.
+        // The inbound_receiver is given to StreamHandler to mock network messages.
         let BroadcastTopicChannels {
             broadcasted_messages_receiver: inbound_receiver,
             broadcast_topic_client: _,

--- a/crates/sequencing/papyrus_consensus_orchestrator/src/papyrus_consensus_context.rs
+++ b/crates/sequencing/papyrus_consensus_orchestrator/src/papyrus_consensus_context.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use papyrus_consensus::types::{
     ConsensusContext,
     ConsensusError,
@@ -23,7 +23,15 @@ use papyrus_consensus::types::{
     ValidatorId,
 };
 use papyrus_network::network_manager::{BroadcastTopicClient, BroadcastTopicClientTrait};
-use papyrus_protobuf::consensus::{ConsensusMessage, Proposal, ProposalInit, Vote};
+use papyrus_protobuf::consensus::{
+    ConsensusMessage,
+    Proposal,
+    ProposalFin,
+    ProposalInit,
+    ProposalPart,
+    TransactionBatch,
+    Vote,
+};
 use papyrus_storage::body::BodyStorageReader;
 use papyrus_storage::header::HeaderStorageReader;
 use papyrus_storage::{StorageError, StorageReader};
@@ -39,6 +47,7 @@ type HeightToIdToContent = BTreeMap<BlockNumber, HashMap<ProposalContentId, Vec<
 pub struct PapyrusConsensusContext {
     storage_reader: StorageReader,
     network_broadcast_client: BroadcastTopicClient<ConsensusMessage>,
+    network_proposal_sender: mpsc::Sender<(u64, mpsc::Receiver<ProposalPart>)>,
     validators: Vec<ValidatorId>,
     sync_broadcast_sender: Option<BroadcastTopicClient<Vote>>,
     // Proposal building/validating returns immediately, leaving the actual processing to a spawned
@@ -51,12 +60,15 @@ impl PapyrusConsensusContext {
     pub fn new(
         storage_reader: StorageReader,
         network_broadcast_client: BroadcastTopicClient<ConsensusMessage>,
+        network_proposal_sender: mpsc::Sender<(u64, mpsc::Receiver<ProposalPart>)>,
+        // network_proposal_sender: mpsc::Sender<(u64, mpsc::Receiver<ProposalPart>)>,
         num_validators: u64,
         sync_broadcast_sender: Option<BroadcastTopicClient<Vote>>,
     ) -> Self {
         Self {
             storage_reader,
             network_broadcast_client,
+            network_proposal_sender,
             validators: (0..num_validators).map(ContractAddress::from).collect(),
             sync_broadcast_sender,
             valid_proposals: Arc::new(Mutex::new(BTreeMap::new())),
@@ -66,14 +78,16 @@ impl PapyrusConsensusContext {
 
 #[async_trait]
 impl ConsensusContext for PapyrusConsensusContext {
-    type ProposalChunk = Transaction;
+    type ProposalPart = ProposalPart;
 
     async fn build_proposal(
         &mut self,
-        init: ProposalInit,
+        proposal_init: ProposalInit,
         _timeout: Duration,
     ) -> oneshot::Receiver<ProposalContentId> {
-        let mut network_broadcast_sender = self.network_broadcast_client.clone();
+        let mut proposal_sender_sender = self.network_proposal_sender.clone();
+        // let mut proposal_sender = self.network_proposal_sender.clone();
+        // let mut network_broadcast_sender = self.network_broadcast_client.clone();
         let (fin_sender, fin_receiver) = oneshot::channel();
 
         let storage_reader = self.storage_reader.clone();
@@ -83,49 +97,70 @@ impl ConsensusContext for PapyrusConsensusContext {
                 // TODO(dvir): consider fix this for the case of reverts. If between the check that
                 // the block in storage and to getting the transaction was a revert
                 // this flow will fail.
-                wait_for_block(&storage_reader, init.height)
+                wait_for_block(&storage_reader, proposal_init.height)
                     .await
                     .expect("Failed to wait to block");
 
                 let txn = storage_reader.begin_ro_txn().expect("Failed to begin ro txn");
                 let transactions = txn
-                    .get_block_transactions(init.height)
+                    .get_block_transactions(proposal_init.height)
                     .expect("Get transactions from storage failed")
                     .unwrap_or_else(|| {
                         panic!(
                             "Block in {} was not found in storage despite waiting for it",
-                            init.height
+                            proposal_init.height
                         )
                     });
 
                 let block_hash = txn
-                    .get_block_header(init.height)
+                    .get_block_header(proposal_init.height)
                     .expect("Get header from storage failed")
                     .unwrap_or_else(|| {
                         panic!(
                             "Block in {} was not found in storage despite waiting for it",
-                            init.height
+                            proposal_init.height
                         )
                     })
                     .block_hash;
 
-                let proposal = Proposal {
-                    height: init.height.0,
-                    round: init.round,
-                    proposer: init.proposer,
-                    transactions: transactions.clone(),
-                    block_hash,
-                    valid_round: init.valid_round,
-                };
-                network_broadcast_sender
-                    .broadcast_message(ConsensusMessage::Proposal(proposal))
+                // let proposal = Proposal {
+                //     height: init.height.0,
+                //     round: init.round,
+                //     proposer: init.proposer,
+                //     transactions: transactions.clone(),
+                //     block_hash,
+                //     valid_round: init.valid_round,
+                // };
+                // network_broadcast_sender
+                let (mut proposal_sender, proposal_receiver) = mpsc::channel(100);
+                let stream_id = proposal_init.height.0;
+                proposal_sender_sender
+                    .send((stream_id, proposal_receiver))
                     .await
-                    .expect("Failed to send proposal");
+                    .expect("Failed to send proposal receiver");
+                proposal_sender
+                    .send(Self::ProposalPart::Init(proposal_init.clone()))
+                    .await
+                    .expect("Failed to send proposal init");
+                proposal_sender
+                    .send(ProposalPart::Transactions(TransactionBatch {
+                        transactions: transactions.clone(),
+                        tx_hashes: vec![],
+                    }))
+                    .await
+                    .expect("Failed to send transactions");
+                proposal_sender
+                    .send(ProposalPart::Fin(ProposalFin { proposal_content_id: block_hash }))
+                    .await
+                    .expect("Failed to send fin");
                 {
                     let mut proposals = valid_proposals
                         .lock()
                         .expect("Lock on active proposals was poisoned due to a previous panic");
-                    proposals.entry(init.height).or_default().insert(block_hash, transactions);
+                    proposals
+                        .entry(proposal_init.height)
+                        .or_default()
+                        .insert(block_hash, transactions);
                 }
                 // Done after inserting the proposal into the map to avoid race conditions between
                 // insertion and calls to `repropose`.
@@ -141,8 +176,8 @@ impl ConsensusContext for PapyrusConsensusContext {
         &mut self,
         height: BlockNumber,
         _timeout: Duration,
-        mut content: mpsc::Receiver<Transaction>,
-    ) -> oneshot::Receiver<ProposalContentId> {
+        mut content: mpsc::Receiver<ProposalPart>,
+    ) -> oneshot::Receiver<(ProposalContentId, ProposalContentId)> {
         let (fin_sender, fin_receiver) = oneshot::channel();
 
         let storage_reader = self.storage_reader.clone();
@@ -162,18 +197,35 @@ impl ConsensusContext for PapyrusConsensusContext {
                         panic!("Block in {height} was not found in storage despite waiting for it")
                     });
 
-                for tx in transactions.iter() {
-                    let received_tx = content
-                        .next()
-                        .await
-                        .unwrap_or_else(|| panic!("Not received transaction equals to {tx:?}"));
+                // First gather all the non-fin transactions.
+                let mut content_transactions: Vec<Transaction> = Vec::new();
+                let received_block_hash = loop {
+                    match content.next().await {
+                        Some(ProposalPart::Init(_)) => {
+                            panic!("Should not have ProposalInit at this point");
+                        }
+                        Some(ProposalPart::Transactions(batch)) => {
+                            for tx in batch.transactions {
+                                content_transactions.push(tx);
+                            }
+                        }
+                        Some(ProposalPart::Fin(fin)) => {
+                            break fin.proposal_content_id;
+                        }
+                        None => {
+                            panic!("Did not receive a Fin message");
+                        }
+                    }
+                };
+
+                // Check each transaction matches the transactions in the storage.
+                for tx in transactions.iter().rev() {
+                    let received_tx = content_transactions
+                        .pop()
+                        .expect("Received less transactions than expected");
                     if tx != &received_tx {
                         panic!("Transactions are not equal. In storage: {tx:?}, : {received_tx:?}");
                     }
-                }
-
-                if content.next().await.is_some() {
-                    panic!("Received more transactions than expected");
                 }
 
                 let block_hash = txn
@@ -192,7 +244,7 @@ impl ConsensusContext for PapyrusConsensusContext {
                 // Done after inserting the proposal into the map to avoid race conditions between
                 // insertion and calls to `repropose`.
                 // This can happen as a result of sync interrupting `run_height`.
-                fin_sender.send(block_hash).unwrap_or_else(|_| {
+                fin_sender.send((block_hash, received_block_hash)).unwrap_or_else(|_| {
                     warn!("Failed to send block to consensus. height={height}");
                 })
             }

--- a/crates/starknet_api/src/test_utils.rs
+++ b/crates/starknet_api/src/test_utils.rs
@@ -3,9 +3,12 @@ use std::env;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-use crate::core::{ContractAddress, Nonce};
+use crate::block::BlockNumber;
+use crate::core::{ChainId, ContractAddress, Nonce};
+use crate::transaction::{Transaction, TransactionHash};
 
 pub mod declare;
 pub mod deploy_account;
@@ -25,6 +28,19 @@ pub fn read_json_file<P: AsRef<Path>>(path_in_resource_dir: P) -> serde_json::Va
     let json_str = read_to_string(path.to_str().unwrap())
         .unwrap_or_else(|_| panic!("Failed to read file at path: {}", path.display()));
     serde_json::from_str(&json_str).unwrap()
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+/// A struct used for reading the transaction test data (e.g., for transaction hash tests).
+pub struct TransactionTestData {
+    /// The actual transaction.
+    pub transaction: Transaction,
+    /// The expected transaction hash.
+    pub transaction_hash: TransactionHash,
+    /// An optional transaction hash to query.
+    pub only_query_transaction_hash: Option<TransactionHash>,
+    pub chain_id: ChainId,
+    pub block_number: BlockNumber,
 }
 
 #[derive(Debug, Default)]

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -799,6 +799,20 @@ impl std::fmt::Display for TransactionHash {
     }
 }
 
+// TODO(guyn): this is only used for conversion of transactions->executable transactions
+// It should be removed once we integrate a proper way to calculate executable transaction hashes
+impl From<TransactionHash> for Vec<u8> {
+    fn from(tx_hash: TransactionHash) -> Vec<u8> {
+        tx_hash.0.to_bytes_be().to_vec()
+    }
+}
+impl From<Vec<u8>> for TransactionHash {
+    fn from(bytes: Vec<u8>) -> TransactionHash {
+        let array: [u8; 32] = bytes.try_into().expect("Expected a Vec of length 32");
+        TransactionHash(StarkHash::from_bytes_be(&array))
+    }
+}
+
 /// A transaction version.
 #[derive(
     Debug,

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -133,6 +133,31 @@ impl From<crate::executable_transaction::Transaction> for Transaction {
     }
 }
 
+impl From<(Transaction, TransactionHash)> for crate::executable_transaction::Transaction {
+    fn from(tup: (Transaction, TransactionHash)) -> Self {
+        let (tx, tx_hash) = tup;
+        match tx {
+            Transaction::Declare(_tx) => {
+                unimplemented!("Declare transactions are not supported yet.")
+            }
+            Transaction::Deploy(_tx) => {
+                unimplemented!("Deploy transactions are not supported yet.")
+            }
+            Transaction::DeployAccount(_tx) => {
+                unimplemented!("DeployAccount transactions are not supported yet.")
+            }
+            Transaction::Invoke(tx) => crate::executable_transaction::Transaction::Account(
+                crate::executable_transaction::AccountTransaction::Invoke(
+                    crate::executable_transaction::InvokeTransaction { tx, tx_hash },
+                ),
+            ),
+            Transaction::L1Handler(_) => {
+                unimplemented!("L1Handler transactions are not supported yet.")
+            }
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct TransactionOptions {
     /// Transaction that shouldn't be broadcasted to StarkNet. For example, users that want to

--- a/crates/starknet_api/src/transaction_hash_test.rs
+++ b/crates/starknet_api/src/transaction_hash_test.rs
@@ -1,13 +1,10 @@
 use pretty_assertions::assert_eq;
-use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use starknet_types_core::felt::Felt;
 
 use super::{get_transaction_hash, validate_transaction_hash, CONSTRUCTOR_ENTRY_POINT_SELECTOR};
-use crate::block::BlockNumber;
-use crate::core::ChainId;
-use crate::test_utils::read_json_file;
-use crate::transaction::{Transaction, TransactionHash, TransactionOptions};
+use crate::test_utils::{read_json_file, TransactionTestData};
+use crate::transaction::{Transaction, TransactionOptions};
 
 #[test]
 fn test_constructor_selector() {
@@ -19,18 +16,9 @@ fn test_constructor_selector() {
     assert_eq!(constructor_felt, CONSTRUCTOR_ENTRY_POINT_SELECTOR);
 }
 
-#[derive(Deserialize, Serialize)]
-struct TransactionTestData {
-    transaction: Transaction,
-    transaction_hash: TransactionHash,
-    only_query_transaction_hash: Option<TransactionHash>,
-    chain_id: ChainId,
-    block_number: BlockNumber,
-}
-
 #[test]
 fn test_transaction_hash() {
-    // The details were taken from Starknet Mainnet. You can found the transactions by hash in:
+    // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
     let transactions_test_data_vec: Vec<TransactionTestData> =
         serde_json::from_value(read_json_file("transaction_hash.json")).unwrap();
@@ -64,7 +52,7 @@ fn test_transaction_hash() {
 
 #[test]
 fn test_deprecated_transaction_hash() {
-    // The details were taken from Starknet Mainnet. You can found the transactions by hash in:
+    // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
     let transaction_test_data_vec: Vec<TransactionTestData> =
         serde_json::from_value(read_json_file("deprecated_transaction_hash.json")).unwrap();

--- a/crates/starknet_api/src/transaction_test.rs
+++ b/crates/starknet_api/src/transaction_test.rs
@@ -1,5 +1,6 @@
 use crate::block::NonzeroGasPrice;
 use crate::execution_resources::GasAmount;
+use crate::test_utils::{read_json_file, TransactionTestData};
 use crate::transaction::Fee;
 
 #[test]
@@ -24,4 +25,16 @@ fn test_fee_div_ceil() {
         GasAmount(10),
         Fee(28).checked_div_ceil(NonzeroGasPrice::try_from(3_u8).unwrap()).unwrap()
     );
+}
+
+#[test]
+fn convert_executable_transaction_and_back() {
+    // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
+    // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
+    let transactions_test_data_vec: Vec<TransactionTestData> =
+        serde_json::from_value(read_json_file("transaction_hash.json")).unwrap();
+
+    for transaction_test_data in transactions_test_data_vec {
+        print!("{:?}", transaction_test_data);
+    }
 }

--- a/crates/starknet_api/src/transaction_test.rs
+++ b/crates/starknet_api/src/transaction_test.rs
@@ -1,4 +1,6 @@
+use super::Transaction;
 use crate::block::NonzeroGasPrice;
+use crate::executable_transaction::Transaction as ExecutableTransaction;
 use crate::execution_resources::GasAmount;
 use crate::test_utils::{read_json_file, TransactionTestData};
 use crate::transaction::Fee;
@@ -31,10 +33,23 @@ fn test_fee_div_ceil() {
 fn convert_executable_transaction_and_back() {
     // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
-    let transactions_test_data_vec: Vec<TransactionTestData> =
+    let mut transactions_test_data_vec: Vec<TransactionTestData> =
         serde_json::from_value(read_json_file("transaction_hash.json")).unwrap();
 
-    for transaction_test_data in transactions_test_data_vec {
-        print!("{:?}", transaction_test_data);
-    }
+    let (tx, tx_hash) = loop {
+        match transactions_test_data_vec.pop() {
+            Some(data) => {
+                if let Transaction::Invoke(tx) = data.transaction {
+                    // Do something with the data
+                    break (Transaction::Invoke(tx), data.transaction_hash);
+                }
+            }
+            None => {
+                panic!("Could not find a single Invoke transaction in the test data");
+            }
+        }
+    };
+    let executable_tx: ExecutableTransaction = (tx.clone(), tx_hash.clone()).into();
+    let tx_back = Transaction::from(executable_tx);
+    assert_eq!(tx, tx_back);
 }


### PR DESCRIPTION
This is still a draft and does not compile! Please look only at the flow and don't worry about the details. 

This PR combines the StreamHandler and ProposalParts structs into the flow of Consensus accepting proposals. 

The Consensus is given a receiver from the StreamHandler, which, in turn, listens to the network and collects messages, sending them as soon as they arrive in the correct order. 

The manager's `run_height` functions takes an additional receiver, and listens separately to regular messages and for proposals (both inside the same `select` statement), 

The new receiver is produced at the begining of the call to `run_consensus` by making a channel and giving one side of it to a newly created StreamHandler and the other side to the `run_height` function. The StreamHandler gets a separate spawned thread to run on, listening to the network. In the future it would also be listening to the consensus context for outgoing proposals. 

TODO: 
- [x] There are two implementations of ConsensusContext, I only updated the "sequencer" one. 
- [ ] There's a difference between Transaction and ExecutableTransaction that I don't really understand. Right now there's an error because some places want a vector of transactions and other places want a vector of executable transactions. 