### PR TITLE
fix(ci): fix warnings

### DIFF
--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -80,6 +80,7 @@ infra_utils.workspace = true
 harness = false
 name = "blockifier_bench"
 path = "bench/blockifier_bench.rs"
+required-features = ["testing"]
 
 [[test]]
 name = "feature_contracts_compatibility_test"

--- a/crates/blockifier/src/state/stateful_compression_test.rs
+++ b/crates/blockifier/src/state/stateful_compression_test.rs
@@ -66,10 +66,10 @@ fn test_alias_updater(
     #[case] expected_alias_keys: Vec<Felt>,
     #[values(0, 2)] n_existing_aliases: u8,
 ) {
-    let mut state = initial_state(n_existing_aliases);
+    let state = initial_state(n_existing_aliases);
 
     // Insert the keys into the alias contract updater and finalize the updates.
-    let mut alias_contract_updater = AliasUpdater::new(&mut state).unwrap();
+    let mut alias_contract_updater = AliasUpdater::new(&state).unwrap();
     for key in keys {
         alias_contract_updater.insert_alias(&StorageKey::try_from(key).unwrap()).unwrap();
     }

--- a/crates/sequencing/papyrus_consensus/src/single_height_consensus_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/single_height_consensus_test.rs
@@ -5,7 +5,6 @@ use papyrus_protobuf::consensus::{ConsensusMessage, ProposalFin, ProposalInit};
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_types_core::felt::Felt;
 use test_case::test_case;
-use tokio;
 
 use super::SingleHeightConsensus;
 use crate::config::TimeoutsConfig;

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -44,7 +44,7 @@ class BaseCommand(Enum):
             return ["scripts/rust_fmt.sh"] + fmt_args + ["--", "--check"]
         elif self == BaseCommand.CLIPPY:
             clippy_args = package_args if len(package_args) > 0 else ["--workspace"]
-            return ["cargo", "clippy"] + clippy_args
+            return ["cargo", "clippy"] + clippy_args + ["--all-targets"]
         elif self == BaseCommand.DOC:
             doc_args = package_args if len(package_args) > 0 else ["--workspace"]
             return ["cargo", "doc", "-r", "--document-private-items", "--no-deps"] + doc_args


### PR DESCRIPTION
Without --all-targets they don't run on tests and benchmarks.