### PR TITLE
refactor(starknet_api): use tx_hash constructor macro

### DIFF
--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -12,11 +12,10 @@ use starknet_api::transaction::{
     EventContent,
     EventData,
     EventKey,
-    TransactionHash,
     TransactionVersion,
     QUERY_VERSION_BASE,
 };
-use starknet_api::{calldata, felt, nonce, storage_key};
+use starknet_api::{calldata, felt, nonce, storage_key, tx_hash};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
@@ -467,7 +466,7 @@ fn test_tx_info(#[values(false, true)] only_query: bool) {
         let simulate_version_base = *QUERY_VERSION_BASE;
         version += simulate_version_base;
     }
-    let tx_hash = TransactionHash(felt!(1991_u16));
+    let tx_hash = tx_hash!(1991);
     let max_fee = Fee(0);
     let nonce = nonce!(3_u16);
     let sender_address = test_contract.get_instance_address(0);

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -13,8 +13,8 @@ use starknet_api::transaction::fields::{
     Tip,
     ValidResourceBounds,
 };
-use starknet_api::transaction::{TransactionHash, TransactionVersion, QUERY_VERSION_BASE};
-use starknet_api::{felt, nonce};
+use starknet_api::transaction::{TransactionVersion, QUERY_VERSION_BASE};
+use starknet_api::{felt, nonce, tx_hash};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
 
@@ -200,7 +200,7 @@ fn test_get_execution_info(
         version = TransactionVersion(query_version);
     }
 
-    let tx_hash = TransactionHash(felt!(1991_u16));
+    let tx_hash = tx_hash!(1991);
     let max_fee = Fee(42);
     let nonce = nonce!(3_u16);
     let sender_address = test_contract_address;

--- a/crates/papyrus_protobuf/src/converters/transaction_test.rs
+++ b/crates/papyrus_protobuf/src/converters/transaction_test.rs
@@ -15,10 +15,9 @@ use starknet_api::transaction::{
     InvokeTransactionOutput,
     L1HandlerTransactionOutput,
     Transaction as StarknetApiTransaction,
-    TransactionHash,
     TransactionOutput,
 };
-use starknet_types_core::felt::Felt;
+use starknet_api::tx_hash;
 
 use crate::sync::DataOrFin;
 
