### PR TITLE
test(starknet_class_manager): test partial write

### DIFF
--- a/crates/starknet_class_manager/src/class_storage.rs
+++ b/crates/starknet_class_manager/src/class_storage.rs
@@ -379,6 +379,14 @@ impl FsClassStorage {
     fn get_deprecated_executable_path(&self, class_id: ClassId) -> PathBuf {
         concat_deprecated_executable_filename(&self.get_persistent_dir(class_id))
     }
+
+    fn mark_class_id_as_existent(
+        &mut self,
+        class_id: ClassId,
+        executable_class_hash: ExecutableClassHash,
+    ) -> FsClassStorageResult<()> {
+        Ok(self.class_hash_storage.set_executable_class_hash(class_id, executable_class_hash)?)
+    }
 }
 
 impl ClassStorage for FsClassStorage {
@@ -405,8 +413,7 @@ impl ClassStorage for FsClassStorage {
         let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
         std::fs::rename(tmp_dir, persistent_dir)?;
 
-        // Mark class as existent.
-        self.class_hash_storage.set_executable_class_hash(class_id, executable_class_hash)?;
+        self.mark_class_id_as_existent(class_id, executable_class_hash)?;
 
         Ok(())
     }

--- a/crates/starknet_class_manager/src/class_storage_test.rs
+++ b/crates/starknet_class_manager/src/class_storage_test.rs
@@ -92,3 +92,22 @@ fn fs_storage_deprecated_class_api() {
 
 // TODO(Elin): check a nonexistent persistent root (should be created).
 // TODO(Elin): add unimplemented skeletons for test above and rest of missing tests.
+
+/// This scenario simulates a (manual) DB corruption; e.g., files were deleted.
+// TODO(Elin): should this flow return an error?
+#[test]
+fn fs_storage_partial_write_only_atomic_marker() {
+    let persistent_root = create_tmp_dir().unwrap();
+    let class_hash_storage_path_prefix = create_tmp_dir().unwrap();
+    let mut storage =
+        FsClassStorage::new_for_testing(&persistent_root, &class_hash_storage_path_prefix);
+
+    // Write only atomic marker, no class files.
+    let class_id = ClassHash(felt!("0x1234"));
+    let executable_class_hash = CompiledClassHash(felt!("0x5678"));
+    storage.mark_class_id_as_existent(class_id, executable_class_hash).unwrap();
+
+    // Query class, should be considered non-existent.
+    assert_eq!(storage.get_sierra(class_id), Ok(None));
+    assert_eq!(storage.get_executable(class_id), Ok(None));
+}


### PR DESCRIPTION
Only atomic marker is set, no class files exist; class should be considered nonexistent (`Ok(None)`, no error).