### PR TITLE
refactor(papyrus_network): name network metrics by the component

### DIFF
--- a/crates/papyrus_network/src/e2e_broadcast_test.rs
+++ b/crates/papyrus_network/src/e2e_broadcast_test.rs
@@ -10,6 +10,7 @@ use starknet_api::core::ChainId;
 use crate::discovery::DiscoveryConfig;
 use crate::gossipsub_impl::Topic;
 use crate::mixed_behaviour::MixedBehaviour;
+use crate::network_manager::test_utils::TEST_METRICS_PREFIX;
 use crate::network_manager::{BroadcastTopicClientTrait, GenericNetworkManager};
 use crate::peer_manager::PeerManagerConfig;
 use crate::sqmr;
@@ -49,7 +50,7 @@ async fn create_swarm(bootstrap_peer_multiaddr: Option<Multiaddr>) -> Swarm<Mixe
 fn create_network_manager(
     swarm: Swarm<MixedBehaviour>,
 ) -> GenericNetworkManager<Swarm<MixedBehaviour>> {
-    GenericNetworkManager::generic_new(swarm, None)
+    GenericNetworkManager::generic_new(swarm, None, TEST_METRICS_PREFIX)
 }
 
 const BUFFER_SIZE: usize = 100;

--- a/crates/papyrus_network/src/network_manager/metrics_suffixes.rs
+++ b/crates/papyrus_network/src/network_manager/metrics_suffixes.rs
@@ -1,0 +1,8 @@
+/// The number of peers this node is connected to.
+pub const NUM_CONNECTED_PEERS: &str = "_num_connected_peers";
+
+/// The number of active sessions this peer has in which it sends data.
+pub const NUM_ACTIVE_INBOUND_SESSIONS: &str = "_num_active_inbound_sessions";
+
+/// The number of active sessions this peer has in which it requests data.
+pub const NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "_num_active_outbound_sessions";

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -1,4 +1,4 @@
-mod network_manager_metrics;
+mod metrics_suffixes;
 mod swarm_trait;
 #[cfg(test)]
 mod test;
@@ -67,6 +67,7 @@ pub struct GenericNetworkManager<SwarmT: SwarmTrait> {
     // Fields for metrics
     num_active_inbound_sessions: usize,
     num_active_outbound_sessions: usize,
+    metrics_prefix: String,
 }
 
 impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
@@ -97,8 +98,13 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
 
     // TODO(shahak): remove the advertised_multiaddr arg once we manage external addresses
     // in a behaviour.
-    pub(crate) fn generic_new(mut swarm: SwarmT, advertised_multiaddr: Option<Multiaddr>) -> Self {
-        gauge!(network_manager_metrics::PAPYRUS_NUM_CONNECTED_PEERS).set(0f64);
+    pub(crate) fn generic_new(
+        mut swarm: SwarmT,
+        advertised_multiaddr: Option<Multiaddr>,
+        metrics_prefix: &str,
+    ) -> Self {
+        let metrics_prefix = metrics_prefix.to_string();
+        gauge!(metrics_prefix.clone() + metrics_suffixes::NUM_CONNECTED_PEERS).set(0f64);
         let reported_peer_receivers = FuturesUnordered::new();
         reported_peer_receivers.push(futures::future::pending().boxed());
         if let Some(address) = advertised_multiaddr.clone() {
@@ -126,6 +132,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             continue_propagation_receiver,
             num_active_inbound_sessions: 0,
             num_active_outbound_sessions: 0,
+            metrics_prefix,
         }
     }
 
@@ -269,7 +276,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 debug!("Connected to peer id: {peer_id:?}");
-                gauge!(network_manager_metrics::PAPYRUS_NUM_CONNECTED_PEERS)
+                gauge!(self.metrics_prefix.clone() + metrics_suffixes::NUM_CONNECTED_PEERS)
                     .set(self.swarm.num_connected_peers() as f64);
             }
             SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
@@ -279,7 +286,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
                     }
                     None => debug!("Connection to {peer_id:?} closed."),
                 }
-                gauge!(network_manager_metrics::PAPYRUS_NUM_CONNECTED_PEERS)
+                gauge!(self.metrics_prefix.clone() + metrics_suffixes::NUM_CONNECTED_PEERS)
                     .set(self.swarm.num_connected_peers() as f64);
             }
             SwarmEvent::Behaviour(event) => {
@@ -415,7 +422,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             return;
         };
         self.num_active_inbound_sessions += 1;
