### PR TITLE
refactor(starknet_class_manager_types): make class hash output of `add_class`

### DIFF
--- a/crates/papyrus_p2p_sync/src/client/class.rs
+++ b/crates/papyrus_p2p_sync/src/client/class.rs
@@ -31,8 +31,8 @@ impl BlockData for (DeclaredClasses, DeprecatedDeclaredClasses, BlockNumber) {
     ) -> BoxFuture<'a, Result<(), P2pSyncClientError>> {
         async move {
             // TODO(noamsp): handle non fatal errors by reporting the peer instead of failing
-            for (class_hash, class) in self.0 {
-                class_manager_client.add_class(class_hash, class).await?;
+            for (_class_hash, class) in self.0 {
+                class_manager_client.add_class(class).await?;
             }
 
             for (class_hash, deprecated_class) in self.1 {

--- a/crates/papyrus_p2p_sync/src/client/class_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/class_test.rs
@@ -24,7 +24,7 @@ use starknet_api::deprecated_contract_class::{
     EntryPointV0,
 };
 use starknet_api::state::SierraContractClass;
-use starknet_class_manager_types::MockClassManagerClient;
+use starknet_class_manager_types::{ClassHashes, MockClassManagerClient};
 
 use super::test_utils::{
     random_header,
@@ -60,12 +60,14 @@ async fn class_basic_flow() {
             let class_hash = state_diff.get_class_hash();
             match class {
                 ApiContractClass::ContractClass(class) => {
-                    let compiled_class_hash = state_diff.get_compiled_class_hash();
+                    let executable_class_hash = state_diff.get_compiled_class_hash();
                     class_manager_client
                         .expect_add_class()
                         .times(1)
-                        .with(eq(class_hash), eq(class.clone()))
-                        .return_once(move |_, _| Ok(compiled_class_hash));
+                        .with(eq(class.clone()))
+                        .return_once(move |_| {
+                            Ok(ClassHashes { class_hash, executable_class_hash })
+                        });
                 }
                 ApiContractClass::DeprecatedContractClass(class) => {
                     class_manager_client

--- a/crates/starknet_class_manager_types/Cargo.toml
+++ b/crates/starknet_class_manager_types/Cargo.toml
@@ -19,3 +19,6 @@ serde = { workspace = true, features = ["derive"] }
 starknet_api.workspace = true
 starknet_sequencer_infra.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+starknet_api = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
In untrusted flows each node needs to calculate class hash by itself. Originally, I wanted the GW to first run
`__validate_declare__(class_hash)` and if successful - request compilation; but it isn't worth optimizing on (`Declare`s are quite rare).