### PR TITLE
feat: add TransactionHash to TransactionBatch

### DIFF
--- a/crates/papyrus_protobuf/src/consensus.rs
+++ b/crates/papyrus_protobuf/src/consensus.rs
@@ -2,7 +2,7 @@ use futures::channel::{mpsc, oneshot};
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ContractAddress;
 use starknet_api::executable_transaction::Transaction as ExecutableTransaction;
-use starknet_api::transaction::Transaction;
+use starknet_api::transaction::{Transaction, TransactionHash};
 
 use crate::converters::ProtobufConversionError;
 
@@ -78,6 +78,9 @@ pub struct ProposalInit {
 pub struct TransactionBatch {
     /// The transactions in the batch.
     pub transactions: Vec<Transaction>,
+    // TODO(guyn): remove this once we settle how to convert transactions to ExecutableTransactions
+    /// The hashes of each transaction.
+    pub tx_hashes: Vec<TransactionHash>,
 }
 
 /// The propsal is done when receiving this fin message, which contains the block hash.

--- a/crates/papyrus_protobuf/src/converters/test_instances.rs
+++ b/crates/papyrus_protobuf/src/converters/test_instances.rs
@@ -2,7 +2,7 @@ use papyrus_test_utils::{auto_impl_get_test_instance, get_number_of_variants, Ge
 use rand::Rng;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ContractAddress;
-use starknet_api::transaction::Transaction;
+use starknet_api::transaction::{Transaction, TransactionHash};
 
 use crate::consensus::{
     ConsensusMessage,
@@ -52,6 +52,7 @@ auto_impl_get_test_instance! {
     }
     pub struct TransactionBatch {
         pub transactions: Vec<Transaction>,
+        pub tx_hashes: Vec<TransactionHash>,
     }
     pub enum ProposalPart {
         Init(ProposalInit) = 0,

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/consensus.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/consensus.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 import "p2p/proto/transaction.proto";
 import "p2p/proto/common.proto";
 
+// To be deprecated
 message Proposal {
     uint64               height       = 1;
     uint32               round        = 2;
@@ -54,6 +55,8 @@ message ProposalInit {
 
 message TransactionBatch {
     repeated Transaction transactions = 1;
+    // TODO(guyn): remove this once we know how to calculate hashes
+    repeated Felt252 tx_hashes = 2;
 }
 
 message ProposalFin {

--- a/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -305,6 +305,7 @@ async fn stream_build_proposal(
                 broadcast_client
                     .broadcast_message(ProposalPart::Transactions(TransactionBatch {
                         transactions,
+                        tx_hashes: transaction_hashes,
                     }))
                     .await
                     .expect("Failed to broadcast proposal content");

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -775,6 +775,20 @@ impl std::fmt::Display for TransactionHash {
     }
 }
 
+// TODO(guyn): this is only used for conversion of transactions->executable transactions
+// It should be removed once we integrate a proper way to calculate executable transaction hashes
+impl From<TransactionHash> for Vec<u8> {
+    fn from(tx_hash: TransactionHash) -> Vec<u8> {
+        tx_hash.0.to_bytes_be().to_vec()
+    }
+}
+impl From<Vec<u8>> for TransactionHash {
+    fn from(bytes: Vec<u8>) -> TransactionHash {
+        let array: [u8; 32] = bytes.try_into().expect("Expected a Vec of length 32");
+        TransactionHash(StarkHash::from_bytes_be(&array))
+    }
+}
+
 /// A transaction version.
 #[derive(
     Debug,


### PR DESCRIPTION
This is a temporary hack (as is evident from the many TODO items), that allows passing in the ProposalPart, specifically in the TransactionBatch, not only a vector of Transactions but also a vector of TransactionHashes. 

This is useful as it lets us convert a regular transaction into an ExecutableTransaction. 

In the future, we will either make the hash part of the transaction we broadcast (whatever we end up naming it) or we will have a tool that calculates this hash at the same time that we also do other calculation needed for executable transactions (e.g., compiling code). 