### PR TITLE
chore(consensus): unify into/try_from Vec<u8> traits

### DIFF
--- a/crates/papyrus_protobuf/src/consensus.rs
+++ b/crates/papyrus_protobuf/src/consensus.rs
@@ -8,6 +8,12 @@ use starknet_api::transaction::Transaction;
 
 use crate::converters::ProtobufConversionError;
 
+pub trait IntoFromProto: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> {}
+impl<T> IntoFromProto for T where
+    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>
+{
+}
+
 #[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
 pub enum VoteType {
     Prevote,
@@ -31,10 +37,7 @@ pub enum StreamMessageBody<T> {
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct StreamMessage<
-    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
-    StreamId: Into<Vec<u8>> + Clone,
-> {
+pub struct StreamMessage<T: IntoFromProto, StreamId: IntoFromProto + Clone> {
     pub message: StreamMessageBody<T>,
     pub stream_id: StreamId,
     pub message_id: u64,
@@ -115,9 +118,10 @@ impl From<ProposalInit> for ProposalPart {
     }
 }
 
-impl<T, StreamId: Into<Vec<u8>> + Clone + Display> std::fmt::Display for StreamMessage<T, StreamId>
+impl<T, StreamId> std::fmt::Display for StreamMessage<T, StreamId>
 where
-    T: Clone + Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
+    T: Clone + IntoFromProto,
+    StreamId: IntoFromProto + Clone + Display,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let StreamMessageBody::Content(message) = &self.message {

--- a/crates/papyrus_protobuf/src/converters/consensus.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus.rs
@@ -10,6 +10,7 @@ use starknet_api::hash::StarkHash;
 use starknet_api::transaction::Transaction;
 
 use crate::consensus::{
+    IntoFromProto,
     ProposalFin,
     ProposalInit,
     ProposalPart,
@@ -82,8 +83,8 @@ auto_impl_into_and_try_from_vec_u8!(Vote, protobuf::Vote);
 
 impl<T, StreamId> TryFrom<protobuf::StreamMessage> for StreamMessage<T, StreamId>
 where
-    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
-    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
+    T: IntoFromProto,
+    StreamId: IntoFromProto + Clone,
 {
     type Error = ProtobufConversionError;
 
@@ -110,10 +111,10 @@ where
     }
 }
 
-impl<
-    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
-    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
-> From<StreamMessage<T, StreamId>> for protobuf::StreamMessage
+impl<T, StreamId> From<StreamMessage<T, StreamId>> for protobuf::StreamMessage
+where
+    T: IntoFromProto,
+    StreamId: IntoFromProto + Clone,
 {
     fn from(value: StreamMessage<T, StreamId>) -> Self {
         Self {
@@ -136,10 +137,10 @@ impl<
 // Can't use auto_impl_into_and_try_from_vec_u8!(StreamMessage, protobuf::StreamMessage);
 // because it doesn't seem to work with generics.
 // TODO(guyn): consider expanding the macro to support generics
-impl<
-    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
-    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
-> From<StreamMessage<T, StreamId>> for Vec<u8>
+impl<T, StreamId> From<StreamMessage<T, StreamId>> for Vec<u8>
+where
+    T: IntoFromProto,
+    StreamId: IntoFromProto + Clone,
 {
     fn from(value: StreamMessage<T, StreamId>) -> Self {
         let protobuf_value = <protobuf::StreamMessage>::from(value);
@@ -147,10 +148,10 @@ impl<
     }
 }
 
-impl<
-    T: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError>,
-    StreamId: Into<Vec<u8>> + TryFrom<Vec<u8>, Error = ProtobufConversionError> + Clone,
-> TryFrom<Vec<u8>> for StreamMessage<T, StreamId>
+impl<T, StreamId> TryFrom<Vec<u8>> for StreamMessage<T, StreamId>
+where
+    T: IntoFromProto,
+    StreamId: IntoFromProto + Clone,
 {
     type Error = ProtobufConversionError;
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {


### PR DESCRIPTION
I've replaced some repeated instances of `Into<Vec<u8> + TryFrom<Vec<u8>...` with a single trait named `Protoable`. 

We can argue about the name. 

So far it is only used in the papyrus_protobuf crate, for consensus related things: the StreamMessage is the only thing that can't automatically generate those conversions, as it has a generic type. 