### PR TITLE
chore(node): add workspace lints

### DIFF
--- a/crates/papyrus_network/Cargo.toml
+++ b/crates/papyrus_network/Cargo.toml
@@ -53,3 +53,6 @@ pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["full", "sync", "test-util"] }
 tokio-stream.workspace = true
 void.workspace = true
+
+[lints]
+workspace = true

--- a/crates/papyrus_network/src/discovery/discovery_test.rs
+++ b/crates/papyrus_network/src/discovery/discovery_test.rs
@@ -31,11 +31,12 @@ use crate::mixed_behaviour::BridgedBehaviour;
 use crate::test_utils::next_on_mutex_stream;
 
 const TIMEOUT: Duration = Duration::from_secs(1);
-const BOOTSTRAP_DIAL_SLEEP: Duration = Duration::from_secs(1);
+const BOOTSTRAP_DIAL_SLEEP_MILLIS: u64 = 1000; // 1 second
+const BOOTSTRAP_DIAL_SLEEP: Duration = Duration::from_millis(BOOTSTRAP_DIAL_SLEEP_MILLIS);
 
 const CONFIG: DiscoveryConfig = DiscoveryConfig {
     bootstrap_dial_retry_config: RetryConfig {
-        base_delay_millis: BOOTSTRAP_DIAL_SLEEP.as_millis() as u64,
+        base_delay_millis: BOOTSTRAP_DIAL_SLEEP_MILLIS,
         max_delay_seconds: BOOTSTRAP_DIAL_SLEEP,
         factor: 1,
     },

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -253,6 +253,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
     }
 
     fn handle_swarm_event(&mut self, event: SwarmEvent<mixed_behaviour::Event>) {
+        #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 debug!("Connected to peer id: {peer_id:?}");
@@ -375,6 +376,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         }
     }
 
+    #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
     fn handle_sqmr_event_new_inbound_session(
         &mut self,
         peer_id: PeerId,
@@ -537,6 +539,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
     ) {
         let SqmrClientPayload { query, report_receiver, responses_sender } = client_payload;
         match self.swarm.send_query(query, PeerId::random(), protocol.clone()) {
+            #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
             Ok(outbound_session_id) => {
                 debug!(
                     "Network received new query. waiting for peer assignment. \
@@ -565,6 +568,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
     }
 
     fn report_session_removed_to_metrics(&mut self, session_id: SessionId) {
+        #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
         match session_id {
             SessionId::InboundSessionId(_) => {
                 self.num_active_inbound_sessions -= 1;

--- a/crates/papyrus_node/Cargo.toml
+++ b/crates/papyrus_node/Cargo.toml
@@ -67,7 +67,5 @@ papyrus_test_utils.workspace = true
 pretty_assertions.workspace = true
 tempfile.workspace = true
 
-[lints.rust]
-# See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
-# needed (from rust 1.80).
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+[lints]
+workspace = true

--- a/crates/papyrus_node/examples/get_transaction_hash.rs
+++ b/crates/papyrus_node/examples/get_transaction_hash.rs
@@ -22,7 +22,7 @@ struct CliParams {
     iteration_increments: u64,
     file_path: String,
     deprecated: bool,
-    concurrent_requests: u64,
+    concurrent_requests: usize,
 }
 
 /// The start_block and end_block arguments are mandatory and define the block range to dump,
@@ -79,7 +79,7 @@ fn get_cli_params() -> CliParams {
     let concurrent_requests = matches
         .get_one::<String>("concurrent_requests")
         .expect("Failed parsing concurrent_requests")
-        .parse::<u64>()
+        .parse::<usize>()
         .expect("Failed parsing concurrent_requests");
     let deprecated = matches
         .get_one::<String>("deprecated")
@@ -156,7 +156,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .lock()
                 .expect("Couldn't lock transaction types")
                 .is_empty()
-            && handles.len() < concurrent_requests as usize
+            && handles.len() < concurrent_requests
         {
             let client_ref = client.clone();
             let node_url_ref = node_url.clone();

--- a/crates/papyrus_node/src/config/pointers.rs
+++ b/crates/papyrus_node/src/config/pointers.rs
@@ -42,8 +42,8 @@ use validator::Validate;
 
 use crate::version::VERSION_FULL;
 
-/// Returns vector of (pointer target name, pointer target serialized param, vec<pointer param
-/// path>) to be applied on the dumped node config.
+/// Returns vector of `(pointer target name, pointer target serialized param, vec<pointer param
+/// path>)` to be applied on the dumped node config.
 /// The config updates will be performed on the shared pointer targets, and finally, the values
 /// will be propagated to the pointer params.
 pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {


### PR DESCRIPTION
Lior banned `as` repo-wide, unless absolutely necessary.

Nearly all as uses can be replaced with [Try]From which doesn't have implicit coercions like as (we encountered several bugs due to these coercions).

Motivation: we are standardizing lints across the repo and CI, instead of each crate having separate sets of lints.