### PR TITLE
refactor(papyrus_base_layer): extract last l1 number

### DIFF
--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -1,5 +1,5 @@
 use pretty_assertions::assert_eq;
-use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
 use starknet_api::felt;
 
 use crate::ethereum_base_layer_contract::{EthereumBaseLayerConfig, EthereumBaseLayerContract};
@@ -26,11 +26,14 @@ async fn latest_proved_block_ethereum() {
     };
     let contract = EthereumBaseLayerContract::new(config);
 
-    let first_sn_state_update = (BlockNumber(100), BlockHash(felt!("0x100")));
-    let second_sn_state_update = (BlockNumber(200), BlockHash(felt!("0x200")));
-    let third_sn_state_update = (BlockNumber(300), BlockHash(felt!("0x300")));
+    let first_sn_state_update =
+        BlockHashAndNumber { number: BlockNumber(100), hash: BlockHash(felt!("0x100")) };
+    let second_sn_state_update =
+        BlockHashAndNumber { number: BlockNumber(200), hash: BlockHash(felt!("0x200")) };
+    let third_sn_state_update =
+        BlockHashAndNumber { number: BlockNumber(300), hash: BlockHash(felt!("0x300")) };
 
-    type Scenario = (u64, Option<(BlockNumber, BlockHash)>);
+    type Scenario = (u64, Option<BlockHashAndNumber>);
     let scenarios: Vec<Scenario> = vec![
         (0, Some(third_sn_state_update)),
         (5, Some(third_sn_state_update)),

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::block::BlockHashAndNumber;
 
 pub mod ethereum_base_layer_contract;
 
@@ -19,5 +19,7 @@ pub trait BaseLayerContract {
     async fn latest_proved_block(
         &self,
         finality: u64,
-    ) -> Result<Option<(BlockNumber, BlockHash)>, Self::Error>;
+    ) -> Result<Option<BlockHashAndNumber>, Self::Error>;
+
+    async fn latest_l1_block_number(&self, finality: u64) -> Result<Option<u64>, Self::Error>;
 }

--- a/crates/papyrus_sync/src/sources/base_layer.rs
+++ b/crates/papyrus_sync/src/sources/base_layer.rs
@@ -39,6 +39,7 @@ impl<
         let finality = 0;
         self.latest_proved_block(finality)
             .await
+            .map(|block| block.map(|block| (block.number, block.hash)))
             .map_err(|e| BaseLayerSourceError::BaseLayerContractError(Box::new(e)))
     }
 }


### PR DESCRIPTION
- add l1 latest block getter to base layer trait (will be used in later commits).
- use `BlockHashAndNumber` instead of tuple.