### PR TITLE
chore: add lints to p2p-sync

### DIFF
--- a/crates/papyrus_p2p_sync/Cargo.toml
+++ b/crates/papyrus_p2p_sync/Cargo.toml
@@ -42,3 +42,6 @@ tokio = { workspace = true, features = ["test-util"] }
 # The `metrics` crate is used by `latency_histogram` proc macro, which is used in this crate.
 [package.metadata.cargo-machete]
 ignored = ["metrics"]
+
+[lints]
+workspace = true

--- a/crates/papyrus_p2p_sync/src/server/utils.rs
+++ b/crates/papyrus_p2p_sync/src/server/utils.rs
@@ -12,13 +12,11 @@ pub(crate) fn calculate_block_number(
         Direction::Backward => -1,
     };
     // TODO(shahak): Fix this code.
-    let blocks_delta: i128 = direction_factor * (query.step * read_blocks_counter) as i128;
-    let block_number: i128 = start_block as i128 + blocks_delta;
-    if block_number < 0 || block_number > u64::MAX as i128 {
-        return Err(P2PSyncServerError::BlockNumberOutOfRange {
-            query: query.clone(),
-            counter: read_blocks_counter,
-        });
-    }
-    Ok(block_number as u64)
+    let blocks_delta: i128 = direction_factor * i128::from(query.step * read_blocks_counter);
+    let block_number: i128 = i128::from(start_block) + blocks_delta;
+
+    u64::try_from(block_number).map_err(|_| P2PSyncServerError::BlockNumberOutOfRange {
+        query: query.clone(),
+        counter: read_blocks_counter,
+    })
 }


### PR DESCRIPTION
Add workspace lints, which in particular ban `as` usage.

Changes:
1. switch `as` into `From` when applicable.
2. replace the conditional+cast with [equivalent](https://github.com/rust-lang/rust/blob/master/library/core/src/convert/num.rs#L277) logic `u64::try_from`.