### PR TITLE
feature(starknet_api, starknet_class_manager_types): new converters

### DIFF
--- a/crates/papyrus_protobuf/build.rs
+++ b/crates/papyrus_protobuf/build.rs
@@ -54,7 +54,7 @@ fn main() -> io::Result<()> {
     prost_build::compile_protos(
         &[
             "src/proto/p2p/proto/class.proto",
-            "src/proto/p2p/proto/consensus.proto",
+            "src/proto/p2p/proto/consensus/consensus.proto",
             "src/proto/p2p/proto/mempool/transaction.proto",
             "src/proto/p2p/proto/sync/class.proto",
             "src/proto/p2p/proto/sync/event.proto",

--- a/crates/papyrus_protobuf/src/converters/transaction.rs
+++ b/crates/papyrus_protobuf/src/converters/transaction.rs
@@ -6,6 +6,7 @@ use std::convert::{TryFrom, TryInto};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::GasPrice;
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::{
     ClassHash,
     CompiledClassHash,
@@ -15,6 +16,16 @@ use starknet_api::core::{
 };
 use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
+use starknet_api::rpc_transaction::{
+    RpcDeclareTransaction,
+    RpcDeclareTransactionV3,
+    RpcDeployAccountTransaction,
+    RpcDeployAccountTransactionV3,
+    RpcInvokeTransaction,
+    RpcInvokeTransactionV3,
+    RpcTransaction,
+};
+use starknet_api::state::SierraContractClass;
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
     AllResourceBounds,
@@ -949,6 +960,119 @@ impl TryFrom<protobuf::DeployAccountV3> for DeployAccountTransactionV3 {
     }
 }
 
+impl TryFrom<protobuf::DeployAccountV3> for RpcDeployAccountTransactionV3 {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::DeployAccountV3) -> Result<Self, Self::Error> {
+        let resource_bounds = AllResourceBounds::try_from(value.resource_bounds.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "DeployAccountV3::resource_bounds",
+            },
+        )?)?;
+
+        let tip = Tip(value.tip);
+
+        let signature = TransactionSignature(
+            value
+                .signature
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::signature",
+                })?
+                .parts
+                .into_iter()
+                .map(Felt::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        let nonce = Nonce(
+            value
+                .nonce
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::nonce",
+                })?
+                .try_into()?,
+        );
+
+        let class_hash = ClassHash(
+            value
+                .class_hash
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::class_hash",
+                })?
+                .try_into()?,
+        );
+
+        let contract_address_salt = ContractAddressSalt(
+            value
+                .address_salt
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::address_salt",
+                })?
+                .try_into()?,
+        );
+
+        let constructor_calldata =
+            value.calldata.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?;
+
+        let constructor_calldata = Calldata(constructor_calldata.into());
+
+        let nonce_data_availability_mode =
+            enum_int_to_volition_domain(value.nonce_data_availability_mode)?;
+
+        let fee_data_availability_mode =
+            enum_int_to_volition_domain(value.fee_data_availability_mode)?;
+
+        let paymaster_data = PaymasterData(
+            value.paymaster_data.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?,
+        );
+
+        Ok(Self {
+            resource_bounds,
+            tip,
+            signature,
+            nonce,
+            class_hash,
+            contract_address_salt,
+            constructor_calldata,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+            paymaster_data,
+        })
+    }
+}
+
+impl From<RpcDeployAccountTransactionV3> for protobuf::DeployAccountV3 {
+    fn from(value: RpcDeployAccountTransactionV3) -> Self {
+        Self {
+            resource_bounds: Some(value.resource_bounds.into()),
+            tip: value.tip.0,
+            signature: Some(protobuf::AccountSignature {
+                parts: value.signature.0.into_iter().map(|stark_felt| stark_felt.into()).collect(),
+            }),
+            nonce: Some(value.nonce.0.into()),
+            class_hash: Some(value.class_hash.0.into()),
+            address_salt: Some(value.contract_address_salt.0.into()),
+            calldata: value
+                .constructor_calldata
+                .0
+                .iter()
+                .map(|calldata| (*calldata).into())
+                .collect(),
+            nonce_data_availability_mode: volition_domain_to_enum_int(
+                value.nonce_data_availability_mode,
+            ),
+            fee_data_availability_mode: volition_domain_to_enum_int(
+                value.fee_data_availability_mode,
+            ),
+            paymaster_data: value
+                .paymaster_data
+                .0
+                .iter()
+                .map(|paymaster_data| (*paymaster_data).into())
+                .collect(),
+        }
+    }
+}
+
 // TODO(alonl): remove once Transaction is replaced with TransacitonInBlock
 impl From<DeployAccountTransactionV3> for protobuf::transaction::DeployAccountV3 {
     fn from(value: DeployAccountTransactionV3) -> Self {
@@ -1499,6 +1623,114 @@ impl TryFrom<protobuf::InvokeV3> for InvokeTransactionV3 {
             paymaster_data,
             account_deployment_data,
         })
+    }
+}
+
+impl TryFrom<protobuf::InvokeV3> for RpcInvokeTransactionV3 {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::InvokeV3) -> Result<Self, Self::Error> {
+        let resource_bounds = AllResourceBounds::try_from(value.resource_bounds.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "InvokeV3::resource_bounds",
+            },
+        )?)?;
+
+        let tip = Tip(value.tip);
+
+        let signature = TransactionSignature(
+            value
+                .signature
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "InvokeV3::signature",
+                })?
+                .parts
+                .into_iter()
+                .map(Felt::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        let nonce = Nonce(
+            value
+                .nonce
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "InvokeV3::nonce",
+                })?
+                .try_into()?,
+        );
+
+        let sender_address = value
+            .sender
+            .ok_or(ProtobufConversionError::MissingField { field_description: "InvokeV3::sender" })?
+            .try_into()?;
+
+        let calldata =
+            value.calldata.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?;
+
+        let calldata = Calldata(calldata.into());
+
+        let nonce_data_availability_mode =
+            enum_int_to_volition_domain(value.nonce_data_availability_mode)?;
+
+        let fee_data_availability_mode =
+            enum_int_to_volition_domain(value.fee_data_availability_mode)?;
+
+        let paymaster_data = PaymasterData(
+            value.paymaster_data.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?,
+        );
+
+        let account_deployment_data = AccountDeploymentData(
+            value
+                .account_deployment_data
+                .into_iter()
+                .map(Felt::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        Ok(Self {
+            resource_bounds,
+            tip,
+            signature,
+            nonce,
+            sender_address,
+            calldata,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+            paymaster_data,
+            account_deployment_data,
+        })
+    }
+}
+
+impl From<RpcInvokeTransactionV3> for protobuf::InvokeV3 {
+    fn from(value: RpcInvokeTransactionV3) -> Self {
+        Self {
+            resource_bounds: Some(value.resource_bounds.into()),
+            tip: value.tip.0,
+            signature: Some(protobuf::AccountSignature {
+                parts: value.signature.0.into_iter().map(|stark_felt| stark_felt.into()).collect(),
+            }),
+            nonce: Some(value.nonce.0.into()),
+            sender: Some(value.sender_address.into()),
+            calldata: value.calldata.0.iter().map(|calldata| (*calldata).into()).collect(),
+            nonce_data_availability_mode: volition_domain_to_enum_int(
+                value.nonce_data_availability_mode,
+            ),
+            fee_data_availability_mode: volition_domain_to_enum_int(
+                value.fee_data_availability_mode,
+            ),
+            paymaster_data: value
+                .paymaster_data
+                .0
+                .iter()
+                .map(|paymaster_data| (*paymaster_data).into())
+                .collect(),
+            account_deployment_data: value
+                .account_deployment_data
+                .0
+                .iter()
+                .map(|account_deployment_data| (*account_deployment_data).into())
+                .collect(),
+        }
     }
 }
 
