### PR TITLE
chore(starknet_gateway): create bench file for benchmark test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10437,6 +10437,7 @@ dependencies = [
  "blockifier",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-starknet-classes",
+ "criterion",
  "futures",
  "mempool_test_utils",
  "mockall",

--- a/crates/starknet_gateway/Cargo.toml
+++ b/crates/starknet_gateway/Cargo.toml
@@ -39,6 +39,7 @@ validator.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 cairo-lang-sierra-to-casm.workspace = true
+criterion.workspace = true
 mockall.workspace = true
 mockito.workspace = true
 num-bigint.workspace = true
@@ -49,3 +50,8 @@ rstest.workspace = true
 starknet_mempool.workspace = true
 starknet_mempool_types = { workspace = true, features = ["testing"] }
 tracing-test.workspace = true
+
+[[bench]]
+harness = false
+name = "gateway_bench"
+path = "bench/gateway_bench.rs"

--- a/crates/starknet_gateway/bench/gateway_bench.rs
+++ b/crates/starknet_gateway/bench/gateway_bench.rs
@@ -1,0 +1,19 @@
+//! Benchmark module for the starknet gateway crate. It provides functionalities to benchmark
+//! the performance of the gateway service, including declare, deploy account and invoke
+//! transactions.
+//!
+//! There are four benchmark functions in this flow: `declare_benchmark`,
+//! `deploy_account_benchmark`, `invoke_benchmark` and `gateway_benchmark` which combines all of the
+//! types. Each of the functions measure the performance of the gateway handling randomly created
+//! txs of the respective type.
+//!
+//! Run the benchmarks using `cargo bench --bench gateway_bench`.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn invoke_benchmark(criterion: &mut Criterion) {
+    criterion.bench_function("invokes", |benchmark| benchmark.iter(|| {}));
+}
+
+criterion_group!(benches, invoke_benchmark);
+criterion_main!(benches);

--- a/crates/starknet_gateway/src/gateway.rs
+++ b/crates/starknet_gateway/src/gateway.rs
@@ -26,14 +26,50 @@ use crate::utils::compile_contract_and_build_executable_tx;
 #[path = "gateway_test.rs"]
 pub mod gateway_test;
 
