### PR TITLE
refactor(mempool): move rpc_invoke_tx to StarknetAPI

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -19,11 +19,10 @@ use starknet_api::rpc_transaction::{
     ContractClass,
     RpcDeclareTransactionV3,
     RpcDeployAccountTransactionV3,
-    RpcInvokeTransactionV3,
     RpcTransaction,
 };
 use starknet_api::test_utils::deploy_account::DeployAccountTxArgs;
-use starknet_api::test_utils::invoke::InvokeTxArgs;
+use starknet_api::test_utils::invoke::{rpc_invoke_tx, InvokeTxArgs};
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::{
     AccountDeploymentData,
@@ -469,31 +468,6 @@ impl Default for DeclareTxArgs {
             contract_class: ContractClass::default(),
         }
     }
-}
-
-pub fn rpc_invoke_tx(invoke_args: InvokeTxArgs) -> RpcTransaction {
-    if invoke_args.version != TransactionVersion::THREE {
-        panic!("Unsupported transaction version: {:?}.", invoke_args.version);
-    }
-
-    let ValidResourceBounds::AllResources(resource_bounds) = invoke_args.resource_bounds else {
-        panic!("Unspported resource bounds type: {:?}.", invoke_args.resource_bounds)
-    };
-
-    starknet_api::rpc_transaction::RpcTransaction::Invoke(
-        starknet_api::rpc_transaction::RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
-            resource_bounds,
-            tip: invoke_args.tip,
-            calldata: invoke_args.calldata,
-            sender_address: invoke_args.sender_address,
-            nonce: invoke_args.nonce,
-            signature: invoke_args.signature,
-            nonce_data_availability_mode: invoke_args.nonce_data_availability_mode,
-            fee_data_availability_mode: invoke_args.fee_data_availability_mode,
-            paymaster_data: invoke_args.paymaster_data,
-            account_deployment_data: invoke_args.account_deployment_data,
-        }),
-    )
 }
 
 pub fn rpc_deploy_account_tx(deploy_tx_args: DeployAccountTxArgs) -> RpcTransaction {

--- a/crates/starknet_api/src/test_utils/invoke.rs
+++ b/crates/starknet_api/src/test_utils/invoke.rs
@@ -2,6 +2,7 @@ use crate::calldata;
 use crate::core::{ContractAddress, Nonce};
 use crate::data_availability::DataAvailabilityMode;
 use crate::executable_transaction::InvokeTransaction as ExecutableInvokeTransaction;
+use crate::rpc_transaction::{RpcInvokeTransaction, RpcInvokeTransactionV3, RpcTransaction};
 use crate::transaction::{
     AccountDeploymentData,
     Calldata,
@@ -113,4 +114,27 @@ pub fn executable_invoke_tx(invoke_args: InvokeTxArgs) -> ExecutableInvokeTransa
     let tx = invoke_tx(invoke_args);
 
     ExecutableInvokeTransaction { tx, tx_hash }
+}
+
+pub fn rpc_invoke_tx(invoke_args: InvokeTxArgs) -> RpcTransaction {
+    if invoke_args.version != TransactionVersion::THREE {
+        panic!("Unsupported transaction version: {:?}.", invoke_args.version);
+    }
+
+    let ValidResourceBounds::AllResources(resource_bounds) = invoke_args.resource_bounds else {
+        panic!("Unspported resource bounds type: {:?}.", invoke_args.resource_bounds)
+    };
+
+    RpcTransaction::Invoke(RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
+        resource_bounds,
+        tip: invoke_args.tip,
+        calldata: invoke_args.calldata,
+        sender_address: invoke_args.sender_address,
+        nonce: invoke_args.nonce,
+        signature: invoke_args.signature,
+        nonce_data_availability_mode: invoke_args.nonce_data_availability_mode,
+        fee_data_availability_mode: invoke_args.fee_data_availability_mode,
+        paymaster_data: invoke_args.paymaster_data,
+        account_deployment_data: invoke_args.account_deployment_data,
+    }))
 }


### PR DESCRIPTION
Move the `rpc_invoke_tx` function from mempool_test_utils to starknet_api/test_utils.