### PR TITLE
chore(starknet_integration_tests): use iterator instead of vec push

### DIFF
--- a/crates/starknet_integration_tests/src/end_to_end_integration.rs
+++ b/crates/starknet_integration_tests/src/end_to_end_integration.rs
@@ -1,28 +1,13 @@
-use std::net::SocketAddr;
-
 use mempool_test_utils::starknet_api_test_utils::{AccountId, MultiAccountTransactionGenerator};
 use starknet_api::block::BlockNumber;
-use starknet_sequencer_infra::test_utils::AvailablePorts;
-use starknet_sequencer_node::config::component_config::ComponentConfig;
-use starknet_sequencer_node::config::component_execution_config::{
-    ActiveComponentExecutionConfig,
-    ReactiveComponentExecutionConfig,
-};
 use starknet_sequencer_node::test_utils::node_runner::get_node_executable_path;
 use tracing::info;
 
 use crate::sequencer_manager::{
     get_sequencer_setup_configs,
     verify_results,
-    ComposedNodeComponentConfigs,
     SequencerSetupManager,
 };
-use crate::test_identifiers::TestIdentifier;
-
-/// The number of consolidated local sequencers that participate in the test.
-const N_CONSOLIDATED_SEQUENCERS: usize = 3;
-/// The number of distributed remote sequencers that participate in the test.
-const N_DISTRIBUTED_SEQUENCERS: usize = 2;
 
 pub async fn end_to_end_integration(tx_generator: MultiAccountTransactionGenerator) {
     const EXPECTED_BLOCK_NUMBER: BlockNumber = BlockNumber(15);
@@ -33,24 +18,8 @@ pub async fn end_to_end_integration(tx_generator: MultiAccountTransactionGenerat
     info!("Checking that the sequencer node executable is present.");
     get_node_executable_path();
 
-    // TODO(Nadin): Assign a dedicated set of available ports to each sequencer.
-    let mut available_ports =
-        AvailablePorts::new(TestIdentifier::EndToEndIntegrationTest.into(), 0);
-
-    let component_configs: Vec<ComposedNodeComponentConfigs> = {
-        let mut combined = Vec::new();
-        // Create elements in place.
-        combined.extend(create_consolidated_sequencer_configs(N_CONSOLIDATED_SEQUENCERS));
-        combined.extend(create_distributed_node_configs(
-            &mut available_ports,
-            N_DISTRIBUTED_SEQUENCERS,
-        ));
-        combined
-    };
-
     // Get the sequencer configurations.
-    let sequencers_setup =
-        get_sequencer_setup_configs(&tx_generator, available_ports, component_configs).await;
+    let sequencers_setup = get_sequencer_setup_configs(&tx_generator).await;
 
     // Run the sequencers.
     // TODO(Nadin, Tsabary): Refactor to separate the construction of SequencerManager from its
@@ -70,79 +39,4 @@ pub async fn end_to_end_integration(tx_generator: MultiAccountTransactionGenerat
 
     // Verify the results.
     verify_results(sender_address, batcher_storage_reader, N_TXS).await;
-}
-
-// TODO(Nadin/Tsabary): find a better name for this function.
-fn get_http_container_config(
-    gateway_socket: SocketAddr,
-    mempool_socket: SocketAddr,
-    mempool_p2p_socket: SocketAddr,
-    state_sync_socket: SocketAddr,
-) -> ComponentConfig {
-    let mut config = ComponentConfig::disabled();
-    config.http_server = ActiveComponentExecutionConfig::default();
-    config.gateway = ReactiveComponentExecutionConfig::local_with_remote_enabled(gateway_socket);
-    config.mempool = ReactiveComponentExecutionConfig::local_with_remote_enabled(mempool_socket);
-    config.mempool_p2p =
-        ReactiveComponentExecutionConfig::local_with_remote_enabled(mempool_p2p_socket);
-    config.state_sync = ReactiveComponentExecutionConfig::remote(state_sync_socket);
-    config.monitoring_endpoint = ActiveComponentExecutionConfig::default();
-    config
-}
-
-fn get_non_http_container_config(
-    gateway_socket: SocketAddr,
-    mempool_socket: SocketAddr,
-    mempool_p2p_socket: SocketAddr,
-    state_sync_socket: SocketAddr,
-) -> ComponentConfig {
-    ComponentConfig {
-        http_server: ActiveComponentExecutionConfig::disabled(),
-        monitoring_endpoint: Default::default(),
-        gateway: ReactiveComponentExecutionConfig::remote(gateway_socket),
-        mempool: ReactiveComponentExecutionConfig::remote(mempool_socket),
-        mempool_p2p: ReactiveComponentExecutionConfig::remote(mempool_p2p_socket),
-        state_sync: ReactiveComponentExecutionConfig::local_with_remote_enabled(state_sync_socket),
-        ..ComponentConfig::default()
-    }
-}
-
-/// Generates configurations for a specified number of distributed sequencer nodes,
-/// each consisting of an HTTP component configuration and a non-HTTP component configuration.
-/// returns a vector of vectors, where each inner vector contains the two configurations.
-fn create_distributed_node_configs(
-    available_ports: &mut AvailablePorts,
-    distributed_sequencers_num: usize,
-) -> Vec<ComposedNodeComponentConfigs> {
-    std::iter::repeat_with(|| {
-        let gateway_socket = available_ports.get_next_local_host_socket();
-        let mempool_socket = available_ports.get_next_local_host_socket();
-        let mempool_p2p_socket = available_ports.get_next_local_host_socket();
-        let state_sync_socket = available_ports.get_next_local_host_socket();
-
-        vec![
-            get_http_container_config(
-                gateway_socket,
-                mempool_socket,
-                mempool_p2p_socket,
-                state_sync_socket,
-            ),
-            get_non_http_container_config(
-                gateway_socket,
-                mempool_socket,
-                mempool_p2p_socket,
-                state_sync_socket,
-            ),
-        ]
-    })
-    .take(distributed_sequencers_num)
-    .collect()
-}
-
-fn create_consolidated_sequencer_configs(
-    num_of_consolidated_nodes: usize,
-) -> Vec<ComposedNodeComponentConfigs> {
-    std::iter::repeat_with(|| vec![ComponentConfig::default()])
-        .take(num_of_consolidated_nodes)
-        .collect()
 }

--- a/crates/starknet_integration_tests/src/sequencer_manager.rs
+++ b/crates/starknet_integration_tests/src/sequencer_manager.rs
@@ -1,3 +1,8 @@
+use std::net::SocketAddr;
+
+use futures::future::join_all;
+use futures::stream::{self, StreamExt};
+use futures::TryFutureExt;
 use infra_utils::run_until::run_until;
 use infra_utils::tracing::{CustomLogger, TraceLevel};
 use itertools::izip;
@@ -10,14 +15,19 @@ use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::state::StateNumber;
 use starknet_api::transaction::TransactionHash;
-use starknet_sequencer_infra::test_utils::AvailablePorts;
+use starknet_sequencer_infra::test_utils::{AvailablePorts, MAX_NUMBER_OF_INSTANCES_PER_TEST};
 use starknet_sequencer_node::config::component_config::ComponentConfig;
+use starknet_sequencer_node::config::component_execution_config::{
+    ActiveComponentExecutionConfig,
+    ReactiveComponentExecutionConfig,
+};
 use starknet_sequencer_node::test_utils::node_runner::{spawn_run_node, NodeRunner};
 use starknet_types_core::felt::Felt;
 use tokio::task::JoinHandle;
 use tracing::info;
 
 use crate::integration_test_setup::SequencerSetup;
+use crate::test_identifiers::TestIdentifier;
 use crate::utils::{
     create_chain_info,
     create_consensus_manager_configs_and_channels,
@@ -27,6 +37,10 @@ use crate::utils::{
 
 pub type ComposedNodeComponentConfigs = Vec<ComponentConfig>;
 
+/// The number of consolidated local sequencers that participate in the test.
+const N_CONSOLIDATED_SEQUENCERS: usize = 3;
+/// The number of distributed remote sequencers that participate in the test.
+const N_DISTRIBUTED_SEQUENCERS: usize = 2;
 pub struct SequencerSetupManager {
     pub sequencers: Vec<SequencerSetup>,
     pub sequencer_run_handles: Vec<JoinHandle<()>>,
@@ -37,9 +51,14 @@ impl SequencerSetupManager {
         info!("Running sequencers.");
         let sequencer_run_handles = sequencers
             .iter()
-            .enumerate()
-            .map(|(i, sequencer)| {
-                spawn_run_node(sequencer.node_config_path.clone(), NodeRunner::new(i))
+            .map(|sequencer_setup| {
+                spawn_run_node(
+                    sequencer_setup.node_config_path.clone(),
+                    NodeRunner::new(
+                        sequencer_setup.sequencer_index,
+                        sequencer_setup.sequencer_part_index,
+                    ),
+                )
             })
             .collect::<Vec<_>>();
 
@@ -51,14 +70,18 @@ impl SequencerSetupManager {
         sequencer_manager
     }
 
-    pub async fn await_alive(&self, interval: u64, max_attempts: usize) {
-        for (sequencer_index, sequencer) in self.sequencers.iter().enumerate() {
-            sequencer
-                .monitoring_client
-                .await_alive(interval, max_attempts)
-                .await
-                .unwrap_or_else(|_| panic!("Node {} should be alive.", sequencer_index));
-        }
+    async fn await_alive(&self, interval: u64, max_attempts: usize) {
+        let await_alive_tasks = self.sequencers.iter().map(|sequencer| {
+            let result = sequencer.monitoring_client.await_alive(interval, max_attempts);
+            result.unwrap_or_else(|_| {
+                panic!(
+                    "Node {} part {} should be alive.",
+                    sequencer.sequencer_index, sequencer.sequencer_part_index
+                )
+            })
+        });
+
+        join_all(await_alive_tasks).await;
     }
 
     pub async fn send_rpc_tx_fn(&self, rpc_tx: RpcTransaction) -> TransactionHash {
@@ -159,9 +182,24 @@ pub async fn verify_results(
 
 pub async fn get_sequencer_setup_configs(
     tx_generator: &MultiAccountTransactionGenerator,
-    mut available_ports: AvailablePorts,
-    component_configs: Vec<ComposedNodeComponentConfigs>,
 ) -> Vec<SequencerSetup> {
+    let test_unique_id = TestIdentifier::EndToEndIntegrationTest;
+
+    // TODO(Nadin): Assign a dedicated set of available ports to each sequencer.
+    let mut available_ports =
+        AvailablePorts::new(test_unique_id.into(), MAX_NUMBER_OF_INSTANCES_PER_TEST - 1);
+
+    let component_configs: Vec<ComposedNodeComponentConfigs> = {
+        let mut combined = Vec::new();
+        // Create elements in place.
+        combined.extend(create_consolidated_sequencer_configs(N_CONSOLIDATED_SEQUENCERS));
+        combined.extend(create_distributed_node_configs(
+            &mut available_ports,
+            N_DISTRIBUTED_SEQUENCERS,
+        ));
+        combined
+    };
+
     info!("Creating sequencer configurations.");
     let chain_info = create_chain_info();
     let accounts = tx_generator.accounts();
@@ -196,25 +234,110 @@ pub async fn get_sequencer_setup_configs(
     // TODO(Nadin/Tsabary): There are redundant p2p configs here, as each distributed node
     // needs only one of them, but the current setup creates one per part. Need to refactor.
 
-    let mut sequencers = vec![];
-    for (
-        ((sequencer_index, _sequencer_part_index), component_config),
-        consensus_manager_config,
-        mempool_p2p_config,
-    ) in izip!(indexed_component_configs, consensus_manager_configs, mempool_p2p_configs)
-    {
-        let sequencer = SequencerSetup::new(
-            accounts.to_vec(),
-            sequencer_index,
-            chain_info.clone(),
-            consensus_manager_config,
-            mempool_p2p_config,
-            &mut available_ports,
-            component_config.clone(),
-        )
-        .await;
-        sequencers.push(sequencer);
-    }
+    stream::iter(
+        izip!(indexed_component_configs, consensus_manager_configs, mempool_p2p_configs)
+            .enumerate(),
+    )
+    .then(
+        |(
+            index,
+            (
+                ((sequencer_index, sequencer_part_index), component_config),
+                consensus_manager_config,
+                mempool_p2p_config,
+            ),
+        )| {
+            let chain_info = chain_info.clone();
+            async move {
+                SequencerSetup::new(
+                    accounts.to_vec(),
+                    sequencer_index,
+                    sequencer_part_index,
+                    chain_info,
+                    consensus_manager_config,
+                    mempool_p2p_config,
+                    AvailablePorts::new(test_unique_id.into(), index.try_into().unwrap()),
+                    component_config.clone(),
+                )
+                .await
+            }
+        },
+    )
+    .collect()
+    .await
+}
 
-    sequencers
+/// Generates configurations for a specified number of distributed sequencer nodes,
+/// each consisting of an HTTP component configuration and a non-HTTP component configuration.
+/// returns a vector of vectors, where each inner vector contains the two configurations.
+fn create_distributed_node_configs(
+    available_ports: &mut AvailablePorts,
+    distributed_sequencers_num: usize,
+) -> Vec<ComposedNodeComponentConfigs> {
+    std::iter::repeat_with(|| {
+        let gateway_socket = available_ports.get_next_local_host_socket();
+        let mempool_socket = available_ports.get_next_local_host_socket();
+        let mempool_p2p_socket = available_ports.get_next_local_host_socket();
+        let state_sync_socket = available_ports.get_next_local_host_socket();
+
+        vec![
+            get_http_container_config(
+                gateway_socket,
+                mempool_socket,
+                mempool_p2p_socket,
+                state_sync_socket,
+            ),
+            get_non_http_container_config(
+                gateway_socket,
+                mempool_socket,
+                mempool_p2p_socket,
+                state_sync_socket,
+            ),
+        ]
+    })
+    .take(distributed_sequencers_num)
+    .collect()
+}
+
+fn create_consolidated_sequencer_configs(
+    num_of_consolidated_nodes: usize,
+) -> Vec<ComposedNodeComponentConfigs> {
+    std::iter::repeat_with(|| vec![ComponentConfig::default()])
+        .take(num_of_consolidated_nodes)
+        .collect()
+}
+
+// TODO(Nadin/Tsabary): find a better name for this function.
+fn get_http_container_config(
+    gateway_socket: SocketAddr,
+    mempool_socket: SocketAddr,
+    mempool_p2p_socket: SocketAddr,
+    state_sync_socket: SocketAddr,
+) -> ComponentConfig {
+    let mut config = ComponentConfig::disabled();
+    config.http_server = ActiveComponentExecutionConfig::default();
+    config.gateway = ReactiveComponentExecutionConfig::local_with_remote_enabled(gateway_socket);
+    config.mempool = ReactiveComponentExecutionConfig::local_with_remote_enabled(mempool_socket);
+    config.mempool_p2p =
+        ReactiveComponentExecutionConfig::local_with_remote_enabled(mempool_p2p_socket);
+    config.state_sync = ReactiveComponentExecutionConfig::remote(state_sync_socket);
+    config.monitoring_endpoint = ActiveComponentExecutionConfig::default();
+    config
+}
+
+fn get_non_http_container_config(
+    gateway_socket: SocketAddr,
+    mempool_socket: SocketAddr,
+    mempool_p2p_socket: SocketAddr,
+    state_sync_socket: SocketAddr,
+) -> ComponentConfig {
+    ComponentConfig {
+        http_server: ActiveComponentExecutionConfig::disabled(),
+        monitoring_endpoint: Default::default(),
+        gateway: ReactiveComponentExecutionConfig::remote(gateway_socket),
+        mempool: ReactiveComponentExecutionConfig::remote(mempool_socket),
+        mempool_p2p: ReactiveComponentExecutionConfig::remote(mempool_p2p_socket),
+        state_sync: ReactiveComponentExecutionConfig::local_with_remote_enabled(state_sync_socket),
+        ..ComponentConfig::default()
+    }
 }

--- a/crates/starknet_integration_tests/src/test_identifiers.rs
+++ b/crates/starknet_integration_tests/src/test_identifiers.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum TestIdentifier {
     EndToEndIntegrationTest,
     EndToEndFlowTest,

--- a/crates/starknet_sequencer_infra/src/test_utils.rs
+++ b/crates/starknet_sequencer_infra/src/test_utils.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::net::TcpListener;
 
 const PORTS_PER_INSTANCE: u16 = 60;
-const MAX_NUMBER_OF_INSTANCES_PER_TEST: u16 = 10;
+pub const MAX_NUMBER_OF_INSTANCES_PER_TEST: u16 = 10;
 const MAX_NUMBER_OF_TESTS: u16 = 10;
 const BASE_PORT: u16 = 55000;
 

--- a/crates/starknet_sequencer_node/src/test_utils/node_runner.rs
+++ b/crates/starknet_sequencer_node/src/test_utils/node_runner.rs
@@ -12,12 +12,15 @@ pub const NODE_EXECUTABLE_PATH: &str = "target/debug/starknet_sequencer_node";
 
 pub struct NodeRunner {
     description: String,
-    index: usize,
+    sequencer_index: usize,
 }
 
 impl NodeRunner {
-    pub fn new(index: usize) -> Self {
-        Self { description: format! {"Node ID {}:", index}, index }
+    pub fn new(sequencer_index: usize, sequencer_part_index: usize) -> Self {
+        Self {
+            description: format! {"Node id {} part {}:", sequencer_index, sequencer_part_index},
+            sequencer_index,
+        }
     }
 
     pub fn get_description(&self) -> String {
@@ -59,7 +62,7 @@ async fn spawn_node_child_process(
     let mut annotator_cmd: Child = create_shell_command("awk")
         .arg("-v")
         // Print the prefix in different colors.
-        .arg(format!("prefix=\u{1b}[3{}m{}\u{1b}[0m", node_runner.index+1, node_runner.get_description()))
+        .arg(format!("prefix=\u{1b}[3{}m{}\u{1b}[0m", node_runner.sequencer_index+1, node_runner.get_description()))
         .arg("{print prefix, $0}")
         .stdin(std::process::Stdio::piped())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
chore(starknet_integration_tests): prepend sequencer part to test output

chore(starknet_integration_tests): awaiting aliveness concurrently

refactor(starknet_integration_tests): move fns to sequencer manager mod

refactor(starknet_integration_tests): move more fns to sequencer manager mod