### PR TITLE
feat(starknet_class_manager): implement FS-based class storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10748,9 +10748,12 @@ dependencies = [
 name = "starknet_class_manager"
 version = "0.0.0"
 dependencies = [
+ "hex",
+ "serde_json",
  "starknet_api",
  "starknet_class_manager_types",
  "starknet_sierra_multicompile_types",
+ "tempfile",
  "thiserror 1.0.69",
 ]
 

--- a/crates/starknet_class_manager/Cargo.toml
+++ b/crates/starknet_class_manager/Cargo.toml
@@ -9,7 +9,13 @@ version.workspace = true
 workspace = true
 
 [dependencies]
+hex.workspace = true
+serde_json.workspace = true
 starknet_api.workspace = true
 starknet_class_manager_types.workspace = true
 starknet_sierra_multicompile_types.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+starknet_api = { path = "../starknet_api", features = ["testing"] }

--- a/crates/starknet_class_manager/src/class_storage.rs
+++ b/crates/starknet_class_manager/src/class_storage.rs
@@ -1,7 +1,16 @@
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::mem;
+use std::path::{Path, PathBuf};
+
 use starknet_api::class_cache::GlobalContractCache;
 use starknet_class_manager_types::{ClassId, ClassStorageError, ExecutableClassHash};
 use starknet_sierra_multicompile_types::{RawClass, RawExecutableClass};
 use thiserror::Error;
+
+#[cfg(test)]
+#[path = "class_storage_test.rs"]
+mod class_storage_test;
 
 // TODO(Elin): restrict visibility once this code is used.
 
@@ -160,4 +169,242 @@ impl<S: ClassStorage> ClassStorage for CachedClassStorage<S> {
 
         Ok(())
     }
+}
+
+// TODO(Elin): remove class hash storage code once mdbx implementation is merged.
+
+#[derive(Debug, Error)]
+pub enum ClassHashStorageError {
+    #[error("Class of hash: {class_id} not found")]
+    ClassNotFound { class_id: ClassId },
+}
+
+type ClassHashStorageResult<T> = Result<T, ClassHashStorageError>;
+
+pub struct ClassHashStorage {
+    class_hash_to_executable_class_hash: GlobalContractCache<ExecutableClassHash>,
+}
+
+impl ClassHashStorage {
+    pub fn new() -> Self {
+        Self { class_hash_to_executable_class_hash: GlobalContractCache::new(100) }
+    }
+
+    fn get_executable_class_hash(
+        &self,
+        class_id: ClassId,
+    ) -> ClassHashStorageResult<ExecutableClassHash> {
+        self.class_hash_to_executable_class_hash
+            .get(&class_id)
+            .ok_or(ClassHashStorageError::ClassNotFound { class_id })
+    }
+
+    fn set_executable_class_hash(
+        &mut self,
+        class_id: ClassId,
+        executable_class_hash: ExecutableClassHash,
+    ) -> ClassHashStorageResult<()> {
+        self.class_hash_to_executable_class_hash.set(class_id, executable_class_hash);
+        Ok(())
+    }
+}
+
+impl Default for ClassHashStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+type FsClassStorageResult<T> = Result<T, FsClassStorageError>;
+
+pub struct FsClassStorage {
+    persistent_root: PathBuf,
+    class_hash_storage: ClassHashStorage,
+}
+
+#[derive(Debug, Error)]
+pub enum FsClassStorageError {
+    #[error(transparent)]
+    ClassHashStorage(#[from] ClassHashStorageError),
+    #[error("Class of hash: {class_id} not found")]
+    ClassNotFound { class_id: ClassId },
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    WriteError(#[from] serde_json::Error),
+}
+
+impl FsClassStorage {
+    pub fn new(persistent_root: PathBuf, class_hash_storage: ClassHashStorage) -> Self {
+        Self { persistent_root, class_hash_storage }
+    }
+
+    fn contains_class(&self, class_id: ClassId) -> bool {
+        self.get_executable_class_hash(class_id).is_ok()
+    }
+
+    fn contains_deprecated_class(&self, class_id: ClassId) -> bool {
+        self.get_executable_path(class_id).exists()
+    }
+
+    /// Returns the directory that will hold classes related to the given class ID.
+    /// For a class ID: 0xa1b2c3... (rest of hash), the structure is:
+    /// a1/
+    /// └── b2c3.../
+    fn get_class_dir(&self, class_id: ClassId) -> PathBuf {
+        let class_id = hex::encode(class_id.to_bytes_be());
+        let (first_msb_byte, rest_of_bytes) = class_id.split_at(2);
+        PathBuf::from(first_msb_byte).join(rest_of_bytes)
+    }
+
+    fn get_persistent_dir(&self, class_id: ClassId) -> PathBuf {
+        self.persistent_root.join(self.get_class_dir(class_id))
+    }
+
+    fn get_persistent_dir_with_create(&self, class_id: ClassId) -> FsClassStorageResult<PathBuf> {
+        let path = self.get_persistent_dir(class_id);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        Ok(path)
+    }
+
+    fn get_sierra_path(&self, class_id: ClassId) -> PathBuf {
+        concat_sierra_filename(&self.get_persistent_dir(class_id))
+    }
+
+    fn get_executable_path(&self, class_id: ClassId) -> PathBuf {
+        concat_executable_filename(&self.get_persistent_dir(class_id))
+    }
+
+    fn read_file(&self, path: PathBuf) -> FsClassStorageResult<serde_json::Value> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        Ok(serde_json::from_reader(reader)?)
+    }
+
+    fn write_file(&self, path: PathBuf, data: serde_json::Value) -> FsClassStorageResult<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Open a file for writing, delete content if exists
+        // (should not happen, since the file is a unique temporary file).
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .expect("Failing to open file with given options is impossible");
+
+        // Write to file.
+        let writer = BufWriter::new(file);
+        serde_json::to_writer(writer, &data)?;
+
+        Ok(())
+    }
+}
+
+impl ClassStorage for FsClassStorage {
+    type Error = FsClassStorageError;
+
+    fn set_class(
+        &mut self,
+        class_id: ClassId,
+        class: RawClass,
+        executable_class_hash: ExecutableClassHash,
+        executable_class: RawExecutableClass,
+    ) -> Result<(), Self::Error> {
+        if self.contains_class(class_id) {
+            return Ok(());
+        }
+
+        // Write classes to a temporary directory.
+        let tmp_dir = tempfile::tempdir()?;
+        let tmp_dir = tmp_dir.path().join(self.get_class_dir(class_id));
+        self.write_file(concat_sierra_filename(&tmp_dir), class.0)?;
+        self.write_file(concat_executable_filename(&tmp_dir), executable_class.0)?;
+
+        // Atomically rename directory to persistent one.
+        let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
+        std::fs::rename(tmp_dir, persistent_dir)?;
+
+        // Mark class as existent.
+        self.class_hash_storage.set_executable_class_hash(class_id, executable_class_hash)?;
+
+        Ok(())
+    }
+
+    fn get_sierra(&self, class_id: ClassId) -> Result<RawClass, Self::Error> {
+        if !self.contains_class(class_id) {
+            return Err(FsClassStorageError::ClassNotFound { class_id });
+        }
+
+        let path = self.get_sierra_path(class_id);
+        let raw_class = self.read_file(path)?;
+        Ok(RawClass(raw_class))
+    }
+
+    fn get_executable(&self, class_id: ClassId) -> Result<RawExecutableClass, Self::Error> {
+        if !self.contains_class(class_id) {
+            return Err(FsClassStorageError::ClassNotFound { class_id });
+        }
+
+        let path = self.get_executable_path(class_id);
+        let raw_class = self.read_file(path)?;
+        Ok(RawExecutableClass(raw_class))
+    }
+
+    fn get_executable_class_hash(
+        &self,
+        class_id: ClassId,
+    ) -> Result<ExecutableClassHash, Self::Error> {
+        Ok(self.class_hash_storage.get_executable_class_hash(class_id)?)
+    }
+
+    fn set_deprecated_class(
+        &mut self,
+        class_id: ClassId,
+        class: RawExecutableClass,
+    ) -> Result<(), Self::Error> {
+        if self.contains_deprecated_class(class_id) {
+            return Ok(());
+        }
+
+        // Write class to a temporary directory.
+        let tmp_dir = tempfile::tempdir()?.into_path();
+        let tmp_dir = tmp_dir.join(self.get_class_dir(class_id));
+        self.write_file(concat_executable_filename(&tmp_dir), class.0)?;
+
+        // Atomically rename directory to persistent one.
+        let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
+        std::fs::rename(tmp_dir, persistent_dir)?;
+
+        Ok(())
+    }
+}
+
+impl PartialEq for FsClassStorageError {
+    fn eq(&self, other: &Self) -> bool {
+        use FsClassStorageError::*;
+
+        match (self, other) {
+            (ClassNotFound { class_id }, ClassNotFound { class_id: other_class_id }) => {
+                class_id == other_class_id
+            }
+            // Only compare enum variants; no need to compare the error values.
+            _ => mem::discriminant(self) == mem::discriminant(other),
+        }
+    }
+}
+
+// Utils.
+
+fn concat_sierra_filename(path: &Path) -> PathBuf {
+    path.join("sierra")
+}
+
+fn concat_executable_filename(path: &Path) -> PathBuf {
+    path.join("casm")
 }

