### PR TITLE
refactor(papyrus_network): use component name for network metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7833,7 +7833,6 @@ dependencies = [
  "libp2p-swarm-test",
  "metrics 0.24.1",
  "mockall",
- "papyrus_common",
  "papyrus_config",
  "papyrus_network_types",
  "pretty_assertions",

--- a/crates/papyrus_common/src/metrics.rs
+++ b/crates/papyrus_common/src/metrics.rs
@@ -1,37 +1,28 @@
 use std::sync::OnceLock;
 
 /// The central marker is the first block number that doesn't exist yet.
-pub const PAPYRUS_CENTRAL_BLOCK_MARKER: &str = "papyrus_central_block_marker";
+pub const APOLLO_CENTRAL_BLOCK_MARKER: &str = "apollo_central_block_marker";
 
 /// The header marker is the first block number for which the node does not have a header.
-pub const PAPYRUS_HEADER_MARKER: &str = "papyrus_header_marker";
+pub const APOLLO_HEADER_MARKER: &str = "apollo_header_marker";
 
 /// The body marker is the first block number for which the node does not have a body.
-pub const PAPYRUS_BODY_MARKER: &str = "papyrus_body_marker";
+pub const APOLLO_BODY_MARKER: &str = "apollo_body_marker";
 
 /// The state marker is the first block number for which the node does not have a state body.
-pub const PAPYRUS_STATE_MARKER: &str = "papyrus_state_marker";
+pub const APOLLO_STATE_MARKER: &str = "apollo_state_marker";
 
 /// The compiled class marker is the first block number for which the node does not have all of the
 /// corresponding compiled classes.
-pub const PAPYRUS_COMPILED_CLASS_MARKER: &str = "papyrus_compiled_class_marker";
+pub const APOLLO_COMPILED_CLASS_MARKER: &str = "apollo_compiled_class_marker";
 
 /// The base layer marker is the first block number for which the node does not guarantee L1
 /// finality.
-pub const PAPYRUS_BASE_LAYER_MARKER: &str = "papyrus_base_layer_marker";
+pub const APOLLO_BASE_LAYER_MARKER: &str = "apollo_base_layer_marker";
 
 /// The latency, in seconds, between a block timestamp (as state in its header) and the time the
 /// node stores the header.
-pub const PAPYRUS_HEADER_LATENCY_SEC: &str = "papyrus_header_latency";
-
-/// The number of peers this node is connected to.
-pub const PAPYRUS_NUM_CONNECTED_PEERS: &str = "papyrus_num_connected_peers";
-
-/// The number of active sessions this peer has in which it sends data.
-pub const PAPYRUS_NUM_ACTIVE_INBOUND_SESSIONS: &str = "papyrus_num_active_inbound_sessions";
-
-/// The number of active sessions this peer has in which it requests data.
-pub const PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "papyrus_num_active_outbound_sessions";
+pub const APOLLO_HEADER_LATENCY_SEC: &str = "apollo_header_latency";
 
 // TODO(Shahak): consider making this value non static and add a way to change this while the app is
 // running. e.g via a monitoring endpoint.
@@ -39,7 +30,7 @@ pub const PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "papyrus_num_active_outbo
 pub static COLLECT_PROFILING_METRICS: OnceLock<bool> = OnceLock::new();
 
 /// The height consensus is currently working on.
-pub const PAPYRUS_CONSENSUS_HEIGHT: &str = "papyrus_consensus_height";
+pub const APOLLO_CONSENSUS_HEIGHT: &str = "apollo_consensus_height";
 
 /// The number of times consensus has progressed due to the sync protocol.
-pub const PAPYRUS_CONSENSUS_SYNC_COUNT: &str = "papyrus_consensus_sync_count";
+pub const APOLLO_CONSENSUS_SYNC_COUNT: &str = "apollo_consensus_sync_count";

--- a/crates/papyrus_network/Cargo.toml
+++ b/crates/papyrus_network/Cargo.toml
@@ -29,7 +29,6 @@ libp2p = { workspace = true, features = [
   "yamux",
 ] }
 metrics.workspace = true
-papyrus_common.workspace = true
 papyrus_config.workspace = true
 papyrus_network_types.workspace = true
 replace_with.workspace = true

--- a/crates/papyrus_network/src/e2e_broadcast_test.rs
+++ b/crates/papyrus_network/src/e2e_broadcast_test.rs
@@ -10,6 +10,7 @@ use starknet_api::core::ChainId;
 use crate::discovery::DiscoveryConfig;
 use crate::gossipsub_impl::Topic;
 use crate::mixed_behaviour::MixedBehaviour;
+use crate::network_manager::test_utils::TEST_COMPONENT_NAME;
 use crate::network_manager::{BroadcastTopicClientTrait, GenericNetworkManager};
 use crate::peer_manager::PeerManagerConfig;
 use crate::sqmr;
@@ -49,7 +50,7 @@ async fn create_swarm(bootstrap_peer_multiaddr: Option<Multiaddr>) -> Swarm<Mixe
 fn create_network_manager(
     swarm: Swarm<MixedBehaviour>,
 ) -> GenericNetworkManager<Swarm<MixedBehaviour>> {
-    GenericNetworkManager::generic_new(swarm, None)
+    GenericNetworkManager::generic_new(swarm, None, TEST_COMPONENT_NAME)
 }
 
 const BUFFER_SIZE: usize = 100;

--- a/crates/papyrus_network/src/network_manager/metrics_suffixes.rs
+++ b/crates/papyrus_network/src/network_manager/metrics_suffixes.rs
@@ -1,0 +1,8 @@
+/// The number of peers this node is connected to.
+pub const APOLLO_NUM_CONNECTED_PEERS: &str = "_num_connected_peers";
+
+/// The number of active sessions this peer has in which it sends data.
+pub const APOLLO_NUM_ACTIVE_INBOUND_SESSIONS: &str = "_num_active_inbound_sessions";
+
+/// The number of active sessions this peer has in which it requests data.
+pub const APOLLO_NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "_num_active_outbound_sessions";

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -1,5 +1,5 @@
+mod network_manager_metrics;
 mod swarm_trait;
-
 #[cfg(test)]
 mod test;
 #[cfg(any(test, feature = "testing"))]
@@ -22,7 +22,6 @@ use libp2p::identity::Keypair;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{noise, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder};
 use metrics::gauge;
-use papyrus_common::metrics as papyrus_metrics;
 use papyrus_network_types::network_types::{BroadcastedMessageMetadata, OpaquePeerId};
 use sqmr::Bytes;
 use tracing::{debug, error, trace, warn};
@@ -99,7 +98,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
     // TODO(shahak): remove the advertised_multiaddr arg once we manage external addresses
     // in a behaviour.
     pub(crate) fn generic_new(mut swarm: SwarmT, advertised_multiaddr: Option<Multiaddr>) -> Self {
-        gauge!(papyrus_metrics::PAPYRUS_NUM_CONNECTED_PEERS).set(0f64);
+        gauge!(network_manager_metrics::APOLLO_NUM_CONNECTED_PEERS).set(0f64);
         let reported_peer_receivers = FuturesUnordered::new();
         reported_peer_receivers.push(futures::future::pending().boxed());
         if let Some(address) = advertised_multiaddr.clone() {
@@ -270,7 +269,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 debug!("Connected to peer id: {peer_id:?}");
-                gauge!(papyrus_metrics::PAPYRUS_NUM_CONNECTED_PEERS)
+                gauge!(network_manager_metrics::APOLLO_NUM_CONNECTED_PEERS)
                     .set(self.swarm.num_connected_peers() as f64);
             }
             SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
@@ -280,7 +279,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
                     }
                     None => debug!("Connection to {peer_id:?} closed."),
                 }
