### PR TITLE
chore(starknet_l1_provider): add l1-reorg error

### DIFF
--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -63,7 +63,7 @@ pub trait BaseLayerContract {
 }
 
 /// Reference to an L1 block, extend as needed.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct L1BlockReference {
     pub number: L1BlockNumber,
     pub hash: [u8; 32],

--- a/crates/starknet_sequencer_node/src/components.rs
+++ b/crates/starknet_sequencer_node/src/components.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerContract;
+use papyrus_base_layer::L1BlockReference;
 use starknet_batcher::batcher::{create_batcher, Batcher};
 use starknet_class_manager_types::EmptyClassManagerClient;
 use starknet_consensus_manager::consensus_manager::ConsensusManager;
@@ -191,7 +192,7 @@ pub async fn create_node_components(
             // once `Anvil` support is added there.
             Some(
                 L1Scraper::new_at_l1_block(
-                    0,
+                    L1BlockReference { number: 0, ..Default::default() },
                     l1_scraper_config,
                     l1_provider_client,
                     base_layer,


### PR DESCRIPTION
Make scraper track also the last processed block hash, in addition to number.
Whenever the scraper is about to start scraping again, check if the last processed block number:
1. Still exists.
2. Fetch it's current block_hash on L1, and compare to the block_hash saved after the last scraping ended. If either of the above checks fail, then this means an L1 reorg has occured, so the infra should crash the provider and initiate the provider/scraper startup flow.