### PR TITLE
fix(sequencing): remove old proposal pipes

### DIFF
--- a/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -93,9 +93,6 @@ pub struct SequencerConsensusContext {
     proposal_id: u64,
     current_height: Option<BlockNumber>,
     current_round: Round,
-    // Used to broadcast proposals to other consensus nodes.
-    // TODO(Guy) switch to the actual streaming struct.
-    _proposal_streaming_client: BroadcastTopicClient<ProposalPart>,
     // The active proposal refers to the proposal being validated at the current height/round.
     // Building proposals are not tracked as active, as consensus can't move on to the next
     // height/round until building is done. Context only works on proposals for the
@@ -112,14 +109,12 @@ pub struct SequencerConsensusContext {
 impl SequencerConsensusContext {
     pub fn new(
         batcher: Arc<dyn BatcherClient>,
-        _proposal_streaming_client: BroadcastTopicClient<ProposalPart>,
         outbound_proposal_sender: mpsc::Sender<(u64, mpsc::Receiver<ProposalPart>)>,
         vote_broadcast_client: BroadcastTopicClient<ConsensusMessage>,
         num_validators: u64,
     ) -> Self {
         Self {
             batcher,
-            _proposal_streaming_client,
             outbound_proposal_sender,
             vote_broadcast_client,
             validators: (0..num_validators).map(ValidatorId::from).collect(),

--- a/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/sequencing/papyrus_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -71,7 +71,6 @@ fn generate_executable_invoke_tx(tx_hash: Felt) -> ExecutableTransaction {
 // Structs which aren't utilized but should not be dropped.
 struct NetworkDependencies {
     _vote_network: BroadcastNetworkMock<ConsensusMessage>,
-    _old_proposal_network: BroadcastNetworkMock<ProposalPart>,
     _new_proposal_network: BroadcastNetworkMock<StreamMessage<ProposalPart>>,
 }
 
@@ -85,12 +84,6 @@ fn setup(batcher: MockBatcherClient) -> (SequencerConsensusContext, NetworkDepen
     let (outbound_proposal_stream_sender, _, _) =
         StreamHandler::get_channels(inbound_network_receiver, outbound_network_sender);
 
-    // TODO(guyn): remove this first set of channels once we are using only the streaming channels.
-    let TestSubscriberChannels { mock_network: mock_proposal_network, subscriber_channels } =
-        mock_register_broadcast_topic().expect("Failed to create mock network");
-    let BroadcastTopicChannels { broadcast_topic_client: proposal_streaming_client, .. } =
-        subscriber_channels;
-
     let TestSubscriberChannels { mock_network: mock_vote_network, subscriber_channels } =
         mock_register_broadcast_topic().expect("Failed to create mock network");
     let BroadcastTopicChannels { broadcast_topic_client: votes_topic_client, .. } =
@@ -98,7 +91,6 @@ fn setup(batcher: MockBatcherClient) -> (SequencerConsensusContext, NetworkDepen
 
     let context = SequencerConsensusContext::new(
         Arc::new(batcher),
-        proposal_streaming_client,
         outbound_proposal_stream_sender,
         votes_topic_client,
         NUM_VALIDATORS,
@@ -106,7 +98,6 @@ fn setup(batcher: MockBatcherClient) -> (SequencerConsensusContext, NetworkDepen
 
     let network_dependencies = NetworkDependencies {
         _vote_network: mock_vote_network,
-        _old_proposal_network: mock_proposal_network,
         _new_proposal_network: mock_proposal_stream_network,
     };
 

--- a/crates/starknet_integration_tests/src/utils.rs
+++ b/crates/starknet_integration_tests/src/utils.rs
@@ -77,8 +77,7 @@ fn create_consensus_manager_configs_and_channels(
         create_network_configs_connected_to_broadcast_channels(
             n_managers,
             papyrus_network::gossipsub_impl::Topic::new(
-                // TODO(guyn): return this to NETWORK_TOPIC once we have integrated streaming.
-                starknet_consensus_manager::consensus_manager::NETWORK_TOPIC2,
+                starknet_consensus_manager::consensus_manager::CONSENSUS_PROPOSALS_TOPIC,
             ),
         );
     // TODO: Need to also add a channel for votes, in addition to the proposals channel.


### PR DESCRIPTION
This cleans up some of the leftover code from before we added streamed proposals. 
In this specific PR I remove the channels that used to pass the proposals into context. 