### PR TITLE
fix(consensus): send init before starting work on proposal content

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/stream_handler.rs
+++ b/crates/sequencing/papyrus_consensus/src/stream_handler.rs
@@ -191,13 +191,6 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
         // TODO(guyn): reconsider the "expect" here.
         let sender = &mut data.sender;
         if let StreamMessageBody::Content(content) = message.message {
-            if message.message_id == 0 {
-                // TODO(guyn): consider the expect in both cases.
-                // If this is the first message, send the receiver to the application.
-                let receiver = data.receiver.take().expect("Receiver should exist");
-                // Send the receiver to the application.
-                self.inbound_channel_sender.try_send(receiver).expect("Send should succeed");
-            }
             match sender.try_send(content) {
                 Ok(_) => {}
                 Err(e) => {
@@ -220,6 +213,14 @@ impl<T: Clone + Send + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversi
                     }
                 }
             };
+            // Send the receiver only once the first message has been sent.
+            if message.message_id == 0 {
+                // TODO(guyn): consider the expect in both cases.
+                // If this is the first message, send the receiver to the application.
+                let receiver = data.receiver.take().expect("Receiver should exist");
+                // Send the receiver to the application.
+                self.inbound_channel_sender.try_send(receiver).expect("Send should succeed");
+            }
             data.next_message_id += 1;
             return false;
         }


### PR DESCRIPTION
Sometimes we get this error: 
`2024-12-24T15:31:05.495525Z ERROR starknet_consensus_manager::consensus_manager: Error running component ConsensusManager: InternalNetworkError("Stream handler must fill the first message before sending the stream")`
From this [test run](https://github.com/starkware-libs/sequencer/actions/runs/12483489296/job/34839351984).

This is probably because of the way `StreamHandler.inbound_send()` works. It first checks if there's a need to send the receiver and then puts a message inside it. I've flipped the order, I hope this solves the problem. 