### PR TITLE
refactor(mempool): mempool content remove unused code

### DIFF
--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -12,7 +12,6 @@ use crate::transaction_queue::transaction_queue_test_utils::{
     TransactionQueueContent,
     TransactionQueueContentBuilder,
 };
-use crate::transaction_queue::TransactionQueue;
 use crate::{add_tx_input, tx};
 
 // Utils.
@@ -126,16 +125,6 @@ impl FromIterator<Transaction> for TransactionPool {
             pool.insert(tx).unwrap();
         }
         pool
-    }
-}
-
-impl FromIterator<TransactionReference> for TransactionQueue {
-    fn from_iter<T: IntoIterator<Item = TransactionReference>>(txs: T) -> Self {
-        let mut queue = Self::default();
-        for tx in txs {
-            queue.insert(tx);
-        }
-        queue
     }
 }
 


### PR DESCRIPTION
Since we implemented with_pending and with_priority, this code is now unused. 
The insertion logic here is unclear, as the gas price threshold may be uninitialized.