### PR TITLE
chore(consensus): move running StreamHandler loop into helper function

### DIFF
--- a/crates/starknet_consensus/src/stream_handler.rs
+++ b/crates/starknet_consensus/src/stream_handler.rs
@@ -31,6 +31,7 @@ type MessageId = u64;
 // TODO(guyn) add all of these to the config
 const CHANNEL_BUFFER_LENGTH: usize = 100;
 const MAX_STREAMS_PER_PEER: NonZeroUsize = NonZeroUsize::new(10).unwrap();
+const MAX_MESSAGES_PER_STREAM: usize = 100;
 
 /// A combination of trait bounds needed for the content of the stream.
 pub trait StreamContentTrait:
@@ -97,6 +98,29 @@ impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
             receiver: Some(receiver),
             message_buffer: HashMap::new(),
         }
+    }
+
+    // Store an inbound message in the buffer.
+    // Returns true if the message was successfully stored.
+    // Returns false if the receiver should be dropped.
+    fn store(&mut self, message: StreamMessage<StreamContent, StreamId>) -> bool {
+        let message_id = message.message_id;
+        let buffer_length = self.message_buffer.len();
+        match self.message_buffer.entry(message_id) {
+            Vacant(e) => {
+                if buffer_length >= MAX_MESSAGES_PER_STREAM {
+                    // Buffer is full. Since we can't record the message we won't be able to
+                    // complete the stream.
+                    return false;
+                }
+                e.insert(message);
+            }
+            Occupied(_) => {
+                // Network replay, ignoring.
+            }
+        }
+        // If the operation successfully inserted the message, return true (no error).
+        true
     }
 }
 
@@ -223,6 +247,9 @@ impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
         }
     }
 
+    // Send the message to the application.
+    // - If the receiver remains viable, return true.
+    // - If the receiver should be dropped, return false.
     fn inbound_send(
         &mut self,
         data: &mut StreamData<StreamContent, StreamId>,
@@ -240,7 +267,7 @@ impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
                              MessageId: {}",
                             message.stream_id, message.message_id
                         );
-                        return true;
+                        return false;
                     } else if e.is_full() {
                         // TODO(guyn): replace panic with buffering of the message.
                         panic!(
@@ -262,10 +289,11 @@ impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
                 self.inbound_channel_sender.try_send(receiver).expect("Send should succeed");
             }
             data.next_message_id += 1;
-            return false;
+            return true; // All is good, keep using the receiver. 
         }
-        // A Fin message is not sent. This is a no-op, can safely return true.
-        true
+        // A Fin message is not sent. This is a no-op.
+        // Can safely return false for dropping the receiver.
+        false
     }
 
     // Send the message to the network.
