### PR TITLE
feat(papyrus_network): split network config creation and conversion to broadcast channels

### DIFF
--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -5,7 +5,10 @@ use mempool_test_utils::starknet_api_test_utils::{
     AccountTransactionGenerator,
     MultiAccountTransactionGenerator,
 };
-use papyrus_network::network_manager::test_utils::create_network_configs_connected_to_broadcast_channels;
+use papyrus_network::network_manager::test_utils::{
+    create_connected_network_configs,
+    network_config_into_broadcast_channels,
+};
 use papyrus_network::network_manager::BroadcastTopicChannels;
 use papyrus_protobuf::consensus::{HeightAndRound, ProposalPart, StreamMessage};
 use starknet_api::rpc_transaction::RpcTransaction;
@@ -180,16 +183,19 @@ pub fn create_consensus_manager_configs_and_channels(
     Vec<ConsensusManagerConfig>,
     BroadcastTopicChannels<StreamMessage<ProposalPart, HeightAndRound>>,
 ) {
-    let (network_configs, broadcast_channels) =
-        create_network_configs_connected_to_broadcast_channels(
-            papyrus_network::gossipsub_impl::Topic::new(
-                starknet_consensus_manager::consensus_manager::CONSENSUS_PROPOSALS_TOPIC,
-            ),
-            ports,
-        );
+    let mut network_configs = create_connected_network_configs(ports);
+
     // TODO: Need to also add a channel for votes, in addition to the proposals channel.
+    let channels_network_config = network_configs.pop().unwrap();
+    let broadcast_channels = network_config_into_broadcast_channels(
+        channels_network_config,
+        papyrus_network::gossipsub_impl::Topic::new(
+            starknet_consensus_manager::consensus_manager::CONSENSUS_PROPOSALS_TOPIC,
+        ),
+    );
 
     let consensus_manager_configs =
         create_consensus_manager_configs_from_network_configs(network_configs);
+
     (consensus_manager_configs, broadcast_channels)
 }


### PR DESCRIPTION
- **revert(starknet_integration_tests): remove mempool p2p flow test**
- **feat(papyrus_network): split network config creation and conversion to broadcast channels**
