### PR TITLE
chore(ci): increase max length of commit message from 50 to 72 inclusive

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -66,6 +66,7 @@ const Configuration = {
             'transaction',
             'types',
         ]],
+        'header-max-length': [2, 'always', 72],
     },
     /*
      * Functions that return true if commitlint should ignore the given message.


### PR DESCRIPTION
    - 50 is too small, especially with large `chore(<big_scope_name>)`
    - For example, Linux kernel uses 72.
    - why 72? that's already the length of the commit body, and having
    a larger title is weird.

