### PR TITLE
refactor(gateway): move test utils to gateway

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -28,7 +28,6 @@ use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
     AllResourceBounds,
-    Calldata,
     ContractAddressSalt,
     PaymasterData,
     ResourceBounds,
@@ -54,108 +53,10 @@ pub const VALID_L2_GAS_MAX_AMOUNT: u64 = 500000;
 pub const VALID_L2_GAS_MAX_PRICE_PER_UNIT: u128 = 100000000000;
 pub const VALID_L1_DATA_GAS_MAX_AMOUNT: u64 = 203484;
 pub const VALID_L1_DATA_GAS_MAX_PRICE_PER_UNIT: u128 = 100000000000;
+// TODO: Move to Gateway's test_utils when DeclareTxArgs is moved to Starknet API.
 pub const TEST_SENDER_ADDRESS: u128 = 0x1000;
 
 // Utils.
-#[derive(Clone)]
-pub enum TransactionType {
-    Declare,
-    DeployAccount,
-    Invoke,
-}
-
-/// Transaction arguments used for the function [rpc_tx_for_testing].
-#[derive(Clone)]
-pub struct RpcTransactionArgs {
-    pub sender_address: ContractAddress,
-    pub resource_bounds: AllResourceBounds,
-    pub calldata: Calldata,
-    pub signature: TransactionSignature,
-    pub account_deployment_data: AccountDeploymentData,
-    pub paymaster_data: PaymasterData,
-    pub nonce_data_availability_mode: DataAvailabilityMode,
-    pub fee_data_availability_mode: DataAvailabilityMode,
-}
-
-impl Default for RpcTransactionArgs {
-    fn default() -> Self {
-        Self {
-            sender_address: TEST_SENDER_ADDRESS.into(),
-            resource_bounds: AllResourceBounds::default(),
-            calldata: Default::default(),
-            signature: Default::default(),
-            account_deployment_data: Default::default(),
-            paymaster_data: Default::default(),
-            nonce_data_availability_mode: DataAvailabilityMode::L1,
-            fee_data_availability_mode: DataAvailabilityMode::L1,
-        }
-    }
-}
-
-pub fn rpc_tx_for_testing(
-    tx_type: TransactionType,
-    rpc_tx_args: RpcTransactionArgs,
-) -> RpcTransaction {
-    let RpcTransactionArgs {
-        sender_address,
-        resource_bounds,
-        calldata,
-        signature,
-        account_deployment_data,
-        paymaster_data,
-        nonce_data_availability_mode,
-        fee_data_availability_mode,
-    } = rpc_tx_args;
-    match tx_type {
-        TransactionType::Declare => {
-            // Minimal contract class.
-            let contract_class = ContractClass {
-                sierra_program: vec![
-                    // Sierra Version ID.
-                    felt!(1_u32),
-                    felt!(3_u32),
-                    felt!(0_u32),
-                    // Compiler version ID.
-                    felt!(1_u32),
-                    felt!(3_u32),
-                    felt!(0_u32),
-                ],
-                ..Default::default()
-            };
-            rpc_declare_tx(declare_tx_args!(
-                signature,
-                sender_address,
-                resource_bounds,
-                contract_class,
-                account_deployment_data,
-                paymaster_data,
-                nonce_data_availability_mode,
-                fee_data_availability_mode,
-            ))
-        }
-        TransactionType::DeployAccount => rpc_deploy_account_tx(deploy_account_tx_args!(
-            signature,
-            resource_bounds: ValidResourceBounds::AllResources(resource_bounds),
-            constructor_calldata: calldata,
-            paymaster_data,
-            nonce_data_availability_mode,
-            fee_data_availability_mode,
-        )),
-        TransactionType::Invoke => rpc_invoke_tx(invoke_tx_args!(
-            signature,
-            sender_address,
-            calldata,
-            resource_bounds: ValidResourceBounds::AllResources(resource_bounds),
-            account_deployment_data,
-            paymaster_data,
-            nonce_data_availability_mode,
-            fee_data_availability_mode,
-        )),
-    }
-}
-
-pub const NON_EMPTY_RESOURCE_BOUNDS: ResourceBounds =
-    ResourceBounds { max_amount: GasAmount(1), max_price_per_unit: GasPrice(1) };
 
 pub fn test_resource_bounds_mapping() -> AllResourceBounds {
     AllResourceBounds {

--- a/crates/starknet_gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/starknet_gateway/src/stateless_transaction_validator_test.rs
@@ -3,13 +3,7 @@ use std::vec;
 
 use assert_matches::assert_matches;
 use mempool_test_utils::declare_tx_args;
-use mempool_test_utils::starknet_api_test_utils::{
-    rpc_declare_tx,
-    rpc_tx_for_testing,
-    RpcTransactionArgs,
-    TransactionType,
-    NON_EMPTY_RESOURCE_BOUNDS,
-};
+use mempool_test_utils::starknet_api_test_utils::rpc_declare_tx;
 use rstest::rstest;
 use starknet_api::core::{EntryPointSelector, L2_ADDRESS_UPPER_BOUND};
 use starknet_api::data_availability::DataAvailabilityMode;
@@ -33,7 +27,13 @@ use crate::stateless_transaction_validator::{
     StatelessTransactionValidator,
     StatelessTransactionValidatorError,
 };
-use crate::test_utils::create_sierra_program;
+use crate::test_utils::{
+    create_sierra_program,
+    rpc_tx_for_testing,
+    RpcTransactionArgs,
+    TransactionType,
+    NON_EMPTY_RESOURCE_BOUNDS,
+};
 
 static MIN_SIERRA_VERSION: LazyLock<VersionId> = LazyLock::new(|| VersionId::new(1, 1, 0));
 static MAX_SIERRA_VERSION: LazyLock<VersionId> = LazyLock::new(|| VersionId::new(1, 5, usize::MAX));

--- a/crates/starknet_gateway/src/test_utils.rs
+++ b/crates/starknet_gateway/src/test_utils.rs
@@ -1,6 +1,31 @@
+use mempool_test_utils::declare_tx_args;
+use mempool_test_utils::starknet_api_test_utils::{
+    rpc_declare_tx,
+    rpc_deploy_account_tx,
+    rpc_invoke_tx,
+    TEST_SENDER_ADDRESS,
+};
+use starknet_api::block::GasPrice;
+use starknet_api::core::ContractAddress;
+use starknet_api::data_availability::DataAvailabilityMode;
+use starknet_api::execution_resources::GasAmount;
+use starknet_api::rpc_transaction::{ContractClass, RpcTransaction};
+use starknet_api::transaction::fields::{
+    AccountDeploymentData,
+    AllResourceBounds,
+    Calldata,
+    PaymasterData,
+    ResourceBounds,
+    TransactionSignature,
+    ValidResourceBounds,
+};
+use starknet_api::{deploy_account_tx_args, felt, invoke_tx_args};
 use starknet_types_core::felt::Felt;
 
 use crate::compiler_version::VersionId;
+
+pub const NON_EMPTY_RESOURCE_BOUNDS: ResourceBounds =
+    ResourceBounds { max_amount: GasAmount(1), max_price_per_unit: GasPrice(1) };
 
 pub fn create_sierra_program(version_id: &VersionId) -> Vec<Felt> {
     let version_id = version_id.0;
@@ -14,4 +39,101 @@ pub fn create_sierra_program(version_id: &VersionId) -> Vec<Felt> {
         Felt::from(u64::try_from(0).unwrap()),
         Felt::from(u64::try_from(0).unwrap()),
     ]
+}
+
+#[derive(Clone)]
+pub enum TransactionType {
+    Declare,
+    DeployAccount,
+    Invoke,
+}
+
+/// Transaction arguments used for the function [rpc_tx_for_testing].
+#[derive(Clone)]
+pub struct RpcTransactionArgs {
+    pub sender_address: ContractAddress,
+    pub resource_bounds: AllResourceBounds,
+    pub calldata: Calldata,
+    pub signature: TransactionSignature,
+    pub account_deployment_data: AccountDeploymentData,
+    pub paymaster_data: PaymasterData,
+    pub nonce_data_availability_mode: DataAvailabilityMode,
+    pub fee_data_availability_mode: DataAvailabilityMode,
+}
+
+impl Default for RpcTransactionArgs {
+    fn default() -> Self {
+        Self {
+            sender_address: TEST_SENDER_ADDRESS.into(),
+            resource_bounds: AllResourceBounds::default(),
+            calldata: Default::default(),
+            signature: Default::default(),
+            account_deployment_data: Default::default(),
+            paymaster_data: Default::default(),
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+        }
+    }
+}
+
+pub fn rpc_tx_for_testing(
+    tx_type: TransactionType,
+    rpc_tx_args: RpcTransactionArgs,
+) -> RpcTransaction {
+    let RpcTransactionArgs {
+        sender_address,
+        resource_bounds,
+        calldata,
+        signature,
+        account_deployment_data,
+        paymaster_data,
+        nonce_data_availability_mode,
+        fee_data_availability_mode,
+    } = rpc_tx_args;
+    match tx_type {
+        TransactionType::Declare => {
+            // Minimal contract class.
+            let contract_class = ContractClass {
+                sierra_program: vec![
+                    // Sierra Version ID.
+                    felt!(1_u32),
+                    felt!(3_u32),
+                    felt!(0_u32),
+                    // Compiler version ID.
+                    felt!(1_u32),
+                    felt!(3_u32),
+                    felt!(0_u32),
+                ],
+                ..Default::default()
+            };
+            rpc_declare_tx(declare_tx_args!(
+                signature,
+                sender_address,
+                resource_bounds,
+                contract_class,
+                account_deployment_data,
+                paymaster_data,
+                nonce_data_availability_mode,
+                fee_data_availability_mode,
+            ))
+        }
+        TransactionType::DeployAccount => rpc_deploy_account_tx(deploy_account_tx_args!(
+            signature,
+            resource_bounds: ValidResourceBounds::AllResources(resource_bounds),
+            constructor_calldata: calldata,
+            paymaster_data,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+        )),
+        TransactionType::Invoke => rpc_invoke_tx(invoke_tx_args!(
+            signature,
+            sender_address,
+            calldata,
+            resource_bounds: ValidResourceBounds::AllResources(resource_bounds),
+            account_deployment_data,
+            paymaster_data,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+        )),
+    }
 }


### PR DESCRIPTION
Moved test utils specific to gateway's tests that probably won’t be used in other crates. 
The use of `declare_tx_args`, `rpc_declare_tx`, `rpc_deploy_account_tx`, `rpc_invoke_tx` from `mempool_test_utils` is temporary, discussions are ongoing about moving them, likely to SN API.


instead of `NON_EMPTY_RESOURCE_BOUNDS` we can use:
1. use this startnet_api's [func](https://github.com/starkware-libs/sequencer/blob/228488fe25742451b3337c6dfe61f4f303a196d0/crates/starknet_api/src/rpc_transaction_test.rs#L32): `create_resource_bounds_for_testing`. I prefer this option if possible.
2. move this blockifier's [func](https://github.com/starkware-libs/sequencer/blob/bd3fad882c3419ad51bc9466abd146f63a859776/crates/blockifier/src/transaction/test_utils.rs#L360): `create_all_resource_bounds`
3. move and use mempool_test_utils' [func](https://github.com/starkware-libs/sequencer/blob/74a5bd5c696ddae5fd541c2f97a8c48e70220b31/crates/mempool_test_utils/src/starknet_api_test_utils.rs#L61): `test_resource_bounds_mapping`

UPDATE: decided to use `NON_EMPTY_RESOURCE_BOUNDS`.

