### PR TITLE
refactor(papyrus_protobuf): add missing converters for RpcTransactions and ConsensusTransaction

### DIFF
--- a/crates/papyrus_protobuf/src/converters/deprecated_transaction.rs
+++ b/crates/papyrus_protobuf/src/converters/deprecated_transaction.rs
@@ -1,28 +1,10 @@
-#[cfg(test)]
-#[path = "transaction_test.rs"]
-mod transaction_test;
-use std::convert::{TryFrom, TryInto};
-
-use prost::Message;
-use serde::{Deserialize, Serialize};
-use starknet_api::block::GasPrice;
-use starknet_api::core::{
-    ClassHash,
-    CompiledClassHash,
-    ContractAddress,
-    EntryPointSelector,
-    Nonce,
-};
-use starknet_api::data_availability::DataAvailabilityMode;
-use starknet_api::execution_resources::GasAmount;
+use starknet_api::core::{ClassHash, CompiledClassHash, EntryPointSelector, Nonce};
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
-    AllResourceBounds,
     Calldata,
     ContractAddressSalt,
     Fee,
     PaymasterData,
-    ResourceBounds,
     Tip,
     TransactionSignature,
     ValidResourceBounds,
@@ -36,15 +18,12 @@ use starknet_api::transaction::{
     DeployAccountTransactionV1,
     DeployAccountTransactionV3,
     DeployTransaction,
-    FullTransaction,
     InvokeTransaction,
     InvokeTransactionV0,
     InvokeTransactionV1,
     InvokeTransactionV3,
     L1HandlerTransaction,
     Transaction,
-    TransactionHash,
-    TransactionOutput,
     TransactionVersion,
 };
 use starknet_types_core::felt::Felt;
@@ -56,215 +35,118 @@ use super::common::{
     volition_domain_to_enum_int,
 };
 use super::ProtobufConversionError;
-use crate::sync::{DataOrFin, Query, TransactionQuery};
-use crate::{auto_impl_into_and_try_from_vec_u8, protobuf};
+use crate::protobuf;
 
