### PR TITLE
chore(config): rename pointer test params according to new convention

### DIFF
--- a/config/papyrus/default_config.json
+++ b/config/papyrus/default_config.json
@@ -54,7 +54,7 @@
     "privacy": "Public",
     "value": 30000
   },
-  "central.url": {
+  "central.starknet_url": {
     "description": "Starknet feeder-gateway URL. It should match chain_id.",
     "pointer_target": "starknet_url",
     "privacy": "Public"

--- a/crates/mempool_node/src/config/node_config.rs
+++ b/crates/mempool_node/src/config/node_config.rs
@@ -33,22 +33,12 @@ use crate::version::VERSION_FULL;
 pub const DEFAULT_CONFIG_PATH: &str = "config/mempool/default_config.json";
 
 // Configuration parameters that share the same value across multiple components.
-type ConfigPointers = Vec<((ParamPath, SerializedParam), Vec<ParamPath>)>;
 pub const DEFAULT_CHAIN_ID: ChainId = ChainId::Mainnet;
-// TODO(Tsabary/AlonH): Discuss testing of required parameters.
-pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
-    vec![(
-        ser_pointer_target_required_param(
-            "chain_id",
-            SerializationType::String,
-            "The chain to follow.",
-        ),
-        vec![
-            "batcher_config.block_builder_config.chain_info.chain_id".to_owned(),
-            "batcher_config.storage.db_config.chain_id".to_owned(),
-            "gateway_config.chain_info.chain_id".to_owned(),
-            "mempool_p2p_config.network_config.chain_id".to_owned(),
-        ],
+pub static CONFIG_POINTERS: LazyLock<Vec<(ParamPath, SerializedParam)>> = LazyLock::new(|| {
+    vec![ser_pointer_target_required_param(
+        "chain_id",
+        SerializationType::String,
+        "The chain to follow.",
     )]
 });
 
@@ -58,16 +48,14 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
 // Creates a vector of strings with the command name and required parameters that can be used as
 // arguments to load a config.
 #[cfg(any(feature = "testing", test))]
-pub fn create_test_config_load_args(
-    pointers: &Vec<((ParamPath, SerializedParam), Vec<ParamPath>)>,
-) -> Vec<String> {
+pub fn create_test_config_load_args(pointers: &Vec<(ParamPath, SerializedParam)>) -> Vec<String> {
     let mut dummy_values = Vec::new();
 
     // Command name.
     dummy_values.push(node_command().to_string());
 
     // Iterate over required config parameters and add them as args with suitable arbitrary values.
-    for ((target_param, serialized_pointer), _) in pointers {
+    for (target_param, serialized_pointer) in pointers {
         // Param name.
         let required_param_name_as_arg = format!("--{}", target_param);
         dummy_values.push(required_param_name_as_arg);

--- a/crates/papyrus_config/src/config_test.rs
+++ b/crates/papyrus_config/src/config_test.rs
@@ -252,35 +252,49 @@ fn test_nested_config_presentation() {
 
 #[test]
 fn test_pointers_flow() {
+    const TARGET_PARAM_NAME: &str = "a";
+    const TARGET_PARAM_DESCRIPTION: &str = "This is common a.";
+    const POINTING_PARAM_DESCRIPTION: &str = "This is a.";
+    const PUBLIC_POINTING_PARAM_NAME: &str = "public_a.a";
+    const PRIVATE_POINTING_PARAM_NAME: &str = "private_a.a";
+
     let config_map = BTreeMap::from([
-        ser_param("a1", &json!(5), "This is a.", ParamPrivacyInput::Public),
-        ser_param("a2", &json!(5), "This is a.", ParamPrivacyInput::Private),
+        ser_param(
+            PUBLIC_POINTING_PARAM_NAME,
+            &json!(5),
+            POINTING_PARAM_DESCRIPTION,
+            ParamPrivacyInput::Public,
+        ),
+        ser_param(
+            PRIVATE_POINTING_PARAM_NAME,
+            &json!(5),
+            POINTING_PARAM_DESCRIPTION,
+            ParamPrivacyInput::Private,
+        ),
     ]);
-    let pointers = vec![(
-        ser_pointer_target_param("common_a", &json!(10), "This is common a"),
-        vec!["a1".to_owned(), "a2".to_owned()],
-    )];
+    let pointers =
+        vec![ser_pointer_target_param(TARGET_PARAM_NAME, &json!(10), TARGET_PARAM_DESCRIPTION)];
     let stored_map = combine_config_map_and_pointers(config_map, &pointers).unwrap();
     assert_eq!(
-        stored_map["a1"],
+        stored_map[PUBLIC_POINTING_PARAM_NAME],
         json!(SerializedParam {
-            description: "This is a.".to_owned(),
-            content: SerializedContent::PointerTarget("common_a".to_owned()),
+            description: POINTING_PARAM_DESCRIPTION.to_owned(),
+            content: SerializedContent::PointerTarget(TARGET_PARAM_NAME.to_owned()),
             privacy: ParamPrivacy::Public,
         })
     );
     assert_eq!(
-        stored_map["a2"],
+        stored_map[PRIVATE_POINTING_PARAM_NAME],
         json!(SerializedParam {
-            description: "This is a.".to_owned(),
-            content: SerializedContent::PointerTarget("common_a".to_owned()),
+            description: POINTING_PARAM_DESCRIPTION.to_owned(),
+            content: SerializedContent::PointerTarget(TARGET_PARAM_NAME.to_owned()),
             privacy: ParamPrivacy::Private,
         })
     );
     assert_eq!(
-        stored_map["common_a"],
+        stored_map[TARGET_PARAM_NAME],
         json!(SerializedParam {
-            description: "This is common a".to_owned(),
+            description: TARGET_PARAM_DESCRIPTION.to_owned(),
             content: SerializedContent::DefaultValue(json!(10)),
             privacy: ParamPrivacy::TemporaryValue,
         })
@@ -290,34 +304,43 @@ fn test_pointers_flow() {
     let (loaded_config_map, loaded_pointers_map) = split_pointers_map(loaded);
     let (mut config_map, _) = split_values_and_types(loaded_config_map);
     update_config_map_by_pointers(&mut config_map, &loaded_pointers_map).unwrap();
-    assert_eq!(config_map["a1"], json!(10));
-    assert_eq!(config_map["a1"], config_map["a2"]);
+    assert_eq!(config_map[PUBLIC_POINTING_PARAM_NAME], json!(10));
+    assert_eq!(config_map[PUBLIC_POINTING_PARAM_NAME], config_map[PRIVATE_POINTING_PARAM_NAME]);
 }
 
 #[test]
 fn test_required_pointers_flow() {
     // Set up the config map and pointers.
-    const REQUIRED_PARAM_NAME: &str = "common_required_b";
+    const REQUIRED_PARAM_NAME: &str = "b";
     const REQUIRED_PARAM_DESCRIPTION: &str = "This is common required b.";
     const POINTING_PARAM_DESCRIPTION: &str = "This is b.";
+    const PUBLIC_POINTING_PARAM_NAME: &str = "public_b.b";
+    const PRIVATE_POINTING_PARAM_NAME: &str = "private_b.b";
 
     let config_map = BTreeMap::from([
-        ser_param("b1", &json!(6), POINTING_PARAM_DESCRIPTION, ParamPrivacyInput::Public),
-        ser_param("b2", &json!(6), POINTING_PARAM_DESCRIPTION, ParamPrivacyInput::Private),
-    ]);
-    let pointers = vec![(
-        ser_pointer_target_required_param(
-            REQUIRED_PARAM_NAME,
-            SerializationType::PositiveInteger,
-            REQUIRED_PARAM_DESCRIPTION,
+        ser_param(
+            PUBLIC_POINTING_PARAM_NAME,
+            &json!(6),
+            POINTING_PARAM_DESCRIPTION,
+            ParamPrivacyInput::Public,
         ),
-        vec!["b1".to_owned(), "b2".to_owned()],
+        ser_param(
+            PRIVATE_POINTING_PARAM_NAME,
+            &json!(6),
+            POINTING_PARAM_DESCRIPTION,
+            ParamPrivacyInput::Private,
+        ),
+    ]);
+    let pointers = vec![ser_pointer_target_required_param(
+        REQUIRED_PARAM_NAME,
+        SerializationType::PositiveInteger,
+        REQUIRED_PARAM_DESCRIPTION,
     )];
     let stored_map = combine_config_map_and_pointers(config_map, &pointers).unwrap();
 
     // Assert the pointing parameters are correctly set.
     assert_eq!(
-        stored_map["b1"],
+        stored_map[PUBLIC_POINTING_PARAM_NAME],
         json!(SerializedParam {
             description: POINTING_PARAM_DESCRIPTION.to_owned(),
             content: SerializedContent::PointerTarget(REQUIRED_PARAM_NAME.to_owned()),
@@ -325,7 +348,7 @@ fn test_required_pointers_flow() {
         })
     );
     assert_eq!(
-        stored_map["b2"],
+        stored_map[PRIVATE_POINTING_PARAM_NAME],
         json!(SerializedParam {
             description: POINTING_PARAM_DESCRIPTION.to_owned(),
             content: SerializedContent::PointerTarget(REQUIRED_PARAM_NAME.to_owned()),

--- a/crates/papyrus_config/src/lib.rs
+++ b/crates/papyrus_config/src/lib.rs
@@ -54,6 +54,7 @@ use validator::ValidationError;
 use validators::ParsedValidationErrors;
 
 pub(crate) const IS_NONE_MARK: &str = "#is_none";
+pub(crate) const FIELD_SEPARATOR: &str = ".";
 
 /// A nested path of a configuration parameter.
 pub type ParamPath = String;

--- a/crates/papyrus_node/src/config/pointers.rs
+++ b/crates/papyrus_node/src/config/pointers.rs
@@ -45,28 +45,21 @@ lazy_static! {
     /// to be applied on the dumped node config.
     /// The config updates will be performed on the shared pointer targets, and finally, the values
     /// will be propagated to the pointer params.
-    pub static ref CONFIG_POINTERS: Vec<((ParamPath, SerializedParam), Vec<ParamPath>)> = vec![(
+    pub static ref CONFIG_POINTERS: Vec<(ParamPath, SerializedParam)> = vec![
         ser_pointer_target_param(
             "chain_id",
             &ChainId::Mainnet,
             "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
         ),
-        vec!["storage.db_config.chain_id".to_owned(), "rpc.chain_id".to_owned(), "network.chain_id".to_owned()],
-    ),
-    (
         ser_pointer_target_param(
             "starknet_url",
             &"https://alpha-mainnet.starknet.io/".to_string(),
             "The URL of a centralized Starknet gateway.",
         ),
-        vec!["rpc.starknet_url".to_owned(), "central.url".to_owned(), "monitoring_gateway.starknet_url".to_owned()],
-    ),
-    (
         ser_pointer_target_param(
             "collect_metrics",
             &false,
             "If true, collect metrics for the node.",
         ),
-        vec!["rpc.collect_metrics".to_owned(), "monitoring_gateway.collect_metrics".to_owned()],
-    )];
+    ];
 }

--- a/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
+++ b/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
@@ -75,7 +75,7 @@ expression: dumped_default_config
     },
     "privacy": "Public"
   },
-  "central.url": {
+  "central.starknet_url": {
     "description": "Starknet feeder-gateway URL. It should match chain_id.",
     "value": "https://alpha-mainnet.starknet.io/",
     "privacy": "Public"

--- a/crates/papyrus_node/src/run_test.rs
+++ b/crates/papyrus_node/src/run_test.rs
@@ -23,7 +23,7 @@ async fn run_threads_stop() {
     config.storage.db_config.path_prefix = temp_dir.path().into();
 
     // Error when not supplying legal central URL.
-    config.central.url = "_not_legal_url".to_string();
+    config.central.starknet_url = "_not_legal_url".to_string();
     let resources = PapyrusResources::new(&config).unwrap();
     let tasks = PapyrusTaskHandles::default();
     let error = run_threads(config, resources, tasks).await.expect_err("Should be an error.");

--- a/crates/papyrus_sync/src/sources/central.rs
+++ b/crates/papyrus_sync/src/sources/central.rs
@@ -45,7 +45,7 @@ type CentralResult<T> = Result<T, CentralError>;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct CentralSourceConfig {
     pub concurrent_requests: usize,
-    pub url: String,
+    pub starknet_url: String,
     #[serde(deserialize_with = "deserialize_optional_map")]
     pub http_headers: Option<HashMap<String, String>>,
     pub max_state_updates_to_download: usize,
@@ -60,7 +60,7 @@ impl Default for CentralSourceConfig {
     fn default() -> Self {
         CentralSourceConfig {
             concurrent_requests: 10,
-            url: String::from("https://alpha-mainnet.starknet.io/"),
+            starknet_url: String::from("https://alpha-mainnet.starknet.io/"),
             http_headers: None,
             max_state_updates_to_download: 20,
             max_state_updates_to_store_in_memory: 20,
@@ -86,8 +86,8 @@ impl SerializeConfig for CentralSourceConfig {
                 ParamPrivacyInput::Public,
             ),
             ser_param(
-                "url",
-                &self.url,
+                "starknet_url",
+                &self.starknet_url,
                 "Starknet feeder-gateway URL. It should match chain_id.",
                 ParamPrivacyInput::Public,
             ),
@@ -445,7 +445,7 @@ impl CentralSource {
         storage_reader: StorageReader,
     ) -> Result<CentralSource, ClientCreationError> {
         let starknet_client = StarknetFeederGatewayClient::new(
-            &config.url,
+            &config.starknet_url,
             config.http_headers,
             node_version,
             config.retry_config,

--- a/crates/papyrus_sync/src/sources/pending.rs
+++ b/crates/papyrus_sync/src/sources/pending.rs
@@ -58,7 +58,7 @@ impl PendingSource {
         node_version: &'static str,
     ) -> Result<PendingSource, ClientCreationError> {
         let starknet_client = StarknetFeederGatewayClient::new(
-            &config.url,
+            &config.starknet_url,
             config.http_headers,
             node_version,
             config.retry_config,


### PR DESCRIPTION
chore(config): rename central url field

chore(config): add explicit usage of field separator

chore(config): set pointer targets based on target name

chore(config): clear explicit pointer vectors

commit-id:1e620e99

---

**Stack**:
- #1701
- #1692 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*