### PR TITLE
refactor(starknet_batcher): use InternalConsensusTransaction

rename GetProposalContent to GetProposalContentDeprecated
rename SendProposalContent to SendProposalContentDeprecated
block builder convert internal to exe tx using class manager

### DIFF
--- a/crates/starknet_api/src/consensus_transaction.rs
+++ b/crates/starknet_api/src/consensus_transaction.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::rpc_transaction::{InternalRpcTransaction, RpcTransaction};
+use crate::transaction::TransactionHash;
 use crate::{executable_transaction, transaction};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Hash)]
@@ -13,4 +14,13 @@ pub enum ConsensusTransaction {
 pub enum InternalConsensusTransaction {
     RpcTransaction(InternalRpcTransaction),
     L1Handler(executable_transaction::L1HandlerTransaction),
+}
+
+impl InternalConsensusTransaction {
+    pub fn tx_hash(&self) -> TransactionHash {
+        match self {
+            Self::RpcTransaction(tx) => tx.tx_hash,
+            Self::L1Handler(tx) => tx.tx_hash,
+        }
+    }
 }

--- a/crates/starknet_batcher/src/batcher.rs
+++ b/crates/starknet_batcher/src/batcher.rs
@@ -6,8 +6,8 @@ use blockifier::state::contract_class_manager::ContractClassManager;
 use mockall::automock;
 use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use starknet_api::block::{BlockHeaderWithoutHash, BlockNumber};
+use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::{ContractAddress, Nonce};
-use starknet_api::executable_transaction::Transaction;
 use starknet_api::state::ThinStateDiff;
 use starknet_api::transaction::TransactionHash;
 use starknet_batcher_types::batcher_types::{
@@ -67,8 +67,8 @@ use crate::utils::{
     ProposalTask,
 };
 
-type OutputStreamReceiver = tokio::sync::mpsc::UnboundedReceiver<Transaction>;
-type InputStreamSender = tokio::sync::mpsc::Sender<Transaction>;
+type OutputStreamReceiver = tokio::sync::mpsc::UnboundedReceiver<InternalConsensusTransaction>;
+type InputStreamSender = tokio::sync::mpsc::Sender<InternalConsensusTransaction>;
 
 pub struct Batcher {
     pub config: BatcherConfig,
@@ -181,7 +181,6 @@ impl Batcher {
         let tx_provider = ProposeTransactionProvider::new(
             self.mempool_client.clone(),
             self.l1_provider_client.clone(),
-            self.transaction_converter.clone(),
             self.config.max_l1_handler_txs_per_block_proposal,
             propose_block_input.block_info.block_number,
         );
@@ -306,7 +305,7 @@ impl Batcher {
     async fn handle_send_txs_request(
         &mut self,
         proposal_id: ProposalId,
-        txs: Vec<Transaction>,
+        txs: Vec<InternalConsensusTransaction>,
     ) -> BatcherResult<SendProposalContentResponse> {
         if self.is_active(proposal_id).await {
             //   The proposal is active. Send the transactions through the tx provider.

--- a/crates/starknet_batcher/src/batcher_test.rs
+++ b/crates/starknet_batcher/src/batcher_test.rs
@@ -9,8 +9,8 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use mockall::predicate::eq;
 use rstest::rstest;
 use starknet_api::block::{BlockHeaderWithoutHash, BlockInfo, BlockNumber};
+use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::{ChainId, ContractAddress, Nonce};
-use starknet_api::executable_transaction::Transaction;
 use starknet_api::state::ThinStateDiff;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{contract_address, nonce, tx_hash};
@@ -168,7 +168,7 @@ fn mock_create_builder_for_validate_block(
 
 fn mock_create_builder_for_propose_block(
     block_builder_factory: &mut MockBlockBuilderFactoryTrait,
-    output_txs: Vec<Transaction>,
+    output_txs: Vec<InternalConsensusTransaction>,
     build_block_result: BlockBuilderResult<BlockExecutionArtifacts>,
 ) {
     block_builder_factory.expect_create_block_builder().times(1).return_once(

--- a/crates/starknet_batcher/src/block_builder_test.rs
+++ b/crates/starknet_batcher/src/block_builder_test.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use blockifier::blockifier::transaction_executor::{
@@ -15,11 +16,14 @@ use indexmap::{indexmap, IndexMap};
 use mockall::predicate::eq;
 use mockall::Sequence;
 use rstest::rstest;
-use starknet_api::executable_transaction::Transaction;
+use starknet_api::consensus_transaction::InternalConsensusTransaction;
+use starknet_api::core::ChainId;
 use starknet_api::execution_resources::{GasAmount, GasVector};
 use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::tx_hash;
+use starknet_class_manager_types::transaction_converter::TransactionConverter;
+use starknet_class_manager_types::MockClassManagerClient;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::block_builder::{
@@ -44,10 +48,12 @@ struct TestExpectations {
     mock_transaction_executor: MockTransactionExecutorTrait,
     mock_tx_provider: MockTransactionProvider,
     expected_block_artifacts: BlockExecutionArtifacts,
-    expected_txs_output: Vec<Transaction>,
+    expected_txs_output: Vec<InternalConsensusTransaction>,
 }
 
-fn output_channel() -> (UnboundedSender<Transaction>, UnboundedReceiver<Transaction>) {
+fn output_channel()
+-> (UnboundedSender<InternalConsensusTransaction>, UnboundedReceiver<InternalConsensusTransaction>)
+{
     tokio::sync::mpsc::unbounded_channel()
 }
 
@@ -99,7 +105,7 @@ fn one_chunk_test_expectations() -> TestExpectations {
 }
 
 fn one_chunk_mock_executor(
-    input_txs: &[Transaction],
+    input_txs: &[InternalConsensusTransaction],
     block_size: usize,
 ) -> (MockTransactionExecutorTrait, BlockExecutionArtifacts) {
     let input_txs_cloned = input_txs.to_vec();
@@ -123,7 +129,8 @@ fn two_chunks_test_expectations() -> TestExpectations {
     let block_size = input_txs.len();
 
     let mut mock_transaction_executor = MockTransactionExecutorTrait::new();
-    let mut mock_add_txs_to_block = |tx_chunk: Vec<Transaction>, seq: &mut Sequence| {
+    let mut mock_add_txs_to_block = |tx_chunk: Vec<InternalConsensusTransaction>,
+                                     seq: &mut Sequence| {
         mock_transaction_executor
             .expect_add_txs_to_block()
             .times(1)
@@ -165,7 +172,9 @@ fn empty_block_test_expectations() -> TestExpectations {
     }
 }
 
-fn mock_transaction_executor_block_full(input_txs: &[Transaction]) -> MockTransactionExecutorTrait {
+fn mock_transaction_executor_block_full(
+    input_txs: &[InternalConsensusTransaction],
+) -> MockTransactionExecutorTrait {
     let input_txs_cloned = input_txs.to_vec();
     let mut mock_transaction_executor = MockTransactionExecutorTrait::new();
     let execution_results = vec![Ok(execution_info())];
@@ -195,7 +204,9 @@ fn block_full_test_expectations() -> TestExpectations {
     }
 }
 
-fn mock_transaction_executor_with_delay(input_txs: &[Transaction]) -> MockTransactionExecutorTrait {
+fn mock_transaction_executor_with_delay(
+    input_txs: &[InternalConsensusTransaction],
+) -> MockTransactionExecutorTrait {
     let input_txs_cloned = input_txs.to_vec();
     let mut mock_transaction_executor = MockTransactionExecutorTrait::new();
     mock_transaction_executor
@@ -319,7 +330,7 @@ fn set_close_block_expectations(
 /// This function assumes constant chunk size of TX_CHUNK_SIZE.
 fn mock_tx_provider_limited_calls(
     n_calls: usize,
-    mut input_chunks: Vec<Vec<Transaction>>,
+    mut input_chunks: Vec<Vec<InternalConsensusTransaction>>,
 ) -> MockTransactionProvider {
     let mut mock_tx_provider = MockTransactionProvider::new();
     mock_tx_provider
@@ -330,7 +341,9 @@ fn mock_tx_provider_limited_calls(
     mock_tx_provider
 }
 
-fn mock_tx_provider_stream_done(input_chunk: Vec<Transaction>) -> MockTransactionProvider {
+fn mock_tx_provider_stream_done(
+    input_chunk: Vec<InternalConsensusTransaction>,
+) -> MockTransactionProvider {
     let mut mock_tx_provider = MockTransactionProvider::new();
     let mut seq = Sequence::new();
     mock_tx_provider
@@ -351,7 +364,7 @@ fn mock_tx_provider_stream_done(input_chunk: Vec<Transaction>) -> MockTransactio
 /// This function assumes constant chunk size of TX_CHUNK_SIZE.
 fn mock_tx_provider_limitless_calls(
     n_calls: usize,
-    input_chunks: Vec<Vec<Transaction>>,
+    input_chunks: Vec<Vec<InternalConsensusTransaction>>,
 ) -> MockTransactionProvider {
     let mut mock_tx_provider = mock_tx_provider_limited_calls(n_calls, input_chunks);
 
@@ -367,7 +380,10 @@ fn add_limitless_empty_calls(mock_tx_provider: &mut MockTransactionProvider) {
         .returning(|_n_txs| Ok(NextTxs::Txs(Vec::new())));
 }
 
-fn compare_tx_hashes(input: &[Transaction], blockifier_input: &[BlockifierTransaction]) -> bool {
+fn compare_tx_hashes(
+    input: &[InternalConsensusTransaction],
+    blockifier_input: &[BlockifierTransaction],
+) -> bool {
     let expected_tx_hashes: Vec<TransactionHash> = input.iter().map(|tx| tx.tx_hash()).collect();
     let input_tx_hashes: Vec<TransactionHash> =
         blockifier_input.iter().map(BlockifierTransaction::tx_hash).collect();
@@ -375,10 +391,10 @@ fn compare_tx_hashes(input: &[Transaction], blockifier_input: &[BlockifierTransa
 }
 
 async fn verify_build_block_output(
-    expected_output_txs: Vec<Transaction>,
+    expected_output_txs: Vec<InternalConsensusTransaction>,
     expected_block_artifacts: BlockExecutionArtifacts,
     result_block_artifacts: BlockExecutionArtifacts,
-    mut output_stream_receiver: UnboundedReceiver<Transaction>,
+    mut output_stream_receiver: UnboundedReceiver<InternalConsensusTransaction>,
 ) {
     // Verify the transactions in the output channel.
     let mut output_txs = vec![];
@@ -396,17 +412,22 @@ async fn verify_build_block_output(
 async fn run_build_block(
     mock_transaction_executor: MockTransactionExecutorTrait,
     tx_provider: MockTransactionProvider,
-    output_sender: Option<UnboundedSender<Transaction>>,
+    output_sender: Option<UnboundedSender<InternalConsensusTransaction>>,
     fail_on_err: bool,
     abort_receiver: tokio::sync::oneshot::Receiver<()>,
     deadline_secs: u64,
 ) -> BlockBuilderResult<BlockExecutionArtifacts> {
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(deadline_secs);
+    let transaction_converter = TransactionConverter::new(
+        Arc::new(MockClassManagerClient::new()),
+        ChainId::create_for_testing(),
+    );
     let mut block_builder = BlockBuilder::new(
         Box::new(mock_transaction_executor),
         Box::new(tx_provider),
         output_sender,
         abort_receiver,
+        transaction_converter,
         TX_CHUNK_SIZE,
         BlockBuilderExecutionParams { deadline, fail_on_err },
     );
@@ -474,7 +495,7 @@ async fn test_validate_block() {
 #[case::deadline_reached(test_txs(0..3), mock_transaction_executor_with_delay(&input_txs), FailOnErrorCause::DeadlineReached)]
 #[tokio::test]
 async fn test_validate_block_with_error(
-    #[case] input_txs: Vec<Transaction>,
+    #[case] input_txs: Vec<InternalConsensusTransaction>,
     #[case] mut mock_transaction_executor: MockTransactionExecutorTrait,
     #[case] expected_error: FailOnErrorCause,
 ) {

--- a/crates/starknet_batcher/src/test_utils.rs
+++ b/crates/starknet_batcher/src/test_utils.rs
@@ -6,9 +6,9 @@ use blockifier::fee::receipt::TransactionReceipt;
 use blockifier::state::cached_state::CommitmentStateDiff;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use indexmap::IndexMap;
-use starknet_api::executable_transaction::Transaction;
+use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::execution_resources::GasAmount;
-use starknet_api::test_utils::invoke::{executable_invoke_tx, InvokeTxArgs};
+use starknet_api::test_utils::invoke::{internal_invoke_tx, InvokeTxArgs};
 use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{class_hash, contract_address, nonce, tx_hash};
@@ -47,8 +47,8 @@ impl BlockBuilderTrait for FakeValidateBlockBuilder {
 // A fake block builder for propose flow, that sends the given transactions to the output content
 // sender.
 pub(crate) struct FakeProposeBlockBuilder {
-    pub output_content_sender: UnboundedSender<Transaction>,
-    pub output_txs: Vec<Transaction>,
+    pub output_content_sender: UnboundedSender<InternalConsensusTransaction>,
+    pub output_txs: Vec<InternalConsensusTransaction>,
     pub build_block_result: Option<BlockBuilderResult<BlockExecutionArtifacts>>,
 }
 
@@ -64,10 +64,10 @@ impl BlockBuilderTrait for FakeProposeBlockBuilder {
     }
 }
 
-pub fn test_txs(tx_hash_range: Range<usize>) -> Vec<Transaction> {
+pub fn test_txs(tx_hash_range: Range<usize>) -> Vec<InternalConsensusTransaction> {
     tx_hash_range
         .map(|i| {
-            Transaction::Account(executable_invoke_tx(InvokeTxArgs {
+            InternalConsensusTransaction::RpcTransaction(internal_invoke_tx(InvokeTxArgs {
                 tx_hash: tx_hash!(i),
                 ..Default::default()
             }))

--- a/crates/starknet_batcher_types/src/batcher_types.rs
+++ b/crates/starknet_batcher_types/src/batcher_types.rs
@@ -6,8 +6,8 @@ use blockifier::transaction::objects::TransactionExecutionInfo;
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHashAndNumber, BlockInfo, BlockNumber};
+use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::StateDiffCommitment;
-use starknet_api::executable_transaction::Transaction;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::state::ThinStateDiff;
 
@@ -61,7 +61,7 @@ pub struct GetProposalContentResponse {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum GetProposalContent {
-    Txs(Vec<Transaction>),
+    Txs(Vec<InternalConsensusTransaction>),
     Finished(ProposalCommitment),
 }
 
@@ -83,7 +83,7 @@ pub struct SendProposalContentInput {
 /// The content of the stream that the consensus sends to the batcher.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SendProposalContent {
-    Txs(Vec<Transaction>),
+    Txs(Vec<InternalConsensusTransaction>),
     Finish,
     Abort,
 }


### PR DESCRIPTION
- **chore(consensus, papyrus_node): delete papyrus context**
- **refactor(papyrus_protobuf): change TransactionBatch to use ConsensusTransaction**
- **refactor(starknet_batcher): use InternalConsensusTransaction**
