### PR TITLE
feat(papyrus_base_layer): add `l1_block_at` (#3763)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11082,7 +11082,6 @@ dependencies = [
  "alloy-primitives",
  "assert_matches",
  "async-trait",
- "colored 3.0.0",
  "indexmap 2.7.0",
  "itertools 0.12.1",
  "papyrus_base_layer",

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -37,6 +37,8 @@ url = { workspace = true, features = ["serde"] }
 validator.workspace = true
 
 [dev-dependencies]
+alloy-node-bindings.workspace = true
+colored.workspace = true
 ethers-core.workspace = true
 pretty_assertions.workspace = true
 starknet-types-core.workspace = true

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -7,7 +7,7 @@ use alloy_json_rpc::RpcError;
 use alloy_primitives::Address as EthereumContractAddress;
 use alloy_provider::network::Ethereum;
 use alloy_provider::{Provider, ProviderBuilder, RootProvider};
-use alloy_rpc_types_eth::Filter as EthEventFilter;
+use alloy_rpc_types_eth::{BlockId, BlockTransactionsKind, Filter as EthEventFilter};
 use alloy_sol_types::{sol, sol_data};
 use alloy_transport::TransportErrorKind;
 use alloy_transport_http::{Client, Http};
@@ -21,7 +21,7 @@ use starknet_api::StarknetApiError;
 use url::Url;
 use validator::Validate;
 
-use crate::{BaseLayerContract, L1BlockNumber, L1Event};
+use crate::{BaseLayerContract, L1BlockNumber, L1BlockReference, L1Event};
 
 pub type EthereumBaseLayerResult<T> = Result<T, EthereumBaseLayerError>;
 
@@ -102,6 +102,23 @@ impl BaseLayerContract for EthereumBaseLayerContract {
         finality: u64,
     ) -> EthereumBaseLayerResult<Option<L1BlockNumber>> {
         Ok(self.contract.provider().get_block_number().await?.checked_sub(finality))
+    }
+
+    async fn l1_block_at(
+        &self,
+        block_number: L1BlockNumber,
+    ) -> EthereumBaseLayerResult<Option<L1BlockReference>> {
+        let only_block_header: BlockTransactionsKind = BlockTransactionsKind::default();
+        let block = self
+            .contract
+            .provider()
+            .get_block(BlockId::Number(block_number.into()), only_block_header)
+            .await?;
+
+        Ok(block.map(|block| L1BlockReference {
+            number: block.header.number,
+            hash: block.header.hash.0,
+        }))
     }
 }
 

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -46,12 +46,24 @@ pub trait BaseLayerContract {
         finality: u64,
     ) -> Result<Option<L1BlockNumber>, Self::Error>;
 
+    async fn l1_block_at(
+        &self,
+        block_number: L1BlockNumber,
+    ) -> Result<Option<L1BlockReference>, Self::Error>;
+
     /// Get specific events from the Starknet base contract between two L1 block numbers.
     async fn events(
         &self,
         block_range: RangeInclusive<L1BlockNumber>,
         event_identifiers: &[&str],
     ) -> Result<Vec<L1Event>, Self::Error>;
+}
+
+/// Reference to an L1 block, extend as needed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct L1BlockReference {
+    pub number: L1BlockNumber,
+    pub hash: [u8; 32],
 }
 
 /// Wraps Starknet L1 events with Starknet API types.

--- a/crates/starknet_l1_provider/Cargo.toml
+++ b/crates/starknet_l1_provider/Cargo.toml
@@ -29,7 +29,6 @@ validator.workspace = true
 alloy-node-bindings.workspace = true
 alloy-primitives.workspace = true
 assert_matches.workspace = true
-colored.workspace = true
 itertools.workspace = true
 papyrus_base_layer = { path = "../papyrus_base_layer", features = ["testing"] }
 pretty_assertions.workspace = true


### PR DESCRIPTION
Will be used soon in the l1 scraper, which compares block hashes of
specific block numbers in order to detect L1 reorgs.

Co-authored-by: Gilad Chase <gilad@starkware.com>

---

**Stack**:
- #3829
- #3828
- #3827
- #3826
- #3825


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*