### PR TITLE
refactor(papyrus_protobuf): move event.proto to the sync folder

### DIFF
--- a/crates/papyrus_protobuf/build.rs
+++ b/crates/papyrus_protobuf/build.rs
@@ -55,10 +55,10 @@ fn main() -> io::Result<()> {
         &[
             "src/proto/p2p/proto/class.proto",
             "src/proto/p2p/proto/consensus.proto",
-            "src/proto/p2p/proto/event.proto",
             "src/proto/p2p/proto/header.proto",
             "src/proto/p2p/proto/mempool/transaction.proto",
             "src/proto/p2p/proto/sync/class.proto",
+            "src/proto/p2p/proto/sync/event.proto",
             "src/proto/p2p/proto/sync/state.proto",
             "src/proto/p2p/proto/transaction.proto",
         ],

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/sync/event.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/sync/event.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 import "p2p/proto/common.proto";
 import "p2p/proto/sync/common.proto";
 
+option go_package = "github.com/starknet-io/starknet-p2pspecs/p2p/proto/sync/event";
+
 message Event {
     Hash transaction_hash = 1;
     Felt252 from_address = 3;


### PR DESCRIPTION
- **refactor(papyrus_protobuf): align common.proto with p2p-specs**
- **refactor(papyrus_protobuf): replace rpc_transaction with mempool_transaction**
- **refactor(papyrus_protobuf): align class.proto**
- **refactor(papyrus_protobuf): move state.proto to sync folder**
- **refactor(papryus_protobuf): move event,proto to the sync folder**
