### PR TITLE
refactor(sync): move state diff related errors to BadPeerError

### DIFF
--- a/crates/papyrus_p2p_sync/src/client/mod.rs
+++ b/crates/papyrus_p2p_sync/src/client/mod.rs
@@ -122,20 +122,6 @@ impl Default for P2PSyncClientConfig {
 #[derive(thiserror::Error, Debug)]
 pub enum P2PSyncClientError {
     // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    #[error(
-        "The header says that the block's state diff should be of length {expected_length}. Can \
-         only divide the state diff parts into the following lengths: {possible_lengths:?}."
-    )]
-    WrongStateDiffLength { expected_length: usize, possible_lengths: Vec<usize> },
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    #[error("Two state diff parts for the same state diff are conflicting.")]
-    ConflictingStateDiffParts,
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
-    #[error(
-        "Received an empty state diff part from the network (this is a potential DDoS vector)."
-    )]
-    EmptyStateDiffPart,
-    // TODO(shahak): Remove this and report to network on invalid data once that's possible.
     #[error("Network returned more responses than expected for a query.")]
     TooManyResponses,
     #[error(

--- a/crates/papyrus_p2p_sync/src/client/stream_builder.rs
+++ b/crates/papyrus_p2p_sync/src/client/stream_builder.rs
@@ -167,6 +167,17 @@ pub(crate) enum BadPeerError {
     NotEnoughTransactions { expected: usize, actual: usize, block_number: u64 },
     #[error("Expected to receive one signature from the network. got {signatures:?} instead.")]
     WrongSignaturesLength { signatures: Vec<BlockSignature> },
+    #[error(
+        "The header says that the block's state diff should be of length {expected_length}. Can \
+         only divide the state diff parts into the following lengths: {possible_lengths:?}."
+    )]
+    WrongStateDiffLength { expected_length: usize, possible_lengths: Vec<usize> },
+    #[error("Two state diff parts for the same state diff are conflicting.")]
+    ConflictingStateDiffParts,
+    #[error(
+        "Received an empty state diff part from the network (this is a potential DDoS vector)."
+    )]
+    EmptyStateDiffPart,
     #[error(transparent)]
     ProtobufConversionError(#[from] ProtobufConversionError),
 }


### PR DESCRIPTION
moves non-fatal state diff related errors to BadPeerError to allow retrying the query with a different peer. previously state diff related tests checked these non-fatal errors as assertions to certain scenarios. we now just check that these scenarios cause peer reporting.