### PR TITLE
fix(sequencing): replace vectors with arrays as test function inputs

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
@@ -35,13 +35,13 @@ mod tests {
     }
 
     // Check if two vectors are the same, regardless of ordering
-    fn do_vecs_match_unordered<T: PartialEq + Ord + Clone>(a: &Vec<T>, b: &Vec<T>) -> bool
+    fn do_vecs_match_unordered<T: PartialEq + Ord + Clone>(a: &[T], b: &[T]) -> bool
     where
         T: std::hash::Hash + Eq,
     {
-        let mut a = a.clone();
+        let mut a = a.to_owned();
         a.sort();
-        let mut b = b.clone();
+        let mut b = b.to_owned();
         b.sort();
         a == b
     }


### PR DESCRIPTION
This solves a clippy error on the test `stream_handler_test` which uses a helper function. Accepting arrays instead of vector refs is a good idea in general. 