-                gauge!(papyrus_metrics::PAPYRUS_NUM_CONNECTED_PEERS)
+                gauge!(network_manager_metrics::APOLLO_NUM_CONNECTED_PEERS)
                     .set(self.swarm.num_connected_peers() as f64);
             }
             SwarmEvent::Behaviour(event) => {
@@ -416,7 +415,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             return;
         };
         self.num_active_inbound_sessions += 1;
-        gauge!(papyrus_metrics::PAPYRUS_NUM_ACTIVE_INBOUND_SESSIONS)
+        gauge!(network_manager_metrics::APOLLO_NUM_ACTIVE_INBOUND_SESSIONS)
             .set(self.num_active_inbound_sessions as f64);
         let (responses_sender, responses_receiver) = futures::channel::mpsc::channel(
             *self
@@ -578,7 +577,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         let outbound_session_id = self.swarm.send_query(query, protocol.clone());
         self.num_active_outbound_sessions += 1;
         #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
-        gauge!(papyrus_metrics::PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS)
+        gauge!(network_manager_metrics::APOLLO_NUM_ACTIVE_OUTBOUND_SESSIONS)
             .set(self.num_active_outbound_sessions as f64);
         self.sqmr_outbound_response_senders.insert(outbound_session_id, responses_sender);
         self.sqmr_outbound_report_receivers_awaiting_assignment
@@ -594,12 +593,12 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         match session_id {
             SessionId::InboundSessionId(_) => {
                 self.num_active_inbound_sessions -= 1;
-                gauge!(papyrus_metrics::PAPYRUS_NUM_ACTIVE_INBOUND_SESSIONS)
+                gauge!(network_manager_metrics::APOLLO_NUM_ACTIVE_INBOUND_SESSIONS)
                     .set(self.num_active_inbound_sessions as f64);
             }
             SessionId::OutboundSessionId(_) => {
                 self.num_active_outbound_sessions += 1;
-                gauge!(papyrus_metrics::PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS)
+                gauge!(network_manager_metrics::APOLLO_NUM_ACTIVE_OUTBOUND_SESSIONS)
                     .set(self.num_active_outbound_sessions as f64);
             }
         }

--- a/crates/papyrus_network/src/network_manager/network_manager_metrics.rs
+++ b/crates/papyrus_network/src/network_manager/network_manager_metrics.rs
@@ -1,8 +1,0 @@
-/// The number of peers this node is connected to.
-pub const APOLLO_NUM_CONNECTED_PEERS: &str = "apollo_num_connected_peers";
-
-/// The number of active sessions this peer has in which it sends data.
-pub const APOLLO_NUM_ACTIVE_INBOUND_SESSIONS: &str = "apollo_num_active_inbound_sessions";
-
-/// The number of active sessions this peer has in which it requests data.
-pub const APOLLO_NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "apollo_num_active_outbound_sessions";

--- a/crates/papyrus_network/src/network_manager/network_manager_metrics.rs
+++ b/crates/papyrus_network/src/network_manager/network_manager_metrics.rs
@@ -1,0 +1,8 @@
+/// The number of peers this node is connected to.
+pub const APOLLO_NUM_CONNECTED_PEERS: &str = "apollo_num_connected_peers";
+
+/// The number of active sessions this peer has in which it sends data.
+pub const APOLLO_NUM_ACTIVE_INBOUND_SESSIONS: &str = "apollo_num_active_inbound_sessions";
+
+/// The number of active sessions this peer has in which it requests data.
+pub const APOLLO_NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "apollo_num_active_outbound_sessions";

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -24,6 +24,7 @@ use super::swarm_trait::{Event, SwarmTrait};
 use super::{BroadcastTopicChannels, GenericNetworkManager};
 use crate::gossipsub_impl::{self, Topic};
 use crate::mixed_behaviour;
+use crate::network_manager::test_utils::TEST_COMPONENT_NAME;
 use crate::network_manager::{BroadcastTopicClientTrait, ServerQueryManager};
 use crate::sqmr::behaviour::SessionIdNotFoundError;
 use crate::sqmr::{Bytes, GenericEvent, InboundSessionId, OutboundSessionId};
@@ -198,7 +199,7 @@ impl SwarmTrait for MockSwarm {
         Ok(PeerId::random())
     }
 
-    // TODO (shahak): Add test for continue propagation.
+    // TODO(shahak): Add test for continue propagation.
     fn continue_propagation(&mut self, _message_metadata: super::BroadcastedMessageMetadata) {
         unimplemented!()
     }
@@ -217,7 +218,8 @@ async fn register_sqmr_protocol_client_and_use_channels() {
     mock_swarm.first_polled_event_notifier = Some(event_notifier);
 
     // network manager to register subscriber
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_COMPONENT_NAME);
 
     // register subscriber and send payload
     let mut payload_sender = network_manager.register_sqmr_protocol_client::<Vec<u8>, Vec<u8>>(
@@ -279,7 +281,8 @@ async fn process_incoming_query() {
     let get_responses_fut = mock_swarm.get_responses_sent_to_inbound_session(inbound_session_id);
     let mut get_supported_inbound_protocol_fut = mock_swarm.get_supported_inbound_protocol();
 
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_COMPONENT_NAME);
 
     let mut inbound_payload_receiver = network_manager
         .register_sqmr_protocol_server::<Vec<u8>, Vec<u8>>(protocol.to_string(), BUFFER_SIZE);
@@ -315,7 +318,8 @@ async fn broadcast_message() {
     let mut mock_swarm = MockSwarm::default();
     let mut messages_we_broadcasted_stream = mock_swarm.stream_messages_we_broadcasted();
 
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_COMPONENT_NAME);
 
     let mut broadcast_topic_client = network_manager
         .register_broadcast_topic(topic.clone(), BUFFER_SIZE)
@@ -351,7 +355,8 @@ async fn receive_broadcasted_message_and_report_it() {
     )));
     let mut reported_peer_receiver = mock_swarm.get_reported_peers_stream();
 
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_COMPONENT_NAME);
 
     let BroadcastTopicChannels {
         mut broadcast_topic_client,

--- a/crates/papyrus_network/src/network_manager/test_utils.rs
+++ b/crates/papyrus_network/src/network_manager/test_utils.rs
@@ -31,6 +31,8 @@ use super::{
 use crate::sqmr::Bytes;
 use crate::NetworkConfig;
 
+pub const TEST_COMPONENT_NAME: &str = "test";
+
 pub fn mock_register_sqmr_protocol_client<Query, Response>(
     buffer_size: usize,
     // TODO(eitan): wrap second type with a struct to make it more readable
@@ -190,7 +192,7 @@ where
 {
     const BUFFER_SIZE: usize = 1000;
 
-    let mut network_manager = NetworkManager::new(network_config, None);
+    let mut network_manager = NetworkManager::new(network_config, None, TEST_COMPONENT_NAME);
     let broadcast_channels =
         network_manager.register_broadcast_topic(topic.clone(), BUFFER_SIZE).unwrap();
 

--- a/crates/papyrus_node/src/run.rs
+++ b/crates/papyrus_node/src/run.rs
@@ -54,6 +54,8 @@ const GENESIS_HASH: &str = "0x0";
 // Duration between updates to the storage metrics (those in the collect_storage_metrics function).
 const STORAGE_METRICS_UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 
+const PAPYRUS_NETWORK_METRICS_PREFIX: &str = "papyrus";
+
 pub struct PapyrusResources {
     pub storage_reader: StorageReader,
     pub storage_writer: StorageWriter,
@@ -118,6 +120,7 @@ fn build_network_manager(
     let network_manager = network_manager::NetworkManager::new(
         network_config.clone(),
         Some(VERSION_FULL.to_string()),
+        PAPYRUS_NETWORK_METRICS_PREFIX,
     );
     let local_peer_id = network_manager.get_local_peer_id();
 

--- a/crates/papyrus_p2p_sync/src/client/header.rs
+++ b/crates/papyrus_p2p_sync/src/client/header.rs
@@ -47,7 +47,7 @@ impl BlockData for SignedBlockHeader {
                     .expect("Vec::first should return a value on a vector of size 1"),
                 )?
                 .commit()?;
-            gauge!(papyrus_metrics::PAPYRUS_HEADER_MARKER).set(
+            gauge!(papyrus_metrics::APOLLO_HEADER_MARKER).set(
                 self.block_header.block_header_without_hash.block_number.unchecked_next().0 as f64,
             );
             // TODO(shahak): Fix code dup with central sync
@@ -62,7 +62,7 @@ impl BlockData for SignedBlockHeader {
             let header_latency = time_delta.num_seconds();
             debug!("Header latency: {}.", header_latency);
             if header_latency >= 0 {
-                gauge!(papyrus_metrics::PAPYRUS_HEADER_LATENCY_SEC).set(header_latency as f64);
+                gauge!(papyrus_metrics::APOLLO_HEADER_LATENCY_SEC).set(header_latency as f64);
             }
             Ok(())
         }

--- a/crates/papyrus_p2p_sync/src/client/state_diff.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff.rs
@@ -34,7 +34,7 @@ impl BlockData for (ThinStateDiff, BlockNumber) {
     ) -> BoxFuture<'a, Result<(), P2pSyncClientError>> {
         async move {
             storage_writer.begin_rw_txn()?.append_state_diff(self.1, self.0)?.commit()?;
-            gauge!(papyrus_metrics::PAPYRUS_STATE_MARKER).set(self.1.unchecked_next().0 as f64);
+            gauge!(papyrus_metrics::APOLLO_STATE_MARKER).set(self.1.unchecked_next().0 as f64);
             Ok(())
         }
         .boxed()

--- a/crates/papyrus_sync/src/lib.rs
+++ b/crates/papyrus_sync/src/lib.rs
@@ -429,9 +429,9 @@ impl<
             .append_block_signature(block_number, signature)?
             .append_body(block_number, block.body)?
             .commit()?;
-        metrics::gauge!(papyrus_metrics::PAPYRUS_HEADER_MARKER)
+        metrics::gauge!(papyrus_metrics::APOLLO_HEADER_MARKER)
             .set(block_number.unchecked_next().0 as f64);
-        metrics::gauge!(papyrus_metrics::PAPYRUS_BODY_MARKER)
+        metrics::gauge!(papyrus_metrics::APOLLO_BODY_MARKER)
             .set(block_number.unchecked_next().0 as f64);
         let time_delta = Utc::now()
             - Utc
@@ -441,7 +441,7 @@ impl<
         let header_latency = time_delta.num_seconds();
         debug!("Header latency: {}.", header_latency);
         if header_latency >= 0 {
-            metrics::gauge!(papyrus_metrics::PAPYRUS_HEADER_LATENCY_SEC).set(header_latency as f64);
+            metrics::gauge!(papyrus_metrics::APOLLO_HEADER_LATENCY_SEC).set(header_latency as f64);
         }
         Ok(())
     }
@@ -478,10 +478,10 @@ impl<
             )?
             .commit()?;
 
-        metrics::gauge!(papyrus_metrics::PAPYRUS_STATE_MARKER)
+        metrics::gauge!(papyrus_metrics::APOLLO_STATE_MARKER)
             .set(block_number.unchecked_next().0 as f64);
         let compiled_class_marker = self.reader.begin_ro_txn()?.get_compiled_class_marker()?;
-        metrics::gauge!(papyrus_metrics::PAPYRUS_COMPILED_CLASS_MARKER)
+        metrics::gauge!(papyrus_metrics::APOLLO_COMPILED_CLASS_MARKER)
             .set(compiled_class_marker.0 as f64);
 
         // Info the user on syncing the block once all the data is stored.
@@ -506,7 +506,7 @@ impl<
                 txn.commit()?;
                 let compiled_class_marker =
                     self.reader.begin_ro_txn()?.get_compiled_class_marker()?;
-                metrics::gauge!(papyrus_metrics::PAPYRUS_COMPILED_CLASS_MARKER)
+                metrics::gauge!(papyrus_metrics::APOLLO_COMPILED_CLASS_MARKER)
                     .set(compiled_class_marker.0 as f64);
                 debug!("Added compiled class.");
                 Ok(())
@@ -549,7 +549,7 @@ impl<
         if txn.get_base_layer_block_marker()? != block_number.unchecked_next() {
             info!("Verified block {block_number} hash against base layer.");
             txn.update_base_layer_block_marker(&block_number.unchecked_next())?.commit()?;
-            metrics::gauge!(papyrus_metrics::PAPYRUS_BASE_LAYER_MARKER)
+            metrics::gauge!(papyrus_metrics::APOLLO_BASE_LAYER_MARKER)
                 .set(block_number.unchecked_next().0 as f64);
         }
         Ok(())
@@ -684,7 +684,7 @@ fn stream_new_blocks<
             let central_block_marker = latest_central_block.map_or(
                 BlockNumber::default(), |block_hash_and_number| block_hash_and_number.number.unchecked_next()
             );
-            metrics::gauge!(papyrus_metrics::PAPYRUS_CENTRAL_BLOCK_MARKER).set(central_block_marker.0 as f64);
+            metrics::gauge!(papyrus_metrics::APOLLO_CENTRAL_BLOCK_MARKER).set(central_block_marker.0 as f64);
             if header_marker == central_block_marker {
                 // Only if the node have the last block and state (without casms), sync pending data.
                 if collect_pending_data && reader.begin_ro_txn()?.get_state_marker()? == header_marker{

--- a/crates/starknet_consensus/src/manager.rs
+++ b/crates/starknet_consensus/src/manager.rs
@@ -16,7 +16,7 @@ use futures::channel::mpsc;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use metrics::counter;
-use papyrus_common::metrics::{PAPYRUS_CONSENSUS_HEIGHT, PAPYRUS_CONSENSUS_SYNC_COUNT};
+use papyrus_common::metrics::{APOLLO_CONSENSUS_HEIGHT, APOLLO_CONSENSUS_SYNC_COUNT};
 use papyrus_network::network_manager::BroadcastTopicClientTrait;
 use papyrus_network_types::network_types::BroadcastedMessageMetadata;
 use papyrus_protobuf::consensus::{ProposalInit, Vote};
@@ -79,7 +79,7 @@ where
     let mut manager = MultiHeightManager::new(validator_id, timeouts);
     #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
     loop {
-        metrics::gauge!(PAPYRUS_CONSENSUS_HEIGHT).set(current_height.0 as f64);
+        metrics::gauge!(APOLLO_CONSENSUS_HEIGHT).set(current_height.0 as f64);
 
         let must_observer = current_height < start_active_height;
         match manager
@@ -101,7 +101,7 @@ where
             }
             RunHeightRes::Sync => {
                 info!(height = current_height.0, "Decision learned via sync protocol.");
-                counter!(PAPYRUS_CONSENSUS_SYNC_COUNT).increment(1);
+                counter!(APOLLO_CONSENSUS_SYNC_COUNT).increment(1);
             }
         }
         current_height = current_height.unchecked_next();

--- a/crates/starknet_consensus_manager/src/consensus_manager.rs
+++ b/crates/starknet_consensus_manager/src/consensus_manager.rs
@@ -28,6 +28,7 @@ use crate::config::ConsensusManagerConfig;
 pub const BROADCAST_BUFFER_SIZE: usize = 10000;
 pub const CONSENSUS_PROPOSALS_TOPIC: &str = "consensus_proposals";
 pub const CONSENSUS_VOTES_TOPIC: &str = "consensus_votes";
+const CONSENSUS_NETWORK_METRICS_PREFIX: &str = "consensus";
 
 #[derive(Clone)]
 pub struct ConsensusManager {
@@ -55,7 +56,11 @@ impl ConsensusManager {
             return std::future::pending().await;
         }
 
-        let mut network_manager = NetworkManager::new(self.config.network_config.clone(), None);
+        let mut network_manager = NetworkManager::new(
+            self.config.network_config.clone(),
+            None,
+            CONSENSUS_NETWORK_METRICS_PREFIX,
+        );
 
         let proposals_broadcast_channels = network_manager
             .register_broadcast_topic::<StreamMessage<ProposalPart, HeightAndRound>>(

--- a/crates/starknet_mempool_p2p/src/lib.rs
+++ b/crates/starknet_mempool_p2p/src/lib.rs
@@ -14,6 +14,7 @@ use crate::propagator::MempoolP2pPropagator;
 use crate::runner::MempoolP2pRunner;
 
 pub const MEMPOOL_TOPIC: &str = "starknet_mempool_transaction_propagation/0.1.0";
+const MEMPOOL_P2P_METRICS_PREFIX: &str = "mempool_p2p";
 
 pub fn create_p2p_propagator_and_runner(
     mempool_p2p_config: MempoolP2pConfig,
@@ -28,6 +29,7 @@ pub fn create_p2p_propagator_and_runner(
         mempool_p2p_config.network_config,
         // TODO(Shahak): Consider filling this once the sequencer node has a name.
         None,
+        MEMPOOL_P2P_METRICS_PREFIX,
     );
     let BroadcastTopicChannels { broadcasted_messages_receiver, broadcast_topic_client } =
         network_manager

--- a/crates/starknet_state_sync/src/runner/mod.rs
+++ b/crates/starknet_state_sync/src/runner/mod.rs
@@ -39,6 +39,8 @@ use tokio::sync::RwLock;
 
 use crate::config::{CentralSyncClientConfig, StateSyncConfig};
 
+const P2P_STATE_SYNC_METRICS_PREFIX: &str = "state_sync";
+
 pub struct StateSyncRunner {
     network_future: BoxFuture<'static, Result<(), NetworkError>>,
     // TODO(Matan): change client and server to requester and responder respectively
@@ -85,8 +87,11 @@ impl StateSyncRunner {
             network_config,
         } = config;
 
-        let mut network_manager =
-            network_manager::NetworkManager::new(network_config, Some(VERSION_FULL.to_string()));
+        let mut network_manager = network_manager::NetworkManager::new(
+            network_config,
+            Some(VERSION_FULL.to_string()),
+            P2P_STATE_SYNC_METRICS_PREFIX,
+        );
 
         let (storage_reader, storage_writer) =
             open_storage(storage_config).expect("StateSyncRunner failed opening storage");


### PR DESCRIPTION
- **refactor(papyrus_common, papyrus_network): move metrics and rename**
- **refactor(papyrus_network): use component name for network metrics**
