### PR TITLE
fix(ci): add a CI type to `lld` whitelist

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,4 +10,5 @@ TABLEGEN_190_PREFIX = "/usr/lib/llvm-19/"
 # TODO: remove this once `rust` stabilizes `lld` as the default linker, currently only on nightly:
 # https://github.com/rust-lang/rust/issues/39915#issuecomment-618726211
 [target.x86_64-unknown-linux-gnu]
+[target.stable-x86_64-unknown-linux-gnu]
 rustflags = ["-Clink-arg=-fuse-ld=lld"]


### PR DESCRIPTION
x86_64-unknown-linux-gnu is run locally and also ran in the CI until we added inherit_toolchain, which seems to prepend `stable-` to the target-string.