### PR TITLE
refactor(starknet_class_manager): encapsulate serde logic in `RawClassData<T>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10896,7 +10896,6 @@ dependencies = [
  "papyrus_config",
  "papyrus_storage",
  "serde",
- "serde_json",
  "starknet_api",
  "starknet_class_manager_types",
  "starknet_sequencer_infra",

--- a/crates/starknet_class_manager/Cargo.toml
+++ b/crates/starknet_class_manager/Cargo.toml
@@ -17,7 +17,6 @@ hex.workspace = true
 papyrus_config.workspace = true
 papyrus_storage.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 starknet_api.workspace = true
 starknet_class_manager_types.workspace = true
 starknet_sequencer_infra.workspace = true

--- a/crates/starknet_class_manager/src/class_manager_test.rs
+++ b/crates/starknet_class_manager/src/class_manager_test.rs
@@ -37,7 +37,7 @@ async fn class_manager() {
     // Prepare mock compiler.
     let mut compiler = MockSierraCompilerClient::new();
     let class = RawClass::try_from(SierraContractClass::default()).unwrap();
-    let expected_executable_class = RawExecutableClass(vec![4, 5, 6].into());
+    let expected_executable_class = RawExecutableClass::new_unchecked(vec![4, 5, 6].into());
     let expected_executable_class_for_closure = expected_executable_class.clone();
     let expected_executable_class_hash = CompiledClassHash(felt!("0x5678"));
     compiler.expect_compile().with(eq(class.clone())).times(1).return_once(move |_| {
@@ -85,7 +85,7 @@ async fn class_manager_get_executable() {
     // Prepare mock compiler.
     let mut compiler = MockSierraCompilerClient::new();
     let class = RawClass::try_from(SierraContractClass::default()).unwrap();
-    let expected_executable_class = RawExecutableClass(vec![4, 5, 6].into());
+    let expected_executable_class = RawExecutableClass::new_unchecked(vec![4, 5, 6].into());
     let expected_executable_class_for_closure = expected_executable_class.clone();
     let expected_executable_class_hash = CompiledClassHash(felt!("0x5678"));
     compiler.expect_compile().with(eq(class.clone())).times(1).return_once(move |_| {
@@ -105,7 +105,7 @@ async fn class_manager_get_executable() {
         class_manager.add_class(class.clone()).await.unwrap();
 
     let deprecated_class_hash = ClassHash(felt!("0x1806"));
-    let deprecated_executable_class = RawExecutableClass(vec![1, 2, 3].into());
+    let deprecated_executable_class = RawExecutableClass::new_unchecked(vec![1, 2, 3].into());
     class_manager
         .add_deprecated_class(deprecated_class_hash, deprecated_executable_class.clone())
         .unwrap();

--- a/crates/starknet_class_manager/src/class_storage.rs
+++ b/crates/starknet_class_manager/src/class_storage.rs
@@ -1,7 +1,5 @@
 use std::collections::BTreeMap;
 use std::error::Error;
-use std::fs::File;
-use std::io::{BufReader, BufWriter};
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -14,7 +12,7 @@ use starknet_api::class_cache::GlobalContractCache;
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::ChainId;
 use starknet_class_manager_types::{CachedClassStorageError, ClassId, ExecutableClassHash};
-use starknet_sierra_multicompile_types::{RawClass, RawExecutableClass};
+use starknet_sierra_multicompile_types::{RawClass, RawClassError, RawExecutableClass};
 use thiserror::Error;
 
 use crate::config::{ClassHashStorageConfig, FsClassStorageConfig};
@@ -328,7 +326,7 @@ pub enum FsClassStorageError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error(transparent)]
-    WriteError(#[from] serde_json::Error),
+    RawClass(#[from] RawClassError),
 }
 
 impl FsClassStorage {
@@ -377,41 +375,6 @@ impl FsClassStorage {
     fn get_executable_path(&self, class_id: ClassId) -> PathBuf {
         concat_executable_filename(&self.get_persistent_dir(class_id))
     }
-
-    fn read_file(&self, path: PathBuf) -> FsClassStorageResult<Option<serde_json::Value>> {
-        let file = match File::open(&path) {
-            Ok(file) => file,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(e) => return Err(e.into()),
-        };
-
-        match serde_json::from_reader(BufReader::new(file)) {
-            Ok(value) => Ok(value),
-            Err(e) if e.is_io() && e.to_string().contains("No such file or directory") => Ok(None),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    fn write_file(&self, path: PathBuf, data: serde_json::Value) -> FsClassStorageResult<()> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        // Open a file for writing, delete content if exists
-        // (should not happen, since the file is a unique temporary file).
-        let file = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(path)
-            .expect("Failing to open file with given options is impossible");
-
-        // Write to file.
-        let writer = BufWriter::new(file);
-        serde_json::to_writer(writer, &data)?;
-
-        Ok(())
-    }
 }
 
 impl ClassStorage for FsClassStorage {
@@ -431,8 +394,8 @@ impl ClassStorage for FsClassStorage {
         // Write classes to a temporary directory.
         let tmp_dir = create_tmp_dir()?;
         let tmp_dir = tmp_dir.path().join(self.get_class_dir(class_id));
-        self.write_file(concat_sierra_filename(&tmp_dir), class.0)?;
-        self.write_file(concat_executable_filename(&tmp_dir), executable_class.0)?;
+        class.write_to_file(concat_sierra_filename(&tmp_dir))?;
+        executable_class.write_to_file(concat_executable_filename(&tmp_dir))?;
 
         // Atomically rename directory to persistent one.
         let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
@@ -450,7 +413,7 @@ impl ClassStorage for FsClassStorage {
         }
 
         let path = self.get_sierra_path(class_id);
-        Ok(self.read_file(path)?.map(RawClass))
+        Ok(RawClass::from_file(path)?)
     }
 
     fn get_executable(&self, class_id: ClassId) -> Result<Option<RawExecutableClass>, Self::Error> {
@@ -461,7 +424,7 @@ impl ClassStorage for FsClassStorage {
         }
 
         let path = self.get_executable_path(class_id);
-        Ok(self.read_file(path)?.map(RawExecutableClass))
+        Ok(RawExecutableClass::from_file(path)?)
     }
 
     fn get_executable_class_hash(
@@ -483,7 +446,7 @@ impl ClassStorage for FsClassStorage {
         // Write class to a temporary directory.
         let tmp_dir = tempfile::tempdir()?.into_path();
         let tmp_dir = tmp_dir.join(self.get_class_dir(class_id));
-        self.write_file(concat_executable_filename(&tmp_dir), class.0)?;
+        class.write_to_file(concat_executable_filename(&tmp_dir))?;
 
         // Atomically rename directory to persistent one.
         let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
@@ -501,7 +464,7 @@ impl ClassStorage for FsClassStorage {
         }
 
         let path = self.get_executable_path(class_id);
-        Ok(self.read_file(path)?.map(RawExecutableClass))
+        Ok(RawExecutableClass::from_file(path)?)
     }
 }
 

--- a/crates/starknet_class_manager/src/class_storage_test.rs
+++ b/crates/starknet_class_manager/src/class_storage_test.rs
@@ -50,7 +50,7 @@ fn fs_storage() {
     // Add new class.
     let class = RawClass::try_from(SierraContractClass::default()).unwrap();
     // TODO(Elin): consider creating an empty Casm instead of vec (doesn't implement default).
-    let executable_class = RawExecutableClass(vec![4, 5, 6].into());
+    let executable_class = RawExecutableClass::new_unchecked(vec![4, 5, 6].into());
     let executable_class_hash = CompiledClassHash(felt!("0x5678"));
     storage
         .set_class(class_id, class.clone(), executable_class_hash, executable_class.clone())
@@ -80,7 +80,7 @@ fn fs_storage_deprecated_class_api() {
 
     // Add new class.
     // TODO(Elin): consider creating an empty Casm instead of vec (doesn't implement default).
-    let executable_class = RawExecutableClass(vec![4, 5, 6].into());
+    let executable_class = RawExecutableClass::new_unchecked(vec![4, 5, 6].into());
     storage.set_deprecated_class(class_id, executable_class.clone()).unwrap();
 
     // Get class.

--- a/crates/starknet_class_manager/src/communication.rs
+++ b/crates/starknet_class_manager/src/communication.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use starknet_api::contract_class::ContractClass;
 use starknet_class_manager_types::{ClassManagerRequest, ClassManagerResponse};
 use starknet_sequencer_infra::component_definitions::ComponentRequestHandler;
 use starknet_sequencer_infra::component_server::{LocalComponentServer, RemoteComponentServer};
@@ -20,8 +21,9 @@ impl ComponentRequestHandler<ClassManagerRequest, ClassManagerResponse> for Clas
                 ClassManagerResponse::AddClass(self.0.add_class(class.try_into().unwrap()).await)
             }
             ClassManagerRequest::AddDeprecatedClass(class_id, class) => {
+                let class = ContractClass::V0(class).try_into().unwrap();
                 ClassManagerResponse::AddDeprecatedClass(
-                    self.0.add_deprecated_class(class_id, class.try_into().unwrap()),
+                    self.0.add_deprecated_class(class_id, class),
                 )
             }
             ClassManagerRequest::GetExecutable(class_id) => {

--- a/crates/starknet_integration_tests/src/state_reader.rs
+++ b/crates/starknet_integration_tests/src/state_reader.rs
@@ -188,17 +188,17 @@ fn initialize_class_manager_test_state(
     let TestClasses { cairo0_contract_classes, cairo1_contract_classes } = classes;
 
     for (class_hash, casm) in cairo0_contract_classes {
-        class_manager_storage.set_deprecated_class(class_hash, casm.try_into().unwrap()).unwrap();
+        let casm = ContractClass::V0(casm).try_into().unwrap();
+        class_manager_storage.set_deprecated_class(class_hash, casm).unwrap();
     }
     for (class_hash, (sierra, casm)) in cairo1_contract_classes {
         let sierra_version = SierraVersion::extract_from_program(&sierra.sierra_program).unwrap();
         let class = ContractClass::V1((casm, sierra_version));
-        let compiled_class_hash = class.compiled_class_hash();
         class_manager_storage
             .set_class(
                 class_hash,
                 sierra.try_into().unwrap(),
-                compiled_class_hash,
+                class.compiled_class_hash(),
                 class.try_into().unwrap(),
             )
             .unwrap();


### PR DESCRIPTION
Particularly, only allow creating a raw class through serializing a Sierra/Casm object; raw new isn't allowed.
Also, removed overloading of `TryFrom` trait for deprecated class.