### PR TITLE
fix(starknet_class_manager): embed class-not-found flow in `Option` return type

### DIFF
--- a/crates/papyrus_p2p_sync/src/server/test.rs
+++ b/crates/papyrus_p2p_sync/src/server/test.rs
@@ -468,6 +468,7 @@ fn insert_to_storage_test_blocks_up_to(storage_writer: &mut StorageWriter) {
     }
 }
 
+// TODO(shahak): test undeclared class flow (when class manager client returns None).
 fn create_mock_class_manager_with_blocks_up_to(
     storage_writer: &mut StorageWriter,
 ) -> SharedClassManagerClient {
@@ -483,7 +484,7 @@ fn create_mock_class_manager_with_blocks_up_to(
             class_manager_client
                 .expect_get_sierra()
                 .with(eq(class_hash))
-                .returning(|_| Ok(contract_class.clone()));
+                .returning(|_| Ok(Some(contract_class.clone())));
         }
 
         let deprecated_classes_with_hashes = DEPRECATED_CLASSES_WITH_HASHES[i]
@@ -496,7 +497,7 @@ fn create_mock_class_manager_with_blocks_up_to(
             class_manager_client
                 .expect_get_executable()
                 .with(eq(class_hash))
-                .returning(|_| Ok(ContractClass::V0(contract_class.clone())));
+                .returning(|_| Ok(Some(ContractClass::V0(contract_class.clone()))));
         }
 
         storage_writer

--- a/crates/papyrus_state_reader/src/papyrus_state.rs
+++ b/crates/papyrus_state_reader/src/papyrus_state.rs
@@ -110,13 +110,15 @@ impl PapyrusReader {
         };
 
         let casm = block_on(class_reader.get_executable(class_hash))
-            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+            .map_err(|e| StateError::StateReadError(e.to_string()))?
+            .ok_or(StateError::UndeclaredClassHash(class_hash))?;
         let ContractClass::V1((casm, _sierra_version)) = casm else {
             panic!("Class hash {class_hash} originated from a Cairo 1 contract.");
         };
         // TODO(Elin): consider not reading Sierra if compilation is disabled.
         let sierra = block_on(class_reader.get_sierra(class_hash))
-            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+            .map_err(|err| StateError::StateReadError(err.to_string()))?
+            .ok_or(StateError::UndeclaredClassHash(class_hash))?;
 
         Ok((casm, sierra))
     }
@@ -134,7 +136,8 @@ impl PapyrusReader {
         };
 
         let casm = block_on(class_reader.get_executable(class_hash))
-            .map_err(|err| StateError::StateReadError(err.to_string()))?;
+            .map_err(|err| StateError::StateReadError(err.to_string()))?
+            .ok_or(StateError::UndeclaredClassHash(class_hash))?;
         let ContractClass::V0(casm) = casm else {
             panic!("Class hash {class_hash} originated from a Cairo 0 contract.");
         };

--- a/crates/starknet_api/src/transaction_hash_test.rs
+++ b/crates/starknet_api/src/transaction_hash_test.rs
@@ -84,7 +84,6 @@ fn test_only_query_transaction_hash() {
             continue;
         }
 
