### PR TITLE
chore(ci): remove clippy.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,8 @@ jobs:
       - name: "Run clippy pull request"
         if: github.event_name == 'pull_request'
         run: ci/bin/python scripts/run_tests.py --command clippy --changes_only --commit_id ${{ github.event.pull_request.base.sha }}
+        env:
+          RUSTFLAGS: "-D warnings"
       - name: "Run cargo doc pull request"
         if: github.event_name == 'pull_request'
         run: ci/bin/python scripts/run_tests.py --command doc --changes_only --commit_id ${{ github.event.pull_request.base.sha }}
@@ -78,6 +80,8 @@ jobs:
       - name: "Run clippy on push"
         if: github.event_name == 'push'
         run: ci/bin/python scripts/run_tests.py --command clippy
+        env:
+          RUSTFLAGS: "-D warnings"
       - name: "Run cargo doc on push"
         if: github.event_name == 'push'
         run: ci/bin/python scripts/run_tests.py --command doc
@@ -121,6 +125,7 @@ jobs:
           ci/bin/python scripts/run_tests.py --command test --changes_only --include_dependencies --commit_id ${{ github.event.pull_request.base.sha }}
         env:
           SEED: 0
+          RUSTFLAGS: "-D warnings"
 
       - name: "Run tests on push"
         if: github.event_name == 'push'
@@ -131,6 +136,7 @@ jobs:
           ci/bin/python scripts/run_tests.py --command test
         env:
           SEED: 0
+          RUSTFLAGS: "-D warnings"
 
   codecov:
     runs-on: starkware-ubuntu-latest-large

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,14 +250,17 @@ validator = "0.12"
 void = "1.0.2"
 zstd = "0.13.1"
 
+# Note: both rust and clippy lints are warning by default and denied on the CI (see run_tests.py).
+# To deny warnings in local dev env:
+# - In the terminal: add to .bashrc `export RUSTFLAGS="$RUSTFLAGS -Dwarnings"
+# - In vscode, add to settings.json "rust-analyzer.cargo.extraEnv": { "RUSTFLAGS": "-Dwarnings" }`
 [workspace.lints.rust]
-future-incompatible = "deny"
-nonstandard-style = "deny"
-rust-2018-idioms = "deny"
+future-incompatible = "warn"
+nonstandard-style = "warn"
+rust-2018-idioms = "warn"
 # See [here](https://github.com/taiki-e/cargo-llvm-cov/issues/370) for a discussion on why this is
 # needed (from rust 1.80).
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
-warnings = "deny"
 
 [workspace.lints.clippy]
-as_conversions = "deny"
+as_conversions = "warn"

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# TODO: Revert clippy::unwrap_used to -D after fixing all the unwraps.
-cargo clippy --all-targets --all-features $@ -- \
-    -D future-incompatible \
-    -D nonstandard-style \
-    -D rust-2018-idioms \
-    -D unused \

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -44,7 +44,7 @@ class BaseCommand(Enum):
             return ["scripts/rust_fmt.sh"] + fmt_args + ["--", "--check"]
         elif self == BaseCommand.CLIPPY:
             clippy_args = package_args if len(package_args) > 0 else ["--workspace"]
-            return ["scripts/clippy.sh"] + clippy_args
+            return ["cargo", "clippy"] + clippy_args
         elif self == BaseCommand.DOC:
             doc_args = package_args if len(package_args) > 0 else ["--workspace"]
             return ["cargo", "doc", "-r", "--document-private-items", "--no-deps"] + doc_args


### PR DESCRIPTION
- Only one source of truth for lints, main Cargo.toml, making clippy.sh unnecessary.
- Warnings no longer denied, only in the CI. To preserve existing behaviors users can add `-Dwarnings` to local RUSTFLAGS.

We still need to enforce in workspace tests that all crates inherit workspace lints.