### PR TITLE
refactor(papyrus_base_layer): consolidate alloy crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcc41e8a11a4975b18ec6afba2cc48d591fa63336a4c526dacb50479a8d6b35"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-node-bindings",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-transport",
+ "alloy-transport-http",
+]
+
+[[package]]
 name = "alloy-chains"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +173,19 @@ dependencies = [
  "futures",
  "futures-util",
  "thiserror 2.0.9",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0713007d14d88a6edb8e248cddab783b698dbb954a28b8eee4bab21cfb7e578"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
 ]
 
 [[package]]
@@ -344,9 +379,13 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -415,6 +454,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9383845dd924939e7ab0298bbfe231505e20928907d7905aa3bf112287305e06"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11495cb8c8d3141fc27556a4c9188b81531ad5ec3076a0394c61a6dcfbce9f34"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
 name = "alloy-rpc-types-any"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +530,22 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
+ "thiserror 2.0.9",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc63ce9eda1283fcbaca66ba4a414b841c0e3edbeef9c86a71242fc9e84ccc"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
  "thiserror 2.0.9",
 ]
 
@@ -7593,7 +7672,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
 dependencies = [
+ "alloy-rlp",
  "const-hex",
+ "proptest",
  "serde",
  "smallvec",
 ]
@@ -7740,16 +7821,7 @@ dependencies = [
 name = "papyrus_base_layer"
 version = "0.0.0"
 dependencies = [
- "alloy-contract",
- "alloy-dyn-abi",
- "alloy-json-rpc",
- "alloy-node-bindings",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy",
  "async-trait",
  "colored 3.0.0",
  "ethers",
@@ -11186,8 +11258,7 @@ dependencies = [
 name = "starknet_l1_provider"
 version = "0.0.0"
 dependencies = [
- "alloy-node-bindings",
- "alloy-primitives",
+ "alloy",
  "assert_matches",
  "async-trait",
  "indexmap 2.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,16 +75,7 @@ license = "Apache-2.0"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-alloy-contract = "0.9"
-alloy-dyn-abi = "0.8.3"
-alloy-json-rpc = "0.9"
-alloy-node-bindings = "0.9"
-alloy-primitives = "0.8.3"
-alloy-provider = "0.9"
-alloy-rpc-types-eth = "0.9"
-alloy-sol-types = "0.8.3"
-alloy-transport = "0.9"
-alloy-transport-http = "0.9"
+alloy = "0.9"
 anyhow = "1.0.44"
 apollo_reverts = { path = "crates/apollo_reverts", version = "0.0.0" }
 ark-ec = "0.4.2"

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -9,19 +9,10 @@ license-file.workspace = true
 workspace = true
 
 [features]
-testing = ["alloy-node-bindings", "colored", "tar", "tempfile"]
+testing = ["alloy/node-bindings", "colored", "tar", "tempfile"]
 
 [dependencies]
-alloy-contract.workspace = true
-alloy-dyn-abi.workspace = true
-alloy-json-rpc.workspace = true
-alloy-node-bindings = { workspace = true, optional = true }
-alloy-primitives.workspace = true
-alloy-provider.workspace = true
-alloy-rpc-types-eth.workspace = true
-alloy-sol-types = { workspace = true, features = ["json"] }
-alloy-transport.workspace = true
-alloy-transport-http.workspace = true
+alloy = { workspace = true, features = ["contract", "json-rpc", "rpc-types"] }
 async-trait.workspace = true
 colored = { workspace = true, optional = true }
 ethers.workspace = true
@@ -37,7 +28,7 @@ url = { workspace = true, features = ["serde"] }
 validator.workspace = true
 
 [dev-dependencies]
-alloy-node-bindings.workspace = true
+alloy.workspace = true
 colored.workspace = true
 ethers-core.workspace = true
 pretty_assertions.workspace = true

--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Address as EthereumContractAddress;
+use alloy::primitives::Address as EthereumContractAddress;
 use pretty_assertions::assert_eq;
 use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
 use starknet_api::felt;

--- a/crates/papyrus_base_layer/src/constants.rs
+++ b/crates/papyrus_base_layer/src/constants.rs
@@ -1,4 +1,4 @@
-use alloy_sol_types::SolEvent;
+use alloy::sol_types::SolEvent;
 
 use crate::ethereum_base_layer_contract::Starknet;
 

--- a/crates/papyrus_base_layer/src/eth_events.rs
+++ b/crates/papyrus_base_layer/src/eth_events.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use alloy_primitives::{Address as EthereumContractAddress, U256};
-use alloy_rpc_types_eth::Log;
-use alloy_sol_types::SolEventInterface;
+use alloy::primitives::{Address as EthereumContractAddress, U256};
+use alloy::rpc::types::Log;
+use alloy::sol_types::SolEventInterface;
 use starknet_api::core::{EntryPointSelector, Nonce};
 use starknet_api::transaction::fields::{Calldata, Fee};
 use starknet_api::transaction::L1HandlerTransaction;

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -2,20 +2,21 @@ use std::collections::BTreeMap;
 use std::future::IntoFuture;
 use std::ops::RangeInclusive;
 
-use alloy_dyn_abi::SolType;
-use alloy_json_rpc::RpcError;
-use alloy_primitives::Address as EthereumContractAddress;
-use alloy_provider::network::Ethereum;
-use alloy_provider::{Provider, ProviderBuilder, RootProvider};
-use alloy_rpc_types_eth::{
+use alloy::dyn_abi::SolType;
+use alloy::primitives::Address as EthereumContractAddress;
+use alloy::providers::network::Ethereum;
+use alloy::providers::{Provider, ProviderBuilder, RootProvider};
+use alloy::rpc::json_rpc::RpcError;
+use alloy::rpc::types::eth::{
     BlockId,
     BlockNumberOrTag,
     BlockTransactionsKind,
     Filter as EthEventFilter,
 };
-use alloy_sol_types::{sol, sol_data};
-use alloy_transport::TransportErrorKind;
-use alloy_transport_http::{Client, Http};
+use alloy::sol;
+use alloy::sol_types::sol_data;
+use alloy::transports::http::{Client, Http};
+use alloy::transports::TransportErrorKind;
 use async_trait::async_trait;
 use papyrus_config::dumping::{ser_param, ser_required_param, SerializeConfig};
 use papyrus_config::{ParamPath, ParamPrivacyInput, SerializationType, SerializedParam};
@@ -167,17 +168,17 @@ impl BaseLayerContract for EthereumBaseLayerContract {
 #[derive(thiserror::Error, Debug)]
 pub enum EthereumBaseLayerError {
     #[error(transparent)]
-    Contract(#[from] alloy_contract::Error),
+    Contract(#[from] alloy::contract::Error),
     #[error("{0}")]
-    FeeOutOfRange(alloy_primitives::ruint::FromUintError<u128>),
+    FeeOutOfRange(alloy::primitives::ruint::FromUintError<u128>),
     #[error(transparent)]
     RpcError(#[from] RpcError<TransportErrorKind>),
     #[error("{0}")]
     StarknetApiParsingError(StarknetApiError),
     #[error(transparent)]
-    TypeError(#[from] alloy_sol_types::Error),
+    TypeError(#[from] alloy::sol_types::Error),
     #[error("{0:?}")]
-    UnhandledL1Event(alloy_primitives::Log),
+    UnhandledL1Event(alloy::primitives::Log),
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]

--- a/crates/papyrus_base_layer/src/test_utils.rs
+++ b/crates/papyrus_base_layer/src/test_utils.rs
@@ -1,8 +1,8 @@
 use std::fs::File;
 use std::process::Command;
 
-use alloy_node_bindings::{Anvil, AnvilInstance, NodeError as AnvilError};
-pub(crate) use alloy_primitives::Address as EthereumContractAddress;
+use alloy::node_bindings::{Anvil, AnvilInstance, NodeError as AnvilError};
+pub(crate) use alloy::primitives::Address as EthereumContractAddress;
 use colored::*;
 use ethers::utils::{Ganache, GanacheInstance};
 use tar::Archive;

--- a/crates/starknet_l1_provider/Cargo.toml
+++ b/crates/starknet_l1_provider/Cargo.toml
@@ -26,8 +26,7 @@ tracing.workspace = true
 validator.workspace = true
 
 [dev-dependencies]
-alloy-node-bindings.workspace = true
-alloy-primitives.workspace = true
+alloy.workspace = true
 assert_matches.workspace = true
 itertools.workspace = true
 papyrus_base_layer = { path = "../papyrus_base_layer", features = ["testing"] }

--- a/crates/starknet_l1_provider/src/l1_scraper_tests.rs
+++ b/crates/starknet_l1_provider/src/l1_scraper_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use alloy_node_bindings::AnvilInstance;
-use alloy_primitives::U256;
+use alloy::node_bindings::AnvilInstance;
+use alloy::primitives::U256;
 use papyrus_base_layer::ethereum_base_layer_contract::{
     EthereumBaseLayerConfig,
     EthereumBaseLayerContract,


### PR DESCRIPTION
 Use alloy + features instead of individual crates to consolidate
 versioning.
 There are no logic changes, only import changes.
    
Warning: Alloy has tons of features; don't activate features greedily; otherwise, our compilation time will suffer.