-        dbg!(transaction_test_data.transaction_hash);
         let actual_transaction_hash = get_transaction_hash(
             &transaction_test_data.transaction,
             &transaction_test_data.chain_id,

--- a/crates/starknet_batcher/src/reader_with_class_manager.rs
+++ b/crates/starknet_batcher/src/reader_with_class_manager.rs
@@ -39,7 +39,8 @@ impl<S: StateReader> StateReader for ReaderWithClassManager<S> {
 
     fn get_compiled_class(&self, class_hash: ClassHash) -> StateResult<RunnableCompiledClass> {
         let contract_class = block_on(self.class_manager_client.get_executable(class_hash))
-            .map_err(|e| StateError::StateReadError(e.to_string()))?;
+            .map_err(|err| StateError::StateReadError(err.to_string()))?
+            .ok_or(StateError::UndeclaredClassHash(class_hash))?;
 
         match contract_class {
             // TODO(noamsp): Remove this once class manager component is implemented.

--- a/crates/starknet_batcher/src/reader_with_class_manager_test.rs
+++ b/crates/starknet_batcher/src/reader_with_class_manager_test.rs
@@ -108,6 +108,7 @@ async fn test_inner_state_reader_negative_flow() {
     assert_matches!(result, StateError::StateReadError(_));
 }
 
+// TODO(NoamS): test undeclared class flow (when class manager client returns None).
 #[tokio::test]
 async fn test_get_compiled_class() {
     let mock_inner_state_reader = MockStateReader::new();
@@ -129,7 +130,7 @@ async fn test_get_compiled_class() {
         .times(1)
         .with(predicate::eq(class_hash))
         .returning(move |_| {
-            Ok(ContractClass::V1((casm_contract_class.clone(), SierraVersion::default())))
+            Ok(Some(ContractClass::V1((casm_contract_class.clone(), SierraVersion::default()))))
         });
 
     let state_reader =

--- a/crates/starknet_class_manager/src/class_manager.rs
+++ b/crates/starknet_class_manager/src/class_manager.rs
@@ -42,7 +42,8 @@ impl<S: ClassStorage> ClassManager<S> {
         let sierra_class =
             SierraContractClass::try_from(class.clone()).map_err(ClassManagerError::from)?;
         let class_hash = sierra_class.calculate_class_hash();
-        if let Ok(executable_class_hash) = self.classes.get_executable_class_hash(class_hash) {
+        if let Ok(Some(executable_class_hash)) = self.classes.get_executable_class_hash(class_hash)
+        {
             // Class already exists.
             let class_hashes = ClassHashes { class_hash, executable_class_hash };
             return Ok(class_hashes);
@@ -57,11 +58,14 @@ impl<S: ClassStorage> ClassManager<S> {
         Ok(class_hashes)
     }
 
-    pub fn get_executable(&self, class_id: ClassId) -> ClassManagerResult<RawExecutableClass> {
+    pub fn get_executable(
+        &self,
+        class_id: ClassId,
+    ) -> ClassManagerResult<Option<RawExecutableClass>> {
         Ok(self.classes.get_executable(class_id)?)
     }
 
-    pub fn get_sierra(&self, class_id: ClassId) -> ClassManagerResult<RawClass> {
+    pub fn get_sierra(&self, class_id: ClassId) -> ClassManagerResult<Option<RawClass>> {
         Ok(self.classes.get_sierra(class_id)?)
     }
 

--- a/crates/starknet_class_manager/src/class_manager_test.rs
+++ b/crates/starknet_class_manager/src/class_manager_test.rs
@@ -4,16 +4,11 @@ use mockall::predicate::eq;
 use starknet_api::core::CompiledClassHash;
 use starknet_api::felt;
 use starknet_api::state::SierraContractClass;
-use starknet_class_manager_types::{CachedClassStorageError, ClassHashes, ClassManagerError};
+use starknet_class_manager_types::ClassHashes;
 use starknet_sierra_multicompile_types::{MockSierraCompilerClient, RawClass, RawExecutableClass};
 
 use crate::class_manager::ClassManager;
-use crate::class_storage::{
-    create_tmp_dir,
-    CachedClassStorageConfig,
-    FsClassStorage,
-    FsClassStorageError,
-};
+use crate::class_storage::{create_tmp_dir, CachedClassStorageConfig, FsClassStorage};
 use crate::config::ClassManagerConfig;
 
 impl ClassManager<FsClassStorage> {
@@ -56,11 +51,8 @@ async fn class_manager() {
 
     // Non-existent class.
     let class_id = SierraContractClass::try_from(class.clone()).unwrap().calculate_class_hash();
-    let class_not_found_error: CachedClassStorageError<FsClassStorageError> =
-        CachedClassStorageError::ClassNotFound { class_id };
-    let class_not_found_error = ClassManagerError::from(class_not_found_error);
-    assert_eq!(class_manager.get_sierra(class_id).unwrap_err(), class_not_found_error);
-    assert_eq!(class_manager.get_executable(class_id).unwrap_err(), class_not_found_error);
+    assert_eq!(class_manager.get_sierra(class_id), Ok(None));
+    assert_eq!(class_manager.get_executable(class_id), Ok(None));
 
     // Add new class.
     let class_hashes = class_manager.add_class(class.clone()).await.unwrap();
@@ -69,8 +61,8 @@ async fn class_manager() {
     assert_eq!(class_hashes, expected_class_hashes);
 
     // Get class.
-    assert_eq!(class_manager.get_sierra(class_id).unwrap(), class);
-    assert_eq!(class_manager.get_executable(class_id).unwrap(), expected_executable_class);
+    assert_eq!(class_manager.get_sierra(class_id).unwrap(), Some(class.clone()));
+    assert_eq!(class_manager.get_executable(class_id).unwrap(), Some(expected_executable_class));
 
     // Add existing class; response returned immediately, without invoking compilation.
     let class_hashes = class_manager.add_class(class).await.unwrap();

--- a/crates/starknet_class_manager/src/class_storage_test.rs
+++ b/crates/starknet_class_manager/src/class_storage_test.rs
@@ -7,10 +7,8 @@ use crate::class_storage::{
     create_tmp_dir,
     ClassHashStorage,
     ClassHashStorageConfig,
-    ClassHashStorageError,
     ClassStorage,
     FsClassStorage,
-    FsClassStorageError,
 };
 
 #[cfg(test)]
@@ -45,13 +43,9 @@ fn fs_storage() {
 
     // Non-existent class.
     let class_id = ClassHash(felt!("0x1234"));
-    let class_not_found_error = FsClassStorageError::ClassNotFound { class_id };
-    assert_eq!(storage.get_sierra(class_id).unwrap_err(), class_not_found_error);
-    assert_eq!(storage.get_executable(class_id).unwrap_err(), class_not_found_error);
-
-    let class_not_found_error =
-        FsClassStorageError::ClassHashStorage(ClassHashStorageError::ClassNotFound { class_id });
-    assert_eq!(storage.get_executable_class_hash(class_id).unwrap_err(), class_not_found_error);
+    assert_eq!(storage.get_sierra(class_id), Ok(None));
+    assert_eq!(storage.get_executable(class_id), Ok(None));
+    assert_eq!(storage.get_executable_class_hash(class_id), Ok(None));
 
     // Add new class.
     let class = RawClass::try_from(SierraContractClass::default()).unwrap();
@@ -63,9 +57,9 @@ fn fs_storage() {
         .unwrap();
 
     // Get class.
-    assert_eq!(storage.get_sierra(class_id).unwrap(), class);
-    assert_eq!(storage.get_executable(class_id).unwrap(), executable_class);
-    assert_eq!(storage.get_executable_class_hash(class_id).unwrap(), executable_class_hash);
+    assert_eq!(storage.get_sierra(class_id).unwrap(), Some(class.clone()));
+    assert_eq!(storage.get_executable(class_id).unwrap(), Some(executable_class.clone()));
+    assert_eq!(storage.get_executable_class_hash(class_id).unwrap(), Some(executable_class_hash));
 
     // Add existing class.
     storage
@@ -82,8 +76,7 @@ fn fs_storage_deprecated_class_api() {
 
     // Non-existent class.
     let class_id = ClassHash(felt!("0x1234"));
-    let class_not_found_error = FsClassStorageError::ClassNotFound { class_id };
-    assert_eq!(storage.get_deprecated_class(class_id).unwrap_err(), class_not_found_error);
+    assert_eq!(storage.get_deprecated_class(class_id), Ok(None));
 
     // Add new class.
     // TODO(Elin): consider creating an empty Casm instead of vec (doesn't implement default).
@@ -91,7 +84,7 @@ fn fs_storage_deprecated_class_api() {
     storage.set_deprecated_class(class_id, executable_class.clone()).unwrap();
 
     // Get class.
-    assert_eq!(storage.get_deprecated_class(class_id).unwrap(), executable_class);
+    assert_eq!(storage.get_deprecated_class(class_id).unwrap(), Some(executable_class.clone()));
 
     // Add existing class.
     storage.set_deprecated_class(class_id, executable_class).unwrap();

--- a/crates/starknet_class_manager/src/communication.rs
+++ b/crates/starknet_class_manager/src/communication.rs
@@ -25,11 +25,17 @@ impl ComponentRequestHandler<ClassManagerRequest, ClassManagerResponse> for Clas
                 )
             }
             ClassManagerRequest::GetExecutable(class_id) => {
-                let result = self.0.get_executable(class_id).map(|class| class.try_into().unwrap());
+                let result = self
+                    .0
+                    .get_executable(class_id)
+                    .map(|optional_class| optional_class.map(|class| class.try_into().unwrap()));
                 ClassManagerResponse::GetExecutable(result)
             }
             ClassManagerRequest::GetSierra(class_id) => {
-                let result = self.0.get_sierra(class_id).map(|class| class.try_into().unwrap());
+                let result = self
+                    .0
+                    .get_sierra(class_id)
+                    .map(|optional_class| optional_class.map(|class| class.try_into().unwrap()));
                 ClassManagerResponse::GetSierra(result)
             }
         }

--- a/crates/starknet_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/starknet_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -646,12 +646,10 @@ async fn test_transactions_conversion() {
         .expect_get_sierra()
         .with(eq(declare_class_hash()))
         .times(2)
-        .returning(|_| Ok(sierra_contract_class()));
-    mock_class_manager
-        .expect_get_executable()
-        .with(eq(declare_class_hash()))
-        .times(2)
-        .returning(|_| Ok(ContractClass::V1((casm_contract_class(), SierraVersion::new(0, 0, 0)))));
+        .returning(|_| Ok(Some(sierra_contract_class())));
+    mock_class_manager.expect_get_executable().with(eq(declare_class_hash())).times(2).returning(
+        |_| Ok(Some(ContractClass::V1((casm_contract_class(), SierraVersion::new(0, 0, 0))))),
+    );
     let cende_ambassador =
         CendeAmbassador::new(CendeConfig::default(), Arc::new(mock_class_manager));
 

--- a/crates/starknet_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/starknet_consensus_orchestrator/src/cende/mod.rs
@@ -30,6 +30,7 @@ use reqwest::{Certificate, Client, ClientBuilder, RequestBuilder};
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockInfo, BlockNumber, StarknetVersion};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
+use starknet_api::core::ClassHash;
 use starknet_api::state::ThinStateDiff;
 use starknet_class_manager_types::{ClassManagerClientError, SharedClassManagerClient};
 use tokio::sync::Mutex;
@@ -41,6 +42,8 @@ use url::Url;
 pub enum CendeAmbassadorError {
     #[error(transparent)]
     ClassManagerError(#[from] ClassManagerClientError),
+    #[error("Class of hash: {class_hash} not found")]
+    ClassNotFound { class_hash: ClassHash },
     #[error(transparent)]
     StarknetApiError(#[from] starknet_api::StarknetApiError),
 }

--- a/crates/starknet_gateway/src/sync_state_reader.rs
+++ b/crates/starknet_gateway/src/sync_state_reader.rs
@@ -103,7 +103,8 @@ impl BlockifierStateReader for SyncStateReader {
 
     fn get_compiled_class(&self, class_hash: ClassHash) -> StateResult<RunnableCompiledClass> {
         let contract_class = block_on(self.class_manager_client.get_executable(class_hash))
-            .map_err(|e| StateError::StateReadError(e.to_string()))?;
+            .map_err(|e| StateError::StateReadError(e.to_string()))?
+            .ok_or(StateError::UndeclaredClassHash(class_hash))?;
 
         // TODO(noamsp): Remove this once class manager component is implemented.
         let contract_class = match contract_class {

--- a/crates/starknet_gateway/src/sync_state_reader_test.rs
+++ b/crates/starknet_gateway/src/sync_state_reader_test.rs
@@ -170,6 +170,7 @@ async fn test_get_class_hash_at() {
     assert_eq!(result, expected_result);
 }
 
+// TODO(NoamS): test undeclared class flow (when class manager client returns None).
 #[tokio::test]
 async fn test_get_compiled_class() {
     let mock_state_sync_client = MockStateSyncClient::new();
@@ -192,7 +193,7 @@ async fn test_get_compiled_class() {
         .times(1)
         .with(predicate::eq(class_hash))
         .returning(move |_| {
-            Ok(ContractClass::V1((casm_contract_class.clone(), SierraVersion::default())))
+            Ok(Some(ContractClass::V1((casm_contract_class.clone(), SierraVersion::default()))))
         });
 
     let state_sync_reader = SyncStateReader::from_number(


### PR DESCRIPTION
Instead of an error variant. For two reasons:
1. `Option` is easier to streamline through abstraction layers; there are quire a few of those in the class manager E2E flow.
2. A class not found flow might be expected at times, it's more idiomatic to leave the decision of how to handle this to the caller, who has more context.