-pub struct Gateway {
-    pub config: GatewayConfig,
+struct GatewayBusinessLogic {
     pub stateless_tx_validator: Arc<StatelessTransactionValidator>,
     pub stateful_tx_validator: Arc<StatefulTransactionValidator>,
     pub state_reader_factory: Arc<dyn StateReaderFactory>,
     pub gateway_compiler: Arc<GatewayCompiler>,
-    pub mempool_client: SharedMempoolClient,
     pub chain_info: ChainInfo,
+}
+
+impl GatewayBusinessLogic {
+    pub fn new(
+        config: GatewayConfig,
+        state_reader_factory: Arc<dyn StateReaderFactory>,
+        gateway_compiler: GatewayCompiler,
+    ) -> Self {
+        Self {
+            stateless_tx_validator: Arc::new(StatelessTransactionValidator {
+                config: config.stateless_tx_validator_config.clone(),
+            }),
+            stateful_tx_validator: Arc::new(StatefulTransactionValidator {
+                config: config.stateful_tx_validator_config.clone(),
+            }),
+            state_reader_factory,
+            gateway_compiler: Arc::new(gateway_compiler),
+            chain_info: config.chain_info.clone(),
+        }
+    }
+
+    pub async fn add_tx(&self, tx: RpcTransaction) -> GatewayResult<AddTransactionArgs> {
+        info!("Processing tx");
+        let blocking_task = ProcessTxBlockingTask::new(self, tx);
+        // Run the blocking task in the current span.
+        let curr_span = Span::current();
+        tokio::task::spawn_blocking(move || curr_span.in_scope(|| blocking_task.process_tx()))
+            .await
+            .map_err(|join_err| {
+                error!("Failed to process tx: {}", join_err);
+                GatewaySpecError::UnexpectedError { data: "Internal server error".to_owned() }
+            })?
+    }
+}
+
+pub struct Gateway {
+    pub mempool_client: SharedMempoolClient,
+    business_logic: GatewayBusinessLogic,
 }
 
 impl Gateway {
@@ -43,19 +79,9 @@ impl Gateway {
         gateway_compiler: GatewayCompiler,
         mempool_client: SharedMempoolClient,
     ) -> Self {
-        Self {
-            config: config.clone(),
-            stateless_tx_validator: Arc::new(StatelessTransactionValidator {
-                config: config.stateless_tx_validator_config.clone(),
-            }),
-            stateful_tx_validator: Arc::new(StatefulTransactionValidator {
-                config: config.stateful_tx_validator_config.clone(),
-            }),
-            state_reader_factory,
-            gateway_compiler: Arc::new(gateway_compiler),
-            mempool_client,
-            chain_info: config.chain_info.clone(),
-        }
+        let business_logic =
+            GatewayBusinessLogic::new(config, state_reader_factory, gateway_compiler);
+        Self { business_logic, mempool_client }
     }
 
     #[instrument(skip(self), ret)]
@@ -64,20 +90,8 @@ impl Gateway {
         tx: RpcTransaction,
         p2p_message_metadata: Option<BroadcastedMessageMetadata>,
     ) -> GatewayResult<TransactionHash> {
-        info!("Processing tx");
-        let blocking_task = ProcessTxBlockingTask::new(self, tx);
-        // Run the blocking task in the current span.
-        let curr_span = Span::current();
-        let add_tx_args =
-            tokio::task::spawn_blocking(move || curr_span.in_scope(|| blocking_task.process_tx()))
-                .await
-                .map_err(|join_err| {
-                    error!("Failed to process tx: {}", join_err);
-                    GatewaySpecError::UnexpectedError { data: "Internal server error".to_owned() }
-                })??;
-
+        let add_tx_args = self.business_logic.add_tx(tx).await?;
         let tx_hash = add_tx_args.tx.tx_hash();
-
         let add_tx_args = AddTransactionArgsWrapper { args: add_tx_args, p2p_message_metadata };
         self.mempool_client.add_tx(add_tx_args).await.map_err(|e| {
             error!("Failed to send tx to mempool: {}", e);
@@ -100,7 +114,7 @@ struct ProcessTxBlockingTask {
 }
 
 impl ProcessTxBlockingTask {
-    pub fn new(gateway: &Gateway, tx: RpcTransaction) -> Self {
+    pub fn new(gateway: &GatewayBusinessLogic, tx: RpcTransaction) -> Self {
         Self {
             stateless_tx_validator: gateway.stateless_tx_validator.clone(),
             stateful_tx_validator: gateway.stateful_tx_validator.clone(),
@@ -123,7 +137,7 @@ impl ProcessTxBlockingTask {
             &self.chain_info.chain_id,
         )?;
 
-        // Perfom post compilation validations.
+        // Perform post compilation validations.
         if let AccountTransaction::Declare(executable_declare_tx) = &executable_tx {
             if !executable_declare_tx.validate_compiled_class_hash() {
                 return Err(GatewaySpecError::CompiledClassHashMismatch);

--- a/crates/starknet_gateway/src/stateful_transaction_validator_test.rs
+++ b/crates/starknet_gateway/src/stateful_transaction_validator_test.rs
@@ -88,7 +88,7 @@ fn test_instantiate_validator(stateful_validator: StatefulTransactionValidator) 
 
     let mut mock_state_reader_factory = MockStateReaderFactory::new();
 
-    // Make sure stateful_validator uses the latest block in the initiall call.
+    // Make sure stateful_validator uses the latest block in the initial call.
     let latest_state_reader = state_reader_factory.get_state_reader_from_latest_block();
     mock_state_reader_factory
         .expect_get_state_reader_from_latest_block()


### PR DESCRIPTION
We can later discuss the details of the test cases we want to benchmark exactly.

Running the benchmarking action:
`cargo bench --bench gateway_bench`

Prints:
```
declares                time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-62.446% -29.235% +34.904%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

deploy_accounts         time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-54.552% -11.417% +70.199%] (p = 0.73 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

invokes                 time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-46.424% -0.1889% +83.908%] (p = 1.00 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

all_transaction_types   time:   [0.0000 ps 0.0000 ps 0.0000 ps]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```