-        gauge!(network_manager_metrics::PAPYRUS_NUM_ACTIVE_INBOUND_SESSIONS)
+        gauge!(self.metrics_prefix.clone() + metrics_suffixes::NUM_ACTIVE_INBOUND_SESSIONS)
             .set(self.num_active_inbound_sessions as f64);
         let (responses_sender, responses_receiver) = futures::channel::mpsc::channel(
             *self
@@ -577,7 +584,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         let outbound_session_id = self.swarm.send_query(query, protocol.clone());
         self.num_active_outbound_sessions += 1;
         #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
-        gauge!(network_manager_metrics::PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS)
+        gauge!(self.metrics_prefix.clone() + metrics_suffixes::NUM_ACTIVE_OUTBOUND_SESSIONS)
             .set(self.num_active_outbound_sessions as f64);
         self.sqmr_outbound_response_senders.insert(outbound_session_id, responses_sender);
         self.sqmr_outbound_report_receivers_awaiting_assignment
@@ -593,13 +600,15 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         match session_id {
             SessionId::InboundSessionId(_) => {
                 self.num_active_inbound_sessions -= 1;
-                gauge!(network_manager_metrics::PAPYRUS_NUM_ACTIVE_INBOUND_SESSIONS)
+                gauge!(self.metrics_prefix.clone() + metrics_suffixes::NUM_ACTIVE_INBOUND_SESSIONS)
                     .set(self.num_active_inbound_sessions as f64);
             }
             SessionId::OutboundSessionId(_) => {
                 self.num_active_outbound_sessions += 1;
-                gauge!(network_manager_metrics::PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS)
-                    .set(self.num_active_outbound_sessions as f64);
+                gauge!(
+                    self.metrics_prefix.clone() + metrics_suffixes::NUM_ACTIVE_OUTBOUND_SESSIONS
+                )
+                .set(self.num_active_outbound_sessions as f64);
             }
         }
     }
