### PR TITLE
chore(starknet_consensus_orchestrator): remove unused test-case dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11098,7 +11098,6 @@ dependencies = [
  "starknet_consensus",
  "starknet_infra_utils",
  "starknet_state_sync_types",
- "test-case",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",

--- a/crates/starknet_consensus_orchestrator/Cargo.toml
+++ b/crates/starknet_consensus_orchestrator/Cargo.toml
@@ -54,7 +54,6 @@ starknet_batcher = { path = "../starknet_batcher" }
 starknet_class_manager_types = { path = "../starknet_class_manager_types", features = ["testing"] }
 starknet_infra_utils.path = "../starknet_infra_utils"
 starknet_state_sync_types = { path = "../starknet_state_sync_types", features = ["testing"] }
-test-case.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Seems the standard is to use rtest to create cases