### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -629,7 +629,7 @@ impl NetworkManager {
         } = config;
 
         let listen_addresses = vec![
-            // TODO: uncomment once quic transpot works.
+            // TODO: uncomment once quic transport works.
             // format!("/ip4/0.0.0.0/udp/{quic_port}/quic-v1"),
             format!("/ip4/0.0.0.0/tcp/{tcp_port}"),
         ];

--- a/crates/papyrus_rpc/src/test_utils.rs
+++ b/crates/papyrus_rpc/src/test_utils.rs
@@ -98,7 +98,7 @@ pub(crate) fn get_test_rpc_server_and_storage_writer_from_params<T: JsonRpcServe
 // `params_obj` should be serialized to the format that JSON-RPC expects, which is either an array
 // of parameters or a map from parameter name to parameter.
 //
-// For example (the parameteres of getTransactionByBlockIdAndIndex"):
+// For example (the parameters of getTransactionByBlockIdAndIndex"):
 // ["latest", 5] or {"block_id": "latest", "index": 5}.
 pub(crate) async fn raw_call<R: JsonRpcServerTrait, S: Serialize, T: for<'a> Deserialize<'a>>(
     module: &RpcModule<R>,

--- a/deployments/papyrus/install_papyrus.py
+++ b/deployments/papyrus/install_papyrus.py
@@ -15,7 +15,7 @@ def parse_command_line_args():
     parser.add_argument("--namespace", type=str, required=True, help="Target namespace for the Papyrus node.")
     parser.add_argument("--create_namespace", action="store_true", default=False, help="Enabling this option will install a new namespace with the given name.")
     parser.add_argument("--values_file", action="store", default=None, help="Add additional values file.")
-    parser.add_argument("--with_alerts", action="store_true", default=False, help="Enabling this option will also deploy a grafana alerts deashboard with the pod.")
+    parser.add_argument("--with_alerts", action="store_true", default=False, help="Enabling this option will also deploy a grafana alerts dashboard with the pod.")
     parser.add_argument("--prometheus_uid", type=str, required=False, help="UID for prometheus (to use with Grafana).")
     parser.add_argument("--old_version", type=str, required=False, help="Represents previous RPC version for the desired env (e.g. v0_3).")
     parser.add_argument("--new_version", type=str, required=False, help="Represents current RPC version for the desired env (e.g. v0_4).")


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `transpot` to `transport`
Corrected `parameteres` to `parameters`
Corrected `deashboard` to `dashboard`

Please review the changes and let me know if any additional changes are needed.