### PR TITLE
refactor(starknet_api): remove invoke_tx_args constructor macro

### DIFF
--- a/crates/blockifier/src/blockifier/transaction_executor_test.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor_test.rs
@@ -1,10 +1,11 @@
 use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
+use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::TransactionVersion;
-use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args, nonce};
+use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, nonce};
 use starknet_types_core::felt::Felt;
 
 use crate::blockifier::config::TransactionExecutorConfig;
@@ -217,10 +218,11 @@ fn test_invoke(
 
     let calldata =
         create_calldata(test_contract.get_instance_address(0), entry_point_name, &entry_point_args);
-    let tx = account_invoke_tx(invoke_tx_args! {
+    let tx = account_invoke_tx(InvokeTxArgs {
         sender_address: account_contract.get_instance_address(0),
         calldata,
         version,
+        ..Default::default()
     })
     .into();
     tx_executor_test_body(state, block_context, tx, expected_bouncer_weights);

--- a/crates/blockifier/src/concurrency/fee_utils_test.rs
+++ b/crates/blockifier/src/concurrency/fee_utils_test.rs
@@ -1,7 +1,8 @@
 use num_bigint::BigUint;
 use rstest::rstest;
+use starknet_api::felt;
+use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::transaction::fields::{Fee, ValidResourceBounds};
-use starknet_api::{felt, invoke_tx_args};
 use starknet_types_core::felt::Felt;
 
 use crate::concurrency::fee_utils::{add_fee_to_sequencer_balance, fill_sequencer_balance_reads};
@@ -26,10 +27,11 @@ pub fn test_fill_sequencer_balance_reads(
     #[values(CairoVersion::Cairo0, CairoVersion::Cairo1)] erc20_version: CairoVersion,
 ) {
     let account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
-    let account_tx = account_invoke_tx(invoke_tx_args! {
+    let account_tx = account_invoke_tx(InvokeTxArgs {
         sender_address: account.get_instance_address(0),
         calldata: create_trivial_calldata(account.get_instance_address(0)),
         resource_bounds: default_all_resource_bounds,
+        ..Default::default()
     });
     let chain_info = &block_context.chain_info;
     let state = &mut test_state_inner(chain_info, BALANCE, &[(account, 1)], erc20_version);

--- a/crates/blockifier/src/execution/stack_trace_test.rs
+++ b/crates/blockifier/src/execution/stack_trace_test.rs
@@ -12,6 +12,7 @@ use starknet_api::core::{
     Nonce,
 };
 use starknet_api::executable_transaction::AccountTransaction as Transaction;
+use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::transaction::constants::{
     DEPLOY_CONTRACT_FUNCTION_ENTRY_POINT_NAME,
     EXECUTE_ENTRY_POINT_NAME,
@@ -27,7 +28,7 @@ use starknet_api::transaction::fields::{
     ValidResourceBounds,
 };
 use starknet_api::transaction::TransactionVersion;
-use starknet_api::{calldata, felt, invoke_tx_args};
+use starknet_api::{calldata, felt};
 use starknet_types_core::felt::Felt;
 
 use crate::context::{BlockContext, ChainInfo};
@@ -88,10 +89,11 @@ fn test_stack_trace_with_inner_error_msg(block_context: BlockContext) {
     let tx_execution_error = run_invoke_tx(
         &mut state,
         &block_context,
-        invoke_tx_args! {
+        InvokeTxArgs {
             sender_address: account_address,
             calldata,
             version: TransactionVersion::ZERO,
+            ..Default::default()
         },
     )
     .unwrap_err();
@@ -177,10 +179,11 @@ fn test_stack_trace(
     let tx_execution_error = run_invoke_tx(
         &mut state,
         &block_context,
-        invoke_tx_args! {
+        InvokeTxArgs {
             sender_address: account_address,
             calldata,
             version: TransactionVersion::ZERO,
+            ..Default::default()
         },
     )
     .unwrap_err();
@@ -303,10 +306,11 @@ fn test_trace_callchain_ends_with_regular_call(
     let tx_execution_error = run_invoke_tx(
         &mut state,
         &block_context,
-        invoke_tx_args! {
+        InvokeTxArgs {
             sender_address: account_address,
             calldata,
             version: TransactionVersion::ZERO,
+            ..Default::default()
         },
     )
     .unwrap_err();
@@ -444,10 +448,11 @@ fn test_trace_call_chain_with_syscalls(
     let tx_execution_error = run_invoke_tx(
         &mut state,
         &block_context,
-        invoke_tx_args! {
+        InvokeTxArgs {
             sender_address: account_address,
             calldata,
             version: TransactionVersion::ZERO,
+            ..Default::default()
         },
     )
     .unwrap_err();
@@ -747,7 +752,7 @@ fn test_contract_ctor_frame_stack_trace(
     )
     .unwrap();
     // Invoke the deploy_contract function on the dummy account to deploy the faulty contract.
-    let invoke_deploy_tx = account_invoke_tx(invoke_tx_args! {
+    let invoke_deploy_tx = account_invoke_tx(InvokeTxArgs {
         sender_address: account_address,
         signature,
         calldata: create_calldata(
@@ -758,10 +763,11 @@ fn test_contract_ctor_frame_stack_trace(
                 salt,
                 felt!(1_u8), // Calldata: ctor args length.
                 validate_constructor,
-            ]
+            ],
         ),
         resource_bounds: default_all_resource_bounds,
         nonce: Nonce(felt!(0_u8)),
+        ..Default::default()
     });
 
     // Construct expected output.

--- a/crates/blockifier/src/fee/fee_test.rs
+++ b/crates/blockifier/src/fee/fee_test.rs
@@ -3,7 +3,7 @@ use cairo_vm::types::builtin_name::BuiltinName;
 use rstest::rstest;
 use starknet_api::block::{GasPrice, NonzeroGasPrice};
 use starknet_api::execution_resources::{GasAmount, GasVector};
-use starknet_api::invoke_tx_args;
+use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::transaction::fields::{
     AllResourceBounds,
     Fee,
@@ -196,9 +196,10 @@ fn test_discounted_gas_overdraft(
 
     let account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0);
     let mut state = test_state(&block_context.chain_info, BALANCE, &[(account, 1)]);
-    let tx = account_invoke_tx(invoke_tx_args! {
+    let tx = account_invoke_tx(InvokeTxArgs {
         sender_address: account.get_instance_address(0),
         resource_bounds: l1_resource_bounds(gas_bound, (gas_price.get().0 * 10).into()),
+        ..Default::default()
     });
 
     let tx_receipt = TransactionReceipt {
@@ -271,9 +272,10 @@ fn test_post_execution_gas_overdraft_all_resource_bounds(
 
     let account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0);
     let mut state = test_state(&block_context.chain_info, BALANCE, &[(account, 1)]);
-    let tx = account_invoke_tx(invoke_tx_args! {
+    let tx = account_invoke_tx(InvokeTxArgs {
         sender_address: account.get_instance_address(0),
         resource_bounds: all_resource_bounds,
+        ..Default::default()
     });
 
     let tx_receipt = TransactionReceipt {
@@ -384,7 +386,7 @@ fn test_initial_sierra_gas(
             ..Default::default()
         }),
     };
-    let account_tx = account_invoke_tx(invoke_tx_args!(resource_bounds));
+    let account_tx = account_invoke_tx(InvokeTxArgs { resource_bounds, ..Default::default() });
     let actual = block_context.to_tx_context(&account_tx).initial_sierra_gas();
     assert_eq!(actual, expected)
 }

--- a/crates/blockifier/src/fee/gas_usage_test.rs
+++ b/crates/blockifier/src/fee/gas_usage_test.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
 use starknet_api::block::StarknetVersion;
 use starknet_api::execution_resources::{GasAmount, GasVector};
-use starknet_api::invoke_tx_args;
+use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 use starknet_api::transaction::{EventContent, EventData, EventKey};
 use starknet_types_core::felt::Felt;
@@ -279,8 +279,8 @@ fn test_get_message_segment_length(
 
 #[rstest]
 fn test_discounted_gas_from_gas_vector_computation() {
-    let tx_context =
-        BlockContext::create_for_testing().to_tx_context(&account_invoke_tx(invoke_tx_args! {}));
+    let tx_context = BlockContext::create_for_testing()
+        .to_tx_context(&account_invoke_tx(InvokeTxArgs::default()));
     let gas_usage =
         GasVector { l1_gas: 100_u8.into(), l1_data_gas: 2_u8.into(), ..Default::default() };
     let actual_result = gas_usage.to_discounted_l1_gas(tx_context.get_gas_prices());

--- a/crates/blockifier/src/fee/receipt_test.rs
+++ b/crates/blockifier/src/fee/receipt_test.rs
@@ -1,8 +1,9 @@
 use rstest::{fixture, rstest};
 use starknet_api::execution_resources::GasVector;
+use starknet_api::nonce;
+use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 use starknet_api::transaction::{constants, L2ToL1Payload};
-use starknet_api::{invoke_tx_args, nonce};
 use starknet_types_core::felt::Felt;
 
 use crate::context::BlockContext;
@@ -357,10 +358,11 @@ fn test_calculate_tx_gas_usage(
     let account_contract_address = account_contract.get_instance_address(0);
     let state = &mut test_state(chain_info, BALANCE, &[(account_contract, 1), (test_contract, 1)]);
 
-    let account_tx = account_invoke_tx(invoke_tx_args! {
-            sender_address: account_contract_address,
-            calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
-            resource_bounds: max_resource_bounds,
+    let account_tx = account_invoke_tx(InvokeTxArgs {
+        sender_address: account_contract_address,
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        resource_bounds: max_resource_bounds,
+        ..Default::default()
     });
     let calldata_length = account_tx.calldata_length();
     let signature_length = account_tx.signature_length();
@@ -409,11 +411,12 @@ fn test_calculate_tx_gas_usage(
         ],
     );
 
-    let account_tx = account_invoke_tx(invoke_tx_args! {
+    let account_tx = account_invoke_tx(InvokeTxArgs {
         resource_bounds: max_resource_bounds,
         sender_address: account_contract_address,
         calldata: execute_calldata,
         nonce: nonce!(1_u8),
+        ..Default::default()
     });
 
     let calldata_length = account_tx.calldata_length();

--- a/crates/blockifier/src/test_utils/transfers_generator.rs
+++ b/crates/blockifier/src/test_utils/transfers_generator.rs
@@ -2,11 +2,12 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::ContractAddress;
+use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::constants::TRANSFER_ENTRY_POINT_NAME;
 use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::TransactionVersion;
-use starknet_api::{calldata, felt, invoke_tx_args};
+use starknet_api::{calldata, felt};
 use starknet_types_core::felt::Felt;
 
 use crate::blockifier::config::{ConcurrencyConfig, TransactionExecutorConfig};
@@ -180,12 +181,13 @@ impl TransfersGenerator {
             felt!(0_u8)                 // Calldata: msb amount.
         ];
 
-        invoke_tx(invoke_tx_args! {
+        invoke_tx(InvokeTxArgs {
             max_fee: self.config.max_fee,
             sender_address,
             calldata: execute_calldata,
             version: self.config.tx_version,
             nonce,
+            ..Default::default()
         })
     }
 }

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -14,7 +14,7 @@ use starknet_api::transaction::fields::{
     ValidResourceBounds,
 };
 use starknet_api::transaction::TransactionVersion;
-use starknet_api::{felt, invoke_tx_args, nonce};
+use starknet_api::{felt, nonce};
 use starknet_types_core::felt::Felt;
 
 use crate::context::{BlockContext, ChainInfo};
@@ -193,13 +193,14 @@ fn get_pre_validate_test_args(
         state, account_address, test_contract_address, nonce_manager, ..
     } = create_flavors_test_state(&block_context.chain_info, cairo_version);
 
-    let pre_validation_base_args = invoke_tx_args! {
+    let pre_validation_base_args = InvokeTxArgs {
         max_fee,
         resource_bounds,
         sender_address: account_address,
         calldata: create_trivial_calldata(test_contract_address),
         version,
         only_query,
+        ..Default::default()
     };
     (block_context, state, pre_validation_base_args, nonce_manager)
 }
@@ -222,7 +223,7 @@ fn test_invalid_nonce_pre_validate(
     let invalid_nonce = nonce!(7_u8);
     let account_nonce = state.get_nonce_at(account_address).unwrap();
     let result =
-        account_invoke_tx(invoke_tx_args! {nonce: invalid_nonce, ..pre_validation_base_args})
+        account_invoke_tx(InvokeTxArgs { nonce: invalid_nonce, ..pre_validation_base_args })
             .execute(&mut state, &block_context, charge_fee, validate);
     assert_matches!(
         result.unwrap_err(),
@@ -260,7 +261,7 @@ fn test_simulate_validate_pre_validate_with_charge_fee(
     let account_address = pre_validation_base_args.sender_address;
 
     // First scenario: minimal fee not covered. Actual fee is precomputed.
-    let err = account_invoke_tx(invoke_tx_args! {
+    let err = account_invoke_tx(InvokeTxArgs {
         max_fee: Fee(10),
         resource_bounds: l1_resource_bounds(10_u8.into(), 10_u8.into()),
         nonce: nonce_manager.next(account_address),
@@ -293,11 +294,11 @@ fn test_simulate_validate_pre_validate_with_charge_fee(
     // Second scenario: resource bounds greater than balance.
     let gas_price = block_context.block_info.gas_prices.get_l1_gas_price_by_fee_type(&fee_type);
     let balance_over_gas_price = BALANCE.checked_div(gas_price).unwrap();
-    let result = account_invoke_tx(invoke_tx_args! {
+    let result = account_invoke_tx(InvokeTxArgs {
         max_fee: Fee(BALANCE.0 + 1),
         resource_bounds: l1_resource_bounds(
             (balance_over_gas_price.0 + 10).into(),
-            gas_price.into()
+            gas_price.into(),
         ),
         nonce: nonce_manager.next(account_address),
         ..pre_validation_base_args.clone()
@@ -328,8 +329,11 @@ fn test_simulate_validate_pre_validate_with_charge_fee(
 
     // Third scenario: L1 gas price bound lower than the price on the block.
     if !is_deprecated {
-        let err = account_invoke_tx(invoke_tx_args! {
-            resource_bounds: l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, (gas_price.get().0 - 1).into()),
+        let err = account_invoke_tx(InvokeTxArgs {
+            resource_bounds: l1_resource_bounds(
+                DEFAULT_L1_GAS_AMOUNT,
+                (gas_price.get().0 - 1).into(),
+            ),
             nonce: nonce_manager.next(account_address),
             ..pre_validation_base_args
         })
@@ -367,7 +371,7 @@ fn test_simulate_validate_pre_validate_not_charge_fee(
         get_pre_validate_test_args(cairo_version, version, only_query);
     let account_address = pre_validation_base_args.sender_address;
 
-    let tx_execution_info = account_invoke_tx(invoke_tx_args! {
+    let tx_execution_info = account_invoke_tx(InvokeTxArgs {
         nonce: nonce_manager.next(account_address),
         ..pre_validation_base_args.clone()
     })
@@ -386,7 +390,7 @@ fn test_simulate_validate_pre_validate_not_charge_fee(
     let (actual_gas_used, actual_fee) = gas_and_fee(base_gas, validate, &fee_type);
     macro_rules! execute_and_check_gas_and_fee {
         ($max_fee:expr, $resource_bounds:expr) => {{
-            let tx_execution_info = account_invoke_tx(invoke_tx_args! {
+            let tx_execution_info = account_invoke_tx(InvokeTxArgs {
                 max_fee: $max_fee,
                 resource_bounds: $resource_bounds,
                 nonce: nonce_manager.next(account_address),
@@ -446,18 +450,16 @@ fn execute_fail_validation(
     } = create_flavors_test_state(&block_context.chain_info, cairo_version);
 
     // Validation scenario: fallible validation.
-    account_invoke_tx(invoke_tx_args! {
+    account_invoke_tx(InvokeTxArgs {
         max_fee,
         resource_bounds: max_resource_bounds,
-        signature: TransactionSignature(vec![
-            Felt::from(INVALID),
-            Felt::ZERO
-        ]),
+        signature: TransactionSignature(vec![Felt::from(INVALID), Felt::ZERO]),
         sender_address: faulty_account_address,
         calldata: create_calldata(faulty_account_address, "foo", &[]),
         version,
         nonce: nonce_manager.next(faulty_account_address),
         only_query,
+        ..Default::default()
     })
     .execute(&mut falliable_state, &block_context, charge_fee, validate)
 }
@@ -566,16 +568,17 @@ fn test_simulate_validate_charge_fee_mid_execution(
     // 1. Execution fails due to logic error.
     // 2. Execution fails due to out-of-resources error, due to max sender bounds, mid-run.
     // 3. Execution fails due to out-of-resources error, due to max block bounds, mid-run.
-    let execution_base_args = invoke_tx_args! {
+    let execution_base_args = InvokeTxArgs {
         max_fee: MAX_FEE,
         resource_bounds: default_l1_resource_bounds,
         sender_address: account_address,
         version,
         only_query,
+        ..Default::default()
     };
 
     // First scenario: logic error. Should result in revert; actual fee should be shown.
-    let tx_execution_info = account_invoke_tx(invoke_tx_args! {
+    let tx_execution_info = account_invoke_tx(InvokeTxArgs {
         calldata: recurse_calldata(test_contract_address, true, 3),
         nonce: nonce_manager.next(account_address),
         ..execution_base_args.clone()
@@ -621,7 +624,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
         validate,
         &fee_type,
     );
-    let tx_execution_info = account_invoke_tx(invoke_tx_args! {
+    let tx_execution_info = account_invoke_tx(InvokeTxArgs {
         max_fee: fee_bound,
         resource_bounds: l1_resource_bounds(gas_bound, gas_price.into()),
         calldata: recurse_calldata(test_contract_address, false, 1000),
@@ -674,7 +677,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
         GasVector::from_l1_gas(block_limit_gas),
         &fee_type,
     );
-    let tx_execution_info = account_invoke_tx(invoke_tx_args! {
+    let tx_execution_info = account_invoke_tx(InvokeTxArgs {
         max_fee: huge_fee,
         resource_bounds: l1_resource_bounds(huge_gas_limit, gas_price.into()),
         calldata: recurse_calldata(test_contract_address, false, 10000),
@@ -758,7 +761,7 @@ fn test_simulate_validate_charge_fee_post_execution(
         validate,
         &fee_type,
     );
-    let tx_execution_info = account_invoke_tx(invoke_tx_args! {
+    let tx_execution_info = account_invoke_tx(InvokeTxArgs {
         max_fee: just_not_enough_fee_bound,
         resource_bounds: l1_resource_bounds(just_not_enough_gas_bound, gas_price.into()),
         calldata: recurse_calldata(test_contract_address, false, 1000),
@@ -766,6 +769,7 @@ fn test_simulate_validate_charge_fee_post_execution(
         sender_address: account_address,
         version,
         only_query,
+        ..Default::default()
     })
     .execute(&mut state, &block_context, charge_fee, validate)
     .unwrap();
@@ -818,7 +822,7 @@ fn test_simulate_validate_charge_fee_post_execution(
             felt!(0_u8),
         ],
     );
-    let tx_execution_info = account_invoke_tx(invoke_tx_args! {
+    let tx_execution_info = account_invoke_tx(InvokeTxArgs {
         max_fee: actual_fee,
         resource_bounds: l1_resource_bounds(success_actual_gas, gas_price.into()),
         calldata: transfer_calldata,
@@ -826,6 +830,7 @@ fn test_simulate_validate_charge_fee_post_execution(
         sender_address: account_address,
         version,
         only_query,
+        ..Default::default()
     })
     .execute(&mut state, &block_context, charge_fee, validate)
     .unwrap();

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -17,7 +17,7 @@ use starknet_api::transaction::fields::{
     ValidResourceBounds,
 };
 use starknet_api::transaction::{constants, TransactionVersion};
-use starknet_api::{calldata, declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args};
+use starknet_api::{calldata, declare_tx_args, deploy_account_tx_args, felt};
 use starknet_types_core::felt::Felt;
 use strum::IntoEnumIterator;
 
@@ -271,7 +271,7 @@ pub fn create_account_tx_for_validate_test(
         }
         TransactionType::InvokeFunction => {
             let execute_calldata = create_calldata(sender_address, "foo", &[]);
-            invoke_tx(invoke_tx_args! {
+            invoke_tx(InvokeTxArgs {
                 max_fee,
                 resource_bounds,
                 signature,
@@ -279,6 +279,7 @@ pub fn create_account_tx_for_validate_test(
                 calldata: execute_calldata,
                 version: tx_version,
                 nonce: nonce_manager.next(sender_address),
+                ..Default::default()
             })
         }
         _ => panic!("{tx_type:?} is not an account transaction."),
@@ -367,9 +368,10 @@ pub fn emit_n_events_tx(
         felt!(0_u32),                     // data length.
     ];
     let calldata = create_calldata(contract_address, "test_emit_events", &entry_point_args);
-    account_invoke_tx(invoke_tx_args! {
+    account_invoke_tx(InvokeTxArgs {
         sender_address: account_contract,
         calldata,
-        nonce
+        nonce,
+        ..Default::default()
     })
 }

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -28,7 +28,7 @@ use starknet_api::transaction::fields::{
     ValidResourceBounds,
 };
 use starknet_api::transaction::TransactionVersion;
-use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args, nonce};
+use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, nonce};
 use starknet_types_core::felt::Felt;
 
 use crate::{COMPILED_CLASS_HASH_OF_CONTRACT_CLASS, CONTRACT_CLASS_FILE, TEST_FILES_FOLDER};
@@ -104,12 +104,13 @@ pub fn invoke_tx(cairo_version: CairoVersion) -> RpcTransaction {
     let sender_address = account_contract.get_instance_address(0);
     let mut nonce_manager = NonceManager::default();
 
-    rpc_invoke_tx(invoke_tx_args!(
+    rpc_invoke_tx(InvokeTxArgs {
         resource_bounds: test_valid_resource_bounds(),
-        nonce : nonce_manager.next(sender_address),
+        nonce: nonce_manager.next(sender_address),
         sender_address,
-        calldata: create_trivial_calldata(test_contract.get_instance_address(0))
-    ))
+        calldata: create_trivial_calldata(test_contract.get_instance_address(0)),
+        ..Default::default()
+    })
 }
 
 pub fn executable_invoke_tx(cairo_version: CairoVersion) -> AccountTransaction {
@@ -235,13 +236,14 @@ impl AccountTransactionGenerator {
             "Cannot invoke on behalf of an undeployed account: the first transaction of every \
              account must be a deploy account transaction."
         );
-        let invoke_args = invoke_tx_args!(
+        let invoke_args = InvokeTxArgs {
             nonce,
-            tip : Tip(tip),
+            tip: Tip(tip),
             sender_address: self.sender_address(),
             resource_bounds: test_valid_resource_bounds(),
             calldata: create_trivial_calldata(self.sender_address()),
-        );
+            ..Default::default()
+        };
         rpc_invoke_tx(invoke_args)
     }
 
@@ -254,12 +256,13 @@ impl AccountTransactionGenerator {
              account must be a deploy account transaction."
         );
 
-        let invoke_args = invoke_tx_args!(
+        let invoke_args = InvokeTxArgs {
             sender_address: self.sender_address(),
             resource_bounds: test_valid_resource_bounds(),
             nonce,
             calldata: create_trivial_calldata(self.sender_address()),
-        );
+            ..Default::default()
+        };
 
         AccountTransaction::Invoke(starknet_api::test_utils::invoke::executable_invoke_tx(
             invoke_args,

--- a/crates/starknet_api/src/test_utils/invoke.rs
+++ b/crates/starknet_api/src/test_utils/invoke.rs
@@ -62,23 +62,6 @@ impl Default for InvokeTxArgs {
     }
 }
 
-/// Utility macro for creating `InvokeTxArgs` to reduce boilerplate.
-#[macro_export]
-macro_rules! invoke_tx_args {
-    ($($field:ident $(: $value:expr)?),* $(,)?) => {
-        $crate::test_utils::invoke::InvokeTxArgs {
-            $($field $(: $value)?,)*
-            ..Default::default()
-        }
-    };
-    ($($field:ident $(: $value:expr)?),* , ..$defaults:expr) => {
-        $crate::test_utils::invoke::InvokeTxArgs {
-            $($field $(: $value)?,)*
-            ..$defaults
-        }
-    };
-}
-
 pub fn invoke_tx(invoke_args: InvokeTxArgs) -> InvokeTransaction {
     // TODO: Make TransactionVersion an enum and use match here.
     if invoke_args.version == TransactionVersion::ZERO {

--- a/crates/starknet_gateway/src/stateful_transaction_validator_test.rs
+++ b/crates/starknet_gateway/src/stateful_transaction_validator_test.rs
@@ -20,10 +20,10 @@ use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::test_utils::declare::TEST_SENDER_ADDRESS;
 use starknet_api::test_utils::deploy_account::executable_deploy_account_tx;
-use starknet_api::test_utils::invoke::executable_invoke_tx;
+use starknet_api::test_utils::invoke::{executable_invoke_tx, InvokeTxArgs};
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::fields::Resource;
-use starknet_api::{deploy_account_tx_args, invoke_tx_args, nonce};
+use starknet_api::{deploy_account_tx_args, nonce};
 use starknet_gateway_types::errors::GatewaySpecError;
 
 use crate::config::StatefulTransactionValidatorConfig;
@@ -109,12 +109,12 @@ fn test_instantiate_validator(stateful_validator: StatefulTransactionValidator) 
 
 #[rstest]
 #[case::should_skip_validation(
-    AccountTransaction::Invoke(executable_invoke_tx(invoke_tx_args!(nonce: nonce!(1)))),
+    AccountTransaction::Invoke(executable_invoke_tx(InvokeTxArgs{nonce: nonce!(1), ..Default::default()})),
     nonce!(0),
     true
 )]
 #[case::should_not_skip_validation_nonce_over_max_nonce_for_skip(
-    AccountTransaction::Invoke(executable_invoke_tx(invoke_tx_args!(nonce: nonce!(0)))),
+    AccountTransaction::Invoke(executable_invoke_tx(InvokeTxArgs{nonce: nonce!(0), ..Default::default()})),
     nonce!(0),
     false
 )]
@@ -127,10 +127,11 @@ fn test_instantiate_validator(stateful_validator: StatefulTransactionValidator) 
 ]
 #[case::should_not_skip_validation_account_nonce_1(
     AccountTransaction::Invoke(executable_invoke_tx(
-        invoke_tx_args!(
+        InvokeTxArgs{
             nonce: nonce!(1),
-            sender_address: TEST_SENDER_ADDRESS.into()
-        )
+            sender_address: TEST_SENDER_ADDRESS.into(),
+            ..Default::default()
+        }
     )),
     nonce!(1),
     false

--- a/crates/starknet_gateway/src/test_utils.rs
+++ b/crates/starknet_gateway/src/test_utils.rs
@@ -5,7 +5,7 @@ use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::{ContractClass, RpcTransaction};
 use starknet_api::test_utils::declare::{rpc_declare_tx, TEST_SENDER_ADDRESS};
-use starknet_api::test_utils::invoke::rpc_invoke_tx;
+use starknet_api::test_utils::invoke::{rpc_invoke_tx, InvokeTxArgs};
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
     AllResourceBounds,
@@ -15,7 +15,7 @@ use starknet_api::transaction::fields::{
     TransactionSignature,
     ValidResourceBounds,
 };
-use starknet_api::{declare_tx_args, deploy_account_tx_args, felt, invoke_tx_args};
+use starknet_api::{declare_tx_args, deploy_account_tx_args, felt};
 use starknet_types_core::felt::Felt;
 
 use crate::compiler_version::VersionId;
@@ -123,7 +123,7 @@ pub fn rpc_tx_for_testing(
             nonce_data_availability_mode,
             fee_data_availability_mode,
         )),
-        TransactionType::Invoke => rpc_invoke_tx(invoke_tx_args!(
+        TransactionType::Invoke => rpc_invoke_tx(InvokeTxArgs {
             signature,
             sender_address,
             calldata,
@@ -132,6 +132,7 @@ pub fn rpc_tx_for_testing(
             paymaster_data,
             nonce_data_availability_mode,
             fee_data_availability_mode,
-        )),
+            ..Default::default()
+        }),
     }
 }

--- a/crates/starknet_mempool/src/test_utils.rs
+++ b/crates/starknet_mempool/src/test_utils.rs
@@ -23,8 +23,7 @@ macro_rules! tx {
             use starknet_api::block::GasPrice;
             use starknet_api::executable_transaction::AccountTransaction;
             use starknet_api::hash::StarkHash;
-            use starknet_api::invoke_tx_args;
-            use starknet_api::test_utils::invoke::executable_invoke_tx;
+            use starknet_api::test_utils::invoke::{executable_invoke_tx, InvokeTxArgs};
             use starknet_api::transaction::fields::{
                 AllResourceBounds,
                 ResourceBounds,
@@ -41,12 +40,13 @@ macro_rules! tx {
                 ..Default::default()
             });
 
-            AccountTransaction::Invoke(executable_invoke_tx(invoke_tx_args!{
+            AccountTransaction::Invoke(executable_invoke_tx(InvokeTxArgs{
                 tx_hash: TransactionHash(StarkHash::from($tx_hash)),
                 sender_address: contract_address!($address),
                 nonce: nonce!($tx_nonce),
                 tip: Tip($tip),
                 resource_bounds,
+                ..Default::default()
             }))
     }};
     (tx_hash: $tx_hash:expr, address: $address:expr, tx_nonce: $tx_nonce:expr, tip: $tip:expr) => {{


### PR DESCRIPTION
The `invoke_tx_args!` macro is a constructor for the `InvokeTxArgs` struct. It calls the default constructor on its input fields and uses default values for all other fields.
It was originally written in such a way that when `resource_bounds` are not supplied they are derived from `max_fee` (see [here](https://reviewable.io/reviews/starkware-libs/blockifier/953)).
Since then the macro was modified and in its current state its only benefit is allowing one to omit the `..Default::default()` for all fields not supplied in instantiation.
No other structs apart from `[Invoke/Declare/DeployAccount]TxArgs` use this form of macro instantiation. As no added benefit exists, we suggest removing these macros.