### PR TITLE
fix(consensus): remove the Clone trait bound from StreamData

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/stream_handler.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler.rs
@@ -32,7 +32,7 @@ const CHANNEL_BUFFER_LENGTH: usize = 100;
 // Drop the struct when:
 // (1) receiver on the other end is dropped,
 // (2) fin message is received and all messages are sent.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct StreamData<
     T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + 'static,
 > {

--- a/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler_test.rs
@@ -184,9 +184,9 @@ mod tests {
         );
         let range: Vec<u64> = (1..6).collect();
         let keys: Vec<u64> = stream_handler.inbound_stream_data[&(peer_id, stream_id)]
-            .clone()
             .message_buffer
-            .into_keys()
+            .keys()
+            .copied()
             .collect();
         assert!(do_vecs_match_unordered(&keys, &range));
 
@@ -254,20 +254,14 @@ mod tests {
         let mut stream_handler = join_handle.await.expect("Task should succeed");
 
         let values = [(peer_id.clone(), 1), (peer_id.clone(), 10), (peer_id.clone(), 127)];
-        assert!(
-            stream_handler
-                .inbound_stream_data
-                .clone()
-                .into_keys()
-                .all(|item| values.contains(&item))
-        );
+        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
 
         // We have all message from 1 to 9 buffered.
         assert!(do_vecs_match_unordered(
             &stream_handler.inbound_stream_data[&(peer_id.clone(), stream_id1)]
                 .message_buffer
-                .clone()
-                .into_keys()
+                .keys()
+                .copied()
                 .collect::<Vec<_>>(),
             &(1..10).collect::<Vec<_>>()
         ));
@@ -276,8 +270,8 @@ mod tests {
         assert!(do_vecs_match_unordered(
             &stream_handler.inbound_stream_data[&(peer_id.clone(), stream_id2)]
                 .message_buffer
-                .clone()
-                .into_keys()
+                .keys()
+                .copied()
                 .collect::<Vec<_>>(),
             &(1..6).collect::<Vec<_>>()
         ));
@@ -286,8 +280,8 @@ mod tests {
         assert!(do_vecs_match_unordered(
             &stream_handler.inbound_stream_data[&(peer_id.clone(), stream_id3)]
                 .message_buffer
-                .clone()
-                .into_keys()
+                .keys()
+                .copied()
                 .collect::<Vec<_>>(),
             &(1..10).collect::<Vec<_>>()
         ));
@@ -328,13 +322,7 @@ mod tests {
 
         // stream_id1 should be gone
         let values = [(peer_id.clone(), 1), (peer_id.clone(), 10)];
-        assert!(
-            stream_handler
-                .inbound_stream_data
-                .clone()
-                .into_keys()
-                .all(|item| values.contains(&item))
-        );
+        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
 
         // Send the last message on stream_id2:
         send(&mut network_sender, &inbound_metadata, make_test_message(stream_id2, 0, false)).await;
@@ -355,13 +343,7 @@ mod tests {
 
         // Stream_id2 should also be gone.
         let values = [(peer_id.clone(), 1)];
-        assert!(
-            stream_handler
-                .inbound_stream_data
-                .clone()
-                .into_keys()
-                .all(|item| values.contains(&item))
-        );
+        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
 
         // Send the last message on stream_id3:
         send(&mut network_sender, &inbound_metadata, make_test_message(stream_id3, 0, false)).await;
@@ -380,13 +362,7 @@ mod tests {
 
         // Stream_id3 should still be there, because we didn't send a fin.
         let values = [(peer_id.clone(), 1)];
-        assert!(
-            stream_handler
-                .inbound_stream_data
-                .clone()
-                .into_keys()
-                .all(|item| values.contains(&item))
-        );
+        assert!(stream_handler.inbound_stream_data.keys().all(|item| values.contains(item)));
 
         // But the buffer should be empty, as we've successfully drained it all.
         assert!(


### PR DESCRIPTION
I found that having `Clone` on `StreamData` is not necessary. I need to remove it so I can add a receiver to the data, and receiver doens't implement `Clone`. The need for this receiver will be made clear in the next PR. 