### PR TITLE
fix(ci): compile rust docs in release and deny warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ on:
 env:
   CI: 1
   RUSTFLAGS: "-D warnings -C link-arg=-fuse-ld=lld"
+  RUSTDOCFLAGS: "-D warnings -C link-arg=-fuse-ld=lld"
   EXTRA_RUST_TOOLCHAINS: nightly-2024-04-29
 
 # On PR events, cancel existing CI runs on this same PR for this workflow.

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -343,8 +343,8 @@ impl SyscallResponse for GetBlockHashResponse {
 
 /// Returns the block hash of a given block_number.
 /// Returns the expected block hash if the given block was created at least
-/// [constants::STORED_BLOCK_HASH_BUFFER] blocks before the current block. Otherwise, returns an
-/// error.
+/// [crate::abi::constants::STORED_BLOCK_HASH_BUFFER] blocks before the current block. Otherwise,
+/// returns an error.
 pub fn get_block_hash(
     request: GetBlockHashRequest,
     _vm: &mut VirtualMachine,

--- a/crates/starknet_api/src/state.rs
+++ b/crates/starknet_api/src/state.rs
@@ -247,7 +247,7 @@ impl From<cairo_lang_starknet_classes::contract_class::ContractClass> for Sierra
     }
 }
 
-/// An entry point of a [ContractClass](`crate::state::ContractClass`).
+/// An entry point of a [SierraContractClass](`SierraContractClass`).
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct EntryPoint {
     pub function_idx: FunctionIndex,

--- a/crates/starknet_sequencer_node/src/clients.rs
+++ b/crates/starknet_sequencer_node/src/clients.rs
@@ -64,8 +64,8 @@ pub struct SequencerNodeClients {
 ///
 /// # Returns
 ///
-/// An Option<Arc<dyn ClientTrait>> containing the available client (local_client or remote_client),
-/// wrapped in Arc. If neither exists, returns None.
+/// An `Option<Arc<dyn ClientTrait>>` containing the available client (local_client or
+/// remote_client), wrapped in Arc. If neither exists, returns None.
 ///
 /// # Example
 ///

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -33,7 +33,7 @@ class BaseCommand(Enum):
             return ["cargo", "clippy"] + clippy_args + ["--all-targets"]
         elif self == BaseCommand.DOC:
             doc_args = package_args if len(package_args) > 0 else ["--workspace"]
-            return ["cargo", "doc", "-r", "--document-private-items", "--no-deps"] + doc_args
+            return ["cargo", "doc", "--document-private-items", "--no-deps"] + doc_args
 
         raise NotImplementedError(f"Command {self} not implemented.")
 


### PR DESCRIPTION
- No reason to run cargo on release in the ci, and this busts cache
- Cargo doc doesn't pick up the usual place we pass -Dwarnings, which is
  RUSTFLAGS, it needs a special flag RUSTDOCFLAGS (it cannot reference
  the usual RUSTFLAGS so we have to duplicate)



