### PR TITLE
refactor(mempool): update MempoolConfig test util

### DIFF
--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -102,8 +102,7 @@ impl MempoolContentBuilder {
     }
 
     fn with_fee_escalation_percentage(mut self, fee_escalation_percentage: u8) -> Self {
-        self.config.enable_fee_escalation = true;
-        self.config.fee_escalation_percentage = fee_escalation_percentage;
+        self.config = MempoolConfig { enable_fee_escalation: true, fee_escalation_percentage };
         self
     }
 


### PR DESCRIPTION
- I updated `with_fee_escalation_percentage` to set config directly, making it more idiomatic by creating a new `MempoolConfig` with only necessary overrides, keeping others unchanged (we can add `..self.config` if more fields are added).
- Adding a `MempoolConfigBuilder` feels unnecessary for now since the config is being updated only in `with_fee_escalation_percentage.` We can revisit a builder if more unrelated functions are added later.