### PR TITLE
chore(consensus): move some network parameter consts into config

### DIFF
--- a/config/papyrus/default_config.json
+++ b/config/papyrus/default_config.json
@@ -79,6 +79,21 @@
     "privacy": "TemporaryValue",
     "value": true
   },
+  "consensus.future_height_limit": {
+    "description": "How many heights in the future should we cache.",
+    "privacy": "Public",
+    "value": 10
+  },
+  "consensus.future_height_round_limit": {
+    "description": "How many rounds should we cache for future heights.",
+    "privacy": "Public",
+    "value": 1
+  },
+  "consensus.future_round_limit": {
+    "description": "How many rounds in the future (for current height) should we cache.",
+    "privacy": "Public",
+    "value": 10
+  },
   "consensus.startup_delay": {
     "description": "Delay (seconds) before starting consensus to give time for network peering.",
     "privacy": "Public",

--- a/config/sequencer/default_config.json
+++ b/config/sequencer/default_config.json
@@ -694,6 +694,21 @@
     "privacy": "TemporaryValue",
     "value": true
   },
+  "consensus_manager_config.consensus_config.future_height_limit": {
+    "description": "How many heights in the future should we cache.",
+    "privacy": "Public",
+    "value": 10
+  },
+  "consensus_manager_config.consensus_config.future_height_round_limit": {
+    "description": "How many rounds should we cache for future heights.",
+    "privacy": "Public",
+    "value": 1
+  },
+  "consensus_manager_config.consensus_config.future_round_limit": {
+    "description": "How many rounds in the future (for current height) should we cache.",
+    "privacy": "Public",
+    "value": 10
+  },
   "consensus_manager_config.consensus_config.startup_delay": {
     "description": "Delay (seconds) before starting consensus to give time for network peering.",
     "privacy": "Public",

--- a/config/sequencer/default_config.json
+++ b/config/sequencer/default_config.json
@@ -669,6 +669,11 @@
     "privacy": "Public",
     "value": "localhost"
   },
+  "consensus_manager_config.broadcast_buffer_size": {
+    "description": "The buffer size for the broadcast channel.",
+    "privacy": "Public",
+    "value": 10000
+  },
   "consensus_manager_config.cende_config.certificates_file_path": {
     "description": "The path to the certificates file. The certificates are used when sending a request to the cende_recorder.",
     "privacy": "Private",

--- a/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
+++ b/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
@@ -90,6 +90,27 @@ snapshot_kind: text
     "value": true,
     "privacy": "TemporaryValue"
   },
+  "consensus.future_height_limit": {
+    "description": "How many heights in the future should we cache.",
+    "value": {
+      "$serde_json::private::Number": "10"
+    },
+    "privacy": "Public"
+  },
+  "consensus.future_height_round_limit": {
+    "description": "How many rounds should we cache for future heights.",
+    "value": {
+      "$serde_json::private::Number": "1"
+    },
+    "privacy": "Public"
+  },
+  "consensus.future_round_limit": {
+    "description": "How many rounds in the future (for current height) should we cache.",
+    "value": {
+      "$serde_json::private::Number": "10"
+    },
+    "privacy": "Public"
+  },
   "consensus.startup_delay": {
     "description": "Delay (seconds) before starting consensus to give time for network peering.",
     "value": {

--- a/crates/starknet_consensus/src/config.rs
+++ b/crates/starknet_consensus/src/config.rs
@@ -30,6 +30,12 @@ pub struct ConsensusConfig {
     /// The duration (seconds) between sync attempts.
     #[serde(deserialize_with = "deserialize_float_seconds_to_duration")]
     pub sync_retry_interval: Duration,
+    /// How many heights in the future should we cache.
+    pub future_height_limit: u32,
+    /// How many rounds in the future (for current height) should we cache.
+    pub future_round_limit: u32,
+    /// How many rounds should we cache for future heights.
+    pub future_height_round_limit: u32,
 }
 
 impl SerializeConfig for ConsensusConfig {
@@ -53,6 +59,24 @@ impl SerializeConfig for ConsensusConfig {
                 "The duration (seconds) between sync attempts.",
                 ParamPrivacyInput::Public,
             ),
+            ser_param(
+                "future_height_limit",
+                &self.future_height_limit,
+                "How many heights in the future should we cache.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "future_round_limit",
+                &self.future_round_limit,
+                "How many rounds in the future (for current height) should we cache.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "future_height_round_limit",
+                &self.future_height_round_limit,
+                "How many rounds should we cache for future heights.",
+                ParamPrivacyInput::Public,
+            ),
         ]);
         config.extend(append_sub_config_name(self.timeouts.dump(), "timeouts"));
         config
@@ -66,6 +90,9 @@ impl Default for ConsensusConfig {
             startup_delay: Duration::from_secs(5),
             timeouts: TimeoutsConfig::default(),
             sync_retry_interval: Duration::from_secs_f64(1.0),
+            future_height_limit: 10,
+            future_round_limit: 10,
+            future_height_round_limit: 1,
         }
     }
 }

