### PR TITLE
fix(mempool): bump nonce before saving in state

### DIFF
--- a/crates/mempool/src/lib.rs
+++ b/crates/mempool/src/lib.rs
@@ -3,6 +3,7 @@ pub mod mempool;
 pub(crate) mod suspended_transaction_pool;
 pub(crate) mod transaction_pool;
 pub(crate) mod transaction_queue;
+pub(crate) mod utils;
 
 #[cfg(any(feature = "testing", test))]
 pub mod test_utils;

--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -7,6 +7,7 @@ use starknet_mempool_types::errors::MempoolError;
 use starknet_mempool_types::mempool_types::{AccountState, MempoolResult};
 
 use crate::mempool::TransactionReference;
+use crate::utils::try_increment_nonce;
 
 type HashToTransaction = HashMap<TransactionHash, Transaction>;
 
@@ -107,7 +108,7 @@ impl TransactionPool {
         current_account_state: AccountState,
     ) -> MempoolResult<Option<&TransactionReference>> {
         let AccountState { address, nonce } = current_account_state;
-        let next_nonce = nonce.try_increment().map_err(|_| MempoolError::NonceTooLarge(nonce))?;
+        let next_nonce = try_increment_nonce(nonce)?;
         Ok(self.get_by_address_and_nonce(address, next_nonce))
     }
 

--- a/crates/mempool/src/utils.rs
+++ b/crates/mempool/src/utils.rs
@@ -1,0 +1,7 @@
+use starknet_api::core::Nonce;
+use starknet_mempool_types::communication::MempoolResult;
+use starknet_mempool_types::errors::MempoolError;
+
+pub fn try_increment_nonce(nonce: Nonce) -> MempoolResult<Nonce> {
+    nonce.try_increment().map_err(|_| MempoolError::NonceTooLarge(nonce))
+}

--- a/crates/mempool/tests/flow_test.rs
+++ b/crates/mempool/tests/flow_test.rs
@@ -48,7 +48,7 @@ fn test_add_tx_fills_nonce_gap(mut mempool: Mempool) {
 }
 
 #[rstest]
-fn test_add_tx_after_get_txs_fails_on_duplicate_nonce(mut mempool: Mempool) {
+fn test_add_tx_rejection_for_txs_passed_to_batcher(mut mempool: Mempool) {
     // Setup.
     let input_tx = add_tx_input!(tx_hash: 0, tx_nonce: 0);
 
@@ -60,7 +60,7 @@ fn test_add_tx_after_get_txs_fails_on_duplicate_nonce(mut mempool: Mempool) {
     add_tx_expect_error(
         &mut mempool,
         &input_tx_duplicate_nonce,
-        MempoolError::DuplicateNonce { address: contract_address!("0x0"), nonce: nonce!(0) },
+        MempoolError::NonceTooOld { address: contract_address!("0x0"), nonce: nonce!(0) },
     );
 }
 

--- a/crates/mempool_types/src/errors.rs
+++ b/crates/mempool_types/src/errors.rs
@@ -11,6 +11,8 @@ pub enum MempoolError {
     DuplicateTransaction { tx_hash: TransactionHash },
     #[error("{0}")]
     NonceTooLarge(Nonce),
+    #[error("Nonce: {nonce} for account address {address} has already been processed.")]
+    NonceTooOld { address: ContractAddress, nonce: Nonce },
     #[error("Transaction with hash: {tx_hash} could not be sent using p2p client.")]
     P2pPropagatorClientError { tx_hash: TransactionHash },
     #[error("Transaction with hash: {tx_hash} not found")]


### PR DESCRIPTION
`mempool_state` had off-by-one error, where the current state was saved instead of the next nonce state. That is, we are eagerly assuming all txs sent to the batcher have been accepted.

Also added util for cast nonce errors and used everywhere (the use everywhere part can be split off to new PR if you prefer).