### PR TITLE
refactor(papyrus_protobuf): TransactionBatch now uses ConsensusTransaction

### DIFF
--- a/crates/papyrus_protobuf/src/consensus.rs
+++ b/crates/papyrus_protobuf/src/consensus.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use bytes::{Buf, BufMut};
 use prost::DecodeError;
 use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::ContractAddress;
-use starknet_api::transaction::Transaction;
 
 use crate::converters::ProtobufConversionError;
 
@@ -75,7 +75,7 @@ impl Default for ProposalInit {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TransactionBatch {
     /// The transactions in the batch.
-    pub transactions: Vec<Transaction>,
+    pub transactions: Vec<ConsensusTransaction>,
 }
 
 /// The proposal is done when receiving this fin message, which contains the block hash.

--- a/crates/papyrus_protobuf/src/converters/consensus.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus.rs
@@ -6,8 +6,8 @@ use std::convert::{TryFrom, TryInto};
 
 use prost::Message;
 use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::hash::StarkHash;
-use starknet_api::transaction::Transaction;
 
 use crate::consensus::{
     IntoFromProto,
@@ -197,7 +197,7 @@ impl TryFrom<protobuf::TransactionBatch> for TransactionBatch {
             .transactions
             .into_iter()
             .map(|tx| tx.try_into())
-            .collect::<Result<Vec<Transaction>, ProtobufConversionError>>()?;
+            .collect::<Result<Vec<ConsensusTransaction>, ProtobufConversionError>>()?;
         Ok(TransactionBatch { transactions })
     }
 }

--- a/crates/papyrus_protobuf/src/converters/consensus_test.rs
+++ b/crates/papyrus_protobuf/src/converters/consensus_test.rs
@@ -1,14 +1,14 @@
 use papyrus_test_utils::{get_rng, GetTestInstance};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::execution_resources::GasAmount;
-use starknet_api::transaction::fields::ValidResourceBounds;
-use starknet_api::transaction::{
-    DeclareTransaction,
-    DeclareTransactionV3,
-    DeployAccountTransaction,
-    DeployAccountTransactionV3,
-    InvokeTransaction,
-    InvokeTransactionV3,
-    Transaction,
+use starknet_api::rpc_transaction::{
+    RpcDeclareTransaction,
+    RpcDeclareTransactionV3,
+    RpcDeployAccountTransaction,
+    RpcDeployAccountTransactionV3,
+    RpcInvokeTransaction,
+    RpcInvokeTransactionV3,
+    RpcTransaction,
 };
 
 use crate::consensus::{
@@ -24,25 +24,25 @@ use crate::converters::test_instances::TestStreamId;
 
 // If all the fields of `AllResources` are 0 upon serialization,
 // then the deserialized value will be interpreted as the `L1Gas` variant.
-fn add_gas_values_to_transaction(transactions: &mut [Transaction]) {
+fn add_gas_values_to_transaction(transactions: &mut [ConsensusTransaction]) {
     let transaction = &mut transactions[0];
     match transaction {
-        Transaction::Declare(DeclareTransaction::V3(DeclareTransactionV3 {
-            resource_bounds,
-            ..
-        }))
-        | Transaction::Invoke(InvokeTransaction::V3(InvokeTransactionV3 {
-            resource_bounds, ..
-        }))
-        | Transaction::DeployAccount(DeployAccountTransaction::V3(DeployAccountTransactionV3 {
-            resource_bounds,
-            ..
-        })) => {
-            if let ValidResourceBounds::AllResources(ref mut bounds) = resource_bounds {
-                bounds.l2_gas.max_amount = GasAmount(1);
+        ConsensusTransaction::RpcTransaction(rpc_transaction) => match rpc_transaction {
+            RpcTransaction::Declare(RpcDeclareTransaction::V3(RpcDeclareTransactionV3 {
+                resource_bounds,
+                ..
+            }))
+            | RpcTransaction::Invoke(RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
+                resource_bounds,
+                ..
+            }))
+            | RpcTransaction::DeployAccount(RpcDeployAccountTransaction::V3(
+                RpcDeployAccountTransactionV3 { resource_bounds, .. },
+            )) => {
+                resource_bounds.l2_gas.max_amount = GasAmount(1);
             }
-        }
-        _ => {}
+        },
+        ConsensusTransaction::L1Handler(_) => {}
     }
 }
 

--- a/crates/papyrus_protobuf/src/converters/test_instances.rs
+++ b/crates/papyrus_protobuf/src/converters/test_instances.rs
@@ -4,8 +4,8 @@ use papyrus_test_utils::{auto_impl_get_test_instance, get_number_of_variants, Ge
 use prost::DecodeError;
 use rand::Rng;
 use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::ContractAddress;
-use starknet_api::transaction::Transaction;
 
 use super::ProtobufConversionError;
 use crate::consensus::{
@@ -41,7 +41,7 @@ auto_impl_get_test_instance! {
         pub proposal_content_id: BlockHash,
     }
     pub struct TransactionBatch {
-        pub transactions: Vec<Transaction>,
+        pub transactions: Vec<ConsensusTransaction>,
     }
     pub enum ProposalPart {
         Init(ProposalInit) = 0,
@@ -96,7 +96,7 @@ impl GetTestInstance for StreamMessage<ProposalPart, TestStreamId> {
     fn get_test_instance(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
         let message = if rng.gen_bool(0.5) {
             StreamMessageBody::Content(ProposalPart::Transactions(TransactionBatch {
-                transactions: vec![Transaction::get_test_instance(rng)],
+                transactions: vec![ConsensusTransaction::get_test_instance(rng)],
             }))
         } else {
             StreamMessageBody::Fin

--- a/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
+++ b/crates/papyrus_protobuf/src/proto/p2p/proto/consensus/consensus.proto
@@ -50,7 +50,7 @@ message ProposalInit {
 }
 
 message TransactionBatch {
-    repeated Transaction transactions = 1;
+    repeated ConsensusTransaction transactions = 1;
 }
 
 message ProposalFin {

--- a/crates/papyrus_test_utils/src/lib.rs
+++ b/crates/papyrus_test_utils/src/lib.rs
@@ -49,6 +49,7 @@ use starknet_api::block::{
     GasPricePerToken,
     StarknetVersion,
 };
+use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     ClassHash,
@@ -502,6 +503,10 @@ auto_impl_get_test_instance! {
     pub struct ClassHash(pub StarkHash);
     pub struct CompiledClassHash(pub StarkHash);
     pub struct ContractAddressSalt(pub StarkHash);
+    pub enum ConsensusTransaction {
+        RpcTransaction(RpcTransaction) = 0,
+        L1Handler(L1HandlerTransaction) = 1,
+    }
     pub struct SierraContractClass {
         pub sierra_program: Vec<Felt>,
         pub contract_class_version: String,


### PR DESCRIPTION
- **refactor(papyrus_protobuf): add converters for new transaction messages**
- **chore(papyrus_protobuf): fix CR comments**
- **chore(papyrus_protobuf): fix CR comments round 2**
- **refactor(papyrus_protobuf): move to-be-deleted converters to a different module**
- **refactor(papyrus_protobuf): add missing converters for RpcTransactions and ConsensusTransaction**
- **refactor(papyrus_protobuf, starknet_api): move DeclareTransactionV3Common to starknet_api**
- **feat(starknet_class_manager_types): convertion InternalConsensusTransaction to ExecutableTransaction**
- **refactor(papyrus_protobuf): TransactionBatch now uses ConsensusTransaction**
