### PR TITLE
refactor(papyrus_p2p_sync): convert class tests to use run_test

### DIFF
--- a/crates/papyrus_p2p_sync/src/client/class_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/class_test.rs
@@ -24,7 +24,7 @@ use starknet_api::state::SierraContractClass;
 use super::test_utils::{
     setup,
     wait_for_marker,
-    MarkerKind,
+    DataType,
     TestArgs,
     CLASS_DIFF_QUERY_LENGTH,
     HEADER_QUERY_LENGTH,
@@ -112,7 +112,7 @@ async fn class_basic_flow() {
                     .unwrap();
 
                 wait_for_marker(
-                    MarkerKind::Class,
+                    DataType::Class,
                     &storage_reader,
                     block_number.unchecked_next(),
                     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,

--- a/crates/papyrus_p2p_sync/src/client/header_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/header_test.rs
@@ -198,23 +198,26 @@ async fn sync_sends_new_header_query_if_it_got_partial_responses() {
 
 #[tokio::test]
 async fn wrong_block_number() {
-    run_test(vec![
-        // We already validate the query content in other tests.
-        Action::ReceiveQuery(Box::new(|_query| ())),
-        Action::SendHeader(DataOrFin(Some(random_header(
-            &mut get_rng(),
-            BlockNumber(1),
-            None,
-            None,
-        )))),
-        Action::ValidateReportSent,
-        Action::CheckStorage(Box::new(|reader| {
-            async move {
-                assert_eq!(0, reader.begin_ro_txn().unwrap().get_header_marker().unwrap().0);
-            }
-            .boxed()
-        })),
-    ])
+    run_test(
+        1,
+        vec![
+            // We already validate the query content in other tests.
+            Action::ReceiveQuery(Box::new(|_query| ())),
+            Action::SendHeader(DataOrFin(Some(random_header(
+                &mut get_rng(),
+                BlockNumber(1),
+                None,
+                None,
+            )))),
+            Action::ValidateReportSent,
+            Action::CheckStorage(Box::new(|reader| {
+                async move {
+                    assert_eq!(0, reader.begin_ro_txn().unwrap().get_header_marker().unwrap().0);
+                }
+                .boxed()
+            })),
+        ],
+    )
     .await;
 }
 

--- a/crates/papyrus_p2p_sync/src/client/header_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/header_test.rs
@@ -8,12 +8,13 @@ use papyrus_protobuf::sync::{
     SignedBlockHeader,
 };
 use papyrus_storage::header::HeaderStorageReader;
-use papyrus_test_utils::{get_rng, GetTestInstance};
+use papyrus_test_utils::get_rng;
 use starknet_api::block::{BlockHeader, BlockHeaderWithoutHash, BlockNumber};
 use tokio::time::timeout;
 
 use super::test_utils::{
     create_block_hashes_and_signatures,
+    random_header,
     run_test,
     setup,
     wait_for_marker,
@@ -197,20 +198,15 @@ async fn sync_sends_new_header_query_if_it_got_partial_responses() {
 
 #[tokio::test]
 async fn wrong_block_number() {
-    let mut rng = get_rng();
     run_test(vec![
         // We already validate the query content in other tests.
         Action::ReceiveQuery(Box::new(|_query| ())),
-        Action::SendHeader(DataOrFin(Some(SignedBlockHeader {
-            block_header: BlockHeader {
-                block_header_without_hash: BlockHeaderWithoutHash {
-                    block_number: BlockNumber(1),
-                    ..GetTestInstance::get_test_instance(&mut rng)
-                },
-                ..GetTestInstance::get_test_instance(&mut rng)
-            },
-            ..GetTestInstance::get_test_instance(&mut rng)
-        }))),
+        Action::SendHeader(DataOrFin(Some(random_header(
+            &mut get_rng(),
+            BlockNumber(1),
+            None,
+            None,
+        )))),
         Action::ValidateReportSent,
         Action::CheckStorage(Box::new(|reader| {
             async move {

--- a/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
@@ -30,8 +30,8 @@ use super::test_utils::{
     create_block_hashes_and_signatures,
     setup,
     wait_for_marker,
+    DataType,
     HeaderTestPayload,
-    MarkerKind,
     StateDiffTestPayload,
     TestArgs,
     HEADER_QUERY_LENGTH,
@@ -95,7 +95,7 @@ async fn state_diff_basic_flow() {
                 // responses.
 
                 wait_for_marker(
-                    MarkerKind::State,
+                    DataType::StateDiff,
                     &storage_reader,
                     block_number.unchecked_next(),
                     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,

--- a/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
+use std::collections::HashMap;
 
-use futures::future::join;
 use futures::{FutureExt, StreamExt};
 use indexmap::indexmap;
 use papyrus_network::network_manager::GenericReceiver;
@@ -16,24 +16,22 @@ use papyrus_protobuf::sync::{
     StateDiffChunk,
 };
 use papyrus_storage::state::StateStorageReader;
-use papyrus_test_utils::{get_rng, GetTestInstance};
-use rand::RngCore;
-use rand_chacha::ChaCha8Rng;
+use papyrus_test_utils::get_rng;
 use starknet_api::block::{BlockHeader, BlockHeaderWithoutHash, BlockNumber};
-use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ascii_as_felt, ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::state::{StorageKey, ThinStateDiff};
 use starknet_types_core::felt::Felt;
-use static_assertions::const_assert;
 use tokio::sync::mpsc::{channel, Receiver};
 
 use super::test_utils::{
     create_block_hashes_and_signatures,
-    setup,
+    random_header,
+    run_test,
     wait_for_marker,
+    Action,
     DataType,
     HeaderTestPayload,
     StateDiffTestPayload,
-    TestArgs,
     HEADER_QUERY_LENGTH,
     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,
     STATE_DIFF_QUERY_LENGTH,
@@ -44,124 +42,152 @@ use super::{P2PSyncClientConfig, StateDiffQuery};
 
 #[tokio::test]
 async fn state_diff_basic_flow() {
-    // Asserting the constants so the test can assume there will be 2 state diff queries for a
-    // single header query and the second will be smaller than the first.
-    const_assert!(STATE_DIFF_QUERY_LENGTH < HEADER_QUERY_LENGTH);
-    const_assert!(HEADER_QUERY_LENGTH < 2 * STATE_DIFF_QUERY_LENGTH);
-
-    let TestArgs {
-        p2p_sync,
-        storage_reader,
-        mut mock_state_diff_response_manager,
-        mut mock_header_response_manager,
-        // The test will fail if we drop these
-        mock_transaction_response_manager: _mock_transaction_responses_manager,
-        mock_class_response_manager: _mock_class_responses_manager,
-        ..
-    } = setup();
-
     let mut rng = get_rng();
-    // TODO(eitan): Add a 3rd constant for NUM_CHUNKS_PER_BLOCK so that ThinStateDiff is made from
-    // multiple StateDiffChunks
-    let (state_diffs, header_state_diff_lengths): (Vec<_>, Vec<_>) = (0..HEADER_QUERY_LENGTH)
-        .map(|_| {
-            let diff = create_random_state_diff_chunk(&mut rng);
-            let length = diff.len();
-            (diff, length)
-        })
-        .unzip();
 
-    let (state_diff_sender, mut state_diff_receiver) = channel(p2p_sync.config.buffer_size);
+    let class_hash0 = ClassHash(ascii_as_felt("class_hash0").unwrap());
+    let class_hash1 = ClassHash(ascii_as_felt("class_hash1").unwrap());
+    let casm_hash0 = CompiledClassHash(ascii_as_felt("casm_hash0").unwrap());
+    let address0 = ContractAddress(ascii_as_felt("address0").unwrap().try_into().unwrap());
+    let address1 = ContractAddress(ascii_as_felt("address1").unwrap().try_into().unwrap());
+    let address2 = ContractAddress(ascii_as_felt("address2").unwrap().try_into().unwrap());
+    let key0 = StorageKey(ascii_as_felt("key0").unwrap().try_into().unwrap());
+    let key1 = StorageKey(ascii_as_felt("key1").unwrap().try_into().unwrap());
+    let value0 = ascii_as_felt("value0").unwrap();
+    let value1 = ascii_as_felt("value1").unwrap();
+    let nonce0 = Nonce(ascii_as_felt("nonce0").unwrap());
 
-    // Create a future that will receive send responses and validate the results.
-    let test_future = async move {
-        for (start_block_number, num_blocks) in [
-            (0u64, STATE_DIFF_QUERY_LENGTH),
-            (STATE_DIFF_QUERY_LENGTH, HEADER_QUERY_LENGTH - STATE_DIFF_QUERY_LENGTH),
-        ] {
-            for block_number in start_block_number..(start_block_number + num_blocks) {
-                let state_diff_chunk = state_diffs[usize::try_from(block_number).unwrap()].clone();
+    let state_diffs_and_chunks = vec![
+        (
+            ThinStateDiff {
+                deployed_contracts: indexmap!(address0 => class_hash0),
+                storage_diffs: indexmap!(address0 => indexmap!(key0 => value0, key1 => value1)),
+                declared_classes: indexmap!(class_hash0 => casm_hash0),
+                deprecated_declared_classes: vec![class_hash1],
+                nonces: indexmap!(address0 => nonce0),
+                replaced_classes: Default::default(),
+            },
+            vec![
+                StateDiffChunk::DeclaredClass(DeclaredClass {
+                    class_hash: class_hash0,
+                    compiled_class_hash: casm_hash0,
+                }),
+                StateDiffChunk::ContractDiff(ContractDiff {
+                    contract_address: address0,
+                    class_hash: Some(class_hash0),
+                    nonce: Some(nonce0),
+                    storage_diffs: indexmap!(key0 => value0, key1 => value1),
+                }),
+                StateDiffChunk::DeprecatedDeclaredClass(DeprecatedDeclaredClass {
+                    class_hash: class_hash1,
+                }),
+            ],
+        ),
+        (
+            ThinStateDiff {
+                deployed_contracts: indexmap!(address1 => class_hash1),
+                storage_diffs: indexmap!(
+                    address1 => indexmap!(key0 => value0),
+                    address2 => indexmap!(key1 => value1)
+                ),
+                nonces: indexmap!(address2 => nonce0),
+                ..Default::default()
+            },
+            vec![
+                StateDiffChunk::ContractDiff(ContractDiff {
+                    contract_address: address1,
+                    class_hash: Some(class_hash1),
+                    nonce: None,
+                    storage_diffs: indexmap!(key0 => value0),
+                }),
+                StateDiffChunk::ContractDiff(ContractDiff {
+                    contract_address: address2,
+                    class_hash: None,
+                    nonce: Some(nonce0),
+                    storage_diffs: indexmap!(key1 => value1),
+                }),
+            ],
+        ),
+    ];
 
-                let block_number = BlockNumber(block_number);
+    let mut actions = vec![
+        // We already validate the header query content in other tests.
+        Action::ReceiveQuery(Box::new(|_query| ()), DataType::Header),
+    ];
 
-                // Check that before we've sent all parts the state diff wasn't written yet.
-                let txn = storage_reader.begin_ro_txn().unwrap();
-                assert_eq!(block_number, txn.get_state_marker().unwrap());
+    // Send headers with corresponding state diff length
+    for (i, (state_diff, _)) in state_diffs_and_chunks.iter().enumerate() {
+        actions.push(Action::SendHeader(DataOrFin(Some(random_header(
+            &mut rng,
+            BlockNumber(i.try_into().unwrap()),
+            Some(state_diff.len()),
+            None,
+        )))));
+    }
+    actions.push(Action::SendHeader(DataOrFin(None)));
 
-                state_diff_sender.send(Some(state_diff_chunk.clone())).await.unwrap();
+    let len = state_diffs_and_chunks.len();
+    actions.push(Action::ReceiveQuery(
+        Box::new(move |query| {
+            assert_eq!(
+                query,
+                Query {
+                    start_block: BlockHashOrNumber::Number(BlockNumber(0)),
+                    direction: Direction::Forward,
+                    limit: len.try_into().unwrap(),
+                    step: 1,
+                }
+            )
+        }),
+        DataType::StateDiff,
+    ));
+    // Send state diff chunks and check storage
+    for (i, (expected_state_diff, state_diff_chunks)) in
+        state_diffs_and_chunks.iter().cloned().enumerate()
+    {
+        for state_diff_chunk in state_diff_chunks {
+            // Check that before the last chunk was sent, the state diff isn't written.
+            actions.push(Action::CheckStorage(Box::new(move |reader| {
+                async move {
+                    assert_eq!(
+                        u64::try_from(i).unwrap(),
+                        reader.begin_ro_txn().unwrap().get_state_marker().unwrap().0
+                    );
+                }
+                .boxed()
+            })));
 
-                // Check state diff was written to the storage. This way we make sure that the sync
-                // writes to the storage each block's state diff before receiving all query
-                // responses.
-
+            actions.push(Action::SendStateDiff(DataOrFin(Some(state_diff_chunk))));
+        }
+        // Check that a block's state diff is written before the entire query finished.
+        actions.push(Action::CheckStorage(Box::new(move |reader| {
+            async move {
+                let block_number = BlockNumber(i.try_into().unwrap());
                 wait_for_marker(
                     DataType::StateDiff,
-                    &storage_reader,
+                    &reader,
                     block_number.unchecked_next(),
                     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,
                     TIMEOUT_FOR_TEST,
                 )
                 .await;
 
-                let txn = storage_reader.begin_ro_txn().unwrap();
-                let state_diff = txn.get_state_diff(block_number).unwrap().unwrap();
-                // TODO(noamsp): refactor test so that we treat multiple state diff chunks as a
-                // single state diff
-                let expected_state_diff = match state_diff_chunk {
-                    StateDiffChunk::ContractDiff(contract_diff) => {
-                        let mut deployed_contracts = indexmap! {};
-                        if let Some(class_hash) = contract_diff.class_hash {
-                            deployed_contracts.insert(contract_diff.contract_address, class_hash);
-                        };
-                        let mut nonces = indexmap! {};
-                        if let Some(nonce) = contract_diff.nonce {
-                            nonces.insert(contract_diff.contract_address, nonce);
-                        }
-                        ThinStateDiff {
-                            deployed_contracts,
-                            nonces,
-                            storage_diffs: indexmap! {
-                                contract_diff.contract_address => contract_diff.storage_diffs
-                            },
-                            ..Default::default()
-                        }
-                    }
-                    StateDiffChunk::DeclaredClass(declared_class) => ThinStateDiff {
-                        declared_classes: indexmap! {
-                            declared_class.class_hash => declared_class.compiled_class_hash
-                        },
-                        ..Default::default()
-                    },
-                    StateDiffChunk::DeprecatedDeclaredClass(deprecated_declared_class) => {
-                        ThinStateDiff {
-                            deprecated_declared_classes: vec![deprecated_declared_class.class_hash],
-                            ..Default::default()
-                        }
-                    }
-                };
-                assert_eq!(state_diff, expected_state_diff);
+                let txn = reader.begin_ro_txn().unwrap();
+                let actual_state_diff = txn.get_state_diff(block_number).unwrap().unwrap();
+                assert_eq!(actual_state_diff, expected_state_diff);
             }
-
-            state_diff_sender.send(None).await.unwrap();
-        }
-    };
-
-    tokio::select! {
-        sync_result = p2p_sync.run() => {
-            sync_result.unwrap();
-            panic!("P2P sync aborted with no failure.");
-        }
-        _ = join(
-                run_state_diff_sync_through_channel(
-                    &mut mock_header_response_manager,
-                    &mut mock_state_diff_response_manager,
-                    header_state_diff_lengths,
-                    &mut state_diff_receiver,
-                    false,
-                ),
-                test_future,
-            ) => {}
+            .boxed()
+        })));
     }
+    actions.push(Action::SendStateDiff(DataOrFin(None)));
+
+    run_test(
+        HashMap::from([
+            (DataType::Header, state_diffs_and_chunks.len().try_into().unwrap()),
+            (DataType::StateDiff, state_diffs_and_chunks.len().try_into().unwrap()),
+        ]),
+        actions,
+    )
+    .await;
 }
 
 // TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(EmptyStateDiffPart) was
@@ -288,46 +314,44 @@ async fn validate_state_diff_fails(
     header_state_diff_lengths: Vec<usize>,
     state_diff_chunks: Vec<Option<StateDiffChunk>>,
 ) {
-    let TestArgs {
-        storage_reader,
-        p2p_sync,
-        mut mock_state_diff_response_manager,
-        mut mock_header_response_manager,
-        // The test will fail if we drop these
-        mock_transaction_response_manager: _mock_transaction_responses_manager,
-        mock_class_response_manager: _mock_class_responses_manager,
-        ..
-    } = setup();
+    let mut rng = get_rng();
 
-    let (state_diff_sender, mut state_diff_receiver) = channel(p2p_sync.config.buffer_size);
+    let mut actions = vec![
+        // We already validate the header query content in other tests.
+        Action::ReceiveQuery(Box::new(|_query| ()), DataType::Header),
+    ];
 
-    // Create a future that will send responses and validate the results.
-    let test_future = async move {
-        for state_diff_chunk in state_diff_chunks {
-            // Check that before we've sent all parts the state diff wasn't written yet.
-            let txn = storage_reader.begin_ro_txn().unwrap();
-            assert_eq!(0, txn.get_state_marker().unwrap().0);
-
-            state_diff_sender.send(state_diff_chunk).await.unwrap();
-        }
-    };
-
-    tokio::select! {
-        sync_result = p2p_sync.run() => {
-            sync_result.unwrap();
-            panic!("P2P sync aborted with no failure.");
-        }
-        _ = join(
-            run_state_diff_sync_through_channel(
-                &mut mock_header_response_manager,
-                &mut mock_state_diff_response_manager,
-                header_state_diff_lengths,
-                &mut state_diff_receiver,
-                true,
-            ),
-            test_future
-         ) => {}
+    // Send headers with corresponding state diff length
+    for (i, state_diff_length) in header_state_diff_lengths.iter().copied().enumerate() {
+        actions.push(Action::SendHeader(DataOrFin(Some(random_header(
+            &mut rng,
+            BlockNumber(i.try_into().unwrap()),
+            Some(state_diff_length),
+            None,
+        )))));
     }
+    actions.push(Action::SendHeader(DataOrFin(None)));
+
+    actions.push(
+        // We already validate the state diff query content in other tests.
+        Action::ReceiveQuery(Box::new(|_query| ()), DataType::StateDiff),
+    );
+
+    // Send state diff chunks.
+    for state_diff_chunk in state_diff_chunks {
+        actions.push(Action::SendStateDiff(DataOrFin(state_diff_chunk)));
+    }
+
+    actions.push(Action::ValidateReportSent(DataType::StateDiff));
+
+    run_test(
+        HashMap::from([
+            (DataType::Header, header_state_diff_lengths.len().try_into().unwrap()),
+            (DataType::StateDiff, header_state_diff_lengths.len().try_into().unwrap()),
+        ]),
+        actions,
+    )
+    .await;
 }
 
 // Advances the header sync with associated header state diffs.
@@ -483,24 +507,4 @@ pub(crate) async fn run_state_diff_sync(
             }
         }
     };
-}
-
-fn create_random_state_diff_chunk(rng: &mut ChaCha8Rng) -> StateDiffChunk {
-    let mut state_diff_chunk = StateDiffChunk::get_test_instance(rng);
-    let contract_address = ContractAddress::from(rng.next_u64());
-    let class_hash = ClassHash(rng.next_u64().into());
-    match &mut state_diff_chunk {
-        StateDiffChunk::ContractDiff(contract_diff) => {
-            contract_diff.contract_address = contract_address;
-            contract_diff.class_hash = Some(class_hash);
-        }
-        StateDiffChunk::DeclaredClass(declared_class) => {
-            declared_class.class_hash = class_hash;
-            declared_class.compiled_class_hash = CompiledClassHash(rng.next_u64().into());
-        }
-        StateDiffChunk::DeprecatedDeclaredClass(deprecated_declared_class) => {
-            deprecated_declared_class.class_hash = class_hash;
-        }
-    }
-    state_diff_chunk
 }

--- a/crates/papyrus_p2p_sync/src/client/test_utils.rs
+++ b/crates/papyrus_p2p_sync/src/client/test_utils.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
 use std::time::{Duration, Instant};
 
 use futures::future::BoxFuture;
@@ -121,40 +123,66 @@ pub fn setup() -> TestArgs {
     }
 }
 
+#[derive(Eq, PartialEq, Hash)]
+pub enum DataType {
+    Header,
+    #[allow(dead_code)]
+    Transaction,
+    StateDiff,
+    #[allow(dead_code)]
+    Class,
+}
+
 pub enum Action {
     /// Get a header query from the sync and run custom validations on it.
-    ReceiveQuery(Box<dyn FnOnce(Query)>),
+    ReceiveQuery(Box<dyn FnOnce(Query)>, DataType),
     /// Send a header as a response to a query we got from ReceiveQuery. Will panic if didn't call
-    /// ReceiveQuery.
+    /// ReceiveQuery with DataType::Header before.
     SendHeader(DataOrFin<SignedBlockHeader>),
+    /// Send a state diff as a response to a query we got from ReceiveQuery. Will panic if didn't
+    /// call ReceiveQuery with DataType::StateDiff before.
+    #[allow(dead_code)]
+    SendStateDiff(DataOrFin<StateDiffChunk>),
+    /// Send a transaction as a response to a query we got from ReceiveQuery. Will panic if didn't
+    /// call ReceiveQuery with DataType::Transaction before.
+    #[allow(dead_code)]
+    SendTransaction(DataOrFin<FullTransaction>),
+    /// Send a class as a response to a query we got from ReceiveQuery. Will panic if didn't
+    /// call ReceiveQuery with DataType::Class before.
+    #[allow(dead_code)]
+    SendClass(DataOrFin<(ApiContractClass, ClassHash)>),
     /// Perform custom validations on the storage. Returns back the storage reader it received as
     /// input
     CheckStorage(Box<dyn FnOnce(StorageReader) -> BoxFuture<'static, ()>>),
     /// Check that a report was sent on the current header query.
-    ValidateReportSent,
+    ValidateReportSent(DataType),
 }
 
 // TODO(shahak): add support for state diffs, transactions and classes.
-pub async fn run_test(header_max_query_length: u64, actions: Vec<Action>) {
+pub async fn run_test(max_query_lengths: HashMap<DataType, u64>, actions: Vec<Action>) {
     let p2p_sync_config = P2PSyncClientConfig {
-        num_headers_per_query: header_max_query_length,
-        num_block_state_diffs_per_query: STATE_DIFF_QUERY_LENGTH,
-        num_block_transactions_per_query: TRANSACTION_QUERY_LENGTH,
-        num_block_classes_per_query: CLASS_DIFF_QUERY_LENGTH,
+        num_headers_per_query: max_query_lengths.get(&DataType::Header).cloned().unwrap_or(1),
+        num_block_state_diffs_per_query: max_query_lengths
+            .get(&DataType::StateDiff)
+            .cloned()
+            .unwrap_or(1),
+        num_block_transactions_per_query: max_query_lengths
+            .get(&DataType::Transaction)
+            .cloned()
+            .unwrap_or(1),
+        num_block_classes_per_query: max_query_lengths.get(&DataType::Class).cloned().unwrap_or(1),
         wait_period_for_new_data: WAIT_PERIOD_FOR_NEW_DATA,
         buffer_size: BUFFER_SIZE,
         stop_sync_at_block_number: None,
     };
     let buffer_size = p2p_sync_config.buffer_size;
     let ((storage_reader, storage_writer), _temp_dir) = get_test_storage();
-    let (header_sender, mut mock_header_response_manager) =
+    let (header_sender, mut mock_header_network) = mock_register_sqmr_protocol_client(buffer_size);
+    let (state_diff_sender, mut mock_state_diff_network) =
         mock_register_sqmr_protocol_client(buffer_size);
-    let (state_diff_sender, _mock_state_diff_response_manager) =
+    let (transaction_sender, mut mock_transaction_network) =
         mock_register_sqmr_protocol_client(buffer_size);
-    let (transaction_sender, _mock_transaction_response_manager) =
-        mock_register_sqmr_protocol_client(buffer_size);
-    let (class_sender, _mock_class_response_manager) =
-        mock_register_sqmr_protocol_client(buffer_size);
+    let (class_sender, mut mock_class_network) = mock_register_sqmr_protocol_client(buffer_size);
     let p2p_sync_channels = P2PSyncClientChannels {
         header_sender,
         state_diff_sender,
@@ -169,30 +197,93 @@ pub async fn run_test(header_max_query_length: u64, actions: Vec<Action>) {
     );
 
     let mut headers_current_query_responses_manager = None;
+    let mut state_diff_current_query_responses_manager = None;
+    let mut transaction_current_query_responses_manager = None;
+    let mut class_current_query_responses_manager = None;
 
     tokio::select! {
         _ = async {
             for action in actions {
                 match action {
-                    Action::ReceiveQuery(validate_query_fn) => {
-                        let responses_manager =
-                            mock_header_response_manager.next().await.unwrap();
-                        let query = responses_manager.query().as_ref().unwrap().0.clone();
+                    Action::ReceiveQuery(validate_query_fn, data_type) => {
+                        let query = match data_type {
+                            DataType::Header => {
+                                get_next_query(
+                                    &mut mock_header_network,
+                                    &mut headers_current_query_responses_manager,
+                                ).await.0
+                            }
+                            DataType::StateDiff => {
+                                get_next_query(
+                                    &mut mock_state_diff_network,
+                                    &mut state_diff_current_query_responses_manager,
+                                ).await.0
+                            }
+                            DataType::Transaction => {
+                                get_next_query(
+                                    &mut mock_transaction_network,
+                                    &mut transaction_current_query_responses_manager,
+                                ).await.0
+                            }
+                            DataType::Class => {
+                                get_next_query(
+                                    &mut mock_class_network,
+                                    &mut class_current_query_responses_manager,
+                                ).await.0
+                            }
+                        };
                         validate_query_fn(query);
-                        headers_current_query_responses_manager = Some(responses_manager);
                     }
                     Action::SendHeader(header_or_fin) => {
                         let responses_manager = headers_current_query_responses_manager.as_mut()
                             .expect("Called SendHeader without calling ReceiveQuery");
                         responses_manager.send_response(header_or_fin).await.unwrap();
                     }
+                    Action::SendStateDiff(state_diff_or_fin) => {
+                        let responses_manager = state_diff_current_query_responses_manager.as_mut()
+                            .expect("Called SendStateDiff without calling ReceiveQuery");
+                        responses_manager.send_response(state_diff_or_fin).await.unwrap();
+                    }
+                    Action::SendTransaction(transaction_or_fin) => {
+                        let responses_manager = transaction_current_query_responses_manager.as_mut()
+                            .expect("Called SendTransaction without calling ReceiveQuery");
+                        responses_manager.send_response(transaction_or_fin).await.unwrap();
+                    }
+                    Action::SendClass(class_or_fin) => {
+                        let responses_manager = class_current_query_responses_manager.as_mut()
+                            .expect("Called SendClass without calling ReceiveQuery");
+                        responses_manager.send_response(class_or_fin).await.unwrap();
+                    }
                     Action::CheckStorage(check_storage_fn) => {
                         // We tried avoiding the clone here but it causes lifetime issues.
                         check_storage_fn(storage_reader.clone()).await;
                     }
-                    Action::ValidateReportSent => {
+                    Action::ValidateReportSent(DataType::Header) => {
                         let responses_manager = headers_current_query_responses_manager.take()
-                            .expect("Called ValidateReportSent without calling ReceiveQuery");
+                            .expect(
+                                "Called ValidateReportSent without calling ReceiveQuery on the same
+                                data type");
+                        responses_manager.assert_reported(TIMEOUT_FOR_TEST).await;
+                    }
+                    Action::ValidateReportSent(DataType::StateDiff) => {
+                        let responses_manager = state_diff_current_query_responses_manager.take()
+                            .expect(
+                                "Called ValidateReportSent without calling ReceiveQuery on the same
+                                data type");
+                        responses_manager.assert_reported(TIMEOUT_FOR_TEST).await;
+                    }
+                    Action::ValidateReportSent(DataType::Transaction) => {
+                        let responses_manager = transaction_current_query_responses_manager.take()
+                            .expect(
+                                "Called ValidateReportSent without calling ReceiveQuery on the same
+                                data type");
+                        responses_manager.assert_reported(TIMEOUT_FOR_TEST).await;
+                    }
+                    Action::ValidateReportSent(DataType::Class) => {
+                        let responses_manager = class_current_query_responses_manager.take()
+                            .expect(
+                                "Called ValidateReportSent without calling ReceiveQuery on the same
+                                data type");
                         responses_manager.assert_reported(TIMEOUT_FOR_TEST).await;
                     }
                 }
@@ -250,18 +341,9 @@ pub fn create_block_hashes_and_signatures(n_blocks: u8) -> Vec<(BlockHash, Block
         .collect()
 }
 
-pub(crate) enum MarkerKind {
-    Header,
-    #[allow(dead_code)]
-    Body,
-    State,
-    #[allow(dead_code)]
-    Class,
-}
-
 // TODO: Consider moving this to storage and to use poll wakeup instead of sleep
 pub(crate) async fn wait_for_marker(
-    marker_kind: MarkerKind,
+    data_type: DataType,
     storage_reader: &StorageReader,
     expected_marker: BlockNumber,
     sleep_duration: Duration,
@@ -273,11 +355,11 @@ pub(crate) async fn wait_for_marker(
         assert!(start_time.elapsed() < timeout, "Timeout waiting for marker");
 
         let txn = storage_reader.begin_ro_txn().unwrap();
-        let storage_marker = match marker_kind {
-            MarkerKind::Header => txn.get_header_marker().unwrap(),
-            MarkerKind::Body => txn.get_body_marker().unwrap(),
-            MarkerKind::State => txn.get_state_marker().unwrap(),
-            MarkerKind::Class => txn.get_class_marker().unwrap(),
+        let storage_marker = match data_type {
+            DataType::Header => txn.get_header_marker().unwrap(),
+            DataType::Transaction => txn.get_body_marker().unwrap(),
+            DataType::StateDiff => txn.get_state_marker().unwrap(),
+            DataType::Class => txn.get_class_marker().unwrap(),
         };
 
         if storage_marker >= expected_marker {
@@ -286,4 +368,17 @@ pub(crate) async fn wait_for_marker(
 
         tokio::time::sleep(sleep_duration).await;
     }
+}
+
+async fn get_next_query<Query: TryFrom<Vec<u8>> + Clone, Response: TryFrom<Vec<u8>>>(
+    mock_network: &mut GenericReceiver<MockClientResponsesManager<Query, Response>>,
+    current_query_responses_manager: &mut Option<MockClientResponsesManager<Query, Response>>,
+) -> Query
+where
+    <Query as TryFrom<Vec<u8>>>::Error: Debug,
+{
+    let responses_manager = mock_network.next().await.unwrap();
+    let query = responses_manager.query().as_ref().unwrap().clone();
+    *current_query_responses_manager = Some(responses_manager);
+    query
 }

--- a/crates/papyrus_p2p_sync/src/client/test_utils.rs
+++ b/crates/papyrus_p2p_sync/src/client/test_utils.rs
@@ -141,7 +141,6 @@ pub enum Action {
     SendHeader(DataOrFin<SignedBlockHeader>),
     /// Send a state diff as a response to a query we got from ReceiveQuery. Will panic if didn't
     /// call ReceiveQuery with DataType::StateDiff before.
-    #[allow(dead_code)]
     SendStateDiff(DataOrFin<StateDiffChunk>),
     /// Send a transaction as a response to a query we got from ReceiveQuery. Will panic if didn't
     /// call ReceiveQuery with DataType::Transaction before.
@@ -149,7 +148,6 @@ pub enum Action {
     SendTransaction(DataOrFin<FullTransaction>),
     /// Send a class as a response to a query we got from ReceiveQuery. Will panic if didn't
     /// call ReceiveQuery with DataType::Class before.
-    #[allow(dead_code)]
     SendClass(DataOrFin<(ApiContractClass, ClassHash)>),
     /// Perform custom validations on the storage. Returns back the storage reader it received as
     /// input

--- a/crates/papyrus_p2p_sync/src/client/test_utils.rs
+++ b/crates/papyrus_p2p_sync/src/client/test_utils.rs
@@ -135,18 +135,38 @@ pub enum Action {
 }
 
 // TODO(shahak): add support for state diffs, transactions and classes.
-// TODO(shahak): add max query size as argument instead of constant.
-pub async fn run_test(actions: Vec<Action>) {
-    let TestArgs {
-        p2p_sync,
-        storage_reader,
-        mut mock_header_response_manager,
-        // The test will fail if we drop these
-        mock_state_diff_response_manager: _mock_state_diff_responses_manager,
-        mock_class_response_manager: _mock_class_responses_manager,
-        mock_transaction_response_manager: _mock_transaction_responses_manager,
-        ..
-    } = setup();
+pub async fn run_test(header_max_query_length: u64, actions: Vec<Action>) {
+    let p2p_sync_config = P2PSyncClientConfig {
+        num_headers_per_query: header_max_query_length,
+        num_block_state_diffs_per_query: STATE_DIFF_QUERY_LENGTH,
+        num_block_transactions_per_query: TRANSACTION_QUERY_LENGTH,
+        num_block_classes_per_query: CLASS_DIFF_QUERY_LENGTH,
+        wait_period_for_new_data: WAIT_PERIOD_FOR_NEW_DATA,
+        buffer_size: BUFFER_SIZE,
+        stop_sync_at_block_number: None,
+    };
+    let buffer_size = p2p_sync_config.buffer_size;
+    let ((storage_reader, storage_writer), _temp_dir) = get_test_storage();
+    let (header_sender, mut mock_header_response_manager) =
+        mock_register_sqmr_protocol_client(buffer_size);
+    let (state_diff_sender, _mock_state_diff_response_manager) =
+        mock_register_sqmr_protocol_client(buffer_size);
+    let (transaction_sender, _mock_transaction_response_manager) =
+        mock_register_sqmr_protocol_client(buffer_size);
+    let (class_sender, _mock_class_response_manager) =
+        mock_register_sqmr_protocol_client(buffer_size);
+    let p2p_sync_channels = P2PSyncClientChannels {
+        header_sender,
+        state_diff_sender,
+        transaction_sender,
+        class_sender,
+    };
+    let p2p_sync = P2PSyncClient::new(
+        p2p_sync_config,
+        storage_reader.clone(),
+        storage_writer,
+        p2p_sync_channels,
+    );
 
     let mut headers_current_query_responses_manager = None;
 

--- a/crates/papyrus_p2p_sync/src/client/transaction_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/transaction_test.rs
@@ -23,7 +23,7 @@ use super::test_utils::{
     TRANSACTION_QUERY_LENGTH,
     WAIT_PERIOD_FOR_NEW_DATA,
 };
-use crate::client::test_utils::{wait_for_marker, MarkerKind, TIMEOUT_FOR_TEST};
+use crate::client::test_utils::{wait_for_marker, DataType, TIMEOUT_FOR_TEST};
 
 #[tokio::test]
 async fn transaction_basic_flow() {
@@ -79,7 +79,7 @@ async fn transaction_basic_flow() {
         }
 
         wait_for_marker(
-            MarkerKind::Header,
+            DataType::Header,
             &storage_reader,
             BlockNumber(HEADER_QUERY_LENGTH),
             SLEEP_DURATION_TO_LET_SYNC_ADVANCE,
@@ -139,7 +139,7 @@ async fn transaction_basic_flow() {
                 // sent.
                 let block_number = BlockNumber(block_number);
                 wait_for_marker(
-                    MarkerKind::Body,
+                    DataType::Transaction,
                     &storage_reader,
                     block_number.unchecked_next(),
                     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,


### PR DESCRIPTION
- **refactor(papyrus_p2p_sync): add random_header utility function**
- **refactor(papyrus_p2p_sync): add_test receives query size instead of constant**
- **refactor(papyrus_p2p_sync): run_test supports all data types**
- **refactor(papyrus_p2p_sync): convert state diff tests to use run_test**
- **refactor(papyrus_p2p_sync): convert class tests to use run_test**
