### PR TITLE
test(blockifier): uncover an error in test_l1_handler in the case of transaction version three

### DIFF
--- a/crates/blockifier/src/blockifier/transaction_executor_test.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor_test.rs
@@ -227,13 +227,17 @@ fn test_invoke(
 }
 
 #[rstest]
-fn test_l1_handler(block_context: BlockContext) {
+fn test_l1_handler(
+    block_context: BlockContext,
+    #[values(TransactionVersion::ZERO, TransactionVersion::THREE)] version: TransactionVersion,
+) {
     let test_contract = FeatureContract::TestContract(CairoVersion::Cairo1);
     let state = test_state(&block_context.chain_info, BALANCE, &[(test_contract, 1)]);
 
     let tx = Transaction::L1Handler(l1handler_tx(
         Fee(1908000000000000),
         test_contract.get_instance_address(0),
+        version,
     ));
     let expected_bouncer_weights = BouncerWeights {
         state_diff_size: 4,

--- a/crates/blockifier/src/test_utils/l1_handler.rs
+++ b/crates/blockifier/src/test_utils/l1_handler.rs
@@ -7,7 +7,11 @@ use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::TransactionVersion;
 use starknet_types_core::felt::Felt;
 
-pub fn l1handler_tx(l1_fee: Fee, contract_address: ContractAddress) -> L1HandlerTransaction {
+pub fn l1handler_tx(
+    l1_fee: Fee,
+    contract_address: ContractAddress,
+    version: TransactionVersion,
+) -> L1HandlerTransaction {
     let calldata = calldata![
         Felt::from(0x123), // from_address.
         Felt::from(0x876), // key.
@@ -15,7 +19,7 @@ pub fn l1handler_tx(l1_fee: Fee, contract_address: ContractAddress) -> L1Handler
     ];
 
     executable_l1_handler_tx(L1HandlerTxArgs {
-        version: TransactionVersion::ZERO,
+        version,
         contract_address,
         entry_point_selector: selector_from_name("l1_handler_set_value"),
         calldata,


### PR DESCRIPTION
The test `test_l1_handler` fails for:
`use_kzg_da = true` and `version = TransactionVersion::THREE`.
I am unsure if it is supposed to pass - but the test fails only on incorrect `actual_fee == expected_actual_fee` in the last assertion of the test.

Please tell me if it is acceptable for this test to fail and if we should avoid this flow - or if we should keep this test - and in that case - fix it or fix the code.