### PR TITLE
fix(blockifier): tx_hash method signature in Transaction enum implementation

### DIFF
--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -71,10 +71,10 @@ impl Transaction {
         }
     }
 
-    pub fn tx_hash(tx: &Transaction) -> TransactionHash {
-        match tx {
-            Transaction::Account(tx) => tx.tx_hash(),
-            Transaction::L1Handler(tx) => tx.tx_hash,
+    pub fn tx_hash(&self) -> TransactionHash {
+        match self {
+            Self::Account(tx) => tx.tx_hash(),
+            Self::L1Handler(tx) => tx.tx_hash,
         }
     }
 


### PR DESCRIPTION
## Fix `tx_hash` method signature in `Transaction` enum implementation

The `tx_hash` method was previously defined as a static function taking a `&Transaction` reference as a parameter. This has been corrected by making `tx_hash` a standard instance method (`&self`), ensuring consistency with other methods such as `nonce` and `sender_address`.

This change improves usability and aligns the method signature with idiomatic patterns.