### PR TITLE
chore(l1_provider): add validate state transition

### DIFF
--- a/crates/starknet_l1_provider/src/l1_provider_tests.rs
+++ b/crates/starknet_l1_provider/src/l1_provider_tests.rs
@@ -8,10 +8,8 @@ use starknet_api::test_utils::l1_handler::executable_l1_handler_tx;
 use starknet_api::transaction::TransactionHash;
 
 use crate::errors::L1ProviderError;
-use crate::errors::L1ProviderError::UnexpectedProviderStateTransition;
 use crate::{L1Provider, ProviderState, TransactionManager};
 
-#[macro_export]
 macro_rules! tx {
     (tx_hash: $tx_hash:expr) => {{
         executable_l1_handler_tx(
@@ -72,10 +70,42 @@ fn proposal_start_errors() {
 
     // Test.
     l1_provider.proposal_start().unwrap();
+
     assert_matches!(
         l1_provider.proposal_start().unwrap_err(),
-        UnexpectedProviderStateTransition {
+        L1ProviderError::UnexpectedProviderStateTransition {
             from: ProviderState::Propose,
+            to: ProviderState::Propose
+        }
+    );
+    assert_matches!(
+        l1_provider.validation_start().unwrap_err(),
+        L1ProviderError::UnexpectedProviderStateTransition {
+            from: ProviderState::Propose,
+            to: ProviderState::Validate
+        }
+    );
+}
+
+#[test]
+fn validation_start_errors() {
+    // Setup.
+    let mut l1_provider = L1Provider::default();
+
+    // Test.
+    l1_provider.validation_start().unwrap();
+
+    assert_matches!(
+        l1_provider.validation_start().unwrap_err(),
+        L1ProviderError::UnexpectedProviderStateTransition {
+            from: ProviderState::Validate,
+            to: ProviderState::Validate
+        }
+    );
+    assert_matches!(
+        l1_provider.proposal_start().unwrap_err(),
+        L1ProviderError::UnexpectedProviderStateTransition {
+            from: ProviderState::Validate,
             to: ProviderState::Propose
         }
     );

--- a/crates/starknet_l1_provider/src/lib.rs
+++ b/crates/starknet_l1_provider/src/lib.rs
@@ -59,7 +59,8 @@ impl L1Provider {
     // TODO: pending formal consensus API, guessing the API here to keep things moving.
     // TODO: consider adding block number, it isn't strictly necessary, but will help debugging.
     pub fn validation_start(&mut self) -> L1ProviderResult<()> {
-        todo!("Sets internal state as validate, returns error if state is Pending.")
+        self.state = self.state.transition_to_validate()?;
+        Ok(())
     }
 
     pub fn proposal_start(&mut self) -> L1ProviderResult<()> {
@@ -144,8 +145,14 @@ impl ProviderState {
         }
     }
 
-    fn _transition_to_validate(self) -> L1ProviderResult<Self> {
-        todo!()
+    fn transition_to_validate(self) -> L1ProviderResult<Self> {
+        match self {
+            ProviderState::Pending => Ok(ProviderState::Validate),
+            _ => Err(L1ProviderError::UnexpectedProviderStateTransition {
+                from: self,
+                to: ProviderState::Validate,
+            }),
+        }
     }
 
     fn _transition_to_pending(self) -> L1ProviderResult<Self> {


### PR DESCRIPTION
Also minor fixes:
- also remove unnecessary `#[macro_export]` for local macro
- use longer path for errors instead of importing the variant.