@@ -2291,6 +2523,72 @@ impl From<DeclareTransactionV3> for protobuf::transaction_in_block::DeclareV3Wit
     }
 }
 
+impl TryFrom<protobuf::DeclareV3WithClass> for RpcDeclareTransactionV3 {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::DeclareV3WithClass) -> Result<Self, Self::Error> {
+        let common = DeclareTransactionV3Common::try_from(value.common.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "DeclareV3WithClass::common",
+            },
+        )?)?;
+        let class: SierraContractClass = SierraContractClass::try_from(value.class.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "DeclareV3WithClass::class",
+            },
+        )?)?;
+        if let ValidResourceBounds::AllResources(resource_bounds) = common.resource_bounds {
+            Ok(Self {
+                sender_address: common.sender_address,
+                compiled_class_hash: common.compiled_class_hash,
+                signature: common.signature,
+                nonce: common.nonce,
+                contract_class: class,
+                resource_bounds,
+                tip: common.tip,
+                paymaster_data: common.paymaster_data,
+                account_deployment_data: common.account_deployment_data,
+                nonce_data_availability_mode: common.nonce_data_availability_mode,
+                fee_data_availability_mode: common.fee_data_availability_mode,
+            })
+        } else {
+            Err(ProtobufConversionError::WrongEnumVariant {
+                type_description: "ValidResourceBounds",
+                value_as_str: format!("{:?}", common.resource_bounds),
+                expected: "AllResources",
+            })
+        }
+    }
+}
+
+impl From<RpcDeclareTransactionV3> for protobuf::DeclareV3WithClass {
+    fn from(value: RpcDeclareTransactionV3) -> Self {
+        let common = protobuf::DeclareV3Common {
+            resource_bounds: Some(value.resource_bounds.into()),
+            sender: Some(value.sender_address.into()),
+            signature: Some(protobuf::AccountSignature {
+                parts: value.signature.0.into_iter().map(|signature| signature.into()).collect(),
+            }),
+            nonce: Some(value.nonce.0.into()),
+            compiled_class_hash: Some(value.compiled_class_hash.0.into()),
+            tip: value.tip.0,
+            paymaster_data: value.paymaster_data.0.into_iter().map(|data| data.into()).collect(),
+            account_deployment_data: value
+                .account_deployment_data
+                .0
+                .into_iter()
+                .map(|data| data.into())
+                .collect(),
+            nonce_data_availability_mode: volition_domain_to_enum_int(
+                value.nonce_data_availability_mode,
+            ),
+            fee_data_availability_mode: volition_domain_to_enum_int(
+                value.fee_data_availability_mode,
+            ),
+        };
+        Self { common: Some(common), class: Some(value.contract_class.into()) }
+    }
+}
+
 // TODO(alonl): remove once Transaction is replaced with TransacitonInBlock
 impl From<DeclareTransactionV3> for protobuf::transaction::DeclareV3 {
     fn from(value: DeclareTransactionV3) -> Self {
@@ -2519,6 +2817,65 @@ impl From<L1HandlerTransaction> for protobuf::L1HandlerV0 {
             entry_point_selector: Some(value.entry_point_selector.0.into()),
             calldata: value.calldata.0.iter().map(|calldata| (*calldata).into()).collect(),
         }
+    }
+}
+
+impl From<ConsensusTransaction> for protobuf::ConsensusTransaction {
+    fn from(value: ConsensusTransaction) -> Self {
+        match value {
+            ConsensusTransaction::RpcTransaction(RpcTransaction::Declare(
+                RpcDeclareTransaction::V3(txn),
+            )) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::DeclareV3(txn.into())),
+                transaction_hash: None,
+            },
+            ConsensusTransaction::RpcTransaction(RpcTransaction::DeployAccount(
+                RpcDeployAccountTransaction::V3(txn),
+            )) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::DeployAccountV3(txn.into())),
+                transaction_hash: None,
+            },
+            ConsensusTransaction::RpcTransaction(RpcTransaction::Invoke(
+                RpcInvokeTransaction::V3(txn),
+            )) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::InvokeV3(txn.into())),
+                transaction_hash: None,
+            },
+            ConsensusTransaction::L1Handler(txn) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::L1Handler(txn.into())),
+                transaction_hash: None,
+            },
+        }
+    }
+}
+
+impl TryFrom<protobuf::ConsensusTransaction> for ConsensusTransaction {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::ConsensusTransaction) -> Result<Self, Self::Error> {
+        let txn = value.txn.ok_or(ProtobufConversionError::MissingField {
+            field_description: "ConsensusTransaction::txn",
+        })?;
+        let txn = match txn {
+            protobuf::consensus_transaction::Txn::DeclareV3(txn) => {
+                ConsensusTransaction::RpcTransaction(RpcTransaction::Declare(
+                    RpcDeclareTransaction::V3(txn.try_into()?),
+                ))
+            }
+            protobuf::consensus_transaction::Txn::DeployAccountV3(txn) => {
+                ConsensusTransaction::RpcTransaction(RpcTransaction::DeployAccount(
+                    RpcDeployAccountTransaction::V3(txn.try_into()?),
+                ))
+            }
+            protobuf::consensus_transaction::Txn::InvokeV3(txn) => {
+                ConsensusTransaction::RpcTransaction(RpcTransaction::Invoke(
+                    RpcInvokeTransaction::V3(txn.try_into()?),
+                ))
+            }
+            protobuf::consensus_transaction::Txn::L1Handler(txn) => {
+                ConsensusTransaction::L1Handler(txn.try_into()?)
+            }
+        };
+        Ok(txn)
     }
 }
 

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
@@ -2,6 +2,20 @@ syntax = "proto3";
 import "p2p/proto/common.proto";
 import "p2p/proto/transaction.proto";
 