-impl TryFrom<protobuf::TransactionsResponse> for DataOrFin<FullTransaction> {
+impl TryFrom<protobuf::Transaction> for Transaction {
     type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::TransactionsResponse) -> Result<Self, Self::Error> {
-        let Some(transaction_message) = value.transaction_message else {
-            return Err(ProtobufConversionError::MissingField {
-                field_description: "TransactionsResponse::transaction_message",
-            });
-        };
-
-        match transaction_message {
-            protobuf::transactions_response::TransactionMessage::TransactionWithReceipt(
-                tx_with_receipt,
-            ) => {
-                let result: FullTransaction = tx_with_receipt.try_into()?;
-                Ok(DataOrFin(Some(result)))
-            }
-            protobuf::transactions_response::TransactionMessage::Fin(_) => Ok(DataOrFin(None)),
-        }
-    }
-}
-impl From<DataOrFin<FullTransaction>> for protobuf::TransactionsResponse {
-    fn from(value: DataOrFin<FullTransaction>) -> Self {
-        match value.0 {
-            Some(FullTransaction { transaction, transaction_output, transaction_hash }) => {
-                protobuf::TransactionsResponse {
-                    transaction_message: Some(
-                        protobuf::transactions_response::TransactionMessage::TransactionWithReceipt(
-                            protobuf::TransactionWithReceipt::from(FullTransaction {
-                                transaction,
-                                transaction_output,
-                                transaction_hash,
-                            }),
-                        ),
-                    ),
-                }
-            }
-            None => protobuf::TransactionsResponse {
-                transaction_message: Some(
-                    protobuf::transactions_response::TransactionMessage::Fin(protobuf::Fin {}),
-                ),
-            },
-        }
-    }
-}
-
-auto_impl_into_and_try_from_vec_u8!(DataOrFin<FullTransaction>, protobuf::TransactionsResponse);
-
-impl TryFrom<protobuf::TransactionWithReceipt> for FullTransaction {
-    type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::TransactionWithReceipt) -> Result<Self, Self::Error> {
-        let (transaction, transaction_hash) = <(Transaction, TransactionHash)>::try_from(
-            value.transaction.ok_or(ProtobufConversionError::MissingField {
-                field_description: "TransactionWithReceipt::transaction",
-            })?,
-        )?;
-
-        let transaction_output = TransactionOutput::try_from(value.receipt.ok_or(
-            ProtobufConversionError::MissingField {
-                field_description: "TransactionWithReceipt::output",
-            },
-        )?)?;
-        Ok(FullTransaction { transaction, transaction_output, transaction_hash })
-    }
-}
-
-impl From<FullTransaction> for protobuf::TransactionWithReceipt {
-    fn from(value: FullTransaction) -> Self {
-        let FullTransaction { transaction, transaction_output, transaction_hash } = value;
-        let transaction = (transaction, transaction_hash).into();
-        let mut receipt = transaction_output.into();
-        set_price_unit_based_on_transaction(&mut receipt, &transaction);
-        Self { transaction: Some(transaction), receipt: Some(receipt) }
-    }
-}
-
-// Used when converting a protobuf::TransactionWithReceipt to a FullTransaction.
-impl TryFrom<protobuf::TransactionInBlock> for (Transaction, TransactionHash) {
-    type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::TransactionInBlock) -> Result<Self, Self::Error> {
-        let tx_hash = value
-            .transaction_hash
-            .clone()
-            .ok_or(ProtobufConversionError::MissingField {
-                field_description: "Transaction::transaction_hash",
-            })?
-            .try_into()
-            .map(TransactionHash)?;
+    fn try_from(value: protobuf::Transaction) -> Result<Self, Self::Error> {
         let txn = value.txn.ok_or(ProtobufConversionError::MissingField {
             field_description: "Transaction::txn",
         })?;
-        let transaction: Transaction = match txn {
-            protobuf::transaction_in_block::Txn::DeclareV0(declare_v0) => Transaction::Declare(
+        Ok(match txn {
+            protobuf::transaction::Txn::DeclareV0(declare_v0) => Transaction::Declare(
                 DeclareTransaction::V0(DeclareTransactionV0V1::try_from(declare_v0)?),
             ),
-            protobuf::transaction_in_block::Txn::DeclareV1(declare_v1) => Transaction::Declare(
+            protobuf::transaction::Txn::DeclareV1(declare_v1) => Transaction::Declare(
                 DeclareTransaction::V1(DeclareTransactionV0V1::try_from(declare_v1)?),
             ),
-            protobuf::transaction_in_block::Txn::DeclareV2(declare_v2) => Transaction::Declare(
+            protobuf::transaction::Txn::DeclareV2(declare_v2) => Transaction::Declare(
                 DeclareTransaction::V2(DeclareTransactionV2::try_from(declare_v2)?),
             ),
-            protobuf::transaction_in_block::Txn::DeclareV3(declare_v3) => Transaction::Declare(
+            protobuf::transaction::Txn::DeclareV3(declare_v3) => Transaction::Declare(
                 DeclareTransaction::V3(DeclareTransactionV3::try_from(declare_v3)?),
             ),
-            protobuf::transaction_in_block::Txn::Deploy(deploy) => {
+            protobuf::transaction::Txn::Deploy(deploy) => {
                 Transaction::Deploy(DeployTransaction::try_from(deploy)?)
             }
-            protobuf::transaction_in_block::Txn::DeployAccountV1(deploy_account_v1) => {
+            protobuf::transaction::Txn::DeployAccountV1(deploy_account_v1) => {
                 Transaction::DeployAccount(DeployAccountTransaction::V1(
                     DeployAccountTransactionV1::try_from(deploy_account_v1)?,
                 ))
             }
-            protobuf::transaction_in_block::Txn::DeployAccountV3(deploy_account_v3) => {
+            protobuf::transaction::Txn::DeployAccountV3(deploy_account_v3) => {
                 Transaction::DeployAccount(DeployAccountTransaction::V3(
                     DeployAccountTransactionV3::try_from(deploy_account_v3)?,
                 ))
             }
-            protobuf::transaction_in_block::Txn::InvokeV0(invoke_v0) => Transaction::Invoke(
+            protobuf::transaction::Txn::InvokeV0(invoke_v0) => Transaction::Invoke(
                 InvokeTransaction::V0(InvokeTransactionV0::try_from(invoke_v0)?),
             ),
-            protobuf::transaction_in_block::Txn::InvokeV1(invoke_v1) => Transaction::Invoke(
+            protobuf::transaction::Txn::InvokeV1(invoke_v1) => Transaction::Invoke(
                 InvokeTransaction::V1(InvokeTransactionV1::try_from(invoke_v1)?),
             ),
-            protobuf::transaction_in_block::Txn::InvokeV3(invoke_v3) => Transaction::Invoke(
+            protobuf::transaction::Txn::InvokeV3(invoke_v3) => Transaction::Invoke(
                 InvokeTransaction::V3(InvokeTransactionV3::try_from(invoke_v3)?),
             ),
-            protobuf::transaction_in_block::Txn::L1Handler(l1_handler) => {
+            protobuf::transaction::Txn::L1Handler(l1_handler) => {
                 Transaction::L1Handler(L1HandlerTransaction::try_from(l1_handler)?)
             }
-        };
-        Ok((transaction, tx_hash))
+        })
     }
 }
 
-impl From<(Transaction, TransactionHash)> for protobuf::TransactionInBlock {
-    fn from(value: (Transaction, TransactionHash)) -> Self {
-        let tx_hash = Some(value.1.0.into());
-        match value.0 {
-            Transaction::Declare(DeclareTransaction::V0(declare_v0)) => {
-                protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::DeclareV0(declare_v0.into())),
-                    transaction_hash: tx_hash,
-                }
-            }
-            Transaction::Declare(DeclareTransaction::V1(declare_v1)) => {
-                protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::DeclareV1(declare_v1.into())),
-                    transaction_hash: tx_hash,
-                }
-            }
-            Transaction::Declare(DeclareTransaction::V2(declare_v2)) => {
-                protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::DeclareV2(declare_v2.into())),
-                    transaction_hash: tx_hash,
-                }
-            }
-            Transaction::Declare(DeclareTransaction::V3(declare_v3)) => {
-                protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::DeclareV3(declare_v3.into())),
-                    transaction_hash: tx_hash,
-                }
-            }
-            Transaction::Deploy(deploy) => protobuf::TransactionInBlock {
-                txn: Some(protobuf::transaction_in_block::Txn::Deploy(deploy.into())),
-                transaction_hash: tx_hash,
+impl From<Transaction> for protobuf::Transaction {
+    fn from(value: Transaction) -> Self {
+        match value {
+            Transaction::Declare(DeclareTransaction::V0(declare_v0)) => protobuf::Transaction {
+                txn: Some(protobuf::transaction::Txn::DeclareV0(declare_v0.into())),
+                transaction_hash: None,
+            },
+            Transaction::Declare(DeclareTransaction::V1(declare_v1)) => protobuf::Transaction {
+                txn: Some(protobuf::transaction::Txn::DeclareV1(declare_v1.into())),
+                transaction_hash: None,
+            },
+            Transaction::Declare(DeclareTransaction::V2(declare_v2)) => protobuf::Transaction {
+                txn: Some(protobuf::transaction::Txn::DeclareV2(declare_v2.into())),
+                transaction_hash: None,
+            },
+            Transaction::Declare(DeclareTransaction::V3(declare_v3)) => protobuf::Transaction {
+                txn: Some(protobuf::transaction::Txn::DeclareV3(declare_v3.into())),
+                transaction_hash: None,
+            },
+            Transaction::Deploy(deploy) => protobuf::Transaction {
+                txn: Some(protobuf::transaction::Txn::Deploy(deploy.into())),
+                transaction_hash: None,
             },
             Transaction::DeployAccount(deploy_account) => match deploy_account {
-                DeployAccountTransaction::V1(deploy_account_v1) => protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::DeployAccountV1(
+                DeployAccountTransaction::V1(deploy_account_v1) => protobuf::Transaction {
+                    txn: Some(protobuf::transaction::Txn::DeployAccountV1(
                         deploy_account_v1.into(),
                     )),
-                    transaction_hash: tx_hash,
+                    transaction_hash: None,
                 },
-                DeployAccountTransaction::V3(deploy_account_v3) => protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::DeployAccountV3(
+                DeployAccountTransaction::V3(deploy_account_v3) => protobuf::Transaction {
+                    txn: Some(protobuf::transaction::Txn::DeployAccountV3(
                         deploy_account_v3.into(),
                     )),
-                    transaction_hash: tx_hash,
+                    transaction_hash: None,
                 },
             },
             Transaction::Invoke(invoke) => match invoke {
-                InvokeTransaction::V0(invoke_v0) => protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::InvokeV0(invoke_v0.into())),
-                    transaction_hash: tx_hash,
+                InvokeTransaction::V0(invoke_v0) => protobuf::Transaction {
+                    txn: Some(protobuf::transaction::Txn::InvokeV0(invoke_v0.into())),
+                    transaction_hash: None,
                 },
-                InvokeTransaction::V1(invoke_v1) => protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::InvokeV1(invoke_v1.into())),
-                    transaction_hash: tx_hash,
+                InvokeTransaction::V1(invoke_v1) => protobuf::Transaction {
+                    txn: Some(protobuf::transaction::Txn::InvokeV1(invoke_v1.into())),
+                    transaction_hash: None,
                 },
-                InvokeTransaction::V3(invoke_v3) => protobuf::TransactionInBlock {
-                    txn: Some(protobuf::transaction_in_block::Txn::InvokeV3(invoke_v3.into())),
-                    transaction_hash: tx_hash,
+                InvokeTransaction::V3(invoke_v3) => protobuf::Transaction {
+                    txn: Some(protobuf::transaction::Txn::InvokeV3(invoke_v3.into())),
+                    transaction_hash: None,
                 },
             },
-            Transaction::L1Handler(l1_handler) => protobuf::TransactionInBlock {
-                txn: Some(protobuf::transaction_in_block::Txn::L1Handler(l1_handler.into())),
-                transaction_hash: tx_hash,
+            Transaction::L1Handler(l1_handler) => protobuf::Transaction {
+                txn: Some(protobuf::transaction::Txn::L1Handler(l1_handler.into())),
+                transaction_hash: None,
             },
         }
     }
 }
 
-impl TryFrom<protobuf::transaction_in_block::DeployAccountV1> for DeployAccountTransactionV1 {
+impl TryFrom<protobuf::transaction::DeployAccountV1> for DeployAccountTransactionV1 {
     type Error = ProtobufConversionError;
-    fn try_from(
-        value: protobuf::transaction_in_block::DeployAccountV1,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::DeployAccountV1) -> Result<Self, Self::Error> {
         let max_fee_felt =
             Felt::try_from(value.max_fee.ok_or(ProtobufConversionError::MissingField {
                 field_description: "DeployAccountV1::max_fee",
@@ -331,7 +213,7 @@ impl TryFrom<protobuf::transaction_in_block::DeployAccountV1> for DeployAccountT
     }
 }
 
-impl From<DeployAccountTransactionV1> for protobuf::transaction_in_block::DeployAccountV1 {
+impl From<DeployAccountTransactionV1> for protobuf::transaction::DeployAccountV1 {
     fn from(value: DeployAccountTransactionV1) -> Self {
         Self {
             max_fee: Some(Felt::from(value.max_fee.0).into()),
@@ -351,9 +233,9 @@ impl From<DeployAccountTransactionV1> for protobuf::transaction_in_block::Deploy
     }
 }
 
-impl TryFrom<protobuf::DeployAccountV3> for DeployAccountTransactionV3 {
+impl TryFrom<protobuf::transaction::DeployAccountV3> for DeployAccountTransactionV3 {
     type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::DeployAccountV3) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::DeployAccountV3) -> Result<Self, Self::Error> {
         let resource_bounds = ValidResourceBounds::try_from(value.resource_bounds.ok_or(
             ProtobufConversionError::MissingField {
                 field_description: "DeployAccountV3::resource_bounds",
@@ -431,7 +313,7 @@ impl TryFrom<protobuf::DeployAccountV3> for DeployAccountTransactionV3 {
     }
 }
 
-impl From<DeployAccountTransactionV3> for protobuf::DeployAccountV3 {
+impl From<DeployAccountTransactionV3> for protobuf::transaction::DeployAccountV3 {
     fn from(value: DeployAccountTransactionV3) -> Self {
         Self {
             resource_bounds: Some(protobuf::ResourceBounds::from(value.resource_bounds)),
@@ -464,88 +346,9 @@ impl From<DeployAccountTransactionV3> for protobuf::DeployAccountV3 {
     }
 }
 
-impl TryFrom<protobuf::ResourceBounds> for ValidResourceBounds {
+impl TryFrom<protobuf::transaction::InvokeV0> for InvokeTransactionV0 {
     type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::ResourceBounds) -> Result<Self, Self::Error> {
-        let Some(l1_gas) = value.l1_gas else {
-            return Err(ProtobufConversionError::MissingField {
-                field_description: "ResourceBounds::l1_gas",
-            });
-        };
-        let Some(l2_gas) = value.l2_gas else {
-            return Err(ProtobufConversionError::MissingField {
-                field_description: "ResourceBounds::l2_gas",
-            });
-        };
-        // TODO(Shahak): Assert data gas is not none once we remove support for 0.13.2.
-        let l1_data_gas = value.l1_data_gas.unwrap_or_default();
-        let l1_gas: ResourceBounds = l1_gas.try_into()?;
-        let l2_gas: ResourceBounds = l2_gas.try_into()?;
-        let l1_data_gas: ResourceBounds = l1_data_gas.try_into()?;
-        Ok(if l1_data_gas.is_zero() && l2_gas.is_zero() {
-            ValidResourceBounds::L1Gas(l1_gas)
-        } else {
-            ValidResourceBounds::AllResources(AllResourceBounds { l1_gas, l2_gas, l1_data_gas })
-        })
-    }
-}
-
-impl TryFrom<protobuf::ResourceLimits> for ResourceBounds {
-    type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::ResourceLimits) -> Result<Self, Self::Error> {
-        let max_amount = value.max_amount;
-        let max_price_per_unit_felt = Felt::try_from(value.max_price_per_unit.ok_or(
-            ProtobufConversionError::MissingField {
-                field_description: "ResourceBounds::ResourceLimits::max_price_per_unit",
-            },
-        )?)?;
-        let max_price_per_unit =
-            try_from_starkfelt_to_u128(max_price_per_unit_felt).map_err(|_| {
-                ProtobufConversionError::OutOfRangeValue {
-                    type_description: "u128",
-                    value_as_str: format!("{max_price_per_unit_felt:?}"),
-                }
-            })?;
-        Ok(ResourceBounds {
-            max_amount: GasAmount(max_amount),
-            max_price_per_unit: GasPrice(max_price_per_unit),
-        })
-    }
-}
-
-impl From<ResourceBounds> for protobuf::ResourceLimits {
-    fn from(value: ResourceBounds) -> Self {
-        protobuf::ResourceLimits {
-            max_amount: value.max_amount.0,
-            max_price_per_unit: Some(Felt::from(value.max_price_per_unit.0).into()),
-        }
-    }
-}
-
-impl From<ValidResourceBounds> for protobuf::ResourceBounds {
-    fn from(value: ValidResourceBounds) -> Self {
-        match value {
-            ValidResourceBounds::L1Gas(l1_gas) => protobuf::ResourceBounds {
-                l1_gas: Some(l1_gas.into()),
-                l2_gas: Some(value.get_l2_bounds().into()),
-                l1_data_gas: Some(ResourceBounds::default().into()),
-            },
-            ValidResourceBounds::AllResources(AllResourceBounds {
-                l1_gas,
-                l2_gas,
-                l1_data_gas,
-            }) => protobuf::ResourceBounds {
-                l1_gas: Some(l1_gas.into()),
-                l2_gas: Some(l2_gas.into()),
-                l1_data_gas: Some(l1_data_gas.into()),
-            },
-        }
-    }
-}
-
-impl TryFrom<protobuf::transaction_in_block::InvokeV0> for InvokeTransactionV0 {
-    type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::transaction_in_block::InvokeV0) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::InvokeV0) -> Result<Self, Self::Error> {
         let max_fee_felt =
             Felt::try_from(value.max_fee.ok_or(ProtobufConversionError::MissingField {
                 field_description: "InvokeV0::max_fee",
@@ -592,7 +395,7 @@ impl TryFrom<protobuf::transaction_in_block::InvokeV0> for InvokeTransactionV0 {
     }
 }
 
-impl From<InvokeTransactionV0> for protobuf::transaction_in_block::InvokeV0 {
+impl From<InvokeTransactionV0> for protobuf::transaction::InvokeV0 {
     fn from(value: InvokeTransactionV0) -> Self {
         Self {
             max_fee: Some(Felt::from(value.max_fee.0).into()),
@@ -606,9 +409,9 @@ impl From<InvokeTransactionV0> for protobuf::transaction_in_block::InvokeV0 {
     }
 }
 
-impl TryFrom<protobuf::transaction_in_block::InvokeV1> for InvokeTransactionV1 {
+impl TryFrom<protobuf::transaction::InvokeV1> for InvokeTransactionV1 {
     type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::transaction_in_block::InvokeV1) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::InvokeV1) -> Result<Self, Self::Error> {
         let max_fee_felt =
             Felt::try_from(value.max_fee.ok_or(ProtobufConversionError::MissingField {
                 field_description: "InvokeV1::max_fee",
@@ -655,7 +458,7 @@ impl TryFrom<protobuf::transaction_in_block::InvokeV1> for InvokeTransactionV1 {
     }
 }
 
-impl From<InvokeTransactionV1> for protobuf::transaction_in_block::InvokeV1 {
+impl From<InvokeTransactionV1> for protobuf::transaction::InvokeV1 {
     fn from(value: InvokeTransactionV1) -> Self {
         Self {
             max_fee: Some(Felt::from(value.max_fee.0).into()),
@@ -669,9 +472,9 @@ impl From<InvokeTransactionV1> for protobuf::transaction_in_block::InvokeV1 {
     }
 }
 
-impl TryFrom<protobuf::InvokeV3> for InvokeTransactionV3 {
+impl TryFrom<protobuf::transaction::InvokeV3> for InvokeTransactionV3 {
     type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::InvokeV3) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::InvokeV3) -> Result<Self, Self::Error> {
         let resource_bounds = ValidResourceBounds::try_from(value.resource_bounds.ok_or(
             ProtobufConversionError::MissingField {
                 field_description: "InvokeV3::resource_bounds",
@@ -744,7 +547,7 @@ impl TryFrom<protobuf::InvokeV3> for InvokeTransactionV3 {
     }
 }
 
-impl From<InvokeTransactionV3> for protobuf::InvokeV3 {
+impl From<InvokeTransactionV3> for protobuf::transaction::InvokeV3 {
     fn from(value: InvokeTransactionV3) -> Self {
         Self {
             resource_bounds: Some(protobuf::ResourceBounds::from(value.resource_bounds)),
@@ -777,11 +580,9 @@ impl From<InvokeTransactionV3> for protobuf::InvokeV3 {
     }
 }
 
-impl TryFrom<protobuf::transaction_in_block::DeclareV0WithoutClass> for DeclareTransactionV0V1 {
+impl TryFrom<protobuf::transaction::DeclareV0> for DeclareTransactionV0V1 {
     type Error = ProtobufConversionError;
-    fn try_from(
-        value: protobuf::transaction_in_block::DeclareV0WithoutClass,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::DeclareV0) -> Result<Self, Self::Error> {
         let max_fee_felt =
             Felt::try_from(value.max_fee.ok_or(ProtobufConversionError::MissingField {
                 field_description: "DeclareV0::max_fee",
@@ -828,7 +629,7 @@ impl TryFrom<protobuf::transaction_in_block::DeclareV0WithoutClass> for DeclareT
     }
 }
 
-impl From<DeclareTransactionV0V1> for protobuf::transaction_in_block::DeclareV0WithoutClass {
+impl From<DeclareTransactionV0V1> for protobuf::transaction::DeclareV0 {
     fn from(value: DeclareTransactionV0V1) -> Self {
         Self {
             max_fee: Some(Felt::from(value.max_fee.0).into()),
@@ -841,11 +642,9 @@ impl From<DeclareTransactionV0V1> for protobuf::transaction_in_block::DeclareV0W
     }
 }
 
-impl TryFrom<protobuf::transaction_in_block::DeclareV1WithoutClass> for DeclareTransactionV0V1 {
+impl TryFrom<protobuf::transaction::DeclareV1> for DeclareTransactionV0V1 {
     type Error = ProtobufConversionError;
-    fn try_from(
-        value: protobuf::transaction_in_block::DeclareV1WithoutClass,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::DeclareV1) -> Result<Self, Self::Error> {
         let max_fee_felt =
             Felt::try_from(value.max_fee.ok_or(ProtobufConversionError::MissingField {
                 field_description: "DeclareV1::max_fee",
@@ -898,7 +697,7 @@ impl TryFrom<protobuf::transaction_in_block::DeclareV1WithoutClass> for DeclareT
     }
 }
 
-impl From<DeclareTransactionV0V1> for protobuf::transaction_in_block::DeclareV1WithoutClass {
+impl From<DeclareTransactionV0V1> for protobuf::transaction::DeclareV1 {
     fn from(value: DeclareTransactionV0V1) -> Self {
         Self {
             max_fee: Some(Felt::from(value.max_fee.0).into()),
@@ -912,11 +711,9 @@ impl From<DeclareTransactionV0V1> for protobuf::transaction_in_block::DeclareV1W
     }
 }
 
-impl TryFrom<protobuf::transaction_in_block::DeclareV2WithoutClass> for DeclareTransactionV2 {
+impl TryFrom<protobuf::transaction::DeclareV2> for DeclareTransactionV2 {
     type Error = ProtobufConversionError;
-    fn try_from(
-        value: protobuf::transaction_in_block::DeclareV2WithoutClass,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::DeclareV2) -> Result<Self, Self::Error> {
         let max_fee_felt =
             Felt::try_from(value.max_fee.ok_or(ProtobufConversionError::MissingField {
                 field_description: "DeclareV2::max_fee",
@@ -978,7 +775,7 @@ impl TryFrom<protobuf::transaction_in_block::DeclareV2WithoutClass> for DeclareT
     }
 }
 
-impl From<DeclareTransactionV2> for protobuf::transaction_in_block::DeclareV2WithoutClass {
+impl From<DeclareTransactionV2> for protobuf::transaction::DeclareV2 {
     fn from(value: DeclareTransactionV2) -> Self {
         Self {
             max_fee: Some(Felt::from(value.max_fee.0).into()),
@@ -993,27 +790,12 @@ impl From<DeclareTransactionV2> for protobuf::transaction_in_block::DeclareV2Wit
     }
 }
 
-/// Defined to match the protobuf schema.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-struct DeclareTransactionV3Common {
-    pub resource_bounds: ValidResourceBounds,
-    pub tip: Tip,
-    pub signature: TransactionSignature,
-    pub nonce: Nonce,
-    pub compiled_class_hash: CompiledClassHash,
-    pub sender_address: ContractAddress,
-    pub nonce_data_availability_mode: DataAvailabilityMode,
-    pub fee_data_availability_mode: DataAvailabilityMode,
-    pub paymaster_data: PaymasterData,
-    pub account_deployment_data: AccountDeploymentData,
-}
-
-impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {
+impl TryFrom<protobuf::transaction::DeclareV3> for DeclareTransactionV3 {
     type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::DeclareV3Common) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::DeclareV3) -> Result<Self, Self::Error> {
         let resource_bounds = ValidResourceBounds::try_from(value.resource_bounds.ok_or(
             ProtobufConversionError::MissingField {
-                field_description: "DeclareV3Common::resource_bounds",
+                field_description: "DeclareV3::resource_bounds",
             },
         )?)?;
 
@@ -1023,7 +805,7 @@ impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {
             value
                 .signature
                 .ok_or(ProtobufConversionError::MissingField {
-                    field_description: "DeclareV3Common::signature",
+                    field_description: "DeclareV3::signature",
                 })?
                 .parts
                 .into_iter()
@@ -1035,7 +817,16 @@ impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {
             value
                 .nonce
                 .ok_or(ProtobufConversionError::MissingField {
-                    field_description: "DeclareV3Common::nonce",
+                    field_description: "DeclareV3::nonce",
+                })?
+                .try_into()?,
+        );
+
+        let class_hash = ClassHash(
+            value
+                .class_hash
+                .ok_or(ProtobufConversionError::MissingField {
+                    field_description: "DeclareV3::class_hash",
                 })?
                 .try_into()?,
         );
@@ -1044,7 +835,7 @@ impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {
             value
                 .compiled_class_hash
                 .ok_or(ProtobufConversionError::MissingField {
-                    field_description: "DeclareV3Common::compiled_class_hash",
+                    field_description: "DeclareV3::compiled_class_hash",
                 })?
                 .try_into()?,
         );
@@ -1052,7 +843,7 @@ impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {
         let sender_address = value
             .sender
             .ok_or(ProtobufConversionError::MissingField {
-                field_description: "DeclareV3Common::sender",
+                field_description: "DeclareV3::sender",
             })?
             .try_into()?;
 
@@ -1079,6 +870,7 @@ impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {
             tip,
             signature,
             nonce,
+            class_hash,
             compiled_class_hash,
             sender_address,
             nonce_data_availability_mode,
@@ -1089,8 +881,8 @@ impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {
     }
 }
 
-impl From<DeclareTransactionV3Common> for protobuf::DeclareV3Common {
-    fn from(value: DeclareTransactionV3Common) -> Self {
+impl From<DeclareTransactionV3> for protobuf::transaction::DeclareV3 {
+    fn from(value: DeclareTransactionV3) -> Self {
         Self {
             resource_bounds: Some(protobuf::ResourceBounds::from(value.resource_bounds)),
             tip: value.tip.0,
@@ -1098,6 +890,7 @@ impl From<DeclareTransactionV3Common> for protobuf::DeclareV3Common {
                 parts: value.signature.0.into_iter().map(|signature| signature.into()).collect(),
             }),
             nonce: Some(value.nonce.0.into()),
+            class_hash: Some(value.class_hash.0.into()),
             compiled_class_hash: Some(value.compiled_class_hash.0.into()),
             sender: Some(value.sender_address.into()),
             nonce_data_availability_mode: volition_domain_to_enum_int(
@@ -1122,78 +915,9 @@ impl From<DeclareTransactionV3Common> for protobuf::DeclareV3Common {
     }
 }
 
-impl TryFrom<protobuf::transaction_in_block::DeclareV3WithoutClass> for DeclareTransactionV3 {
+impl TryFrom<protobuf::transaction::Deploy> for DeployTransaction {
     type Error = ProtobufConversionError;
-    fn try_from(
-        value: protobuf::transaction_in_block::DeclareV3WithoutClass,
-    ) -> Result<Self, Self::Error> {
-        let common = DeclareTransactionV3Common::try_from(value.common.ok_or(
-            ProtobufConversionError::MissingField {
-                field_description: "DeclareV3WithoutClass::common",
-            },
-        )?)?;
-        let class_hash = ClassHash(
-            value
-                .class_hash
-                .ok_or(ProtobufConversionError::MissingField {
-                    field_description: "DeclareV3WithoutClass::class_hash",
-                })?
-                .try_into()?,
-        );
-
-        Ok(Self {
-            resource_bounds: common.resource_bounds,
-            tip: common.tip,
-            signature: common.signature,
-            nonce: common.nonce,
-            class_hash,
-            compiled_class_hash: common.compiled_class_hash,
-            sender_address: common.sender_address,
-            nonce_data_availability_mode: common.nonce_data_availability_mode,
-            fee_data_availability_mode: common.fee_data_availability_mode,
-            paymaster_data: common.paymaster_data,
-            account_deployment_data: common.account_deployment_data,
-        })
-    }
-}
-
-impl From<DeclareTransactionV3> for protobuf::transaction_in_block::DeclareV3WithoutClass {
-    fn from(value: DeclareTransactionV3) -> Self {
-        let common = protobuf::DeclareV3Common {
-            resource_bounds: Some(value.resource_bounds.into()),
-            tip: value.tip.0,
-            signature: Some(protobuf::AccountSignature {
-                parts: value.signature.0.into_iter().map(|signature| signature.into()).collect(),
-            }),
-            nonce: Some(value.nonce.0.into()),
-            compiled_class_hash: Some(value.compiled_class_hash.0.into()),
-            sender: Some(value.sender_address.into()),
-            nonce_data_availability_mode: volition_domain_to_enum_int(
-                value.nonce_data_availability_mode,
-            ),
-            fee_data_availability_mode: volition_domain_to_enum_int(
-                value.fee_data_availability_mode,
-            ),
-            paymaster_data: value
-                .paymaster_data
-                .0
-                .iter()
-                .map(|paymaster_data| (*paymaster_data).into())
-                .collect(),
-            account_deployment_data: value
-                .account_deployment_data
-                .0
-                .iter()
-                .map(|account_deployment_data| (*account_deployment_data).into())
-                .collect(),
-        };
-        Self { common: Some(common), class_hash: Some(value.class_hash.0.into()) }
-    }
-}
-
-impl TryFrom<protobuf::transaction_in_block::Deploy> for DeployTransaction {
-    type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::transaction_in_block::Deploy) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::Deploy) -> Result<Self, Self::Error> {
         let version = TransactionVersion(Felt::from(value.version));
 
         let class_hash = ClassHash(
@@ -1223,7 +947,7 @@ impl TryFrom<protobuf::transaction_in_block::Deploy> for DeployTransaction {
     }
 }
 
-impl From<DeployTransaction> for protobuf::transaction_in_block::Deploy {
+impl From<DeployTransaction> for protobuf::transaction::Deploy {
     fn from(value: DeployTransaction) -> Self {
         Self {
             version: try_from_starkfelt_to_u32(value.version.0).unwrap_or_default(),
@@ -1239,9 +963,9 @@ impl From<DeployTransaction> for protobuf::transaction_in_block::Deploy {
     }
 }
 
-impl TryFrom<protobuf::L1HandlerV0> for L1HandlerTransaction {
+impl TryFrom<protobuf::transaction::L1HandlerV0> for L1HandlerTransaction {
     type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::L1HandlerV0) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::transaction::L1HandlerV0) -> Result<Self, Self::Error> {
         let version = L1HandlerTransaction::VERSION;
 
         let nonce = Nonce(
@@ -1276,7 +1000,7 @@ impl TryFrom<protobuf::L1HandlerV0> for L1HandlerTransaction {
     }
 }
 
-impl From<L1HandlerTransaction> for protobuf::L1HandlerV0 {
+impl From<L1HandlerTransaction> for protobuf::transaction::L1HandlerV0 {
     fn from(value: L1HandlerTransaction) -> Self {
         Self {
             nonce: Some(value.nonce.0.into()),
@@ -1284,73 +1008,5 @@ impl From<L1HandlerTransaction> for protobuf::L1HandlerV0 {
             entry_point_selector: Some(value.entry_point_selector.0.into()),
             calldata: value.calldata.0.iter().map(|calldata| (*calldata).into()).collect(),
         }
-    }
-}
-
-impl TryFrom<protobuf::TransactionsRequest> for Query {
-    type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::TransactionsRequest) -> Result<Self, Self::Error> {
-        Ok(TransactionQuery::try_from(value)?.0)
-    }
-}
-
-impl TryFrom<protobuf::TransactionsRequest> for TransactionQuery {
-    type Error = ProtobufConversionError;
-    fn try_from(value: protobuf::TransactionsRequest) -> Result<Self, Self::Error> {
-        Ok(TransactionQuery(
-            value
-                .iteration
-                .ok_or(ProtobufConversionError::MissingField {
-                    field_description: "TransactionsRequest::iteration",
-                })?
-                .try_into()?,
-        ))
-    }
-}
-
-impl From<Query> for protobuf::TransactionsRequest {
-    fn from(value: Query) -> Self {
-        protobuf::TransactionsRequest { iteration: Some(value.into()) }
-    }
-}
-
-impl From<TransactionQuery> for protobuf::TransactionsRequest {
-    fn from(value: TransactionQuery) -> Self {
-        protobuf::TransactionsRequest { iteration: Some(value.0.into()) }
-    }
-}
-
-auto_impl_into_and_try_from_vec_u8!(TransactionQuery, protobuf::TransactionsRequest);
-
-pub fn set_price_unit_based_on_transaction(
-    receipt: &mut protobuf::Receipt,
-    transaction: &protobuf::TransactionInBlock,
-) {
-    let price_unit = match &transaction.txn {
-        Some(protobuf::transaction_in_block::Txn::DeclareV1(_)) => protobuf::PriceUnit::Wei,
-        Some(protobuf::transaction_in_block::Txn::DeclareV2(_)) => protobuf::PriceUnit::Wei,
-        Some(protobuf::transaction_in_block::Txn::DeclareV3(_)) => protobuf::PriceUnit::Fri,
-        Some(protobuf::transaction_in_block::Txn::Deploy(_)) => protobuf::PriceUnit::Wei,
-        Some(protobuf::transaction_in_block::Txn::DeployAccountV1(_)) => protobuf::PriceUnit::Wei,
-        Some(protobuf::transaction_in_block::Txn::DeployAccountV3(_)) => protobuf::PriceUnit::Fri,
-        Some(protobuf::transaction_in_block::Txn::InvokeV1(_)) => protobuf::PriceUnit::Wei,
-        Some(protobuf::transaction_in_block::Txn::InvokeV3(_)) => protobuf::PriceUnit::Fri,
-        Some(protobuf::transaction_in_block::Txn::L1Handler(_)) => protobuf::PriceUnit::Wei,
-        _ => return,
-    };
-    let Some(ref mut receipt_type) = receipt.r#type else {
-        return;
-    };
-
-    let common = match receipt_type {
-        protobuf::receipt::Type::Invoke(invoke) => invoke.common.as_mut(),
-        protobuf::receipt::Type::L1Handler(l1_handler) => l1_handler.common.as_mut(),
-        protobuf::receipt::Type::Declare(declare) => declare.common.as_mut(),
-        protobuf::receipt::Type::DeprecatedDeploy(deploy) => deploy.common.as_mut(),
-        protobuf::receipt::Type::DeployAccount(deploy_account) => deploy_account.common.as_mut(),
-    };
-
-    if let Some(common) = common {
-        common.price_unit = price_unit.into();
     }
 }

--- a/crates/papyrus_protobuf/src/converters/mod.rs
+++ b/crates/papyrus_protobuf/src/converters/mod.rs
@@ -11,6 +11,8 @@ mod state_diff;
 mod test_instances;
 mod transaction;
 
+mod deprecated_transaction;
+
 use papyrus_common::compression_utils::CompressionError;
 use prost::DecodeError;
 

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/sync/transaction.proto
@@ -24,8 +24,7 @@ message TransactionsResponse {
 }
 
 message TransactionWithReceipt {
-    //TODO(alonl): change transaction type to TransactionInBlock
-    Transaction transaction = 1;
+    TransactionInBlock transaction = 1;
     Receipt receipt = 2;
 }
 


### PR DESCRIPTION
- **refactor(papyrus_protobuf): add converters for new transaction messages**
- **refactor(papyrus_protobuf): mv consensus.proto to new folder and add ConsensusTransaction**
- **refactor(papyrus_protobuf): add missing converters for RpcTransactions and ConsensusTransaction**
