### PR TITLE
chore(starknet_infra_utils): remove get_available_socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11223,6 +11223,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "hyper 0.14.32",
+ "once_cell",
  "papyrus_config",
  "pretty_assertions",
  "rstest",

--- a/crates/starknet_infra_utils/Cargo.toml
+++ b/crates/starknet_infra_utils/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Infrastructure utility."
 
 [features]
-testing = ["tokio/net"]
+testing = []
 
 [lints]
 workspace = true

--- a/crates/starknet_infra_utils/src/test_utils.rs
+++ b/crates/starknet_infra_utils/src/test_utils.rs
@@ -1,7 +1,5 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use tokio::net::TcpListener;
-
 const PORTS_PER_INSTANCE: u16 = 60;
 pub const MAX_NUMBER_OF_INSTANCES_PER_TEST: u16 = 10;
 const MAX_NUMBER_OF_TESTS: u16 = 10;
@@ -22,6 +20,7 @@ pub enum TestIdentifier {
     EndToEndFlowTest,
     MempoolSendsTxToOtherPeerTest,
     MempoolReceivesTxFromOtherPeerTest,
+    InfraUnitTests,
 }
 
 impl From<TestIdentifier> for u16 {
@@ -31,6 +30,7 @@ impl From<TestIdentifier> for u16 {
             TestIdentifier::EndToEndFlowTest => 1,
             TestIdentifier::MempoolSendsTxToOtherPeerTest => 2,
             TestIdentifier::MempoolReceivesTxFromOtherPeerTest => 3,
+            TestIdentifier::InfraUnitTests => 4,
         }
     }
 }
@@ -80,18 +80,4 @@ impl AvailablePorts {
     pub fn get_next_local_host_socket(&mut self) -> SocketAddr {
         SocketAddr::new(IpAddr::from(Ipv4Addr::LOCALHOST), self.get_next_port())
     }
-}
-
-/// Returns a unique IP address and port for testing purposes.
-/// Tests run in parallel, so servers (like RPC or web) running on separate tests must have
-/// different ports, otherwise the server will fail with "address already in use".
-pub async fn get_available_socket() -> SocketAddr {
-    // Dynamically select port.
-    // First, set the port to 0 (dynamic port).
-    TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("Failed to bind to address")
-        // Then, resolve to the actual selected port.
-        .local_addr()
-        .expect("Failed to get local address")
 }

--- a/crates/starknet_sequencer_infra/Cargo.toml
+++ b/crates/starknet_sequencer_infra/Cargo.toml
@@ -29,6 +29,7 @@ validator.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+once_cell.workspace = true
 pretty_assertions.workspace = true
 starknet-types-core.workspace = true
 starknet_infra_utils = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
**Stack**:
- chore(papyrus_common): reallocate and remove redundant functions #3342
- chore(starknet_infra_utils): remove get_available_socket #3323 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*