### PR TITLE
feat(starknet_sierra_compile): add `SierraCompiler`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11217,6 +11217,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "starknet_infra_utils",
+ "starknet_sierra_compile_types",
  "tempfile",
  "thiserror 1.0.69",
  "validator",

--- a/crates/starknet_sierra_compile/Cargo.toml
+++ b/crates/starknet_sierra_compile/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
+starknet_sierra_compile_types.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 validator.workspace = true
@@ -30,6 +31,7 @@ validator.workspace = true
 assert_matches.workspace = true
 mempool_test_utils.workspace = true
 rstest.workspace = true
+starknet_api.workspace = true
 starknet_infra_utils.workspace = true
 
 [build-dependencies]

--- a/crates/starknet_sierra_compile/src/compile_test.rs
+++ b/crates/starknet_sierra_compile/src/compile_test.rs
@@ -2,9 +2,11 @@ use std::env;
 use std::path::Path;
 
 use assert_matches::assert_matches;
-use cairo_lang_starknet_classes::contract_class::ContractClass;
+use cairo_lang_starknet_classes::contract_class::ContractClass as CairoLangContractClass;
 use mempool_test_utils::{FAULTY_ACCOUNT_CLASS_FILE, TEST_FILES_FOLDER};
 use rstest::rstest;
+use starknet_api::contract_class::{ContractClass, SierraVersion};
+use starknet_api::state::SierraContractClass;
 use starknet_infra_utils::path::resolve_project_relative_path;
 
 use crate::command_line_compiler::CommandLineCompiler;
@@ -17,9 +19,9 @@ use crate::config::{
 };
 use crate::errors::CompilationUtilError;
 use crate::test_utils::contract_class_from_file;
-use crate::SierraToCasmCompiler;
 #[cfg(feature = "cairo_native")]
 use crate::SierraToNativeCompiler;
