### PR TITLE
fix: remove orphan docstrings in starknet_api/core

### DIFF
--- a/crates/starknet_api/src/core.rs
+++ b/crates/starknet_api/src/core.rs
@@ -84,10 +84,6 @@ impl ChainId {
     }
 }
 
-/// The address of a contract, used for example in [StateDiff](`crate::state::StateDiff`),
-/// [DeclareTransaction](`crate::transaction::DeclareTransaction`), and
-/// [BlockHeader](`crate::block::BlockHeader`).
-
 // The block hash table is stored in address 0x1,
 // this is a special address that is not used for contracts.
 pub const BLOCK_HASH_TABLE_ADDRESS: ContractAddress = ContractAddress(PatriciaKey(StarkHash::ONE));


### PR DESCRIPTION
I belive these are old lines that no one is using, but due to recent hardening of clippy restrictions on PRs this is breaking the tests. 