@@ -638,7 +647,7 @@ fn send_now<Item>(
 pub type NetworkManager = GenericNetworkManager<Swarm<mixed_behaviour::MixedBehaviour>>;
 
 impl NetworkManager {
-    pub fn new(config: NetworkConfig, node_version: Option<String>) -> Self {
+    pub fn new(config: NetworkConfig, node_version: Option<String>, metrics_prefix: &str) -> Self {
         let NetworkConfig {
             tcp_port,
             session_timeout,
@@ -693,7 +702,7 @@ impl NetworkManager {
                 .with_p2p(*swarm.local_peer_id())
                 .expect("advertised_multiaddr has a peer id different than the local peer id")
         });
-        Self::generic_new(swarm, advertised_multiaddr)
+        Self::generic_new(swarm, advertised_multiaddr, metrics_prefix)
     }
 
     pub fn get_local_peer_id(&self) -> String {

--- a/crates/papyrus_network/src/network_manager/network_manager_metrics.rs
+++ b/crates/papyrus_network/src/network_manager/network_manager_metrics.rs
@@ -1,8 +1,0 @@
-/// The number of peers this node is connected to.
-pub const PAPYRUS_NUM_CONNECTED_PEERS: &str = "papyrus_num_connected_peers";
-
-/// The number of active sessions this peer has in which it sends data.
-pub const PAPYRUS_NUM_ACTIVE_INBOUND_SESSIONS: &str = "papyrus_num_active_inbound_sessions";
-
-/// The number of active sessions this peer has in which it requests data.
-pub const PAPYRUS_NUM_ACTIVE_OUTBOUND_SESSIONS: &str = "papyrus_num_active_outbound_sessions";

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -24,6 +24,7 @@ use super::swarm_trait::{Event, SwarmTrait};
 use super::{BroadcastTopicChannels, GenericNetworkManager};
 use crate::gossipsub_impl::{self, Topic};
 use crate::mixed_behaviour;
+use crate::network_manager::test_utils::TEST_METRICS_PREFIX;
 use crate::network_manager::{BroadcastTopicClientTrait, ServerQueryManager};
 use crate::sqmr::behaviour::SessionIdNotFoundError;
 use crate::sqmr::{Bytes, GenericEvent, InboundSessionId, OutboundSessionId};
@@ -217,7 +218,8 @@ async fn register_sqmr_protocol_client_and_use_channels() {
     mock_swarm.first_polled_event_notifier = Some(event_notifier);
 
     // network manager to register subscriber
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_METRICS_PREFIX);
 
     // register subscriber and send payload
     let mut payload_sender = network_manager.register_sqmr_protocol_client::<Vec<u8>, Vec<u8>>(
@@ -279,7 +281,8 @@ async fn process_incoming_query() {
     let get_responses_fut = mock_swarm.get_responses_sent_to_inbound_session(inbound_session_id);
     let mut get_supported_inbound_protocol_fut = mock_swarm.get_supported_inbound_protocol();
 
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_METRICS_PREFIX);
 
     let mut inbound_payload_receiver = network_manager
         .register_sqmr_protocol_server::<Vec<u8>, Vec<u8>>(protocol.to_string(), BUFFER_SIZE);
@@ -315,7 +318,8 @@ async fn broadcast_message() {
     let mut mock_swarm = MockSwarm::default();
     let mut messages_we_broadcasted_stream = mock_swarm.stream_messages_we_broadcasted();
 
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_METRICS_PREFIX);
 
     let mut broadcast_topic_client = network_manager
         .register_broadcast_topic(topic.clone(), BUFFER_SIZE)
@@ -351,7 +355,8 @@ async fn receive_broadcasted_message_and_report_it() {
     )));
     let mut reported_peer_receiver = mock_swarm.get_reported_peers_stream();
 
-    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, None);
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, None, TEST_METRICS_PREFIX);
 
     let BroadcastTopicChannels {
         mut broadcast_topic_client,

--- a/crates/papyrus_network/src/network_manager/test_utils.rs
+++ b/crates/papyrus_network/src/network_manager/test_utils.rs
@@ -31,6 +31,8 @@ use super::{
 use crate::sqmr::Bytes;
 use crate::NetworkConfig;
 
+pub const TEST_METRICS_PREFIX: &str = "test";
+
 pub fn mock_register_sqmr_protocol_client<Query, Response>(
     buffer_size: usize,
     // TODO(eitan): wrap second type with a struct to make it more readable
@@ -190,7 +192,7 @@ where
 {
     const BUFFER_SIZE: usize = 1000;
 
-    let mut network_manager = NetworkManager::new(network_config, None);
+    let mut network_manager = NetworkManager::new(network_config, None, TEST_METRICS_PREFIX);
     let broadcast_channels =
         network_manager.register_broadcast_topic(topic.clone(), BUFFER_SIZE).unwrap();
 

--- a/crates/papyrus_node/src/run.rs
+++ b/crates/papyrus_node/src/run.rs
@@ -54,6 +54,8 @@ const GENESIS_HASH: &str = "0x0";
 // Duration between updates to the storage metrics (those in the collect_storage_metrics function).
 const STORAGE_METRICS_UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 
+const PAPYRUS_NETWORK_METRICS_PREFIX: &str = "papyrus";
+
 pub struct PapyrusResources {
     pub storage_reader: StorageReader,
     pub storage_writer: StorageWriter,
@@ -118,6 +120,7 @@ fn build_network_manager(
     let network_manager = network_manager::NetworkManager::new(
         network_config.clone(),
         Some(VERSION_FULL.to_string()),
+        PAPYRUS_NETWORK_METRICS_PREFIX,
     );
     let local_peer_id = network_manager.get_local_peer_id();
 

--- a/crates/starknet_consensus_manager/src/consensus_manager.rs
+++ b/crates/starknet_consensus_manager/src/consensus_manager.rs
@@ -24,6 +24,8 @@ use tracing::{error, info};
 
 use crate::config::ConsensusManagerConfig;
 
+const CONSENSUS_NETWORK_METRICS_PREFIX: &str = "consensus";
+
 #[derive(Clone)]
 pub struct ConsensusManager {
     pub config: ConsensusManagerConfig,
@@ -50,7 +52,11 @@ impl ConsensusManager {
             return std::future::pending().await;
         }
 
-        let mut network_manager = NetworkManager::new(self.config.network_config.clone(), None);
+        let mut network_manager = NetworkManager::new(
+            self.config.network_config.clone(),
+            None,
+            CONSENSUS_NETWORK_METRICS_PREFIX,
+        );
 
         let proposals_broadcast_channels = network_manager
             .register_broadcast_topic::<StreamMessage<ProposalPart, HeightAndRound>>(

--- a/crates/starknet_mempool_p2p/src/lib.rs
+++ b/crates/starknet_mempool_p2p/src/lib.rs
@@ -14,6 +14,7 @@ use crate::propagator::MempoolP2pPropagator;
 use crate::runner::MempoolP2pRunner;
 
 pub const MEMPOOL_TOPIC: &str = "starknet_mempool_transaction_propagation/0.1.0";
+const MEMPOOL_P2P_METRICS_PREFIX: &str = "mempool_p2p";
 
 pub fn create_p2p_propagator_and_runner(
     mempool_p2p_config: MempoolP2pConfig,
@@ -28,6 +29,7 @@ pub fn create_p2p_propagator_and_runner(
         mempool_p2p_config.network_config,
         // TODO(Shahak): Consider filling this once the sequencer node has a name.
         None,
+        MEMPOOL_P2P_METRICS_PREFIX,
     );
     let BroadcastTopicChannels { broadcasted_messages_receiver, broadcast_topic_client } =
         network_manager

--- a/crates/starknet_state_sync/src/runner/mod.rs
+++ b/crates/starknet_state_sync/src/runner/mod.rs
@@ -39,6 +39,8 @@ use tokio::sync::RwLock;
 
 use crate::config::{CentralSyncClientConfig, StateSyncConfig};
 
+const P2P_STATE_SYNC_METRICS_PREFIX: &str = "state_sync";
+
 pub struct StateSyncRunner {
     network_future: BoxFuture<'static, Result<(), NetworkError>>,
     // TODO(Matan): change client and server to requester and responder respectively
@@ -85,8 +87,11 @@ impl StateSyncRunner {
             network_config,
         } = config;
 
-        let mut network_manager =
-            network_manager::NetworkManager::new(network_config, Some(VERSION_FULL.to_string()));
+        let mut network_manager = network_manager::NetworkManager::new(
+            network_config,
+            Some(VERSION_FULL.to_string()),
+            P2P_STATE_SYNC_METRICS_PREFIX,
+        );
 
         let (storage_reader, storage_writer) =
             open_storage(storage_config).expect("StateSyncRunner failed opening storage");


### PR DESCRIPTION
- **refactor(papyrus_common,papyrus_network): move network metrics to crate**
- **refactor(papyrus_network): name network metrics by the component**
