### PR TITLE
feat: allow StreamHandler to use a generic StreamId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7653,6 +7653,7 @@ dependencies = [
  "papyrus_protobuf",
  "papyrus_storage",
  "papyrus_test_utils",
+ "prost",
  "serde",
  "starknet-types-core",
  "starknet_api",
@@ -7906,6 +7907,7 @@ dependencies = [
 name = "papyrus_protobuf"
 version = "0.0.0"
 dependencies = [
+ "bytes",
  "indexmap 2.7.0",
  "lazy_static",
  "papyrus_common",

--- a/crates/papyrus_node/src/run.rs
+++ b/crates/papyrus_node/src/run.rs
@@ -23,7 +23,7 @@ use papyrus_network::{network_manager, NetworkConfig};
 use papyrus_p2p_sync::client::{P2PSyncClient, P2PSyncClientChannels};
 use papyrus_p2p_sync::server::{P2PSyncServer, P2PSyncServerChannels};
 use papyrus_p2p_sync::{Protocol, BUFFER_SIZE};
-use papyrus_protobuf::consensus::{ProposalPart, StreamMessage};
+use papyrus_protobuf::consensus::{HeightAndRound, ProposalPart, StreamMessage};
 #[cfg(feature = "rpc")]
 use papyrus_rpc::run_server;
 use papyrus_storage::storage_metrics::update_storage_metrics;
@@ -192,8 +192,9 @@ fn spawn_consensus(
 
     let network_channels = network_manager
         .register_broadcast_topic(Topic::new(config.network_topic.clone()), BUFFER_SIZE)?;
-    let proposal_network_channels: BroadcastTopicChannels<StreamMessage<ProposalPart>> =
-        network_manager.register_broadcast_topic(Topic::new(NETWORK_TOPIC), BUFFER_SIZE)?;
+    let proposal_network_channels: BroadcastTopicChannels<
+        StreamMessage<ProposalPart, HeightAndRound>,
+    > = network_manager.register_broadcast_topic(Topic::new(NETWORK_TOPIC), BUFFER_SIZE)?;
     let BroadcastTopicChannels {
         broadcasted_messages_receiver: inbound_network_receiver,
         broadcast_topic_client: outbound_network_sender,

--- a/crates/papyrus_protobuf/Cargo.toml
+++ b/crates/papyrus_protobuf/Cargo.toml
@@ -9,6 +9,7 @@ license-file.workspace = true
 testing = ["papyrus_test_utils", "rand", "rand_chacha"]
 
 [dependencies]
+bytes.workspace = true
 indexmap.workspace = true
 lazy_static.workspace = true
 primitive-types.workspace = true

--- a/crates/papyrus_protobuf/src/converters/consensus.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 #[path = "consensus_test.rs"]
 mod consensus_test;
+
 use std::convert::{TryFrom, TryInto};
 
 use prost::Message;
@@ -79,8 +80,10 @@ impl From<Vote> for protobuf::Vote {
 
 auto_impl_into_and_try_from_vec_u8!(Vote, protobuf::Vote);
 
-impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>>
-    TryFrom<protobuf::StreamMessage> for StreamMessage<T>
+impl<T, StreamId> TryFrom<protobuf::StreamMessage> for StreamMessage<T, StreamId>
+where
+    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
+    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
 {
     type Error = ProtobufConversionError;
 
@@ -101,16 +104,18 @@ impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>>
                     StreamMessageBody::Fin
                 }
             },
-            stream_id: value.stream_id,
+            stream_id: value.stream_id.try_into()?,
             message_id: value.message_id,
         })
     }
 }
 
-impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>> From<StreamMessage<T>>
-    for protobuf::StreamMessage
+impl<
+    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
+    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
+> From<StreamMessage<T, StreamId>> for protobuf::StreamMessage
 {
-    fn from(value: StreamMessage<T>) -> Self {
+    fn from(value: StreamMessage<T, StreamId>) -> Self {
         Self {
             message: match value {
                 StreamMessage {
@@ -122,7 +127,7 @@ impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>> From<
                     Some(protobuf::stream_message::Message::Fin(protobuf::Fin {}))
                 }
             },
-            stream_id: value.stream_id,
+            stream_id: value.stream_id.into(),
             message_id: value.message_id,
         }
     }
@@ -131,17 +136,21 @@ impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>> From<
 // Can't use auto_impl_into_and_try_from_vec_u8!(StreamMessage, protobuf::StreamMessage);
 // because it doesn't seem to work with generics.
 // TODO(guyn): consider expanding the macro to support generics
-impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>> From<StreamMessage<T>>
-    for Vec<u8>
+impl<
+    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
+    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
+> From<StreamMessage<T, StreamId>> for Vec<u8>
 {
-    fn from(value: StreamMessage<T>) -> Self {
+    fn from(value: StreamMessage<T, StreamId>) -> Self {
         let protobuf_value = <protobuf::StreamMessage>::from(value);
         protobuf_value.encode_to_vec()
     }
 }
 
-impl<T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>> TryFrom<Vec<u8>>
-    for StreamMessage<T>
+impl<
+    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
+    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
+> TryFrom<Vec<u8>> for StreamMessage<T, StreamId>
 {
     type Error = ProtobufConversionError;
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {

--- a/crates/papyrus_protobuf/src/converters/consensus_test.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus_test.rs
@@ -20,6 +20,7 @@ use crate::consensus::{
     TransactionBatch,
     Vote,
 };
+use crate::converters::test_instances::TestStreamId;
 
 // If all the fields of `AllResources` are 0 upon serialization,
 // then the deserialized value will be interpreted as the `L1Gas` variant.
@@ -50,7 +51,7 @@ fn convert_stream_message_to_vec_u8_and_back() {
     let mut rng = get_rng();
 
     // Test that we can convert a StreamMessage with a ProposalPart message to bytes and back.
-    let mut stream_message: StreamMessage<ProposalPart> =
+    let mut stream_message: StreamMessage<ProposalPart, TestStreamId> =
         StreamMessage::get_test_instance(&mut rng);
 
     if let StreamMessageBody::Content(ProposalPart::Transactions(proposal)) =
@@ -128,7 +129,7 @@ fn convert_proposal_part_to_vec_u8_and_back() {
 #[test]
 fn stream_message_display() {
     let mut rng = get_rng();
-    let stream_id = 42;
+    let stream_id = TestStreamId(42);
     let message_id = 127;
     let proposal = ProposalPart::get_test_instance(&mut rng);
     let proposal_bytes: Vec<u8> = proposal.clone().into();

--- a/crates/papyrus_protobuf/src/converters/test_instances.rs
+++ b/crates/papyrus_protobuf/src/converters/test_instances.rs
@@ -1,9 +1,13 @@
+use std::fmt::Display;
+
 use papyrus_test_utils::{auto_impl_get_test_instance, get_number_of_variants, GetTestInstance};
+use prost::DecodeError;
 use rand::Rng;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ContractAddress;
 use starknet_api::transaction::Transaction;
 
+use super::ProtobufConversionError;
 use crate::consensus::{
     ProposalFin,
     ProposalInit,
@@ -47,9 +51,48 @@ auto_impl_get_test_instance! {
 
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TestStreamId(pub u64);
+
+impl From<TestStreamId> for Vec<u8> {
+    fn from(value: TestStreamId) -> Self {
+        value.0.to_be_bytes().to_vec()
+    }
+}
+
+impl TryFrom<Vec<u8>> for TestStreamId {
+    type Error = ProtobufConversionError;
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        if bytes.len() != 8 {
+            return Err(ProtobufConversionError::DecodeError(DecodeError::new("Invalid length")));
+        };
+        let mut array = [0; 8];
+        array.copy_from_slice(&bytes);
+        Ok(TestStreamId(u64::from_be_bytes(array)))
+    }
+}
+
+impl PartialOrd for TestStreamId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TestStreamId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl Display for TestStreamId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TestStreamId({})", self.0)
+    }
+}
+
 // The auto_impl_get_test_instance macro does not work for StreamMessage because it has
 // a generic type. TODO(guyn): try to make the macro work with generic types.
-impl GetTestInstance for StreamMessage<ProposalPart> {
+impl GetTestInstance for StreamMessage<ProposalPart, TestStreamId> {
     fn get_test_instance(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
         let message = if rng.gen_bool(0.5) {
             StreamMessageBody::Content(ProposalPart::Transactions(TransactionBatch {
@@ -58,6 +101,6 @@ impl GetTestInstance for StreamMessage<ProposalPart> {
         } else {
             StreamMessageBody::Fin
         };
-        Self { message, stream_id: 12, message_id: 47 }
+        Self { message, stream_id: TestStreamId(12), message_id: 47 }
     }
 }

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/consensus.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/consensus.proto
@@ -24,7 +24,7 @@ message StreamMessage {
         bytes content = 1;
         Fin fin = 2;
     }
-    uint64 stream_id = 3;
+    bytes stream_id = 3;
     uint64 message_id = 4;
 }
 

--- a/crates/sequencing/papyrus_consensus/Cargo.toml
+++ b/crates/sequencing/papyrus_consensus/Cargo.toml
@@ -20,6 +20,7 @@ papyrus_config.workspace = true
 papyrus_network.workspace = true
 papyrus_network_types.workspace = true
 papyrus_protobuf.workspace = true
+prost.workspace = true
 serde = { workspace = true, features = ["derive"] }
 starknet-types-core.workspace = true
 starknet_api.workspace = true

--- a/crates/sequencing/papyrus_consensus/src/stream_handler.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler.rs
@@ -3,6 +3,8 @@
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
 
 use futures::channel::mpsc;
 use futures::StreamExt;
@@ -22,32 +24,65 @@ use tracing::{instrument, warn};
 mod stream_handler_test;
 
 type PeerId = OpaquePeerId;
-type StreamId = u64;
 type MessageId = u64;
-type StreamKey = (PeerId, StreamId);
 
 const CHANNEL_BUFFER_LENGTH: usize = 100;
+
+/// A combination of trait bounds needed for the content of the stream.
+pub trait StreamContentTrait:
+    Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Send
+{
+}
+impl<StreamContent> StreamContentTrait for StreamContent where
+    StreamContent: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Send
+{
+}
+/// A combination of trait bounds needed for the stream ID.
+pub trait StreamIdTrait:
+    Into<Vec<u8>>
+    + TryFrom<Vec<u8>, Error = ProtobufConversionError>
+    + Eq
+    + Hash
+    + Clone
+    + Unpin
+    + Display
+    + Debug
+    + Send
+{
+}
+impl<StreamId> StreamIdTrait for StreamId where
+    StreamId: Into<Vec<u8>>
+        + TryFrom<Vec<u8>, Error = ProtobufConversionError>
+        + Eq
+        + Hash
+        + Clone
+        + Unpin
+        + Display
+        + Debug
+        + Send
+{
+}
 
 // Use this struct for each inbound stream.
 // Drop the struct when:
 // (1) receiver on the other end is dropped,
 // (2) fin message is received and all messages are sent.
 #[derive(Debug)]
-struct StreamData<
-    T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + 'static,
-> {
+struct StreamData<StreamContent: StreamContentTrait, StreamId: StreamIdTrait> {
     next_message_id: MessageId,
     // Last message ID. If None, it means we have not yet gotten to it.
     fin_message_id: Option<MessageId>,
     max_message_id_received: MessageId,
     // Keep the receiver until it is time to send it to the application.
-    receiver: Option<mpsc::Receiver<T>>,
-    sender: mpsc::Sender<T>,
+    receiver: Option<mpsc::Receiver<StreamContent>>,
+    sender: mpsc::Sender<StreamContent>,
     // A buffer for messages that were received out of order.
-    message_buffer: HashMap<MessageId, StreamMessage<T>>,
+    message_buffer: HashMap<MessageId, StreamMessage<StreamContent, StreamId>>,
 }
 
-impl<T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>> StreamData<T> {
+impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
+    StreamData<StreamContent, StreamId>
+{
     fn new() -> Self {
         let (sender, receiver) = mpsc::channel(CHANNEL_BUFFER_LENGTH);
         StreamData {
@@ -64,39 +99,37 @@ impl<T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError
 /// A StreamHandler is responsible for:
 /// - Buffering inbound messages and reporting them to the application in order.
 /// - Sending outbound messages to the network, wrapped in StreamMessage.
-pub struct StreamHandler<
-    T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + 'static,
-> {
+pub struct StreamHandler<StreamContent: StreamContentTrait, StreamId: StreamIdTrait> {
     // For each stream ID from the network, send the application a Receiver
     // that will receive the messages in order. This allows sending such Receivers.
-    inbound_channel_sender: mpsc::Sender<mpsc::Receiver<T>>,
+    inbound_channel_sender: mpsc::Sender<mpsc::Receiver<StreamContent>>,
     // This receives messages from the network.
-    inbound_receiver: BroadcastTopicServer<StreamMessage<T>>,
+    inbound_receiver: BroadcastTopicServer<StreamMessage<StreamContent, StreamId>>,
     // A map from (peer_id, stream_id) to a struct that contains all the information
     // about the stream. This includes both the message buffer and some metadata
     // (like the latest message ID).
-    inbound_stream_data: HashMap<StreamKey, StreamData<T>>,
+    inbound_stream_data: HashMap<(PeerId, StreamId), StreamData<StreamContent, StreamId>>,
     // Whenever application wants to start a new stream, it must send out a
     // (stream_id, Receiver) pair. Each receiver gets messages that should
     // be sent out to the network.
-    outbound_channel_receiver: mpsc::Receiver<(StreamId, mpsc::Receiver<T>)>,
+    outbound_channel_receiver: mpsc::Receiver<(StreamId, mpsc::Receiver<StreamContent>)>,
     // A map where the abovementioned Receivers are stored.
-    outbound_stream_receivers: StreamHashMap<StreamId, mpsc::Receiver<T>>,
+    outbound_stream_receivers: StreamHashMap<StreamId, mpsc::Receiver<StreamContent>>,
     // A network sender that allows sending StreamMessages to peers.
-    outbound_sender: BroadcastTopicClient<StreamMessage<T>>,
+    outbound_sender: BroadcastTopicClient<StreamMessage<StreamContent, StreamId>>,
     // For each stream, keep track of the message_id of the last message sent.
     outbound_stream_number: HashMap<StreamId, MessageId>,
 }
 
-impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>>
-    StreamHandler<T>
+impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
+    StreamHandler<StreamContent, StreamId>
 {
     /// Create a new StreamHandler.
     pub fn new(
-        inbound_channel_sender: mpsc::Sender<mpsc::Receiver<T>>,
-        inbound_receiver: BroadcastTopicServer<StreamMessage<T>>,
-        outbound_channel_receiver: mpsc::Receiver<(StreamId, mpsc::Receiver<T>)>,
-        outbound_sender: BroadcastTopicClient<StreamMessage<T>>,
+        inbound_channel_sender: mpsc::Sender<mpsc::Receiver<StreamContent>>,
+        inbound_receiver: BroadcastTopicServer<StreamMessage<StreamContent, StreamId>>,
+        outbound_channel_receiver: mpsc::Receiver<(StreamId, mpsc::Receiver<StreamContent>)>,
+        outbound_sender: BroadcastTopicClient<StreamMessage<StreamContent, StreamId>>,
     ) -> Self {
         Self {
             inbound_channel_sender,
@@ -113,30 +146,30 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
     /// Gets network input/output channels and returns application input/output channels.
     #[allow(clippy::type_complexity)]
     pub fn get_channels(
-        inbound_network_receiver: BroadcastTopicServer<StreamMessage<T>>,
-        outbound_network_sender: BroadcastTopicClient<StreamMessage<T>>,
+        inbound_network_receiver: BroadcastTopicServer<StreamMessage<StreamContent, StreamId>>,
+        outbound_network_sender: BroadcastTopicClient<StreamMessage<StreamContent, StreamId>>,
     ) -> (
-        mpsc::Sender<(StreamId, mpsc::Receiver<T>)>,
-        mpsc::Receiver<mpsc::Receiver<T>>,
+        mpsc::Sender<(StreamId, mpsc::Receiver<StreamContent>)>,
+        mpsc::Receiver<mpsc::Receiver<StreamContent>>,
         tokio::task::JoinHandle<()>,
-    ) {
+    )
+    where
+        StreamContent: 'static,
+        StreamId: 'static,
+    {
         // The inbound messages come into StreamHandler via inbound_network_receiver.
         // The application gets the messages from inbound_internal_receiver
         // (the StreamHandler keeps the inbound_internal_sender to pass the messages).
-        let (inbound_internal_sender, inbound_internal_receiver): (
-            mpsc::Sender<mpsc::Receiver<T>>,
-            mpsc::Receiver<mpsc::Receiver<T>>,
-        ) = mpsc::channel(CHANNEL_BUFFER_LENGTH);
+        let (inbound_internal_sender, inbound_internal_receiver) =
+            mpsc::channel(CHANNEL_BUFFER_LENGTH);
         // The outbound messages that an application would like to send are:
         //  1. Sent into outbound_internal_sender as tuples of (StreamId, Receiver)
         //  2. Ingested by StreamHandler by its outbound_internal_receiver.
         //  3. Broadcast by the StreamHandler using its outbound_network_sender.
-        let (outbound_internal_sender, outbound_internal_receiver): (
-            mpsc::Sender<(StreamId, mpsc::Receiver<T>)>,
-            mpsc::Receiver<(StreamId, mpsc::Receiver<T>)>,
-        ) = mpsc::channel(CHANNEL_BUFFER_LENGTH);
+        let (outbound_internal_sender, outbound_internal_receiver) =
+            mpsc::channel(CHANNEL_BUFFER_LENGTH);
 
-        let mut stream_handler = StreamHandler::<T>::new(
+        let mut stream_handler = StreamHandler::<StreamContent, StreamId>::new(
             inbound_internal_sender,    // Sender<Receiver<T>>,
             inbound_network_receiver,   // BroadcastTopicServer<StreamMessage<T>>,
             outbound_internal_receiver, // Receiver<(StreamId, Receiver<T>)>,
@@ -186,8 +219,11 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
         }
     }
 
-    // Returns true if the receiver for this stream is dropped.
-    fn inbound_send(&mut self, data: &mut StreamData<T>, message: StreamMessage<T>) -> bool {
+    fn inbound_send(
+        &mut self,
+        data: &mut StreamData<StreamContent, StreamId>,
+        message: StreamMessage<StreamContent, StreamId>,
+    ) -> bool {
         // TODO(guyn): reconsider the "expect" here.
         let sender = &mut data.sender;
         if let StreamMessageBody::Content(content) = message.message {
@@ -229,23 +265,28 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
     }
 
     // Send the message to the network.
-    async fn broadcast(&mut self, stream_id: StreamId, message: T) {
+    async fn broadcast(&mut self, stream_id: StreamId, message: StreamContent) {
+        // TODO(guyn): add a random nonce to the outbound stream ID,
+        // such that even if the client sends the same stream ID,
+        // (e.g., after a crash) this will be treated as a new stream.
         let message = StreamMessage {
             message: StreamMessageBody::Content(message),
-            stream_id,
+            stream_id: stream_id.clone(),
             message_id: *self.outbound_stream_number.get(&stream_id).unwrap_or(&0),
         };
         // TODO(guyn): reconsider the "expect" here.
         self.outbound_sender.broadcast_message(message).await.expect("Send should succeed");
-        self.outbound_stream_number
-            .insert(stream_id, self.outbound_stream_number.get(&stream_id).unwrap_or(&0) + 1);
+        self.outbound_stream_number.insert(
+            stream_id.clone(),
+            self.outbound_stream_number.get(&stream_id).unwrap_or(&0) + 1,
+        );
     }
 
     // Send a fin message to the network.
     async fn broadcast_fin(&mut self, stream_id: StreamId) {
         let message = StreamMessage {
             message: StreamMessageBody::Fin,
-            stream_id,
+            stream_id: stream_id.clone(),
             message_id: *self.outbound_stream_number.get(&stream_id).unwrap_or(&0),
         };
         self.outbound_sender.broadcast_message(message).await.expect("Send should succeed");
@@ -256,7 +297,10 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
     #[instrument(skip_all, level = "warn")]
     fn handle_message(
         &mut self,
-        message: (Result<StreamMessage<T>, ProtobufConversionError>, BroadcastedMessageMetadata),
+        message: (
+            Result<StreamMessage<StreamContent, StreamId>, ProtobufConversionError>,
+            BroadcastedMessageMetadata,
+        ),
     ) {
         let (message, metadata) = message;
         let message = match message {
@@ -268,7 +312,7 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
         };
 
         let peer_id = metadata.originator_id.clone();
-        let stream_id = message.stream_id;
+        let stream_id = message.stream_id.clone();
         let key = (peer_id, stream_id);
 
         let data = match self.inbound_stream_data.entry(key.clone()) {
@@ -289,12 +333,12 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
     /// should be dropped.
     fn handle_message_inner(
         &mut self,
-        message: StreamMessage<T>,
+        message: StreamMessage<StreamContent, StreamId>,
         metadata: BroadcastedMessageMetadata,
-        mut data: StreamData<T>,
-    ) -> Option<StreamData<T>> {
+        mut data: StreamData<StreamContent, StreamId>,
+    ) -> Option<StreamData<StreamContent, StreamId>> {
         let peer_id = metadata.originator_id;
-        let stream_id = message.stream_id;
+        let stream_id = message.stream_id.clone();
         let key = (peer_id, stream_id);
         let message_id = message.message_id;
 
@@ -367,7 +411,11 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
     }
 
     // Store an inbound message in the buffer.
-    fn store(data: &mut StreamData<T>, key: StreamKey, message: StreamMessage<T>) {
+    fn store(
+        data: &mut StreamData<StreamContent, StreamId>,
+        key: (PeerId, StreamId),
+        message: StreamMessage<StreamContent, StreamId>,
+    ) {
         let message_id = message.message_id;
 
         match data.message_buffer.entry(message_id) {
@@ -387,7 +435,7 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
     // Tries to drain as many messages as possible from the buffer (in order),
     // DOES NOT guarantee that the buffer will be empty after calling this function.
     // Returns true if the receiver for this stream is dropped.
-    fn process_buffer(&mut self, data: &mut StreamData<T>) -> bool {
+    fn process_buffer(&mut self, data: &mut StreamData<StreamContent, StreamId>) -> bool {
         while let Some(message) = data.message_buffer.remove(&data.next_message_id) {
             if self.inbound_send(data, message) {
                 return true;

--- a/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::time::Duration;
 
 use futures::channel::mpsc;
@@ -11,12 +12,53 @@ use papyrus_network::network_manager::test_utils::{
 use papyrus_network::network_manager::BroadcastTopicChannels;
 use papyrus_network_types::network_types::BroadcastedMessageMetadata;
 use papyrus_protobuf::consensus::{StreamMessage, StreamMessageBody};
+use papyrus_protobuf::converters::ProtobufConversionError;
 use papyrus_test_utils::{get_rng, GetTestInstance};
+use prost::DecodeError;
 
-use super::{MessageId, StreamHandler, StreamId};
+use super::{MessageId, StreamHandler};
 
 const TIMEOUT: Duration = Duration::from_millis(100);
 const CHANNEL_SIZE: usize = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct TestStreamId(u64);
+
+impl From<TestStreamId> for Vec<u8> {
+    fn from(value: TestStreamId) -> Self {
+        value.0.to_be_bytes().to_vec()
+    }
+}
+
+impl TryFrom<Vec<u8>> for TestStreamId {
+    type Error = ProtobufConversionError;
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        if bytes.len() != 8 {
+            return Err(ProtobufConversionError::DecodeError(DecodeError::new("Invalid length")));
+        }
+        let mut array = [0; 8];
+        array.copy_from_slice(&bytes);
+        Ok(TestStreamId(u64::from_be_bytes(array)))
+    }
+}
+
+impl PartialOrd for TestStreamId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TestStreamId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl Display for TestStreamId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TestStreamId({})", self.0)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -25,10 +67,10 @@ mod tests {
     use super::*;
 
     fn make_test_message(
-        stream_id: StreamId,
+        stream_id: TestStreamId,
         message_id: MessageId,
         fin: bool,
-    ) -> StreamMessage<ProposalPart> {
+    ) -> StreamMessage<ProposalPart, TestStreamId> {
         let content = match fin {
             true => StreamMessageBody::Fin,
             false => StreamMessageBody::Content(ProposalPart::Init(ProposalInit::default())),
@@ -49,21 +91,24 @@ mod tests {
     }
 
     async fn send(
-        sender: &mut MockBroadcastedMessagesSender<StreamMessage<ProposalPart>>,
+        sender: &mut MockBroadcastedMessagesSender<StreamMessage<ProposalPart, TestStreamId>>,
         metadata: &BroadcastedMessageMetadata,
-        msg: StreamMessage<ProposalPart>,
+        msg: StreamMessage<ProposalPart, TestStreamId>,
     ) {
         sender.send((msg, metadata.clone())).await.unwrap();
     }
 
     #[allow(clippy::type_complexity)]
     fn setup_test() -> (
-        StreamHandler<ProposalPart>,
-        MockBroadcastedMessagesSender<StreamMessage<ProposalPart>>,
+        StreamHandler<ProposalPart, TestStreamId>,
+        MockBroadcastedMessagesSender<StreamMessage<ProposalPart, TestStreamId>>,
         mpsc::Receiver<mpsc::Receiver<ProposalPart>>,
         BroadcastedMessageMetadata,
-        mpsc::Sender<(StreamId, mpsc::Receiver<ProposalPart>)>,
-        futures::stream::Map<mpsc::Receiver<Vec<u8>>, fn(Vec<u8>) -> StreamMessage<ProposalPart>>,
+        mpsc::Sender<(TestStreamId, mpsc::Receiver<ProposalPart>)>,
+        futures::stream::Map<
+            mpsc::Receiver<Vec<u8>>,
+            fn(Vec<u8>) -> StreamMessage<ProposalPart, TestStreamId>,
+        >,
     ) {
         // The outbound_sender is the network connector for broadcasting messages.
         // The network_broadcast_receiver is used to catch those messages in the test.
@@ -80,7 +125,7 @@ mod tests {
         // The receiver goes into StreamHandler, sender is used by the test (as mock Consensus).
         // Note that each new channel comes in a tuple with (stream_id, receiver).
         let (outbound_channel_sender, outbound_channel_receiver) =
-            mpsc::channel::<(StreamId, mpsc::Receiver<ProposalPart>)>(CHANNEL_SIZE);
+            mpsc::channel::<(TestStreamId, mpsc::Receiver<ProposalPart>)>(CHANNEL_SIZE);
 
         // The network_sender_to_inbound is the sender of the mock network, that is used by the
         // test to send messages into the StreamHandler (from the mock network).
@@ -126,7 +171,7 @@ mod tests {
         let (mut stream_handler, mut network_sender, mut inbound_channel_receiver, metadata, _, _) =
             setup_test();
 
-        let stream_id = 127;
+        let stream_id = TestStreamId(127);
         for i in 0..10 {
             let message = make_test_message(stream_id, i, i == 9);
             send(&mut network_sender, &metadata, message).await;
@@ -158,7 +203,7 @@ mod tests {
             _,
         ) = setup_test();
         let peer_id = inbound_metadata.originator_id.clone();
-        let stream_id = 127;
+        let stream_id = TestStreamId(127);
 
         for i in 0..5 {
             let message = make_test_message(stream_id, 5 - i, i == 0);
@@ -233,9 +278,9 @@ mod tests {
         ) = setup_test();
         let peer_id = inbound_metadata.originator_id.clone();
 
-        let stream_id1 = 127; // Send all messages in order (except the first one).
-        let stream_id2 = 10; // Send in reverse order (except the first one).
-        let stream_id3 = 1; // Send in two batches, without the first one, don't send fin.
+        let stream_id1 = TestStreamId(127); // Send all messages in order (except the first one).
+        let stream_id2 = TestStreamId(10); // Send in reverse order (except the first one).
+        let stream_id3 = TestStreamId(1); // Send in two batches, without the first one, don't send fin.
 
         for i in 1..10 {
             let message = make_test_message(stream_id1, i, i == 9);
@@ -264,8 +309,14 @@ mod tests {
         });
         let mut stream_handler = join_handle.await.expect("Task should succeed");
 
-        let values = [(peer_id.clone(), 1), (peer_id.clone(), 10), (peer_id.clone(), 127)];
-        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
+        let values = [
+            (peer_id.clone(), TestStreamId(1)),
+            (peer_id.clone(), TestStreamId(10)),
+            (peer_id.clone(), TestStreamId(127)),
+        ];
+        assert!(
+            stream_handler.inbound_stream_data.keys().to_owned().all(|item| values.contains(item))
+        );
 
         // We have all message from 1 to 9 buffered.
         assert!(do_vecs_match_unordered(
@@ -320,8 +371,10 @@ mod tests {
         let mut stream_handler = join_handle.await.expect("Task should succeed");
 
         // stream_id1 should be gone
-        let values = [(peer_id.clone(), 1), (peer_id.clone(), 10)];
-        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
+        let values = [(peer_id.clone(), TestStreamId(1)), (peer_id.clone(), TestStreamId(10))];
+        assert!(
+            stream_handler.inbound_stream_data.keys().to_owned().all(|item| values.contains(item))
+        );
 
         // Send the last message on stream_id2:
         send(&mut network_sender, &inbound_metadata, make_test_message(stream_id2, 0, false)).await;
@@ -344,8 +397,10 @@ mod tests {
         let mut stream_handler = join_handle.await.expect("Task should succeed");
 
         // Stream_id2 should also be gone.
-        let values = [(peer_id.clone(), 1)];
-        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
+        let values = [(peer_id.clone(), TestStreamId(1))];
+        assert!(
+            stream_handler.inbound_stream_data.keys().to_owned().all(|item| values.contains(item))
+        );
 
         // Send the last message on stream_id3:
         send(&mut network_sender, &inbound_metadata, make_test_message(stream_id3, 0, false)).await;
@@ -366,8 +421,10 @@ mod tests {
         }
 
         // Stream_id3 should still be there, because we didn't send a fin.
-        let values = [(peer_id.clone(), 1)];
-        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
+        let values = [(peer_id.clone(), TestStreamId(1))];
+        assert!(
+            stream_handler.inbound_stream_data.keys().to_owned().all(|item| values.contains(item))
+        );
 
         // But the buffer should be empty, as we've successfully drained it all.
         assert!(
@@ -380,7 +437,7 @@ mod tests {
         let (mut stream_handler, mut network_sender, mut inbound_channel_receiver, metadata, _, _) =
             setup_test();
 
-        let stream_id = 127;
+        let stream_id = TestStreamId(127);
         // Send two messages, no Fin.
         for i in 0..2 {
             let message = make_test_message(stream_id, i, false);
@@ -442,8 +499,8 @@ mod tests {
             mut broadcasted_messages_receiver,
         ) = setup_test();
 
-        let stream_id1: StreamId = 42;
-        let stream_id2: StreamId = 127;
+        let stream_id1 = TestStreamId(42);
+        let stream_id2 = TestStreamId(127);
 
         // Start a new stream by sending the (stream_id, receiver).
         let (mut sender1, receiver1) = mpsc::channel(CHANNEL_SIZE);
@@ -470,7 +527,7 @@ mod tests {
 
         // Check that internally, stream_handler holds this receiver.
         assert_eq!(
-            stream_handler.outbound_stream_receivers.keys().collect::<Vec<&u64>>(),
+            stream_handler.outbound_stream_receivers.keys().collect::<Vec<&TestStreamId>>(),
             vec![&stream_id1]
         );
         // Check that the number of messages sent on this stream is 1.
@@ -520,7 +577,8 @@ mod tests {
         assert_eq!(broadcasted_message.message, StreamMessageBody::Content(message3));
         assert_eq!(broadcasted_message.stream_id, stream_id2);
         assert_eq!(broadcasted_message.message_id, 0);
-        let mut vec1 = stream_handler.outbound_stream_receivers.keys().collect::<Vec<&u64>>();
+        let mut vec1 =
+            stream_handler.outbound_stream_receivers.keys().collect::<Vec<&TestStreamId>>();
         vec1.sort();
         let mut vec2 = vec![&stream_id1, &stream_id2];
         vec2.sort();
@@ -544,7 +602,7 @@ mod tests {
 
         // Check that the information about this stream is gone.
         assert_eq!(
-            stream_handler.outbound_stream_receivers.keys().collect::<Vec<&u64>>(),
+            stream_handler.outbound_stream_receivers.keys().collect::<Vec<&TestStreamId>>(),
             vec![&stream_id2]
         );
     }

--- a/crates/sequencing/papyrus_consensus_orchestrator/src/papyrus_consensus_context_test.rs
+++ b/crates/sequencing/papyrus_consensus_orchestrator/src/papyrus_consensus_context_test.rs
@@ -11,6 +11,7 @@ use papyrus_network::network_manager::test_utils::{
 };
 use papyrus_network::network_manager::BroadcastTopicChannels;
 use papyrus_protobuf::consensus::{
+    HeightAndRound,
     ProposalFin,
     ProposalInit,
     ProposalPart,
@@ -128,8 +129,9 @@ fn test_setup()
         .unwrap();
 
     let network_channels = mock_register_broadcast_topic().unwrap();
-    let network_proposal_channels: TestSubscriberChannels<StreamMessage<ProposalPart>> =
-        mock_register_broadcast_topic().unwrap();
+    let network_proposal_channels: TestSubscriberChannels<
+        StreamMessage<ProposalPart, HeightAndRound>,
+    > = mock_register_broadcast_topic().unwrap();
     let BroadcastTopicChannels {
         broadcasted_messages_receiver: inbound_network_receiver,
         broadcast_topic_client: outbound_network_sender,

--- a/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -21,6 +21,7 @@ use papyrus_consensus::types::{
 };
 use papyrus_network::network_manager::{BroadcastTopicClient, BroadcastTopicClientTrait};
 use papyrus_protobuf::consensus::{
+    HeightAndRound,
     ProposalFin,
     ProposalInit,
     ProposalPart,
@@ -130,7 +131,7 @@ pub struct SequencerConsensusContext {
     // Stores proposals for future rounds until the round is reached.
     queued_proposals:
         BTreeMap<Round, (ValidationParams, oneshot::Sender<(ProposalContentId, ProposalFin)>)>,
-    outbound_proposal_sender: mpsc::Sender<(u64, mpsc::Receiver<ProposalPart>)>,
+    outbound_proposal_sender: mpsc::Sender<(HeightAndRound, mpsc::Receiver<ProposalPart>)>,
     // Used to broadcast votes to other consensus nodes.
     vote_broadcast_client: BroadcastTopicClient<Vote>,
     // Used to convert Transaction to ExecutableTransaction.
@@ -145,7 +146,7 @@ impl SequencerConsensusContext {
     pub fn new(
         state_sync_client: SharedStateSyncClient,
         batcher: Arc<dyn BatcherClient>,
-        outbound_proposal_sender: mpsc::Sender<(u64, mpsc::Receiver<ProposalPart>)>,
+        outbound_proposal_sender: mpsc::Sender<(HeightAndRound, mpsc::Receiver<ProposalPart>)>,
         vote_broadcast_client: BroadcastTopicClient<Vote>,
         num_validators: u64,
         chain_id: ChainId,
@@ -208,7 +209,7 @@ impl ConsensusContext for SequencerConsensusContext {
         self.proposal_id += 1;
         assert!(timeout > BUILD_PROPOSAL_MARGIN);
         let (proposal_sender, proposal_receiver) = mpsc::channel(CHANNEL_SIZE);
-        let stream_id = proposal_init.height.0;
+        let stream_id = HeightAndRound(proposal_init.height.0, proposal_init.round);
         self.outbound_proposal_sender
             .send((stream_id, proposal_receiver))
             .await

--- a/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -16,6 +16,7 @@ use papyrus_network::network_manager::test_utils::{
 };
 use papyrus_network::network_manager::BroadcastTopicChannels;
 use papyrus_protobuf::consensus::{
+    HeightAndRound,
     ProposalFin,
     ProposalInit,
     ProposalPart,
@@ -71,7 +72,7 @@ fn generate_invoke_tx(nonce: u8) -> Transaction {
 // Structs which aren't utilized but should not be dropped.
 struct NetworkDependencies {
     _vote_network: BroadcastNetworkMock<Vote>,
-    _new_proposal_network: BroadcastNetworkMock<StreamMessage<ProposalPart>>,
+    _new_proposal_network: BroadcastNetworkMock<StreamMessage<ProposalPart, HeightAndRound>>,
 }
 
 fn setup(

--- a/crates/starknet_consensus_manager/src/consensus_manager.rs
+++ b/crates/starknet_consensus_manager/src/consensus_manager.rs
@@ -7,7 +7,7 @@ use papyrus_consensus_orchestrator::cende::CendeAmbassador;
 use papyrus_consensus_orchestrator::sequencer_consensus_context::SequencerConsensusContext;
 use papyrus_network::gossipsub_impl::Topic;
 use papyrus_network::network_manager::{BroadcastTopicChannels, NetworkManager};
-use papyrus_protobuf::consensus::{ProposalPart, StreamMessage, Vote};
+use papyrus_protobuf::consensus::{HeightAndRound, ProposalPart, StreamMessage, Vote};
 use starknet_api::block::BlockNumber;
 use starknet_batcher_types::communication::SharedBatcherClient;
 use starknet_infra_utils::type_name::short_type_name;
@@ -44,7 +44,7 @@ impl ConsensusManager {
             NetworkManager::new(self.config.consensus_config.network_config.clone(), None);
 
         let proposals_broadcast_channels = network_manager
-            .register_broadcast_topic::<StreamMessage<ProposalPart>>(
+            .register_broadcast_topic::<StreamMessage<ProposalPart, HeightAndRound>>(
                 Topic::new(CONSENSUS_PROPOSALS_TOPIC),
                 BROADCAST_BUFFER_SIZE,
             )

--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -7,7 +7,7 @@ use mempool_test_utils::starknet_api_test_utils::{
 };
 use papyrus_network::network_manager::test_utils::create_network_configs_connected_to_broadcast_channels;
 use papyrus_network::network_manager::BroadcastTopicChannels;
-use papyrus_protobuf::consensus::{ProposalPart, StreamMessage};
+use papyrus_protobuf::consensus::{HeightAndRound, ProposalPart, StreamMessage};
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_consensus_manager::config::ConsensusManagerConfig;
@@ -44,7 +44,8 @@ pub struct FlowTestSetup {
     pub sequencer_1: FlowSequencerSetup,
 
     // Channels for consensus proposals, used for asserting the right transactions are proposed.
-    pub consensus_proposals_channels: BroadcastTopicChannels<StreamMessage<ProposalPart>>,
+    pub consensus_proposals_channels:
+        BroadcastTopicChannels<StreamMessage<ProposalPart, HeightAndRound>>,
 }
 
 impl FlowTestSetup {
@@ -175,7 +176,10 @@ impl FlowSequencerSetup {
 
 pub fn create_consensus_manager_configs_and_channels(
     ports: Vec<u16>,
-) -> (Vec<ConsensusManagerConfig>, BroadcastTopicChannels<StreamMessage<ProposalPart>>) {
+) -> (
+    Vec<ConsensusManagerConfig>,
+    BroadcastTopicChannels<StreamMessage<ProposalPart, HeightAndRound>>,
+) {
     let (network_configs, broadcast_channels) =
         create_network_configs_connected_to_broadcast_channels(
             papyrus_network::gossipsub_impl::Topic::new(

--- a/crates/starknet_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/starknet_integration_tests/tests/end_to_end_flow_test.rs
@@ -5,6 +5,7 @@ use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerato
 use papyrus_consensus::types::ValidatorId;
 use papyrus_network::network_manager::BroadcastTopicChannels;
 use papyrus_protobuf::consensus::{
+    HeightAndRound,
     ProposalFin,
     ProposalInit,
     ProposalPart,
@@ -149,7 +150,9 @@ async fn wait_for_sequencer_node(sequencer: &FlowSequencerSetup) {
 }
 
 async fn listen_to_broadcasted_messages(
-    consensus_proposals_channels: &mut BroadcastTopicChannels<StreamMessage<ProposalPart>>,
+    consensus_proposals_channels: &mut BroadcastTopicChannels<
+        StreamMessage<ProposalPart, HeightAndRound>,
+    >,
     expected_batched_tx_hashes: &[TransactionHash],
     expected_height: BlockNumber,
     expected_content_id: Felt,


### PR DESCRIPTION
The stream ID is used to uniquely separate streams coming from the same peer. In the use case of consensus, this can be the `(height, round)` we are in. 

In general, the `stream_id` should be convertible into a `Vec<u8>>` and should have some other traits like `Display` and `Clone`, etc. 