### PR TITLE
chore: move abi utils to snapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sha3",
  "starknet-types-core",
  "starknet_api",
  "strum 0.25.0",

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -49,7 +49,6 @@ semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 sha2.workspace = true
-sha3.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 strum.workspace = true

--- a/crates/blockifier/src/abi.rs
+++ b/crates/blockifier/src/abi.rs
@@ -1,3 +1,2 @@
-pub mod abi_utils;
 pub mod constants;
 pub mod sierra_types;

--- a/crates/blockifier/src/abi/constants.rs
+++ b/crates/blockifier/src/abi/constants.rs
@@ -1,11 +1,6 @@
 use starknet_api::transaction::TransactionVersion;
 use starknet_types_core::felt::Felt;
 
-pub const CONSTRUCTOR_ENTRY_POINT_NAME: &str = "constructor";
-pub const DEFAULT_ENTRY_POINT_NAME: &str = "__default__";
-pub const DEFAULT_ENTRY_POINT_SELECTOR: u64 = 0;
-pub const DEFAULT_L1_ENTRY_POINT_NAME: &str = "__l1_default__";
-
 // The version is considered 0 for L1-Handler transaction hash calculation purposes.
 pub const L1_HANDLER_VERSION: TransactionVersion = TransactionVersion(Felt::ZERO);
 

--- a/crates/blockifier/src/concurrency/versioned_state_test.rs
+++ b/crates/blockifier/src/concurrency/versioned_state_test.rs
@@ -4,6 +4,7 @@ use std::thread;
 
 use assert_matches::assert_matches;
 use rstest::{fixture, rstest};
+use starknet_api::abi::abi_utils::{get_fee_token_var_address, get_storage_var_address};
 use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress};
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::fields::{ContractAddressSalt, ValidResourceBounds};
@@ -18,7 +19,6 @@ use starknet_api::{
     storage_key,
 };
 
-use crate::abi::abi_utils::{get_fee_token_var_address, get_storage_var_address};
 use crate::concurrency::test_utils::{
     class_hash,
     contract_address,

--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use rstest::rstest;
+use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::constants::DEPLOY_CONTRACT_FUNCTION_ENTRY_POINT_NAME;
@@ -11,7 +12,6 @@ use starknet_api::{contract_address, declare_tx_args, felt, invoke_tx_args, nonc
 use starknet_types_core::felt::Felt;
 
 use super::WorkerExecutor;
-use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::bouncer::Bouncer;
 use crate::concurrency::fee_utils::STORAGE_READ_SEQUENCER_BALANCE_INDICES;
 use crate::concurrency::scheduler::{Task, TransactionStatus};

--- a/crates/blockifier/src/execution/contract_address_test.rs
+++ b/crates/blockifier/src/execution/contract_address_test.rs
@@ -1,9 +1,9 @@
 use rstest::rstest;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress};
 use starknet_api::transaction::fields::{Calldata, ContractAddressSalt};
 use starknet_api::{calldata, felt};
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
+++ b/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
@@ -5,13 +5,13 @@ use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use cairo_vm::vm::runners::cairo_runner::{CairoArg, CairoRunner, ExecutionResources};
+use starknet_api::abi::abi_utils::selector_from_name;
+use starknet_api::abi::constants::{CONSTRUCTOR_ENTRY_POINT_NAME, DEFAULT_ENTRY_POINT_SELECTOR};
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::EntryPointSelector;
 use starknet_api::hash::StarkHash;
 
 use super::execution_utils::SEGMENT_ARENA_BUILTIN_SIZE;
-use crate::abi::abi_utils::selector_from_name;
-use crate::abi::constants::{CONSTRUCTOR_ENTRY_POINT_NAME, DEFAULT_ENTRY_POINT_SELECTOR};
 use crate::execution::call_info::{CallExecution, CallInfo, ChargedResources};
 use crate::execution::contract_class::{ContractClassV0, TrackedResource};
 use crate::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallHintProcessor;

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -5,6 +5,7 @@ use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_traits::Pow;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::{calculate_contract_address, ChainId};
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::fields::{Calldata, ContractAddressSalt, Fee};
@@ -20,7 +21,6 @@ use starknet_api::{calldata, felt, nonce, storage_key};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo, ChargedResources, OrderedEvent};
 use crate::execution::common_hints::ExecutionMode;

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use cairo_vm::vm::runners::cairo_runner::{ExecutionResources, ResourceTracker, RunResources};
 use num_traits::{Inv, Zero};
 use serde::Serialize;
