### PR TITLE
feat(starknet_class_manager): make class manager `Clone`able

### DIFF
--- a/crates/starknet_class_manager/src/class_manager.rs
+++ b/crates/starknet_class_manager/src/class_manager.rs
@@ -9,6 +9,7 @@ use starknet_sierra_multicompile_types::{
 
 use crate::class_storage::{CachedClassStorage, ClassHashStorage, ClassStorage, FsClassStorage};
 use crate::config::{ClassHashStorageConfig, ClassManagerConfig};
+use crate::FsClassManager;
 
 #[cfg(test)]
 #[path = "class_manager_test.rs"]
@@ -78,7 +79,7 @@ impl<S: ClassStorage> ClassManager<S> {
 pub fn create_class_manager(
     config: ClassManagerConfig,
     compiler_client: SharedSierraCompilerClient,
-) -> ClassManager<FsClassStorage> {
+) -> FsClassManager {
     let persistent_root = tempfile::tempdir().unwrap().path().to_path_buf();
     let storage_config = ClassHashStorageConfig {
         path_prefix: tempfile::tempdir().unwrap().path().to_path_buf(),
@@ -87,7 +88,8 @@ pub fn create_class_manager(
     let class_hash_storage = ClassHashStorage::new(storage_config).unwrap();
     let fs_class_storage = FsClassStorage::new(persistent_root, class_hash_storage);
 
-    ClassManager::new(config, compiler_client, fs_class_storage)
+    let class_manager = ClassManager::new(config, compiler_client, fs_class_storage);
+    FsClassManager(class_manager)
 }
 
-impl ComponentStarter for ClassManager<FsClassStorage> {}
+impl ComponentStarter for FsClassManager {}

--- a/crates/starknet_class_manager/src/class_storage.rs
+++ b/crates/starknet_class_manager/src/class_storage.rs
@@ -198,6 +198,18 @@ impl<S: ClassStorage> ClassStorage for CachedClassStorage<S> {
     }
 }
 
+impl Clone for CachedClassStorage<FsClassStorage> {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+            classes: self.classes.clone(),
+            executable_classes: self.executable_classes.clone(),
+            executable_class_hashes: self.executable_class_hashes.clone(),
+            deprecated_classes: self.deprecated_classes.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ClassHashStorageError {
     #[error("Class of hash: {class_id} not found")]
@@ -209,6 +221,7 @@ pub enum ClassHashStorageError {
 type ClassHashStorageResult<T> = Result<T, ClassHashStorageError>;
 type LockedWriter<'a> = MutexGuard<'a, papyrus_storage::StorageWriter>;
 
+#[derive(Clone)]
 pub struct ClassHashStorage {
     reader: papyrus_storage::StorageReader,
     writer: Arc<Mutex<papyrus_storage::StorageWriter>>,
@@ -267,6 +280,7 @@ impl ClassHashStorage {
 
 type FsClassStorageResult<T> = Result<T, FsClassStorageError>;
 
+#[derive(Clone)]
 pub struct FsClassStorage {
     persistent_root: PathBuf,
     class_hash_storage: ClassHashStorage,

--- a/crates/starknet_class_manager/src/lib.rs
+++ b/crates/starknet_class_manager/src/lib.rs
@@ -6,5 +6,18 @@ pub mod config;
 use crate::class_manager::ClassManager as GenericClassManager;
 use crate::class_storage::FsClassStorage;
 
-pub type FsClassManager = GenericClassManager<FsClassStorage>;
+pub struct FsClassManager(pub GenericClassManager<FsClassStorage>);
+
+impl Clone for FsClassManager {
+    fn clone(&self) -> Self {
+        let GenericClassManager { config, compiler, classes } = &self.0;
+
+        FsClassManager(GenericClassManager {
+            config: config.clone(),
+            compiler: compiler.clone(),
+            classes: classes.clone(),
+        })
+    }
+}
+
 pub use FsClassManager as ClassManager;


### PR DESCRIPTION
This is required to allow it to act as a concurrent component, according to the current design.
To avoid requiring `Clone` on all future implementations, I manually implemented it for `FsClassStorage`. If we decide to stick to this design longterm, it can be demanded and derived. I believe `Clone` is a stonger requirement than needed for concurrency, so made the minimal easy-to-refactor change possible.