### PR TITLE
feat(blockifier): add support for secp256k1 syscall for native

### DIFF
--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -608,46 +608,66 @@ impl<'state> StarknetSyscallHandler for &mut NativeSyscallHandler<'state> {
 
     fn secp256k1_new(
         &mut self,
-        _x: U256,
-        _y: U256,
-        _remaining_gas: &mut u64,
+        x: U256,
+        y: U256,
+        remaining_gas: &mut u64,
     ) -> SyscallResult<Option<Secp256k1Point>> {
-        todo!("Implement secp256k1_new syscall.");
+        self.pre_execute_syscall(remaining_gas, self.context.gas_costs().secp256k1_new_gas_cost)?;
+
+        Secp256Point::new(x, y)
+            .map(|op| op.map(|p| p.into()))
+            .map_err(|e| self.handle_error(remaining_gas, e))
     }
 
     fn secp256k1_add(
         &mut self,
-        _p0: Secp256k1Point,
-        _p1: Secp256k1Point,
-        _remaining_gas: &mut u64,
+        p0: Secp256k1Point,
+        p1: Secp256k1Point,
+        remaining_gas: &mut u64,
     ) -> SyscallResult<Secp256k1Point> {
-        todo!("Implement secp256k1_add syscall.");
+        self.pre_execute_syscall(remaining_gas, self.context.gas_costs().secp256k1_add_gas_cost)?;
+
+        Ok(Secp256Point::add(p0.into(), p1.into()).into())
     }
 
     fn secp256k1_mul(
         &mut self,
-        _p: Secp256k1Point,
-        _m: U256,
-        _remaining_gas: &mut u64,
+        p: Secp256k1Point,
+        m: U256,
+        remaining_gas: &mut u64,
     ) -> SyscallResult<Secp256k1Point> {
-        todo!("Implement secp256k1_mul syscall.");
+        self.pre_execute_syscall(remaining_gas, self.context.gas_costs().secp256k1_mul_gas_cost)?;
+
+        Ok(Secp256Point::mul(p.into(), m).into())
     }
 
     fn secp256k1_get_point_from_x(
         &mut self,
-        _x: U256,
-        _y_parity: bool,
-        _remaining_gas: &mut u64,
+        x: U256,
+        y_parity: bool,
+        remaining_gas: &mut u64,
     ) -> SyscallResult<Option<Secp256k1Point>> {
-        todo!("Implement secp256k1_get_point_from_x syscall.");
+        self.pre_execute_syscall(
+            remaining_gas,
+            self.context.gas_costs().secp256k1_get_point_from_x_gas_cost,
+        )?;
+
+        Secp256Point::get_point_from_x(x, y_parity)
+            .map(|op| op.map(|p| p.into()))
+            .map_err(|e| self.handle_error(remaining_gas, e))
     }
 
     fn secp256k1_get_xy(
         &mut self,
-        _p: Secp256k1Point,
-        _remaining_gas: &mut u64,
+        p: Secp256k1Point,
+        remaining_gas: &mut u64,
     ) -> SyscallResult<(U256, U256)> {
-        todo!("Implement secp256k1_get_xy syscall.");
+        self.pre_execute_syscall(
+            remaining_gas,
+            self.context.gas_costs().secp256k1_get_xy_gas_cost,
+        )?;
+
+        Ok((p.x, p.y))
     }
 
     fn secp256r1_new(

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
@@ -9,6 +9,10 @@ use crate::test_utils::contracts::FeatureContract;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::{trivial_external_entry_point_new, CairoVersion, BALANCE};
 
+#[cfg_attr(
+    feature = "cairo_native",
+    test_case(FeatureContract::TestContract(CairoVersion::Native); "Native")
+)]
 #[test_case(FeatureContract::TestContract(CairoVersion::Cairo1); "VM")]
 fn test_secp256k1(test_contract: FeatureContract) {
     let chain_info = &ChainInfo::create_for_testing();


### PR DESCRIPTION
Should go after #1675 , #1813 , #1546 , #1545 

Commit history will be changed in the future, so "feat: add support for keccak syscall" will be removed