### PR TITLE
fix(ci): cache machete install

### DIFF
--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -8,6 +8,6 @@ runs:
       with:
         cache-base: main(-v[0-9].*)?
         inherit-toolchain: true
-        bins: taplo-cli@0.9.0
+        bins: taplo-cli@0.9.0, cargo-machete
       env:
         RUSTFLAGS: "-C link-arg=-fuse-ld=lld"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       - name: "Run taplo"
         run: scripts/taplo.sh
       - name: Run Machete (detect unused dependencies)
-        uses: bnjbvr/cargo-machete@main
+        run: cargo machete
 
   run-workspace-tests:
     runs-on: starkware-ubuntu-latest-medium


### PR DESCRIPTION
Benchmark: installation is cached, now 7 seconds down from 45.

Verify that machete still fails builds with this setting: https://github.com/starkware-libs/sequencer/actions/runs/12399068544/job/34613195214?pr=2783