### PR TITLE
fix(starknet_api): use RpcTransaction variants in InternalRpcTransaction

RpcTransaction variants contain AllResources in resource_bounds,
while regular transaction variants contain ValidResourceBounds.

### DIFF
--- a/crates/starknet_api/src/rpc_transaction.rs
+++ b/crates/starknet_api/src/rpc_transaction.rs
@@ -55,7 +55,7 @@ pub enum RpcTransaction {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Hash)]
 pub struct DeployAccountTransactionV3WithAddress {
-    pub tx: DeployAccountTransactionV3,
+    pub tx: RpcDeployAccountTransaction,
     pub contract_address: ContractAddress,
 }
 
@@ -64,9 +64,9 @@ pub struct DeployAccountTransactionV3WithAddress {
 #[serde(deny_unknown_fields)]
 pub enum InternalRpcTransactionWithoutTxHash {
     #[serde(rename = "DECLARE")]
-    Declare(DeclareTransactionV3),
+    Declare(InternalRpcDeclareTransactionV3),
     #[serde(rename = "INVOKE")]
-    Invoke(InvokeTransactionV3),
+    Invoke(RpcInvokeTransaction),
     #[serde(rename = "DEPLOY_ACCOUNT")]
     DeployAccount(DeployAccountTransactionV3WithAddress),
 }
@@ -206,6 +206,22 @@ pub struct RpcDeclareTransactionV3 {
     pub signature: TransactionSignature,
     pub nonce: Nonce,
     pub contract_class: SierraContractClass,
+    pub resource_bounds: AllResourceBounds,
+    pub tip: Tip,
+    pub paymaster_data: PaymasterData,
+    pub account_deployment_data: AccountDeploymentData,
+    pub nonce_data_availability_mode: DataAvailabilityMode,
+    pub fee_data_availability_mode: DataAvailabilityMode,
+}
+
+/// An [RpcDeclareTransactionV3] that contains a class hash instead of the full contract class.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Hash)]
+pub struct InternalRpcDeclareTransactionV3 {
+    pub sender_address: ContractAddress,
+    pub compiled_class_hash: CompiledClassHash,
+    pub signature: TransactionSignature,
+    pub nonce: Nonce,
+    pub class_hash: ClassHash,
     pub resource_bounds: AllResourceBounds,
     pub tip: Tip,
     pub paymaster_data: PaymasterData,


### PR DESCRIPTION
- **feat(starknet_api): add contract_address to InternalRpcTransaction**
- **fix(starknet_api): use RpcTransaction variants in InternalRpcTransaction**