@@ -167,7 +166,7 @@ fn assert_transaction_to_vec_u8_and_back(
     transaction: StarknetApiTransaction,
     transaction_output: TransactionOutput,
 ) {
-    let random_transaction_hash = TransactionHash(Felt::from(random::<u64>()));
+    let random_transaction_hash = tx_hash!(random::<u64>());
     let data = DataOrFin(Some(FullTransaction {
         transaction,
         transaction_output,

--- a/crates/papyrus_rpc/src/v0_8/execution_test.rs
+++ b/crates/papyrus_rpc/src/v0_8/execution_test.rs
@@ -71,7 +71,7 @@ use starknet_api::transaction::{
     TransactionOffsetInBlock,
     TransactionVersion,
 };
-use starknet_api::{calldata, class_hash, contract_address, felt, nonce};
+use starknet_api::{calldata, class_hash, contract_address, felt, nonce, tx_hash};
 use starknet_client::reader::objects::pending_data::{
     PendingBlock,
     PendingBlockOrDeprecated,
@@ -302,7 +302,7 @@ async fn execution_call() {
         *BLOCK_TIMESTAMP,
         *SEQUENCER_ADDRESS,
         &InvokeTransactionV1::default(),
-        TransactionHash(StarkHash::ZERO),
+        tx_hash!(0),
         Some(Felt::ZERO),
     );
     // Calling the contract directly and not through the account contract.
@@ -363,7 +363,7 @@ async fn pending_execution_call() {
         *BLOCK_TIMESTAMP,
         *SEQUENCER_ADDRESS,
         &InvokeTransactionV1::default(),
-        TransactionHash(StarkHash::ZERO),
+        tx_hash!(0),
         Some(Felt::ZERO),
     );
     // Calling the contract directly and not through the account contract.
@@ -630,7 +630,7 @@ async fn test_call_simulate(
         // Because the transaction hash depends on the calldata and the calldata needs to contain
         // the transaction hash, there's no way to put the correct hash here. Instead, we'll check
         // that the function `test_get_execution_info` fails on the transaction hash validation.
-        TransactionHash(StarkHash::ZERO),
+        tx_hash!(0),
         None,
     );
     invoke_v1.calldata = calldata;
@@ -763,8 +763,8 @@ async fn trace_block_transactions_regular_and_pending() {
 
     let mut writer = prepare_storage_for_execution(storage_writer);
 
-    let tx_hash1 = TransactionHash(felt!("0x1234"));
-    let tx_hash2 = TransactionHash(felt!("0x5678"));
+    let tx_hash1 = tx_hash!(0x1234);
+    let tx_hash2 = tx_hash!(0x5678);
 
     let client_tx1 = ClientTransaction::Invoke(ClientInvokeTransaction {
         max_fee: Some(*MAX_FEE),
@@ -945,8 +945,8 @@ async fn trace_block_transactions_regular_and_pending() {
 
 #[tokio::test]
 async fn trace_block_transactions_and_trace_transaction_execution_context() {
-    let tx_hash1 = TransactionHash(felt!("0x1234"));
-    let tx_hash2 = TransactionHash(felt!("0x5678"));
+    let tx_hash1 = tx_hash!(0x1234);
+    let tx_hash2 = tx_hash!(0x5678);
 
     let mut invoke_tx1 = starknet_api::transaction::InvokeTransactionV1 {
         max_fee: *MAX_FEE,
@@ -1084,8 +1084,8 @@ async fn trace_block_transactions_and_trace_transaction_execution_context() {
 
 #[tokio::test]
 async fn pending_trace_block_transactions_and_trace_transaction_execution_context() {
-    let tx_hash1 = TransactionHash(felt!("0x1234"));
-    let tx_hash2 = TransactionHash(felt!("0x5678"));
+    let tx_hash1 = tx_hash!(0x1234);
+    let tx_hash2 = tx_hash!(0x5678);
 
     let mut client_invoke_tx1 = ClientInvokeTransaction {
         max_fee: Some(*MAX_FEE),

--- a/crates/papyrus_rpc/src/v0_8/write_api_result_test.rs
+++ b/crates/papyrus_rpc/src/v0_8/write_api_result_test.rs
@@ -2,7 +2,7 @@ use papyrus_test_utils::{auto_impl_get_test_instance, get_rng, GetTestInstance};
 use serde::Serialize;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::transaction::TransactionHash;
-use starknet_api::{class_hash, felt};
+use starknet_api::{class_hash, felt, tx_hash};
 use starknet_client::writer::objects::response::{
     DeclareResponse,
     DeployAccountResponse,
@@ -54,7 +54,7 @@ fn add_deploy_account_ok_result_fits_rpc() {
 
 #[test]
 fn add_invoke_ok_result_from_response() {
-    let transaction_hash = TransactionHash(felt!("0x12345"));
+    let transaction_hash = tx_hash!(0x12345);
     let ok_result = AddInvokeOkResult::from(InvokeResponse {
         code: SuccessfulStarknetErrorCode::default(),
         transaction_hash,
@@ -65,7 +65,7 @@ fn add_invoke_ok_result_from_response() {
 
 #[test]
 fn add_declare_ok_result_from_response() {
-    let transaction_hash = TransactionHash(felt!("0x12345"));
+    let transaction_hash = tx_hash!(0x12345);
     let class_hash = class_hash!("0xabcde");
     let ok_result = AddDeclareOkResult::from(DeclareResponse {
         code: SuccessfulStarknetErrorCode::default(),
@@ -78,7 +78,7 @@ fn add_declare_ok_result_from_response() {
 
 #[test]
 fn add_deploy_account_ok_result_from_response() {
-    let transaction_hash = TransactionHash(felt!("0x12345"));
+    let transaction_hash = tx_hash!(0x12345);
     let contract_address = ContractAddress(PatriciaKey::try_from(felt!("0xabcde")).unwrap());
     let ok_result = AddDeployAccountOkResult::from(DeployAccountResponse {
         code: SuccessfulStarknetErrorCode::default(),

--- a/crates/papyrus_test_utils/src/lib.rs
+++ b/crates/papyrus_test_utils/src/lib.rs
@@ -49,7 +49,6 @@ use starknet_api::block::{
     GasPricePerToken,
     StarknetVersion,
 };
-use starknet_api::class_hash;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     ClassHash,
@@ -156,6 +155,7 @@ use starknet_api::transaction::{
     TransactionOutput,
     TransactionVersion,
 };
+use starknet_api::{class_hash, tx_hash};
 use starknet_types_core::felt::Felt;
 
 //////////////////////////////////////////////////////////////////////////
@@ -280,7 +280,7 @@ fn get_rand_test_body_with_events(
         while is_v3_transaction(&transaction) {
             transaction = Transaction::get_test_instance(rng);
         }
-        transaction_hashes.push(TransactionHash(StarkHash::from(u128::try_from(i).unwrap())));
+        transaction_hashes.push(tx_hash!(i));
         let transaction_output = get_test_transaction_output(&transaction);
         transactions.push(transaction);
         transaction_outputs.push(transaction_output);

--- a/crates/starknet_api/src/block_hash/block_hash_calculator_test.rs
+++ b/crates/starknet_api/src/block_hash/block_hash_calculator_test.rs
@@ -28,10 +28,9 @@ use crate::core::{
     TransactionCommitment,
 };
 use crate::data_availability::L1DataAvailabilityMode;
-use crate::felt;
 use crate::hash::PoseidonHash;
 use crate::transaction::fields::TransactionSignature;
-use crate::transaction::TransactionHash;
+use crate::{felt, tx_hash};
 
 /// Macro to test if changing any field in the header or commitments
 /// results a change in the block hash.
@@ -95,7 +94,7 @@ fn test_block_hash_regression(
     let transactions_data = vec![TransactionHashingData {
         transaction_signature: TransactionSignature(vec![Felt::TWO, Felt::THREE]),
         transaction_output: get_transaction_output(),
-        transaction_hash: TransactionHash(Felt::ONE),
+        transaction_hash: tx_hash!(1),
     }];
 
     let state_diff = get_state_diff();

--- a/crates/starknet_api/src/block_hash/event_commitment_test.rs
+++ b/crates/starknet_api/src/block_hash/event_commitment_test.rs
@@ -3,8 +3,8 @@ use starknet_types_core::hash::Poseidon;
 
 use super::{calculate_event_commitment, calculate_event_hash, EventLeafElement};
 use crate::core::EventCommitment;
-use crate::transaction::{Event, EventContent, EventData, EventKey, TransactionHash};
-use crate::{contract_address, felt};
+use crate::transaction::{Event, EventContent, EventData, EventKey};
+use crate::{contract_address, felt, tx_hash};
 
 #[test]
 fn test_event_commitment_regression() {
@@ -39,6 +39,6 @@ fn get_event_leaf_element(seed: u8) -> EventLeafElement {
                 ),
             },
         },
-        transaction_hash: TransactionHash(felt!("0x1234")),
+        transaction_hash: tx_hash!(0x1234),
     }
 }

--- a/crates/starknet_api/src/block_hash/receipt_commitment_test.rs
+++ b/crates/starknet_api/src/block_hash/receipt_commitment_test.rs
@@ -10,17 +10,13 @@ use crate::block_hash::receipt_commitment::{
 };
 use crate::block_hash::test_utils::{generate_message_to_l1, get_transaction_output};
 use crate::core::ReceiptCommitment;
-use crate::felt;
-use crate::transaction::{
-    RevertedTransactionExecutionStatus,
-    TransactionExecutionStatus,
-    TransactionHash,
-};
+use crate::transaction::{RevertedTransactionExecutionStatus, TransactionExecutionStatus};
+use crate::{felt, tx_hash};
 
 #[test]
 fn test_receipt_hash_regression() {
     let transaction_receipt = ReceiptElement {
-        transaction_hash: TransactionHash(Felt::from(1234_u16)),
+        transaction_hash: tx_hash!(1234),
         transaction_output: get_transaction_output(),
     };
 

--- a/crates/starknet_api/src/block_hash/transaction_commitment_test.rs
+++ b/crates/starknet_api/src/block_hash/transaction_commitment_test.rs
@@ -7,9 +7,8 @@ use crate::block_hash::transaction_commitment::{
     calculate_transaction_leaf,
 };
 use crate::core::TransactionCommitment;
-use crate::felt;
 use crate::transaction::fields::TransactionSignature;
-use crate::transaction::TransactionHash;
+use crate::{felt, tx_hash};
 
 #[test]
 fn test_transaction_leaf_regression() {
@@ -22,7 +21,7 @@ fn test_transaction_leaf_regression() {
 #[test]
 fn test_transaction_leaf_without_signature_regression() {
     let transaction_leaf_elements = TransactionLeafElement {
-        transaction_hash: TransactionHash(Felt::ONE),
+        transaction_hash: tx_hash!(1),
         transaction_signature: TransactionSignature(vec![]),
     };
     let expected_leaf = felt!("0x579e8877c7755365d5ec1ec7d3a94a457eff5d1f40482bbe9729c064cdead2");
@@ -45,7 +44,7 @@ fn test_transaction_commitment_regression() {
 }
 
 fn get_transaction_leaf_element() -> TransactionLeafElement {
-    let transaction_hash = TransactionHash(Felt::ONE);
+    let transaction_hash = tx_hash!(1);
     let transaction_signature = TransactionSignature(vec![Felt::TWO, Felt::THREE]);
     TransactionLeafElement { transaction_hash, transaction_signature }
 }

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -792,6 +792,15 @@ impl From<Vec<u8>> for TransactionHash {
     }
 }
 
+/// A utility macro to create a [`TransactionHash`] from an unsigned integer representation.
+#[cfg(any(feature = "testing", test))]
+#[macro_export]
+macro_rules! tx_hash {
+    ($tx_hash:expr) => {
+        $crate::transaction::TransactionHash($crate::hash::StarkHash::from($tx_hash))
+    };
+}
+
 /// A transaction version.
 #[derive(
     Debug,

--- a/crates/starknet_batcher/src/batcher_test.rs
+++ b/crates/starknet_batcher/src/batcher_test.rs
@@ -16,7 +16,7 @@ use starknet_api::executable_transaction::Transaction;
 use starknet_api::hash::PoseidonHash;
 use starknet_api::state::ThinStateDiff;
 use starknet_api::transaction::TransactionHash;
-use starknet_api::{contract_address, felt, nonce};
+use starknet_api::{contract_address, felt, nonce, tx_hash};
 use starknet_batcher_types::batcher_types::{
     DecisionReachedInput,
     GetProposalContent,
@@ -647,7 +647,7 @@ impl<T: ProposalManagerTraitWrapper> ProposalManagerTrait for T {
 }
 
 fn test_tx_hashes(range: std::ops::Range<u128>) -> HashSet<TransactionHash> {
-    range.map(|i| TransactionHash(felt!(i))).collect()
+    range.map(|i| tx_hash!(i)).collect()
 }
 
 fn test_contract_nonces(range: std::ops::Range<u128>) -> HashMap<ContractAddress, Nonce> {

--- a/crates/starknet_batcher/src/block_builder_test.rs
+++ b/crates/starknet_batcher/src/block_builder_test.rs
@@ -10,9 +10,9 @@ use mockall::predicate::eq;
 use mockall::Sequence;
 use rstest::rstest;
 use starknet_api::executable_transaction::Transaction;
-use starknet_api::felt;
 use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::TransactionHash;
+use starknet_api::tx_hash;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::block_builder::{
@@ -247,8 +247,8 @@ fn transaction_failed_test_expectations() -> TestExpectations {
     });
 
     let execution_infos_mapping = indexmap![
-        TransactionHash(felt!(u8::try_from(0).unwrap()))=> execution_info(),
-        TransactionHash(felt!(u8::try_from(2).unwrap()))=> execution_info(),
+        tx_hash!(0)=> execution_info(),
+        tx_hash!(2)=> execution_info(),
     ];
     let expected_block_artifacts = block_execution_artifacts(execution_infos_mapping);
     let expected_block_artifacts_copy = expected_block_artifacts.clone();
@@ -275,7 +275,7 @@ fn transaction_failed_test_expectations() -> TestExpectations {
 fn block_builder_expected_output(execution_info_len: usize) -> BlockExecutionArtifacts {
     let execution_info_len_u8 = u8::try_from(execution_info_len).unwrap();
     let execution_infos_mapping =
-        (0..execution_info_len_u8).map(|i| (TransactionHash(felt!(i)), execution_info())).collect();
+        (0..execution_info_len_u8).map(|i| (tx_hash!(i), execution_info())).collect();
     block_execution_artifacts(execution_infos_mapping)
 }
 

--- a/crates/starknet_batcher/src/test_utils.rs
+++ b/crates/starknet_batcher/src/test_utils.rs
@@ -5,9 +5,8 @@ use blockifier::bouncer::BouncerWeights;
 use blockifier::state::cached_state::CommitmentStateDiff;
 use indexmap::IndexMap;
 use starknet_api::executable_transaction::{AccountTransaction, Transaction};
-use starknet_api::felt;
 use starknet_api::test_utils::invoke::{executable_invoke_tx, InvokeTxArgs};
-use starknet_api::transaction::TransactionHash;
+use starknet_api::tx_hash;
 
 use crate::block_builder::BlockExecutionArtifacts;
 
@@ -15,7 +14,7 @@ pub fn test_txs(tx_hash_range: Range<usize>) -> Vec<Transaction> {
     tx_hash_range
         .map(|i| {
             Transaction::Account(AccountTransaction::Invoke(executable_invoke_tx(InvokeTxArgs {
-                tx_hash: TransactionHash(felt!(u128::try_from(i).unwrap())),
+                tx_hash: tx_hash!(i),
                 ..Default::default()
             })))
         })

--- a/crates/starknet_batcher/src/transaction_provider_test.rs
+++ b/crates/starknet_batcher/src/transaction_provider_test.rs
@@ -5,9 +5,8 @@ use mockall::predicate::eq;
 use rstest::{fixture, rstest};
 use starknet_api::executable_transaction::{AccountTransaction, L1HandlerTransaction, Transaction};
 use starknet_api::test_utils::invoke::{executable_invoke_tx, InvokeTxArgs};
-use starknet_api::transaction::TransactionHash;
+use starknet_api::tx_hash;
 use starknet_mempool_types::communication::MockMempoolClient;
-use starknet_types_core::felt::Felt;
 
 use crate::transaction_provider::{
     MockL1ProviderClient,
@@ -95,7 +94,7 @@ fn tx_channel() -> (tokio::sync::mpsc::Sender<Transaction>, tokio::sync::mpsc::R
 }
 
 fn test_l1handler_tx() -> L1HandlerTransaction {
-    L1HandlerTransaction { tx_hash: TransactionHash(Felt::ONE), ..Default::default() }
+    L1HandlerTransaction { tx_hash: tx_hash!(1), ..Default::default() }
 }
 
 #[rstest]

--- a/crates/starknet_client/src/reader/objects/block_test.rs
+++ b/crates/starknet_client/src/reader/objects/block_test.rs
@@ -4,8 +4,8 @@ use pretty_assertions::assert_eq;
 use starknet_api::block::BlockHash;
 use starknet_api::core::{CompiledClassHash, Nonce};
 use starknet_api::hash::StarkHash;
-use starknet_api::transaction::{TransactionHash, TransactionOffsetInBlock};
-use starknet_api::{class_hash, contract_address, felt, storage_key};
+use starknet_api::transaction::TransactionOffsetInBlock;
+use starknet_api::{class_hash, contract_address, felt, storage_key, tx_hash};
 
 use super::{Block, GlobalRoot, TransactionReceiptsError};
 use crate::reader::objects::block::BlockPostV0_13_1;
@@ -135,7 +135,7 @@ async fn to_starknet_api_block_and_version() {
     );
 
     let mut err_block: BlockPostV0_13_1 = serde_json::from_str(&raw_block).unwrap();
-    err_block.transaction_receipts[0].transaction_hash = TransactionHash(felt!("0x4"));
+    err_block.transaction_receipts[0].transaction_hash = tx_hash!(0x4);
     let err = err_block.to_starknet_api_block_and_version().unwrap_err();
     assert_matches!(
         err,

--- a/crates/starknet_l1_provider/src/l1_provider_tests.rs
+++ b/crates/starknet_l1_provider/src/l1_provider_tests.rs
@@ -1,9 +1,7 @@
 use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
-use starknet_api::hash::StarkHash;
-use starknet_api::l1_handler_tx_args;
 use starknet_api::test_utils::l1_handler::executable_l1_handler_tx;
-use starknet_api::transaction::TransactionHash;
+use starknet_api::{l1_handler_tx_args, tx_hash};
 
 use crate::errors::L1ProviderError;
 use crate::test_utils::L1ProviderContentBuilder;
@@ -14,16 +12,10 @@ macro_rules! tx {
     (tx_hash: $tx_hash:expr) => {{
         executable_l1_handler_tx(
             l1_handler_tx_args!(
-                tx_hash: TransactionHash(StarkHash::from($tx_hash)) , ..Default::default()
+                tx_hash: tx_hash!($tx_hash) , ..Default::default()
             )
         )
     }};
-}
-
-macro_rules! tx_hash {
-    ($tx_hash:expr) => {
-        TransactionHash(StarkHash::from($tx_hash))
-    };
 }
 
 #[test]

--- a/crates/starknet_mempool/src/test_utils.rs
+++ b/crates/starknet_mempool/src/test_utils.rs
@@ -2,8 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use pretty_assertions::assert_eq;
 use starknet_api::executable_transaction::AccountTransaction;
-use starknet_api::transaction::TransactionHash;
-use starknet_api::{contract_address, felt, nonce};
+use starknet_api::{contract_address, nonce, tx_hash};
 use starknet_mempool_types::errors::MempoolError;
 use starknet_mempool_types::mempool_types::{AddTransactionArgs, CommitBlockArgs};
 
@@ -22,8 +21,7 @@ macro_rules! tx {
     ) => {{
             use starknet_api::block::GasPrice;
             use starknet_api::executable_transaction::AccountTransaction;
-            use starknet_api::hash::StarkHash;
-            use starknet_api::invoke_tx_args;
+            use starknet_api::{invoke_tx_args, tx_hash};
             use starknet_api::test_utils::invoke::executable_invoke_tx;
             use starknet_api::transaction::fields::{
                 AllResourceBounds,
@@ -31,7 +29,6 @@ macro_rules! tx {
                 Tip,
                 ValidResourceBounds,
             };
-            use starknet_api::transaction::TransactionHash;
 
             let resource_bounds = ValidResourceBounds::AllResources(AllResourceBounds {
                 l2_gas: ResourceBounds {
@@ -42,7 +39,7 @@ macro_rules! tx {
             });
 
             AccountTransaction::Invoke(executable_invoke_tx(invoke_tx_args!{
-                tx_hash: TransactionHash(StarkHash::from($tx_hash)),
+                tx_hash: tx_hash!($tx_hash),
                 sender_address: contract_address!($address),
                 nonce: nonce!($tx_nonce),
                 tip: Tip($tip),
@@ -242,8 +239,7 @@ pub fn commit_block(
     let nonces = HashMap::from_iter(
         nonces.into_iter().map(|(address, nonce)| (contract_address!(address), nonce!(nonce))),
     );
-    let tx_hashes =
-        HashSet::from_iter(tx_hashes.into_iter().map(|tx_hash| TransactionHash(felt!(tx_hash))));
+    let tx_hashes = HashSet::from_iter(tx_hashes.into_iter().map(|tx_hash| tx_hash!(tx_hash)));
     let args = CommitBlockArgs { address_to_nonce: nonces, tx_hashes };
 
     assert_eq!(mempool.commit_block(args), Ok(()));


### PR DESCRIPTION
Move `tx_hash!` macro constructor to `core.rs` in SN API and use macro throughout codebase.