### PR TITLE
chore: add gitconfig that ignores cairo native

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[submodule "crates/blockifier/cairo_native"]
+    ignore = all


### PR DESCRIPTION
- **test(blockifier): fix broken revert-recurse fee check in test (#3133)**
- **fix(cairo_native): fix cairo native submdoule commit hash (#3199)**
- **chore(blockifier): prepare consuming finalize (#3188)**
- **refactor(starknet_api,blockifier): to_discounted_gas_amount (#2874)**
- **test(blockifier_reexecution): get_block_numbers_for_reexecution (#3211)**
- **test(cairo_native): test papyrus state reader get compiled class (#2949)**
- **test(blockifier): refactor account_transaction_test (#3250)**
- **test(blockifier): add old cairo 1 to test_initial_gas (#3262)**
- **test(cairo_native): add native to transactions test (#3041)**
- **chore: add gitconfig that ignores cairo native**
