### PR TITLE
refactor(papyrus_protobuf, starknet_api): move DeclareTransactionV3Common to starknet_api

### DIFF
--- a/crates/papyrus_protobuf/src/converters/transaction.rs
+++ b/crates/papyrus_protobuf/src/converters/transaction.rs
@@ -4,17 +4,9 @@ mod transaction_test;
 use std::convert::{TryFrom, TryInto};
 
 use prost::Message;
-use serde::{Deserialize, Serialize};
 use starknet_api::block::GasPrice;
 use starknet_api::consensus_transaction::ConsensusTransaction;
-use starknet_api::core::{
-    ClassHash,
-    CompiledClassHash,
-    ContractAddress,
-    EntryPointSelector,
-    Nonce,
-};
-use starknet_api::data_availability::DataAvailabilityMode;
+use starknet_api::core::{ClassHash, CompiledClassHash, EntryPointSelector, Nonce};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::{
     RpcDeclareTransaction,
@@ -68,6 +60,7 @@ use super::common::{
 };
 use super::ProtobufConversionError;
 use crate::sync::{DataOrFin, Query, TransactionQuery};
+use crate::transaction::DeclareTransactionV3Common;
 use crate::{auto_impl_into_and_try_from_vec_u8, protobuf};
 
 impl TryFrom<protobuf::TransactionsResponse> for DataOrFin<FullTransaction> {
@@ -1223,21 +1216,6 @@ impl From<DeclareTransactionV2> for protobuf::transaction_in_block::DeclareV2Wit
             sender: Some(value.sender_address.into()),
         }
     }
-}
-
-/// Defined to match the protobuf schema.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-struct DeclareTransactionV3Common {
-    pub resource_bounds: ValidResourceBounds,
-    pub tip: Tip,
-    pub signature: TransactionSignature,
-    pub nonce: Nonce,
-    pub compiled_class_hash: CompiledClassHash,
-    pub sender_address: ContractAddress,
-    pub nonce_data_availability_mode: DataAvailabilityMode,
-    pub fee_data_availability_mode: DataAvailabilityMode,
-    pub paymaster_data: PaymasterData,
-    pub account_deployment_data: AccountDeploymentData,
 }
 
 impl TryFrom<protobuf::DeclareV3Common> for DeclareTransactionV3Common {

--- a/crates/papyrus_protobuf/src/lib.rs
+++ b/crates/papyrus_protobuf/src/lib.rs
@@ -5,3 +5,4 @@ pub mod consensus;
 pub mod mempool;
 pub mod protobuf;
 pub mod sync;
+mod transaction;

--- a/crates/papyrus_protobuf/src/transaction.rs
+++ b/crates/papyrus_protobuf/src/transaction.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+use starknet_api::core::{CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::data_availability::DataAvailabilityMode;
+use starknet_api::transaction::fields::{
+    AccountDeploymentData,
+    PaymasterData,
+    Tip,
+    TransactionSignature,
+    ValidResourceBounds,
+};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub(crate) struct DeclareTransactionV3Common {
+    pub resource_bounds: ValidResourceBounds,
+    pub tip: Tip,
+    pub signature: TransactionSignature,
+    pub nonce: Nonce,
+    pub compiled_class_hash: CompiledClassHash,
+    pub sender_address: ContractAddress,
+    pub nonce_data_availability_mode: DataAvailabilityMode,
+    pub fee_data_availability_mode: DataAvailabilityMode,
+    pub paymaster_data: PaymasterData,
+    pub account_deployment_data: AccountDeploymentData,
+}

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -164,7 +164,7 @@ impl TryFrom<(Transaction, &ChainId)> for executable_transaction::Transaction {
                 executable_transaction::L1HandlerTransaction {
                     tx,
                     tx_hash,
-                    // TODO (yael 1/12/2024): The paid fee should be an input from the l1_handler.
+                    // TODO(yael): The paid fee should be an input from the l1_handler.
                     paid_fee_on_l1: Fee(1),
                 },
             )),


### PR DESCRIPTION
- **refactor(papyrus_protobuf): add converters for new transaction messages**
- **chore(papyrus_protobuf): fix CR comments**
- **chore(papyrus_protobuf): fix CR comments round 2**
- **refactor(papyrus_protobuf): move to-be-deleted converters to a different module**
- **refactor(papyrus_protobuf, starknet_api): move DeclareTransactionV3Common to starknet_api**
