### PR TITLE
feat(starknet_l1_provider): add uninitiailized state and make it the default

### DIFF
--- a/crates/starknet_l1_provider/src/l1_provider_tests.rs
+++ b/crates/starknet_l1_provider/src/l1_provider_tests.rs
@@ -5,7 +5,7 @@ use starknet_api::{l1_handler_tx_args, tx_hash};
 
 use crate::errors::L1ProviderError;
 use crate::test_utils::L1ProviderContentBuilder;
-use crate::ProviderState::{Propose, Validate};
+use crate::ProviderState::{Pending, Propose, Uninitialized, Validate};
 use crate::{L1Provider, ValidationStatus};
 
 macro_rules! tx {
@@ -54,8 +54,10 @@ fn validate_happy_flow() {
 #[test]
 fn pending_state_errors() {
     // Setup.
-    let mut l1_provider =
-        L1ProviderContentBuilder::new().with_txs([tx!(tx_hash: 1)]).build_into_l1_provider();
+    let mut l1_provider = L1ProviderContentBuilder::new()
+        .with_state(Pending)
+        .with_txs([tx!(tx_hash: 1)])
+        .build_into_l1_provider();
 
     // Test.
     assert_matches!(
@@ -70,10 +72,28 @@ fn pending_state_errors() {
 }
 
 #[test]
+#[should_panic(expected = "Uninitialized L1 provider")]
+fn uninitialized_get_txs() {
+    let mut uninitialized_l1_provider = L1Provider::default();
+    assert_eq!(uninitialized_l1_provider.state, Uninitialized);
+
+    uninitialized_l1_provider.get_txs(1).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Uninitialized L1 provider")]
+fn uninitialized_validate() {
+    let uninitialized_l1_provider = L1Provider::default();
+    assert_eq!(uninitialized_l1_provider.state, Uninitialized);
+
+    uninitialized_l1_provider.validate(Default::default()).unwrap();
+}
+
+#[test]
 fn proposal_start_errors() {
     // Setup.
-    let mut l1_provider = L1Provider::default();
-
+    let mut l1_provider =
+        L1ProviderContentBuilder::new().with_state(Pending).build_into_l1_provider();
     // Test.
     l1_provider.proposal_start().unwrap();
 
@@ -90,7 +110,8 @@ fn proposal_start_errors() {
 #[test]
 fn validation_start_errors() {
     // Setup.
-    let mut l1_provider = L1Provider::default();
+    let mut l1_provider =
+        L1ProviderContentBuilder::new().with_state(Pending).build_into_l1_provider();
 
     // Test.
     l1_provider.validation_start().unwrap();

--- a/crates/starknet_l1_provider/src/lib.rs
+++ b/crates/starknet_l1_provider/src/lib.rs
@@ -39,6 +39,7 @@ impl L1Provider {
             ProviderState::Propose => Ok(self.tx_manager.get_txs(n_txs)),
             ProviderState::Pending => Err(L1ProviderError::GetTransactionsInPendingState),
             ProviderState::Validate => Err(L1ProviderError::GetTransactionConsensusBug),
+            ProviderState::Uninitialized => panic!("Uninitialized L1 provider"),
         }
     }
 
@@ -49,6 +50,7 @@ impl L1Provider {
             ProviderState::Validate => Ok(self.tx_manager.tx_status(tx_hash)),
             ProviderState::Propose => Err(L1ProviderError::ValidateTransactionConsensusBug),
             ProviderState::Pending => Err(L1ProviderError::ValidateInPendingState),
+            ProviderState::Uninitialized => panic!("Uninitialized L1 provider"),
         }
     }
 
@@ -148,9 +150,10 @@ pub enum ValidationStatus {
 }
 
 /// Current state of the provider, where pending means: idle, between proposal/validation cycles.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ProviderState {
     #[default]
+    Uninitialized,
     Pending,
     Propose,
     Validate,
@@ -185,6 +188,7 @@ impl ProviderState {
         match self {
             ProviderState::Pending => "Pending",
             ProviderState::Propose => "Propose",
+            ProviderState::Uninitialized => "Uninitialized",
             ProviderState::Validate => "Validate",
         }
     }


### PR DESCRIPTION
This is to comply with upcoming integration with infra, which separates instantiation with initialization. In particular, `Pending` state should be already post-syncing with L1, whereas `Uninitialized` is unsynced and unusable.

Using panicking here because trying to call this service while uninitialized is a serious bug.