### PR TITLE
chore(starknet_batcher): fix error message on transaction provider error on l1 validation

### DIFF
--- a/crates/starknet_batcher/src/transaction_provider.rs
+++ b/crates/starknet_batcher/src/transaction_provider.rs
@@ -18,8 +18,15 @@ type TransactionProviderResult<T> = Result<T, TransactionProviderError>;
 pub enum TransactionProviderError {
     #[error(transparent)]
     MempoolError(#[from] MempoolClientError),
-    #[error("L1Handler transaction validation failed for tx with hash {0}.")]
-    L1HandlerTransactionValidationFailed(TransactionHash),
+    #[error(
+        "L1Handler transaction validation failed for tx with hash {} status {:?}.",
+        tx_hash.0.to_hex_string(),
+        validation_status
+    )]
+    L1HandlerTransactionValidationFailed {
+        tx_hash: TransactionHash,
+        validation_status: L1ValidationStatus,
+    },
     #[error(transparent)]
     L1ProviderError(#[from] L1ProviderClientError),
 }
@@ -150,10 +157,10 @@ impl TransactionProvider for ValidateTransactionProvider {
                 let l1_validation_status =
                     self.l1_provider_client.validate(tx.tx_hash, self.height).await?;
                 if l1_validation_status != L1ValidationStatus::Validated {
-                    // TODO(AlonH): add the validation status into the error.
-                    return Err(TransactionProviderError::L1HandlerTransactionValidationFailed(
-                        tx.tx_hash,
-                    ));
+                    return Err(TransactionProviderError::L1HandlerTransactionValidationFailed {
+                        tx_hash: tx.tx_hash,
+                        validation_status: l1_validation_status,
+                    });
                 }
             }
         }

--- a/crates/starknet_l1_provider_types/src/lib.rs
+++ b/crates/starknet_l1_provider_types/src/lib.rs
@@ -21,6 +21,9 @@ pub type L1ProviderResult<T> = Result<T, L1ProviderError>;
 pub type L1ProviderClientResult<T> = Result<T, L1ProviderClientError>;
 pub type SharedL1ProviderClient = Arc<dyn L1ProviderClient>;
 
+// TODO(Arni): Consider splitting this enum into valid and invalid status where the invalid status
+// holds the flavor of the invalidity. Propagate this change to
+// [TransactionProviderError::L1HandlerTransactionValidationFailed].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ValidationStatus {
     AlreadyIncludedInProposedBlock,


### PR DESCRIPTION
The new error message prints as:
```
L1Handler transaction validation failed for tx with hash 0x11faf080dfd62a9505a328e1f86c7e9e60e9752d9e18ddea5af46f8debf5205 status ConsumedOnL1OrUnknown
```