### PR TITLE
chore(blockifier): remove fn into_keys, fn keys is used instead, created in PR #3580

### DIFF
--- a/crates/blockifier/src/bouncer_test.rs
+++ b/crates/blockifier/src/bouncer_test.rs
@@ -257,7 +257,7 @@ fn test_bouncer_try_update(#[case] added_ecdsa: usize, #[case] scenario: &'stati
         ..Default::default()
     };
     let tx_state_changes_keys =
-        transactional_state.get_actual_state_changes().unwrap().state_maps.into_keys();
+        transactional_state.get_actual_state_changes().unwrap().state_maps.keys();
 
     // TODO(Yoni, 1/10/2024): simplify this test and move tx-too-large cases out.
 

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -355,16 +355,6 @@ impl StateMaps {
         modified_contracts
     }
 
-    pub fn into_keys(self) -> StateChangesKeys {
-        StateChangesKeys {
-            modified_contracts: self.get_contract_addresses(),
-            nonce_keys: self.nonces.into_keys().collect(),
-            class_hash_keys: self.class_hashes.into_keys().collect(),
-            storage_keys: self.storage.into_keys().collect(),
-            compiled_class_hash_keys: self.compiled_class_hashes.into_keys().collect(),
-        }
-    }
-
     pub fn keys(&self) -> StateChangesKeys {
         StateChangesKeys {
             modified_contracts: self.get_contract_addresses(),

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -547,7 +547,7 @@ fn test_contract_cache_is_used() {
 #[test]
 fn test_cache_get_write_keys() {
     // Trivial case.
-    assert_eq!(StateMaps::default().into_keys(), StateChangesKeys::default());
+    assert_eq!(StateMaps::default().keys(), StateChangesKeys::default());
 
     // Interesting case.
     let some_felt = felt!("0x1");
@@ -592,7 +592,7 @@ fn test_cache_get_write_keys() {
         ]),
     };
 
-    assert_eq!(state_maps.into_keys(), expected_keys);
+    assert_eq!(state_maps.keys(), expected_keys);
 }
 
 #[test]

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -208,7 +208,7 @@ impl<U: UpdatableState> ExecutableTransaction<U> for Transaction {
         // Check if the transaction is too large to fit any block.
         // TODO(Yoni, 1/8/2024): consider caching these two.
         let tx_execution_summary = tx_execution_info.summarize(&block_context.versioned_constants);
-        let mut tx_state_changes_keys = state.get_actual_state_changes()?.state_maps.into_keys();
+        let mut tx_state_changes_keys = state.get_actual_state_changes()?.state_maps.keys();
         tx_state_changes_keys.update_sequencer_key_in_storage(
             &block_context.to_tx_context(self),
             &tx_execution_info,


### PR DESCRIPTION
in PR #3580