### PR TITLE
fix(starknet_mempool_p2p): use random tx in runner tests

### DIFF
--- a/crates/starknet_mempool_p2p/src/runner/test.rs
+++ b/crates/starknet_mempool_p2p/src/runner/test.rs
@@ -13,7 +13,7 @@ use papyrus_network::network_manager::{BroadcastTopicChannels, NetworkError};
 use papyrus_network_types::network_types::BroadcastedMessageMetadata;
 use papyrus_protobuf::mempool::RpcTransactionWrapper;
 use papyrus_test_utils::{get_rng, GetTestInstance};
-use starknet_api::rpc_transaction::{RpcInvokeTransaction, RpcTransaction};
+use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_gateway_types::communication::{GatewayClient, GatewayClientError, MockGatewayClient};
 use starknet_gateway_types::errors::{GatewayError, GatewaySpecError};
@@ -65,10 +65,8 @@ async fn incoming_p2p_tx_reaches_gateway_client() {
     let (add_tx_indicator_sender, add_tx_indicator_receiver) = futures::channel::oneshot::channel();
 
     let message_metadata = BroadcastedMessageMetadata::get_test_instance(&mut get_rng());
-    // TODO(alonl): use a random rpc transaction instead of specifying invoke once declare is fixed
-    let expected_rpc_transaction = RpcTransactionWrapper(RpcTransaction::Invoke(
-        RpcInvokeTransaction::get_test_instance(&mut get_rng()),
-    ));
+    let expected_rpc_transaction =
+        RpcTransactionWrapper(RpcTransaction::get_test_instance(&mut get_rng()));
     let gateway_input = GatewayInput {
         rpc_tx: expected_rpc_transaction.0.clone(),
         message_metadata: Some(message_metadata.clone()),
@@ -116,10 +114,8 @@ async fn incoming_p2p_tx_fails_on_gateway_client() {
 
     let message_metadata = BroadcastedMessageMetadata::get_test_instance(&mut get_rng());
     let message_metadata_clone = message_metadata.clone();
-    // TODO(alonl): use a random rpc transaction instead of specifying invoke once declare is fixed
-    let expected_rpc_transaction = RpcTransactionWrapper(RpcTransaction::Invoke(
-        RpcInvokeTransaction::get_test_instance(&mut get_rng()),
-    ));
+    let expected_rpc_transaction =
+        RpcTransactionWrapper(RpcTransaction::get_test_instance(&mut get_rng()));
 
     let mut mock_gateway_client = MockGatewayClient::new();
     mock_gateway_client.expect_add_tx().return_once(move |_| {


### PR DESCRIPTION
- **fix(papyrus_test_utils): generate random values for resource bounds test instance**
- **fix(starknet_mempool_p2p): use random tx in runner tests**
