### PR TITLE
test(network): add test utility to create network config connected to broadcast channels

### DIFF
--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -2,7 +2,7 @@ mod swarm_trait;
 
 #[cfg(test)]
 mod test;
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 
 use std::collections::HashMap;


### PR DESCRIPTION
- **feat(common): move find_free_port to papyrus_common and add find_n_free_ports**
- **test(network): add test utility to create network config connected to broadcast channels**
