### PR TITLE
fix(consensus): add message cache to end to end test

### DIFF
--- a/crates/starknet_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/starknet_integration_tests/tests/end_to_end_flow_test.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use futures::StreamExt;
 use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerator;
 use papyrus_network::network_manager::BroadcastTopicChannels;
@@ -165,6 +167,28 @@ async fn listen_to_broadcasted_messages(
     let chain_id = CHAIN_ID_FOR_TESTS.clone();
     let broadcasted_messages_receiver =
         &mut consensus_proposals_channels.broadcasted_messages_receiver;
+    // Collect messages in a map so that validations will use the ordering defined by `message_id`,
+    // meaning we ignore network reordering, like the StreamHandler.
+    let mut messages_cache = HashMap::new();
+    let mut last_message_id = 0;
+
+    while let Some((Ok(message), _)) = broadcasted_messages_receiver.next().await {
+        if message.stream_id.0 == expected_height.0 {
+            messages_cache.insert(message.message_id, message.clone());
+        } else {
+            panic!(
+                "Expected height: {}. Received message from unexpected height: {}",
+                expected_height.0, message.stream_id.0
+            );
+        }
+        if message.message == papyrus_protobuf::consensus::StreamMessageBody::Fin {
+            last_message_id = message.message_id;
+        }
+        // Check that we got the Fin message and all previous messages.
+        if last_message_id > 0 && (0..=last_message_id).all(|id| messages_cache.contains_key(&id)) {
+            break;
+        }
+    }
     // TODO(Dan, Guy): retrieve / calculate the expected proposal init and fin.
     let expected_proposal_init = ProposalInit {
         height: expected_height,
@@ -177,7 +201,7 @@ async fn listen_to_broadcasted_messages(
         stream_id: first_stream_id,
         message: init_message,
         message_id: incoming_message_id,
-    } = broadcasted_messages_receiver.next().await.unwrap().0.unwrap();
+    } = messages_cache.remove(&0).expect("Stream is missing its first message");
 
     assert_eq!(
         incoming_message_id, 0,
@@ -197,9 +221,9 @@ async fn listen_to_broadcasted_messages(
     let mut received_tx_hashes = Vec::new();
     let mut got_proposal_fin = false;
     let mut got_channel_fin = false;
-    loop {
+    for i in 1_u64..messages_cache.len().try_into().unwrap() {
         let StreamMessage { message, stream_id, message_id: _ } =
-            broadcasted_messages_receiver.next().await.unwrap().0.unwrap();
+            messages_cache.remove(&i).expect("Stream should have all consecutive messages");
         assert_eq!(stream_id, first_stream_id, "Expected the same stream id for all messages");
         match message {
             StreamMessageBody::Content(ProposalPart::Init(init)) => {


### PR DESCRIPTION
This adds a HashMap to cache messages coming in as the proposal in the end to end flow test. It replaces the need to have a StreamHandler, but still prevents the situation that sometimes fails the test because the first message isn't the first to arrive through the network. 