### PR TITLE
chore(sequencer_node): drop redundant chain_id field from config

### DIFF
--- a/crates/mempool_node/src/config/node_config.rs
+++ b/crates/mempool_node/src/config/node_config.rs
@@ -10,7 +10,6 @@ use papyrus_config::dumping::{
     SerializeConfig,
 };
 use papyrus_config::loading::load_and_process_config;
-use papyrus_config::validators::validate_ascii;
 use papyrus_config::{ConfigError, ParamPath, SerializationType, SerializedParam};
 use serde::{Deserialize, Serialize};
 use starknet_api::core::ChainId;
@@ -51,11 +50,8 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
 
 // TODO(yair): Make the GW and batcher execution config point to the same values.
 /// The configurations of the various components of the node.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Validate)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Validate)]
 pub struct SequencerNodeConfig {
-    /// The [chain id](https://docs.rs/starknet_api/latest/starknet_api/core/struct.ChainId.html) of the Starknet network.
-    #[validate(custom = "validate_ascii")]
-    pub chain_id: ChainId,
     #[validate]
     pub components: ComponentConfig,
     #[validate]
@@ -95,25 +91,7 @@ impl SerializeConfig for SequencerNodeConfig {
                 "monitoring_endpoint_config",
             ),
         ];
-
         sub_configs.into_iter().flatten().collect()
-    }
-}
-
-impl Default for SequencerNodeConfig {
-    fn default() -> Self {
-        Self {
-            chain_id: DEFAULT_CHAIN_ID,
-            components: Default::default(),
-            batcher_config: Default::default(),
-            consensus_manager_config: Default::default(),
-            gateway_config: Default::default(),
-            http_server_config: Default::default(),
-            rpc_state_reader_config: Default::default(),
-            compiler_config: Default::default(),
-            mempool_p2p_config: Default::default(),
-            monitoring_endpoint_config: Default::default(),
-        }
     }
 }
 

--- a/crates/tests-integration/src/bin/run_test_rpc_state_reader.rs
+++ b/crates/tests-integration/src/bin/run_test_rpc_state_reader.rs
@@ -3,7 +3,7 @@ use std::future::pending;
 use anyhow::Ok;
 use starknet_integration_tests::integration_test_config_utils::dump_config_file_changes;
 use starknet_integration_tests::integration_test_utils::{
-    create_config,
+    create_integration_test_config,
     create_integration_test_tx_generator,
 };
 use starknet_integration_tests::state_reader::{spawn_test_rpc_state_reader, StorageTestSetup};
