### PR TITLE
refactor(mempool): change with_priority_queue input to Transaction iterator

### DIFF
--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -78,11 +78,13 @@ impl MempoolContentBuilder {
         self
     }
 
-    fn with_priority_queue<Q>(mut self, queue_txs: Q) -> Self
+    fn with_priority_queue<'a, Q>(mut self, queue_txs: Q) -> Self
     where
-        Q: IntoIterator<Item = TransactionReference>,
+        Q: IntoIterator<Item = &'a Transaction>,
     {
-        self.tx_queue_content_builder = self.tx_queue_content_builder.with_priority(queue_txs);
+        self.tx_queue_content_builder = self
+            .tx_queue_content_builder
+            .with_priority(queue_txs.into_iter().map(TransactionReference::new));
         self
     }
 
@@ -189,7 +191,7 @@ fn test_get_txs_returns_by_priority_order(#[case] n_requested_txs: usize) {
 
     let mut mempool = MempoolContentBuilder::new()
         .with_pool(txs.iter().cloned())
-        .with_priority_queue(txs.iter().map(TransactionReference::new))
+        .with_priority_queue(&txs)
         .build_into_mempool();
 
     // Test.
@@ -201,9 +203,7 @@ fn test_get_txs_returns_by_priority_order(#[case] n_requested_txs: usize) {
     assert_eq!(fetched_txs, expected_fetched_txs);
 
     // Assert: non-returned transactions are still in the mempool.
-    let remaining_tx_references = remaining_txs.iter().map(TransactionReference::new);
-    let mempool_content =
-        MempoolContentBuilder::new().with_priority_queue(remaining_tx_references).build();
+    let mempool_content = MempoolContentBuilder::new().with_priority_queue(remaining_txs).build();
     mempool_content.assert_eq(&mempool);
 }
 
@@ -226,8 +226,8 @@ fn test_get_txs_does_not_remove_returned_txs_from_pool() {
     // Setup.
     let tx = tx!();
 
-    let queue_txs = [TransactionReference::new(&tx)];
-    let pool_txs = [tx];
+    let queue_txs = [&tx];
+    let pool_txs = [tx.clone()];
     let mut mempool = MempoolContentBuilder::new()
         .with_pool(pool_txs.clone())
         .with_priority_queue(queue_txs)
@@ -247,7 +247,7 @@ fn test_get_txs_replenishes_queue_only_between_chunks() {
     let tx_address_0_nonce_1 = tx!(tx_hash: 2, address: "0x0", tx_nonce: 1, tip: 20);
     let tx_address_1_nonce_0 = tx!(tx_hash: 3, address: "0x1", tx_nonce: 0, tip: 10);
 
-    let queue_txs = [&tx_address_0_nonce_0, &tx_address_1_nonce_0].map(TransactionReference::new);
+    let queue_txs = [&tx_address_0_nonce_0, &tx_address_1_nonce_0];
     let pool_txs =
         [&tx_address_0_nonce_0, &tx_address_0_nonce_1, &tx_address_1_nonce_0].map(|tx| tx.clone());
     let mut mempool = MempoolContentBuilder::new()
@@ -273,7 +273,7 @@ fn test_get_txs_with_nonce_gap() {
     let tx_address_0_nonce_1 = tx!(tx_hash: 2, address: "0x0", tx_nonce: 1);
     let tx_address_1_nonce_0 = tx!(tx_hash: 3, address: "0x1", tx_nonce: 0);
 
-    let queue_txs = [TransactionReference::new(&tx_address_1_nonce_0)];
+    let queue_txs = [&tx_address_1_nonce_0];
     let pool_txs = [tx_address_0_nonce_1, tx_address_1_nonce_0.clone()];
     let mut mempool = MempoolContentBuilder::new()
         .with_pool(pool_txs)
@@ -307,9 +307,9 @@ fn test_add_tx(mut mempool: Mempool) {
     add_tx_inputs.sort_by_key(|input| std::cmp::Reverse(tip(&input.tx)));
 
     // Assert: transactions are ordered by priority.
-    let expected_queue_txs: Vec<TransactionReference> =
-        add_tx_inputs.iter().map(|input| TransactionReference::new(&input.tx)).collect();
-    let expected_pool_txs = add_tx_inputs.into_iter().map(|input| input.tx);
+    let expected_pool_txs = add_tx_inputs.iter().map(|input| input.tx.clone());
+    let expected_queue_txs: Vec<&Transaction> =
+        add_tx_inputs.iter().map(|input| &input.tx).collect();
     let expected_mempool_content = MempoolContentBuilder::new()
         .with_pool(expected_pool_txs)
         .with_priority_queue(expected_queue_txs)
@@ -333,10 +333,12 @@ fn test_add_tx_correctly_places_txs_in_queue_and_pool(mut mempool: Mempool) {
     }
 
     // Assert: only the eligible transactions appear in the queue.
-    let expected_queue_txs =
-        [&input_address_1_nonce_0.tx, &input_address_0_nonce_0.tx].map(TransactionReference::new);
-    let expected_pool_txs =
-        [input_address_0_nonce_0.tx, input_address_1_nonce_0.tx, input_address_0_nonce_1.tx];
+    let expected_pool_txs = [
+        input_address_0_nonce_0.tx.clone(),
+        input_address_1_nonce_0.tx.clone(),
+        input_address_0_nonce_1.tx,
+    ];
+    let expected_queue_txs = [&input_address_1_nonce_0.tx, &input_address_0_nonce_0.tx];
     let expected_mempool_content = MempoolContentBuilder::new()
         .with_pool(expected_pool_txs)
         .with_priority_queue(expected_queue_txs)
@@ -371,8 +373,8 @@ fn test_add_tx_failure_on_duplicate_tx_hash(mut mempool: Mempool) {
 fn test_add_tx_lower_than_queued_nonce() {
     // Setup.
     let tx = tx!(tx_hash: 1, address: "0x0", tx_nonce: 1);
-    let queue_txs = [TransactionReference::new(&tx)];
-    let pool_txs = [tx];
+    let queue_txs = [&tx];
+    let pool_txs = [&tx].map(|tx| tx.clone());
     let mut mempool = MempoolContentBuilder::new()
         .with_pool(pool_txs.clone())
         .with_priority_queue(queue_txs)
@@ -411,8 +413,8 @@ fn test_add_tx_with_identical_tip_succeeds(mut mempool: Mempool) {
     }
 
     // Assert: both transactions are in the mempool.
-    let expected_queue_txs = [&input1.tx, &input2.tx].map(TransactionReference::new);
-    let expected_pool_txs = [input1.tx, input2.tx];
+    let expected_queue_txs = [&input1.tx, &input2.tx];
+    let expected_pool_txs = [&input1.tx, &input2.tx].map(|tx| tx.clone());
     let expected_mempool_content = MempoolContentBuilder::new()
         .with_pool(expected_pool_txs)
         .with_priority_queue(expected_queue_txs)
@@ -437,8 +439,7 @@ fn test_add_tx_tip_priority_over_tx_hash(mut mempool: Mempool) {
     }
 
     // Assert: ensure that the transaction with the higher tip is prioritized higher.
-    let expected_queue_txs =
-        [&input_big_tip_small_hash.tx, &input_small_tip_big_hash.tx].map(TransactionReference::new);
+    let expected_queue_txs = [&input_big_tip_small_hash.tx, &input_small_tip_big_hash.tx];
     let expected_mempool_content =
         MempoolContentBuilder::new().with_priority_queue(expected_queue_txs).build();
     expected_mempool_content.assert_eq(&mempool);
@@ -463,8 +464,8 @@ fn test_add_tx_fills_nonce_gap(mut mempool: Mempool) {
     add_tx(&mut mempool, &input_nonce_0);
 
     // Assert: only the eligible transaction appears in the queue.
-    let expected_queue_txs = [TransactionReference::new(&input_nonce_0.tx)];
-    let expected_pool_txs = [input_nonce_1.tx, input_nonce_0.tx];
+    let expected_pool_txs = [input_nonce_1.tx, input_nonce_0.tx.clone()];
+    let expected_queue_txs = [&input_nonce_0.tx];
     let expected_mempool_content = MempoolContentBuilder::new()
         .with_pool(expected_pool_txs)
         .with_priority_queue(expected_queue_txs)
@@ -484,8 +485,7 @@ fn test_commit_block_includes_all_proposed_txs() {
     let tx_address_1_nonce_3 = tx!(tx_hash: 5, address: "0x1", tx_nonce: 3);
     let tx_address_2_nonce_1 = tx!(tx_hash: 6, address: "0x2", tx_nonce: 1);
 
-    let queue_txs = [&tx_address_2_nonce_1, &tx_address_1_nonce_3, &tx_address_0_nonce_4]
-        .map(TransactionReference::new);
+    let queue_txs = [&tx_address_2_nonce_1, &tx_address_1_nonce_3, &tx_address_0_nonce_4];
     let pool_txs = [
         tx_address_0_nonce_3,
         tx_address_0_nonce_4.clone(),
@@ -505,8 +505,12 @@ fn test_commit_block_includes_all_proposed_txs() {
     commit_block(&mut mempool, nonces, tx_hashes);
 
     // Assert.
-    let pool_txs =
-        [tx_address_0_nonce_4, tx_address_0_nonce_5, tx_address_1_nonce_3, tx_address_2_nonce_1];
+    let pool_txs = [
+        tx_address_0_nonce_4.clone(),
+        tx_address_0_nonce_5,
+        tx_address_1_nonce_3.clone(),
+        tx_address_2_nonce_1.clone(),
+    ];
     let expected_mempool_content =
         MempoolContentBuilder::new().with_pool(pool_txs).with_priority_queue(queue_txs).build();
     expected_mempool_content.assert_eq(&mempool);


### PR DESCRIPTION
In order to encapsulate `TransactionReference` from mempool tests, change the input of `with_priority_queue` from a `TransactionReference` iterator to a `&Transaction` iterator.

The execution of `with_priority_queue` maps each `&Transaction` to a `TransactionReference`.

Some tests still require cloning of transactions due to the fact that `with_pool` uses `Transaction` iterators instead of `&Transactions`. See comments for specific tests in the PR.

We propose modifying `with_pool` and `with_pending_queue` to accept  `&Transaction` as well. This makes sense for two reasons:
1. The `Transaction` objects passed to the functions `with_[pool/priority_queue/pending_queue]` are not modified.
2. Using references instead of objects will allow us to omit cloning of `Transaction` objects inside tests allowing for more readable code.