### PR TITLE
feat(starknet_sequencer_metrics): add panels and rows for p2p metrics

### DIFF
--- a/crates/starknet_sequencer_metrics/src/dashboard_definitions.rs
+++ b/crates/starknet_sequencer_metrics/src/dashboard_definitions.rs
@@ -2,9 +2,18 @@ use crate::dashboard::{Dashboard, Panel, PanelType, Row};
 use crate::metric_definitions::{
     ADDED_TRANSACTIONS_TOTAL,
     BATCHED_TRANSACTIONS,
+    CONSENSUS_NUM_CONNECTED_PEERS,
+    CONSENSUS_NUM_RECEIVED_MESSAGES,
+    CONSENSUS_NUM_SENT_MESSAGES,
+    MEMPOOL_P2P_NUM_CONNECTED_PEERS,
+    MEMPOOL_P2P_NUM_RECEIVED_MESSAGES,
+    MEMPOOL_P2P_NUM_SENT_MESSAGES,
     PROPOSAL_FAILED,
     PROPOSAL_STARTED,
     PROPOSAL_SUCCEEDED,
+    STATE_SYNC_P2P_NUM_ACTIVE_INBOUND_SESSIONS,
+    STATE_SYNC_P2P_NUM_ACTIVE_OUTBOUND_SESSIONS,
+    STATE_SYNC_P2P_NUM_CONNECTED_PEERS,
 };
 
 const PANEL_ADDED_TRANSACTIONS_TOTAL: Panel = Panel::new(
@@ -39,6 +48,99 @@ const PANEL_BATCHED_TRANSACTIONS: Panel = Panel::new(
     PanelType::Stat,
 );
 
+const PANEL_MEMPOOL_P2P_NUM_CONNECTED_PEERS: Panel = Panel::new(
+    MEMPOOL_P2P_NUM_CONNECTED_PEERS.get_name(),
+    MEMPOOL_P2P_NUM_CONNECTED_PEERS.get_description(),
+    MEMPOOL_P2P_NUM_CONNECTED_PEERS.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_MEMPOOL_P2P_NUM_SENT_MESSAGES: Panel = Panel::new(
+    MEMPOOL_P2P_NUM_SENT_MESSAGES.get_name(),
+    MEMPOOL_P2P_NUM_SENT_MESSAGES.get_description(),
+    MEMPOOL_P2P_NUM_SENT_MESSAGES.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_MEMPOOL_P2P_NUM_RECEIVED_MESSAGES: Panel = Panel::new(
+    MEMPOOL_P2P_NUM_RECEIVED_MESSAGES.get_name(),
+    MEMPOOL_P2P_NUM_RECEIVED_MESSAGES.get_description(),
+    MEMPOOL_P2P_NUM_RECEIVED_MESSAGES.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_CONSENSUS_NUM_CONNECTED_PEERS: Panel = Panel::new(
+    CONSENSUS_NUM_CONNECTED_PEERS.get_name(),
+    CONSENSUS_NUM_CONNECTED_PEERS.get_description(),
+    CONSENSUS_NUM_CONNECTED_PEERS.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_CONSENSUS_NUM_SENT_MESSAGES: Panel = Panel::new(
+    CONSENSUS_NUM_SENT_MESSAGES.get_name(),
+    CONSENSUS_NUM_SENT_MESSAGES.get_description(),
+    CONSENSUS_NUM_SENT_MESSAGES.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_CONSENSUS_NUM_RECEIVED_MESSAGES: Panel = Panel::new(
+    CONSENSUS_NUM_RECEIVED_MESSAGES.get_name(),
+    CONSENSUS_NUM_RECEIVED_MESSAGES.get_description(),
+    CONSENSUS_NUM_RECEIVED_MESSAGES.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_STATE_SYNC_P2P_NUM_CONNECTED_PEERS: Panel = Panel::new(
+    STATE_SYNC_P2P_NUM_CONNECTED_PEERS.get_name(),
+    STATE_SYNC_P2P_NUM_CONNECTED_PEERS.get_description(),
+    STATE_SYNC_P2P_NUM_CONNECTED_PEERS.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_STATE_SYNC_P2P_NUM_ACTIVE_INBOUND_SESSIONS: Panel = Panel::new(
+    STATE_SYNC_P2P_NUM_ACTIVE_INBOUND_SESSIONS.get_name(),
+    STATE_SYNC_P2P_NUM_ACTIVE_INBOUND_SESSIONS.get_description(),
+    STATE_SYNC_P2P_NUM_ACTIVE_INBOUND_SESSIONS.get_name(),
+    PanelType::Stat,
+);
+
+const PANEL_STATE_SYNC_P2P_NUM_ACTIVE_OUTBOUND_SESSIONS: Panel = Panel::new(
+    STATE_SYNC_P2P_NUM_ACTIVE_OUTBOUND_SESSIONS.get_name(),
+    STATE_SYNC_P2P_NUM_ACTIVE_OUTBOUND_SESSIONS.get_description(),
+    STATE_SYNC_P2P_NUM_ACTIVE_OUTBOUND_SESSIONS.get_name(),
+    PanelType::Stat,
+);
+
+const MEMPOOL_P2P_ROW: Row<'_> = Row::new(
+    "MempoolP2p",
+    "Mempool peer to peer metrics",
+    &[
+        PANEL_MEMPOOL_P2P_NUM_CONNECTED_PEERS,
+        PANEL_MEMPOOL_P2P_NUM_SENT_MESSAGES,
+        PANEL_MEMPOOL_P2P_NUM_RECEIVED_MESSAGES,
+    ],
+);
+
+const CONSENSUS_P2P_ROW: Row<'_> = Row::new(
+    "ConsensusP2p",
+    "Consensus peer to peer metrics",
+    &[
+        PANEL_CONSENSUS_NUM_CONNECTED_PEERS,
+        PANEL_CONSENSUS_NUM_SENT_MESSAGES,
+        PANEL_CONSENSUS_NUM_RECEIVED_MESSAGES,
+    ],
+);
+
+const STATE_SYNC_P2P_ROW: Row<'_> = Row::new(
+    "StateSyncP2p",
+    "State sync peer to peer metrics",
+    &[
+        PANEL_STATE_SYNC_P2P_NUM_CONNECTED_PEERS,
+        PANEL_STATE_SYNC_P2P_NUM_ACTIVE_INBOUND_SESSIONS,
+        PANEL_STATE_SYNC_P2P_NUM_ACTIVE_OUTBOUND_SESSIONS,
+    ],
+);
+
 const BATCHER_ROW: Row<'_> = Row::new(
     "Batcher",
     "Batcher metrics including proposals and transactions",
@@ -58,5 +160,5 @@ const HTTP_SERVER_ROW: Row<'_> = Row::new(
 pub const SEQUENCER_DASHBOARD: Dashboard<'_> = Dashboard::new(
     "Sequencer Node Dashboard",
     "Monitoring of the decentralized sequencer node",
-    &[BATCHER_ROW, HTTP_SERVER_ROW],
+    &[BATCHER_ROW, HTTP_SERVER_ROW, MEMPOOL_P2P_ROW, CONSENSUS_P2P_ROW, STATE_SYNC_P2P_ROW],
 );


### PR DESCRIPTION
- **refactor(papyrus_network): require network mamanger metrics when constructing nm**
- **refactor(papyrus_network): clean up metrics tracking**
- **feat(papyrus_network): add broadcast and sqmr metrics structs**
- **feat(papyrus_network): track broadcast metrics**
- **feat(starknet_sequencer_metrics): add panels and rows for p2p metrics**
