### PR TITLE
refactor(starknet_api): move `GlobalContractCache` from `blockifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10680,6 +10680,7 @@ dependencies = [
  "assert-json-diff",
  "assert_matches",
  "bitvec",
+ "cached",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
  "derive_more 0.99.18",

--- a/crates/blockifier/src/state/global_cache.rs
+++ b/crates/blockifier/src/state/global_cache.rs
@@ -1,6 +1,6 @@
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 
-use cached::{Cached, SizedCache};
+use starknet_api::class_cache::GlobalContractCache;
 use starknet_api::core::ClassHash;
 use starknet_api::state::SierraContractClass;
 
@@ -8,13 +8,7 @@ use crate::execution::contract_class::RunnableCompiledClass;
 #[cfg(feature = "cairo_native")]
 use crate::execution::native::contract_class::NativeCompiledClassV1;
 
-type ContractLRUCache<T> = SizedCache<ClassHash, T>;
-pub type LockedClassCache<'a, T> = MutexGuard<'a, ContractLRUCache<T>>;
-#[derive(Debug, Clone)]
-// Thread-safe LRU cache for contract classes (Seirra or compiled Casm/Native), optimized for
-// inter-language sharing when `blockifier` compiles as a shared library.
-// TODO(Yoni, 1/1/2025): consider defining CachedStateReader.
-pub struct GlobalContractCache<T: Clone>(pub Arc<Mutex<ContractLRUCache<T>>>);
+pub const GLOBAL_CONTRACT_CACHE_SIZE_FOR_TEST: usize = 400;
 
 #[derive(Debug, Clone)]
 pub enum CachedCasm {
@@ -34,32 +28,6 @@ impl CachedCasm {
 pub enum CachedCairoNative {
     Compiled(NativeCompiledClassV1),
     CompilationFailed,
-}
-
-pub const GLOBAL_CONTRACT_CACHE_SIZE_FOR_TEST: usize = 400;
-
-impl<T: Clone> GlobalContractCache<T> {
-    /// Locks the cache for atomic access. Although conceptually shared, writing to this cache is
-    /// only possible for one writer at a time.
-    pub fn lock(&self) -> LockedClassCache<'_, T> {
-        self.0.lock().expect("Global contract cache is poisoned.")
-    }
-
-    pub fn get(&self, class_hash: &ClassHash) -> Option<T> {
-        self.lock().cache_get(class_hash).cloned()
-    }
-
-    pub fn set(&self, class_hash: ClassHash, contract_class: T) {
-        self.lock().cache_set(class_hash, contract_class);
-    }
-
-    pub fn clear(&mut self) {
-        self.lock().cache_clear();
-    }
-
-    pub fn new(cache_size: usize) -> Self {
-        Self(Arc::new(Mutex::new(ContractLRUCache::<T>::with_size(cache_size))))
-    }
 }
 
 #[derive(Clone)]

--- a/crates/starknet_api/Cargo.toml
+++ b/crates/starknet_api/Cargo.toml
@@ -12,6 +12,7 @@ testing = ["dep:assert-json-diff", "starknet_infra_utils"]
 [dependencies]
 assert-json-diff = { workspace = true, optional = true }
 bitvec.workspace = true
+cached.workspace = true
 cairo-lang-runner.workspace = true
 cairo-lang-starknet-classes.workspace = true
 derive_more.workspace = true

--- a/crates/starknet_api/src/class_cache.rs
+++ b/crates/starknet_api/src/class_cache.rs
@@ -1,0 +1,38 @@
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use cached::{Cached, SizedCache};
+
+use crate::core::ClassHash;
+
+type ContractLRUCache<T> = SizedCache<ClassHash, T>;
+type LockedClassCache<'a, T> = MutexGuard<'a, ContractLRUCache<T>>;
+
+// TODO(Yoni, 1/2/2025): consider defining CachedStateReader.
+/// Thread-safe LRU cache for contract classes (Sierra or compiled Casm/Native), optimized for
+/// inter-language sharing when `blockifier` compiles as a shared library.
+#[derive(Clone, Debug)]
+pub struct GlobalContractCache<T: Clone>(pub Arc<Mutex<ContractLRUCache<T>>>);
+
+impl<T: Clone> GlobalContractCache<T> {
+    /// Locks the cache for atomic access. Although conceptually shared, writing to this cache is
+    /// only possible for one writer at a time.
+    pub fn lock(&self) -> LockedClassCache<'_, T> {
+        self.0.lock().expect("Global contract cache is poisoned.")
+    }
+
+    pub fn get(&self, class_hash: &ClassHash) -> Option<T> {
+        self.lock().cache_get(class_hash).cloned()
+    }
+
+    pub fn set(&self, class_hash: ClassHash, contract_class: T) {
+        self.lock().cache_set(class_hash, contract_class);
+    }
+
+    pub fn clear(&mut self) {
+        self.lock().cache_clear();
+    }
+
+    pub fn new(cache_size: usize) -> Self {
+        Self(Arc::new(Mutex::new(ContractLRUCache::<T>::with_size(cache_size))))
+    }
+}

--- a/crates/starknet_api/src/lib.rs
+++ b/crates/starknet_api/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod abi;
 pub mod block;
 pub mod block_hash;
+pub mod class_cache;
 pub mod consensus_transaction;
 pub mod contract_class;
 pub mod core;


### PR DESCRIPTION
To be used by `ClassManager`, which should not depend on `blockifier`. Also, it's standalone.
Code move only, no changes.