### PR TITLE
refactor(mempool): call declare_tx_args from StarknetAPI

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -12,7 +12,6 @@ use pretty_assertions::assert_ne;
 use serde_json::to_string_pretty;
 use starknet_api::block::GasPrice;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
-use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::{
@@ -21,29 +20,23 @@ use starknet_api::rpc_transaction::{
     RpcDeployAccountTransactionV3,
     RpcTransaction,
 };
+use starknet_api::test_utils::declare::DeclareTxArgs;
 use starknet_api::test_utils::deploy_account::DeployAccountTxArgs;
 use starknet_api::test_utils::invoke::{rpc_invoke_tx, InvokeTxArgs};
 use starknet_api::test_utils::{get_absolute_path, NonceManager};
 use starknet_api::transaction::fields::{
-    AccountDeploymentData,
     AllResourceBounds,
     ContractAddressSalt,
-    PaymasterData,
     ResourceBounds,
     Tip,
     TransactionSignature,
     ValidResourceBounds,
 };
 use starknet_api::transaction::TransactionVersion;
-use starknet_api::{deploy_account_tx_args, felt, invoke_tx_args, nonce};
+use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args, nonce};
 use starknet_types_core::felt::Felt;
 
-use crate::{
-    declare_tx_args,
-    COMPILED_CLASS_HASH_OF_CONTRACT_CLASS,
-    CONTRACT_CLASS_FILE,
-    TEST_FILES_FOLDER,
-};
+use crate::{COMPILED_CLASS_HASH_OF_CONTRACT_CLASS, CONTRACT_CLASS_FILE, TEST_FILES_FOLDER};
 
 pub const VALID_L1_GAS_MAX_AMOUNT: u64 = 203484;
 pub const VALID_L1_GAS_MAX_PRICE_PER_UNIT: u128 = 100000000000;
@@ -51,11 +44,10 @@ pub const VALID_L2_GAS_MAX_AMOUNT: u64 = 500000;
 pub const VALID_L2_GAS_MAX_PRICE_PER_UNIT: u128 = 100000000000;
 pub const VALID_L1_DATA_GAS_MAX_AMOUNT: u64 = 203484;
 pub const VALID_L1_DATA_GAS_MAX_PRICE_PER_UNIT: u128 = 100000000000;
-// TODO: Move to Gateway's test_utils when DeclareTxArgs is moved to Starknet API.
-pub const TEST_SENDER_ADDRESS: u128 = 0x1000;
 
 // Utils.
 
