### PR TITLE
chore(starknet_integration_tests): separate utils, use proper fn

### DIFF
--- a/crates/starknet_integration_tests/src/sequencer_manager.rs
+++ b/crates/starknet_integration_tests/src/sequencer_manager.rs
@@ -8,6 +8,7 @@ use infra_utils::tracing::{CustomLogger, TraceLevel};
 use itertools::izip;
 use mempool_test_utils::starknet_api_test_utils::{AccountId, MultiAccountTransactionGenerator};
 use papyrus_execution::execution_utils::get_nonce_at;
+use papyrus_network::network_manager::test_utils::create_connected_network_configs;
 use papyrus_storage::state::StateStorageReader;
 use papyrus_storage::StorageReader;
 use starknet_api::block::BlockNumber;
@@ -30,7 +31,7 @@ use crate::integration_test_setup::{SequencerExecutionId, SequencerSetup};
 use crate::test_identifiers::TestIdentifier;
 use crate::utils::{
     create_chain_info,
-    create_consensus_manager_configs_and_channels,
+    create_consensus_manager_configs_from_network_configs,
     create_mempool_p2p_configs,
     send_account_txs,
 };
@@ -216,10 +217,8 @@ pub async fn get_sequencer_setup_configs(
         .map(|composed_node_component_configs| composed_node_component_configs.len())
         .sum();
 
-    // TODO(Tsabary): remove '+1', replace with 'create_connected_network_configs' and
-    // 'create_consensus_manager_configs_from_network_config'.
-    let (consensus_manager_configs, _) = create_consensus_manager_configs_and_channels(
-        available_ports.get_next_ports(n_distributed_sequencers + 1),
+    let consensus_manager_configs = create_consensus_manager_configs_from_network_configs(
+        create_connected_network_configs(available_ports.get_next_ports(n_distributed_sequencers)),
     );
 
     let mempool_p2p_configs = create_mempool_p2p_configs(

--- a/crates/starknet_integration_tests/src/utils.rs
+++ b/crates/starknet_integration_tests/src/utils.rs
@@ -17,13 +17,8 @@ use mempool_test_utils::starknet_api_test_utils::{
 use papyrus_consensus::config::{ConsensusConfig, TimeoutsConfig};
 use papyrus_consensus::types::ValidatorId;
 use papyrus_consensus_orchestrator::cende::RECORDER_WRITE_BLOB_PATH;
-use papyrus_network::network_manager::test_utils::{
-    create_connected_network_configs,
-    create_network_configs_connected_to_broadcast_channels,
-};
-use papyrus_network::network_manager::BroadcastTopicChannels;
+use papyrus_network::network_manager::test_utils::create_connected_network_configs;
 use papyrus_network::NetworkConfig;
-use papyrus_protobuf::consensus::{ProposalPart, StreamMessage};
 use papyrus_storage::StorageConfig;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::ChainId;
@@ -122,24 +117,7 @@ pub async fn create_node_config(
     )
 }
 
-pub fn create_consensus_manager_configs_and_channels(
-    ports: Vec<u16>,
-) -> (Vec<ConsensusManagerConfig>, BroadcastTopicChannels<StreamMessage<ProposalPart>>) {
-    let (network_configs, broadcast_channels) =
-        create_network_configs_connected_to_broadcast_channels(
-            papyrus_network::gossipsub_impl::Topic::new(
-                starknet_consensus_manager::consensus_manager::CONSENSUS_PROPOSALS_TOPIC,
-            ),
-            ports,
-        );
-    // TODO: Need to also add a channel for votes, in addition to the proposals channel.
-
-    let consensus_manager_configs =
-        create_consensus_manager_configs_from_network_configs(network_configs);
-    (consensus_manager_configs, broadcast_channels)
-}
-
-fn create_consensus_manager_configs_from_network_configs(
+pub(crate) fn create_consensus_manager_configs_from_network_configs(
     network_configs: Vec<NetworkConfig>,
 ) -> Vec<ConsensusManagerConfig> {
     // TODO(Matan, Dan): set reasonable default timeouts.


### PR DESCRIPTION
**Stack**:
- chore(starknet_integration_tests): create execution index when applicable #3207
- chore(starknet_integration_tests): remove redundant async #3206
- chore(starknet_integration_tests): remove redundant fn visibility #3205
- chore(starknet_integration_tests): separate utils, use proper fn #3204 ⬅
- chore(starknet_integration_tests): separate fn #3203
- chore(starknet_integration_tests): replace composed node type with struct #3202
- chore(starknet_integration_tests): bundle node exec id #3201
- chore(starknet_integration_tests): move verify results to manager struct #3200


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*