### PR TITLE
chore(consensus): add lints to consensus

### DIFF
--- a/crates/sequencing/papyrus_consensus/Cargo.toml
+++ b/crates/sequencing/papyrus_consensus/Cargo.toml
@@ -34,3 +34,6 @@ papyrus_network_types = { workspace = true, features = ["testing"] }
 papyrus_storage = { workspace = true, features = ["testing"] }
 papyrus_test_utils.workspace = true
 test-case.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sequencing/papyrus_consensus/src/manager.rs
+++ b/crates/sequencing/papyrus_consensus/src/manager.rs
@@ -60,6 +60,7 @@ where
     tokio::time::sleep(consensus_delay).await;
     let mut current_height = start_height;
     let mut manager = MultiHeightManager::new(validator_id, timeouts);
+    #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
     loop {
         metrics::gauge!(PAPYRUS_CONSENSUS_HEIGHT, current_height.0 as f64);
 

--- a/crates/sequencing/papyrus_consensus/src/simulation_network_receiver.rs
+++ b/crates/sequencing/papyrus_consensus/src/simulation_network_receiver.rs
@@ -95,6 +95,7 @@ impl NetworkReceiver {
     }
 
     fn should_drop_msg(&self, msg_hash: u64) -> bool {
+        #[allow(clippy::as_conversions)]
         let prob = (msg_hash as f64) / (u64::MAX as f64);
         prob <= self.drop_probability
     }
@@ -104,6 +105,7 @@ impl NetworkReceiver {
         mut msg: ConsensusMessage,
         msg_hash: u64,
     ) -> ConsensusMessage {
+        #[allow(clippy::as_conversions)]
         if (msg_hash as f64) / (u64::MAX as f64) > self.invalid_probability {
             return msg;
         }

--- a/crates/sequencing/papyrus_consensus/src/single_height_consensus.rs
+++ b/crates/sequencing/papyrus_consensus/src/single_height_consensus.rs
@@ -60,7 +60,9 @@ impl SingleHeightConsensus {
         timeouts: TimeoutsConfig,
     ) -> Self {
         // TODO(matan): Use actual weights, not just `len`.
-        let state_machine = StateMachine::new(id, validators.len() as u32);
+        let n_validators =
+            u32::try_from(validators.len()).expect("Should have way less than u32::MAX validators");
+        let state_machine = StateMachine::new(id, n_validators);
         Self {
             height,
             validators,
@@ -445,7 +447,11 @@ impl SingleHeightConsensus {
             })
             .collect();
         // TODO(matan): Check actual weights.
-        assert!(supporting_precommits.len() >= self.state_machine.quorum_size() as usize);
+        assert!(
+            supporting_precommits.len()
+                >= usize::try_from(self.state_machine.quorum_size())
+                    .expect("u32 should fit in usize")
+        );
         Ok(ShcReturn::Decision(Decision { precommits: supporting_precommits, block }))
     }
 }


### PR DESCRIPTION
Lior banned `as` repo-wide, unless absolutely necessary.

Nearly all as uses can be replaced with [Try]From which doesn't have implicit coercions like as (we encountered several bugs due to these coercions).

Motivation: we are standardizing lints across the repo and CI, instead of each crate having separate sets of lints.