### PR TITLE
chore(starknet_integration_tests): move verify results to manager struct

### DIFF
--- a/crates/starknet_integration_tests/src/end_to_end_integration.rs
+++ b/crates/starknet_integration_tests/src/end_to_end_integration.rs
@@ -3,11 +3,7 @@ use starknet_api::block::BlockNumber;
 use starknet_sequencer_node::test_utils::node_runner::get_node_executable_path;
 use tracing::info;
 
-use crate::sequencer_manager::{
-    get_sequencer_setup_configs,
-    verify_results,
-    SequencerSetupManager,
-};
+use crate::sequencer_manager::{get_sequencer_setup_configs, SequencerSetupManager};
 
 pub async fn end_to_end_integration(tx_generator: MultiAccountTransactionGenerator) {
     const EXPECTED_BLOCK_NUMBER: BlockNumber = BlockNumber(15);
@@ -34,9 +30,6 @@ pub async fn end_to_end_integration(tx_generator: MultiAccountTransactionGenerat
     info!("Shutting down nodes.");
     sequencer_manager.shutdown_nodes();
 
-    // TODO(AlonH): Consider checking all sequencer storage readers.
-    let batcher_storage_reader = sequencer_manager.batcher_storage_reader();
-
     // Verify the results.
-    verify_results(sender_address, batcher_storage_reader, N_TXS).await;
+    sequencer_manager.verify_results(sender_address, N_TXS).await;
 }


### PR DESCRIPTION
**Stack**:
- chore(starknet_integration_tests): create execution index when applicable #3207
- chore(starknet_integration_tests): remove redundant async #3206
- chore(starknet_integration_tests): remove redundant fn visibility #3205
- chore(starknet_integration_tests): separate utils, use proper fn #3204
- chore(starknet_integration_tests): separate fn #3203
- chore(starknet_integration_tests): replace composed node type with struct #3202
- chore(starknet_integration_tests): bundle node exec id #3201
- chore(starknet_integration_tests): move verify results to manager struct #3200 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*