### PR TITLE
chore: add lint to p2p_sync

### DIFF
--- a/crates/papyrus_p2p_sync/src/client/header.rs
+++ b/crates/papyrus_p2p_sync/src/client/header.rs
@@ -14,6 +14,7 @@ use super::stream_builder::{BlockData, BlockNumberLimit, DataStreamBuilder};
 use super::{P2PSyncClientError, ALLOWED_SIGNATURES_LENGTH, NETWORK_DATA_TIMEOUT};
 
 impl BlockData for SignedBlockHeader {
+    #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
     fn write_to_storage(
         self: Box<Self>,
         storage_writer: &mut StorageWriter,

--- a/crates/papyrus_p2p_sync/src/client/state_diff.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff.rs
@@ -18,6 +18,7 @@ use crate::client::{P2PSyncClientError, NETWORK_DATA_TIMEOUT};
 
 impl BlockData for (ThinStateDiff, BlockNumber) {
     #[latency_histogram("p2p_sync_state_diff_write_to_storage_latency_seconds", true)]
+    #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
     fn write_to_storage(
         self: Box<Self>,
         storage_writer: &mut StorageWriter,


### PR DESCRIPTION
Lior banned `as` repo-wide, unless absolutely necessary.

Nearly all as uses can be replaced with [Try]From which doesn't have implicit coercions like as (we encountered several bugs due to these coercions).

Motivation: we are standardizing lints across the repo and CI, instead of each crate having separate sets of lints.

Changes:
1. header/state_diff: added clippy ignore to `gauge!` metric usage which requires f64. This is probably unnecessary since metrics used are int values, but fixing this is out of scope, and there are no other sensible conversions from unsigned to floats.
2. test.rs: most usages of these two vars were for usize, and only a couple needed u64, so i flipped the usages.