### PR TITLE
feat: convert a regular Transaction (plus hash) into an executable Transaction

### DIFF
--- a/crates/starknet_api/src/test_utils.rs
+++ b/crates/starknet_api/src/test_utils.rs
@@ -3,9 +3,12 @@ use std::env;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-use crate::core::{ContractAddress, Nonce};
+use crate::block::BlockNumber;
+use crate::core::{ChainId, ContractAddress, Nonce};
+use crate::transaction::{Transaction, TransactionHash};
 
 pub mod declare;
 pub mod deploy_account;
@@ -25,6 +28,19 @@ pub fn read_json_file<P: AsRef<Path>>(path_in_resource_dir: P) -> serde_json::Va
     let json_str = read_to_string(path.to_str().unwrap())
         .unwrap_or_else(|_| panic!("Failed to read file at path: {}", path.display()));
     serde_json::from_str(&json_str).unwrap()
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+/// A struct used for reading the transaction test data (e.g., for transaction hash tests).
+pub struct TransactionTestData {
+    /// The actual transaction.
+    pub transaction: Transaction,
+    /// The expected transaction hash.
+    pub transaction_hash: TransactionHash,
+    /// An optional transaction hash to query.
+    pub only_query_transaction_hash: Option<TransactionHash>,
+    pub chain_id: ChainId,
+    pub block_number: BlockNumber,
 }
 
 #[derive(Debug, Default)]

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -133,6 +133,31 @@ impl From<crate::executable_transaction::Transaction> for Transaction {
     }
 }
 
+impl From<(Transaction, TransactionHash)> for crate::executable_transaction::Transaction {
+    fn from(tup: (Transaction, TransactionHash)) -> Self {
+        let (tx, tx_hash) = tup;
+        match tx {
+            Transaction::Declare(_tx) => {
+                unimplemented!("Declare transactions are not supported yet.")
+            }
+            Transaction::Deploy(_tx) => {
+                unimplemented!("Deploy transactions are not supported yet.")
+            }
+            Transaction::DeployAccount(_tx) => {
+                unimplemented!("DeployAccount transactions are not supported yet.")
+            }
+            Transaction::Invoke(tx) => crate::executable_transaction::Transaction::Account(
+                crate::executable_transaction::AccountTransaction::Invoke(
+                    crate::executable_transaction::InvokeTransaction { tx, tx_hash },
+                ),
+            ),
+            Transaction::L1Handler(_) => {
+                unimplemented!("L1Handler transactions are not supported yet.")
+            }
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct TransactionOptions {
     /// Transaction that shouldn't be broadcasted to StarkNet. For example, users that want to

--- a/crates/starknet_api/src/transaction_hash_test.rs
+++ b/crates/starknet_api/src/transaction_hash_test.rs
@@ -1,13 +1,10 @@
 use pretty_assertions::assert_eq;
-use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use starknet_types_core::felt::Felt;
 
 use super::{get_transaction_hash, validate_transaction_hash, CONSTRUCTOR_ENTRY_POINT_SELECTOR};
-use crate::block::BlockNumber;
-use crate::core::ChainId;
-use crate::test_utils::read_json_file;
-use crate::transaction::{Transaction, TransactionHash, TransactionOptions};
+use crate::test_utils::{read_json_file, TransactionTestData};
+use crate::transaction::{Transaction, TransactionOptions};
 
 #[test]
 fn test_constructor_selector() {
@@ -19,18 +16,9 @@ fn test_constructor_selector() {
     assert_eq!(constructor_felt, CONSTRUCTOR_ENTRY_POINT_SELECTOR);
 }
 
-#[derive(Deserialize, Serialize)]
-struct TransactionTestData {
-    transaction: Transaction,
-    transaction_hash: TransactionHash,
-    only_query_transaction_hash: Option<TransactionHash>,
-    chain_id: ChainId,
-    block_number: BlockNumber,
-}
-
 #[test]
 fn test_transaction_hash() {
-    // The details were taken from Starknet Mainnet. You can found the transactions by hash in:
+    // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
     let transactions_test_data_vec: Vec<TransactionTestData> =
         serde_json::from_value(read_json_file("transaction_hash.json")).unwrap();
@@ -64,7 +52,7 @@ fn test_transaction_hash() {
 
 #[test]
 fn test_deprecated_transaction_hash() {
-    // The details were taken from Starknet Mainnet. You can found the transactions by hash in:
+    // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
     let transaction_test_data_vec: Vec<TransactionTestData> =
         serde_json::from_value(read_json_file("deprecated_transaction_hash.json")).unwrap();

--- a/crates/starknet_api/src/transaction_test.rs
+++ b/crates/starknet_api/src/transaction_test.rs
@@ -1,5 +1,6 @@
 use crate::block::NonzeroGasPrice;
 use crate::execution_resources::GasAmount;
+use crate::test_utils::{read_json_file, TransactionTestData};
 use crate::transaction::Fee;
 
 #[test]
@@ -24,4 +25,16 @@ fn test_fee_div_ceil() {
         GasAmount(10),
         Fee(28).checked_div_ceil(NonzeroGasPrice::try_from(3_u8).unwrap()).unwrap()
     );
+}
+
+#[test]
+fn convert_executable_transaction_and_back() {
+    // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
+    // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
+    let transactions_test_data_vec: Vec<TransactionTestData> =
+        serde_json::from_value(read_json_file("transaction_hash.json")).unwrap();
+
+    for transaction_test_data in transactions_test_data_vec {
+        print!("{:?}", transaction_test_data);
+    }
 }

--- a/crates/starknet_api/src/transaction_test.rs
+++ b/crates/starknet_api/src/transaction_test.rs
@@ -1,4 +1,6 @@
+use super::Transaction;
 use crate::block::NonzeroGasPrice;
+use crate::executable_transaction::Transaction as ExecutableTransaction;
 use crate::execution_resources::GasAmount;
 use crate::test_utils::{read_json_file, TransactionTestData};
 use crate::transaction::Fee;
@@ -31,10 +33,23 @@ fn test_fee_div_ceil() {
 fn convert_executable_transaction_and_back() {
     // The details were taken from Starknet Mainnet. You can find the transactions by hash in:
     // https://alpha-mainnet.starknet.io/feeder_gateway/get_transaction?transactionHash=<transaction_hash>
-    let transactions_test_data_vec: Vec<TransactionTestData> =
+    let mut transactions_test_data_vec: Vec<TransactionTestData> =
         serde_json::from_value(read_json_file("transaction_hash.json")).unwrap();
 
-    for transaction_test_data in transactions_test_data_vec {
-        print!("{:?}", transaction_test_data);
-    }
+    let (tx, tx_hash) = loop {
+        match transactions_test_data_vec.pop() {
+            Some(data) => {
+                if let Transaction::Invoke(tx) = data.transaction {
+                    // Do something with the data
+                    break (Transaction::Invoke(tx), data.transaction_hash);
+                }
+            }
+            None => {
+                panic!("Could not find a single Invoke transaction in the test data");
+            }
+        }
+    };
+    let executable_tx: ExecutableTransaction = (tx.clone(), tx_hash.clone()).into();
+    let tx_back = Transaction::from(executable_tx);
+    assert_eq!(tx, tx_back);
 }


### PR DESCRIPTION
Note that this only works for invoke right now. 

This is a temporary placeholder, until we have a proper compilation of transactions (those sent between instances of consensus) and the executable transactions sent into/from the batcher. 