### PR TITLE
wip - converting to and from executable transaction so batcher doesnt change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10901,6 +10901,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "starknet_batcher_types",
+ "starknet_class_manager_types",
  "starknet_consensus",
  "starknet_infra_utils",
  "starknet_state_sync_types",

--- a/crates/papyrus_protobuf/build.rs
+++ b/crates/papyrus_protobuf/build.rs
@@ -54,7 +54,7 @@ fn main() -> io::Result<()> {
     prost_build::compile_protos(
         &[
             "src/proto/p2p/proto/class.proto",
-            "src/proto/p2p/proto/consensus.proto",
+            "src/proto/p2p/proto/consensus/consensus.proto",
             "src/proto/p2p/proto/mempool/transaction.proto",
             "src/proto/p2p/proto/sync/class.proto",
             "src/proto/p2p/proto/sync/event.proto",

--- a/crates/papyrus_protobuf/src/consensus.rs
+++ b/crates/papyrus_protobuf/src/consensus.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use bytes::{Buf, BufMut};
 use prost::DecodeError;
 use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::ContractAddress;
-use starknet_api::transaction::Transaction;
 
 use crate::converters::ProtobufConversionError;
 
@@ -75,7 +75,7 @@ impl Default for ProposalInit {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TransactionBatch {
     /// The transactions in the batch.
-    pub transactions: Vec<Transaction>,
+    pub transactions: Vec<ConsensusTransaction>,
 }
 
 /// The proposal is done when receiving this fin message, which contains the block hash.

--- a/crates/papyrus_protobuf/src/converters/consensus.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus.rs
@@ -6,8 +6,8 @@ use std::convert::{TryFrom, TryInto};
 
 use prost::Message;
 use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::hash::StarkHash;
-use starknet_api::transaction::Transaction;
 
 use crate::consensus::{
     IntoFromProto,
@@ -197,7 +197,7 @@ impl TryFrom<protobuf::TransactionBatch> for TransactionBatch {
             .transactions
             .into_iter()
             .map(|tx| tx.try_into())
-            .collect::<Result<Vec<Transaction>, ProtobufConversionError>>()?;
+            .collect::<Result<Vec<ConsensusTransaction>, ProtobufConversionError>>()?;
         Ok(TransactionBatch { transactions })
     }
 }

--- a/crates/papyrus_protobuf/src/converters/consensus_test.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus_test.rs
@@ -1,14 +1,14 @@
 use papyrus_test_utils::{get_rng, GetTestInstance};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::execution_resources::GasAmount;
-use starknet_api::transaction::fields::ValidResourceBounds;
-use starknet_api::transaction::{
-    DeclareTransaction,
-    DeclareTransactionV3,
-    DeployAccountTransaction,
-    DeployAccountTransactionV3,
-    InvokeTransaction,
-    InvokeTransactionV3,
-    Transaction,
+use starknet_api::rpc_transaction::{
+    RpcDeclareTransaction,
+    RpcDeclareTransactionV3,
+    RpcDeployAccountTransaction,
+    RpcDeployAccountTransactionV3,
+    RpcInvokeTransaction,
+    RpcInvokeTransactionV3,
+    RpcTransaction,
 };
 
 use crate::consensus::{
@@ -24,25 +24,25 @@ use crate::converters::test_instances::TestStreamId;
 
 // If all the fields of `AllResources` are 0 upon serialization,
 // then the deserialized value will be interpreted as the `L1Gas` variant.
-fn add_gas_values_to_transaction(transactions: &mut [Transaction]) {
+fn add_gas_values_to_transaction(transactions: &mut [ConsensusTransaction]) {
     let transaction = &mut transactions[0];
     match transaction {
-        Transaction::Declare(DeclareTransaction::V3(DeclareTransactionV3 {
-            resource_bounds,
-            ..
-        }))
-        | Transaction::Invoke(InvokeTransaction::V3(InvokeTransactionV3 {
-            resource_bounds, ..
-        }))
-        | Transaction::DeployAccount(DeployAccountTransaction::V3(DeployAccountTransactionV3 {
-            resource_bounds,
-            ..
-        })) => {
-            if let ValidResourceBounds::AllResources(ref mut bounds) = resource_bounds {
-                bounds.l2_gas.max_amount = GasAmount(1);
+        ConsensusTransaction::RpcTransaction(rpc_transaction) => match rpc_transaction {
+            RpcTransaction::Declare(RpcDeclareTransaction::V3(RpcDeclareTransactionV3 {
+                resource_bounds,
+                ..
+            }))
+            | RpcTransaction::Invoke(RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
+                resource_bounds,
+                ..
+            }))
+            | RpcTransaction::DeployAccount(RpcDeployAccountTransaction::V3(
+                RpcDeployAccountTransactionV3 { resource_bounds, .. },
+            )) => {
+                resource_bounds.l2_gas.max_amount = GasAmount(1);
             }
-        }
-        _ => {}
+        },
+        ConsensusTransaction::L1Handler(_) => {}
     }
 }
 

--- a/crates/papyrus_protobuf/src/converters/test_instances.rs
+++ b/crates/papyrus_protobuf/src/converters/test_instances.rs
@@ -4,8 +4,8 @@ use papyrus_test_utils::{auto_impl_get_test_instance, get_number_of_variants, Ge
 use prost::DecodeError;
 use rand::Rng;
 use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::ContractAddress;
-use starknet_api::transaction::Transaction;
 
 use super::ProtobufConversionError;
 use crate::consensus::{
@@ -41,7 +41,7 @@ auto_impl_get_test_instance! {
         pub proposal_content_id: BlockHash,
     }
     pub struct TransactionBatch {
-        pub transactions: Vec<Transaction>,
+        pub transactions: Vec<ConsensusTransaction>,
     }
     pub enum ProposalPart {
         Init(ProposalInit) = 0,
@@ -96,7 +96,7 @@ impl GetTestInstance for StreamMessage<ProposalPart, TestStreamId> {
     fn get_test_instance(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
         let message = if rng.gen_bool(0.5) {
             StreamMessageBody::Content(ProposalPart::Transactions(TransactionBatch {
-                transactions: vec![Transaction::get_test_instance(rng)],
+                transactions: vec![ConsensusTransaction::get_test_instance(rng)],
             }))
         } else {
             StreamMessageBody::Fin

--- a/crates/papyrus_protobuf/src/converters/transaction.rs
+++ b/crates/papyrus_protobuf/src/converters/transaction.rs
@@ -6,6 +6,7 @@ use std::convert::{TryFrom, TryInto};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::GasPrice;
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::{
     ClassHash,
     CompiledClassHash,
@@ -15,6 +16,16 @@ use starknet_api::core::{
 };
 use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
+use starknet_api::rpc_transaction::{
+    RpcDeclareTransaction,
+    RpcDeclareTransactionV3,
+    RpcDeployAccountTransaction,
+    RpcDeployAccountTransactionV3,
+    RpcInvokeTransaction,
+    RpcInvokeTransactionV3,
+    RpcTransaction,
+};
+use starknet_api::state::SierraContractClass;
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
     AllResourceBounds,
@@ -949,6 +960,119 @@ impl TryFrom<protobuf::DeployAccountV3> for DeployAccountTransactionV3 {
     }
 }
 
+impl TryFrom<protobuf::DeployAccountV3> for RpcDeployAccountTransactionV3 {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::DeployAccountV3) -> Result<Self, Self::Error> {
+        let resource_bounds = AllResourceBounds::try_from(value.resource_bounds.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "DeployAccountV3::resource_bounds",
+            },
+        )?)?;
+
+        let tip = Tip(value.tip);
+
+        let signature = TransactionSignature(
+            value
+                .signature
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::signature",
+                })?
+                .parts
+                .into_iter()
+                .map(Felt::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        let nonce = Nonce(
+            value
+                .nonce
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::nonce",
+                })?
+                .try_into()?,
+        );
+
+        let class_hash = ClassHash(
+            value
+                .class_hash
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::class_hash",
+                })?
+                .try_into()?,
+        );
+
+        let contract_address_salt = ContractAddressSalt(
+            value
+                .address_salt
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeployAccountV3::address_salt",
+                })?
+                .try_into()?,
+        );
+
+        let constructor_calldata =
+            value.calldata.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?;
+
+        let constructor_calldata = Calldata(constructor_calldata.into());
+
+        let nonce_data_availability_mode =
+            enum_int_to_volition_domain(value.nonce_data_availability_mode)?;
+
+        let fee_data_availability_mode =
+            enum_int_to_volition_domain(value.fee_data_availability_mode)?;
+
+        let paymaster_data = PaymasterData(
+            value.paymaster_data.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?,
+        );
+
+        Ok(Self {
+            resource_bounds,
+            tip,
+            signature,
+            nonce,
+            class_hash,
+            contract_address_salt,
+            constructor_calldata,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+            paymaster_data,
+        })
+    }
+}
+
+impl From<RpcDeployAccountTransactionV3> for protobuf::DeployAccountV3 {
+    fn from(value: RpcDeployAccountTransactionV3) -> Self {
+        Self {
+            resource_bounds: Some(value.resource_bounds.into()),
+            tip: value.tip.0,
+            signature: Some(protobuf::AccountSignature {
+                parts: value.signature.0.into_iter().map(|stark_felt| stark_felt.into()).collect(),
+            }),
+            nonce: Some(value.nonce.0.into()),
+            class_hash: Some(value.class_hash.0.into()),
+            address_salt: Some(value.contract_address_salt.0.into()),
+            calldata: value
+                .constructor_calldata
+                .0
+                .iter()
+                .map(|calldata| (*calldata).into())
+                .collect(),
+            nonce_data_availability_mode: volition_domain_to_enum_int(
+                value.nonce_data_availability_mode,
+            ),
+            fee_data_availability_mode: volition_domain_to_enum_int(
+                value.fee_data_availability_mode,
+            ),
+            paymaster_data: value
+                .paymaster_data
+                .0
+                .iter()
+                .map(|paymaster_data| (*paymaster_data).into())
+                .collect(),
+        }
+    }
+}
+
 // TODO(alonl): remove once Transaction is replaced with TransacitonInBlock
 impl From<DeployAccountTransactionV3> for protobuf::transaction::DeployAccountV3 {
     fn from(value: DeployAccountTransactionV3) -> Self {
@@ -1499,6 +1623,114 @@ impl TryFrom<protobuf::InvokeV3> for InvokeTransactionV3 {
             paymaster_data,
             account_deployment_data,
         })
+    }
+}
+
+impl TryFrom<protobuf::InvokeV3> for RpcInvokeTransactionV3 {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::InvokeV3) -> Result<Self, Self::Error> {
+        let resource_bounds = AllResourceBounds::try_from(value.resource_bounds.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "InvokeV3::resource_bounds",
+            },
+        )?)?;
+
+        let tip = Tip(value.tip);
+
+        let signature = TransactionSignature(
+            value
+                .signature
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "InvokeV3::signature",
+                })?
+                .parts
+                .into_iter()
+                .map(Felt::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        let nonce = Nonce(
+            value
+                .nonce
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "InvokeV3::nonce",
+                })?
+                .try_into()?,
+        );
+
+        let sender_address = value
+            .sender
+            .ok_or(ProtobufConversionError::MissingField { field_description: "InvokeV3::sender" })?
+            .try_into()?;
+
+        let calldata =
+            value.calldata.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?;
+
+        let calldata = Calldata(calldata.into());
+
+        let nonce_data_availability_mode =
+            enum_int_to_volition_domain(value.nonce_data_availability_mode)?;
+
+        let fee_data_availability_mode =
+            enum_int_to_volition_domain(value.fee_data_availability_mode)?;
+
+        let paymaster_data = PaymasterData(
+            value.paymaster_data.into_iter().map(Felt::try_from).collect::<Result<Vec<_>, _>>()?,
+        );
+
+        let account_deployment_data = AccountDeploymentData(
+            value
+                .account_deployment_data
+                .into_iter()
+                .map(Felt::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        Ok(Self {
+            resource_bounds,
+            tip,
+            signature,
+            nonce,
+            sender_address,
+            calldata,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+            paymaster_data,
+            account_deployment_data,
+        })
+    }
+}
+
+impl From<RpcInvokeTransactionV3> for protobuf::InvokeV3 {
+    fn from(value: RpcInvokeTransactionV3) -> Self {
+        Self {
+            resource_bounds: Some(value.resource_bounds.into()),
+            tip: value.tip.0,
+            signature: Some(protobuf::AccountSignature {
+                parts: value.signature.0.into_iter().map(|stark_felt| stark_felt.into()).collect(),
+            }),
+            nonce: Some(value.nonce.0.into()),
+            sender: Some(value.sender_address.into()),
+            calldata: value.calldata.0.iter().map(|calldata| (*calldata).into()).collect(),
+            nonce_data_availability_mode: volition_domain_to_enum_int(
+                value.nonce_data_availability_mode,
+            ),
+            fee_data_availability_mode: volition_domain_to_enum_int(
+                value.fee_data_availability_mode,
+            ),
+            paymaster_data: value
+                .paymaster_data
+                .0
+                .iter()
+                .map(|paymaster_data| (*paymaster_data).into())
+                .collect(),
+            account_deployment_data: value
+                .account_deployment_data
+                .0
+                .iter()
+                .map(|account_deployment_data| (*account_deployment_data).into())
+                .collect(),
+        }
     }
 }
 
