### PR TITLE
chore(sequencing): remove ConsensusMessage from converter test

### DIFF
--- a/crates/papyrus_protobuf/src/consensus.rs
+++ b/crates/papyrus_protobuf/src/consensus.rs
@@ -31,6 +31,7 @@ pub struct Vote {
     pub voter: ContractAddress,
 }
 
+// TODO: remove this once we are sure everything works using just Vote.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum ConsensusMessage {
     Proposal(Proposal), // To be deprecated

--- a/crates/papyrus_protobuf/src/converters/consensus.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus.rs
@@ -24,6 +24,7 @@ use crate::consensus::{
 use crate::converters::ProtobufConversionError;
 use crate::{auto_impl_into_and_try_from_vec_u8, protobuf};
 
+// TODO(guyn): remove this once we integrate ProposalPart everywhere.
 impl TryFrom<protobuf::Proposal> for Proposal {
     type Error = ProtobufConversionError;
 

--- a/crates/papyrus_protobuf/src/converters/consensus_test.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus_test.rs
@@ -12,8 +12,8 @@ use starknet_api::transaction::{
 };
 
 use crate::consensus::{
-    ConsensusMessage,
-    Proposal,
+    ConsensusMessage, // TODO: remove this
+    Proposal,         // TODO: remove this
     ProposalFin,
     ProposalInit,
     ProposalPart,
@@ -51,11 +51,11 @@ fn add_gas_values_to_transaction(transactions: &mut [Transaction]) {
 fn convert_stream_message_to_vec_u8_and_back() {
     let mut rng = get_rng();
 
-    // Test that we can convert a StreamMessage with a ConsensusMessage message to bytes and back.
-    let mut stream_message: StreamMessage<ConsensusMessage> =
+    // Test that we can convert a StreamMessage with a ProposalPart message to bytes and back.
+    let mut stream_message: StreamMessage<ProposalPart> =
         StreamMessage::get_test_instance(&mut rng);
 
-    if let StreamMessageBody::Content(ConsensusMessage::Proposal(proposal)) =
+    if let StreamMessageBody::Content(ProposalPart::Transactions(proposal)) =
         &mut stream_message.message
     {
         add_gas_values_to_transaction(&mut proposal.transactions);

--- a/crates/papyrus_protobuf/src/converters/test_instances.rs
+++ b/crates/papyrus_protobuf/src/converters/test_instances.rs
@@ -64,10 +64,13 @@ auto_impl_get_test_instance! {
 
 // The auto_impl_get_test_instance macro does not work for StreamMessage because it has
 // a generic type. TODO(guyn): try to make the macro work with generic types.
-impl GetTestInstance for StreamMessage<ConsensusMessage> {
+impl GetTestInstance for StreamMessage<ProposalPart> {
     fn get_test_instance(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
         let message = if rng.gen_bool(0.5) {
-            StreamMessageBody::Content(ConsensusMessage::Proposal(Proposal::get_test_instance(rng)))
+            StreamMessageBody::Content(ProposalPart::Transactions(TransactionBatch {
+                transactions: vec![Transaction::get_test_instance(rng)],
+                tx_hashes: vec![TransactionHash::get_test_instance(rng)],
+            }))
         } else {
             StreamMessageBody::Fin
         };


### PR DESCRIPTION
I'm starting to remove the ConsensusMessage from where ever I can find it. It will come out in pieces. When done, I'll make another PR to remove it from the proto. 