### PR TITLE
refactor(papyrus_protobuf): add converters for new transaction messages

### DIFF
--- a/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
@@ -23,8 +23,7 @@ message TransactionsResponse {
 }
 
 message TransactionWithReceipt {
-    //TODO(alonl): change transaction type to TransactionInBlock
-    Transaction transaction = 1;
+    TransactionInBlock transaction = 1;
     Receipt receipt = 2;
 }
 


### PR DESCRIPTION
- **refactor(papyrus_protobuf): align common.proto with p2p-specs**
- **refactor(papyrus_protobuf): replace rpc_transaction with mempool_transaction**
- **refactor(papyrus_protobuf): align class.proto**
- **refactor(papyrus_protobuf): move state.proto to sync folder**
- **refactor(papryus_protobuf): move event,proto to the sync folder**
- **refactor(papyrus_protobuf): align header.proto**
- **refactor(papyrus_protobuf): partial alignment of receipt.proto**
- **refactor(papyrus_protobuf): align transaction.proto files**
- **refactor(papyrus_protobuf): add converters for new transaction messages**
