### PR TITLE
refactor(papyrus_p2p_sync): add wait period for other protocol

### DIFF
--- a/config/papyrus/default_config.json
+++ b/config/papyrus/default_config.json
@@ -289,6 +289,11 @@
     "privacy": "Public",
     "value": 50
   },
+  "p2p_sync.wait_period_for_other_protocol": {
+    "description": "Time in millisseconds to wait for a dependency protocol to advance (e.g.state diff sync depends on header sync)",
+    "privacy": "Public",
+    "value": 50
+  },
   "rpc.chain_id": {
     "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
     "pointer_target": "chain_id",

--- a/config/sequencer/default_config.json
+++ b/config/sequencer/default_config.json
@@ -1304,6 +1304,11 @@
     "privacy": "Public",
     "value": 50
   },
+  "state_sync_config.p2p_sync_client_config.wait_period_for_other_protocol": {
+    "description": "Time in millisseconds to wait for a dependency protocol to advance (e.g.state diff sync depends on header sync)",
+    "privacy": "Public",
+    "value": 50
+  },
   "state_sync_config.storage_config.db_config.chain_id": {
     "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
     "pointer_target": "chain_id",

--- a/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
+++ b/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/papyrus_node/src/config/config_test.rs
 expression: dumped_default_config
+snapshot_kind: text
 ---
 {
   "base_layer.node_url": {
@@ -342,6 +343,13 @@ expression: dumped_default_config
   },
   "p2p_sync.wait_period_for_new_data": {
     "description": "Time in millisseconds to wait when a query returned with partial data before sending a new query",
+    "value": {
+      "$serde_json::private::Number": "50"
+    },
+    "privacy": "Public"
+  },
+  "p2p_sync.wait_period_for_other_protocol": {
+    "description": "Time in millisseconds to wait for a dependency protocol to advance (e.g.state diff sync depends on header sync)",
     "value": {
       "$serde_json::private::Number": "50"
     },

--- a/crates/papyrus_p2p_sync/src/client/block_data_stream_builder.rs
+++ b/crates/papyrus_p2p_sync/src/client/block_data_stream_builder.rs
@@ -103,6 +103,7 @@ where
         storage_reader: StorageReader,
         mut internal_block_receiver: Option<Receiver<SyncBlock>>,
         wait_period_for_new_data: Duration,
+        wait_period_for_other_protocol: Duration,
         num_blocks_per_query: u64,
     ) -> BoxStream<'static, BlockDataResult>
     where
@@ -124,7 +125,7 @@ where
                         let limit = min(last_block_number.0 - current_block_number.0, num_blocks_per_query);
                         if limit == 0 {
                             trace!("{:?} sync is waiting for a new {}", Self::TYPE_DESCRIPTION, description);
-                            tokio::time::sleep(wait_period_for_new_data).await;
+                            tokio::time::sleep(wait_period_for_other_protocol).await;
                             continue;
                         }
                         limit

--- a/crates/papyrus_p2p_sync/src/client/class_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/class_test.rs
@@ -127,7 +127,7 @@ async fn class_basic_flow() {
         }
         .boxed()
     })));
