### PR TITLE
fix(papyrus_network): track connection id for peers before identify event

### DIFF
--- a/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
+++ b/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
@@ -139,13 +139,16 @@ impl NetworkBehaviour for PeerManager {
                         )
                         .add_connection_id(connection_id);
                 } else {
-                    let Some(peer) = self.peers.get_mut(&peer_id) else {
-                        // TODO(shahak): Consider tracking connection ids for peers we don't know
-                        // yet because once a connection is established we'll shortly receive an
-                        // identify message and add this peer.
+                    if let Some(peer) = self.peers.get_mut(&peer_id) {
+                        peer.add_connection_id(connection_id);
                         return;
                     };
-                    peer.add_connection_id(connection_id);
+                    match self.connections_for_unknown_peers.get_mut(&peer_id) {
+                        Some(connection_ids) => connection_ids.push(connection_id),
+                        None => {
+                            self.connections_for_unknown_peers.insert(peer_id, vec![connection_id]);
+                        }
+                    }
                 }
             }
             libp2p::swarm::FromSwarm::ConnectionClosed(ConnectionClosed {
@@ -153,17 +156,22 @@ impl NetworkBehaviour for PeerManager {
                 connection_id,
                 ..
             }) => {
-                if let Some(peer) = self.peers.get_mut(&peer_id) {
-                    let known_connection_ids = peer.connection_ids();
-                    if known_connection_ids.contains(&connection_id) {
-                        peer.remove_connection_id(connection_id);
-                    } else {
-                        error!(
-                            "Connection closed event for a peer with a different connection id. \
-                             known connection ids: {:?}, emitted connection id: {}",
-                            known_connection_ids, connection_id
-                        );
-                    }
+                let mut empty_connection_ids = vec![];
+                let known_connection_ids = match self.peers.get_mut(&peer_id) {
+                    Some(peer) => peer.connection_ids_mut(),
+                    None => self
+                        .connections_for_unknown_peers
+                        .get_mut(&peer_id)
+                        .unwrap_or(&mut empty_connection_ids),
+                };
+                if known_connection_ids.contains(&connection_id) {
+                    known_connection_ids.retain(|&id| id != connection_id);
+                } else {
+                    error!(
+                        "Connection id {:?} was closed and it should appear in the known \
+                         connection ids, but it doesn't. known connection ids: {:?}.",
+                        connection_id, known_connection_ids
+                    );
                 }
             }
             _ => {}

--- a/crates/papyrus_network/src/peer_manager/mod.rs
+++ b/crates/papyrus_network/src/peer_manager/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use libp2p::swarm::dial_opts::DialOpts;
-use libp2p::swarm::ToSwarm;
+use libp2p::swarm::{ConnectionId, ToSwarm};
 use libp2p::PeerId;
 use papyrus_config::converters::{
     deserialize_milliseconds_to_duration,
@@ -51,6 +51,8 @@ pub struct PeerManager {
     peers_pending_dial_with_sessions: HashMap<PeerId, Vec<OutboundSessionId>>,
     sessions_received_when_no_peers: Vec<OutboundSessionId>,
     sleep_waiting_for_unblocked_peer: Option<BoxFuture<'static, ()>>,
+    // A peer is known only after we get the identify message.
+    connections_for_unknown_peers: HashMap<PeerId, Vec<ConnectionId>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -113,6 +115,7 @@ impl PeerManager {
             peers_pending_dial_with_sessions: HashMap::new(),
             sessions_received_when_no_peers: Vec::new(),
             sleep_waiting_for_unblocked_peer: None,
+            connections_for_unknown_peers: HashMap::default(),
         }
     }
 
@@ -276,7 +279,10 @@ impl BridgedBehaviour for PeerManager {
                     return;
                 };
 
-                let peer = Peer::new(*peer_id, address.clone());
+                let mut peer = Peer::new(*peer_id, address.clone());
+                if let Some(connection_ids) = self.connections_for_unknown_peers.remove(peer_id) {
+                    *peer.connection_ids_mut() = connection_ids;
+                }
                 self.add_peer(peer);
             }
             _ => {}

--- a/crates/papyrus_network/src/peer_manager/peer.rs
+++ b/crates/papyrus_network/src/peer_manager/peer.rs
@@ -57,12 +57,12 @@ impl Peer {
         &self.connection_ids
     }
 
-    pub fn add_connection_id(&mut self, connection_id: ConnectionId) {
-        self.connection_ids.push(connection_id);
+    pub fn connection_ids_mut(&mut self) -> &mut Vec<ConnectionId> {
+        &mut self.connection_ids
     }
 
-    pub fn remove_connection_id(&mut self, connection_id: ConnectionId) {
-        self.connection_ids.retain(|&id| id != connection_id);
+    pub fn add_connection_id(&mut self, connection_id: ConnectionId) {
+        self.connection_ids.push(connection_id);
     }
 
     pub fn reset_misconduct_score(&mut self) {


### PR DESCRIPTION
- **chore(papyrus_network): remove PeerTrait which is leftover of mock peer**
- **fix(papyrus_network): track connection id for peers before identify event**
