### PR TITLE
feat(starknet_mempool): in CommitBlockArgs delete tx_hashes and add rejected_tx_hashes

### DIFF
--- a/crates/starknet_batcher/src/batcher_test.rs
+++ b/crates/starknet_batcher/src/batcher_test.rs
@@ -501,7 +501,7 @@ async fn add_sync_block() {
         .times(1)
         .with(eq(CommitBlockArgs {
             address_to_nonce: test_contract_nonces(),
-            tx_hashes: test_tx_hashes(),
+            rejected_tx_hashes: [].into(),
         }))
         .returning(|_| Ok(()));
 
@@ -546,7 +546,7 @@ async fn decision_reached() {
         .times(1)
         .with(eq(CommitBlockArgs {
             address_to_nonce: expected_artifacts.address_to_nonce(),
-            tx_hashes: expected_artifacts.tx_hashes(),
+            rejected_tx_hashes: [].into(),
         }))
         .returning(|_| Ok(()));
 

--- a/crates/starknet_batcher/src/block_builder_test.rs
+++ b/crates/starknet_batcher/src/block_builder_test.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use assert_matches::assert_matches;
 use blockifier::blockifier::transaction_executor::TransactionExecutorError;
 use blockifier::bouncer::BouncerWeights;
@@ -48,10 +50,12 @@ fn output_channel() -> (UnboundedSender<Transaction>, UnboundedReceiver<Transact
 
 fn block_execution_artifacts(
     execution_infos: IndexMap<TransactionHash, TransactionExecutionInfo>,
+    rejected_tx_hashes: HashSet<TransactionHash>,
 ) -> BlockExecutionArtifacts {
     let l2_gas_used = GasAmount(execution_infos.len().try_into().unwrap());
     BlockExecutionArtifacts {
         execution_infos,
+        rejected_tx_hashes,
         commitment_state_diff: Default::default(),
         visited_segments_mapping: Default::default(),
         bouncer_weights: BouncerWeights { l1_gas: 100, ..BouncerWeights::empty() },
@@ -259,7 +263,8 @@ fn transaction_failed_test_expectations() -> TestExpectations {
         tx_hash!(0)=> execution_info(),
         tx_hash!(2)=> execution_info(),
     ];
-    let expected_block_artifacts = block_execution_artifacts(execution_infos_mapping);
+    let expected_block_artifacts =
+        block_execution_artifacts(execution_infos_mapping, vec![tx_hash!(1)].into_iter().collect());
     let expected_block_artifacts_copy = expected_block_artifacts.clone();
     mock_transaction_executor.expect_close_block().times(1).return_once(move || {
         Ok((
@@ -285,7 +290,7 @@ fn block_builder_expected_output(execution_info_len: usize) -> BlockExecutionArt
     let execution_info_len_u8 = u8::try_from(execution_info_len).unwrap();
     let execution_infos_mapping =
         (0..execution_info_len_u8).map(|i| (tx_hash!(i), execution_info())).collect();
-    block_execution_artifacts(execution_infos_mapping)
+    block_execution_artifacts(execution_infos_mapping, Default::default())
 }
 
 fn set_close_block_expectations(

--- a/crates/starknet_batcher/src/test_utils.rs
+++ b/crates/starknet_batcher/src/test_utils.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ops::Range;
 
 use async_trait::async_trait;
@@ -75,6 +76,7 @@ impl BlockExecutionArtifacts {
         // Use a non-empty commitment_state_diff to make the tests more realistic.
         Self {
             execution_infos: IndexMap::default(),
+            rejected_tx_hashes: HashSet::default(),
             commitment_state_diff: CommitmentStateDiff {
                 address_to_class_hash: IndexMap::from_iter([(
                     contract_address!("0x7"),

--- a/crates/starknet_mempool/src/mempool.rs
+++ b/crates/starknet_mempool/src/mempool.rs
@@ -224,8 +224,12 @@ impl Mempool {
     /// updates account balances).
     #[instrument(skip(self, args), err)]
     pub fn commit_block(&mut self, args: CommitBlockArgs) -> MempoolResult<()> {
-        let CommitBlockArgs { address_to_nonce, tx_hashes } = args;
-        debug!("Committing block with {} transactions to mempool.", tx_hashes.len());
+        let CommitBlockArgs { address_to_nonce, rejected_tx_hashes } = args;
+        debug!(
+            "Committing block with {} addresses and {} rejected tx to the mempool.",
+            address_to_nonce.len(),
+            rejected_tx_hashes.len()
+        );
 
         // Align mempool data to committed nonces.
         for (&address, &next_nonce) in &address_to_nonce {
@@ -268,8 +272,8 @@ impl Mempool {
 
         debug!("Aligned mempool to committed nonces.");
 
-        // Hard-delete: finally, remove committed transactions from the mempool.
-        for tx_hash in tx_hashes {
+        // Remove rejected transactions from the mempool.
+        for tx_hash in rejected_tx_hashes {
             let Ok(_tx) = self.tx_pool.remove(tx_hash) else {
                 continue; // Transaction hash unknown to mempool, from a different node.
             };
@@ -277,7 +281,7 @@ impl Mempool {
             // TODO(clean_accounts): remove address with no transactions left after a block cycle /
             // TTL.
         }
-        debug!("Removed committed transactions known to mempool.");
+        debug!("Removed rejected transactions known to mempool.");
 
         Ok(())
     }

--- a/crates/starknet_mempool/src/mempool_test.rs
+++ b/crates/starknet_mempool/src/mempool_test.rs
@@ -575,8 +575,7 @@ fn test_commit_block_includes_all_proposed_txs() {
 
     // Test.
     let nonces = [("0x0", 4), ("0x1", 3)];
-    let tx_hashes = [1, 4];
-    commit_block(&mut mempool, nonces, tx_hashes);
+    commit_block(&mut mempool, nonces, []);
 
     // Assert.
     let pool_txs =
@@ -847,4 +846,41 @@ async fn test_propagated_tx_sent_to_p2p(mempool: Mempool) {
         MempoolCommunicationWrapper::new(mempool, Arc::new(mock_mempool_p2p_propagator_client));
 
     mempool_wrapper.add_tx(propagated_args).await.unwrap();
+}
+
+#[rstest]
+fn test_rejected_tx_deleted_from_mempool(mut mempool: Mempool) {
+    // Setup.
+    let tx_address_1_nonce_2 =
+        add_tx_input!(tx_hash: 4, address: "0x1", tx_nonce: 2, account_nonce: 2);
+    let tx_address_1_nonce_3 =
+        add_tx_input!(tx_hash: 5, address: "0x1", tx_nonce: 3, account_nonce: 2);
+
+    let tx_address_2_nonce_1 =
+        add_tx_input!(tx_hash: 7, address: "0x2", tx_nonce: 1, account_nonce: 1);
+    let tx_address_2_nonce_2 =
+        add_tx_input!(tx_hash: 8, address: "0x2", tx_nonce: 2, account_nonce: 1);
+
+    let mut expected_pool_txs = vec![];
+    for input in
+        [&tx_address_1_nonce_2, &tx_address_1_nonce_3, &tx_address_2_nonce_1, &tx_address_2_nonce_2]
+    {
+        add_tx(&mut mempool, input);
+        expected_pool_txs.push(input.tx.clone());
+    }
+
+    // All the transactions are in the mempool.
+    let expected_mempool_content =
+        MempoolContentBuilder::new().with_pool(expected_pool_txs.clone()).build();
+    expected_mempool_content.assert_eq(&mempool);
+
+    // Transaction 4 and 8 are rejected.
+    let rejected_tx = [4, 8];
+    commit_block(&mut mempool, [], rejected_tx);
+
+    // Assert transactions 4 and 8 are removed from the mempool.
+    expected_pool_txs.retain(|x| *x != tx_address_1_nonce_2.tx && *x != tx_address_2_nonce_2.tx);
+    let expected_mempool_content =
+        MempoolContentBuilder::new().with_pool(expected_pool_txs).build();
+    expected_mempool_content.assert_eq(&mempool);
 }

--- a/crates/starknet_mempool/src/test_utils.rs
+++ b/crates/starknet_mempool/src/test_utils.rs
@@ -233,13 +233,14 @@ pub fn add_tx_expect_error(
 pub fn commit_block(
     mempool: &mut Mempool,
     nonces: impl IntoIterator<Item = (&'static str, u8)>,
-    tx_hashes: impl IntoIterator<Item = u8>,
+    rejected_tx_hashes: impl IntoIterator<Item = u8>,
 ) {
     let nonces = HashMap::from_iter(
         nonces.into_iter().map(|(address, nonce)| (contract_address!(address), nonce!(nonce))),
     );
-    let tx_hashes = HashSet::from_iter(tx_hashes.into_iter().map(|tx_hash| tx_hash!(tx_hash)));
-    let args = CommitBlockArgs { address_to_nonce: nonces, tx_hashes };
+    let rejected_tx_hashes =
+        HashSet::from_iter(rejected_tx_hashes.into_iter().map(|tx_hash| tx_hash!(tx_hash)));
+    let args = CommitBlockArgs { address_to_nonce: nonces, rejected_tx_hashes };
 
     assert_eq!(mempool.commit_block(args), Ok(()));
 }

--- a/crates/starknet_mempool/tests/flow_test.rs
+++ b/crates/starknet_mempool/tests/flow_test.rs
@@ -88,8 +88,7 @@ fn test_add_same_nonce_tx_after_previous_not_included_in_block(mut mempool: Memp
     );
 
     let nonces = [("0x0", 4)]; // Transaction with nonce 3 was included, 4 was not.
-    let tx_hashes = [1];
-    commit_block(&mut mempool, nonces, tx_hashes);
+    commit_block(&mut mempool, nonces, []);
 
     let tx_nonce_4_account_nonce_4 =
         add_tx_input!(tx_hash: 4, address: "0x0", tx_nonce: 4, account_nonce: 4);
@@ -178,8 +177,7 @@ fn test_commit_block_includes_proposed_txs_subset(mut mempool: Mempool) {
 
     // Address 0x0 stays as proposed, address 0x1 rewinds nonce 4, address 0x2 rewinds completely.
     let nonces = [("0x0", 2), ("0x1", 4)];
-    let tx_hashes = [1, 4];
-    commit_block(&mut mempool, nonces, tx_hashes);
+    commit_block(&mut mempool, nonces, []);
 
     get_txs_and_assert_expected(
         &mut mempool,
@@ -204,8 +202,7 @@ fn test_commit_block_fills_nonce_gap(mut mempool: Mempool) {
     get_txs_and_assert_expected(&mut mempool, 2, &[tx_nonce_3_account_nonce_3.tx]);
 
     let nonces = [("0x0", 5)];
-    let tx_hashes = [1, 3];
-    commit_block(&mut mempool, nonces, tx_hashes);
+    commit_block(&mut mempool, nonces, []);
 
     // Assert: hole was indeed closed.
     let tx_nonce_4_account_nonce_4 =
@@ -249,11 +246,10 @@ fn test_commit_block_rewinds_queued_nonce(mut mempool: Mempool) {
     );
 
     // Test.
-    let nonces = [("0x0", 3)];
-    let tx_hashes = [1];
     // Address 0x0: nonce 2 was accepted, but 3 was not, so is rewound.
     // Address 0x1: nonce 2 was not accepted, both 2 and 3 were rewound.
-    commit_block(&mut mempool, nonces, tx_hashes);
+    let nonces = [("0x0", 3)];
+    commit_block(&mut mempool, nonces, []);
 
     // Nonces 3 and 4 were re-enqueued correctly.
     get_txs_and_assert_expected(
@@ -277,13 +273,11 @@ fn test_commit_block_from_different_leader(mut mempool: Mempool) {
     }
 
     // Test.
+    // Address 0: known hash accepted for nonce 2.
+    // Address 0: unknown hash accepted for nonce 3.
+    // Unknown Address 1 (with unknown hash) for nonce 2.
     let nonces = [("0x0", 4), ("0x1", 2)];
-    let tx_hashes = [
-        1,  // Address 0: known hash accepted for nonce 2.
-        99, // Address 0: unknown hash accepted for nonce 3.
-        4,  // Unknown Address 1 (with unknown hash) for nonce 2.
-    ];
-    commit_block(&mut mempool, nonces, tx_hashes);
+    commit_block(&mut mempool, nonces, []);
 
     // Assert: two stale transactions were removed, one was added to a block by a different leader
     // and the other "lost" to a different transaction with the same nonce that was added by the
@@ -307,8 +301,7 @@ fn test_update_gas_price_threshold(mut mempool: Mempool) {
     get_txs_and_assert_expected(&mut mempool, 2, &[input_gas_price_30.tx]);
 
     let nonces = [("0x1", 1)];
-    let tx_hashes = [2];
-    commit_block(&mut mempool, nonces, tx_hashes);
+    commit_block(&mut mempool, nonces, []);
 
     mempool.update_gas_price_threshold(GasPrice(10));
     get_txs_and_assert_expected(&mut mempool, 2, &[input_gas_price_20.tx]);

--- a/crates/starknet_mempool_types/src/mempool_types.rs
+++ b/crates/starknet_mempool_types/src/mempool_types.rs
@@ -30,7 +30,7 @@ pub struct AddTransactionArgs {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CommitBlockArgs {
     pub address_to_nonce: HashMap<ContractAddress, Nonce>,
-    pub tx_hashes: HashSet<TransactionHash>,
+    pub rejected_tx_hashes: HashSet<TransactionHash>,
 }
 
 pub type MempoolResult<T> = Result<T, MempoolError>;


### PR DESCRIPTION
Deleted tx_hashes from the commit_block input because they are removed from the pool when calling remove_up_to_nonce on the address-nonce input.

Added rejected_tx_hashes to explicitly delete them from the pool.