### PR TITLE
feat(starknet_sierra_compile_types): add crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11128,6 +11128,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet_sierra_compile_types"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "papyrus_proc_macros",
+ "serde",
+ "serde_json",
+ "starknet_api",
+ "starknet_sequencer_infra",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "starknet_state_sync"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
   "crates/starknet_sequencer_infra",
   "crates/starknet_sequencer_node",
   "crates/starknet_sierra_compile",
+  "crates/starknet_sierra_compile_types",
   "crates/starknet_state_sync",
   "crates/starknet_state_sync_types",
   "crates/starknet_task_executor",
@@ -239,6 +240,7 @@ starknet_patricia = { path = "crates/starknet_patricia", version = "0.0.0" }
 starknet_sequencer_infra = { path = "crates/starknet_sequencer_infra", version = "0.0.0" }
 starknet_sequencer_node = { path = "crates/starknet_sequencer_node", version = "0.0.0" }
 starknet_sierra_compile = { path = "crates/starknet_sierra_compile", version = "0.0.0" }
+starknet_sierra_compile_types = { path = "crates/starknet_sierra_compile_types", version = "0.0.0" }
 starknet_state_sync = { path = "crates/starknet_state_sync", version = "0.0.0" }
 starknet_state_sync_types = { path = "crates/starknet_state_sync_types", version = "0.0.0" }
 starknet_task_executor = { path = "crates/starknet_task_executor", version = "0.0.0" }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -72,6 +72,7 @@ const Configuration = {
             'starknet_sequencer_infra',
             'starknet_sequencer_node',
             'starknet_sierra_compile',
+            'starknet_sierra_compile_types',
             'starknet_state_sync',
             'starknet_state_sync_types',
             'starknet_task_executor',

--- a/crates/starknet_sierra_compile_types/Cargo.toml
+++ b/crates/starknet_sierra_compile_types/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "starknet_sierra_compile_types"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait.workspace = true
+bytes = { workspace = true, features = ["serde"] }
+papyrus_proc_macros.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+starknet_api.workspace = true
+starknet_sequencer_infra.workspace = true
+thiserror.workspace = true

--- a/crates/starknet_sierra_compile_types/src/lib.rs
+++ b/crates/starknet_sierra_compile_types/src/lib.rs
@@ -1,0 +1,120 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use papyrus_proc_macros::handle_response_variants;
+use serde::{Deserialize, Serialize};
+use starknet_api::contract_class::ContractClass;
+use starknet_api::core::CompiledClassHash;
+use starknet_api::state::SierraContractClass;
+use starknet_sequencer_infra::component_client::ClientError;
+use starknet_sequencer_infra::component_definitions::ComponentClient;
+use thiserror::Error;
+
+pub type SierraCompilerResult<T> = Result<T, SierraCompilerError>;
+pub type SierraCompilerClientResult<T> = Result<T, SierraCompilerClientError>;
+
+pub type RawExecutableHashedClass = (RawExecutableClass, CompiledClassHash);
+
+pub type SharedSierraCompilerClient = Arc<dyn SierraCompilerClient>;
+
+// TODO(Elin): change to a more efficient serde (bytes, or something similar).
+// A prerequisite for this is to solve serde-untagged lack of support.
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RawClass(Bytes);
+
+impl TryFrom<SierraContractClass> for RawClass {
+    type Error = serde_json::Error;
+
+    fn try_from(class: SierraContractClass) -> Result<Self, Self::Error> {
+        let class = serde_json::to_vec(&class)?.into();
+        Ok(Self(class))
+    }
+}
+
+impl TryFrom<RawClass> for SierraContractClass {
+    type Error = serde_json::Error;
+
+    fn try_from(class: RawClass) -> Result<Self, Self::Error> {
+        let class: SierraContractClass = serde_json::from_slice(class.0.as_ref())?;
+        Ok(class)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RawExecutableClass(Bytes);
+
+impl TryFrom<ContractClass> for RawExecutableClass {
+    type Error = serde_json::Error;
+
+    fn try_from(class: ContractClass) -> Result<Self, Self::Error> {
+        let class = serde_json::to_vec(&class)?.into();
+        Ok(Self(class))
+    }
+}
+
+impl TryFrom<RawExecutableClass> for ContractClass {
+    type Error = serde_json::Error;
+
+    fn try_from(class: RawExecutableClass) -> Result<Self, Self::Error> {
+        let class: ContractClass = serde_json::from_slice(class.0.as_ref())?;
+        Ok(class)
+    }
+}
+
+/// Serves as the Sierra compilation unit's shared interface.
+/// Requires `Send + Sync` to allow transferring and sharing resources (inputs, futures) across
+/// threads.
+#[async_trait]
+pub trait SierraCompilerClient: Send + Sync {
+    async fn compile(
+        &self,
+        class: RawClass,
+    ) -> SierraCompilerClientResult<RawExecutableHashedClass>;
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SierraCompilerError {
+    #[error("Compilation failed: {0}")]
+    SierraCompilerError(String),
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum SierraCompilerClientError {
+    #[error(transparent)]
+    ClientError(#[from] ClientError),
+    #[error(transparent)]
+    SierraCompilerError(#[from] SierraCompilerError),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SierraCompilerRequest {
+    Compile(RawClass),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SierraCompilerResponse {
+    Compile(SierraCompilerResult<RawExecutableHashedClass>),
+}
+
+#[async_trait]
+impl<ComponentClientType> SierraCompilerClient for ComponentClientType
+where
+    ComponentClientType:
+        Send + Sync + ComponentClient<SierraCompilerRequest, SierraCompilerResponse>,
+{
+    async fn compile(
+        &self,
+        class: RawClass,
+    ) -> SierraCompilerClientResult<RawExecutableHashedClass> {
+        let request = SierraCompilerRequest::Compile(class);
+        let response = self.send(request).await;
+        handle_response_variants!(
+            SierraCompilerResponse,
+            Compile,
+            SierraCompilerClientError,
+            SierraCompilerError
+        )
+    }
+}


### PR DESCRIPTION
This is the `_types` crate for the compiler component that the class manager will use (a thin functional wrapper will wrap the existing compiler code in `starknet_sierra_compile` crate, thus will be added there. This is the reason the non-`_types` crate already exists.