### PR TITLE
chore: add lints to papyrus_common

### DIFF
--- a/crates/batcher_types/Cargo.toml
+++ b/crates/batcher_types/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
-
 [lints]
 workspace = true
 

--- a/crates/consensus_manager/Cargo.toml
+++ b/crates/consensus_manager/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
-
 [lints]
 workspace = true
 

--- a/crates/mempool_test_utils/Cargo.toml
+++ b/crates/mempool_test_utils/Cargo.toml
@@ -5,7 +5,8 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
-[features]
+[lints]
+workspace = true
 
 [dependencies]
 assert_matches.workspace = true

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -275,7 +275,7 @@ impl MultiAccountTransactionGenerator {
 }
 
 /// Manages transaction generation for a single account.
-/// Supports faulty transaction generation via [AccountTransactionGenerator::generate_raw].
+/// Supports faulty transaction generation via [AccountTransactionGenerator::generate_raw_invoke].
 ///
 /// This struct provides methods to generate both default and fully customized transactions,
 /// with room for future extensions.

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy-contract.workspace = true
 alloy-dyn-abi.workspace = true

--- a/crates/papyrus_common/Cargo.toml
+++ b/crates/papyrus_common/Cargo.toml
@@ -25,3 +25,6 @@ assert_matches.workspace = true
 papyrus_test_utils.workspace = true
 pretty_assertions.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
+
+[lints]
+workspace = true

--- a/crates/papyrus_common/src/python_json.rs
+++ b/crates/papyrus_common/src/python_json.rs
@@ -37,7 +37,7 @@ impl Formatter for PythonJsonFormatter {
         let mut buf = [0u16; 2];
         for ch in fragment.chars() {
             if ch.is_ascii() {
-                writer.write_all(&[ch as u8])?;
+                writer.write_all(&[u8::try_from(ch).expect("ASCII fits in u8")])?;
             } else {
                 let slice = ch.encode_utf16(&mut buf);
                 for num in slice {

--- a/crates/papyrus_config/Cargo.toml
+++ b/crates/papyrus_config/Cargo.toml
@@ -25,7 +25,5 @@ lazy_static.workspace = true
 papyrus_test_utils.workspace = true
 tempfile.workspace = true
 
-[lints.rust]
-# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
-# needed (from rust 1.80).
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+[lints]
+workspace = true

--- a/crates/papyrus_load_test/Cargo.toml
+++ b/crates/papyrus_load_test/Cargo.toml
@@ -23,7 +23,5 @@ tokio.workspace = true
 lazy_static.workspace = true
 pretty_assertions.workspace = true
 
-[lints.rust]
-# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
-# needed (from rust 1.80).
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+[lints]
+workspace = true

--- a/crates/papyrus_monitoring_gateway/Cargo.toml
+++ b/crates/papyrus_monitoring_gateway/Cargo.toml
@@ -29,7 +29,5 @@ pretty_assertions.workspace = true
 starknet_client = { workspace = true, features = ["testing"] }
 tower = { workspace = true, features = ["util"] }
 
-[lints.rust]
-# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
-# needed (from rust 1.80).
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+[lints]
+workspace = true

--- a/crates/papyrus_network_types/Cargo.toml
+++ b/crates/papyrus_network_types/Cargo.toml
@@ -13,3 +13,6 @@ libp2p = { workspace = true, features = ["serde"] }
 papyrus_test_utils = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/papyrus_proc_macros/Cargo.toml
+++ b/crates/papyrus_proc_macros/Cargo.toml
@@ -20,3 +20,6 @@ prometheus-parse.workspace = true
 
 [lib]
 proc-macro = true
+
+[lints]
+workspace = true

--- a/crates/sequencing/papyrus_consensus_orchestrator/Cargo.toml
+++ b/crates/sequencing/papyrus_consensus_orchestrator/Cargo.toml
@@ -27,3 +27,6 @@ papyrus_network = { workspace = true, features = ["testing"] }
 papyrus_storage = { workspace = true, features = ["testing"] }
 papyrus_test_utils.workspace = true
 test-case.workspace = true
+
+[lints]
+workspace = true

--- a/crates/starknet_client/Cargo.toml
+++ b/crates/starknet_client/Cargo.toml
@@ -54,7 +54,5 @@ papyrus_test_utils.workspace = true
 # `strum` is used by `EnumIter` which is used in this crate.
 ignored = ["rand", "rand_chacha", "strum"]
 
-[lints.rust]
-# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
-# needed (from rust 1.80).
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+[lints]
+workspace = true


### PR DESCRIPTION
Lior banned `as` repo-wide, unless absolutely necessary.

Nearly all `as` uses can be replaced with `[Try]From` which doesn't have implicit coercions like `as` (we encountered several bugs due to these coersions).

Motivation: we are standardizing lints across the repo and CI, instead of each crate having separate sets of lints.