### PR TITLE
feat: allow DataStreamBuilder to retry queries if non fatal err

### DIFF
--- a/crates/papyrus_p2p_sync/src/client/header.rs
+++ b/crates/papyrus_p2p_sync/src/client/header.rs
@@ -10,7 +10,13 @@ use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use starknet_api::block::BlockNumber;
 use tracing::debug;
 
-use super::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder, ParseDataError};
+use super::stream_builder::{
+    BadPeerError,
+    BlockData,
+    BlockNumberLimit,
+    DataStreamBuilder,
+    ParseDataError,
+};
 use super::{P2PSyncClientError, ALLOWED_SIGNATURES_LENGTH, NETWORK_DATA_TIMEOUT};
 
 impl BlockData for SignedBlockHeader {
@@ -85,7 +91,7 @@ impl DataStreamBuilder<SignedBlockHeader> for HeaderStreamBuilder {
             if block_number
                 != signed_block_header.block_header.block_header_without_hash.block_number
             {
-                return Err(ParseDataError::Fatal(P2PSyncClientError::HeadersUnordered {
+                return Err(ParseDataError::BadPeer(BadPeerError::HeadersUnordered {
                     expected_block_number: block_number,
                     actual_block_number: signed_block_header
                         .block_header
@@ -94,7 +100,7 @@ impl DataStreamBuilder<SignedBlockHeader> for HeaderStreamBuilder {
                 }));
             }
             if signed_block_header.signatures.len() != ALLOWED_SIGNATURES_LENGTH {
-                return Err(ParseDataError::Fatal(P2PSyncClientError::WrongSignaturesLength {
+                return Err(ParseDataError::BadPeer(BadPeerError::WrongSignaturesLength {
                     signatures: signed_block_header.signatures,
                 }));
             }

--- a/crates/papyrus_p2p_sync/src/client/header.rs
+++ b/crates/papyrus_p2p_sync/src/client/header.rs
@@ -10,7 +10,7 @@ use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use starknet_api::block::BlockNumber;
 use tracing::debug;
 
-use super::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder};
+use super::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder, ParseDataError};
 use super::{P2PSyncClientError, ALLOWED_SIGNATURES_LENGTH, NETWORK_DATA_TIMEOUT};
 
 impl BlockData for SignedBlockHeader {
@@ -69,7 +69,7 @@ impl DataStreamBuilder<SignedBlockHeader> for HeaderStreamBuilder {
         >,
         block_number: BlockNumber,
         _storage_reader: &'a StorageReader,
-    ) -> BoxFuture<'a, Result<Option<Self::Output>, P2PSyncClientError>> {
+    ) -> BoxFuture<'a, Result<Option<Self::Output>, ParseDataError>> {
         async move {
             let maybe_signed_header =
                 tokio::time::timeout(NETWORK_DATA_TIMEOUT, signed_headers_response_manager.next())
@@ -85,18 +85,18 @@ impl DataStreamBuilder<SignedBlockHeader> for HeaderStreamBuilder {
             if block_number
                 != signed_block_header.block_header.block_header_without_hash.block_number
             {
-                return Err(P2PSyncClientError::HeadersUnordered {
+                return Err(ParseDataError::Fatal(P2PSyncClientError::HeadersUnordered {
                     expected_block_number: block_number,
                     actual_block_number: signed_block_header
                         .block_header
                         .block_header_without_hash
                         .block_number,
-                });
+                }));
             }
             if signed_block_header.signatures.len() != ALLOWED_SIGNATURES_LENGTH {
-                return Err(P2PSyncClientError::WrongSignaturesLength {
+                return Err(ParseDataError::Fatal(P2PSyncClientError::WrongSignaturesLength {
                     signatures: signed_block_header.signatures,
-                });
+                }));
             }
             Ok(Some(signed_block_header))
         }

--- a/crates/papyrus_p2p_sync/src/client/mod.rs
+++ b/crates/papyrus_p2p_sync/src/client/mod.rs
@@ -122,20 +122,6 @@ impl Default for P2PSyncClientConfig {
 #[derive(thiserror::Error, Debug)]
 pub enum P2PSyncClientError {
     // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    #[error(
-        "The header says that the block's state diff should be of length {expected_length}. Can \
-         only divide the state diff parts into the following lengths: {possible_lengths:?}."
-    )]
-    WrongStateDiffLength { expected_length: usize, possible_lengths: Vec<usize> },
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    #[error("Two state diff parts for the same state diff are conflicting.")]
-    ConflictingStateDiffParts,
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    #[error(
-        "Received an empty state diff part from the network (this is a potential DDoS vector)."
-    )]
-    EmptyStateDiffPart,
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
     #[error("Network returned more responses than expected for a query.")]
     TooManyResponses,
     #[error(

--- a/crates/papyrus_p2p_sync/src/client/mod.rs
+++ b/crates/papyrus_p2p_sync/src/client/mod.rs
@@ -20,7 +20,6 @@ use papyrus_config::converters::deserialize_seconds_to_duration;
 use papyrus_config::dumping::{ser_optional_param, ser_param, SerializeConfig};
 use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use papyrus_network::network_manager::SqmrClientSender;
-use papyrus_protobuf::converters::ProtobufConversionError;
 use papyrus_protobuf::sync::{
     ClassQuery,
     DataOrFin,
@@ -32,7 +31,7 @@ use papyrus_protobuf::sync::{
 };
 use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{BlockNumber, BlockSignature};
+use starknet_api::block::BlockNumber;
 use starknet_api::core::ClassHash;
 use starknet_api::transaction::FullTransaction;
 use state_diff::StateDiffStreamBuilder;
@@ -123,23 +122,6 @@ impl Default for P2PSyncClientConfig {
 #[derive(thiserror::Error, Debug)]
 pub enum P2PSyncClientError {
     // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    // TODO(shahak): Consider removing this error and handling unordered headers without failing.
-    #[error(
-        "Blocks returned unordered from the network. Expected header with \
-         {expected_block_number}, got {actual_block_number}."
-    )]
-    HeadersUnordered { expected_block_number: BlockNumber, actual_block_number: BlockNumber },
-    #[error(
-        "Expected to receive {expected} transactions for {block_number} from the network. Got \
-         {actual} instead."
-    )]
-    // TODO(eitan): Remove this and report to network on invalid data once that's possible.
-    NotEnoughTransactions { expected: usize, actual: usize, block_number: u64 },
-    #[error("Expected to receive one signature from the network. got {signatures:?} instead.")]
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    // Right now we support only one signature. In the future we will support many signatures.
-    WrongSignaturesLength { signatures: Vec<BlockSignature> },
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
     #[error(
         "The header says that the block's state diff should be of length {expected_length}. Can \
          only divide the state diff parts into the following lengths: {possible_lengths:?}."
@@ -156,9 +138,6 @@ pub enum P2PSyncClientError {
     // TODO(shahak): Remove this and report to network on invalid data once that's possible.
     #[error("Network returned more responses than expected for a query.")]
     TooManyResponses,
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    #[error(transparent)]
-    ProtobufConversionError(#[from] ProtobufConversionError),
     #[error(
         "Encountered an old header in the storage at {block_number:?} that's missing the field \
          {missing_field}. Re-sync the node from {block_number:?} from a node that provides this \

--- a/crates/papyrus_p2p_sync/src/client/state_diff.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff.rs
@@ -13,7 +13,12 @@ use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use starknet_api::block::BlockNumber;
 use starknet_api::state::ThinStateDiff;
 
-use crate::client::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder};
+use crate::client::stream_builder::{
+    BlockData,
+    BlockNumberLimit,
+    DataStreamBuilder,
+    ParseDataError,
+};
 use crate::client::{P2PSyncClientError, NETWORK_DATA_TIMEOUT};
 
 impl BlockData for (ThinStateDiff, BlockNumber) {
@@ -44,7 +49,7 @@ impl DataStreamBuilder<StateDiffChunk> for StateDiffStreamBuilder {
         >,
         block_number: BlockNumber,
         storage_reader: &'a StorageReader,
-    ) -> BoxFuture<'a, Result<Option<Self::Output>, P2PSyncClientError>> {
+    ) -> BoxFuture<'a, Result<Option<Self::Output>, ParseDataError>> {
         async move {
             let mut result = ThinStateDiff::default();
             let mut prev_result_len = 0;
@@ -72,15 +77,17 @@ impl DataStreamBuilder<StateDiffChunk> for StateDiffStreamBuilder {
                     if current_state_diff_len == 0 {
                         return Ok(None);
                     } else {
-                        return Err(P2PSyncClientError::WrongStateDiffLength {
-                            expected_length: target_state_diff_len,
-                            possible_lengths: vec![current_state_diff_len],
-                        });
+                        return Err(ParseDataError::Fatal(
+                            P2PSyncClientError::WrongStateDiffLength {
+                                expected_length: target_state_diff_len,
+                                possible_lengths: vec![current_state_diff_len],
+                            },
+                        ));
                     }
                 };
                 prev_result_len = current_state_diff_len;
                 if state_diff_chunk.is_empty() {
-                    return Err(P2PSyncClientError::EmptyStateDiffPart);
+                    return Err(ParseDataError::Fatal(P2PSyncClientError::EmptyStateDiffPart));
                 }
                 // It's cheaper to calculate the length of `state_diff_part` than the length of
                 // `result`.
@@ -89,10 +96,10 @@ impl DataStreamBuilder<StateDiffChunk> for StateDiffStreamBuilder {
             }
 
             if current_state_diff_len != target_state_diff_len {
-                return Err(P2PSyncClientError::WrongStateDiffLength {
+                return Err(ParseDataError::Fatal(P2PSyncClientError::WrongStateDiffLength {
                     expected_length: target_state_diff_len,
                     possible_lengths: vec![prev_result_len, current_state_diff_len],
-                });
+                }));
             }
 
             validate_deprecated_declared_classes_non_conflicting(&result)?;

--- a/crates/papyrus_p2p_sync/src/client/state_diff.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff.rs
@@ -13,6 +13,7 @@ use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use starknet_api::block::BlockNumber;
 use starknet_api::state::ThinStateDiff;
 
+use super::stream_builder::BadPeerError;
 use crate::client::stream_builder::{
     BlockData,
     BlockNumberLimit,
@@ -77,17 +78,15 @@ impl DataStreamBuilder<StateDiffChunk> for StateDiffStreamBuilder {
                     if current_state_diff_len == 0 {
                         return Ok(None);
                     } else {
-                        return Err(ParseDataError::Fatal(
-                            P2PSyncClientError::WrongStateDiffLength {
-                                expected_length: target_state_diff_len,
-                                possible_lengths: vec![current_state_diff_len],
-                            },
-                        ));
+                        return Err(ParseDataError::BadPeer(BadPeerError::WrongStateDiffLength {
+                            expected_length: target_state_diff_len,
+                            possible_lengths: vec![current_state_diff_len],
+                        }));
                     }
                 };
                 prev_result_len = current_state_diff_len;
                 if state_diff_chunk.is_empty() {
-                    return Err(ParseDataError::Fatal(P2PSyncClientError::EmptyStateDiffPart));
+                    return Err(ParseDataError::BadPeer(BadPeerError::EmptyStateDiffPart));
                 }
                 // It's cheaper to calculate the length of `state_diff_part` than the length of
                 // `result`.
@@ -96,7 +95,7 @@ impl DataStreamBuilder<StateDiffChunk> for StateDiffStreamBuilder {
             }
 
             if current_state_diff_len != target_state_diff_len {
-                return Err(ParseDataError::Fatal(P2PSyncClientError::WrongStateDiffLength {
+                return Err(ParseDataError::BadPeer(BadPeerError::WrongStateDiffLength {
                     expected_length: target_state_diff_len,
                     possible_lengths: vec![prev_result_len, current_state_diff_len],
                 }));
@@ -119,7 +118,7 @@ impl DataStreamBuilder<StateDiffChunk> for StateDiffStreamBuilder {
 fn unite_state_diffs(
     state_diff: &mut ThinStateDiff,
     state_diff_chunk: StateDiffChunk,
-) -> Result<(), P2PSyncClientError> {
+) -> Result<(), BadPeerError> {
     match state_diff_chunk {
         StateDiffChunk::ContractDiff(contract_diff) => {
             if let Some(class_hash) = contract_diff.class_hash {
@@ -128,12 +127,12 @@ fn unite_state_diffs(
                     .insert(contract_diff.contract_address, class_hash)
                     .is_some()
                 {
-                    return Err(P2PSyncClientError::ConflictingStateDiffParts);
+                    return Err(BadPeerError::ConflictingStateDiffParts);
                 }
             }
             if let Some(nonce) = contract_diff.nonce {
                 if state_diff.nonces.insert(contract_diff.contract_address, nonce).is_some() {
-                    return Err(P2PSyncClientError::ConflictingStateDiffParts);
+                    return Err(BadPeerError::ConflictingStateDiffParts);
                 }
             }
             if !contract_diff.storage_diffs.is_empty() {
@@ -141,7 +140,7 @@ fn unite_state_diffs(
                     Some(storage_diffs) => {
                         for (k, v) in contract_diff.storage_diffs {
                             if storage_diffs.insert(k, v).is_some() {
-                                return Err(P2PSyncClientError::ConflictingStateDiffParts);
+                                return Err(BadPeerError::ConflictingStateDiffParts);
                             }
                         }
                     }
@@ -159,7 +158,7 @@ fn unite_state_diffs(
                 .insert(declared_class.class_hash, declared_class.compiled_class_hash)
                 .is_some()
             {
-                return Err(P2PSyncClientError::ConflictingStateDiffParts);
+                return Err(BadPeerError::ConflictingStateDiffParts);
             }
         }
         StateDiffChunk::DeprecatedDeclaredClass(deprecated_declared_class) => {
@@ -175,13 +174,13 @@ fn unite_state_diffs(
 )]
 fn validate_deprecated_declared_classes_non_conflicting(
     state_diff: &ThinStateDiff,
-) -> Result<(), P2PSyncClientError> {
+) -> Result<(), BadPeerError> {
     // TODO(shahak): Check if sorting is more efficient.
     if state_diff.deprecated_declared_classes.len()
         == state_diff.deprecated_declared_classes.iter().cloned().collect::<HashSet<_>>().len()
     {
         Ok(())
     } else {
-        Err(P2PSyncClientError::ConflictingStateDiffParts)
+        Err(BadPeerError::ConflictingStateDiffParts)
     }
 }

--- a/crates/papyrus_p2p_sync/src/client/stream_builder.rs
+++ b/crates/papyrus_p2p_sync/src/client/stream_builder.rs
@@ -167,6 +167,17 @@ pub(crate) enum BadPeerError {
     NotEnoughTransactions { expected: usize, actual: usize, block_number: u64 },
     #[error("Expected to receive one signature from the network. got {signatures:?} instead.")]
     WrongSignaturesLength { signatures: Vec<BlockSignature> },
+    #[error(
+        "The header says that the block's state diff should be of length {expected_length}. Can \
+         only divide the state diff parts into the following lengths: {possible_lengths:?}."
+    )]
+    WrongStateDiffLength { expected_length: usize, possible_lengths: Vec<usize> },
+    #[error("Two state diff parts for the same state diff are conflicting.")]
+    ConflictingStateDiffParts,
+    #[error(
+        "Received an empty state diff part from the network (this is a potential DDoS vector)."
+    )]
+    EmptyStateDiffPart,
     #[error(transparent)]
     ProtobufConversionError(#[from] ProtobufConversionError),
 }

--- a/crates/papyrus_p2p_sync/src/client/stream_builder.rs
+++ b/crates/papyrus_p2p_sync/src/client/stream_builder.rs
@@ -11,7 +11,7 @@ use papyrus_protobuf::sync::{BlockHashOrNumber, DataOrFin, Direction, Query};
 use papyrus_storage::header::HeaderStorageReader;
 use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use starknet_api::block::BlockNumber;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use super::{P2PSyncClientError, STEP};
 
@@ -46,7 +46,7 @@ where
         client_response_manager: &'a mut ClientResponsesManager<DataOrFin<InputFromNetwork>>,
         block_number: BlockNumber,
         storage_reader: &'a StorageReader,
-    ) -> BoxFuture<'a, Result<Option<Self::Output>, P2PSyncClientError>>;
+    ) -> BoxFuture<'a, Result<Option<Self::Output>, ParseDataError>>;
 
     fn get_start_block_number(storage_reader: &StorageReader) -> Result<BlockNumber, StorageError>;
 
@@ -102,18 +102,30 @@ where
                 while current_block_number.0 < end_block_number {
                     match Self::parse_data_for_block(
                         &mut client_response_manager, current_block_number, &storage_reader
-                    ).await? {
-                        Some(output) => yield Ok(Box::<dyn BlockData>::from(Box::new(output))),
-                        None => {
+                    ).await {
+                        Ok(Some(output)) => yield Ok(Box::<dyn BlockData>::from(Box::new(output))),
+                        Ok(None) => {
                             debug!(
-                                "Query for {:?} returned with partial data. Waiting {:?} before \
+                                "Query for {:?} on {:?} returned with partial data. Waiting {:?} before \
                                  sending another query.",
-                                Self::TYPE_DESCRIPTION,
-                                wait_period_for_new_data
+                                Self::TYPE_DESCRIPTION, current_block_number, wait_period_for_new_data
                             );
                             tokio::time::sleep(wait_period_for_new_data).await;
                             continue 'send_query_and_parse_responses;
-                        }
+                        },
+                        Err(ParseDataError::BadPeer(err)) => {
+                            warn!(
+                                "Query for {:?} on {:?} returned with bad peer error: {:?}. reporting \
+                                 peer and retrying query.",
+                                Self::TYPE_DESCRIPTION, current_block_number, err
+                            );
+                            client_response_manager.report_peer();
+                            continue 'send_query_and_parse_responses;
+                        },
+                        Err(ParseDataError::Fatal(err)) => {
+                            yield Err(err);
+                            return;
+                        },
                     }
                     info!("Added {:?} for block {}.", Self::TYPE_DESCRIPTION, current_block_number);
                     current_block_number = current_block_number.unchecked_next();
@@ -138,5 +150,34 @@ where
             }
         }
         .boxed()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum BadPeerError {}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum ParseDataError {
+    #[error(transparent)]
+    Fatal(#[from] P2PSyncClientError),
+    #[error(transparent)]
+    BadPeer(#[from] BadPeerError),
+}
+
+impl From<StorageError> for ParseDataError {
+    fn from(err: StorageError) -> Self {
+        ParseDataError::Fatal(P2PSyncClientError::StorageError(err))
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for ParseDataError {
+    fn from(err: tokio::time::error::Elapsed) -> Self {
+        ParseDataError::Fatal(P2PSyncClientError::NetworkTimeout(err))
+    }
+}
+
+impl From<ProtobufConversionError> for ParseDataError {
+    fn from(err: ProtobufConversionError) -> Self {
+        ParseDataError::Fatal(P2PSyncClientError::ProtobufConversionError(err))
     }
 }

--- a/crates/papyrus_p2p_sync/src/client/transaction.rs
+++ b/crates/papyrus_p2p_sync/src/client/transaction.rs
@@ -8,7 +8,13 @@ use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use starknet_api::block::{BlockBody, BlockNumber};
 use starknet_api::transaction::FullTransaction;
 
-use super::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder, ParseDataError};
+use super::stream_builder::{
+    BadPeerError,
+    BlockData,
+    BlockNumberLimit,
+    DataStreamBuilder,
+    ParseDataError,
+};
 use super::{P2PSyncClientError, NETWORK_DATA_TIMEOUT};
 
 impl BlockData for (BlockBody, BlockNumber) {
@@ -57,13 +63,11 @@ impl DataStreamBuilder<FullTransaction> for TransactionStreamFactory {
                     if current_transaction_len == 0 {
                         return Ok(None);
                     } else {
-                        return Err(ParseDataError::Fatal(
-                            P2PSyncClientError::NotEnoughTransactions {
-                                expected: target_transaction_len,
-                                actual: current_transaction_len,
-                                block_number: block_number.0,
-                            },
-                        ));
+                        return Err(ParseDataError::BadPeer(BadPeerError::NotEnoughTransactions {
+                            expected: target_transaction_len,
+                            actual: current_transaction_len,
+                            block_number: block_number.0,
+                        }));
                     }
                 };
                 block_body.transactions.push(transaction);

--- a/crates/papyrus_p2p_sync/src/client/transaction.rs
+++ b/crates/papyrus_p2p_sync/src/client/transaction.rs
@@ -8,7 +8,7 @@ use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use starknet_api::block::{BlockBody, BlockNumber};
 use starknet_api::transaction::FullTransaction;
 
-use super::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder};
+use super::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder, ParseDataError};
 use super::{P2PSyncClientError, NETWORK_DATA_TIMEOUT};
 
 impl BlockData for (BlockBody, BlockNumber) {
@@ -33,7 +33,7 @@ impl DataStreamBuilder<FullTransaction> for TransactionStreamFactory {
         transactions_response_manager: &'a mut ClientResponsesManager<DataOrFin<FullTransaction>>,
         block_number: BlockNumber,
         storage_reader: &'a StorageReader,
-    ) -> BoxFuture<'a, Result<Option<Self::Output>, P2PSyncClientError>> {
+    ) -> BoxFuture<'a, Result<Option<Self::Output>, ParseDataError>> {
         async move {
             let mut block_body = BlockBody::default();
             let mut current_transaction_len = 0;
@@ -57,11 +57,13 @@ impl DataStreamBuilder<FullTransaction> for TransactionStreamFactory {
                     if current_transaction_len == 0 {
                         return Ok(None);
                     } else {
-                        return Err(P2PSyncClientError::NotEnoughTransactions {
-                            expected: target_transaction_len,
-                            actual: current_transaction_len,
-                            block_number: block_number.0,
-                        });
+                        return Err(ParseDataError::Fatal(
+                            P2PSyncClientError::NotEnoughTransactions {
+                                expected: target_transaction_len,
+                                actual: current_transaction_len,
+                                block_number: block_number.0,
+                            },
+                        ));
                     }
                 };
                 block_body.transactions.push(transaction);


### PR DESCRIPTION
Create err types BadPeerError,ParseDataError. later on the errors from P2PSyncClientError will be sorted to fatal and non-fatal(BadPeer). this will allow to retry on non fatal errors during parsing of data blocks.