### PR TITLE
chore(starknet_integration_tests): create execution index when applic…

### DIFF
--- a/crates/starknet_integration_tests/src/end_to_end_integration.rs
+++ b/crates/starknet_integration_tests/src/end_to_end_integration.rs
@@ -3,11 +3,7 @@ use starknet_api::block::BlockNumber;
 use starknet_sequencer_node::test_utils::node_runner::get_node_executable_path;
 use tracing::info;
 
-use crate::sequencer_manager::{
-    get_sequencer_setup_configs,
-    verify_results,
-    SequencerSetupManager,
-};
+use crate::sequencer_manager::{get_sequencer_setup_configs, SequencerSetupManager};
 
 pub async fn end_to_end_integration(tx_generator: MultiAccountTransactionGenerator) {
     const EXPECTED_BLOCK_NUMBER: BlockNumber = BlockNumber(15);
@@ -34,9 +30,6 @@ pub async fn end_to_end_integration(tx_generator: MultiAccountTransactionGenerat
     info!("Shutting down nodes.");
     sequencer_manager.shutdown_nodes();
 
-    // TODO(AlonH): Consider checking all sequencer storage readers.
-    let batcher_storage_reader = sequencer_manager.batcher_storage_reader();
-
     // Verify the results.
-    verify_results(sender_address, batcher_storage_reader, N_TXS).await;
+    sequencer_manager.verify_results(sender_address, N_TXS).await;
 }

--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -24,6 +24,7 @@ use starknet_sequencer_node::utils::create_node_modules;
 use tempfile::TempDir;
 use tracing::{debug, instrument};
 
+use crate::integration_test_setup::SequencerExecutionId;
 use crate::state_reader::StorageTestSetup;
 use crate::utils::{
     create_chain_info,
@@ -135,7 +136,7 @@ impl FlowSequencerSetup {
         // Derive the configuration for the sequencer node.
         let (node_config, _required_params) = create_node_config(
             &mut available_ports,
-            sequencer_index,
+            SequencerExecutionId::new(sequencer_index, 0),
             chain_info,
             storage_for_test.batcher_storage_config,
             storage_for_test.state_sync_storage_config,

--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -58,7 +58,6 @@ impl FlowTestSetup {
         let accounts = tx_generator.accounts();
         let (consensus_manager_configs, consensus_proposals_channels) =
             create_consensus_manager_configs_and_channels(
-                SEQUENCER_INDICES.len(),
                 available_ports.get_next_ports(SEQUENCER_INDICES.len() + 1),
             );
         let [sequencer_0_consensus_manager_config, sequencer_1_consensus_manager_config]: [ConsensusManagerConfig;

--- a/crates/starknet_integration_tests/src/integration_test_setup.rs
+++ b/crates/starknet_integration_tests/src/integration_test_setup.rs
@@ -14,6 +14,7 @@ use starknet_monitoring_endpoint::config::MonitoringEndpointConfig;
 use starknet_monitoring_endpoint::test_utils::MonitoringClient;
 use starknet_sequencer_infra::test_utils::AvailablePorts;
 use starknet_sequencer_node::config::component_config::ComponentConfig;
+use starknet_sequencer_node::test_utils::node_runner::NodeRunner;
 use tempfile::{tempdir, TempDir};
 use tracing::instrument;
 
@@ -21,11 +22,33 @@ use crate::config_utils::dump_config_file_changes;
 use crate::state_reader::StorageTestSetup;
 use crate::utils::{create_node_config, spawn_success_recorder};
 
+#[derive(Debug, Copy, Clone)]
+pub struct SequencerExecutionId {
+    sequencer_index: usize,
+    sequencer_part_index: usize,
+}
+
+impl SequencerExecutionId {
+    pub fn new(sequencer_index: usize, sequencer_part_index: usize) -> Self {
+        Self { sequencer_index, sequencer_part_index }
+    }
+    pub fn get_sequencer_index(&self) -> usize {
+        self.sequencer_index
+    }
+    pub fn get_sequencer_part_index(&self) -> usize {
+        self.sequencer_part_index
+    }
+}
+
+impl From<SequencerExecutionId> for NodeRunner {
+    fn from(val: SequencerExecutionId) -> Self {
+        NodeRunner::new(val.sequencer_index, val.sequencer_part_index)
+    }
+}
+
 pub struct SequencerSetup {
-    /// Sequencer index in the test.
-    pub sequencer_index: usize,
-    /// Sequencer part index in the test, per sequencer index.
-    pub sequencer_part_index: usize,
+    // Sequencer test identifier.
+    pub sequencer_execution_id: SequencerExecutionId,
     // Client for adding transactions to the sequencer node.
     pub add_tx_http_client: HttpTestClient,
     // Client for checking liveness of the sequencer node.
@@ -50,11 +73,9 @@ pub struct SequencerSetup {
 // TODO(Tsabary/ Nadin): reduce number of args.
 impl SequencerSetup {
     #[instrument(skip(accounts, chain_info, consensus_manager_config), level = "debug")]
-    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         accounts: Vec<AccountTransactionGenerator>,
-        sequencer_index: usize,
-        sequencer_part_index: usize,
+        sequencer_execution_id: SequencerExecutionId,
         chain_info: ChainInfo,
         mut consensus_manager_config: ConsensusManagerConfig,
         mempool_p2p_config: MempoolP2pConfig,
@@ -70,7 +91,7 @@ impl SequencerSetup {
         // Derive the configuration for the sequencer node.
         let (config, required_params) = create_node_config(
             &mut available_ports,
-            sequencer_index,
+            sequencer_execution_id,
             chain_info,
             storage_for_test.batcher_storage_config,
             storage_for_test.state_sync_storage_config,
@@ -95,8 +116,7 @@ impl SequencerSetup {
         let add_tx_http_client = HttpTestClient::new(SocketAddr::from((ip, port)));
 
         Self {
-            sequencer_index,
-            sequencer_part_index,
+            sequencer_execution_id,
             add_tx_http_client,
             monitoring_client,
             batcher_storage_handle: storage_for_test.batcher_storage_handle,

--- a/crates/starknet_integration_tests/src/sequencer_manager.rs
+++ b/crates/starknet_integration_tests/src/sequencer_manager.rs
@@ -147,7 +147,7 @@ impl SequencerSetupManager {
 }
 
 /// Reads the latest block number from the storage.
-pub fn get_latest_block_number(storage_reader: &StorageReader) -> BlockNumber {
+fn get_latest_block_number(storage_reader: &StorageReader) -> BlockNumber {
     let txn = storage_reader.begin_ro_txn().unwrap();
     txn.get_state_marker()
         .expect("There should always be a state marker")
@@ -156,10 +156,7 @@ pub fn get_latest_block_number(storage_reader: &StorageReader) -> BlockNumber {
 }
 
 /// Reads an account nonce after a block number from storage.
-pub fn get_account_nonce(
-    storage_reader: &StorageReader,
-    contract_address: ContractAddress,
-) -> Nonce {
+fn get_account_nonce(storage_reader: &StorageReader, contract_address: ContractAddress) -> Nonce {
     let block_number = get_latest_block_number(storage_reader);
     let txn = storage_reader.begin_ro_txn().unwrap();
     let state_number = StateNumber::unchecked_right_after_block(block_number);
@@ -170,7 +167,7 @@ pub fn get_account_nonce(
 
 /// Sample a storage until sufficiently many blocks have been stored. Returns an error if after
 /// the given number of attempts the target block number has not been reached.
-pub async fn await_block(
+async fn await_block(
     interval: u64,
     target_block_number: BlockNumber,
     max_attempts: usize,
@@ -189,7 +186,7 @@ pub async fn await_block(
         .ok_or(())
 }
 
-pub async fn get_sequencer_setup_configs(
+pub(crate) async fn get_sequencer_setup_configs(
     tx_generator: &MultiAccountTransactionGenerator,
 ) -> Vec<SequencerSetup> {
     let test_unique_id = TestIdentifier::EndToEndIntegrationTest;

--- a/crates/starknet_integration_tests/src/sequencer_manager.rs
+++ b/crates/starknet_integration_tests/src/sequencer_manager.rs
@@ -216,8 +216,9 @@ pub async fn get_sequencer_setup_configs(
         .map(|composed_node_component_configs| composed_node_component_configs.len())
         .sum();
 
+    // TODO(Tsabary): remove '+1', replace with 'create_connected_network_configs' and
+    // 'create_consensus_manager_configs_from_network_config'.
     let (consensus_manager_configs, _) = create_consensus_manager_configs_and_channels(
-        n_distributed_sequencers,
         available_ports.get_next_ports(n_distributed_sequencers + 1),
     );
 

--- a/crates/starknet_integration_tests/src/sequencer_manager.rs
+++ b/crates/starknet_integration_tests/src/sequencer_manager.rs
@@ -8,6 +8,7 @@ use infra_utils::tracing::{CustomLogger, TraceLevel};
 use itertools::izip;
 use mempool_test_utils::starknet_api_test_utils::{AccountId, MultiAccountTransactionGenerator};
 use papyrus_execution::execution_utils::get_nonce_at;
+use papyrus_network::network_manager::test_utils::create_connected_network_configs;
 use papyrus_storage::state::StateStorageReader;
 use papyrus_storage::StorageReader;
 use starknet_api::block::BlockNumber;
@@ -30,7 +31,7 @@ use crate::integration_test_setup::{SequencerExecutionId, SequencerSetup};
 use crate::test_identifiers::TestIdentifier;
 use crate::utils::{
     create_chain_info,
-    create_consensus_manager_configs_and_channels,
+    create_consensus_manager_configs_from_network_configs,
     create_mempool_p2p_configs,
     send_account_txs,
 };
@@ -216,10 +217,8 @@ pub async fn get_sequencer_setup_configs(
         .map(|composed_node_component_configs| composed_node_component_configs.len())
         .sum();
 
-    // TODO(Tsabary): remove '+1', replace with 'create_connected_network_configs' and
-    // 'create_consensus_manager_configs_from_network_config'.
-    let (consensus_manager_configs, _) = create_consensus_manager_configs_and_channels(
-        available_ports.get_next_ports(n_distributed_sequencers + 1),
+    let consensus_manager_configs = create_consensus_manager_configs_from_network_configs(
+        create_connected_network_configs(available_ports.get_next_ports(n_distributed_sequencers)),
     );
 
     let mempool_p2p_configs = create_mempool_p2p_configs(

--- a/crates/starknet_integration_tests/src/sequencer_manager.rs
+++ b/crates/starknet_integration_tests/src/sequencer_manager.rs
@@ -224,13 +224,16 @@ pub(crate) async fn get_sequencer_setup_configs(
     );
 
     // Flatten while enumerating sequencer and sequencer part indices.
-    let indexed_component_configs: Vec<((usize, usize), ComponentConfig)> = component_configs
+    let indexed_component_configs: Vec<(SequencerExecutionId, ComponentConfig)> = component_configs
         .into_iter()
         .enumerate()
         .flat_map(|(sequencer_index, parts_component_configs)| {
             parts_component_configs.into_iter().enumerate().map(
-                move |(sequencer_part_config, value)| {
-                    ((sequencer_index, sequencer_part_config), value) // Combine indices with the value
+                move |(sequencer_part_index, parts_component_config)| {
+                    (
+                        SequencerExecutionId::new(sequencer_index, sequencer_part_index),
+                        parts_component_config,
+                    ) // Combine indices with the value
                 },
             )
         })
@@ -247,7 +250,7 @@ pub(crate) async fn get_sequencer_setup_configs(
         |(
             index,
             (
-                ((sequencer_index, sequencer_part_index), component_config),
+                (sequencer_execution_id, component_config),
                 consensus_manager_config,
                 mempool_p2p_config,
             ),
@@ -256,7 +259,7 @@ pub(crate) async fn get_sequencer_setup_configs(
             async move {
                 SequencerSetup::new(
                     accounts.to_vec(),
-                    SequencerExecutionId::new(sequencer_index, sequencer_part_index),
+                    sequencer_execution_id,
                     chain_info,
                     consensus_manager_config,
                     mempool_p2p_config,

--- a/crates/starknet_integration_tests/src/utils.rs
+++ b/crates/starknet_integration_tests/src/utils.rs
@@ -17,13 +17,8 @@ use mempool_test_utils::starknet_api_test_utils::{
 use papyrus_consensus::config::{ConsensusConfig, TimeoutsConfig};
 use papyrus_consensus::types::ValidatorId;
 use papyrus_consensus_orchestrator::cende::RECORDER_WRITE_BLOB_PATH;
-use papyrus_network::network_manager::test_utils::{
-    create_connected_network_configs,
-    create_network_configs_connected_to_broadcast_channels,
-};
-use papyrus_network::network_manager::BroadcastTopicChannels;
+use papyrus_network::network_manager::test_utils::create_connected_network_configs;
 use papyrus_network::NetworkConfig;
-use papyrus_protobuf::consensus::{ProposalPart, StreamMessage};
 use papyrus_storage::StorageConfig;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::ChainId;
@@ -122,24 +117,7 @@ pub async fn create_node_config(
     )
 }
 
-pub fn create_consensus_manager_configs_and_channels(
-    ports: Vec<u16>,
-) -> (Vec<ConsensusManagerConfig>, BroadcastTopicChannels<StreamMessage<ProposalPart>>) {
-    let (network_configs, broadcast_channels) =
-        create_network_configs_connected_to_broadcast_channels(
-            papyrus_network::gossipsub_impl::Topic::new(
-                starknet_consensus_manager::consensus_manager::CONSENSUS_PROPOSALS_TOPIC,
-            ),
-            ports,
-        );
-    // TODO: Need to also add a channel for votes, in addition to the proposals channel.
-
-    let consensus_manager_configs =
-        create_consensus_manager_configs_from_network_configs(network_configs);
-    (consensus_manager_configs, broadcast_channels)
-}
-
-fn create_consensus_manager_configs_from_network_configs(
+pub(crate) fn create_consensus_manager_configs_from_network_configs(
     network_configs: Vec<NetworkConfig>,
 ) -> Vec<ConsensusManagerConfig> {
     // TODO(Matan, Dan): set reasonable default timeouts.

--- a/crates/starknet_integration_tests/src/utils.rs
+++ b/crates/starknet_integration_tests/src/utils.rs
@@ -51,6 +51,8 @@ use starknet_state_sync::config::StateSyncConfig;
 use starknet_types_core::felt::Felt;
 use url::Url;
 
+use crate::integration_test_setup::SequencerExecutionId;
+
 pub const ACCOUNT_ID_0: AccountId = 0;
 pub const ACCOUNT_ID_1: AccountId = 1;
 pub const NEW_ACCOUNT_SALT: ContractAddressSalt = ContractAddressSalt(Felt::THREE);
@@ -71,7 +73,7 @@ pub fn create_chain_info() -> ChainInfo {
 #[allow(clippy::too_many_arguments)]
 pub async fn create_node_config(
     available_ports: &mut AvailablePorts,
-    sequencer_index: usize,
+    sequencer_execution_id: SequencerExecutionId,
     chain_info: ChainInfo,
     batcher_storage_config: StorageConfig,
     state_sync_storage_config: StorageConfig,
@@ -79,7 +81,10 @@ pub async fn create_node_config(
     mempool_p2p_config: MempoolP2pConfig,
     component_config: ComponentConfig,
 ) -> (SequencerNodeConfig, RequiredParams) {
-    let validator_id = set_validator_id(&mut consensus_manager_config, sequencer_index);
+    let validator_id = set_validator_id(
+        &mut consensus_manager_config,
+        sequencer_execution_id.get_sequencer_index(),
+    );
     let recorder_url = consensus_manager_config.cende_config.recorder_url.clone();
     let fee_token_addresses = chain_info.fee_token_addresses.clone();
     let batcher_config = create_batcher_config(batcher_storage_config, chain_info.clone());

--- a/crates/starknet_integration_tests/src/utils.rs
+++ b/crates/starknet_integration_tests/src/utils.rs
@@ -84,7 +84,7 @@ pub async fn create_node_config(
     let recorder_url = consensus_manager_config.cende_config.recorder_url.clone();
     let fee_token_addresses = chain_info.fee_token_addresses.clone();
     let batcher_config = create_batcher_config(batcher_storage_config, chain_info.clone());
-    let gateway_config = create_gateway_config(chain_info.clone()).await;
+    let gateway_config = create_gateway_config(chain_info.clone());
     let http_server_config =
         create_http_server_config(available_ports.get_next_local_host_socket());
     let monitoring_endpoint_config =
@@ -291,7 +291,7 @@ where
     send_rpc_txs(rpc_txs, send_rpc_tx_fn).await
 }
 
-pub async fn create_gateway_config(chain_info: ChainInfo) -> GatewayConfig {
+pub fn create_gateway_config(chain_info: ChainInfo) -> GatewayConfig {
     let stateless_tx_validator_config = StatelessTransactionValidatorConfig {
         validate_non_zero_l1_gas_fee: true,
         max_calldata_length: 10,

--- a/crates/starknet_integration_tests/tests/mempool_p2p_flow_test.rs
+++ b/crates/starknet_integration_tests/tests/mempool_p2p_flow_test.rs
@@ -76,7 +76,7 @@ async fn setup(
 
     let batcher_config =
         create_batcher_config(storage_for_test.batcher_storage_config, chain_info.clone());
-    let gateway_config = create_gateway_config(chain_info).await;
+    let gateway_config = create_gateway_config(chain_info);
     let http_server_config =
         create_http_server_config(available_ports.get_next_local_host_socket());
     let state_sync_config = create_state_sync_config(


### PR DESCRIPTION
…able

commit-id:c03907ce

---

**Stack**:
- chore(starknet_integration_tests): create execution index when applicable #3207 ⬅
- chore(starknet_integration_tests): remove redundant async #3206
- chore(starknet_integration_tests): remove redundant fn visibility #3205
- chore(starknet_integration_tests): separate utils, use proper fn #3204
- chore(starknet_integration_tests): separate fn #3203
- chore(starknet_integration_tests): replace composed node type with struct #3202
- chore(starknet_integration_tests): bundle node exec id #3201
- chore(starknet_integration_tests): move verify results to manager struct #3200


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*