### PR TITLE
fix(ci): install deps before rust, fixes taplo sporadic OOM (#3355)

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -13,9 +13,9 @@ runs:
     - name: Submodules update.
       run: git submodule update --init --recursive
       shell: bash
+    - name: Install cairo native.
+      uses: ./.github/actions/setup_native_deps
     - name: Install rust.
       uses: ./.github/actions/install_rust
       with:
         extra_rust_toolchains: ${{ inputs.extra_rust_toolchains }}
-    - name: Install cairo native.
-      uses: ./.github/actions/setup_native_deps

--- a/.github/workflows/blockifier_ci.yml
+++ b/.github/workflows/blockifier_ci.yml
@@ -22,6 +22,7 @@ on:
     paths:
       # Other than code-related changes, all changes related to the native-blockifier build-and-push
       # process should trigger the build (e.g., changes to the Dockerfile, build scripts, etc.).
+      - '.github/actions/bootstrap/action.yml'
       - '.github/workflows/blockifier_ci.yml'
       - '.github/workflows/upload_artifacts_workflow.yml'
       - 'build_native_in_docker.sh'


### PR DESCRIPTION
Installing `taplo` binary is done inside `install_rust` action through
moonrepo, this hits OOM sporadically, which we fix by using `lld`, which
is installed in `setup_native_deps`.

Co-authored-by: Gilad Chase <gilad@starkware.com>

---

**Stack**:
- #3419
- #3418
- #3417
- #3416
- #3415
- #3414
- #3413
- #3412
- #3411
- #3410
- #3409


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*