@@ -401,20 +429,20 @@ impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
         // This means we can just send the message without buffering it.
         match message_id.cmp(&data.next_message_id) {
             Ordering::Equal => {
-                let mut receiver_dropped = self.inbound_send(&mut data, message);
-                if !receiver_dropped {
-                    receiver_dropped = self.process_buffer(&mut data);
+                let mut receiver_ok = self.inbound_send(&mut data, message);
+                if receiver_ok {
+                    receiver_ok = self.process_buffer(&mut data);
                 }
 
-                if data.message_buffer.is_empty() && data.fin_message_id.is_some()
-                    || receiver_dropped
-                {
+                if data.message_buffer.is_empty() && data.fin_message_id.is_some() || !receiver_ok {
                     data.sender.close_channel();
                     return None;
                 }
             }
             Ordering::Greater => {
-                Self::store(&mut data, peer_id.clone(), stream_id.clone(), message);
+                if !data.store(message) {
+                    return None;
+                }
             }
             Ordering::Less => {
                 // TODO(guyn): replace warnings with more graceful error handling
@@ -430,40 +458,17 @@ impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
         Some(data)
     }
 
-    // Store an inbound message in the buffer.
-    fn store(
-        data: &mut StreamData<StreamContent, StreamId>,
-        peer_id: PeerId,
-        stream_id: StreamId,
-        message: StreamMessage<StreamContent, StreamId>,
-    ) {
-        let message_id = message.message_id;
-
-        match data.message_buffer.entry(message_id) {
-            Vacant(e) => {
-                e.insert(message);
-            }
-            Occupied(_) => {
-                // TODO(guyn): replace warnings with more graceful error handling
-                warn!(
-                    "Two messages with the same message_id in buffer! peer_id: {:?}, stream_id: \
-                     {:?}",
-                    peer_id.clone(),
-                    stream_id.clone(),
-                );
-            }
-        }
-    }
-
     // Tries to drain as many messages as possible from the buffer (in order),
     // DOES NOT guarantee that the buffer will be empty after calling this function.
-    // Returns true if the receiver for this stream is dropped.
+    // Returns false if the receiver for this stream is dropped.
     fn process_buffer(&mut self, data: &mut StreamData<StreamContent, StreamId>) -> bool {
         while let Some(message) = data.message_buffer.remove(&data.next_message_id) {
-            if self.inbound_send(data, message) {
-                return true;
+            if !self.inbound_send(data, message) {
+                // After sending we got false, meaning the receiver should be dropped.
+                return false;
             }
         }
-        false
+        // If nothing went wrong, we keep the receiver.
+        true
     }
 }

--- a/crates/starknet_consensus/src/stream_handler.rs
+++ b/crates/starknet_consensus/src/stream_handler.rs
@@ -5,9 +5,11 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
+use std::num::NonZeroUsize;
 
 use futures::channel::mpsc;
 use futures::StreamExt;
+use lru::LruCache;
 use papyrus_network::network_manager::{
     BroadcastTopicClient,
     BroadcastTopicClientTrait,
@@ -26,7 +28,9 @@ mod stream_handler_test;
 type PeerId = OpaquePeerId;
 type MessageId = u64;
 
+// TODO(guyn) add all of these to the config
 const CHANNEL_BUFFER_LENGTH: usize = 100;
+const MAX_STREAMS_PER_PEER: NonZeroUsize = NonZeroUsize::new(10).unwrap();
 
 /// A combination of trait bounds needed for the content of the stream.
 pub trait StreamContentTrait:
@@ -105,10 +109,10 @@ pub struct StreamHandler<StreamContent: StreamContentTrait, StreamId: StreamIdTr
     inbound_channel_sender: mpsc::Sender<mpsc::Receiver<StreamContent>>,
     // This receives messages from the network.
     inbound_receiver: BroadcastTopicServer<StreamMessage<StreamContent, StreamId>>,
-    // A map from (peer_id, stream_id) to a struct that contains all the information
+    // A map from peer_id and stream_id to a struct that contains all the information
     // about the stream. This includes both the message buffer and some metadata
-    // (like the latest message ID).
-    inbound_stream_data: HashMap<(PeerId, StreamId), StreamData<StreamContent, StreamId>>,
+    // (like the latest message ID). The mapping is {peer_id: {stream_id: StreamData}}.
+    inbound_stream_data: HashMap<PeerId, LruCache<StreamId, StreamData<StreamContent, StreamId>>>,
     // Whenever application wants to start a new stream, it must send out a
     // (stream_id, Receiver) pair. Each receiver gets messages that should
     // be sent out to the network.
@@ -313,19 +317,34 @@ impl<StreamContent: StreamContentTrait, StreamId: StreamIdTrait>
 
         let peer_id = metadata.originator_id.clone();
         let stream_id = message.stream_id.clone();
-        let key = (peer_id, stream_id);
 
-        let data = match self.inbound_stream_data.entry(key.clone()) {
+        let data = match self.inbound_stream_data.entry(peer_id.clone()) {
             // If data exists, remove it (it will be returned to hash map at end of function).
-            Occupied(entry) => entry.remove_entry().1,
+            Occupied(mut entry) => {
+                // If we received a message for a stream_id that we have not seen before,
+                // we need to create a new receiver for it.
+                let data = entry.get_mut().pop(&stream_id).unwrap_or_else(|| StreamData::new());
+                // If the Lru cache is left empty, remove it.
+                if entry.get().is_empty() {
+                    entry.remove();
+                }
+                data
+            }
             Vacant(_) => {
-                // If we received a message for a stream that we have not seen before,
+                // If we received a message for a peer_id that we have not seen before,
                 // we need to create a new receiver for it.
                 StreamData::new()
             }
         };
         if let Some(data) = self.handle_message_inner(message, metadata, data) {
-            self.inbound_stream_data.insert(key, data);
+            let existing_data = self
+                .inbound_stream_data
+                .entry(peer_id)
+                .or_insert_with(|| LruCache::new(MAX_STREAMS_PER_PEER))
+                .put(stream_id, data);
+            if existing_data.is_some() {
+                panic!("This stream data should have been removed from the cache!");
+            }
         }
     }
 


### PR DESCRIPTION
There's a repeating pattern in the StreamHandler test file, where we send the StreamHandler into a separate task, with a timeout, and then join it back to check its internal state. 

I've moved this pattern into a helper function. 