### PR TITLE
refactor(mempool): return `TransactionReference` by value from pool

### DIFF
--- a/crates/starknet_mempool/src/mempool.rs
+++ b/crates/starknet_mempool/src/mempool.rs
@@ -227,7 +227,7 @@ impl Mempool {
             if let Some(next_tx_reference) =
                 self.tx_pool.get_next_eligible_tx(current_account_state)?
             {
-                self.tx_queue.insert(*next_tx_reference);
+                self.tx_queue.insert(next_tx_reference);
             }
         }
 
@@ -250,7 +250,7 @@ impl Mempool {
         // Maybe close nonce gap.
         if self.tx_queue.get_nonce(address).is_none() {
             if let Some(tx_reference) = self.tx_pool.get_by_address_and_nonce(address, nonce) {
-                self.tx_queue.insert(*tx_reference);
+                self.tx_queue.insert(tx_reference);
             }
         }
     }
@@ -268,10 +268,10 @@ impl Mempool {
             return Ok(());
         };
 
-        if !self.should_replace_tx(existing_tx_ref, &incoming_tx_ref) {
+        if !self.should_replace_tx(&existing_tx_ref, &incoming_tx_ref) {
             tracing::debug!(
                 "{existing_tx_ref} was not replaced by {incoming_tx_ref} due to insufficient
-            fee escalation."
+                fee escalation."
             );
             // TODO(Elin): consider adding a more specific error type / message.
             return Err(MempoolError::DuplicateNonce { address, nonce });

--- a/crates/starknet_mempool/src/transaction_pool.rs
+++ b/crates/starknet_mempool/src/transaction_pool.rs
@@ -99,14 +99,14 @@ impl TransactionPool {
         &self,
         address: ContractAddress,
         nonce: Nonce,
-    ) -> Option<&TransactionReference> {
+    ) -> Option<TransactionReference> {
         self.txs_by_account.get(address, nonce)
     }
 
     pub fn get_next_eligible_tx(
         &self,
         current_account_state: AccountState,
-    ) -> MempoolResult<Option<&TransactionReference>> {
+    ) -> MempoolResult<Option<TransactionReference>> {
         let AccountState { address, nonce } = current_account_state;
         let next_nonce = try_increment_nonce(nonce)?;
         Ok(self.get_by_address_and_nonce(address, next_nonce))
@@ -139,8 +139,8 @@ impl AccountTransactionIndex {
         removed_tx
     }
 
-    fn get(&self, address: ContractAddress, nonce: Nonce) -> Option<&TransactionReference> {
-        self.0.get(&address)?.get(&nonce)
+    fn get(&self, address: ContractAddress, nonce: Nonce) -> Option<TransactionReference> {
+        self.0.get(&address)?.get(&nonce).copied()
     }
 
     fn account_txs_sorted_by_nonce(


### PR DESCRIPTION
It's `Copy`, less boilerplate in callsites.