### PR TITLE
chore(execution): add workspace lints

### DIFF
--- a/crates/papyrus_execution/Cargo.toml
+++ b/crates/papyrus_execution/Cargo.toml
@@ -44,3 +44,6 @@ papyrus_test_utils.workspace = true
 [package.metadata.cargo-machete]
 # The `rand` crate is used in the `testing` feature, which is optional.
 ignored = ["rand"]
+
+[lints]
+workspace = true

--- a/crates/papyrus_execution/src/objects.rs
+++ b/crates/papyrus_execution/src/objects.rs
@@ -10,6 +10,7 @@ use blockifier::execution::call_info::{
 };
 use blockifier::execution::entry_point::CallType as BlockifierCallType;
 use blockifier::transaction::objects::{FeeType, TransactionExecutionInfo};
+use blockifier::utils::u64_from_usize;
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use indexmap::IndexMap;
@@ -368,7 +369,7 @@ fn vm_resources_to_execution_resources(
         if count == 0 {
             continue;
         }
-        let count: u64 = count as u64;
+        let count = u64_from_usize(count);
         match builtin_name {
             BuiltinName::output => continue,
             BuiltinName::pedersen => builtin_instance_counter.insert(Builtin::Pedersen, count),
@@ -391,9 +392,9 @@ fn vm_resources_to_execution_resources(
         };
     }
     Ok(ExecutionResources {
-        steps: vm_resources.n_steps as u64,
+        steps: u64_from_usize(vm_resources.n_steps),
         builtin_instance_counter,
-        memory_holes: vm_resources.n_memory_holes as u64,
+        memory_holes: u64_from_usize(vm_resources.n_memory_holes),
         da_gas_consumed: StarknetApiGasVector { l1_gas, l2_gas, l1_data_gas },
         gas_consumed: StarknetApiGasVector::default(),
     })


### PR DESCRIPTION
Lior banned `as` repo-wide, unless absolutely necessary.

Nearly all as uses can be replaced with [Try]From which doesn't have implicit coercions like as (we encountered several bugs due to these coercions).

Motivation: we are standardizing lints across the repo and CI, instead of each crate having separate sets of lints.