### PR TITLE
fix(starknet_batcher): run execution inside spawn_blocking

### DIFF
--- a/crates/starknet_batcher/Cargo.toml
+++ b/crates/starknet_batcher/Cargo.toml
@@ -35,7 +35,7 @@ validator.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
-blockifier = { path = "../blockifier", features = ["testing"] }
+blockifier = { workspace = true, features = ["testing"] }
 cairo-lang-starknet-classes.workspace = true
 chrono = { workspace = true }
 futures.workspace = true

--- a/crates/starknet_batcher/src/block_builder_test.rs
+++ b/crates/starknet_batcher/src/block_builder_test.rs
@@ -423,7 +423,7 @@ async fn run_build_block(
         ChainId::create_for_testing(),
     );
     let mut block_builder = BlockBuilder::new(
-        Box::new(mock_transaction_executor),
+        mock_transaction_executor,
         Box::new(tx_provider),
         output_sender,
         abort_receiver,


### PR DESCRIPTION
Avoid deadlock that is caused by waiting server to respond while blocking the executor