### PR TITLE
refactor(papyrus_p2p_sync): run_test supports all data types

### DIFF
--- a/crates/papyrus_p2p_sync/src/client/class_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/class_test.rs
@@ -24,7 +24,7 @@ use starknet_api::state::SierraContractClass;
 use super::test_utils::{
     setup,
     wait_for_marker,
-    MarkerKind,
+    DataType,
     TestArgs,
     CLASS_DIFF_QUERY_LENGTH,
     HEADER_QUERY_LENGTH,
@@ -112,7 +112,7 @@ async fn class_basic_flow() {
                     .unwrap();
 
                 wait_for_marker(
-                    MarkerKind::Class,
+                    DataType::Class,
                     &storage_reader,
                     block_number.unchecked_next(),
                     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,

--- a/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
@@ -30,8 +30,8 @@ use super::test_utils::{
     create_block_hashes_and_signatures,
     setup,
     wait_for_marker,
+    DataType,
     HeaderTestPayload,
-    MarkerKind,
     StateDiffTestPayload,
     TestArgs,
     HEADER_QUERY_LENGTH,
@@ -95,7 +95,7 @@ async fn state_diff_basic_flow() {
                 // responses.
 
                 wait_for_marker(
-                    MarkerKind::State,
+                    DataType::StateDiff,
                     &storage_reader,
                     block_number.unchecked_next(),
                     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,

--- a/crates/papyrus_p2p_sync/src/client/transaction_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/transaction_test.rs
@@ -23,7 +23,7 @@ use super::test_utils::{
     TRANSACTION_QUERY_LENGTH,
     WAIT_PERIOD_FOR_NEW_DATA,
 };
-use crate::client::test_utils::{wait_for_marker, MarkerKind, TIMEOUT_FOR_TEST};
+use crate::client::test_utils::{wait_for_marker, DataType, TIMEOUT_FOR_TEST};
 
 #[tokio::test]
 async fn transaction_basic_flow() {
@@ -79,7 +79,7 @@ async fn transaction_basic_flow() {
         }
 
         wait_for_marker(
-            MarkerKind::Header,
+            DataType::Header,
             &storage_reader,
             BlockNumber(HEADER_QUERY_LENGTH),
             SLEEP_DURATION_TO_LET_SYNC_ADVANCE,
@@ -139,7 +139,7 @@ async fn transaction_basic_flow() {
                 // sent.
                 let block_number = BlockNumber(block_number);
                 wait_for_marker(
-                    MarkerKind::Body,
+                    DataType::Transaction,
                     &storage_reader,
                     block_number.unchecked_next(),
                     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,


### PR DESCRIPTION
- **refactor(papyrus_p2p_sync): add_test receives query size instead of constant**
- **refactor(papyrus_p2p_sync): run_test supports all data types**
