### PR TITLE
chore(mempool): add nonce increment error

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -122,7 +122,8 @@ impl Mempool {
 
         // Align mempool data to committed nonces.
         for (&address, &nonce) in &nonces {
-            let next_nonce = nonce.try_increment().map_err(|_| MempoolError::FeltOutOfRange)?;
+            let next_nonce =
+                nonce.try_increment().map_err(|_| MempoolError::NonceTooLarge(nonce))?;
             let account_state = AccountState { address, nonce: next_nonce };
             self.align_to_account_state(account_state);
         }

--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -107,8 +107,7 @@ impl TransactionPool {
         current_account_state: AccountState,
     ) -> MempoolResult<Option<&TransactionReference>> {
         let AccountState { address, nonce } = current_account_state;
-        // TOOD(Ayelet): Change to StarknetApiError.
-        let next_nonce = nonce.try_increment().map_err(|_| MempoolError::FeltOutOfRange)?;
+        let next_nonce = nonce.try_increment().map_err(|_| MempoolError::NonceTooLarge(nonce))?;
         Ok(self.get_by_address_and_nonce(address, next_nonce))
     }
 

--- a/crates/mempool_types/src/errors.rs
+++ b/crates/mempool_types/src/errors.rs
@@ -9,11 +9,10 @@ pub enum MempoolError {
     DuplicateNonce { address: ContractAddress, nonce: Nonce },
     #[error("Duplicate transaction, with hash: {tx_hash}")]
     DuplicateTransaction { tx_hash: TransactionHash },
-    #[error("Transaction with hash: {tx_hash} not found")]
-    TransactionNotFound { tx_hash: TransactionHash },
-    // TODO(Mohammad): Consider using `StarknetApiError` once it implements `PartialEq`.
-    #[error("Out of range.")]
-    FeltOutOfRange,
+    #[error("{0}")]
+    NonceTooLarge(Nonce),
     #[error("Transaction with hash: {tx_hash} could not be sent using p2p client.")]
     P2pPropagatorClientError { tx_hash: TransactionHash },
+    #[error("Transaction with hash: {tx_hash} not found")]
+    TransactionNotFound { tx_hash: TransactionHash },
 }


### PR DESCRIPTION
More direct error type.
Also removed TODOs, we don't need all of SNAPI error if only this error is possible.

Side-note: we are assuming that try_increment only fails due to addition overflow, but in the future that might not be the case, though i doubt this edge case will occur and is worth `match`ing the actual error variant we get from SNAPI.