--- a/crates/starknet_class_manager/src/class_storage_test.rs
+++ b/crates/starknet_class_manager/src/class_storage_test.rs
@@ -1,0 +1,43 @@
+use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::felt;
+use starknet_api::state::SierraContractClass;
+use starknet_sierra_multicompile_types::{RawClass, RawExecutableClass};
+
+use crate::class_storage::{
+    ClassHashStorage,
+    ClassHashStorageError,
+    ClassStorage,
+    FsClassStorage,
+    FsClassStorageError,
+};
+
+#[test]
+fn fs_storage() {
+    let test_persistent_root = tempfile::tempdir().unwrap();
+    let test_persistent_root = test_persistent_root.path().to_path_buf();
+    let mut storage = FsClassStorage::new(test_persistent_root, ClassHashStorage::new());
+
+    // Non-existent class.
+    let class_id = ClassHash(felt!("0x1234"));
+    let class_not_found_error = FsClassStorageError::ClassNotFound { class_id };
+    assert_eq!(storage.get_sierra(class_id).unwrap_err(), class_not_found_error);
+    assert_eq!(storage.get_executable(class_id).unwrap_err(), class_not_found_error);
+
+    let class_not_found_error =
+        FsClassStorageError::ClassHashStorage(ClassHashStorageError::ClassNotFound { class_id });
+    assert_eq!(storage.get_executable_class_hash(class_id).unwrap_err(), class_not_found_error);
+
+    // Add class.
+    let class = RawClass::try_from(SierraContractClass::default()).unwrap();
+    // TODO(Elin): consider creating an empty Casm instead of vec (doesn't implement default).
+    let executable_class = RawExecutableClass(vec![4, 5, 6].into());
+    let executable_class_hash = CompiledClassHash(felt!("0x5678"));
+    storage
+        .set_class(class_id, class.clone(), executable_class_hash, executable_class.clone())
+        .unwrap();
+
+    // Get class.
+    assert_eq!(storage.get_sierra(class_id).unwrap(), class);
+    assert_eq!(storage.get_executable(class_id).unwrap(), executable_class);
+    assert_eq!(storage.get_executable_class_hash(class_id).unwrap(), executable_class_hash);
+}

--- a/crates/starknet_sierra_multicompile_types/src/lib.rs
+++ b/crates/starknet_sierra_multicompile_types/src/lib.rs
@@ -33,8 +33,8 @@ pub type SierraCompilerRequestAndResponseSender =
 // TODO(Elin): change to a more efficient serde (bytes, or something similar).
 // A prerequisite for this is to solve serde-untagged lack of support.
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RawClass(serde_json::Value);
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawClass(pub serde_json::Value);
 
 impl TryFrom<SierraContractClass> for RawClass {
     type Error = serde_json::Error;
@@ -52,8 +52,8 @@ impl TryFrom<RawClass> for SierraContractClass {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RawExecutableClass(serde_json::Value);
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawExecutableClass(pub serde_json::Value);
 
 impl TryFrom<ContractClass> for RawExecutableClass {
     type Error = serde_json::Error;


### PR DESCRIPTION
The `ClassHashStorage` (mapping of `class_hash ->
executable_class_hash`) is local for now; will move to over-`mdbx` soon.