@@ -2291,6 +2523,72 @@ impl From<DeclareTransactionV3> for protobuf::transaction_in_block::DeclareV3Wit
     }
 }
 
+impl TryFrom<protobuf::DeclareV3WithClass> for RpcDeclareTransactionV3 {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::DeclareV3WithClass) -> Result<Self, Self::Error> {
+        let common = DeclareTransactionV3Common::try_from(value.common.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "DeclareV3WithClass::common",
+            },
+        )?)?;
+        let class: SierraContractClass = SierraContractClass::try_from(value.class.ok_or(
+            ProtobufConversionError::MissingField {
+                field_description: "DeclareV3WithClass::class",
+            },
+        )?)?;
+        if let ValidResourceBounds::AllResources(resource_bounds) = common.resource_bounds {
+            Ok(Self {
+                sender_address: common.sender_address,
+                compiled_class_hash: common.compiled_class_hash,
+                signature: common.signature,
+                nonce: common.nonce,
+                contract_class: class,
+                resource_bounds,
+                tip: common.tip,
+                paymaster_data: common.paymaster_data,
+                account_deployment_data: common.account_deployment_data,
+                nonce_data_availability_mode: common.nonce_data_availability_mode,
+                fee_data_availability_mode: common.fee_data_availability_mode,
+            })
+        } else {
+            Err(ProtobufConversionError::WrongEnumVariant {
+                type_description: "ValidResourceBounds",
+                value_as_str: format!("{:?}", common.resource_bounds),
+                expected: "AllResources",
+            })
+        }
+    }
+}
+
+impl From<RpcDeclareTransactionV3> for protobuf::DeclareV3WithClass {
+    fn from(value: RpcDeclareTransactionV3) -> Self {
+        let common = protobuf::DeclareV3Common {
+            resource_bounds: Some(value.resource_bounds.into()),
+            sender: Some(value.sender_address.into()),
+            signature: Some(protobuf::AccountSignature {
+                parts: value.signature.0.into_iter().map(|signature| signature.into()).collect(),
+            }),
+            nonce: Some(value.nonce.0.into()),
+            compiled_class_hash: Some(value.compiled_class_hash.0.into()),
+            tip: value.tip.0,
+            paymaster_data: value.paymaster_data.0.into_iter().map(|data| data.into()).collect(),
+            account_deployment_data: value
+                .account_deployment_data
+                .0
+                .into_iter()
+                .map(|data| data.into())
+                .collect(),
+            nonce_data_availability_mode: volition_domain_to_enum_int(
+                value.nonce_data_availability_mode,
+            ),
+            fee_data_availability_mode: volition_domain_to_enum_int(
+                value.fee_data_availability_mode,
+            ),
+        };
+        Self { common: Some(common), class: Some(value.contract_class.into()) }
+    }
+}
+
 // TODO(alonl): remove once Transaction is replaced with TransacitonInBlock
 impl From<DeclareTransactionV3> for protobuf::transaction::DeclareV3 {
     fn from(value: DeclareTransactionV3) -> Self {
@@ -2519,6 +2817,65 @@ impl From<L1HandlerTransaction> for protobuf::L1HandlerV0 {
             entry_point_selector: Some(value.entry_point_selector.0.into()),
             calldata: value.calldata.0.iter().map(|calldata| (*calldata).into()).collect(),
         }
+    }
+}
+
+impl From<ConsensusTransaction> for protobuf::ConsensusTransaction {
+    fn from(value: ConsensusTransaction) -> Self {
+        match value {
+            ConsensusTransaction::RpcTransaction(RpcTransaction::Declare(
+                RpcDeclareTransaction::V3(txn),
+            )) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::DeclareV3(txn.into())),
+                transaction_hash: None,
+            },
+            ConsensusTransaction::RpcTransaction(RpcTransaction::DeployAccount(
+                RpcDeployAccountTransaction::V3(txn),
+            )) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::DeployAccountV3(txn.into())),
+                transaction_hash: None,
+            },
+            ConsensusTransaction::RpcTransaction(RpcTransaction::Invoke(
+                RpcInvokeTransaction::V3(txn),
+            )) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::InvokeV3(txn.into())),
+                transaction_hash: None,
+            },
+            ConsensusTransaction::L1Handler(txn) => protobuf::ConsensusTransaction {
+                txn: Some(protobuf::consensus_transaction::Txn::L1Handler(txn.into())),
+                transaction_hash: None,
+            },
+        }
+    }
+}
+
+impl TryFrom<protobuf::ConsensusTransaction> for ConsensusTransaction {
+    type Error = ProtobufConversionError;
+    fn try_from(value: protobuf::ConsensusTransaction) -> Result<Self, Self::Error> {
+        let txn = value.txn.ok_or(ProtobufConversionError::MissingField {
+            field_description: "ConsensusTransaction::txn",
+        })?;
+        let txn = match txn {
+            protobuf::consensus_transaction::Txn::DeclareV3(txn) => {
+                ConsensusTransaction::RpcTransaction(RpcTransaction::Declare(
+                    RpcDeclareTransaction::V3(txn.try_into()?),
+                ))
+            }
+            protobuf::consensus_transaction::Txn::DeployAccountV3(txn) => {
+                ConsensusTransaction::RpcTransaction(RpcTransaction::DeployAccount(
+                    RpcDeployAccountTransaction::V3(txn.try_into()?),
+                ))
+            }
+            protobuf::consensus_transaction::Txn::InvokeV3(txn) => {
+                ConsensusTransaction::RpcTransaction(RpcTransaction::Invoke(
+                    RpcInvokeTransaction::V3(txn.try_into()?),
+                ))
+            }
+            protobuf::consensus_transaction::Txn::L1Handler(txn) => {
+                ConsensusTransaction::L1Handler(txn.try_into()?)
+            }
+        };
+        Ok(txn)
     }
 }
 

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
@@ -50,7 +50,7 @@ message ProposalInit {
 }
 
 message TransactionBatch {
-    repeated Transaction transactions = 1;
+    repeated ConsensusTransaction transactions = 1;
 }
 
 message ProposalFin {

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
@@ -2,6 +2,20 @@ syntax = "proto3";
 import "p2p/proto/common.proto";
 import "p2p/proto/transaction.proto";
 
+option go_package = "github.com/starknet-io/starknet-p2pspecs/p2p/proto/consensus/consensus";
+
+// Contains all variants of mempool and an L1Handler variant to cover all transactions that can be
+// in a new block.
+message ConsensusTransaction {
+    oneof txn {
+        DeclareV3WithClass declare_v3 = 1;
+        DeployAccountV3 deploy_account_v3 = 2;
+        InvokeV3 invoke_v3 = 3;
+        L1HandlerV0 l1_handler = 4;
+    }
+    Hash transaction_hash = 5;
+}
+
 message Vote {
     enum  VoteType {
         Prevote   = 0;

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/mempool/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/mempool/transaction.proto
@@ -5,7 +5,7 @@ import "p2p/proto/common.proto";
 import "p2p/proto/transaction.proto";
 import "p2p/proto/sync/transaction.proto";
 // TODO(alonl): remove this import (used only for the old Transaction struct as an intermediate step)
-import "p2p/proto/consensus.proto";
+import "p2p/proto/consensus/consensus.proto";
 
 
 option go_package = "github.com/starknet-io/starknet-p2pspecs/p2p/proto/mempool/transaction";

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
@@ -23,8 +23,7 @@ message TransactionsResponse {
 }
 
 message TransactionWithReceipt {
-    //TODO(alonl): change transaction type to TransactionInBlock
-    Transaction transaction = 1;
+    TransactionInBlock transaction = 1;
     Receipt receipt = 2;
 }
 

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 import "p2p/proto/common.proto";
-import "p2p/proto/consensus.proto";
 import "p2p/proto/sync/common.proto";
 import "p2p/proto/sync/receipt.proto";
 import "p2p/proto/transaction.proto";

--- a/crates/papyrus_storage/src/body/mod.rs
+++ b/crates/papyrus_storage/src/body/mod.rs
@@ -169,6 +169,8 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
     }
 
     // TODO(dvir): add option to get transaction with its hash.
+    // Getting transactions from storage should return InternalConsensusTransactions, not
+    // Transactions.
     fn get_transaction(
         &self,
         transaction_index: TransactionIndex,
@@ -217,6 +219,7 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         Ok(Some(tx_metadata.tx_hash))
     }
 
+    // Getting blocks from storage should return InternalConsensusTransactions, not Transactions.
     fn get_block_transactions(
         &self,
         block_number: BlockNumber,

--- a/crates/papyrus_test_utils/src/lib.rs
+++ b/crates/papyrus_test_utils/src/lib.rs
@@ -49,6 +49,7 @@ use starknet_api::block::{
     GasPricePerToken,
     StarknetVersion,
 };
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     ClassHash,
@@ -497,6 +498,10 @@ auto_impl_get_test_instance! {
     pub struct ClassHash(pub StarkHash);
     pub struct CompiledClassHash(pub StarkHash);
     pub struct ContractAddressSalt(pub StarkHash);
+    pub enum ConsensusTransaction {
+        RpcTransaction(RpcTransaction) = 1,
+        L1Handler(L1HandlerTransaction) = 2,
+    }
     pub struct SierraContractClass {
         pub sierra_program: Vec<Felt>,
         pub contract_class_version: String,

--- a/crates/starknet_api/src/consensus_transaction.rs
+++ b/crates/starknet_api/src/consensus_transaction.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::rpc_transaction::{InternalRpcTransaction, RpcTransaction};
+use crate::transaction::TransactionHash;
 use crate::{executable_transaction, transaction};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Hash)]
@@ -13,4 +14,13 @@ pub enum ConsensusTransaction {
 pub enum InternalConsensusTransaction {
     RpcTransaction(InternalRpcTransaction),
     L1Handler(executable_transaction::L1HandlerTransaction),
+}
+
+impl InternalConsensusTransaction {
+    pub fn tx_hash(&self) -> TransactionHash {
+        match self {
+            InternalConsensusTransaction::RpcTransaction(tx) => tx.tx_hash,
+            InternalConsensusTransaction::L1Handler(tx) => tx.tx_hash,
+        }
+    }
 }

--- a/crates/starknet_api/src/executable_transaction.rs
+++ b/crates/starknet_api/src/executable_transaction.rs
@@ -97,7 +97,7 @@ impl AccountTransaction {
     }
 }
 
-// TODO(AlonLukatch): add a converter for Declare transactions as well.
+// TODO(alonl): add a converter for Declare transactions as well.
 impl From<InvokeTransaction> for RpcInvokeTransactionV3 {
     fn from(tx: InvokeTransaction) -> Self {
         Self {

--- a/crates/starknet_api/src/rpc_transaction.rs
+++ b/crates/starknet_api/src/rpc_transaction.rs
@@ -293,6 +293,28 @@ impl From<RpcDeployAccountTransactionV3> for DeployAccountTransactionV3 {
     }
 }
 
+impl From<DeployAccountTransactionV3> for RpcDeployAccountTransactionV3 {
+    fn from(tx: DeployAccountTransactionV3) -> Self {
+        Self {
+            resource_bounds: match tx.resource_bounds {
+                ValidResourceBounds::AllResources(all_resource_bounds) => all_resource_bounds,
+                ValidResourceBounds::L1Gas(l1_gas) => {
+                    AllResourceBounds { l1_gas, ..Default::default() }
+                }
+            },
+            tip: tx.tip,
+            signature: tx.signature,
+            nonce: tx.nonce,
+            nonce_data_availability_mode: tx.nonce_data_availability_mode,
+            fee_data_availability_mode: tx.fee_data_availability_mode,
+            paymaster_data: tx.paymaster_data,
+            class_hash: tx.class_hash,
+            contract_address_salt: tx.contract_address_salt,
+            constructor_calldata: tx.constructor_calldata,
+        }
+    }
+}
+
 /// An invoke account transaction that can be added to Starknet through the RPC.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RpcInvokeTransactionV3 {
@@ -312,6 +334,28 @@ impl From<RpcInvokeTransactionV3> for InvokeTransactionV3 {
     fn from(tx: RpcInvokeTransactionV3) -> Self {
         Self {
             resource_bounds: ValidResourceBounds::AllResources(tx.resource_bounds),
+            tip: tx.tip,
+            signature: tx.signature,
+            nonce: tx.nonce,
+            sender_address: tx.sender_address,
+            calldata: tx.calldata,
+            nonce_data_availability_mode: tx.nonce_data_availability_mode,
+            fee_data_availability_mode: tx.fee_data_availability_mode,
+            paymaster_data: tx.paymaster_data,
+            account_deployment_data: tx.account_deployment_data,
+        }
+    }
+}
+
+impl From<InvokeTransactionV3> for RpcInvokeTransactionV3 {
+    fn from(tx: InvokeTransactionV3) -> Self {
+        Self {
+            resource_bounds: match tx.resource_bounds {
+                ValidResourceBounds::AllResources(all_resource_bounds) => all_resource_bounds,
+                ValidResourceBounds::L1Gas(l1_gas) => {
+                    AllResourceBounds { l1_gas, ..Default::default() }
+                }
+            },
             tip: tx.tip,
             signature: tx.signature,
             nonce: tx.nonce,

--- a/crates/starknet_class_manager_types/src/transaction_converter.rs
+++ b/crates/starknet_class_manager_types/src/transaction_converter.rs
@@ -37,7 +37,7 @@ pub enum TransactionConverterError {
 pub type TransactionConverterResult<T> = Result<T, TransactionConverterError>;
 
 #[async_trait]
-pub trait TransactionConverterTrait {
+pub trait TransactionConverterTrait: Send + Sync {
     async fn convert_internal_consensus_tx_to_consensus_tx(
         &self,
         tx: InternalConsensusTransaction,

--- a/crates/starknet_class_manager_types/src/transaction_converter.rs
+++ b/crates/starknet_class_manager_types/src/transaction_converter.rs
@@ -58,12 +58,12 @@ pub trait TransactionConverterTrait: Send + Sync {
         tx: RpcTransaction,
     ) -> TransactionConverterResult<InternalRpcTransaction>;
 
-    async fn convert_internal_tx_to_executable_tx(
+    async fn convert_internal_consensus_tx_to_executable_tx(
         &self,
         tx: InternalConsensusTransaction,
     ) -> TransactionConverterResult<ExecutableTransaction>;
 
-    async fn convert_executable_tx_to_internal_tx(
+    async fn convert_executable_tx_to_internal_consensus_tx(
         &self,
         tx: ExecutableTransaction,
     ) -> TransactionConverterResult<InternalConsensusTransaction>;
@@ -182,7 +182,7 @@ impl TransactionConverterTrait for TransactionConverter {
         Ok(InternalRpcTransaction { tx: tx_without_hash, tx_hash })
     }
 
-    async fn convert_internal_tx_to_executable_tx(
+    async fn convert_internal_consensus_tx_to_executable_tx(
         &self,
         internal_tx: InternalConsensusTransaction,
     ) -> TransactionConverterResult<ExecutableTransaction> {
@@ -234,7 +234,7 @@ impl TransactionConverterTrait for TransactionConverter {
         }
     }
 
-    async fn convert_executable_tx_to_internal_tx(
+    async fn convert_executable_tx_to_internal_consensus_tx(
         &self,
         tx: ExecutableTransaction,
     ) -> TransactionConverterResult<InternalConsensusTransaction> {

--- a/crates/starknet_consensus_orchestrator/Cargo.toml
+++ b/crates/starknet_consensus_orchestrator/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true, features = ["arbitrary_precision"] }
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_batcher_types = { workspace = true, features = ["testing"] }
+starknet_class_manager_types.workspace = true
 starknet_consensus.workspace = true
 starknet_infra_utils.workspace = true
 starknet_state_sync_types = { workspace = true, features = ["testing"] }

--- a/crates/starknet_consensus_orchestrator/src/papyrus_consensus_context.rs
+++ b/crates/starknet_consensus_orchestrator/src/papyrus_consensus_context.rs
@@ -29,7 +29,7 @@ use papyrus_storage::body::BodyStorageReader;
 use papyrus_storage::header::HeaderStorageReader;
 use papyrus_storage::{StorageError, StorageReader};
 use starknet_api::block::BlockNumber;
-use starknet_api::transaction::Transaction;
+use starknet_api::consensus_transaction::{ConsensusTransaction, InternalConsensusTransaction};
 use starknet_consensus::types::{
     ConsensusContext,
     ConsensusError,
@@ -41,7 +41,8 @@ use tracing::{debug, debug_span, info, warn, Instrument};
 
 // TODO(Asmaa): add debug messages and span to the tasks.
 
-type HeightToIdToContent = BTreeMap<BlockNumber, HashMap<ProposalContentId, Vec<Transaction>>>;
+type HeightToIdToContent =
+    BTreeMap<BlockNumber, HashMap<ProposalContentId, Vec<InternalConsensusTransaction>>>;
 
 const CHANNEL_SIZE: usize = 100;
 
@@ -180,7 +181,7 @@ impl ConsensusContext for PapyrusConsensusContext {
                     });
 
                 // First gather all the non-fin transactions.
-                let mut content_transactions: Vec<Transaction> = Vec::new();
+                let mut content_transactions: Vec<ConsensusTransaction> = Vec::new();
                 let received_block_hash = loop {
                     match content.next().await {
                         Some(ProposalPart::Transactions(batch)) => {

--- a/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -839,7 +839,6 @@ async fn handle_proposal_part(
         None => HandledProposalPart::Failed("Failed to receive proposal content".to_string()),
         Some(ProposalPart::Transactions(TransactionBatch { transactions: txs })) => {
             debug!("Received transaction batch with {} txs", txs.len());
-            // txs is snapi::tx while exe_tx is executable_tx
             // TODO(alonl): remove conversion to executable transaction before sending to batcher.
             let internal_txs: Vec<InternalConsensusTransaction> = futures::stream::iter(txs)
                 .then(|tx| transaction_converter.convert_consensus_tx_to_internal_consensus_tx(tx))

--- a/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use blockifier::test_utils::l1_handler;
 use futures::channel::{mpsc, oneshot};
 use futures::{FutureExt, SinkExt, StreamExt};
 use papyrus_network::network_manager::{BroadcastTopicClient, BroadcastTopicClientTrait};
@@ -22,6 +23,7 @@ use papyrus_protobuf::consensus::{
     Vote,
     DEFAULT_VALIDATOR_ID,
 };
+use papyrus_protobuf::protobuf::transaction;
 use starknet_api::block::{
     BlockHash,
     BlockHashAndNumber,
@@ -35,9 +37,10 @@ use starknet_api::block::{
     GasPrices,
     NonzeroGasPrice,
 };
+use starknet_api::consensus_transaction::{ConsensusTransaction, InternalConsensusTransaction};
 use starknet_api::core::{ChainId, ContractAddress, SequencerContractAddress};
-use starknet_api::executable_transaction::Transaction as ExecutableTransaction;
-use starknet_api::transaction::{Transaction, TransactionHash};
+use starknet_api::executable_transaction::{self, Transaction as ExecutableTransaction};
+use starknet_api::transaction::TransactionHash;
 use starknet_batcher_types::batcher_types::{
     DecisionReachedInput,
     DecisionReachedResponse,
@@ -52,6 +55,8 @@ use starknet_batcher_types::batcher_types::{
     ValidateBlockInput,
 };
 use starknet_batcher_types::communication::BatcherClient;
+use starknet_class_manager_types::transaction_converter::{self, TransactionConverterTrait};
+use starknet_class_manager_types::ClassManagerClient;
 use starknet_consensus::types::{
     ConsensusContext,
     ConsensusError,
@@ -87,8 +92,10 @@ const TEMPORARY_GAS_PRICES: GasPrices = GasPrices {
 // {height: {proposal_id: (content, [proposal_ids])}}
 // Note that multiple proposals IDs can be associated with the same content, but we only need to
 // store one of them.
-type HeightToIdToContent =
-    BTreeMap<BlockNumber, HashMap<ProposalContentId, (Vec<ExecutableTransaction>, ProposalId)>>;
+type HeightToIdToContent = BTreeMap<
+    BlockNumber,
+    HashMap<ProposalContentId, (Vec<InternalConsensusTransaction>, ProposalId)>,
+>;
 type ValidationParams = (BlockNumber, ValidatorId, Duration, mpsc::Receiver<ProposalPart>);
 
 const CHANNEL_SIZE: usize = 100;
@@ -141,6 +148,7 @@ pub struct SequencerConsensusContext {
     // The next block's l2 gas price, calculated based on EIP-1559, used for building and
     // validating proposals.
     l2_gas_price: u64,
+    transaction_converter: Arc<dyn TransactionConverterTrait>,
 }
 
 impl SequencerConsensusContext {
@@ -152,6 +160,7 @@ impl SequencerConsensusContext {
         num_validators: u64,
         chain_id: ChainId,
         cende_ambassador: Arc<dyn CendeContext>,
+        transaction_converter: Arc<dyn TransactionConverterTrait>,
     ) -> Self {
         Self {
             state_sync_client,
@@ -171,6 +180,7 @@ impl SequencerConsensusContext {
             chain_id,
             cende_ambassador,
             l2_gas_price: VersionedConstants::latest_constants().min_gas_price,
+            transaction_converter,
         }
     }
 
@@ -215,6 +225,7 @@ impl ConsensusContext for SequencerConsensusContext {
             .await
             .expect("Failed to send proposal receiver");
         let gas_prices = self.gas_prices();
+        let transaction_converter = Arc::clone(&self.transaction_converter);
 
         info!(?proposal_init, ?timeout, %proposal_id, "Building proposal");
         let handle = tokio::spawn(
@@ -229,6 +240,7 @@ impl ConsensusContext for SequencerConsensusContext {
                     proposal_id,
                     cende_write_success,
                     gas_prices,
+                    transaction_converter,
                 )
                 .await;
             }
@@ -376,12 +388,33 @@ impl ConsensusContext for SequencerConsensusContext {
         // TODO(dvir): pass here real `BlobParameters` info.
         // TODO(dvir): when passing here the correct `BlobParameters`, also test that
         // `prepare_blob_for_next_height` is called with the correct parameters.
+
+        // TODO(alonl): Figure out which tx type should be sent to cende
+        let mut exe_txs = vec![];
+        for tx in transactions {
+            let executable_tx =
+                self.transaction_converter.convert_internal_tx_to_executable_tx(tx).await;
+            // match tx {
+            //     InternalConsensusTransaction::RpcTransaction(internal_rpc_tx) => {
+            //         executable_transaction::Transaction::Account(
+            //             self.transaction_converter
+            //                 .convert_internal_rpc_tx_to_executable_tx(internal_rpc_tx)
+            //                 .await
+            //                 .expect("Failed to convert tx"),
+            //         )
+            //     }
+            //     InternalConsensusTransaction::L1Handler(l1_handler) => {
+            //         executable_transaction::Transaction::L1Handler(l1_handler)
+            //     }
+            // };
+            exe_txs.push(executable_tx);
+        }
         self.cende_ambassador
             .prepare_blob_for_next_height(BlobParameters {
                 // TODO(dvir): use the real `BlockInfo` when consensus will save it.
                 block_info: BlockInfo { block_number: BlockNumber(height), ..Default::default() },
                 state_diff,
-                transactions,
+                transactions: exe_txs,
                 execution_infos: central_objects.execution_infos,
                 bouncer_weights: central_objects.bouncer_weights,
             })
@@ -467,6 +500,7 @@ impl SequencerConsensusContext {
         let proposal_id = ProposalId(self.proposal_id);
         self.proposal_id += 1;
         let gas_prices = self.gas_prices();
+        let transaction_converter = Arc::clone(&self.transaction_converter);
 
         info!(?timeout, %proposal_id, %proposer, round=self.current_round, "Validating proposal.");
 
@@ -484,6 +518,7 @@ impl SequencerConsensusContext {
                     fin_sender,
                     cancel_token_clone,
                     gas_prices,
+                    transaction_converter,
                 )
                 .await
             }
@@ -514,6 +549,7 @@ async fn build_proposal(
     proposal_id: ProposalId,
     cende_write_success: AbortOnDropHandle<bool>,
     gas_prices: GasPrices,
+    transaction_converter: Arc<dyn TransactionConverterTrait>,
 ) {
     initialize_build(proposal_id, &proposal_init, timeout, batcher.as_ref(), gas_prices).await;
     proposal_sender
@@ -521,9 +557,14 @@ async fn build_proposal(
         .await
         .expect("Failed to send proposal init");
 
-    let Some((proposal_content_id, content)) =
-        get_proposal_content(proposal_id, batcher.as_ref(), proposal_sender, cende_write_success)
-            .await
+    let Some((proposal_content_id, content)) = get_proposal_content(
+        proposal_id,
+        batcher.as_ref(),
+        proposal_sender,
+        cende_write_success,
+        transaction_converter,
+    )
+    .await
     else {
         return;
     };
@@ -585,7 +626,8 @@ async fn get_proposal_content(
     batcher: &dyn BatcherClient,
     mut proposal_sender: mpsc::Sender<ProposalPart>,
     cende_write_success: AbortOnDropHandle<bool>,
-) -> Option<(ProposalContentId, Vec<ExecutableTransaction>)> {
+    transaction_converter: Arc<dyn TransactionConverterTrait>,
+) -> Option<(ProposalContentId, Vec<InternalConsensusTransaction>)> {
     let mut content = Vec::new();
     loop {
         // We currently want one part of the node failing to cause all components to fail. If this
@@ -605,9 +647,16 @@ async fn get_proposal_content(
                     "Sending transaction batch with {} txs.",
                     txs.len()
                 );
-                let transactions =
-                    txs.into_iter().map(|tx| tx.into()).collect::<Vec<Transaction>>();
+                let transactions = futures::stream::iter(txs)
+                    .then(|tx| {
+                        transaction_converter.convert_internal_consensus_tx_to_consensus_tx(tx)
+                    })
+                    .map(|conversion_result| conversion_result.expect("Failed to convert tx"))
+                    .collect::<Vec<ConsensusTransaction>>()
+                    .await;
                 trace!(?transactions, "Sending transaction batch with {} txs.", transactions.len());
+
+                // convert to ConsensusTransaction
                 proposal_sender
                     .send(ProposalPart::Transactions(TransactionBatch { transactions }))
                     .await
@@ -661,6 +710,7 @@ async fn validate_proposal(
     fin_sender: oneshot::Sender<(ProposalContentId, ProposalFin)>,
     cancel_token: CancellationToken,
     gas_prices: GasPrices,
+    transaction_converter: Arc<dyn TransactionConverterTrait>,
 ) {
     initiate_validation(batcher, proposal_id, height, proposer, timeout, gas_prices).await;
 
@@ -684,7 +734,8 @@ async fn validate_proposal(
                     batcher,
                     proposal_part,
                     &mut content,
-                    chain_id.clone()
+                    chain_id.clone(),
+                    Arc::clone(&transaction_converter),
                 ).await {
                     HandledProposalPart::Finished(built_block, received_fin) => {
                         break (built_block, received_fin);
@@ -709,6 +760,11 @@ async fn validate_proposal(
     // with `get_proposal` being called before `valid_proposals` is updated.
     // TODO(Matan): Consider validating the ProposalFin signature here.
     let mut valid_proposals = valid_proposals.lock().unwrap();
+    // let content = futures::stream::iter(content)
+    //     .then(|tx| transaction_converter.convert_consensus_tx_to_internal_consensus_tx(tx))
+    //     .map(|conversion_result| conversion_result.expect("Failed to convert tx"))
+    //     .collect::<Vec<InternalConsensusTransaction>>()
+    //     .await;
     valid_proposals.entry(height).or_default().insert(built_block, (content, proposal_id));
     if fin_sender.send((built_block, received_fin)).is_err() {
         // Consensus may exit early (e.g. sync).
@@ -759,26 +815,23 @@ async fn handle_proposal_part(
     proposal_id: ProposalId,
     batcher: &dyn BatcherClient,
     proposal_part: Option<ProposalPart>,
-    content: &mut Vec<ExecutableTransaction>,
+    content: &mut Vec<InternalConsensusTransaction>,
     chain_id: ChainId,
+    transaction_converter: Arc<dyn TransactionConverterTrait>,
 ) -> HandledProposalPart {
     match proposal_part {
         None => HandledProposalPart::Failed("Failed to receive proposal content".to_string()),
         Some(ProposalPart::Transactions(TransactionBatch { transactions: txs })) => {
             debug!("Received transaction batch with {} txs", txs.len());
-            let exe_txs: Vec<ExecutableTransaction> = txs
-                .into_iter()
-                .map(|tx| {
-                    // An error means we have an invalid chain_id.
-                    (tx, &chain_id)
-                        .try_into()
-                        .expect("Failed to convert transaction to executable_transation.")
-                })
-                .collect();
-            content.extend_from_slice(&exe_txs[..]);
+            let internal_txs: Vec<InternalConsensusTransaction> = futures::stream::iter(txs)
+                .then(|tx| transaction_converter.convert_consensus_tx_to_internal_consensus_tx(tx))
+                .map(|conversion_result| conversion_result.expect("Failed to convert tx"))
+                .collect::<Vec<InternalConsensusTransaction>>()
+                .await;
+            content.extend_from_slice(&internal_txs[..]);
             let input = SendProposalContentInput {
                 proposal_id,
-                content: SendProposalContent::Txs(exe_txs),
+                content: SendProposalContent::Txs(internal_txs),
             };
             let response = batcher.send_proposal_content(input).await.unwrap_or_else(|e| {
                 panic!("Failed to send proposal content to batcher: {proposal_id:?}. {e:?}")

--- a/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use std::vec;
 
 use futures::channel::{mpsc, oneshot};
-use futures::future::pending;
-use futures::{FutureExt, SinkExt};
+use futures::future::{self, pending};
+use futures::{FutureExt, SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use papyrus_network::network_manager::test_utils::{
     mock_register_broadcast_topic,
@@ -23,10 +23,12 @@ use papyrus_protobuf::consensus::{
     Vote,
 };
 use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::{ChainId, Nonce, StateDiffCommitment};
 use starknet_api::executable_transaction::Transaction as ExecutableTransaction;
 use starknet_api::felt;
 use starknet_api::hash::PoseidonHash;
+use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::test_utils::invoke::{invoke_tx, InvokeTxArgs};
 use starknet_api::transaction::Transaction;
 use starknet_batcher_types::batcher_types::{
@@ -42,6 +44,12 @@ use starknet_batcher_types::batcher_types::{
     ValidateBlockInput,
 };
 use starknet_batcher_types::communication::MockBatcherClient;
+use starknet_class_manager_types::transaction_converter::{
+    self,
+    TransactionConverter,
+    TransactionConverterTrait,
+};
+use starknet_class_manager_types::EmptyClassManagerClient;
 use starknet_consensus::stream_handler::StreamHandler;
 use starknet_consensus::types::ConsensusContext;
 use starknet_state_sync_types::communication::MockStateSyncClient;
@@ -199,8 +207,19 @@ async fn validate_proposal_success() {
     context.set_height_and_round(BlockNumber(0), 0).await;
 
     let (mut content_sender, content_receiver) = mpsc::channel(CHANNEL_SIZE);
+    // TODO(alonl): instead of converting here, TX_BATCH should be Vec<InternalConsensusTransaction>
+    let transaction_converter =
+        TransactionConverter::new(Arc::new(EmptyClassManagerClient), CHAIN_ID);
+    let rpc_transactions =
+        TX_BATCH.to_vec().into_iter().map(|tx| tx.into()).collect::<Vec<RpcTransaction>>();
+    let internal_transactions = futures::stream::iter(TX_BATCH.to_vec())
+        .then(|tx: ExecutableTransaction| {
+            transaction_converter.convert_executable_tx_to_internal_consensus_tx(tx)
+        })
+        .map(|conversion_result| conversion_result.expect("Failed to convert transaction"))
+        .collect::<Vec<InternalConsensusTransaction>>();
     content_sender
-        .send(ProposalPart::Transactions(TransactionBatch { transactions: TX_BATCH.to_vec() }))
+        .send(ProposalPart::Transactions(TransactionBatch { transactions: internal_transactions }))
         .await
         .unwrap();
     content_sender


### PR DESCRIPTION
- **refactor(papyrus_protobuf): add converters for new transaction messages**
- **refactor(papyrus_protobuf): move consensus.proto to a different folder and added ConsensusTransaction**
- **refactor(papyrus_protobuf): add missing converters for RpcTransactions and ConsensusTransaction**
- **feature(starknet_api, starknet_class_manager_types): new converters**
- **wip - changing transaction batch to use consensus transaction and consensus to use the new transaction types**
- **wip - converting to and from executable transaction so batcher doesnt change**