+use starknet_api::abi::abi_utils::selector_from_name;
+use starknet_api::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::state::StorageKey;
@@ -18,9 +20,6 @@ use starknet_api::transaction::fields::{
 use starknet_api::transaction::TransactionVersion;
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::selector_from_name;
-use crate::abi::constants;
-use crate::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use crate::context::{BlockContext, TransactionContext};
 use crate::execution::call_info::CallInfo;
 use crate::execution::common_hints::ExecutionMode;
@@ -468,7 +467,7 @@ pub fn handle_empty_constructor(
             class_hash: Some(ctor_context.class_hash),
             code_address: ctor_context.code_address,
             entry_point_type: EntryPointType::Constructor,
-            entry_point_selector: selector_from_name(constants::CONSTRUCTOR_ENTRY_POINT_NAME),
+            entry_point_selector: selector_from_name(CONSTRUCTOR_ENTRY_POINT_NAME),
             calldata: Calldata::default(),
             storage_address: ctor_context.storage_address,
             caller_address: ctor_context.caller_address,

--- a/crates/blockifier/src/execution/entry_point_test.rs
+++ b/crates/blockifier/src/execution/entry_point_test.rs
@@ -3,12 +3,12 @@ use std::collections::HashSet;
 use cairo_vm::types::builtin_name::BuiltinName;
 use num_bigint::BigInt;
 use pretty_assertions::assert_eq;
+use starknet_api::abi::abi_utils::{get_storage_var_address, selector_from_name};
 use starknet_api::core::EntryPointSelector;
 use starknet_api::execution_utils::format_panic_data;
 use starknet_api::transaction::fields::{Calldata, Fee};
 use starknet_api::{calldata, felt, storage_key};
 
-use crate::abi::abi_utils::{get_storage_var_address, selector_from_name};
 use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo};
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/stack_trace_test.rs
+++ b/crates/blockifier/src/execution/stack_trace_test.rs
@@ -2,6 +2,8 @@ use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
 use regex::Regex;
 use rstest::rstest;
+use starknet_api::abi::abi_utils::selector_from_name;
+use starknet_api::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use starknet_api::core::{
     calculate_contract_address,
     ClassHash,
@@ -28,8 +30,6 @@ use starknet_api::transaction::TransactionVersion;
 use starknet_api::{calldata, felt, invoke_tx_args};
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::selector_from_name;
-use crate::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use crate::context::{BlockContext, ChainInfo};
 use crate::execution::call_info::{CallExecution, CallInfo, Retdata};
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/call_contract.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/call_contract.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::execution_utils::format_panic_data;
 use starknet_api::felt;
 use starknet_api::transaction::fields::Calldata;
 use test_case::test_case;
 
 use super::constants::REQUIRED_GAS_CALL_CONTRACT_TEST;
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::contract_class::TrackedResource;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
@@ -1,10 +1,10 @@
 use pretty_assertions::assert_eq;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::calculate_contract_address;
 use starknet_api::transaction::fields::{Calldata, ContractAddressSalt, Fee};
 use starknet_api::{calldata, felt};
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/emit_event.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/emit_event.rs
@@ -1,13 +1,13 @@
 use itertools::concat;
 #[cfg(feature = "cairo_native")]
 use pretty_assertions::assert_eq;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::felt;
 use starknet_api::transaction::fields::Calldata;
 use starknet_api::transaction::{EventContent, EventData, EventKey};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo, OrderedEvent};
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
@@ -1,4 +1,5 @@
 use pretty_assertions::assert_eq;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::ContractAddress;
 use starknet_api::execution_utils::format_panic_data;
 use starknet_api::state::StorageKey;
@@ -6,7 +7,6 @@ use starknet_api::{calldata, felt};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_class_hash_at.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_class_hash_at.rs
@@ -1,7 +1,7 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::{calldata, class_hash, contract_address, felt};
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -1,5 +1,6 @@
 use cairo_vm::Felt252;
 use num_traits::Pow;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::block::GasPrice;
 use starknet_api::core::ChainId;
 use starknet_api::data_availability::DataAvailabilityMode;
@@ -19,7 +20,6 @@ use starknet_api::{felt, nonce};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::common_hints::ExecutionMode;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/keccak.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/keccak.rs
@@ -1,7 +1,7 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::transaction::fields::Calldata;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
@@ -3,13 +3,13 @@ use std::collections::{HashMap, HashSet};
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use pretty_assertions::assert_eq;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::execution_utils::format_panic_data;
 use starknet_api::transaction::fields::GasVectorComputationMode;
 use starknet_api::{calldata, felt, storage_key};
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, CallInfo, ChargedResources};
 use crate::execution::entry_point::{CallEntryPoint, CallType};

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/out_of_gas.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/out_of_gas.rs
@@ -1,8 +1,8 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::execution_utils::format_panic_data;
 use starknet_api::{calldata, felt};
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::entry_point::CallEntryPoint;
 use crate::execution::syscalls::syscall_tests::constants::REQUIRED_GAS_STORAGE_READ_WRITE_TEST;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
