### PR TITLE
chore: rename broadcasted_message_manager to _metadata

### DIFF
--- a/crates/mempool_p2p/src/runner/mod.rs
+++ b/crates/mempool_p2p/src/runner/mod.rs
@@ -53,7 +53,7 @@ impl ComponentStarter for MempoolP2pRunner {
                     panic!("Network stopped unexpectedly");
                 }
                 // TODO(eitan): Extract the logic into a handle_broadcasted_message method
-                Some((message_result, broadcasted_message_manager)) = self.broadcasted_topic_server.next() => {
+                Some((message_result, broadcasted_message_metadata)) = self.broadcasted_topic_server.next() => {
                     match message_result {
                         Ok(message) => {
                             // TODO(eitan): Add message metadata.
@@ -66,7 +66,7 @@ impl ComponentStarter for MempoolP2pRunner {
                                 Err(e) => {
                                     warn!(
                                         "Failed to forward transaction from MempoolP2pRunner to gateway: {:?}", e);
-                                    if let Err(e) = self.broadcast_topic_client.report_peer(broadcasted_message_manager).await {
+                                    if let Err(e) = self.broadcast_topic_client.report_peer(broadcasted_message_metadata).await {
                                         warn!("Failed to report peer: {:?}", e);
                                     }
                                 }
@@ -74,7 +74,7 @@ impl ComponentStarter for MempoolP2pRunner {
                         }
                         Err(e) => {
                             warn!("Received a faulty transaction from network: {:?}. Attempting to report the sending peer", e);
-                            if let Err(e) = self.broadcast_topic_client.report_peer(broadcasted_message_manager).await {
+                            if let Err(e) = self.broadcast_topic_client.report_peer(broadcasted_message_metadata).await {
                                 warn!("Failed to report peer: {:?}", e);
                             }
                         }

--- a/crates/sequencing/papyrus_consensus/src/manager.rs
+++ b/crates/sequencing/papyrus_consensus/src/manager.rs
@@ -235,7 +235,7 @@ where
         return Ok(msg);
     }
 
-    let (msg, broadcasted_message_manager) =
+    let (msg, broadcasted_message_metadata) =
         broadcasted_messages_receiver.next().await.ok_or_else(|| {
             ConsensusError::InternalNetworkError(
                 "NetworkReceiver should never be closed".to_string(),
@@ -244,12 +244,13 @@ where
     match msg {
         // TODO(matan): Return report_sender for use in later errors by SHC.
         Ok(msg) => {
-            let _ = broadcast_topic_client.continue_propagation(&broadcasted_message_manager).await;
+            let _ =
+                broadcast_topic_client.continue_propagation(&broadcasted_message_metadata).await;
             Ok(msg)
         }
         Err(e) => {
             // Failed to parse consensus message
-            let _ = broadcast_topic_client.report_peer(broadcasted_message_manager).await;
+            let _ = broadcast_topic_client.report_peer(broadcasted_message_metadata).await;
             Err(e.into())
         }
     }

--- a/crates/sequencing/papyrus_consensus/src/simulation_network_receiver.rs
+++ b/crates/sequencing/papyrus_consensus/src/simulation_network_receiver.rs
@@ -130,14 +130,14 @@ impl Stream for NetworkReceiver {
     ) -> Poll<Option<Self::Item>> {
         loop {
             let item = self.broadcasted_messages_receiver.poll_next_unpin(cx);
-            let (msg, broadcasted_message_manager) = match item {
-                Poll::Ready(Some((Ok(msg), broadcasted_message_manager))) => {
-                    (msg, broadcasted_message_manager)
+            let (msg, broadcasted_message_metadata) = match item {
+                Poll::Ready(Some((Ok(msg), broadcasted_message_metadata))) => {
+                    (msg, broadcasted_message_metadata)
                 }
                 _ => return item,
             };
             if let Some(msg) = self.filter_msg(msg) {
-                return Poll::Ready(Some((Ok(msg), broadcasted_message_manager)));
+                return Poll::Ready(Some((Ok(msg), broadcasted_message_metadata)));
             }
         }
     }


### PR DESCRIPTION
The name "broadcasted message manager" has changed to "broadcasted message metadata". I've updated a few places where the variable names were not updated to reflect this.