### PR TITLE
chore(starknet_integration_tests): separate fn

### DIFF
--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -58,7 +58,6 @@ impl FlowTestSetup {
         let accounts = tx_generator.accounts();
         let (consensus_manager_configs, consensus_proposals_channels) =
             create_consensus_manager_configs_and_channels(
-                SEQUENCER_INDICES.len(),
                 available_ports.get_next_ports(SEQUENCER_INDICES.len() + 1),
             );
         let [sequencer_0_consensus_manager_config, sequencer_1_consensus_manager_config]: [ConsensusManagerConfig;

--- a/crates/starknet_integration_tests/src/sequencer_manager.rs
+++ b/crates/starknet_integration_tests/src/sequencer_manager.rs
@@ -216,8 +216,9 @@ pub async fn get_sequencer_setup_configs(
         .map(|composed_node_component_configs| composed_node_component_configs.len())
         .sum();
 
+    // TODO(Tsabary): remove '+1', replace with 'create_connected_network_configs' and
+    // 'create_consensus_manager_configs_from_network_config'.
     let (consensus_manager_configs, _) = create_consensus_manager_configs_and_channels(
-        n_distributed_sequencers,
         available_ports.get_next_ports(n_distributed_sequencers + 1),
     );
 


### PR DESCRIPTION
**Stack**:
- chore(starknet_integration_tests): create execution index when applicable #3207
- chore(starknet_integration_tests): remove redundant async #3206
- chore(starknet_integration_tests): remove redundant fn visibility #3205
- chore(starknet_integration_tests): separate utils, use proper fn #3204
- chore(starknet_integration_tests): separate fn #3203 ⬅
- chore(starknet_integration_tests): replace composed node type with struct #3202
- chore(starknet_integration_tests): bundle node exec id #3201
- chore(starknet_integration_tests): move verify results to manager struct #3200


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*