### PR TITLE
chore: change sequencer_node_handle type to Vec to support multiple handles

### DIFF
--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -30,7 +30,7 @@ pub struct FlowTestSetup {
     pub rpc_storage_file_handle: TempDir,
 
     // Handle of the sequencer node.
-    pub sequencer_node_handle: JoinHandle<Result<(), anyhow::Error>>,
+    pub sequencer_node_handles: Vec<JoinHandle<Result<(), anyhow::Error>>>,
 
     // Channels for consensus proposals, used for asserting the right transactions are proposed.
     pub consensus_proposals_channels: BroadcastTopicChannels<StreamMessage<ProposalPart>>,
@@ -67,7 +67,7 @@ impl FlowTestSetup {
 
         // Build and run the sequencer node.
         let sequencer_node_future = run_component_servers(servers);
-        let sequencer_node_handle = task_executor.spawn_with_handle(sequencer_node_future);
+        let sequencer_node_handles = vec![task_executor.spawn_with_handle(sequencer_node_future)];
 
         // Wait for server to spin up.
         // TODO(Gilad): Replace with a persistent Client with a built-in retry to protect against CI
@@ -79,7 +79,7 @@ impl FlowTestSetup {
             add_tx_http_client,
             batcher_storage_file_handle: storage_for_test.batcher_storage_handle,
             rpc_storage_file_handle: storage_for_test.rpc_storage_handle,
-            sequencer_node_handle,
+            sequencer_node_handles,
             consensus_proposals_channels,
         }
     }


### PR DESCRIPTION
**Stack**:
- #2587
- #2585
- #2584
- #2583
- #2572 ⬅
- #2555
- #2554
- #2553


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*