@@ -1,8 +1,8 @@
 use pretty_assertions::assert_eq;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::{calldata, felt};
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
@@ -1,7 +1,7 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::transaction::fields::Calldata;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
@@ -1,11 +1,11 @@
 use itertools::concat;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::EthAddress;
 use starknet_api::felt;
 use starknet_api::transaction::fields::Calldata;
 use starknet_api::transaction::L2ToL1Payload;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::{CallExecution, MessageToL1, OrderedL2ToL1Message};
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/sha256.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/sha256.rs
@@ -1,7 +1,7 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::transaction::fields::Calldata;
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/storage_read_write.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/storage_read_write.rs
@@ -1,8 +1,8 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::state::StorageKey;
 use starknet_api::{calldata, felt};
 use test_case::test_case;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::ChainInfo;
 use crate::execution::call_info::CallExecution;
 use crate::execution::entry_point::CallEntryPoint;

--- a/crates/blockifier/src/fee/fee_utils.rs
+++ b/crates/blockifier/src/fee/fee_utils.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use num_bigint::BigUint;
+use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::core::ContractAddress;
 use starknet_api::execution_resources::GasVector;
 use starknet_api::state::StorageKey;
@@ -10,7 +11,6 @@ use starknet_api::transaction::fields::ValidResourceBounds::{AllResources, L1Gas
 use starknet_api::transaction::fields::{Fee, GasVectorComputationMode, Resource};
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::blockifier::block::BlockInfo;
 use crate::context::{BlockContext, TransactionContext};
 use crate::fee::resources::TransactionFeeResult;

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -2,11 +2,11 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
 use indexmap::IndexMap;
+use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::state::StorageKey;
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::context::TransactionContext;
 use crate::execution::contract_class::RunnableContractClass;
 use crate::state::errors::StateError;

--- a/crates/blockifier/src/state/state_api.rs
+++ b/crates/blockifier/src/state/state_api.rs
@@ -1,11 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
+use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::state::StorageKey;
 use starknet_types_core::felt::Felt;
 
 use super::cached_state::{ContractClassMapping, StateMaps};
-use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::execution::contract_class::RunnableContractClass;
 use crate::state::errors::StateError;
 

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use starknet_api::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
 use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber, GasPrice, NonzeroGasPrice};
 use starknet_api::core::{ClassHash, ContractAddress};
 use starknet_api::execution_resources::{GasAmount, GasVector};