+// TODO(Noam): Merge this into test_valid_resource_bounds
 pub fn test_resource_bounds_mapping() -> AllResourceBounds {
     AllResourceBounds {
         l1_gas: ResourceBounds {
@@ -96,14 +88,16 @@ pub fn declare_tx() -> RpcTransaction {
     let mut nonce_manager = NonceManager::default();
     let nonce = nonce_manager.next(account_address);
 
-    rpc_declare_tx(declare_tx_args!(
-        signature: TransactionSignature(vec![Felt::ZERO]),
-        sender_address: account_address,
-        resource_bounds: test_resource_bounds_mapping(),
-        nonce,
-        class_hash: compiled_class_hash,
+    rpc_declare_tx(
+        declare_tx_args!(
+            signature: TransactionSignature(vec![Felt::ZERO]),
+            sender_address: account_address,
+            resource_bounds: test_valid_resource_bounds(),
+            nonce,
+            compiled_class_hash: compiled_class_hash
+        ),
         contract_class,
-    ))
+    )
 }
 
 /// Convenience method for generating a single invoke transaction with trivial fields.
@@ -371,64 +365,13 @@ impl Contract {
     }
 }
 
-#[macro_export]
-macro_rules! declare_tx_args {
-    ($($field:ident $(: $value:expr)?),* $(,)?) => {
-        $crate::starknet_api_test_utils::DeclareTxArgs {
-            $($field $(: $value)?,)*
-            ..Default::default()
-        }
-    };
-    ($($field:ident $(: $value:expr)?),* , ..$defaults:expr) => {
-        $crate::starknet_api_test_utils::DeclareTxArgs {
-            $($field $(: $value)?,)*
-            ..$defaults
-        }
-    };
-}
-
-#[derive(Clone)]
-pub struct DeclareTxArgs {
-    pub signature: TransactionSignature,
-    pub sender_address: ContractAddress,
-    pub version: TransactionVersion,
-    pub resource_bounds: AllResourceBounds,
-    pub tip: Tip,
-    pub nonce_data_availability_mode: DataAvailabilityMode,
-    pub fee_data_availability_mode: DataAvailabilityMode,
-    pub paymaster_data: PaymasterData,
-    pub account_deployment_data: AccountDeploymentData,
-    pub nonce: Nonce,
-    pub class_hash: CompiledClassHash,
-    pub contract_class: ContractClass,
-}
-
-impl Default for DeclareTxArgs {
-    fn default() -> Self {
-        Self {
-            signature: TransactionSignature::default(),
-            sender_address: TEST_SENDER_ADDRESS.into(),
-            version: TransactionVersion::THREE,
-            resource_bounds: AllResourceBounds::default(),
-            tip: Tip::default(),
-            nonce_data_availability_mode: DataAvailabilityMode::L1,
-            fee_data_availability_mode: DataAvailabilityMode::L1,
-            paymaster_data: PaymasterData::default(),
-            account_deployment_data: AccountDeploymentData::default(),
-            nonce: Nonce::default(),
-            class_hash: CompiledClassHash::default(),
-            contract_class: ContractClass::default(),
-        }
-    }
-}
-
 pub fn rpc_deploy_account_tx(deploy_tx_args: DeployAccountTxArgs) -> RpcTransaction {
     if deploy_tx_args.version != TransactionVersion::THREE {
         panic!("Unsupported transaction version: {:?}.", deploy_tx_args.version);
     }
 
     let ValidResourceBounds::AllResources(resource_bounds) = deploy_tx_args.resource_bounds else {
-        panic!("Unspported resource bounds type: {:?}.", deploy_tx_args.resource_bounds)
+        panic!("Unsupported resource bounds type: {:?}.", deploy_tx_args.resource_bounds)
     };
 
     starknet_api::rpc_transaction::RpcTransaction::DeployAccount(
@@ -449,24 +392,31 @@ pub fn rpc_deploy_account_tx(deploy_tx_args: DeployAccountTxArgs) -> RpcTransact
     )
 }
 
-pub fn rpc_declare_tx(declare_tx_args: DeclareTxArgs) -> RpcTransaction {
+pub fn rpc_declare_tx(
+    declare_tx_args: DeclareTxArgs,
+    contract_class: ContractClass,
+) -> RpcTransaction {
     if declare_tx_args.version != TransactionVersion::THREE {
         panic!("Unsupported transaction version: {:?}.", declare_tx_args.version);
     }
 
+    let ValidResourceBounds::AllResources(resource_bounds) = declare_tx_args.resource_bounds else {
+        panic!("Unsupported resource bounds type: {:?}.", declare_tx_args.resource_bounds)
+    };
+
     starknet_api::rpc_transaction::RpcTransaction::Declare(
         starknet_api::rpc_transaction::RpcDeclareTransaction::V3(RpcDeclareTransactionV3 {
-            contract_class: declare_tx_args.contract_class,
+            contract_class,
             signature: declare_tx_args.signature,
             sender_address: declare_tx_args.sender_address,
-            resource_bounds: declare_tx_args.resource_bounds,
+            resource_bounds,
             tip: declare_tx_args.tip,
             nonce_data_availability_mode: declare_tx_args.nonce_data_availability_mode,
             fee_data_availability_mode: declare_tx_args.fee_data_availability_mode,
             paymaster_data: declare_tx_args.paymaster_data,
             account_deployment_data: declare_tx_args.account_deployment_data,
             nonce: declare_tx_args.nonce,
-            compiled_class_hash: declare_tx_args.class_hash,
+            compiled_class_hash: declare_tx_args.compiled_class_hash,
         }),
     )
 }

--- a/crates/starknet_api/src/test_utils/declare.rs
+++ b/crates/starknet_api/src/test_utils/declare.rs
@@ -1,3 +1,4 @@
+use crate::contract_address;
 use crate::contract_class::ClassInfo;
 use crate::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use crate::data_availability::DataAvailabilityMode;
@@ -18,6 +19,8 @@ use crate::transaction::{
     TransactionHash,
     TransactionVersion,
 };
+
+pub const TEST_SENDER_ADDRESS: u128 = 0x1000;
 
 #[derive(Clone)]
 pub struct DeclareTxArgs {
@@ -43,7 +46,7 @@ impl Default for DeclareTxArgs {
         Self {
             max_fee: Fee::default(),
             signature: TransactionSignature::default(),
-            sender_address: ContractAddress::default(),
+            sender_address: contract_address!(TEST_SENDER_ADDRESS),
             version: TransactionVersion::THREE,
             resource_bounds: ValidResourceBounds::create_for_testing_no_fee_enforcement(),
             tip: Tip::default(),

--- a/crates/starknet_gateway/src/stateful_transaction_validator_test.rs
+++ b/crates/starknet_gateway/src/stateful_transaction_validator_test.rs
@@ -7,7 +7,6 @@ use blockifier::test_utils::CairoVersion;
 use blockifier::transaction::errors::{TransactionFeeError, TransactionPreValidationError};
 use mempool_test_utils::starknet_api_test_utils::{
     executable_invoke_tx as create_executable_invoke_tx,
-    TEST_SENDER_ADDRESS,
     VALID_L1_GAS_MAX_AMOUNT,
     VALID_L1_GAS_MAX_PRICE_PER_UNIT,
 };
@@ -19,6 +18,7 @@ use starknet_api::block::GasPrice;
 use starknet_api::core::Nonce;
 use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::execution_resources::GasAmount;
+use starknet_api::test_utils::declare::TEST_SENDER_ADDRESS;
 use starknet_api::test_utils::deploy_account::executable_deploy_account_tx;
 use starknet_api::test_utils::invoke::executable_invoke_tx;
 use starknet_api::test_utils::NonceManager;

--- a/crates/starknet_gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/starknet_gateway/src/stateless_transaction_validator_test.rs
@@ -2,7 +2,6 @@ use std::sync::LazyLock;
 use std::vec;
 
 use assert_matches::assert_matches;
-use mempool_test_utils::declare_tx_args;
 use mempool_test_utils::starknet_api_test_utils::rpc_declare_tx;
 use rstest::rstest;
 use starknet_api::core::{EntryPointSelector, L2_ADDRESS_UPPER_BOUND};
@@ -17,7 +16,7 @@ use starknet_api::transaction::fields::{
     ResourceBounds,
     TransactionSignature,
 };
-use starknet_api::{calldata, contract_address, felt, StarknetApiError};
+use starknet_api::{calldata, contract_address, declare_tx_args, felt, StarknetApiError};
 use starknet_types_core::felt::Felt;
 
 use crate::compiler_version::{VersionId, VersionIdError};
@@ -361,7 +360,7 @@ fn test_declare_sierra_version_failure(
         StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
 
     let contract_class = ContractClass { sierra_program, ..Default::default() };
-    let tx = rpc_declare_tx(declare_tx_args!(contract_class));
+    let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
 
     assert_eq!(tx_validator.validate(&tx).unwrap_err(), expected_error);
 }
@@ -381,7 +380,7 @@ fn test_declare_sierra_version_sucsses(#[case] sierra_program: Vec<Felt>) {
         StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
 
     let contract_class = ContractClass { sierra_program, ..Default::default() };
-    let tx = rpc_declare_tx(declare_tx_args!(contract_class));
+    let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
 
     assert_matches!(tx_validator.validate(&tx), Ok(()));
 }
@@ -400,7 +399,7 @@ fn test_declare_contract_class_size_too_long() {
         ..Default::default()
     };
     let contract_class_length = serde_json::to_string(&contract_class).unwrap().len();
-    let tx = rpc_declare_tx(declare_tx_args!(contract_class));
+    let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
 
     assert_matches!(
         tx_validator.validate(&tx).unwrap_err(),
@@ -468,7 +467,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
         },
         ..Default::default()
     };
-    let tx = rpc_declare_tx(declare_tx_args!(contract_class));
+    let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
 
     assert_eq!(tx_validator.validate(&tx), expected);
 
@@ -481,7 +480,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
         },
         ..Default::default()
     };
-    let tx = rpc_declare_tx(declare_tx_args!(contract_class));
+    let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
 
     assert_eq!(tx_validator.validate(&tx), expected);
 
@@ -494,7 +493,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
         },
         ..Default::default()
     };
-    let tx = rpc_declare_tx(declare_tx_args!(contract_class));
+    let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
 
     assert_eq!(tx_validator.validate(&tx), expected);
 }

