### PR TITLE
refactor(starknet_api): delete NonzeroGasPrice, use GasPrice instead

### DIFF
--- a/crates/blockifier/src/blockifier/block.rs
+++ b/crates/blockifier/src/blockifier/block.rs
@@ -1,12 +1,5 @@
 use log::warn;
-use starknet_api::block::{
-    BlockHashAndNumber,
-    BlockNumber,
-    GasPrice,
-    GasPriceVector,
-    GasPrices,
-    NonzeroGasPrice,
-};
+use starknet_api::block::{BlockHashAndNumber, BlockNumber, GasPrice, GasPriceVector, GasPrices};
 use starknet_api::state::StorageKey;
 
 use crate::abi::constants;
@@ -23,8 +16,8 @@ fn validate_l2_gas_price(gas_prices: &GasPrices) {
     // TODO(Aner): fix backwards compatibility.
     let eth_l2_gas_price = gas_prices.eth_gas_prices.l2_gas_price;
     let expected_eth_l2_gas_price = VersionedConstants::latest_constants()
-        .convert_l1_to_l2_gas_price_round_up(gas_prices.eth_gas_prices.l1_gas_price.into());
-    if GasPrice::from(eth_l2_gas_price) != expected_eth_l2_gas_price {
+        .convert_l1_to_l2_gas_price_round_up(gas_prices.eth_gas_prices.l1_gas_price);
+    if eth_l2_gas_price != expected_eth_l2_gas_price {
         // TODO(Aner): change to panic! Requires fixing several tests.
         warn!(
             "eth_l2_gas_price {} does not match expected eth_l2_gas_price {}.",
@@ -33,8 +26,8 @@ fn validate_l2_gas_price(gas_prices: &GasPrices) {
     }
     let strk_l2_gas_price = gas_prices.strk_gas_prices.l2_gas_price;
     let expected_strk_l2_gas_price = VersionedConstants::latest_constants()
-        .convert_l1_to_l2_gas_price_round_up(gas_prices.strk_gas_prices.l1_gas_price.into());
-    if GasPrice::from(strk_l2_gas_price) != expected_strk_l2_gas_price {
+        .convert_l1_to_l2_gas_price_round_up(gas_prices.strk_gas_prices.l1_gas_price);
+    if strk_l2_gas_price != expected_strk_l2_gas_price {
         // TODO(Aner): change to panic! Requires fixing test_discounted_gas_overdraft
         warn!(
             "strk_l2_gas_price {} does not match expected strk_l2_gas_price {}.",
@@ -44,12 +37,12 @@ fn validate_l2_gas_price(gas_prices: &GasPrices) {
 }
 
 pub fn validated_gas_prices(
-    eth_l1_gas_price: NonzeroGasPrice,
-    strk_l1_gas_price: NonzeroGasPrice,
-    eth_l1_data_gas_price: NonzeroGasPrice,
-    strk_l1_data_gas_price: NonzeroGasPrice,
-    eth_l2_gas_price: NonzeroGasPrice,
-    strk_l2_gas_price: NonzeroGasPrice,
+    eth_l1_gas_price: GasPrice,
+    strk_l1_gas_price: GasPrice,
+    eth_l1_data_gas_price: GasPrice,
+    strk_l1_data_gas_price: GasPrice,
+    eth_l2_gas_price: GasPrice,
+    strk_l2_gas_price: GasPrice,
 ) -> GasPrices {
     let gas_prices = GasPrices {
         eth_gas_prices: GasPriceVector {

--- a/crates/blockifier/src/blockifier/transaction_executor_test.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor_test.rs
@@ -129,7 +129,7 @@ fn test_declare(
             class_hash: declared_contract.get_class_hash(),
             compiled_class_hash: declared_contract.get_compiled_class_hash(),
             version: tx_version,
-            resource_bounds: l1_resource_bounds(0_u8.into(), DEFAULT_STRK_L1_GAS_PRICE.into()),
+            resource_bounds: l1_resource_bounds(0_u8.into(), DEFAULT_STRK_L1_GAS_PRICE),
         },
         calculate_class_info_for_testing(declared_contract.get_class()),
     );
@@ -149,7 +149,7 @@ fn test_deploy_account(
 
     let deploy_account_tx = executable_deploy_account_tx(deploy_account_tx_args! {
         class_hash: account_contract.get_class_hash(),
-        resource_bounds: l1_resource_bounds(0_u8.into(), DEFAULT_STRK_L1_GAS_PRICE.into()),
+        resource_bounds: l1_resource_bounds(0_u8.into(), DEFAULT_STRK_L1_GAS_PRICE),
         version,
     });
     let tx = AccountTransaction::new_for_sequencing(deploy_account_tx).into();

--- a/crates/blockifier/src/concurrency/versioned_state_test.rs
+++ b/crates/blockifier/src/concurrency/versioned_state_test.rs
@@ -227,7 +227,7 @@ fn test_run_parallel_txs(default_all_resource_bounds: ValidResourceBounds) {
 
     // Prepare transactions
     let max_amount = 0_u8.into();
-    let max_price_per_unit = DEFAULT_STRK_L1_GAS_PRICE.into();
+    let max_price_per_unit = DEFAULT_STRK_L1_GAS_PRICE;
     let tx = executable_deploy_account_tx(deploy_account_tx_args! {
         class_hash: account_without_validation.get_class_hash(),
         resource_bounds: l1_resource_bounds(max_amount, max_price_per_unit),

--- a/crates/blockifier/src/fee/fee_test.rs
+++ b/crates/blockifier/src/fee/fee_test.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use cairo_vm::types::builtin_name::BuiltinName;
 use rstest::rstest;
-use starknet_api::block::{FeeType, GasPrice, NonzeroGasPrice};
+use starknet_api::block::{FeeType, GasPrice};
 use starknet_api::execution_resources::{GasAmount, GasVector};
 use starknet_api::invoke_tx_args;
 use starknet_api::test_utils::{
@@ -169,10 +169,8 @@ fn test_discounted_gas_overdraft(
 ) {
     let (l1_gas_used, l1_data_gas_used, gas_bound) =
         (GasAmount(l1_gas_used), GasAmount(l1_data_gas_used), GasAmount(gas_bound));
-    let (gas_price, data_gas_price) = (
-        NonzeroGasPrice::try_from(gas_price).unwrap(),
-        NonzeroGasPrice::try_from(data_gas_price).unwrap(),
-    );
+    let (gas_price, data_gas_price) =
+        (GasPrice::new_unchecked(gas_price), GasPrice::new_unchecked(data_gas_price));
     let mut block_context = BlockContext::create_for_account_testing();
     block_context.block_info.gas_prices = validated_gas_prices(
         DEFAULT_ETH_L1_GAS_PRICE,
@@ -180,21 +178,17 @@ fn test_discounted_gas_overdraft(
         DEFAULT_ETH_L1_DATA_GAS_PRICE,
         data_gas_price,
         VersionedConstants::latest_constants()
-            .convert_l1_to_l2_gas_price_round_up(DEFAULT_ETH_L1_GAS_PRICE.into())
-            .try_into()
-            .unwrap(),
+            .convert_l1_to_l2_gas_price_round_up(DEFAULT_ETH_L1_GAS_PRICE),
         // TODO(Aner): fix test parameters to allow using `gas_price` here.
         VersionedConstants::latest_constants()
-            .convert_l1_to_l2_gas_price_round_up(DEFAULT_STRK_L1_GAS_PRICE.into())
-            .try_into()
-            .unwrap(),
+            .convert_l1_to_l2_gas_price_round_up(DEFAULT_STRK_L1_GAS_PRICE),
     );
 
     let account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0);
     let mut state = test_state(&block_context.chain_info, BALANCE, &[(account, 1)]);
     let tx = invoke_tx_with_default_flags(invoke_tx_args! {
         sender_address: account.get_instance_address(0),
-        resource_bounds: l1_resource_bounds(gas_bound, (gas_price.get().0 * 10).try_into().unwrap()),
+        resource_bounds: l1_resource_bounds(gas_bound, (gas_price.get() * 10).try_into().unwrap()),
     });
 
     let tx_receipt = TransactionReceipt {
@@ -214,7 +208,7 @@ fn test_discounted_gas_overdraft(
     if expect_failure {
         let error = report.error().unwrap();
         let expected_actual_amount = l1_gas_used
-            + (l1_data_gas_used.checked_mul(data_gas_price.into()).unwrap())
+            + (l1_data_gas_used.checked_mul(data_gas_price).unwrap())
                 .checked_div(gas_price)
                 .unwrap();
         assert_matches!(
@@ -310,12 +304,12 @@ fn test_get_fee_by_gas_vector_regression(
 ) {
     let mut block_info = BlockContext::create_for_account_testing().block_info;
     block_info.gas_prices = validated_gas_prices(
-        1_u8.try_into().unwrap(),
-        2_u8.try_into().unwrap(),
-        3_u8.try_into().unwrap(),
-        4_u8.try_into().unwrap(),
-        5_u8.try_into().unwrap(),
-        6_u8.try_into().unwrap(),
+        GasPrice::new_unchecked(1),
+        GasPrice::new_unchecked(2),
+        GasPrice::new_unchecked(3),
+        GasPrice::new_unchecked(4),
+        GasPrice::new_unchecked(5),
+        GasPrice::new_unchecked(6),
     );
     let gas_vector =
         GasVector { l1_gas: l1_gas.into(), l1_data_gas: l1_data_gas.into(), l2_gas: l2_gas.into() };
@@ -341,7 +335,7 @@ fn test_get_fee_by_gas_vector_overflow(
     #[case] l1_data_gas: u64,
     #[case] l2_gas: u64,
 ) {
-    let huge_gas_price = NonzeroGasPrice::try_from(2_u128 * u128::from(u64::MAX)).unwrap();
+    let huge_gas_price = GasPrice::new_unchecked(2_u128 * u128::from(u64::MAX));
     let mut block_info = BlockContext::create_for_account_testing().block_info;
     block_info.gas_prices = validated_gas_prices(
         huge_gas_price,

--- a/crates/blockifier/src/fee/fee_utils.rs
+++ b/crates/blockifier/src/fee/fee_utils.rs
@@ -44,7 +44,7 @@ impl GasVectorToL1GasForFee for GasVector {
         // Discounted gas converts data gas to L1 gas. Add L2 gas using conversion ratio.
         let discounted_l1_gas = to_discounted_l1_gas(
             gas_prices.l1_gas_price,
-            gas_prices.l1_data_gas_price.into(),
+            gas_prices.l1_data_gas_price,
             self.l1_gas,
             self.l1_data_gas,
         );

--- a/crates/blockifier/src/fee/gas_usage_test.rs
+++ b/crates/blockifier/src/fee/gas_usage_test.rs
@@ -293,12 +293,12 @@ fn test_discounted_gas_from_gas_vector_computation() {
         .sierra_gas_to_l1_gas_amount_round_up(gas_usage.l2_gas);
 
     let result_div_ceil = gas_usage.l1_gas
-        + (gas_usage.l1_data_gas.checked_mul(DEFAULT_ETH_L1_DATA_GAS_PRICE.into()).unwrap())
+        + (gas_usage.l1_data_gas.checked_mul(DEFAULT_ETH_L1_DATA_GAS_PRICE).unwrap())
             .checked_div_ceil(DEFAULT_ETH_L1_GAS_PRICE)
             .unwrap()
         + converted_l2_gas;
     let result_div_floor = gas_usage.l1_gas
-        + (gas_usage.l1_data_gas.checked_mul(DEFAULT_ETH_L1_DATA_GAS_PRICE.into()).unwrap())
+        + (gas_usage.l1_data_gas.checked_mul(DEFAULT_ETH_L1_DATA_GAS_PRICE).unwrap())
             .checked_div(DEFAULT_ETH_L1_GAS_PRICE)
             .unwrap()
         + converted_l2_gas;
@@ -307,7 +307,7 @@ fn test_discounted_gas_from_gas_vector_computation() {
     assert_eq!(actual_result, result_div_floor + 1_u8.into());
     assert!(
         get_fee_by_gas_vector(&tx_context.block_context.block_info, gas_usage, &FeeType::Eth)
-            <= actual_result.checked_mul(DEFAULT_ETH_L1_GAS_PRICE.into()).unwrap()
+            <= actual_result.checked_mul(DEFAULT_ETH_L1_GAS_PRICE).unwrap()
     );
 
     // Make sure L2 gas has an effect.

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -166,12 +166,10 @@ pub fn test_erc20_sequencer_balance_key() -> StorageKey {
 
 // Commitment fee bounds.
 const DEFAULT_L1_BOUNDS_COMMITTED_FEE: Fee =
-    DEFAULT_L1_GAS_AMOUNT.nonzero_saturating_mul(DEFAULT_STRK_L1_GAS_PRICE);
+    DEFAULT_L1_GAS_AMOUNT.saturating_mul(DEFAULT_STRK_L1_GAS_PRICE);
 const DEFAULT_ALL_BOUNDS_COMMITTED_FEE: Fee = DEFAULT_L1_BOUNDS_COMMITTED_FEE
-    .saturating_add(DEFAULT_L2_GAS_MAX_AMOUNT.nonzero_saturating_mul(DEFAULT_STRK_L2_GAS_PRICE))
-    .saturating_add(
-        DEFAULT_L1_DATA_GAS_MAX_AMOUNT.nonzero_saturating_mul(DEFAULT_STRK_L1_DATA_GAS_PRICE),
-    );
+    .saturating_add(DEFAULT_L2_GAS_MAX_AMOUNT.saturating_mul(DEFAULT_STRK_L2_GAS_PRICE))
+    .saturating_add(DEFAULT_L1_DATA_GAS_MAX_AMOUNT.saturating_mul(DEFAULT_STRK_L1_DATA_GAS_PRICE));
 // The amount of test-token allocated to the account in this test, set to a multiple of the max
 // amount deprecated / non-deprecated transactions commit to paying.
 pub const BALANCE: Fee = Fee(10

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -328,11 +328,11 @@ impl AccountTransaction {
                                     max_gas_amount: resource_bounds.max_amount,
                                     minimal_gas_amount: *minimal_gas_amount,
                                 })
-                            } else if resource_bounds.max_price_per_unit < actual_gas_price.get() {
+                            } else if resource_bounds.max_price_per_unit < *actual_gas_price {
                                 Some(ResourceBoundsError::MaxGasPriceTooLow {
                                     resource: *resource,
                                     max_gas_price: resource_bounds.max_price_per_unit,
-                                    actual_gas_price: (*actual_gas_price).into(),
+                                    actual_gas_price: *actual_gas_price,
                                 })
                             } else {
                                 None

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -222,7 +222,7 @@ fn test_fee_enforcement(
         resource_bounds: match gas_bounds_mode {
             GasVectorComputationMode::NoL2Gas => l1_resource_bounds(
                 (if zero_bounds { 0 } else { DEFAULT_L1_GAS_AMOUNT.0 }).into(),
-                DEFAULT_STRK_L1_GAS_PRICE.into()
+                DEFAULT_STRK_L1_GAS_PRICE
             ),
             GasVectorComputationMode::All => create_gas_amount_bounds_with_default_price(
                 GasVector{
@@ -579,19 +579,19 @@ fn test_max_fee_limit_validate(
                         estimated_min_gas_usage_vector.to_l1_gas_for_fee(
                             gas_prices, &tx_context.block_context.versioned_constants
                         ),
-                        gas_prices.l1_gas_price.into(),
+                        gas_prices.l1_gas_price,
                     )
                 }
                 GasVectorComputationMode::All => create_all_resource_bounds(
                     estimated_min_gas_usage_vector.l1_gas,
                     block_info.gas_prices
-                        .l1_gas_price(&account_tx.fee_type()).into(),
+                        .l1_gas_price(&account_tx.fee_type()),
                     estimated_min_gas_usage_vector.l2_gas,
                     block_info.gas_prices
-                        .l2_gas_price(&account_tx.fee_type()).into(),
+                        .l2_gas_price(&account_tx.fee_type()),
                     estimated_min_gas_usage_vector.l1_data_gas,
                     block_info.gas_prices
-                        .l1_data_gas_price(&account_tx.fee_type()).into(),
+                        .l1_data_gas_price(&account_tx.fee_type()),
                 ),
             },
             ..tx_args
@@ -1078,7 +1078,7 @@ fn test_n_reverted_computation_units(
                 (i128::try_from(actual_fee_1 - actual_fee_0).unwrap()
                     - i128::try_from(actual_fee_2 - actual_fee_1).unwrap())
                 .unsigned_abs()
-                    <= block_context.block_info.gas_prices.l1_gas_price(&FeeType::Strk).get().0
+                    <= block_context.block_info.gas_prices.l1_gas_price(&FeeType::Strk).get()
             );
         }
         _ => {
@@ -1134,8 +1134,7 @@ fn test_n_reverted_computation_units(
                 (i128::try_from(100 * single_call_fee_delta).unwrap()
                     - i128::try_from(actual_fee_100 - actual_fee_0).unwrap())
                 .unsigned_abs()
-                    < 100
-                        * block_context.block_info.gas_prices.l1_gas_price(&FeeType::Strk).get().0
+                    < 100 * block_context.block_info.gas_prices.l1_gas_price(&FeeType::Strk).get()
             );
         }
         _ => {
@@ -1195,7 +1194,7 @@ fn test_max_fee_computation_from_tx_bounds(block_context: BlockContext) {
         resource_bounds: ValidResourceBounds::AllResources(AllResourceBounds {
             l2_gas: ResourceBounds {
                 max_amount: l2_gas_bound.into(),
-                max_price_per_unit: DEFAULT_STRK_L2_GAS_PRICE.into(),
+                max_price_per_unit: DEFAULT_STRK_L2_GAS_PRICE,
             },
             ..Default::default()
         }),
@@ -1237,7 +1236,7 @@ fn test_max_fee_to_max_steps_conversion(
         sender_address: account_address,
         calldata: execute_calldata.clone(),
         version,
-        resource_bounds: l1_resource_bounds(actual_gas_used, actual_strk_gas_price.into()),
+        resource_bounds: l1_resource_bounds(actual_gas_used, actual_strk_gas_price),
         nonce: nonce_manager.next(account_address),
     });
     let tx_context1 = Arc::new(block_context.to_tx_context(&account_tx1));
@@ -1262,7 +1261,7 @@ fn test_max_fee_to_max_steps_conversion(
         calldata: execute_calldata,
         version,
         resource_bounds:
-            l1_resource_bounds((2 * actual_gas_used.0).into(), actual_strk_gas_price.into()),
+            l1_resource_bounds((2 * actual_gas_used.0).into(), actual_strk_gas_price),
         nonce: nonce_manager.next(account_address),
     });
     let tx_context2 = Arc::new(block_context.to_tx_context(&account_tx2));
@@ -1329,7 +1328,7 @@ fn test_insufficient_max_fee_reverts(
     let resource_used_depth1 = match gas_mode {
         GasVectorComputationMode::NoL2Gas => l1_resource_bounds(
             tx_execution_info1.receipt.gas.l1_gas,
-            block_context.block_info.gas_prices.strk_gas_prices.l1_gas_price.into(),
+            block_context.block_info.gas_prices.strk_gas_prices.l1_gas_price,
         ),
         GasVectorComputationMode::All => ValidResourceBounds::all_bounds_from_vectors(
             &tx_execution_info1.receipt.gas,
@@ -1413,9 +1412,7 @@ fn test_insufficient_max_fee_reverts(
                 tx_execution_info3.receipt.fee,
                 l1_bound
                     .max_amount
-                    .checked_mul(
-                        block_context.block_info.gas_prices.l1_gas_price(&FeeType::Strk).into()
-                    )
+                    .checked_mul(block_context.block_info.gas_prices.l1_gas_price(&FeeType::Strk))
                     .unwrap()
             );
         }

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -191,8 +191,7 @@ fn get_pre_validate_test_args(
     let max_fee = MAX_FEE;
     // The max resource bounds fixture is not used here because this function already has the
     // maximum number of arguments.
-    let resource_bounds =
-        l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, DEFAULT_STRK_L1_GAS_PRICE.into());
+    let resource_bounds = l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, DEFAULT_STRK_L1_GAS_PRICE);
     let FlavorTestInitialState {
         state, account_address, test_contract_address, nonce_manager, ..
     } = create_flavors_test_state(&block_context.chain_info, cairo_version);
@@ -308,7 +307,7 @@ fn test_simulate_validate_pre_validate_with_charge_fee(
         max_fee: Fee(BALANCE.0 + 1),
         resource_bounds: l1_resource_bounds(
             (balance_over_gas_price.0 + 10).into(),
-            gas_price.into()
+            gas_price
         ),
         nonce: nonce_manager.next(account_address),
 
@@ -345,7 +344,7 @@ fn test_simulate_validate_pre_validate_with_charge_fee(
     // Third scenario: L1 gas price bound lower than the price on the block.
     if !is_deprecated {
         let tx = executable_invoke_tx(invoke_tx_args! {
-            resource_bounds: l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, (gas_price.get().0 - 1).try_into().unwrap()),
+            resource_bounds: l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, (gas_price.get() - 1).try_into().unwrap()),
             nonce: nonce_manager.next(account_address),
 
             ..pre_validation_base_args
@@ -447,14 +446,14 @@ fn test_simulate_validate_pre_validate_not_charge_fee(
     let balance_over_gas_price = BALANCE.checked_div(gas_price).unwrap();
     execute_and_check_gas_and_fee!(
         Fee(BALANCE.0 + 1),
-        l1_resource_bounds((balance_over_gas_price.0 + 10).into(), gas_price.into())
+        l1_resource_bounds((balance_over_gas_price.0 + 10).into(), gas_price)
     );
 
     // Third scenario: L1 gas price bound lower than the price on the block.
     if !is_deprecated {
         execute_and_check_gas_and_fee!(
             pre_validation_base_args.max_fee,
-            l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, (gas_price.get().0 - 1).try_into().unwrap())
+            l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, (gas_price.get() - 1).try_into().unwrap())
         );
     }
 }
@@ -662,7 +661,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
     );
     let tx = executable_invoke_tx(invoke_tx_args! {
         max_fee: fee_bound,
-        resource_bounds: l1_resource_bounds(gas_bound, gas_price.into()),
+        resource_bounds: l1_resource_bounds(gas_bound, gas_price),
         calldata: recurse_calldata(test_contract_address, false, 1000),
         nonce: nonce_manager.next(account_address),
         ..execution_base_args.clone()
@@ -719,7 +718,7 @@ fn test_simulate_validate_charge_fee_mid_execution(
 
     let tx = executable_invoke_tx(invoke_tx_args! {
         max_fee: huge_fee,
-        resource_bounds: l1_resource_bounds(huge_gas_limit, gas_price.into()),
+        resource_bounds: l1_resource_bounds(huge_gas_limit, gas_price),
         calldata: recurse_calldata(test_contract_address, false, 10000),
         nonce: nonce_manager.next(account_address),
         ..execution_base_args
@@ -807,7 +806,7 @@ fn test_simulate_validate_charge_fee_post_execution(
     );
     let tx = executable_invoke_tx(invoke_tx_args! {
         max_fee: just_not_enough_fee_bound,
-        resource_bounds: l1_resource_bounds(just_not_enough_gas_bound, gas_price.into()),
+        resource_bounds: l1_resource_bounds(just_not_enough_gas_bound, gas_price),
         calldata: recurse_calldata(test_contract_address, false, 1000),
         nonce: nonce_manager.next(account_address),
         sender_address: account_address,
@@ -869,7 +868,7 @@ fn test_simulate_validate_charge_fee_post_execution(
     );
     let tx = executable_invoke_tx(invoke_tx_args! {
         max_fee: actual_fee,
-        resource_bounds: l1_resource_bounds(success_actual_gas, gas_price.into()),
+        resource_bounds: l1_resource_bounds(success_actual_gas, gas_price),
         calldata: transfer_calldata,
         nonce: nonce_manager.next(account_address),
         sender_address: account_address,

--- a/crates/blockifier/src/transaction/post_execution_test.rs
+++ b/crates/blockifier/src/transaction/post_execution_test.rs
@@ -312,7 +312,7 @@ fn test_revert_on_resource_overuse(
     let tight_resource_bounds = match gas_mode {
         GasVectorComputationMode::NoL2Gas => l1_resource_bounds(
             actual_gas_usage.to_l1_gas_for_fee(gas_prices, &block_context.versioned_constants),
-            DEFAULT_STRK_L1_GAS_PRICE.into(),
+            DEFAULT_STRK_L1_GAS_PRICE,
         ),
         GasVectorComputationMode::All => {
             ValidResourceBounds::all_bounds_from_vectors(&actual_gas_usage, gas_prices)
@@ -357,7 +357,7 @@ fn test_revert_on_resource_overuse(
     } else {
         match tight_resource_bounds {
             ValidResourceBounds::L1Gas(ResourceBounds { max_amount, .. }) => {
-                l1_resource_bounds(GasAmount(max_amount.0 - 1), DEFAULT_STRK_L1_GAS_PRICE.into())
+                l1_resource_bounds(GasAmount(max_amount.0 - 1), DEFAULT_STRK_L1_GAS_PRICE)
             }
             ValidResourceBounds::AllResources(AllResourceBounds {
                 l1_gas: ResourceBounds { max_amount: mut l1_gas, .. },

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -89,7 +89,7 @@ pub fn default_all_resource_bounds() -> ValidResourceBounds {
 pub fn create_resource_bounds(computation_mode: &GasVectorComputationMode) -> ValidResourceBounds {
     match computation_mode {
         GasVectorComputationMode::NoL2Gas => {
-            l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, DEFAULT_STRK_L1_GAS_PRICE.into())
+            l1_resource_bounds(DEFAULT_L1_GAS_AMOUNT, DEFAULT_STRK_L1_GAS_PRICE)
         }
         GasVectorComputationMode::All => create_gas_amount_bounds_with_default_price(GasVector {
             l1_gas: DEFAULT_L1_GAS_AMOUNT,
@@ -104,11 +104,11 @@ pub fn create_gas_amount_bounds_with_default_price(
 ) -> ValidResourceBounds {
     create_all_resource_bounds(
         l1_gas,
-        DEFAULT_STRK_L1_GAS_PRICE.into(),
+        DEFAULT_STRK_L1_GAS_PRICE,
         l2_gas,
-        DEFAULT_STRK_L2_GAS_PRICE.into(),
+        DEFAULT_STRK_L2_GAS_PRICE,
         l1_data_gas,
-        DEFAULT_STRK_L1_DATA_GAS_PRICE.into(),
+        DEFAULT_STRK_L1_DATA_GAS_PRICE,
     )
 }
 
@@ -345,11 +345,11 @@ pub fn l1_resource_bounds(
 #[fixture]
 pub fn all_resource_bounds(
     #[default(DEFAULT_L1_GAS_AMOUNT)] l1_max_amount: GasAmount,
-    #[default(GasPrice::from(DEFAULT_STRK_L1_GAS_PRICE))] l1_max_price: GasPrice,
+    #[default(DEFAULT_STRK_L1_GAS_PRICE)] l1_max_price: GasPrice,
     #[default(DEFAULT_L2_GAS_MAX_AMOUNT)] l2_max_amount: GasAmount,
-    #[default(GasPrice::from(DEFAULT_STRK_L2_GAS_PRICE))] l2_max_price: GasPrice,
+    #[default(DEFAULT_STRK_L2_GAS_PRICE)] l2_max_price: GasPrice,
     #[default(DEFAULT_L1_DATA_GAS_MAX_AMOUNT)] l1_data_max_amount: GasAmount,
-    #[default(GasPrice::from(DEFAULT_STRK_L1_DATA_GAS_PRICE))] l1_data_max_price: GasPrice,
+    #[default(DEFAULT_STRK_L1_DATA_GAS_PRICE)] l1_data_max_price: GasPrice,
 ) -> ValidResourceBounds {
     create_all_resource_bounds(
         l1_max_amount,

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -1092,7 +1092,7 @@ fn test_max_fee_exceeds_balance(
             let balance_over_l1_gas_price = BALANCE.checked_div(DEFAULT_STRK_L1_GAS_PRICE).unwrap();
             let invalid_resource_bounds = l1_resource_bounds(
                 (balance_over_l1_gas_price.0 + 1).into(),
-                DEFAULT_STRK_L1_GAS_PRICE.into(),
+                DEFAULT_STRK_L1_GAS_PRICE,
             );
             assert_resource_overdraft!(invalid_resource_bounds);
         }
@@ -1164,15 +1164,15 @@ fn test_insufficient_new_resource_bounds_pre_validation(
     let default_resource_bounds = AllResourceBounds {
         l1_gas: ResourceBounds {
             max_amount: minimal_gas_vector.l1_gas,
-            max_price_per_unit: actual_strk_l1_gas_price.get(),
+            max_price_per_unit: actual_strk_l1_gas_price,
         },
         l2_gas: ResourceBounds {
             max_amount: minimal_gas_vector.l2_gas,
-            max_price_per_unit: actual_strk_l2_gas_price.get(),
+            max_price_per_unit: actual_strk_l2_gas_price,
         },
         l1_data_gas: ResourceBounds {
             max_amount: minimal_gas_vector.l1_data_gas,
-            max_price_per_unit: actual_strk_l1_data_gas_price.get(),
+            max_price_per_unit: actual_strk_l1_data_gas_price,
         },
     };
 
@@ -1294,8 +1294,7 @@ fn test_insufficient_deprecated_resource_bounds_pre_validation(
 
     let gas_prices = &block_context.block_info.gas_prices;
     // TODO(Aner): change to linear combination.
-    let minimal_fee =
-        minimal_l1_gas.checked_mul(gas_prices.eth_gas_prices.l1_gas_price.get()).unwrap();
+    let minimal_fee = minimal_l1_gas.checked_mul(gas_prices.eth_gas_prices.l1_gas_price).unwrap();
     // Max fee too low (lower than minimal estimated fee).
     let invalid_max_fee = Fee(minimal_fee.0 - 1);
     let invalid_v1_tx = invoke_tx_with_default_flags(
@@ -1319,7 +1318,7 @@ fn test_insufficient_deprecated_resource_bounds_pre_validation(
     // TODO(Ori, 1/2/2024): Write an indicative expect message explaining why the conversion works.
     let insufficient_max_l1_gas_amount = (minimal_l1_gas.0 - 1).into();
     let invalid_v3_tx = invoke_tx_with_default_flags(invoke_tx_args! {
-        resource_bounds: l1_resource_bounds(insufficient_max_l1_gas_amount, actual_strk_l1_gas_price.into()),
+        resource_bounds: l1_resource_bounds(insufficient_max_l1_gas_amount, actual_strk_l1_gas_price),
         ..valid_invoke_tx_args.clone()
     });
     let execution_error = invalid_v3_tx.execute(&mut state, &block_context).unwrap_err();
@@ -1342,7 +1341,7 @@ fn test_insufficient_deprecated_resource_bounds_pre_validation(
     );
 
     // Max L1 gas price too low, old resource bounds.
-    let insufficient_max_l1_gas_price = (actual_strk_l1_gas_price.get().0 - 1).try_into().unwrap();
+    let insufficient_max_l1_gas_price = (actual_strk_l1_gas_price.get() - 1).try_into().unwrap();
     let invalid_v3_tx = invoke_tx_with_default_flags(invoke_tx_args! {
         resource_bounds: l1_resource_bounds(minimal_l1_gas, insufficient_max_l1_gas_price),
         ..valid_invoke_tx_args.clone()
@@ -1359,7 +1358,7 @@ fn test_insufficient_deprecated_resource_bounds_pre_validation(
                 errors[0],
                 ResourceBoundsError::MaxGasPriceTooLow{ resource: L1Gas ,max_gas_price: max_l1_gas_price, actual_gas_price: actual_l1_gas_price }
                 if max_l1_gas_price == insufficient_max_l1_gas_price &&
-                actual_l1_gas_price == actual_strk_l1_gas_price.into()
+                actual_l1_gas_price == actual_strk_l1_gas_price
             )
         }
     );
@@ -1414,7 +1413,7 @@ fn test_actual_fee_gt_resource_bounds(
             );
             (
                 GasVector::from_l1_gas(l1_gas_bound).cost(gas_prices),
-                l1_resource_bounds(l1_gas_bound, gas_prices.l1_gas_price.into()),
+                l1_resource_bounds(l1_gas_bound, gas_prices.l1_gas_price),
             )
         }
         GasVectorComputationMode::All => {
@@ -2382,16 +2381,16 @@ fn test_only_query_flag(
     ];
 
     let expected_resource_bounds = vec![
-        Felt::THREE,                                   // Length of ResourceBounds array.
-        felt!(L1Gas.to_hex()),                         // Resource.
-        felt!(DEFAULT_L1_GAS_AMOUNT.0),                // Max amount.
-        felt!(DEFAULT_STRK_L1_GAS_PRICE.get().0),      // Max price per unit.
-        felt!(L2Gas.to_hex()),                         // Resource.
-        felt!(DEFAULT_L2_GAS_MAX_AMOUNT.0),            // Max amount.
-        felt!(DEFAULT_STRK_L2_GAS_PRICE.get().0),      // Max price per unit.
-        felt!(L1DataGas.to_hex()),                     // Resource.
-        felt!(DEFAULT_L1_DATA_GAS_MAX_AMOUNT.0),       // Max amount.
-        felt!(DEFAULT_STRK_L1_DATA_GAS_PRICE.get().0), // Max price per unit.
+        Felt::THREE,                                 // Length of ResourceBounds array.
+        felt!(L1Gas.to_hex()),                       // Resource.
+        felt!(DEFAULT_L1_GAS_AMOUNT.0),              // Max amount.
+        felt!(DEFAULT_STRK_L1_GAS_PRICE.get()),      // Max price per unit.
+        felt!(L2Gas.to_hex()),                       // Resource.
+        felt!(DEFAULT_L2_GAS_MAX_AMOUNT.0),          // Max amount.
+        felt!(DEFAULT_STRK_L2_GAS_PRICE.get()),      // Max price per unit.
+        felt!(L1DataGas.to_hex()),                   // Resource.
+        felt!(DEFAULT_L1_DATA_GAS_MAX_AMOUNT.0),     // Max amount.
+        felt!(DEFAULT_STRK_L1_DATA_GAS_PRICE.get()), // Max price per unit.
     ];
 
     let expected_unsupported_fields = vec![

--- a/crates/native_blockifier/src/errors.rs
+++ b/crates/native_blockifier/src/errors.rs
@@ -115,8 +115,6 @@ pub enum InvalidNativeBlockifierInputError {
     InvalidL1DataGasPriceFri(u128),
     #[error("Invalid Wei l2 gas price: {0}.")]
     InvalidL2GasPriceWei(u128),
-    #[error("Invalid Fri l2 gas price: {0}.")]
-    InvalidL2GasPriceFri(u128),
 }
 
 create_exception!(native_blockifier, UndeclaredClassHashError, PyException);

--- a/crates/native_blockifier/src/py_state_diff.rs
+++ b/crates/native_blockifier/src/py_state_diff.rs
@@ -7,16 +7,11 @@ use blockifier::versioned_constants::VersionedConstants;
 use indexmap::IndexMap;
 use pyo3::prelude::*;
 use pyo3::FromPyObject;
-use starknet_api::block::{BlockInfo, BlockNumber, BlockTimestamp, GasPrice, NonzeroGasPrice};
+use starknet_api::block::{BlockInfo, BlockNumber, BlockTimestamp, GasPrice};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::state::{StateDiff, StorageKey};
 
-use crate::errors::{
-    InvalidNativeBlockifierInputError,
-    NativeBlockifierError,
-    NativeBlockifierInputError,
-    NativeBlockifierResult,
-};
+use crate::errors::{NativeBlockifierError, NativeBlockifierResult};
 use crate::py_utils::PyFelt;
 
 // TODO(Arni): consider moving to starknet api.
@@ -182,52 +177,12 @@ impl TryFrom<PyBlockInfo> for BlockInfo {
             block_timestamp: BlockTimestamp(block_info.block_timestamp),
             sequencer_address: ContractAddress::try_from(block_info.sequencer_address.0)?,
             gas_prices: validated_gas_prices(
-                NonzeroGasPrice::try_from(block_info.l1_gas_price.price_in_wei).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL1GasPriceWei(
-                            block_info.l1_gas_price.price_in_wei,
-                        ),
-                    )
-                })?,
-                NonzeroGasPrice::try_from(block_info.l1_gas_price.price_in_fri).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL1GasPriceFri(
-                            block_info.l1_gas_price.price_in_fri,
-                        ),
-                    )
-                })?,
-                NonzeroGasPrice::try_from(block_info.l1_data_gas_price.price_in_wei).map_err(
-                    |_| {
-                        NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                            InvalidNativeBlockifierInputError::InvalidL1DataGasPriceWei(
-                                block_info.l1_data_gas_price.price_in_wei,
-                            ),
-                        )
-                    },
-                )?,
-                NonzeroGasPrice::try_from(block_info.l1_data_gas_price.price_in_fri).map_err(
-                    |_| {
-                        NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                            InvalidNativeBlockifierInputError::InvalidL1DataGasPriceFri(
-                                block_info.l1_data_gas_price.price_in_fri,
-                            ),
-                        )
-                    },
-                )?,
-                NonzeroGasPrice::try_from(block_info.l2_gas_price.price_in_wei).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL2GasPriceWei(
-                            block_info.l2_gas_price.price_in_wei,
-                        ),
-                    )
-                })?,
-                NonzeroGasPrice::try_from(block_info.l2_gas_price.price_in_fri).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL2GasPriceFri(
-                            block_info.l2_gas_price.price_in_fri,
-                        ),
-                    )
-                })?,
+                block_info.l1_gas_price.price_in_wei.try_into()?,
+                block_info.l1_gas_price.price_in_fri.try_into()?,
+                block_info.l1_data_gas_price.price_in_wei.try_into()?,
+                block_info.l1_data_gas_price.price_in_fri.try_into()?,
+                block_info.l2_gas_price.price_in_wei.try_into()?,
+                block_info.l2_gas_price.price_in_fri.try_into()?,
             ),
             use_kzg_da: block_info.use_kzg_da,
         })

--- a/crates/papyrus_execution/src/lib.rs
+++ b/crates/papyrus_execution/src/lib.rs
@@ -52,13 +52,7 @@ use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use papyrus_storage::header::HeaderStorageReader;
 use papyrus_storage::{StorageError, StorageReader};
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{
-    BlockHashAndNumber,
-    BlockInfo,
-    BlockNumber,
-    NonzeroGasPrice,
-    StarknetVersion,
-};
+use starknet_api::block::{BlockHashAndNumber, BlockInfo, BlockNumber, StarknetVersion};
 use starknet_api::contract_class::{ClassInfo, EntryPointType, SierraVersion};
 use starknet_api::core::{ChainId, ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::data_availability::L1DataAvailabilityMode;
@@ -379,12 +373,12 @@ fn create_block_context(
         block_number,
         // TODO(yair): What to do about blocks pre 0.13.1 where the data gas price were 0?
         gas_prices: validated_gas_prices(
-            NonzeroGasPrice::new(l1_gas_price.price_in_wei).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l1_gas_price.price_in_fri).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l1_data_gas_price.price_in_wei).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l1_data_gas_price.price_in_fri).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l2_gas_price.price_in_wei).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l2_gas_price.price_in_fri).unwrap_or(NonzeroGasPrice::MIN),
+            l1_gas_price.price_in_wei,
+            l1_gas_price.price_in_fri,
+            l1_data_gas_price.price_in_wei,
+            l1_data_gas_price.price_in_fri,
+            l2_gas_price.price_in_wei,
+            l2_gas_price.price_in_fri,
         ),
     };
     let chain_info = ChainInfo {

--- a/crates/papyrus_execution/src/objects.rs
+++ b/crates/papyrus_execution/src/objects.rs
@@ -164,9 +164,9 @@ pub(crate) fn tx_execution_output_to_fee_estimation(
 ) -> ExecutionResult<FeeEstimation> {
     let gas_prices = &block_context.block_info().gas_prices;
     let (l1_gas_price, l1_data_gas_price, l2_gas_price) = (
-        gas_prices.l1_gas_price(&tx_execution_output.price_unit.into()).get(),
-        gas_prices.l1_data_gas_price(&tx_execution_output.price_unit.into()).get(),
-        gas_prices.l2_gas_price(&tx_execution_output.price_unit.into()).get(),
+        gas_prices.l1_gas_price(&tx_execution_output.price_unit.into()),
+        gas_prices.l1_data_gas_price(&tx_execution_output.price_unit.into()),
+        gas_prices.l2_gas_price(&tx_execution_output.price_unit.into()),
     );
 
     let gas_vector = tx_execution_output.execution_info.receipt.gas;

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -398,77 +398,12 @@ impl Default for GasPrice {
     }
 }
 
-/// Utility struct representing a non-zero gas price. Useful when a gas amount must be computed by
-/// taking a fee amount and dividing by the gas price.
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, derive_more::Display)]
-pub struct NonzeroGasPrice(GasPrice);
-
-impl NonzeroGasPrice {
-    pub const MIN: Self = Self(GasPrice(1));
-
-    pub fn new(price: GasPrice) -> Result<Self, StarknetApiError> {
-        if price.0 == 0 {
-            return Err(StarknetApiError::ZeroGasPrice);
-        }
-        Ok(Self(price))
-    }
-
-    pub const fn get(&self) -> GasPrice {
-        self.0
-    }
-
-    pub const fn saturating_mul(self, rhs: GasAmount) -> Fee {
-        self.get().saturating_mul(rhs)
-    }
-
-    #[cfg(any(test, feature = "testing"))]
-    pub const fn new_unchecked(price: GasPrice) -> Self {
-        Self(price)
-    }
-}
-
-impl Default for NonzeroGasPrice {
-    fn default() -> Self {
-        Self::MIN
-    }
-}
-
-impl From<NonzeroGasPrice> for GasPrice {
-    fn from(val: NonzeroGasPrice) -> Self {
-        val.0
-    }
-}
-
-impl TryFrom<GasPrice> for NonzeroGasPrice {
-    type Error = StarknetApiError;
-
-    fn try_from(price: GasPrice) -> Result<Self, Self::Error> {
-        NonzeroGasPrice::new(price)
-    }
-}
-
-macro_rules! impl_try_from_uint_for_nonzero_gas_price {
-    ($($uint:ty),*) => {
-        $(
-            impl TryFrom<$uint> for NonzeroGasPrice {
-                type Error = StarknetApiError;
-
-                fn try_from(val: $uint) -> Result<Self, Self::Error> {
-                    NonzeroGasPrice::new(GasPrice::try_from(val)?)
-                }
-            }
-        )*
-    };
-}
-
-impl_try_from_uint_for_nonzero_gas_price!(u8, u16, u32, u64, u128);
-
 // TODO(Arni): Remove derive of Default. Gas prices should always be set.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GasPriceVector {
-    pub l1_gas_price: NonzeroGasPrice,
-    pub l1_data_gas_price: NonzeroGasPrice,
-    pub l2_gas_price: NonzeroGasPrice,
+    pub l1_gas_price: GasPrice,
+    pub l1_data_gas_price: GasPrice,
+    pub l2_gas_price: GasPrice,
 }
 
 #[derive(Clone, Copy, Hash, EnumIter, Eq, PartialEq)]
@@ -485,15 +420,15 @@ pub struct GasPrices {
 }
 
 impl GasPrices {
-    pub fn l1_gas_price(&self, fee_type: &FeeType) -> NonzeroGasPrice {
+    pub fn l1_gas_price(&self, fee_type: &FeeType) -> GasPrice {
         self.gas_price_vector(fee_type).l1_gas_price
     }
 
-    pub fn l1_data_gas_price(&self, fee_type: &FeeType) -> NonzeroGasPrice {
+    pub fn l1_data_gas_price(&self, fee_type: &FeeType) -> GasPrice {
         self.gas_price_vector(fee_type).l1_data_gas_price
     }
 
-    pub fn l2_gas_price(&self, fee_type: &FeeType) -> NonzeroGasPrice {
+    pub fn l2_gas_price(&self, fee_type: &FeeType) -> GasPrice {
         self.gas_price_vector(fee_type).l2_gas_price
     }
 

--- a/crates/starknet_api/src/execution_resources.rs
+++ b/crates/starknet_api/src/execution_resources.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 use strum_macros::EnumIter;
 
-use crate::block::{GasPrice, GasPriceVector, NonzeroGasPrice};
+use crate::block::{GasPrice, GasPriceVector};
 use crate::transaction::fields::{Fee, Resource};
 
 #[cfg_attr(
@@ -64,10 +64,6 @@ impl GasAmount {
 
     pub fn checked_sub(self, rhs: Self) -> Option<Self> {
         self.0.checked_sub(rhs.0).map(Self)
-    }
-
-    pub const fn nonzero_saturating_mul(self, rhs: NonzeroGasPrice) -> Fee {
-        rhs.saturating_mul(self)
     }
 
     pub const fn saturating_mul(self, rhs: GasPrice) -> Fee {
@@ -145,7 +141,7 @@ impl GasVector {
             (self.l1_data_gas, gas_prices.l1_data_gas_price, Resource::L1DataGas),
             (self.l2_gas, gas_prices.l2_gas_price, Resource::L2Gas),
         ] {
-            let cost = gas.checked_mul(price.get()).unwrap_or_else(|| {
+            let cost = gas.checked_mul(price).unwrap_or_else(|| {
                 panic!(
                     "{} cost overflowed: multiplication of gas amount ({}) by price per unit ({}) \
                      resulted in overflow.",
@@ -178,7 +174,7 @@ impl GasVector {
 /// Does not take L2 gas into account - more context is required to convert L2 gas units to L1 gas
 /// units (context defined outside of the current crate).
 pub fn to_discounted_l1_gas(
-    l1_gas_price: NonzeroGasPrice,
+    l1_gas_price: GasPrice,
     l1_data_gas_price: GasPrice,
     l1_gas: GasAmount,
     l1_data_gas: GasAmount,

--- a/crates/starknet_api/src/lib.rs
+++ b/crates/starknet_api/src/lib.rs
@@ -53,7 +53,7 @@ pub enum StarknetApiError {
     InvalidResourceMappingInitializer(String),
     #[error("Invalid Starknet version: {0:?}")]
     InvalidStarknetVersion(Vec<u8>),
-    #[error("NonzeroGasPrice cannot be zero.")]
+    #[error("GasPrice cannot be zero.")]
     ZeroGasPrice,
     #[error(
         "Sierra program length must be > 0 for Cairo1, and == 0 for Cairo0. Got: \

--- a/crates/starknet_api/src/test_utils.rs
+++ b/crates/starknet_api/src/test_utils.rs
@@ -7,15 +7,7 @@ use serde_json::to_string_pretty;
 use starknet_infra_utils::path::current_dir;
 use starknet_types_core::felt::Felt;
 
-use crate::block::{
-    BlockInfo,
-    BlockNumber,
-    BlockTimestamp,
-    GasPrice,
-    GasPriceVector,
-    GasPrices,
-    NonzeroGasPrice,
-};
+use crate::block::{BlockInfo, BlockNumber, BlockTimestamp, GasPrice, GasPriceVector, GasPrices};
 use crate::contract_address;
 use crate::core::{ChainId, ContractAddress, Nonce};
 use crate::execution_resources::GasAmount;
@@ -149,22 +141,16 @@ pub fn rpc_tx_to_json(tx: &RpcTransaction) -> String {
 pub const DEFAULT_L1_GAS_AMOUNT: GasAmount = GasAmount(u64::pow(10, 6));
 pub const DEFAULT_L1_DATA_GAS_MAX_AMOUNT: GasAmount = GasAmount(u64::pow(10, 6));
 pub const DEFAULT_L2_GAS_MAX_AMOUNT: GasAmount = GasAmount(u64::pow(10, 9));
-pub const MAX_L1_GAS_PRICE: NonzeroGasPrice = DEFAULT_STRK_L1_GAS_PRICE;
-pub const MAX_L2_GAS_PRICE: NonzeroGasPrice = DEFAULT_STRK_L2_GAS_PRICE;
-pub const MAX_L1_DATA_GAS_PRICE: NonzeroGasPrice = DEFAULT_STRK_L1_DATA_GAS_PRICE;
+pub const MAX_L1_GAS_PRICE: GasPrice = DEFAULT_STRK_L1_GAS_PRICE;
+pub const MAX_L2_GAS_PRICE: GasPrice = DEFAULT_STRK_L2_GAS_PRICE;
+pub const MAX_L1_DATA_GAS_PRICE: GasPrice = DEFAULT_STRK_L1_DATA_GAS_PRICE;
 
-pub const DEFAULT_ETH_L1_GAS_PRICE: NonzeroGasPrice =
-    NonzeroGasPrice::new_unchecked(GasPrice(100 * u128::pow(10, 9))); // Given in units of Wei.
-pub const DEFAULT_STRK_L1_GAS_PRICE: NonzeroGasPrice =
-    NonzeroGasPrice::new_unchecked(GasPrice(100 * u128::pow(10, 9))); // Given in units of Fri.
-pub const DEFAULT_ETH_L1_DATA_GAS_PRICE: NonzeroGasPrice =
-    NonzeroGasPrice::new_unchecked(GasPrice(u128::pow(10, 6))); // Given in units of Wei.
-pub const DEFAULT_STRK_L1_DATA_GAS_PRICE: NonzeroGasPrice =
-    NonzeroGasPrice::new_unchecked(GasPrice(u128::pow(10, 9))); // Given in units of Fri.
-pub const DEFAULT_ETH_L2_GAS_PRICE: NonzeroGasPrice =
-    NonzeroGasPrice::new_unchecked(GasPrice(u128::pow(10, 6)));
-pub const DEFAULT_STRK_L2_GAS_PRICE: NonzeroGasPrice =
-    NonzeroGasPrice::new_unchecked(GasPrice(u128::pow(10, 9)));
+pub const DEFAULT_ETH_L1_GAS_PRICE: GasPrice = GasPrice::new_unchecked(100 * u128::pow(10, 9)); // Given in units of Wei.
+pub const DEFAULT_STRK_L1_GAS_PRICE: GasPrice = GasPrice::new_unchecked(100 * u128::pow(10, 9)); // Given in units of Fri.
+pub const DEFAULT_ETH_L1_DATA_GAS_PRICE: GasPrice = GasPrice::new_unchecked(u128::pow(10, 6)); // Given in units of Wei.
+pub const DEFAULT_STRK_L1_DATA_GAS_PRICE: GasPrice = GasPrice::new_unchecked(u128::pow(10, 9)); // Given in units of Fri.
+pub const DEFAULT_ETH_L2_GAS_PRICE: GasPrice = GasPrice::new_unchecked(u128::pow(10, 6));
+pub const DEFAULT_STRK_L2_GAS_PRICE: GasPrice = GasPrice::new_unchecked(u128::pow(10, 9));
 
 pub const DEFAULT_GAS_PRICES: GasPrices = GasPrices {
     eth_gas_prices: GasPriceVector {
@@ -180,7 +166,7 @@ pub const DEFAULT_GAS_PRICES: GasPrices = GasPrices {
 };
 
 // Deprecated transactions:
-pub const MAX_FEE: Fee = DEFAULT_L1_GAS_AMOUNT.nonzero_saturating_mul(DEFAULT_ETH_L1_GAS_PRICE);
+pub const MAX_FEE: Fee = DEFAULT_L1_GAS_AMOUNT.saturating_mul(DEFAULT_ETH_L1_GAS_PRICE);
 
 impl BlockInfo {
     pub fn create_for_testing() -> Self {

--- a/crates/starknet_api/src/transaction_test.rs
+++ b/crates/starknet_api/src/transaction_test.rs
@@ -1,7 +1,7 @@
 use rstest::{fixture, rstest};
 
 use super::Transaction;
-use crate::block::NonzeroGasPrice;
+use crate::block::GasPrice;
 use crate::core::ChainId;
 use crate::executable_transaction::{
     AccountTransaction,
@@ -33,26 +33,11 @@ fn verify_transaction_conversion(tx: &Transaction, expected_executable_tx: Execu
 
 #[test]
 fn test_fee_div_ceil() {
-    assert_eq!(
-        GasAmount(1),
-        Fee(1).checked_div_ceil(NonzeroGasPrice::try_from(1_u8).unwrap()).unwrap()
-    );
-    assert_eq!(
-        GasAmount(0),
-        Fee(0).checked_div_ceil(NonzeroGasPrice::try_from(1_u8).unwrap()).unwrap()
-    );
-    assert_eq!(
-        GasAmount(1),
-        Fee(1).checked_div_ceil(NonzeroGasPrice::try_from(2_u8).unwrap()).unwrap()
-    );
-    assert_eq!(
-        GasAmount(9),
-        Fee(27).checked_div_ceil(NonzeroGasPrice::try_from(3_u8).unwrap()).unwrap()
-    );
-    assert_eq!(
-        GasAmount(10),
-        Fee(28).checked_div_ceil(NonzeroGasPrice::try_from(3_u8).unwrap()).unwrap()
-    );
+    assert_eq!(GasAmount(1), Fee(1).checked_div_ceil(GasPrice::new_unchecked(1)).unwrap());
+    assert_eq!(GasAmount(0), Fee(0).checked_div_ceil(GasPrice::new_unchecked(1)).unwrap());
+    assert_eq!(GasAmount(1), Fee(1).checked_div_ceil(GasPrice::new_unchecked(2)).unwrap());
+    assert_eq!(GasAmount(9), Fee(27).checked_div_ceil(GasPrice::new_unchecked(3)).unwrap());
+    assert_eq!(GasAmount(10), Fee(28).checked_div_ceil(GasPrice::new_unchecked(3)).unwrap());
 }
 
 #[rstest]

--- a/crates/starknet_consensus_orchestrator/src/cende/central_objects.rs
+++ b/crates/starknet_consensus_orchestrator/src/cende/central_objects.rs
@@ -11,13 +11,7 @@ use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::NestedIntList;
 use indexmap::{indexmap, IndexMap};
 use serde::Serialize;
-use starknet_api::block::{
-    BlockInfo,
-    BlockNumber,
-    BlockTimestamp,
-    NonzeroGasPrice,
-    StarknetVersion,
-};
+use starknet_api::block::{BlockInfo, BlockNumber, BlockTimestamp, GasPrice, StarknetVersion};
 use starknet_api::contract_class::SierraVersion;
 use starknet_api::core::{
     ClassHash,
@@ -64,8 +58,8 @@ pub type CentralCasmContractClass = CasmContractClass;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CentralResourcePrice {
-    pub price_in_wei: NonzeroGasPrice,
-    pub price_in_fri: NonzeroGasPrice,
+    pub price_in_wei: GasPrice,
+    pub price_in_fri: GasPrice,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]

--- a/crates/starknet_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/starknet_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -52,7 +52,6 @@ use starknet_api::block::{
     GasPrice,
     GasPriceVector,
     GasPrices,
-    NonzeroGasPrice,
     StarknetVersion,
 };
 use starknet_api::contract_class::{ClassInfo, ContractClass, EntryPointType, SierraVersion};
@@ -166,14 +165,14 @@ fn block_info() -> BlockInfo {
         sequencer_address: contract_address!(7_u8),
         gas_prices: GasPrices {
             eth_gas_prices: GasPriceVector {
-                l1_gas_price: NonzeroGasPrice::new(GasPrice(8)).unwrap(),
-                l1_data_gas_price: NonzeroGasPrice::new(GasPrice(10)).unwrap(),
-                l2_gas_price: NonzeroGasPrice::new(GasPrice(12)).unwrap(),
+                l1_gas_price: GasPrice::new_unchecked(8),
+                l1_data_gas_price: GasPrice::new_unchecked(10),
+                l2_gas_price: GasPrice::new_unchecked(12),
             },
             strk_gas_prices: GasPriceVector {
-                l1_gas_price: NonzeroGasPrice::new(GasPrice(9)).unwrap(),
-                l1_data_gas_price: NonzeroGasPrice::new(GasPrice(11)).unwrap(),
-                l2_gas_price: NonzeroGasPrice::new(GasPrice(13)).unwrap(),
+                l1_gas_price: GasPrice::new_unchecked(9),
+                l1_data_gas_price: GasPrice::new_unchecked(11),
+                l2_gas_price: GasPrice::new_unchecked(13),
             },
         },
         use_kzg_da: true,

--- a/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -33,7 +33,6 @@ use starknet_api::block::{
     GasPricePerToken,
     GasPriceVector,
     GasPrices,
-    NonzeroGasPrice,
 };
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::{ContractAddress, SequencerContractAddress};
@@ -79,14 +78,14 @@ use crate::versioned_constants::VersionedConstants;
 // TODO(Dan, Matan): Remove this once and replace with real gas prices.
 const TEMPORARY_GAS_PRICES: GasPrices = GasPrices {
     eth_gas_prices: GasPriceVector {
-        l1_gas_price: NonzeroGasPrice::MIN,
-        l1_data_gas_price: NonzeroGasPrice::MIN,
-        l2_gas_price: NonzeroGasPrice::MIN,
+        l1_gas_price: GasPrice::MIN,
+        l1_data_gas_price: GasPrice::MIN,
+        l2_gas_price: GasPrice::MIN,
     },
     strk_gas_prices: GasPriceVector {
-        l1_gas_price: NonzeroGasPrice::MIN,
-        l1_data_gas_price: NonzeroGasPrice::MIN,
-        l2_gas_price: NonzeroGasPrice::MIN,
+        l1_gas_price: GasPrice::MIN,
+        l1_data_gas_price: GasPrice::MIN,
+        l2_gas_price: GasPrice::MIN,
     },
 };
 
@@ -187,10 +186,9 @@ impl SequencerConsensusContext {
     }
 
     fn gas_prices(&self) -> GasPrices {
-        // TODO(Ayelet): Remove unwrap when deleting NonzeroGasPrice.
         GasPrices {
             strk_gas_prices: GasPriceVector {
-                l2_gas_price: NonzeroGasPrice::new(self.l2_gas_price.try_into().unwrap())
+                l2_gas_price: GasPrice::new(self.l2_gas_price.into())
                     .expect("Failed to convert l2_gas_price to NonzeroGasPrice, should not be 0."),
                 ..TEMPORARY_GAS_PRICES.strk_gas_prices
             },

--- a/crates/starknet_gateway/src/rpc_objects.rs
+++ b/crates/starknet_gateway/src/rpc_objects.rs
@@ -1,14 +1,7 @@
 use blockifier::blockifier::block::validated_gas_prices;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use starknet_api::block::{
-    BlockHash,
-    BlockInfo,
-    BlockNumber,
-    BlockTimestamp,
-    GasPrice,
-    NonzeroGasPrice,
-};
+use starknet_api::block::{BlockHash, BlockInfo, BlockNumber, BlockTimestamp, GasPrice};
 use starknet_api::core::{ClassHash, ContractAddress, GlobalRoot};
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::state::StorageKey;
@@ -94,21 +87,16 @@ impl TryInto<BlockInfo> for BlockHeader {
             sequencer_address: self.sequencer_address,
             block_timestamp: self.timestamp,
             gas_prices: validated_gas_prices(
-                parse_gas_price(self.l1_gas_price.price_in_wei)?,
-                parse_gas_price(self.l1_gas_price.price_in_fri)?,
-                parse_gas_price(self.l1_data_gas_price.price_in_wei)?,
-                parse_gas_price(self.l1_data_gas_price.price_in_fri)?,
-                parse_gas_price(self.l2_gas_price.price_in_wei)?,
-                parse_gas_price(self.l2_gas_price.price_in_fri)?,
+                self.l1_gas_price.price_in_wei,
+                self.l1_gas_price.price_in_fri,
+                self.l1_data_gas_price.price_in_wei,
+                self.l1_data_gas_price.price_in_fri,
+                self.l2_gas_price.price_in_wei,
+                self.l2_gas_price.price_in_fri,
             ),
             use_kzg_da: matches!(self.l1_da_mode, L1DataAvailabilityMode::Blob),
         })
     }
-}
-
-fn parse_gas_price(gas_price: GasPrice) -> Result<NonzeroGasPrice, RPCStateReaderError> {
-    NonzeroGasPrice::new(gas_price)
-        .map_err(|_| RPCStateReaderError::GasPriceParsingFailure(gas_price))
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/starknet_gateway/src/rpc_state_reader_test.rs
+++ b/crates/starknet_gateway/src/rpc_state_reader_test.rs
@@ -64,12 +64,12 @@ async fn test_get_block_info() {
     let l2_gas_price =
         ResourcePrice { price_in_wei: GasPrice::default(), price_in_fri: GasPrice::default() };
     let gas_prices = validated_gas_prices(
-        l1_gas_price.price_in_wei.try_into().unwrap(),
-        l1_gas_price.price_in_fri.try_into().unwrap(),
-        l1_data_gas_price.price_in_wei.try_into().unwrap(),
-        l1_data_gas_price.price_in_fri.try_into().unwrap(),
-        l2_gas_price.price_in_wei.try_into().unwrap(),
-        l2_gas_price.price_in_fri.try_into().unwrap(),
+        l1_gas_price.price_in_wei,
+        l1_gas_price.price_in_fri,
+        l1_data_gas_price.price_in_wei,
+        l1_data_gas_price.price_in_fri,
+        l2_gas_price.price_in_wei,
+        l2_gas_price.price_in_fri,
     );
 
     let block_number = BlockNumber(100);

--- a/crates/starknet_gateway/src/sync_state_reader.rs
+++ b/crates/starknet_gateway/src/sync_state_reader.rs
@@ -47,14 +47,14 @@ impl MempoolStateReader for SyncStateReader {
             sequencer_address: block_header.sequencer.0,
             gas_prices: GasPrices {
                 eth_gas_prices: GasPriceVector {
-                    l1_gas_price: block_header.l1_gas_price.price_in_wei.try_into()?,
-                    l1_data_gas_price: block_header.l1_data_gas_price.price_in_wei.try_into()?,
-                    l2_gas_price: block_header.l2_gas_price.price_in_wei.try_into()?,
+                    l1_gas_price: block_header.l1_gas_price.price_in_wei,
+                    l1_data_gas_price: block_header.l1_data_gas_price.price_in_wei,
+                    l2_gas_price: block_header.l2_gas_price.price_in_wei,
                 },
                 strk_gas_prices: GasPriceVector {
-                    l1_gas_price: block_header.l1_gas_price.price_in_fri.try_into()?,
-                    l1_data_gas_price: block_header.l1_data_gas_price.price_in_fri.try_into()?,
-                    l2_gas_price: block_header.l2_gas_price.price_in_fri.try_into()?,
+                    l1_gas_price: block_header.l1_gas_price.price_in_fri,
+                    l1_data_gas_price: block_header.l1_data_gas_price.price_in_fri,
+                    l2_gas_price: block_header.l2_gas_price.price_in_fri,
                 },
             },
             use_kzg_da: match block_header.l1_da_mode {

--- a/crates/starknet_gateway/src/sync_state_reader_test.rs
+++ b/crates/starknet_gateway/src/sync_state_reader_test.rs
@@ -14,7 +14,6 @@ use starknet_api::block::{
     GasPricePerToken,
     GasPriceVector,
     GasPrices,
-    NonzeroGasPrice,
 };
 use starknet_api::contract_class::{ContractClass, SierraVersion};
 use starknet_api::core::SequencerContractAddress;
@@ -81,18 +80,14 @@ async fn test_get_block_info() {
             sequencer_address,
             gas_prices: GasPrices {
                 eth_gas_prices: GasPriceVector {
-                    l1_gas_price: NonzeroGasPrice::new_unchecked(l1_gas_price.price_in_wei),
-                    l1_data_gas_price: NonzeroGasPrice::new_unchecked(
-                        l1_data_gas_price.price_in_wei
-                    ),
-                    l2_gas_price: NonzeroGasPrice::new_unchecked(l2_gas_price.price_in_wei),
+                    l1_gas_price: l1_gas_price.price_in_wei,
+                    l1_data_gas_price: l1_data_gas_price.price_in_wei,
+                    l2_gas_price: l2_gas_price.price_in_wei,
                 },
                 strk_gas_prices: GasPriceVector {
-                    l1_gas_price: NonzeroGasPrice::new_unchecked(l1_gas_price.price_in_fri),
-                    l1_data_gas_price: NonzeroGasPrice::new_unchecked(
-                        l1_data_gas_price.price_in_fri
-                    ),
-                    l2_gas_price: NonzeroGasPrice::new_unchecked(l2_gas_price.price_in_fri),
+                    l1_gas_price: l1_gas_price.price_in_fri,
+                    l1_data_gas_price: l1_data_gas_price.price_in_fri,
+                    l2_gas_price: l2_gas_price.price_in_fri,
                 },
             },
             use_kzg_da: match l1_da_mode {

--- a/crates/starknet_integration_tests/src/state_reader.rs
+++ b/crates/starknet_integration_tests/src/state_reader.rs
@@ -260,18 +260,18 @@ fn test_block_header(block_number: BlockNumber) -> BlockHeader {
             block_number,
             sequencer: SequencerContractAddress(contract_address!(TEST_SEQUENCER_ADDRESS)),
             l1_gas_price: GasPricePerToken {
-                price_in_wei: DEFAULT_ETH_L1_GAS_PRICE.into(),
-                price_in_fri: DEFAULT_STRK_L1_GAS_PRICE.into(),
+                price_in_wei: DEFAULT_ETH_L1_GAS_PRICE,
+                price_in_fri: DEFAULT_STRK_L1_GAS_PRICE,
             },
             l1_data_gas_price: GasPricePerToken {
-                price_in_wei: DEFAULT_ETH_L1_GAS_PRICE.into(),
-                price_in_fri: DEFAULT_STRK_L1_GAS_PRICE.into(),
+                price_in_wei: DEFAULT_ETH_L1_GAS_PRICE,
+                price_in_fri: DEFAULT_STRK_L1_GAS_PRICE,
             },
             l2_gas_price: GasPricePerToken {
                 price_in_wei: VersionedConstants::latest_constants()
-                    .convert_l1_to_l2_gas_price_round_up(DEFAULT_ETH_L1_GAS_PRICE.into()),
+                    .convert_l1_to_l2_gas_price_round_up(DEFAULT_ETH_L1_GAS_PRICE),
                 price_in_fri: VersionedConstants::latest_constants()
-                    .convert_l1_to_l2_gas_price_round_up(DEFAULT_STRK_L1_GAS_PRICE.into()),
+                    .convert_l1_to_l2_gas_price_round_up(DEFAULT_STRK_L1_GAS_PRICE),
             },
             timestamp: BlockTimestamp(CURRENT_BLOCK_TIMESTAMP),
             ..Default::default()


### PR DESCRIPTION
Refactoring GasPrice: Merging GasPrice and NonzeroGasPrice into a single struct named GasPrice with NonzeroGasPrice functionality.

*This PR:*
* Use only GasPrice instead of NonzeroGasPrice.
* Delete the NonzeroGasPrice struct entirely.