+option go_package = "github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus";
+
+// Contains all variants of mempool and an L1Handler variant to cover all transactions that can be
+// in a new block.
+message ConsensusTransaction {
+    oneof txn {
+        DeclareV3WithClass declare_v3 = 1;
+        DeployAccountV3 deploy_account_v3 = 2;
+        InvokeV3 invoke_v3 = 3;
+        L1HandlerV0 l1_handler = 4;
+    }
+    Hash transaction_hash = 5;
+}
+
 message Vote {
     enum  VoteType {
         Prevote   = 0;

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/mempool/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/mempool/transaction.proto
@@ -5,7 +5,7 @@ import "p2p/proto/common.proto";
 import "p2p/proto/transaction.proto";
 import "p2p/proto/sync/transaction.proto";
 // TODO(alonl): remove this import (used only for the old Transaction struct as an intermediate step)
-import "p2p/proto/consensus.proto";
+import "p2p/proto/consensus/consensus.proto";
 
 
 option go_package = "github.com/starknet-io/starknet-p2pspecs/p2p/proto/mempool/transaction";

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
@@ -23,8 +23,7 @@ message TransactionsResponse {
 }
 
 message TransactionWithReceipt {
-    //TODO(alonl): change transaction type to TransactionInBlock
-    Transaction transaction = 1;
+    TransactionInBlock transaction = 1;
     Receipt receipt = 2;
 }
 

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 import "p2p/proto/common.proto";
-import "p2p/proto/consensus.proto";
 import "p2p/proto/sync/common.proto";
 import "p2p/proto/sync/receipt.proto";
 import "p2p/proto/transaction.proto";

--- a/crates/starknet_api/src/executable_transaction.rs
+++ b/crates/starknet_api/src/executable_transaction.rs
@@ -97,7 +97,7 @@ impl AccountTransaction {
     }
 }
 
-// TODO(AlonLukatch): add a converter for Declare transactions as well.
+// TODO(alonl): add a converter for Declare transactions as well.
 impl From<InvokeTransaction> for RpcInvokeTransactionV3 {
     fn from(tx: InvokeTransaction) -> Self {
         Self {

--- a/crates/starknet_api/src/rpc_transaction.rs
+++ b/crates/starknet_api/src/rpc_transaction.rs
@@ -293,6 +293,28 @@ impl From<RpcDeployAccountTransactionV3> for DeployAccountTransactionV3 {
     }
 }
 
+impl From<DeployAccountTransactionV3> for RpcDeployAccountTransactionV3 {
+    fn from(tx: DeployAccountTransactionV3) -> Self {
+        Self {
+            resource_bounds: match tx.resource_bounds {
+                ValidResourceBounds::AllResources(all_resource_bounds) => all_resource_bounds,
+                ValidResourceBounds::L1Gas(l1_gas) => {
+                    AllResourceBounds { l1_gas, ..Default::default() }
+                }
+            },
+            tip: tx.tip,
+            signature: tx.signature,
+            nonce: tx.nonce,
+            nonce_data_availability_mode: tx.nonce_data_availability_mode,
+            fee_data_availability_mode: tx.fee_data_availability_mode,
+            paymaster_data: tx.paymaster_data,
+            class_hash: tx.class_hash,
+            contract_address_salt: tx.contract_address_salt,
+            constructor_calldata: tx.constructor_calldata,
+        }
+    }
+}
+
 /// An invoke account transaction that can be added to Starknet through the RPC.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RpcInvokeTransactionV3 {
@@ -312,6 +334,28 @@ impl From<RpcInvokeTransactionV3> for InvokeTransactionV3 {
     fn from(tx: RpcInvokeTransactionV3) -> Self {
         Self {
             resource_bounds: ValidResourceBounds::AllResources(tx.resource_bounds),
+            tip: tx.tip,
+            signature: tx.signature,
+            nonce: tx.nonce,
+            sender_address: tx.sender_address,
+            calldata: tx.calldata,
+            nonce_data_availability_mode: tx.nonce_data_availability_mode,
+            fee_data_availability_mode: tx.fee_data_availability_mode,
+            paymaster_data: tx.paymaster_data,
+            account_deployment_data: tx.account_deployment_data,
+        }
+    }
+}
+
+impl From<InvokeTransactionV3> for RpcInvokeTransactionV3 {
+    fn from(tx: InvokeTransactionV3) -> Self {
+        Self {
+            resource_bounds: match tx.resource_bounds {
+                ValidResourceBounds::AllResources(all_resource_bounds) => all_resource_bounds,
+                ValidResourceBounds::L1Gas(l1_gas) => {
+                    AllResourceBounds { l1_gas, ..Default::default() }
+                }
+            },
             tip: tx.tip,
             signature: tx.signature,
             nonce: tx.nonce,


### PR DESCRIPTION
- **refactor(papyrus_protobuf): add converters for new transaction messages**
- **refactor(papyrus_protobuf): move consensus.proto to a different folder and added ConsensusTransaction**
- **refactor(papyrus_protobuf): add missing converters for RpcTransactions and ConsensusTransaction**
- **feature(starknet_api, starknet_class_manager_types): new converters**