--- a/crates/starknet_gateway/src/test_utils.rs
+++ b/crates/starknet_gateway/src/test_utils.rs
@@ -1,14 +1,10 @@
-use mempool_test_utils::declare_tx_args;
-use mempool_test_utils::starknet_api_test_utils::{
-    rpc_declare_tx,
-    rpc_deploy_account_tx,
-    TEST_SENDER_ADDRESS,
-};
+use mempool_test_utils::starknet_api_test_utils::{rpc_declare_tx, rpc_deploy_account_tx};
 use starknet_api::block::GasPrice;
 use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::{ContractClass, RpcTransaction};
+use starknet_api::test_utils::declare::TEST_SENDER_ADDRESS;
 use starknet_api::test_utils::invoke::rpc_invoke_tx;
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
@@ -19,7 +15,7 @@ use starknet_api::transaction::fields::{
     TransactionSignature,
     ValidResourceBounds,
 };
-use starknet_api::{deploy_account_tx_args, felt, invoke_tx_args};
+use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args};
 use starknet_types_core::felt::Felt;
 
 use crate::compiler_version::VersionId;
@@ -106,16 +102,18 @@ pub fn rpc_tx_for_testing(
                 ],
                 ..Default::default()
             };
-            rpc_declare_tx(declare_tx_args!(
-                signature,
-                sender_address,
-                resource_bounds,
+            rpc_declare_tx(
+                declare_tx_args!(
+                    signature,
+                    sender_address,
+                    resource_bounds: ValidResourceBounds::AllResources(resource_bounds),
+                    account_deployment_data,
+                    paymaster_data,
+                    nonce_data_availability_mode,
+                    fee_data_availability_mode,
+                ),
                 contract_class,
-                account_deployment_data,
-                paymaster_data,
-                nonce_data_availability_mode,
-                fee_data_availability_mode,
-            ))
+            )
         }
         TransactionType::DeployAccount => rpc_deploy_account_tx(deploy_account_tx_args!(
             signature,


### PR DESCRIPTION
The `DeclareTxArgs` in the mempool contained a `ContractClass` field which does not exist in the appropriate struct in StarknetAPI. The field is required for RPCs from the gateway. Two possible solutions were to either add it as a new field in the struct in the StarknetAPI or add it as an additional argument in the RPC.

Since the struct is used both in internal cases (e.g., by the blockifier) and external cases (the gateway) we've decided not to add the field (which is external in type) to the struct but rather supply it as additional input in the RPC.

Another difference between the two structs is that the default `resource_bound` type in the mempool is `AllResources` while in the StarknetAPI it is `L1Gas`. After refactoring we've supplied all invocations of the macro with a default `AllResources` value and we defer changing the default type in the constructor to `AllResources` for a separate PR.