@@ -31,7 +32,6 @@ use starknet_api::transaction::TransactionVersion;
 use starknet_api::{contract_address, felt};
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
 use crate::abi::constants;
 use crate::execution::call_info::ExecutionSummary;
 use crate::execution::contract_class::TrackedResource;

--- a/crates/blockifier/src/test_utils/contracts.rs
+++ b/crates/blockifier/src/test_utils/contracts.rs
@@ -1,4 +1,6 @@
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
+use starknet_api::abi::abi_utils::selector_from_name;
+use starknet_api::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use starknet_api::contract_class::{ContractClass, EntryPointType};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::deprecated_contract_class::{
@@ -10,8 +12,6 @@ use starknet_types_core::felt::Felt;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-use crate::abi::abi_utils::selector_from_name;
-use crate::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use crate::execution::contract_class::RunnableContractClass;
 use crate::execution::entry_point::CallEntryPoint;
 #[cfg(feature = "cairo_native")]

--- a/crates/blockifier/src/test_utils/initial_test_state.rs
+++ b/crates/blockifier/src/test_utils/initial_test_state.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
+use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::core::ContractAddress;
 use starknet_api::felt;
 use starknet_api::transaction::fields::Fee;
 use strum::IntoEnumIterator;
 
-use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::context::ChainInfo;
 use crate::state::cached_state::CachedState;
 use crate::test_utils::contracts::FeatureContract;

--- a/crates/blockifier/src/test_utils/invoke.rs
+++ b/crates/blockifier/src/test_utils/invoke.rs
@@ -1,3 +1,4 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::executable_transaction::{
     AccountTransaction as ExecutableTransaction,
     InvokeTransaction as ExecutableInvokeTransaction,
@@ -6,7 +7,6 @@ use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::transaction::constants::EXECUTE_ENTRY_POINT_NAME;
 use starknet_api::transaction::{InvokeTransaction, InvokeTransactionV0, TransactionVersion};
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::transaction::account_transaction::AccountTransaction;
 
 pub fn invoke_tx(invoke_args: InvokeTxArgs) -> AccountTransaction {

--- a/crates/blockifier/src/test_utils/l1_handler.rs
+++ b/crates/blockifier/src/test_utils/l1_handler.rs
@@ -1,11 +1,10 @@
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::calldata;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::executable_transaction::L1HandlerTransaction;
 use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::{TransactionHash, TransactionVersion};
 use starknet_types_core::felt::Felt;
-
-use crate::abi::abi_utils::selector_from_name;
 
 pub fn l1handler_tx(l1_fee: Fee, contract_address: ContractAddress) -> L1HandlerTransaction {
     let calldata = calldata![

--- a/crates/blockifier/src/test_utils/prices.rs
+++ b/crates/blockifier/src/test_utils/prices.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use cached::proc_macro::cached;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use starknet_api::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
 use starknet_api::core::ContractAddress;
 use starknet_api::test_utils::invoke::InvokeTxArgs;
 use starknet_api::transaction::constants;
 use starknet_api::{calldata, felt};
 
-use crate::abi::abi_utils::{get_fee_token_var_address, selector_from_name};
 use crate::context::BlockContext;
 use crate::execution::common_hints::ExecutionMode;
 use crate::execution::entry_point::{CallEntryPoint, EntryPointExecutionContext};

--- a/crates/blockifier/src/test_utils/transfers_generator.rs
+++ b/crates/blockifier/src/test_utils/transfers_generator.rs
@@ -1,5 +1,6 @@
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::ContractAddress;
 use starknet_api::test_utils::NonceManager;
 use starknet_api::transaction::constants::TRANSFER_ENTRY_POINT_NAME;
@@ -8,7 +9,6 @@ use starknet_api::transaction::TransactionVersion;
 use starknet_api::{calldata, felt, invoke_tx_args};
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::blockifier::config::{ConcurrencyConfig, TransactionExecutorConfig};
 use crate::blockifier::transaction_executor::TransactionExecutor;
 use crate::context::{BlockContext, ChainInfo};

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::block::GasPriceVector;
 use starknet_api::calldata;
 use starknet_api::contract_class::EntryPointType;
@@ -26,7 +27,6 @@ use starknet_api::transaction::fields::{
 use starknet_api::transaction::{constants, TransactionHash, TransactionVersion};
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::{BlockContext, TransactionContext};
 use crate::execution::call_info::CallInfo;
 use crate::execution::contract_class::RunnableContractClass;

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -6,6 +6,11 @@ use cairo_vm::vm::runners::cairo_runner::ResourceTracker;
 use num_traits::Inv;
 use pretty_assertions::{assert_eq, assert_ne};
 use rstest::rstest;
+use starknet_api::abi::abi_utils::{
+    get_fee_token_var_address,
+    get_storage_var_address,
+    selector_from_name,
+};
 use starknet_api::block::GasPrice;
 use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress};
 use starknet_api::executable_transaction::{
@@ -47,11 +52,6 @@ use starknet_api::{
 };
 use starknet_types_core::felt::Felt;
 
-use crate::abi::abi_utils::{
-    get_fee_token_var_address,
-    get_storage_var_address,
-    selector_from_name,
-};
 use crate::check_tx_execution_error_for_invalid_scenario;
 use crate::context::{BlockContext, TransactionContext};
 use crate::execution::call_info::CallInfo;

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -1,4 +1,5 @@
 use rstest::fixture;
+use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::block::GasPrice;
 use starknet_api::contract_class::{ClassInfo, ContractClass};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
@@ -20,7 +21,6 @@ use starknet_api::{calldata, declare_tx_args, deploy_account_tx_args, felt, invo
 use starknet_types_core::felt::Felt;
 use strum::IntoEnumIterator;
 
-use crate::abi::abi_utils::get_fee_token_var_address;
 use crate::context::{BlockContext, ChainInfo};
 use crate::state::cached_state::CachedState;
 use crate::state::state_api::State;

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
 use starknet_api::executable_transaction::{
@@ -22,7 +23,6 @@ use starknet_api::transaction::{
     TransactionVersion,
 };
 
-use crate::abi::abi_utils::selector_from_name;
 use crate::context::{BlockContext, TransactionContext};
 use crate::execution::call_info::CallInfo;
 use crate::execution::entry_point::{

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -8,6 +8,12 @@ use num_bigint::BigUint;
 use num_traits::Pow;
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
+use starknet_api::abi::abi_utils::{
+    get_fee_token_var_address,
+    get_storage_var_address,
+    selector_from_name,
+};
+use starknet_api::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use starknet_api::block::GasPriceVector;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{ChainId, ClassHash, ContractAddress, EthAddress, Nonce};
@@ -49,12 +55,6 @@ use starknet_api::{
 use starknet_types_core::felt::Felt;
 use strum::IntoEnumIterator;
 
-use crate::abi::abi_utils::{
-    get_fee_token_var_address,
-    get_storage_var_address,
-    selector_from_name,
-};
-use crate::abi::constants as abi_constants;
 use crate::context::{BlockContext, ChainInfo, FeeTokenAddresses, TransactionContext};
 use crate::execution::call_info::{
     CallExecution,
@@ -1764,7 +1764,7 @@ fn test_deploy_account_tx(
             class_hash: Some(account_class_hash),
             code_address: None,
             entry_point_type: EntryPointType::Constructor,
-            entry_point_selector: selector_from_name(abi_constants::CONSTRUCTOR_ENTRY_POINT_NAME),
+            entry_point_selector: selector_from_name(CONSTRUCTOR_ENTRY_POINT_NAME),
             storage_address: deployed_account_address,
             initial_gas: user_initial_gas.unwrap_or(GasAmount(default_initial_gas_cost())).0,
             ..Default::default()

--- a/crates/papyrus_execution/src/execution_test.rs
+++ b/crates/papyrus_execution/src/execution_test.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
-use blockifier::abi::abi_utils::get_storage_var_address;
 use blockifier::execution::call_info::Retdata;
 use blockifier::execution::errors::ConstructorEntryPointExecutionError;
 use blockifier::execution::stack_trace::gen_tx_execution_error_trace;
@@ -12,6 +11,7 @@ use blockifier::versioned_constants::VersionedConstants;
 use indexmap::indexmap;
 use papyrus_storage::test_utils::get_test_storage;
 use pretty_assertions::assert_eq;
+use starknet_api::abi::abi_utils::get_storage_var_address;
 use starknet_api::block::{BlockNumber, StarknetVersion};
 use starknet_api::core::{ChainId, CompiledClassHash, EntryPointSelector};
 use starknet_api::state::{StateNumber, ThinStateDiff};

--- a/crates/papyrus_execution/src/execution_utils.rs
+++ b/crates/papyrus_execution/src/execution_utils.rs
@@ -2,8 +2,6 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-// Expose the tool for creating entry point selectors from function names.
-pub use blockifier::abi::abi_utils::selector_from_name;
 use blockifier::execution::contract_class::{
     ContractClassV0,
     ContractClassV1,
@@ -19,6 +17,8 @@ use papyrus_storage::compiled_class::CasmStorageReader;
 use papyrus_storage::db::{TransactionKind, RO};
 use papyrus_storage::state::StateStorageReader;
 use papyrus_storage::{StorageError, StorageResult, StorageTxn};
+// Expose the tool for creating entry point selectors from function names.
+pub use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::state::{StateNumber, StorageKey, ThinStateDiff};
 use starknet_types_core::felt::Felt;

--- a/crates/papyrus_execution/src/test_utils.rs
+++ b/crates/papyrus_execution/src/test_utils.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use blockifier::abi::abi_utils::get_storage_var_address;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use indexmap::indexmap;
 use lazy_static::lazy_static;
@@ -11,6 +10,7 @@ use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::{StorageReader, StorageWriter};
 use serde::de::DeserializeOwned;
+use starknet_api::abi::abi_utils::get_storage_var_address;
 use starknet_api::block::{
     BlockBody,
     BlockHash,

--- a/crates/papyrus_execution/src/testing_instances.rs
+++ b/crates/papyrus_execution/src/testing_instances.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::unwrap_used)]
 //! Utilities for generating testing instances of the execution objects.
 
-/// Returns the storage key of a storage variable.
-pub use blockifier::abi::abi_utils::get_storage_var_address;
 use papyrus_test_utils::{auto_impl_get_test_instance, get_number_of_variants, GetTestInstance};
+/// Returns the storage key of a storage variable.
+pub use starknet_api::abi::abi_utils::get_storage_var_address;
 use starknet_api::block::GasPrice;
 use starknet_api::contract_address;
 use starknet_api::contract_class::EntryPointType;

--- a/crates/papyrus_state_reader/src/papyrus_state_test.rs
+++ b/crates/papyrus_state_reader/src/papyrus_state_test.rs
@@ -1,5 +1,4 @@
 use assert_matches::assert_matches;
-use blockifier::abi::abi_utils::selector_from_name;
 use blockifier::execution::call_info::CallExecution;
 use blockifier::execution::entry_point::CallEntryPoint;
 use blockifier::retdata;
@@ -11,6 +10,7 @@ use blockifier::test_utils::{trivial_external_entry_point_new, CairoVersion};
 use indexmap::IndexMap;
 use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
+use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::block::BlockNumber;
 use starknet_api::contract_class::ContractClass;
 use starknet_api::state::{StateDiff, StorageKey};

--- a/crates/starknet_api/src/abi.rs
+++ b/crates/starknet_api/src/abi.rs
@@ -1,0 +1,2 @@
+pub mod abi_utils;
+pub mod constants;

--- a/crates/starknet_api/src/abi/abi_utils.rs
+++ b/crates/starknet_api/src/abi/abi_utils.rs
@@ -1,15 +1,10 @@
 use sha3::{Digest, Keccak256};
-use starknet_api::core::{
-    ContractAddress,
-    EntryPointSelector,
-    PatriciaKey,
-    L2_ADDRESS_UPPER_BOUND,
-};
-use starknet_api::state::StorageKey;
 use starknet_types_core::felt::{Felt, NonZeroFelt};
 use starknet_types_core::hash::{Pedersen, StarkHash};
 
 use crate::abi::constants;
+use crate::core::{ContractAddress, EntryPointSelector, PatriciaKey, L2_ADDRESS_UPPER_BOUND};
+use crate::state::StorageKey;
 
 #[cfg(test)]
 #[path = "abi_utils_test.rs"]

--- a/crates/starknet_api/src/abi/abi_utils_test.rs
+++ b/crates/starknet_api/src/abi/abi_utils_test.rs
@@ -1,9 +1,8 @@
-use starknet_api::core::EntryPointSelector;
-use starknet_api::felt;
-use starknet_api::transaction::constants as tx_constants;
-
 use crate::abi::abi_utils::selector_from_name;
 use crate::abi::constants as abi_constants;
+use crate::core::EntryPointSelector;
+use crate::felt;
+use crate::transaction::constants as tx_constants;
 
 #[test]
 fn test_selector_from_name() {

--- a/crates/starknet_api/src/abi/constants.rs
+++ b/crates/starknet_api/src/abi/constants.rs
@@ -1,0 +1,4 @@
+pub const CONSTRUCTOR_ENTRY_POINT_NAME: &str = "constructor";
+pub const DEFAULT_ENTRY_POINT_NAME: &str = "__default__";
+pub const DEFAULT_ENTRY_POINT_SELECTOR: u64 = 0;
+pub const DEFAULT_L1_ENTRY_POINT_NAME: &str = "__l1_default__";

--- a/crates/starknet_api/src/lib.rs
+++ b/crates/starknet_api/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! [`Starknet`]: https://starknet.io/
 
+pub mod abi;
 pub mod block;
 pub mod block_hash;
 pub mod contract_class;

--- a/crates/starknet_integration_tests/src/state_reader.rs
+++ b/crates/starknet_integration_tests/src/state_reader.rs
@@ -2,7 +2,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
-use blockifier::abi::abi_utils::get_fee_token_var_address;
 use blockifier::context::{BlockContext, ChainInfo};
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::{
@@ -27,6 +26,7 @@ use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::{get_test_storage, get_test_storage_with_config_by_scope};
 use papyrus_storage::{StorageConfig, StorageReader, StorageWriter};
+use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::block::{
     BlockBody,
     BlockHeader,


### PR DESCRIPTION
In this PR we move code from the `blockifier` crate, the `abi` folder, into `starknet_api`.

Specifically:
0. Split the model `crates/blockifier/src/abi.rs`. The other part is moved to `crates/starknet_api/src/abi.rs`.
1. Split the file: `crates/blockfier/src/abi/constants.rs`. The other part is moved to `crates/starknet_api/src/abi/constants.rs`.
2. The file: `crates/blockifier/src/abi/abi_utils.rs` is moved to `crates/starknet_api/src/abi/abi_utils.rs` (with the corresponding test util).