### PR TITLE
chore(ci): print filename in case of error in todo_checker

### DIFF
--- a/scripts/named_todos.py
+++ b/scripts/named_todos.py
@@ -31,11 +31,16 @@ def validate_todo_format(file_path: str) -> bool:
     # parenthesis bounding a non-empty string (owner name), and a colon.
     required_comment_todo_pattern = re.compile(r"(\/\/|#) ?TODO\([^)]+\):")
     invalid_todos = []
-    with open(file_path, "r") as file:
-        for line_number, line in enumerate(file, start=1):
-            if comment_todo_pattern.search(line):
-                if not required_comment_todo_pattern.search(line):
-                    invalid_todos.append((file_path, line_number, line.strip()))
+    try: 
+        with open(file_path, "r") as file:
+            for line_number, line in enumerate(file, start=1):
+                if comment_todo_pattern.search(line):
+                    if not required_comment_todo_pattern.search(line):
+                        invalid_todos.append((file_path, line_number, line.strip()))
+    except Exception as e:
+        # Make sure to report which file caused the error before re-raising the exception.
+        print(f"Error while reading file {file_path}: {e}")
+        raise e
     if len(invalid_todos) > 0:
         print(f"{len(invalid_todos)} invalid TODOs found.")
         for file_path, line_number, line in invalid_todos:


### PR DESCRIPTION
I used a try/catch with a generic Exception because I am re-raising it. I just want to know which file caused the error. 

One case that I found was when I accidentally had a binary file in the PR. It could not be parsed so the script crashed and I had to guess which file caused it. 