### PR TITLE
typos-Update entry_point.rs

### DIFF
--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -170,7 +170,7 @@ impl CallEntryPoint {
     ) -> EntryPointExecutionResult<CallInfo> {
         let execution_result = self.execute(state, context, remaining_gas);
         if let Ok(call_info) = &execution_result {
-            // If the execution of the outer call failed, revert the transction.
+            // If the execution of the outer call failed, revert the transaction.
             if call_info.execution.failed {
                 return Err(EntryPointExecutionError::ExecutionFailed {
                     error_trace: extract_trailing_cairo1_revert_trace(
@@ -221,7 +221,7 @@ pub struct EntryPointExecutionContext {
     // The call stack of tracked resources from the first entry point to the current.
     pub tracked_resource_stack: Vec<TrackedResource>,
 
-    // Information for reverting the state (inludes the revert info of the callers).
+    // Information for reverting the state (includes the revert info of the callers).
     pub revert_infos: ExecutionRevertInfo,
 }
 


### PR DESCRIPTION
# Fix: Corrected typos in Rust source files

## What was changed
1. **Corrected typos**:
   - Replaced `transction` with `transaction` in `crates/blockifier/src/execution/entry_point.rs:173`.
   - Replaced `inludes` with `includes` in `crates/blockifier/src/execution/entry_point.rs:224`.

## Why these changes were made
- **Fixing typos** improves the clarity and professionalism of the codebase, ensuring accuracy and ease of understanding for developers.

## Additional Notes
- These changes focus solely on correcting typographical errors and do not affect the functionality of the code.
