### PR TITLE
dev: Minor SNOS changes

### DIFF
--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -34,7 +34,7 @@ use crate::execution::syscalls::syscall_base::SyscallResult;
 use crate::versioned_constants::{EventLimits, VersionedConstants};
 
 pub mod hint_processor;
-mod secp;
+pub mod secp;
 pub mod syscall_base;
 
 #[cfg(test)]

--- a/crates/blockifier/src/execution/syscalls/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/secp.rs
@@ -72,7 +72,7 @@ where
         id
     }
 
-    fn get_point_by_id(
+    pub fn get_point_by_id(
         &self,
         ec_point_id: Felt,
     ) -> SyscallResult<&short_weierstrass::Affine<Curve>> {

--- a/crates/blockifier/src/execution/syscalls/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/secp.rs
@@ -169,10 +169,10 @@ pub fn secp256r1_add(
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct SecpGetPointFromXRequest {
-    x: BigUint,
+    pub x: BigUint,
     // The parity of the y coordinate, assuming a point with the given x coordinate exists.
     // True means the y coordinate is odd.
-    y_parity: bool,
+    pub y_parity: bool,
 }
 
 impl SyscallRequest for SecpGetPointFromXRequest {

--- a/crates/blockifier/src/versioned_constants.rs
+++ b/crates/blockifier/src/versioned_constants.rs
@@ -324,6 +324,7 @@ impl VersionedConstants {
                 (BuiltinName::pedersen, ResourceCost::from_integer(1)),
                 (BuiltinName::range_check, ResourceCost::from_integer(1)),
                 (BuiltinName::ecdsa, ResourceCost::from_integer(1)),
+                (BuiltinName::keccak, ResourceCost::from_integer(1)),
                 (BuiltinName::bitwise, ResourceCost::from_integer(1)),
                 (BuiltinName::poseidon, ResourceCost::from_integer(1)),
                 (BuiltinName::output, ResourceCost::from_integer(1)),


### PR DESCRIPTION
This is a small set of changes we have been using on [SNOS](https://github.com/keep-starknet-strange/snos/) for quite some time.

As they are probably only useful for us, we have maintained our own fork and ported them during upgrades. However, for projects which use SNOS as a dependency, this inevitably creates duplicated versions of `blockifier` in the dependency tree, so it would be great to get them included in the main repo.

### Backporting

While this PR proposes these changes for `main`, it would help more immediately to backport these into the current `v0.8.0-rc.3` release and roll a new release on `crates.io`. I am not sure what the best way to approach this would be, so please provide some feedback :) 

The "compare" here shows what is intended: https://github.com/starkware-libs/sequencer/compare/blockifier-v0.8.0-rc.3...Moonsong-Labs:sequencer:notlesh/blockifier-v0.8.0-rc.3-snos

Note that it includes one additional commit (`5ab9ae7`) which is not included in this PR because it is far more complicated against `main` and we may be able to work around it on SNOS anyway.