@@ -24,11 +24,13 @@ async fn main() -> anyhow::Result<()> {
             .await;
 
     // Derive the configuration for the sequencer node.
-    let config = create_config(rpc_server_addr, storage_for_test.batcher_storage_config).await;
+    let (config, chain_id) =
+        create_integration_test_config(rpc_server_addr, storage_for_test.batcher_storage_config)
+            .await;
 
     // Note: the batcher storage file handle is passed as a reference to maintain its ownership in
     // this scope, such that the handle is not dropped and the storage is maintained.
-    dump_config_file_changes(config)?;
+    dump_config_file_changes(config, chain_id)?;
 
     // Keep the program running so the rpc state reader server, its storage, and the batcher
     // storage, are all maintained.

--- a/crates/tests-integration/src/integration_test_config_utils.rs
+++ b/crates/tests-integration/src/integration_test_config_utils.rs
@@ -1,9 +1,10 @@
 use std::fs::File;
 use std::io::Write;
 
+use anyhow::Result;
 use serde_json::{json, Value};
+use starknet_api::core::ChainId;
 use starknet_sequencer_node::config::SequencerNodeConfig;
-use tokio::io::Result;
 use tracing::info;
 
 // TODO(Tsabary): Move here all config-related functions from "integration_test_utils.rs".
@@ -42,15 +43,27 @@ macro_rules! config_fields_to_json {
 /// cargo run --bin starknet_sequencer_node -- --config_file NODE_CONFIG_CHANGES_FILE_PATH
 /// Transaction generator:
 /// cargo run --bin run_test_tx_generator -- --config_file TX_GEN_CONFIG_CHANGES_FILE_PATH
-pub fn dump_config_file_changes(config: SequencerNodeConfig) -> anyhow::Result<()> {
+pub fn dump_config_file_changes(config: SequencerNodeConfig, chain_id: ChainId) -> Result<()> {
     // Dump config changes file for the sequencer node.
     let json_data = config_fields_to_json!(
-        config.chain_id,
+        chain_id,
         config.rpc_state_reader_config.json_rpc_version,
         config.rpc_state_reader_config.url,
         config.batcher_config.storage.db_config.path_prefix,
         config.http_server_config.ip,
         config.http_server_config.port,
+        config
+            .batcher_config
+            .block_builder_config
+            .chain_info
+            .fee_token_addresses
+            .eth_fee_token_address,
+        config
+            .batcher_config
+            .block_builder_config
+            .chain_info
+            .fee_token_addresses
+            .strk_fee_token_address,
         config.gateway_config.chain_info.fee_token_addresses.eth_fee_token_address,
         config.gateway_config.chain_info.fee_token_addresses.strk_fee_token_address,
         config.consensus_manager_config.consensus_config.start_height,
@@ -58,8 +71,11 @@ pub fn dump_config_file_changes(config: SequencerNodeConfig) -> anyhow::Result<(
     dump_json_data(json_data, NODE_CONFIG_CHANGES_FILE_PATH)?;
 
     //  Dump config changes file for the transaction generator.
-    let json_data =
-        config_fields_to_json!(config.http_server_config.ip, config.http_server_config.port,);
+    let json_data = config_fields_to_json!(
+        config.http_server_config.ip,
+        config.http_server_config.port,
+        chain_id,
+    );
     dump_json_data(json_data, TX_GEN_CONFIG_CHANGES_FILE_PATH)?;
 
     Ok(())

--- a/crates/tests-integration/src/integration_test_utils.rs
+++ b/crates/tests-integration/src/integration_test_utils.rs
@@ -13,7 +13,7 @@ use papyrus_consensus::config::ConsensusConfig;
 use papyrus_storage::StorageConfig;
 use reqwest::{Client, Response};
 use starknet_api::block::BlockNumber;
-use starknet_api::core::{ContractAddress, PatriciaKey};
+use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{contract_address, patricia_key};
@@ -36,6 +36,8 @@ use starknet_sequencer_node::config::{
 };
 use tokio::net::TcpListener;
 
+// TODO(Tsabary): As the number of required parameters grow, bundle them in a struct and modify the
+// return type.
 pub async fn create_config(
     rpc_server_addr: SocketAddr,
     batcher_storage_config: StorageConfig,
@@ -59,8 +61,8 @@ pub async fn create_config(
     let consensus_manager_config = ConsensusManagerConfig {
         consensus_config: ConsensusConfig { start_height: BlockNumber(1), ..Default::default() },
     };
+
     SequencerNodeConfig {
-        chain_id,
         components,
         batcher_config,
         consensus_manager_config,
@@ -69,6 +71,33 @@ pub async fn create_config(
         rpc_state_reader_config,
         ..SequencerNodeConfig::default()
     }
+}
+
+pub async fn create_integration_test_config(
+    rpc_server_addr: SocketAddr,
+    batcher_storage_config: StorageConfig,
+) -> (SequencerNodeConfig, ChainId) {
+    let chain_id = batcher_storage_config.db_config.chain_id.clone();
+    let mut chain_info = ChainInfo::create_for_testing();
+    chain_info.chain_id = chain_id.clone();
+    let batcher_config = create_batcher_config(batcher_storage_config, chain_info.clone());
+    let gateway_config = create_gateway_config(chain_info).await;
+    let http_server_config = create_http_server_config().await;
+    let rpc_state_reader_config = test_rpc_state_reader_config(rpc_server_addr);
+    let consensus_manager_config = ConsensusManagerConfig {
+        consensus_config: ConsensusConfig { start_height: BlockNumber(1), ..Default::default() },
+    };
+    (
+        SequencerNodeConfig {
+            batcher_config,
+            consensus_manager_config,
+            gateway_config,
+            http_server_config,
+            rpc_state_reader_config,
+            ..SequencerNodeConfig::default()
+        },
+        chain_id,
+    )
 }
 
 pub fn test_rpc_state_reader_config(rpc_server_addr: SocketAddr) -> RpcStateReaderConfig {


### PR DESCRIPTION
**Stack**:
- #1671
- #1670
- #1669
- #1668
- #1667
- #1666
- #1665
- #1664 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*