### PR TITLE
feat(starknet_gateway): use sync state reader instead of rpc

### DIFF
--- a/config/sequencer/default_config.json
+++ b/config/sequencer/default_config.json
@@ -944,16 +944,6 @@
     "privacy": "Public",
     "value": 8082
   },
-  "rpc_state_reader_config.json_rpc_version": {
-    "description": "The json rpc version.",
-    "privacy": "Public",
-    "value": "2.0"
-  },
-  "rpc_state_reader_config.url": {
-    "description": "The url of the rpc server.",
-    "privacy": "Public",
-    "value": ""
-  },
   "state_sync_config.network_config.advertised_multiaddr": {
     "description": "The external address other peers see this node. If this is set, the node will not try to find out which addresses it has and will write this address as external instead",
     "privacy": "Public",

--- a/crates/starknet_gateway/src/gateway.rs
+++ b/crates/starknet_gateway/src/gateway.rs
@@ -11,15 +11,16 @@ use starknet_mempool_types::communication::{AddTransactionArgsWrapper, SharedMem
 use starknet_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
 use starknet_sequencer_infra::component_definitions::ComponentStarter;
 use starknet_sierra_compile::config::SierraToCasmCompilationConfig;
+use starknet_state_sync_types::communication::SharedStateSyncClient;
 use tracing::{error, info, instrument, Span};
 
 use crate::compilation::GatewayCompiler;
-use crate::config::{GatewayConfig, RpcStateReaderConfig};
+use crate::config::GatewayConfig;
 use crate::errors::GatewayResult;
-use crate::rpc_state_reader::RpcStateReaderFactory;
 use crate::state_reader::StateReaderFactory;
 use crate::stateful_transaction_validator::StatefulTransactionValidator;
 use crate::stateless_transaction_validator::StatelessTransactionValidator;
+use crate::sync_state_reader::SyncStateReaderFactory;
 use crate::utils::compile_contract_and_build_executable_tx;
 
 #[cfg(test)]
@@ -148,11 +149,11 @@ impl ProcessTxBlockingTask {
 
 pub fn create_gateway(
     config: GatewayConfig,
-    rpc_state_reader_config: RpcStateReaderConfig,
+    shared_state_sync_client: SharedStateSyncClient,
     compiler_config: SierraToCasmCompilationConfig,
     mempool_client: SharedMempoolClient,
 ) -> Gateway {
-    let state_reader_factory = Arc::new(RpcStateReaderFactory { config: rpc_state_reader_config });
+    let state_reader_factory = Arc::new(SyncStateReaderFactory { shared_state_sync_client });
     let gateway_compiler = GatewayCompiler::new_command_line_compiler(compiler_config);
 
     Gateway::new(config, state_reader_factory, gateway_compiler, mempool_client)

--- a/crates/starknet_gateway/src/sync_state_reader.rs
+++ b/crates/starknet_gateway/src/sync_state_reader.rs
@@ -12,7 +12,6 @@ use starknet_types_core::felt::Felt;
 
 use crate::state_reader::{MempoolStateReader, StateReaderFactory};
 
-#[allow(dead_code)]
 struct SyncStateReader {
     block_number: BlockNumber,
     state_sync_client: SharedStateSyncClient,

--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -21,7 +21,7 @@ use starknet_sequencer_node::utils::create_node_modules;
 use tempfile::TempDir;
 use tracing::{debug, instrument};
 
-use crate::state_reader::{spawn_test_rpc_state_reader, StorageTestSetup};
+use crate::state_reader::StorageTestSetup;
 use crate::utils::{
     create_chain_info,
     create_config,
@@ -105,7 +105,6 @@ pub struct FlowSequencerSetup {
 
     // Handlers for the storage files, maintained so the files are not deleted.
     pub batcher_storage_file_handle: TempDir,
-    pub rpc_storage_file_handle: TempDir,
     pub state_sync_storage_file_handle: TempDir,
 
     // Node configuration.
@@ -127,13 +126,6 @@ impl FlowSequencerSetup {
     ) -> Self {
         let storage_for_test = StorageTestSetup::new(accounts, &chain_info);
 
-        // Spawn a papyrus rpc server for a papyrus storage reader.
-        let rpc_server_addr = spawn_test_rpc_state_reader(
-            storage_for_test.rpc_storage_reader,
-            chain_info.chain_id.clone(),
-        )
-        .await;
-
         let component_config = ComponentConfig::default();
 
         // Derive the configuration for the sequencer node.
@@ -141,7 +133,6 @@ impl FlowSequencerSetup {
             &mut available_ports,
             sequencer_index,
             chain_info,
-            rpc_server_addr,
             storage_for_test.batcher_storage_config,
             storage_for_test.state_sync_storage_config,
             consensus_manager_config,
@@ -166,7 +157,6 @@ impl FlowSequencerSetup {
             sequencer_index,
             add_tx_http_client,
             batcher_storage_file_handle: storage_for_test.batcher_storage_handle,
-            rpc_storage_file_handle: storage_for_test.rpc_storage_handle,
             state_sync_storage_file_handle: storage_for_test.state_sync_storage_handle,
             config,
             is_alive_test_client,

--- a/crates/starknet_integration_tests/src/integration_test_setup.rs
+++ b/crates/starknet_integration_tests/src/integration_test_setup.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinHandle;
 use tracing::{info, instrument};
 
 use crate::config_utils::dump_config_file_changes;
-use crate::state_reader::{spawn_test_rpc_state_reader_with_socket, StorageTestSetup};
+use crate::state_reader::StorageTestSetup;
 use crate::utils::{
     create_chain_info,
     create_config,
@@ -134,8 +134,6 @@ pub struct IntegrationSequencerSetup {
     #[allow(dead_code)]
     batcher_storage_handle: TempDir,
     #[allow(dead_code)]
-    rpc_storage_handle: TempDir,
-    #[allow(dead_code)]
     node_config_dir_handle: TempDir,
     #[allow(dead_code)]
     state_sync_storage_handle: TempDir,
@@ -155,20 +153,11 @@ impl IntegrationSequencerSetup {
         // Creating the storage for the test.
         let storage_for_test = StorageTestSetup::new(accounts, &chain_info);
 
-        // Spawn a papyrus rpc server for a papyrus storage reader.
-        let rpc_server_addr = spawn_test_rpc_state_reader_with_socket(
-            storage_for_test.rpc_storage_reader,
-            chain_info.chain_id.clone(),
-            available_ports.get_next_local_host_socket(),
-        )
-        .await;
-
         // Derive the configuration for the sequencer node.
         let (config, required_params) = create_config(
             available_ports,
             sequencer_index,
             chain_info,
-            rpc_server_addr,
             storage_for_test.batcher_storage_config,
             storage_for_test.state_sync_storage_config,
             consensus_manager_config,
@@ -197,7 +186,6 @@ impl IntegrationSequencerSetup {
             is_alive_test_client,
             batcher_storage_handle: storage_for_test.batcher_storage_handle,
             batcher_storage_config: config.batcher_config.storage,
-            rpc_storage_handle: storage_for_test.rpc_storage_handle,
             node_config_dir_handle,
             node_config_path,
             state_sync_storage_handle: storage_for_test.state_sync_storage_handle,

--- a/crates/starknet_integration_tests/src/state_reader.rs
+++ b/crates/starknet_integration_tests/src/state_reader.rs
@@ -50,9 +50,6 @@ type ContractClassesMap =
     (Vec<(ClassHash, DeprecatedContractClass)>, Vec<(ClassHash, CasmContractClass)>);
 
 pub struct StorageTestSetup {
-    // TODO(Shahak): Remove rpc storage reader and handle
-    pub rpc_storage_reader: StorageReader,
-    pub rpc_storage_handle: TempDir,
     pub batcher_storage_config: StorageConfig,
     pub batcher_storage_handle: TempDir,
     pub state_sync_storage_config: StorageConfig,
@@ -61,9 +58,6 @@ pub struct StorageTestSetup {
 
 impl StorageTestSetup {
     pub fn new(test_defined_accounts: Vec<Contract>, chain_info: &ChainInfo) -> Self {
-        let ((rpc_storage_reader, mut rpc_storage_writer), _, rpc_storage_file_handle) =
-            TestStorageBuilder::default().chain_id(chain_info.chain_id.clone()).build();
-        create_test_state(&mut rpc_storage_writer, chain_info, test_defined_accounts.clone());
         let ((_, mut batcher_storage_writer), batcher_storage_config, batcher_storage_file_handle) =
             TestStorageBuilder::default()
                 .scope(StorageScope::StateOnly)
@@ -80,8 +74,6 @@ impl StorageTestSetup {
             .build();
         create_test_state(&mut state_sync_storage_writer, chain_info, test_defined_accounts);
         Self {
-            rpc_storage_reader,
-            rpc_storage_handle: rpc_storage_file_handle,
             batcher_storage_config,
             batcher_storage_handle: batcher_storage_file_handle,
             state_sync_storage_config,

--- a/crates/starknet_integration_tests/src/utils.rs
+++ b/crates/starknet_integration_tests/src/utils.rs
@@ -1,5 +1,4 @@
 use std::future::Future;
-use std::net::SocketAddr;
 use std::time::Duration;
 
 use blockifier::context::ChainInfo;
@@ -24,7 +23,6 @@ use starknet_batcher::config::BatcherConfig;
 use starknet_consensus_manager::config::ConsensusManagerConfig;
 use starknet_gateway::config::{
     GatewayConfig,
-    RpcStateReaderConfig,
     StatefulTransactionValidatorConfig,
     StatelessTransactionValidatorConfig,
 };
@@ -55,7 +53,6 @@ pub async fn create_config(
     available_ports: &mut AvailablePorts,
     sequencer_index: usize,
     chain_info: ChainInfo,
-    rpc_server_addr: SocketAddr,
     batcher_storage_config: StorageConfig,
     state_sync_storage_config: StorageConfig,
     mut consensus_manager_config: ConsensusManagerConfig,
@@ -68,7 +65,6 @@ pub async fn create_config(
     let gateway_config = create_gateway_config(chain_info.clone()).await;
     let http_server_config =
         create_http_server_config(available_ports.get_next_local_host_socket()).await;
-    let rpc_state_reader_config = test_rpc_state_reader_config(rpc_server_addr);
     let monitoring_endpoint_config =
         MonitoringEndpointConfig { port: available_ports.get_next_port(), ..Default::default() };
     let state_sync_config =
@@ -80,7 +76,6 @@ pub async fn create_config(
             consensus_manager_config,
             gateway_config,
             http_server_config,
-            rpc_state_reader_config,
             mempool_p2p_config,
             monitoring_endpoint_config,
             state_sync_config,
@@ -133,12 +128,6 @@ pub fn create_consensus_manager_configs_and_channels(
         .collect();
 
     (consensus_manager_configs, broadcast_channels)
-}
-
-pub fn test_rpc_state_reader_config(rpc_server_addr: SocketAddr) -> RpcStateReaderConfig {
-    // TODO(Tsabary): get the latest version from the RPC crate.
-    const RPC_SPEC_VERSION: &str = "V0_8";
-    RpcStateReaderConfig::from_url(format!("http://{rpc_server_addr:?}/rpc/{RPC_SPEC_VERSION}"))
 }
 
 pub fn create_mempool_p2p_configs(
@@ -298,7 +287,7 @@ fn set_validator_id(
     validator_id
 }
 
-fn create_state_sync_config(
+pub fn create_state_sync_config(
     state_sync_storage_config: StorageConfig,
     port: u16,
 ) -> StateSyncConfig {

--- a/crates/starknet_integration_tests/tests/mempool_p2p_flow_test.rs
+++ b/crates/starknet_integration_tests/tests/mempool_p2p_flow_test.rs
@@ -18,16 +18,16 @@ use starknet_api::rpc_transaction::{
 use starknet_api::transaction::TransactionHash;
 use starknet_http_server::config::HttpServerConfig;
 use starknet_http_server::test_utils::{create_http_server_config, HttpTestClient};
-use starknet_integration_tests::state_reader::{spawn_test_rpc_state_reader, StorageTestSetup};
+use starknet_integration_tests::state_reader::StorageTestSetup;
 use starknet_integration_tests::test_identifiers::TestIdentifier;
 use starknet_integration_tests::utils::{
     create_batcher_config,
     create_chain_info,
     create_gateway_config,
     create_integration_test_tx_generator,
+    create_state_sync_config,
     create_txs_for_integration_test,
     run_integration_test_scenario,
-    test_rpc_state_reader_config,
     test_tx_hashes_for_integration_test,
 };
 use starknet_mempool_p2p::config::MempoolP2pConfig;
@@ -60,22 +60,10 @@ async fn setup(
     let storage_for_test = StorageTestSetup::new(accounts, &chain_info);
     let mut available_ports = AvailablePorts::new(test_identifier.into(), 0);
 
-    // Spawn a papyrus rpc server for a papyrus storage reader.
-    let rpc_server_addr = spawn_test_rpc_state_reader(
-        storage_for_test.rpc_storage_reader,
-        chain_info.chain_id.clone(),
-    )
-    .await;
-
     // Derive the configuration for the mempool node.
     let components = ComponentConfig {
         consensus_manager: ActiveComponentExecutionConfig::disabled(),
         batcher: ReactiveComponentExecutionConfig {
-            execution_mode: ReactiveComponentExecutionMode::Disabled,
-            local_server_config: None,
-            ..Default::default()
-        },
-        state_sync: ReactiveComponentExecutionConfig {
             execution_mode: ReactiveComponentExecutionMode::Disabled,
             local_server_config: None,
             ..Default::default()
@@ -88,7 +76,10 @@ async fn setup(
     let gateway_config = create_gateway_config(chain_info).await;
     let http_server_config =
         create_http_server_config(available_ports.get_next_local_host_socket()).await;
-    let rpc_state_reader_config = test_rpc_state_reader_config(rpc_server_addr);
+    let state_sync_config = create_state_sync_config(
+        storage_for_test.state_sync_storage_config,
+        available_ports.get_next_port(),
+    );
     let (mut network_configs, broadcast_channels) =
         create_network_configs_connected_to_broadcast_channels::<RpcTransactionWrapper>(
             1,
@@ -104,9 +95,9 @@ async fn setup(
         batcher_config,
         gateway_config,
         http_server_config,
-        rpc_state_reader_config,
         mempool_p2p_config,
         monitoring_endpoint_config,
+        state_sync_config,
         ..SequencerNodeConfig::default()
     };
     (config, broadcast_channels)

--- a/crates/starknet_sequencer_node/src/components.rs
+++ b/crates/starknet_sequencer_node/src/components.rs
@@ -72,10 +72,13 @@ pub fn create_node_components(
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
             let mempool_client =
                 clients.get_mempool_shared_client().expect("Mempool Client should be available");
+            let state_sync_client = clients
+                .get_state_sync_shared_client()
+                .expect("State Sync Client should be available");
 
             Some(create_gateway(
                 config.gateway_config.clone(),
-                config.rpc_state_reader_config.clone(),
+                state_sync_client,
                 config.compiler_config.clone(),
                 mempool_client,
             ))

--- a/crates/starknet_sequencer_node/src/config/node_config.rs
+++ b/crates/starknet_sequencer_node/src/config/node_config.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use starknet_batcher::config::BatcherConfig;
 use starknet_batcher::VersionedConstantsOverrides;
 use starknet_consensus_manager::config::ConsensusManagerConfig;
-use starknet_gateway::config::{GatewayConfig, RpcStateReaderConfig};
+use starknet_gateway::config::GatewayConfig;
 use starknet_http_server::config::HttpServerConfig;
 use starknet_l1_provider::L1ProviderConfig;
 use starknet_mempool_p2p::config::MempoolP2pConfig;
@@ -120,8 +120,6 @@ pub struct SequencerNodeConfig {
     #[validate]
     pub http_server_config: HttpServerConfig,
     #[validate]
-    pub rpc_state_reader_config: RpcStateReaderConfig,
-    #[validate]
     pub compiler_config: SierraToCasmCompilationConfig,
     #[validate]
     pub l1_provider_config: L1ProviderConfig,
@@ -144,7 +142,6 @@ impl SerializeConfig for SequencerNodeConfig {
             ),
             append_sub_config_name(self.gateway_config.dump(), "gateway_config"),
             append_sub_config_name(self.http_server_config.dump(), "http_server_config"),
-            append_sub_config_name(self.rpc_state_reader_config.dump(), "rpc_state_reader_config"),
             append_sub_config_name(self.compiler_config.dump(), "compiler_config"),
             append_sub_config_name(self.mempool_p2p_config.dump(), "mempool_p2p_config"),
             append_sub_config_name(


### PR DESCRIPTION
feat(starknet_gateway): use sync state reader instead of rpc

feat(starknet_sequencer_node): remove rpc state reader

Due to this change we also fix the integration tests accordingly

fix(starknet_mempool_p2p): fix directory erasing after setup

Tests were running without the temporary directory handles, causing
these directory to be erased when setup would finish running.

This commit Adds temp dir handles to the setup output for the test to
hold to prevent the eraseure.