### PR TITLE
chore(blockifier): remove warning about versioned constants

### DIFF
--- a/crates/blockifier/src/fee/gas_usage_test.rs
+++ b/crates/blockifier/src/fee/gas_usage_test.rs
@@ -70,7 +70,7 @@ fn starknet_resources() -> StarknetResources {
         .map(|call_info| call_info.with_some_class_hash())
         .collect();
     let execution_summary =
-        CallInfo::summarize_many(call_infos.iter(), &VersionedConstants::latest_constants());
+        CallInfo::summarize_many(call_infos.iter(), VersionedConstants::latest_constants());
     let state_resources = StateResources::new_for_testing(StateChangesCount {
         n_storage_updates: 7,
         n_class_hash_updates: 11,

--- a/crates/blockifier/src/fee/receipt_test.rs
+++ b/crates/blockifier/src/fee/receipt_test.rs
@@ -432,7 +432,7 @@ fn test_calculate_tx_gas_usage(
     let execution_call_info =
         &tx_execution_info.execute_call_info.expect("Execution call info should exist.");
     let execution_summary =
-        CallInfo::summarize_many(vec![execution_call_info].into_iter(), &versioned_constants);
+        CallInfo::summarize_many(vec![execution_call_info].into_iter(), versioned_constants);
     let starknet_resources = StarknetResources::new(
         calldata_length,
         signature_length,

--- a/crates/blockifier/src/transaction/objects_test.rs
+++ b/crates/blockifier/src/transaction/objects_test.rs
@@ -139,7 +139,7 @@ fn test_events_counter_in_tx_execution_info(
     };
 
     assert_eq!(
-        tx_execution_info.summarize(&VersionedConstants::latest_constants()).event_summary.n_events,
+        tx_execution_info.summarize(VersionedConstants::latest_constants()).event_summary.n_events,
         n_validate_events + n_execute_events + n_fee_transfer_events + n_inner_calls
     );
 }


### PR DESCRIPTION
Warning: this expression creates a reference which is immediately dereferenced by the compiler