### PR TITLE
refactor(gateway): remove wrapper function

### DIFF
--- a/crates/gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/gateway/src/stateless_transaction_validator_test.rs
@@ -5,7 +5,6 @@ use assert_matches::assert_matches;
 use mempool_test_utils::starknet_api_test_utils::{
     rpc_declare_tx,
     rpc_tx_for_testing,
-    zero_resource_bounds_mapping,
     RpcTransactionArgs,
     TransactionType,
     NON_EMPTY_RESOURCE_BOUNDS,
@@ -125,7 +124,8 @@ fn test_positive_flow(
         validate_non_zero_l2_gas_fee: false,
         ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
     },
-    zero_resource_bounds_mapping(),
+    AllResourceBounds::default()
+    ,
     StatelessTransactionValidatorError::ZeroResourceBounds{
         resource: Resource::L1Gas, resource_bounds: ResourceBounds::default()
     }

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -76,7 +76,7 @@ impl Default for RpcTransactionArgs {
     fn default() -> Self {
         Self {
             sender_address: TEST_SENDER_ADDRESS.into(),
-            resource_bounds: zero_resource_bounds_mapping(),
+            resource_bounds: AllResourceBounds::default(),
             calldata: Default::default(),
             signature: Default::default(),
         }
@@ -144,10 +144,6 @@ pub fn rpc_tx_for_testing(
 
 pub const NON_EMPTY_RESOURCE_BOUNDS: ResourceBounds =
     ResourceBounds { max_amount: GasAmount(1), max_price_per_unit: GasPrice(1) };
-
-pub fn zero_resource_bounds_mapping() -> AllResourceBounds {
-    AllResourceBounds::default()
-}
 
 pub fn test_resource_bounds_mapping() -> AllResourceBounds {
     AllResourceBounds {
@@ -500,7 +496,7 @@ impl Default for DeclareTxArgs {
             signature: TransactionSignature::default(),
             sender_address: TEST_SENDER_ADDRESS.into(),
             version: TransactionVersion::THREE,
-            resource_bounds: zero_resource_bounds_mapping(),
+            resource_bounds: AllResourceBounds::default(),
             tip: Tip::default(),
             nonce_data_availability_mode: DataAvailabilityMode::L1,
             fee_data_availability_mode: DataAvailabilityMode::L1,


### PR DESCRIPTION
I removed the function and used default directly, as it no longer adds value beyond calling the default implementation.