### PR TITLE
chore(starknet_sequencer_infra): remove Sync trait bound from client

### DIFF
--- a/crates/starknet_sequencer_infra/src/component_client/local_component_client.rs
+++ b/crates/starknet_sequencer_infra/src/component_client/local_component_client.rs
@@ -12,8 +12,8 @@ use crate::component_definitions::{ComponentClient, ComponentRequestAndResponseS
 /// receiving responses asynchronously.
 ///
 /// # Type Parameters
-/// - `Request`: The type of the request. This type must implement both `Send` and `Sync` traits.
-/// - `Response`: The type of the response. This type must implement both `Send` and `Sync` traits.
+/// - `Request`: The type of the request. This type must implement `Send`.
+/// - `Response`: The type of the response. This type must implement `Send`.
 ///
 /// # Fields
 /// - `tx`: An asynchronous sender channel for transmitting

--- a/crates/starknet_sequencer_infra/src/component_client/remote_component_client.rs
+++ b/crates/starknet_sequencer_infra/src/component_client/remote_component_client.rs
@@ -103,8 +103,8 @@ impl RemoteComponentClient {
 #[async_trait]
 impl<Request, Response> ComponentClient<Request, Response> for RemoteComponentClient
 where
-    Request: Send + Sync + Serialize + DeserializeOwned + Debug + 'static,
-    Response: Send + Sync + Serialize + DeserializeOwned + Debug,
+    Request: Send + Serialize + DeserializeOwned + Debug + 'static,
+    Response: Send + Serialize + DeserializeOwned + Debug,
 {
     async fn send(&self, component_request: Request) -> ClientResult<Response> {
         // Serialize the request.
@@ -134,7 +134,7 @@ async fn try_send<Response>(
     http_request: HyperRequest<Body>,
 ) -> ClientResult<Response>
 where
-    Response: Send + Sync + Serialize + DeserializeOwned + Debug,
+    Response: Send + Serialize + DeserializeOwned + Debug,
 {
     let http_response = client
         .request(http_request)


### PR DESCRIPTION
**Stack**:
- #3096 ⬅
- #3095
- #3094


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*