### PR TITLE
chore(starknet_api): streamline the base invoke tx creator to include v0 towards code dedup

### DIFF
--- a/crates/blockifier/src/test_utils/invoke.rs
+++ b/crates/blockifier/src/test_utils/invoke.rs
@@ -1,32 +1,15 @@
-use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::executable_transaction::{
     AccountTransaction as ExecutableTransaction,
     InvokeTransaction as ExecutableInvokeTransaction,
 };
 use starknet_api::test_utils::invoke::InvokeTxArgs;
-use starknet_api::transaction::constants::EXECUTE_ENTRY_POINT_NAME;
-use starknet_api::transaction::{InvokeTransaction, InvokeTransactionV0, TransactionVersion};
 
 use crate::transaction::account_transaction::AccountTransaction;
 
 pub fn invoke_tx(invoke_args: InvokeTxArgs) -> AccountTransaction {
     let tx_hash = invoke_args.tx_hash;
     let only_query = invoke_args.only_query;
-    // TODO: Make TransactionVersion an enum and use match here.
-    let invoke_tx = if invoke_args.version == TransactionVersion::ZERO {
-        InvokeTransaction::V0(InvokeTransactionV0 {
-            max_fee: invoke_args.max_fee,
-            calldata: invoke_args.calldata,
-            contract_address: invoke_args.sender_address,
-            signature: invoke_args.signature,
-            // V0 transactions should always select the `__execute__` entry point.
-            entry_point_selector: selector_from_name(EXECUTE_ENTRY_POINT_NAME),
-        })
-    } else {
-        // TODO(AvivG): Have test util 'invoke_tx' support creation of TransactionVersion::ZERO
-        // invoke transactions.
-        starknet_api::test_utils::invoke::invoke_tx(invoke_args)
-    };
+    let invoke_tx = starknet_api::test_utils::invoke::invoke_tx(invoke_args);
 
     let invoke_tx =
         ExecutableTransaction::Invoke(ExecutableInvokeTransaction { tx: invoke_tx, tx_hash });


### PR DESCRIPTION
This PR replaces #1930. Thanks to the PRs this is on top of, it is much simpler now. 