### PR TITLE
chore(consensus): move the todo on ProposalFin to Matan

### DIFF
--- a/crates/papyrus_protobuf/src/consensus.rs
+++ b/crates/papyrus_protobuf/src/consensus.rs
@@ -86,7 +86,7 @@ pub struct TransactionBatch {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProposalFin {
     /// The block hash of the proposed block.
-    /// TODO(guyn): Consider changing the content ID
+    /// TODO(Matan): Consider changing the content ID to a signature.
     pub proposal_content_id: BlockHash,
 }
 


### PR DESCRIPTION
This todo item seems more like something Matan would know how to do. 
Need to either move it to him or remove the comment. 