### PR TITLE
chore(starknet_l1_provider): get errors ready for infra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10481,6 +10481,7 @@ dependencies = [
  "indexmap 2.6.0",
  "papyrus_base_layer",
  "pretty_assertions",
+ "serde",
  "starknet_api",
  "thiserror",
 ]

--- a/crates/starknet_l1_provider/Cargo.toml
+++ b/crates/starknet_l1_provider/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 indexmap.workspace = true
 papyrus_base_layer.workspace = true
+serde.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
 

--- a/crates/starknet_l1_provider/src/errors.rs
+++ b/crates/starknet_l1_provider/src/errors.rs
@@ -1,12 +1,9 @@
 use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerError;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::ProviderState;
-
-#[derive(Error, Debug)]
+#[derive(Clone, Debug, Error, PartialEq, Eq, Serialize, Deserialize)]
 pub enum L1ProviderError {
-    #[error(transparent)]
-    BaseLayer(#[from] EthereumBaseLayerError),
     #[error(
         "`get_txs` called while in `Pending` state, likely due to a crash; restart block proposal"
     )]
@@ -14,11 +11,24 @@ pub enum L1ProviderError {
     #[error("`get_txs` while in validate state")]
     GetTransactionConsensusBug,
     #[error("Cannot transition from {from} to {to}")]
-    UnexpectedProviderStateTransition { from: ProviderState, to: ProviderState },
+    UnexpectedProviderStateTransition { from: String, to: String },
     #[error(
         "`validate` called while in `Pending` state, likely due to a crash; restart block proposal"
     )]
     ValidateInPendingState,
     #[error("`validate` called while in `Propose`")]
     ValidateTransactionConsensusBug,
+}
+
+impl L1ProviderError {
+    pub fn unexpected_transition(from: impl ToString, to: impl ToString) -> Self {
+        Self::UnexpectedProviderStateTransition { from: from.to_string(), to: to.to_string() }
+    }
+}
+
+// TODO(Gilad): move to scraper module once it's created.
+#[derive(Error, Debug)]
+pub enum L1ScraperError {
+    #[error(transparent)]
+    BaseLayer(#[from] EthereumBaseLayerError),
 }

--- a/crates/starknet_l1_provider/src/l1_provider_tests.rs
+++ b/crates/starknet_l1_provider/src/l1_provider_tests.rs
@@ -1,6 +1,7 @@
 use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
 use starknet_api::test_utils::l1_handler::executable_l1_handler_tx;
+use starknet_api::transaction::TransactionHash;
 use starknet_api::{l1_handler_tx_args, tx_hash};
 
 use crate::errors::L1ProviderError;
@@ -86,7 +87,7 @@ fn uninitialized_validate() {
     let uninitialized_l1_provider = L1Provider::default();
     assert_eq!(uninitialized_l1_provider.state, Uninitialized);
 
-    uninitialized_l1_provider.validate(Default::default()).unwrap();
+    uninitialized_l1_provider.validate(TransactionHash::default()).unwrap();
 }
 
 #[test]
@@ -97,13 +98,13 @@ fn proposal_start_errors() {
     // Test.
     l1_provider.proposal_start().unwrap();
 
-    assert_matches!(
+    assert_eq!(
         l1_provider.proposal_start().unwrap_err(),
-        L1ProviderError::UnexpectedProviderStateTransition { from: Propose, to: Propose }
+        L1ProviderError::unexpected_transition(Propose, Propose)
     );
-    assert_matches!(
+    assert_eq!(
         l1_provider.validation_start().unwrap_err(),
-        L1ProviderError::UnexpectedProviderStateTransition { from: Propose, to: Validate }
+        L1ProviderError::unexpected_transition(Propose, Validate)
     );
 }
 
@@ -116,12 +117,12 @@ fn validation_start_errors() {
     // Test.
     l1_provider.validation_start().unwrap();
 
-    assert_matches!(
+    assert_eq!(
         l1_provider.validation_start().unwrap_err(),
-        L1ProviderError::UnexpectedProviderStateTransition { from: Validate, to: Validate }
+        L1ProviderError::unexpected_transition(Validate, Validate)
     );
-    assert_matches!(
+    assert_eq!(
         l1_provider.proposal_start().unwrap_err(),
-        L1ProviderError::UnexpectedProviderStateTransition { from: Validate, to: Propose }
+        L1ProviderError::unexpected_transition(Validate, Propose)
     );
 }

--- a/crates/starknet_l1_provider/src/lib.rs
+++ b/crates/starknet_l1_provider/src/lib.rs
@@ -142,7 +142,7 @@ impl TransactionManager {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ValidationStatus {
     Validated,
     AlreadyIncludedOnL2,
@@ -150,12 +150,12 @@ pub enum ValidationStatus {
 }
 
 /// Current state of the provider, where pending means: idle, between proposal/validation cycles.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum ProviderState {
-    #[default]
-    Uninitialized,
     Pending,
     Propose,
+    #[default]
+    Uninitialized,
     Validate,
 }
 
@@ -163,20 +163,14 @@ impl ProviderState {
     fn transition_to_propose(self) -> L1ProviderResult<Self> {
         match self {
             ProviderState::Pending => Ok(ProviderState::Propose),
-            _ => Err(L1ProviderError::UnexpectedProviderStateTransition {
-                from: self,
-                to: ProviderState::Propose,
-            }),
+            _ => Err(L1ProviderError::unexpected_transition(self, ProviderState::Propose)),
         }
     }
 
     fn transition_to_validate(self) -> L1ProviderResult<Self> {
         match self {
             ProviderState::Pending => Ok(ProviderState::Validate),
-            _ => Err(L1ProviderError::UnexpectedProviderStateTransition {
-                from: self,
-                to: ProviderState::Validate,
-            }),
+            _ => Err(L1ProviderError::unexpected_transition(self, ProviderState::Validate)),
         }
     }
 
@@ -188,8 +182,8 @@ impl ProviderState {
         match self {
             ProviderState::Pending => "Pending",
             ProviderState::Propose => "Propose",
-            ProviderState::Uninitialized => "Uninitialized",
             ProviderState::Validate => "Validate",
+            ProviderState::Uninitialized => "Validate",
         }
     }
 }


### PR DESCRIPTION
- don't expose internal module `ProviderState`
- add serde
- extract scraping error, it will be added to a separate interface.