### PR TITLE
feat(papyrus_storage): add class hash to executable class hash table

### DIFF
--- a/crates/papyrus_storage/src/class_hash.rs
+++ b/crates/papyrus_storage/src/class_hash.rs
@@ -1,0 +1,64 @@
+//! Interface for handling hashes of Starknet [classes (Cairo 1)](https://docs.rs/starknet_api/latest/starknet_api/state/struct.ContractClass.html).
+//! This is a table separate from Papyrus storage; scope and version do not apply on it.
+//! Use carefully, only within class manager code, which is responsible for maintaining this table.
+//!
+//! Import [`ClassHashStorageReader`] and [`ClassHashStorageWriter`] to read and write data related
+//! to classes using a [`StorageTxn`].
+
+use starknet_api::core::{ClassHash, CompiledClassHash};
+
+use crate::db::table_types::Table;
+use crate::db::{TransactionKind, RW};
+use crate::{StorageResult, StorageTxn};
+
+#[cfg(test)]
+#[path = "class_hash_test.rs"]
+mod class_hash_test;
+
+// TODO(Elin): consider implementing directly over `libmdbx`.
+
+/// Interface for reading executable class hashes.
+pub trait ClassHashStorageReader {
+    /// Returns the executable class hash corresponding to the given class hash.
+    /// Returns `None` if the class hash is not found.
+    fn get_executable_class_hash(
+        &self,
+        class_hash: &ClassHash,
+    ) -> StorageResult<Option<CompiledClassHash>>;
+}
+
+/// Interface for writing executable class hashes.
+pub trait ClassHashStorageWriter
+where
+    Self: Sized,
+{
+    /// Inserts the executable class hash corresponding to the given class hash.
+    /// An error is returned if the class hash already exists.
+    fn set_executable_class_hash(
+        self,
+        class_hash: &ClassHash,
+        executable_class_hash: CompiledClassHash,
+    ) -> StorageResult<Self>;
+}
+
+impl<Mode: TransactionKind> ClassHashStorageReader for StorageTxn<'_, Mode> {
+    fn get_executable_class_hash(
+        &self,
+        class_hash: &ClassHash,
+    ) -> StorageResult<Option<CompiledClassHash>> {
+        let table = self.open_table(&self.tables.class_hash_to_executable_class_hash)?;
+        Ok(table.get(&self.txn, class_hash)?)
+    }
+}
+
+impl ClassHashStorageWriter for StorageTxn<'_, RW> {
+    fn set_executable_class_hash(
+        self,
+        class_hash: &ClassHash,
+        executable_class_hash: CompiledClassHash,
+    ) -> StorageResult<Self> {
+        let table = self.open_table(&self.tables.class_hash_to_executable_class_hash)?;
+        table.insert(&self.txn, class_hash, &executable_class_hash)?;
+        Ok(self)
+    }
+}

--- a/crates/papyrus_storage/src/class_hash_test.rs
+++ b/crates/papyrus_storage/src/class_hash_test.rs
@@ -1,0 +1,31 @@
+use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::felt;
+
+use crate::class_hash::{ClassHashStorageReader, ClassHashStorageWriter};
+use crate::test_utils::get_test_storage;
+
+#[test]
+fn class_hash_storage() {
+    let ((reader, mut writer), _temp_dir) = get_test_storage();
+
+    // Non-existent entry.
+    let class_hash = ClassHash(felt!("0x1234"));
+    let executable_class_hash =
+        reader.begin_ro_txn().unwrap().get_executable_class_hash(&class_hash).unwrap();
+    assert_eq!(executable_class_hash, None);
+
+    // Insert an entry.
+    let expected_executable_class_hash = CompiledClassHash(felt!("0x5678"));
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .set_executable_class_hash(&class_hash, expected_executable_class_hash)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    // Read the inserted entry.
+    let executable_class_hash =
+        reader.begin_ro_txn().unwrap().get_executable_class_hash(&class_hash).unwrap();
+    assert_eq!(executable_class_hash, Some(expected_executable_class_hash));
+}

--- a/crates/papyrus_storage/src/db/mod.rs
+++ b/crates/papyrus_storage/src/db/mod.rs
@@ -43,7 +43,7 @@ use self::table_types::{DbCursor, DbCursorTrait};
 use crate::db::table_types::TableType;
 
 // Maximum number of Sub-Databases.
-const MAX_DBS: usize = 18;
+const MAX_DBS: usize = 19;
 
 // Note that NO_TLS mode is used by default.
 type EnvironmentKind = WriteMap;

--- a/crates/papyrus_storage/src/lib.rs
+++ b/crates/papyrus_storage/src/lib.rs
@@ -78,6 +78,7 @@
 pub mod base_layer;
 pub mod body;
 pub mod class;
+pub mod class_hash;
 pub mod class_manager;
 pub mod compiled_class;
 #[cfg(feature = "document_calls")]
@@ -125,7 +126,7 @@ use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use papyrus_proc_macros::latency_histogram;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockNumber, BlockSignature, StarknetVersion};
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::state::{SierraContractClass, StateNumber, StorageKey, ThinStateDiff};
 use starknet_api::transaction::{Transaction, TransactionHash, TransactionOutput};
@@ -191,9 +192,13 @@ pub fn open_storage(
         transaction_hash_to_idx: db_writer.create_simple_table("transaction_hash_to_idx")?,
         transaction_metadata: db_writer.create_simple_table("transaction_metadata")?,
 
-        // Version tables
+        // Version tables.
         starknet_version: db_writer.create_simple_table("starknet_version")?,
         storage_version: db_writer.create_simple_table("storage_version")?,
+
+        // Class hashes.
+        class_hash_to_executable_class_hash: db_writer
+            .create_simple_table("class_hash_to_executable_class_hash")?,
     });
     let (file_writers, file_readers) = open_storage_files(
         &storage_config.db_config,
@@ -541,7 +546,10 @@ struct_field_names! {
 
         // Version tables
         starknet_version: TableIdentifier<BlockNumber, VersionZeroWrapper<StarknetVersion>, SimpleTable>,
-        storage_version: TableIdentifier<String, NoVersionValueWrapper<Version>, SimpleTable>
+        storage_version: TableIdentifier<String, NoVersionValueWrapper<Version>, SimpleTable>,
+
+        // Class hashes.
+        class_hash_to_executable_class_hash: TableIdentifier<ClassHash, NoVersionValueWrapper<CompiledClassHash>, SimpleTable>
     }
 }
 


### PR DESCRIPTION
Will act as the atomic marker of a class, indicating its existence in the class manager.