+use crate::{RawClass, SierraCompiler, SierraToCasmCompiler};
 
 const SIERRA_COMPILATION_CONFIG: SierraCompilationConfig = SierraCompilationConfig {
     max_casm_bytecode_size: DEFAULT_MAX_CASM_BYTECODE_SIZE,
@@ -34,14 +36,14 @@ fn command_line_compiler() -> CommandLineCompiler {
     CommandLineCompiler::new(SIERRA_COMPILATION_CONFIG)
 }
 
-fn get_test_contract() -> ContractClass {
+fn get_test_contract() -> CairoLangContractClass {
     env::set_current_dir(resolve_project_relative_path(TEST_FILES_FOLDER).unwrap())
         .expect("Failed to set current dir.");
     let sierra_path = Path::new(FAULTY_ACCOUNT_CLASS_FILE);
     contract_class_from_file(sierra_path)
 }
 
-fn get_faulty_test_contract() -> ContractClass {
+fn get_faulty_test_contract() -> CairoLangContractClass {
     let mut contract_class = get_test_contract();
     // Truncate the sierra program to trigger an error.
     contract_class.sierra_program = contract_class.sierra_program[..100].to_vec();
@@ -114,4 +116,27 @@ fn test_max_casm_bytecode_size() {
     assert_matches!(result, Err(CompilationUtilError::CompilationError(string))
         if string.contains("Code size limit exceeded.")
     );
+}
+
+// TODO: mock compiler.
+#[test]
+fn test_sierra_compiler() {
+    // Setup.
+    let compiler = command_line_compiler();
+    let class = get_test_contract();
+    let expected_executable_class = compiler.compile(class.clone()).unwrap();
+
+    let compiler = SierraCompiler::new(compiler);
+    let class = SierraContractClass::from(class);
+    let sierra_version = SierraVersion::extract_from_program(&class.sierra_program).unwrap();
+    let expected_executable_class = ContractClass::V1((expected_executable_class, sierra_version));
+
+    // Test.
+    let raw_class = RawClass::try_from(class).unwrap();
+    let (raw_executable_class, executable_class_hash) = compiler.compile(raw_class).unwrap();
+    let executable_class = ContractClass::try_from(raw_executable_class).unwrap();
+
+    // Assert.
+    assert_eq!(executable_class, expected_executable_class);
+    assert_eq!(executable_class_hash, expected_executable_class.compiled_class_hash());
 }

--- a/crates/starknet_sierra_compile/src/lib.rs
+++ b/crates/starknet_sierra_compile/src/lib.rs
@@ -1,10 +1,18 @@
 //! A lib for compiling Sierra into Casm.
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
-use cairo_lang_starknet_classes::contract_class::ContractClass;
+use cairo_lang_starknet_classes::contract_class::ContractClass as CairoLangContractClass;
 #[cfg(feature = "cairo_native")]
 use cairo_native::executor::AotContractExecutor;
+use starknet_api::contract_class::{ContractClass, SierraVersion};
+use starknet_api::core::CompiledClassHash;
+use starknet_api::state::SierraContractClass;
+use starknet_api::StarknetApiError;
+use starknet_sierra_compile_types::{RawClass, RawExecutableClass, RawExecutableHashedClass};
+use thiserror::Error;
 
+use crate::command_line_compiler::CommandLineCompiler;
 use crate::errors::CompilationUtilError;
+use crate::utils::into_contract_class_for_compilation;
 
 pub mod command_line_compiler;
 pub mod config;
@@ -21,10 +29,12 @@ pub mod test_utils;
 #[path = "compile_test.rs"]
 pub mod compile_test;
 
+pub type SierraCompilerResult<T> = Result<T, SierraCompilerError>;
+
 pub trait SierraToCasmCompiler: Send + Sync {
     fn compile(
         &self,
-        contract_class: ContractClass,
+        contract_class: CairoLangContractClass,
     ) -> Result<CasmContractClass, CompilationUtilError>;
 }
 
@@ -32,6 +42,45 @@ pub trait SierraToCasmCompiler: Send + Sync {
 pub trait SierraToNativeCompiler: Send + Sync {
     fn compile_to_native(
         &self,
-        contract_class: ContractClass,
+        contract_class: CairoLangContractClass,
     ) -> Result<AotContractExecutor, CompilationUtilError>;
+}
+
+#[derive(Debug, Error)]
+pub enum SierraCompilerError {
+    #[error(transparent)]
+    ClassSerde(#[from] serde_json::Error),
+    #[error(transparent)]
+    CompilationFailed(#[from] CompilationUtilError),
+    #[error("Failed to parse Sierra version: {0}")]
+    SierraVersionFormat(StarknetApiError),
+}
+
+// TODO: consider generalizing the compiler if invocation implementations are added.
+#[derive(Clone)]
+pub struct SierraCompiler {
+    compiler: CommandLineCompiler,
+}
+
+impl SierraCompiler {
+    pub fn new(compiler: CommandLineCompiler) -> Self {
+        Self { compiler }
+    }
+
+    // TODO(Elin): move (de)serialization to infra. layer.
+    pub fn compile(&self, class: RawClass) -> SierraCompilerResult<RawExecutableHashedClass> {
+        let class = SierraContractClass::try_from(class)?;
+        let sierra_version = SierraVersion::extract_from_program(&class.sierra_program)
+            .map_err(SierraCompilerError::SierraVersionFormat)?;
+        let class = into_contract_class_for_compilation(&class);
+
+        // TODO(Elin): handle resources (whether here or an infra. layer load-balancing).
+        let executable_class = self.compiler.compile(class)?;
+        // TODO(Elin): consider spawning a worker for hash calculation.
+        let executable_class_hash = CompiledClassHash(executable_class.compiled_class_hash());
+        let executable_class = ContractClass::V1((executable_class, sierra_version));
+        let executable_class = RawExecutableClass::try_from(executable_class)?;
+
+        Ok((executable_class, executable_class_hash))
+    }
 }


### PR DESCRIPTION
A wrapper around the CLI compiler that also takes care of class serde. It will serve as the compilation CPU unit of the `ClassManager`.