### PR TITLE
feat(blockifier): version bound accounts: add class_hash to DeprecatedSyscallHintProcessor

### DIFF
--- a/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
+++ b/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
@@ -102,6 +102,7 @@ pub fn initialize_execution_context<'a>(
         initial_syscall_ptr,
         call.storage_address,
         call.caller_address,
+        call.class_hash.expect("Class hash must be resolved prior to call execution."),
     );
 
     Ok(VmExecutionContext { runner, syscall_handler, initial_syscall_ptr, entry_point_pc })

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -166,6 +166,7 @@ pub struct DeprecatedSyscallHintProcessor<'a> {
     pub context: &'a mut EntryPointExecutionContext,
     pub storage_address: ContractAddress,
     pub caller_address: ContractAddress,
+    pub class_hash: ClassHash,
 
     // Execution results.
     /// Inner calls invoked by the current execution.
@@ -197,12 +198,14 @@ impl<'a> DeprecatedSyscallHintProcessor<'a> {
         initial_syscall_ptr: Relocatable,
         storage_address: ContractAddress,
         caller_address: ContractAddress,
+        class_hash: ClassHash,
     ) -> Self {
         DeprecatedSyscallHintProcessor {
             state,
             context,
             storage_address,
             caller_address,
+            class_hash,
             inner_calls: vec![],
             events: vec![],
             l2_to_l1_messages: vec![],

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -98,6 +98,7 @@ pub enum CallType {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 pub struct CallEntryPoint {
     // The class hash is not given if it can be deduced from the storage address.
+    // It is resolved prior to entry point's execution.
     pub class_hash: Option<ClassHash>,
     // Optional, since there is no address to the code implementation in a library call.
     // and for outermost calls (triggered by the transaction itself).


### PR DESCRIPTION
**Stack**:
- #3657
- #3647
- #3646
- #3644
- #3643 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*