### PR TITLE
fix(ci): install taplo through moonrepo

### DIFF
--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -8,3 +8,6 @@ runs:
       with:
         cache-base: main(-v[0-9].*)?
         inherit-toolchain: true
+        bins: taplo-cli@0.9.0
+      env:
+        RUSTFLAGS: "-C link-arg=-fuse-ld=lld"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,7 @@ jobs:
           # Fetch the entire history. Required to checkout the merge target commit, so the diff can
           # be computed.
           fetch-depth: 0
-      - uses: baptiste0928/cargo-install@v3
-        with:
-          crate: taplo-cli
-          version: '0.9.0'
-          locked: true
+
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Looks like cargo-install action isn't picking up the `lld` rustflags inside main.yml.

Anyhow, installing through moonrepo is probably better anyway, since it
is already installing rust.