-    actions.push(Action::SimulateWaitPeriodForNewData);
+    actions.push(Action::SimulateWaitPeriodForOtherProtocol);
 
     actions.push(Action::ReceiveQuery(
         Box::new(move |query| {

--- a/crates/papyrus_p2p_sync/src/client/mod.rs
+++ b/crates/papyrus_p2p_sync/src/client/mod.rs
@@ -64,6 +64,8 @@ pub struct P2pSyncClientConfig {
     pub num_block_classes_per_query: u64,
     #[serde(deserialize_with = "deserialize_milliseconds_to_duration")]
     pub wait_period_for_new_data: Duration,
+    #[serde(deserialize_with = "deserialize_milliseconds_to_duration")]
+    pub wait_period_for_other_protocol: Duration,
     pub buffer_size: usize,
 }
 
@@ -103,6 +105,13 @@ impl SerializeConfig for P2pSyncClientConfig {
                 ParamPrivacyInput::Public,
             ),
             ser_param(
+                "wait_period_for_other_protocol",
+                &self.wait_period_for_other_protocol.as_millis(),
+                "Time in millisseconds to wait for a dependency protocol to advance (e.g.state \
+                 diff sync depends on header sync)",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
                 "buffer_size",
                 &self.buffer_size,
                 "Size of the buffer for read from the storage and for incoming responses.",
@@ -122,6 +131,7 @@ impl Default for P2pSyncClientConfig {
             num_block_transactions_per_query: 100,
             num_block_classes_per_query: 100,
             wait_period_for_new_data: Duration::from_millis(50),
+            wait_period_for_other_protocol: Duration::from_millis(50),
             // TODO(eitan): split this by protocol
             buffer_size: 100000,
         }
@@ -181,6 +191,7 @@ impl P2pSyncClientChannels {
             storage_reader.clone(),
             Some(internal_blocks_receivers.header_receiver),
             config.wait_period_for_new_data,
+            config.wait_period_for_other_protocol,
             config.num_headers_per_query,
         );
 
@@ -189,6 +200,7 @@ impl P2pSyncClientChannels {
             storage_reader.clone(),
             Some(internal_blocks_receivers.state_diff_receiver),
             config.wait_period_for_new_data,
+            config.wait_period_for_other_protocol,
             config.num_block_state_diffs_per_query,
         );
 
@@ -197,6 +209,7 @@ impl P2pSyncClientChannels {
             storage_reader.clone(),
             Some(internal_blocks_receivers.transaction_receiver),
             config.wait_period_for_new_data,
+            config.wait_period_for_other_protocol,
             config.num_block_transactions_per_query,
         );
 
@@ -205,6 +218,7 @@ impl P2pSyncClientChannels {
             storage_reader.clone(),
             Some(internal_blocks_receivers.class_receiver),
             config.wait_period_for_new_data,
+            config.wait_period_for_other_protocol,
             config.num_block_classes_per_query,
         );
 

--- a/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/state_diff_test.rs
@@ -133,7 +133,7 @@ async fn state_diff_basic_flow() {
         }
         .boxed()
     })));
-    actions.push(Action::SimulateWaitPeriodForNewData);
+    actions.push(Action::SimulateWaitPeriodForOtherProtocol);
 
     let len = state_diffs_and_chunks.len();
     actions.push(Action::ReceiveQuery(

--- a/crates/papyrus_p2p_sync/src/client/test_utils.rs
+++ b/crates/papyrus_p2p_sync/src/client/test_utils.rs
@@ -59,6 +59,7 @@ pub const CLASS_DIFF_QUERY_LENGTH: u64 = 3;
 pub const TRANSACTION_QUERY_LENGTH: u64 = 3;
 pub const SLEEP_DURATION_TO_LET_SYNC_ADVANCE: Duration = Duration::from_millis(10);
 pub const WAIT_PERIOD_FOR_NEW_DATA: Duration = Duration::from_secs(1);
+pub const WAIT_PERIOD_FOR_OTHER_PROTOCOL: Duration = Duration::from_secs(1);
 pub const TIMEOUT_FOR_NEW_QUERY_AFTER_PARTIAL_RESPONSE: Duration =
     WAIT_PERIOD_FOR_NEW_DATA.saturating_add(Duration::from_secs(1));
 
@@ -69,6 +70,7 @@ lazy_static! {
         num_block_transactions_per_query: TRANSACTION_QUERY_LENGTH,
         num_block_classes_per_query: CLASS_DIFF_QUERY_LENGTH,
         wait_period_for_new_data: WAIT_PERIOD_FOR_NEW_DATA,
+        wait_period_for_other_protocol: WAIT_PERIOD_FOR_OTHER_PROTOCOL,
         buffer_size: BUFFER_SIZE,
     };
 }
@@ -168,9 +170,8 @@ pub enum Action {
     SendInternalBlock(SyncBlock),
     /// Sleep for SLEEP_DURATION_TO_LET_SYNC_ADVANCE duration.
     SleepToLetSyncAdvance,
-    // TODO(noamsp): Rename once we split wait_period_for_new_data.
-    /// Simulate WAIT_PERIOD_FOR_NEW_DATA duration has passed.
-    SimulateWaitPeriodForNewData,
+    /// Simulate WAIT_PERIOD_FOR_OTHER_PROTOCOL duration has passed.
+    SimulateWaitPeriodForOtherProtocol,
 }
 
 // TODO(shahak): add support for state diffs, transactions and classes.
@@ -191,6 +192,7 @@ pub async fn run_test(
             .unwrap_or(1),
         num_block_classes_per_query: max_query_lengths.get(&DataType::Class).cloned().unwrap_or(1),
         wait_period_for_new_data: WAIT_PERIOD_FOR_NEW_DATA,
+        wait_period_for_other_protocol: WAIT_PERIOD_FOR_OTHER_PROTOCOL,
         buffer_size: BUFFER_SIZE,
     };
     let class_manager_client = class_manager_client.unwrap_or_default();
@@ -321,9 +323,9 @@ pub async fn run_test(
                     Action::SleepToLetSyncAdvance => {
                         tokio::time::sleep(SLEEP_DURATION_TO_LET_SYNC_ADVANCE).await;
                     }
-                    Action::SimulateWaitPeriodForNewData => {
+                    Action::SimulateWaitPeriodForOtherProtocol => {
                         tokio::time::pause();
-                        tokio::time::advance(WAIT_PERIOD_FOR_NEW_DATA).await;
+                        tokio::time::advance(WAIT_PERIOD_FOR_OTHER_PROTOCOL).await;
                         tokio::time::resume();
                     }
                 }

--- a/crates/papyrus_p2p_sync/src/client/transaction_test.rs
+++ b/crates/papyrus_p2p_sync/src/client/transaction_test.rs
@@ -74,7 +74,7 @@ async fn transaction_basic_flow() {
         }
         .boxed()
     })));
-    actions.push(Action::SimulateWaitPeriodForNewData);
+    actions.push(Action::SimulateWaitPeriodForOtherProtocol);
 
     // Send transactions for each block and then validate they were written
     for (i, BlockBody { transactions, transaction_outputs, transaction_hashes }) in


### PR DESCRIPTION
split wait period for new data into 2 configs.
when p2p_sync waits for a dependency protocol to advance, it waits for
wait_period_for_other_protocol duration.
fixes the client tests using this config accordingly.