--- a/crates/starknet_consensus_manager/src/config.rs
+++ b/crates/starknet_consensus_manager/src/config.rs
@@ -27,6 +27,7 @@ pub struct ConsensusManagerConfig {
     pub revert_up_to_and_including: Option<BlockNumber>,
     pub votes_topic: String,
     pub proposals_topic: String,
+    pub broadcast_buffer_size: usize,
     pub immediate_active_height: BlockNumber,
 }
 
@@ -43,6 +44,12 @@ impl SerializeConfig for ConsensusManagerConfig {
                 "proposals_topic",
                 &self.proposals_topic,
                 "The topic for consensus proposals.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "broadcast_buffer_size",
+                &self.broadcast_buffer_size,
+                "The buffer size for the broadcast channel.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(
@@ -80,6 +87,7 @@ impl Default for ConsensusManagerConfig {
             revert_up_to_and_including: None,
             votes_topic: "consensus_votes".to_string(),
             proposals_topic: "consensus_proposals".to_string(),
+            broadcast_buffer_size: 10000,
             immediate_active_height: BlockNumber::default(),
         }
     }

--- a/crates/starknet_consensus_manager/src/consensus_manager.rs
+++ b/crates/starknet_consensus_manager/src/consensus_manager.rs
@@ -24,11 +24,6 @@ use tracing::{error, info};
 
 use crate::config::ConsensusManagerConfig;
 
-// TODO(Dan, Guy): move to config.
-pub const BROADCAST_BUFFER_SIZE: usize = 10000;
-pub const CONSENSUS_PROPOSALS_TOPIC: &str = "consensus_proposals";
-pub const CONSENSUS_VOTES_TOPIC: &str = "consensus_votes";
-
 #[derive(Clone)]
 pub struct ConsensusManager {
     pub config: ConsensusManagerConfig,
@@ -59,15 +54,15 @@ impl ConsensusManager {
 
         let proposals_broadcast_channels = network_manager
             .register_broadcast_topic::<StreamMessage<ProposalPart, HeightAndRound>>(
-                Topic::new(CONSENSUS_PROPOSALS_TOPIC),
-                BROADCAST_BUFFER_SIZE,
+                Topic::new(self.config.proposals_topic.clone()),
+                self.config.broadcast_buffer_size,
             )
             .expect("Failed to register broadcast topic");
 
         let votes_broadcast_channels = network_manager
             .register_broadcast_topic::<Vote>(
-                Topic::new(CONSENSUS_VOTES_TOPIC),
-                BROADCAST_BUFFER_SIZE,
+                Topic::new(self.config.votes_topic.clone()),
+                self.config.broadcast_buffer_size,
             )
             .expect("Failed to register broadcast topic");
 

--- a/crates/starknet_integration_tests/src/flow_test_setup.rs
+++ b/crates/starknet_integration_tests/src/flow_test_setup.rs
@@ -5,6 +5,7 @@ use mempool_test_utils::starknet_api_test_utils::{
     AccountTransactionGenerator,
     MultiAccountTransactionGenerator,
 };
+use papyrus_network::gossipsub_impl::Topic;
 use papyrus_network::network_manager::test_utils::{
     create_connected_network_configs,
     network_config_into_broadcast_channels,
@@ -15,7 +16,6 @@ use papyrus_storage::StorageConfig;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_consensus_manager::config::ConsensusManagerConfig;
-use starknet_consensus_manager::consensus_manager::CONSENSUS_PROPOSALS_TOPIC;
 use starknet_gateway_types::errors::GatewaySpecError;
 use starknet_http_server::config::HttpServerConfig;
 use starknet_http_server::test_utils::HttpTestClient;
@@ -218,14 +218,15 @@ pub fn create_consensus_manager_configs_and_channels(
 
     // TODO(Tsabary): Need to also add a channel for votes, in addition to the proposals channel.
     let channels_network_config = network_configs.pop().unwrap();
-    let broadcast_channels = network_config_into_broadcast_channels(
-        channels_network_config,
-        papyrus_network::gossipsub_impl::Topic::new(CONSENSUS_PROPOSALS_TOPIC),
-    );
 
     let n_network_configs = network_configs.len();
     let consensus_manager_configs =
         create_consensus_manager_configs_from_network_configs(network_configs, n_network_configs);
+
+    let broadcast_channels = network_config_into_broadcast_channels(
+        channels_network_config,
+        Topic::new(consensus_manager_configs[0].proposals_topic.clone()),
+    );
 
     (consensus_manager_configs, broadcast_channels)
 }


### PR DESCRIPTION
Remove some constants that were used as network parameters and use the config fields instead. 

Adds one parameter, `broadcast_buffer_size` to `ConsensusManagerConfig`. 