### PR TITLE
feat(starknet_batcher): support l1 provider {commit,start}_block

### DIFF
--- a/crates/starknet_l1_provider/src/l1_provider.rs
+++ b/crates/starknet_l1_provider/src/l1_provider.rs
@@ -188,5 +188,9 @@ impl L1Provider {
 impl ComponentStarter for L1Provider {}
 
 pub fn create_l1_provider(_config: L1ProviderConfig) -> L1Provider {
-    L1Provider { state: ProviderState::Propose, ..Default::default() }
+    L1Provider {
+        state: ProviderState::Pending,
+        current_height: BlockNumber(1),
+        ..Default::default()
+    }
 }


### PR DESCRIPTION
- Every propose/validate session has to begin with a `start_block` call that sets the l1 provider inner state for proposition/validation.
- Whenever a block is committed, `commit_block` must be called in order to remove all txs that were committed from the buffers.

  TODOS:
  1. commit_block: send to L1 provider the _committed_ l1_handler tx hashes.
  2. Error handling for start_blocks.