### PR TITLE
feat(blockifier): integrate Casm read from class manager client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8044,6 +8044,7 @@ dependencies = [
  "assert_matches",
  "blockifier",
  "cairo-lang-starknet-classes",
+ "futures",
  "indexmap 2.7.0",
  "log",
  "papyrus_storage",

--- a/crates/papyrus_state_reader/Cargo.toml
+++ b/crates/papyrus_state_reader/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 blockifier.workspace = true
 cairo-lang-starknet-classes.workspace = true
+futures.workspace = true
 log.workspace = true
 papyrus_storage.workspace = true
 starknet-types-core.workspace = true

--- a/crates/papyrus_state_reader/src/papyrus_state.rs
+++ b/crates/papyrus_state_reader/src/papyrus_state.rs
@@ -10,17 +10,18 @@ use blockifier::state::errors::{couple_casm_and_sierra, StateError};
 use blockifier::state::global_cache::CachedClass;
 use blockifier::state::state_api::{StateReader, StateResult};
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
+use futures::executor::block_on;
 use log;
 use papyrus_storage::compiled_class::CasmStorageReader;
 use papyrus_storage::db::RO;
 use papyrus_storage::state::StateStorageReader;
 use papyrus_storage::StorageReader;
 use starknet_api::block::BlockNumber;
-use starknet_api::contract_class::SierraVersion;
+use starknet_api::contract_class::{ContractClass, SierraVersion};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedClass;
 use starknet_api::state::{SierraContractClass, StateNumber, StorageKey};
-use starknet_class_manager_types::{EmptyClassManagerClient, SharedClassManagerClient};
+use starknet_class_manager_types::SharedClassManagerClient;
 use starknet_types_core::felt::Felt;
 
 #[cfg(test)]
@@ -33,7 +34,8 @@ pub struct PapyrusReader {
     storage_reader: StorageReader,
     latest_block: BlockNumber,
     contract_class_manager: ContractClassManager,
-    _class_reader: SharedClassManagerClient,
+    // Reader is `None` for reader invoked through `native_blockifier`.
+    class_reader: Option<SharedClassManagerClient>,
 }
 
 impl PapyrusReader {
@@ -42,9 +44,13 @@ impl PapyrusReader {
         latest_block: BlockNumber,
         contract_class_manager: ContractClassManager,
     ) -> Self {
-        // TODO(Elin): integrate class manager client.
-        let _class_reader = Arc::new(EmptyClassManagerClient);
-        Self { storage_reader, latest_block, contract_class_manager, _class_reader }
+        Self {
+            storage_reader,
+            latest_block,
+            contract_class_manager,
+            // TODO(Elin): integrate class manager client.
+            class_reader: None,
+        }
     }
 
     fn reader(&self) -> StateResult<RawPapyrusReader<'_>> {
@@ -89,28 +95,51 @@ impl PapyrusReader {
         &self,
         class_hash: ClassHash,
     ) -> StateResult<(CasmContractClass, SierraContractClass)> {
-        let (option_casm, option_sierra) = self
-            .reader()?
-            .get_casm_and_sierra(&class_hash)
+        let Some(class_reader) = &self.class_reader else {
+            let (option_casm, option_sierra) = self
+                .reader()?
+                .get_casm_and_sierra(&class_hash)
+                .map_err(|err| StateError::StateReadError(err.to_string()))?;
+            let (casm, sierra) = couple_casm_and_sierra(class_hash, option_casm, option_sierra)?
+                .expect(
+                    "Should be able to fetch a Casm and Sierra class if its definition exists,
+                    database is inconsistent.",
+                );
+
+            return Ok((casm, sierra));
+        };
+
+        let casm = block_on(class_reader.get_executable(class_hash))
             .map_err(|err| StateError::StateReadError(err.to_string()))?;
-        let (casm, sierra) = couple_casm_and_sierra(class_hash, option_casm, option_sierra)?
-            .expect(
-                "Should be able to fetch a Casm and Sierra class if its definition exists,
-                database is inconsistent.",
-            );
+        let ContractClass::V1((casm, _sierra_version)) = casm else {
+            panic!("Class hash {class_hash} originated from a Cairo 1 contract.");
+        };
+        // TODO(Elin): consider not reading Sierra if compilation is disabled.
+        let sierra = block_on(class_reader.get_sierra(class_hash))
+            .map_err(|err| StateError::StateReadError(err.to_string()))?;
 
         Ok((casm, sierra))
     }
 
     fn read_deprecated_casm(&self, class_hash: ClassHash) -> StateResult<Option<DeprecatedClass>> {
-        let state_number = StateNumber(self.latest_block);
-        let option_casm = self
-            .reader()?
-            .get_state_reader()
-            .and_then(|sr| sr.get_deprecated_class_definition_at(state_number, &class_hash))
-            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+        let Some(class_reader) = &self.class_reader else {
+            let state_number = StateNumber(self.latest_block);
+            let option_casm = self
+                .reader()?
+                .get_state_reader()
+                .and_then(|sr| sr.get_deprecated_class_definition_at(state_number, &class_hash))
+                .map_err(|err| StateError::StateReadError(err.to_string()))?;
 
-        Ok(option_casm)
+            return Ok(option_casm);
+        };
+
+        let casm = block_on(class_reader.get_executable(class_hash))
+            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+        let ContractClass::V0(casm) = casm else {
+            panic!("Class hash {class_hash} originated from a Cairo 0 contract.");
+        };
+
+        Ok(Some(casm))
     }
 }
 

--- a/crates/starknet_class_manager_types/src/lib.rs
+++ b/crates/starknet_class_manager_types/src/lib.rs
@@ -55,6 +55,7 @@ pub struct ClassHashes {
 pub trait ClassManagerClient: Send + Sync {
     async fn add_class(&self, class: Class) -> ClassManagerClientResult<ClassHashes>;
 
+    // TODO(Elin): separate V0 and V1 APIs; remove Sierra version.
     async fn get_executable(&self, class_id: ClassId) -> ClassManagerClientResult<ExecutableClass>;
 
     async fn get_sierra(&self, class_id: ClassId) -> ClassManagerClientResult<Class>;
@@ -75,6 +76,7 @@ pub enum CachedClassStorageError<E: Error> {
     Storage(#[from] E),
 }
 
+// TODO(Elin): express class not found, either as `Option`, or as a dedicated error variant.
 #[derive(Clone, Debug, Error, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ClassManagerError {
     #[error("Internal client error: {0}")]


### PR DESCRIPTION
Chose this simpler option to implement, instead of making Papyrus state generic by `CR: CasmReader` trait, since it would require cloning `mdbx` resources, which is flaky working with PyO3.

After `native_blockifier` is deprecated, the client should become non-`Option` and Papyrus state (in the new Batcher) should always be initialized with a concrete instance.