### PR TITLE
chore(starknet_integration_tests): use available ports for rpc state reader

### DIFF
--- a/crates/starknet_integration_tests/src/integration_test_setup.rs
+++ b/crates/starknet_integration_tests/src/integration_test_setup.rs
@@ -11,7 +11,7 @@ use starknet_sequencer_infra::test_utils::AvailablePorts;
 use tempfile::{tempdir, TempDir};
 
 use crate::config_utils::dump_config_file_changes;
-use crate::state_reader::{spawn_test_rpc_state_reader, StorageTestSetup};
+use crate::state_reader::{spawn_test_rpc_state_reader_with_socket, StorageTestSetup};
 use crate::utils::{
     create_chain_info,
     create_config,
@@ -53,16 +53,17 @@ impl IntegrationTestSetup {
         tx_generator: &MultiAccountTransactionGenerator,
         test_unique_index: u16,
     ) -> Self {
-        let available_ports = AvailablePorts::new(test_unique_index, 0);
+        let mut available_ports = AvailablePorts::new(test_unique_index, 0);
 
         let chain_info = create_chain_info();
         // Creating the storage for the test.
         let storage_for_test = StorageTestSetup::new(tx_generator.accounts(), &chain_info);
 
         // Spawn a papyrus rpc server for a papyrus storage reader.
-        let rpc_server_addr = spawn_test_rpc_state_reader(
+        let rpc_server_addr = spawn_test_rpc_state_reader_with_socket(
             storage_for_test.rpc_storage_reader,
             chain_info.chain_id.clone(),
+            available_ports.get_next_local_host_socket(),
         )
         .await;
 

--- a/crates/starknet_integration_tests/src/state_reader.rs
+++ b/crates/starknet_integration_tests/src/state_reader.rs
@@ -274,17 +274,25 @@ fn test_block_header(block_number: BlockNumber) -> BlockHeader {
     }
 }
 
-/// Spawns a papyrus rpc server for given state reader.
+/// Spawns a papyrus rpc server for given state reader and chain id.
 /// Returns the address of the rpc server.
 pub async fn spawn_test_rpc_state_reader(
     storage_reader: StorageReader,
     chain_id: ChainId,
 ) -> SocketAddr {
-    let rpc_config = RpcConfig {
-        chain_id,
-        server_address: get_available_socket().await.to_string(),
-        ..Default::default()
-    };
+    let socket = get_available_socket().await;
+    spawn_test_rpc_state_reader_with_socket(storage_reader, chain_id, socket).await;
+    socket
+}
+
+/// Spawns a papyrus rpc server for given state reader, chain id, and socket address.
+pub async fn spawn_test_rpc_state_reader_with_socket(
+    storage_reader: StorageReader,
+    chain_id: ChainId,
+    socket: SocketAddr,
+) -> SocketAddr {
+    let rpc_config =
+        RpcConfig { chain_id, server_address: socket.to_string(), ..Default::default() };
     let (addr, handle) = run_server(
         &rpc_config,
         Arc::new(RwLock::new(None)),


### PR DESCRIPTION
**Stack**:
- #2796
- #2795
- #2794
- #2789
- #2788
- #2787
- #2786
- #2781 ⬅
- #2780


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*