### PR TITLE
chore: starknet API add lints

### DIFF
--- a/crates/starknet_api/Cargo.toml
+++ b/crates/starknet_api/Cargo.toml
@@ -35,3 +35,6 @@ rstest.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["strum"]
+
+[lints]
+workspace = true

--- a/crates/starknet_api/src/core.rs
+++ b/crates/starknet_api/src/core.rs
@@ -250,7 +250,7 @@ impl Nonce {
     }
 }
 
-/// The selector of an [EntryPoint](`crate::deprecated_contract_class::EntryPoint`).
+/// The selector of an [EntryPoint](`crate::state::EntryPoint`).
 #[derive(
     Debug, Copy, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord,
 )]

--- a/crates/starknet_api/src/deprecated_contract_class.rs
+++ b/crates/starknet_api/src/deprecated_contract_class.rs
@@ -195,7 +195,7 @@ pub struct TypedParameter {
     pub r#type: String,
 }
 
-/// The offset of an [EntryPoint](`crate::deprecated_contract_class::EntryPoint`).
+/// The offset of an [EntryPoint](`crate::state::EntryPoint`).
 #[derive(
     Debug, Copy, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord,
 )]
@@ -212,10 +212,10 @@ impl TryFrom<String> for EntryPointOffset {
 
 pub fn number_or_string<'de, D: Deserializer<'de>>(deserializer: D) -> Result<usize, D::Error> {
     let usize_value = match Value::deserialize(deserializer)? {
-        Value::Number(number) => {
-            number.as_u64().ok_or(DeserializationError::custom("Cannot cast number to usize."))?
-                as usize
-        }
+        Value::Number(number) => number
+            .as_u64()
+            .and_then(|num_u64| usize::try_from(num_u64).ok())
+            .ok_or(DeserializationError::custom("Cannot cast number to usize."))?,
         Value::String(s) => hex_string_try_into_usize(&s).map_err(DeserializationError::custom)?,
         _ => return Err(DeserializationError::custom("Cannot cast value into usize.")),
     };


### PR DESCRIPTION
Lior banned `as` repo-wide, unless absolutely necessary.

Nearly all as uses can be replaced with [Try]From which doesn't have implicit coercions like as (we encountered several bugs due to these coercions).

Motivation: we are standardizing lints across the repo and CI, instead of each crate having separate sets of lints.