### PR TITLE
refactor(starknet_batcher): pack metadata in exec artifacts

### DIFF
--- a/crates/starknet_batcher/src/batcher.rs
+++ b/crates/starknet_batcher/src/batcher.rs
@@ -480,13 +480,14 @@ impl Batcher {
         let state_diff = block_execution_artifacts.thin_state_diff();
         let n_txs = u64::try_from(block_execution_artifacts.tx_hashes().len())
             .expect("Number of transactions should fit in u64");
-        let n_rejected_txs = u64::try_from(block_execution_artifacts.rejected_tx_hashes.len())
-            .expect("Number of rejected transactions should fit in u64");
+        let n_rejected_txs =
+            u64::try_from(block_execution_artifacts.metadata.rejected_tx_hashes.len())
+                .expect("Number of rejected transactions should fit in u64");
         self.commit_proposal_and_block(
             height,
             state_diff.clone(),
             block_execution_artifacts.address_to_nonce(),
-            block_execution_artifacts.rejected_tx_hashes,
+            block_execution_artifacts.metadata.rejected_tx_hashes,
         )
         .await?;
         let execution_infos: Vec<_> =

--- a/crates/starknet_batcher/src/batcher_test.rs
+++ b/crates/starknet_batcher/src/batcher_test.rs
@@ -877,7 +877,7 @@ async fn decision_reached() {
         .times(1)
         .with(eq(CommitBlockArgs {
             address_to_nonce: expected_artifacts.address_to_nonce(),
-            rejected_tx_hashes: expected_artifacts.rejected_tx_hashes.clone(),
+            rejected_tx_hashes: expected_artifacts.metadata.rejected_tx_hashes.clone(),
         }))
         .returning(|_| Ok(()));
 
@@ -923,7 +923,7 @@ async fn decision_reached() {
     );
     assert_eq!(
         REJECTED_TRANSACTIONS.parse_numeric_metric::<usize>(&metrics),
-        Some(expected_artifacts.rejected_tx_hashes.len())
+        Some(expected_artifacts.metadata.rejected_tx_hashes.len())
     );
 }
 

--- a/crates/starknet_batcher/src/block_builder.rs
+++ b/crates/starknet_batcher/src/block_builder.rs
@@ -86,7 +86,7 @@ pub struct BlockExecutionArtifacts {
     // Note: The execution_infos must be ordered to match the order of the transactions in the
     // block.
     pub execution_infos: IndexMap<TransactionHash, TransactionExecutionInfo>,
-    pub rejected_tx_hashes: HashSet<TransactionHash>,
+    pub metadata: BlockExecutionMetadata,
     pub commitment_state_diff: CommitmentStateDiff,
     pub compressed_state_diff: Option<CommitmentStateDiff>,
     pub bouncer_weights: BouncerWeights,
@@ -257,7 +257,7 @@ impl BlockBuilderTrait for BlockBuilder {
             self.executor.lock().await.close_block()?;
         Ok(BlockExecutionArtifacts {
             execution_infos,
-            rejected_tx_hashes,
+            metadata: BlockExecutionMetadata { rejected_tx_hashes },
             commitment_state_diff: state_diff,
             compressed_state_diff,
             bouncer_weights,
@@ -464,4 +464,11 @@ impl BlockBuilderFactoryTrait for BlockBuilderFactory {
         ));
         Ok((block_builder, abort_signal_sender))
     }
+}
+
+/// Supplementary information for use by downstream services.
+#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BlockExecutionMetadata {
+    pub rejected_tx_hashes: HashSet<TransactionHash>,
 }

--- a/crates/starknet_batcher/src/block_builder_test.rs
+++ b/crates/starknet_batcher/src/block_builder_test.rs
@@ -33,6 +33,7 @@ use crate::block_builder::{
     BlockBuilderResult,
     BlockBuilderTrait,
     BlockExecutionArtifacts,
+    BlockExecutionMetadata,
     FailOnErrorCause,
 };
 use crate::test_utils::test_txs;
@@ -64,7 +65,7 @@ fn block_execution_artifacts(
     let l2_gas_used = GasAmount(execution_infos.len().try_into().unwrap());
     BlockExecutionArtifacts {
         execution_infos,
-        rejected_tx_hashes,
+        metadata: BlockExecutionMetadata { rejected_tx_hashes },
         commitment_state_diff: Default::default(),
         compressed_state_diff: Default::default(),
         bouncer_weights: BouncerWeights { l1_gas: 100, ..BouncerWeights::empty() },

--- a/crates/starknet_batcher/src/test_utils.rs
+++ b/crates/starknet_batcher/src/test_utils.rs
@@ -14,7 +14,12 @@ use starknet_api::transaction::TransactionHash;
 use starknet_api::{class_hash, contract_address, nonce, tx_hash};
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::block_builder::{BlockBuilderResult, BlockBuilderTrait, BlockExecutionArtifacts};
+use crate::block_builder::{
+    BlockBuilderResult,
+    BlockBuilderTrait,
+    BlockExecutionArtifacts,
+    BlockExecutionMetadata,
+};
 use crate::transaction_provider::{NextTxs, TransactionProvider};
 
 pub const EXECUTION_INFO_LEN: usize = 10;
@@ -109,7 +114,9 @@ impl BlockExecutionArtifacts {
         // Use a non-empty commitment_state_diff to get a valuable test verification of the result.
         Self {
             execution_infos: indexed_execution_infos(),
-            rejected_tx_hashes: test_txs(10..15).iter().map(|tx| tx.tx_hash()).collect(),
+            metadata: BlockExecutionMetadata {
+                rejected_tx_hashes: test_txs(10..15).iter().map(|tx| tx.tx_hash()).collect(),
+            },
             commitment_state_diff: CommitmentStateDiff {
                 address_to_class_hash: IndexMap::from_iter([(
                     contract_address!("0x7"),


### PR DESCRIPTION
Will soon add `accepted_l1_tx_hashes` into this struct, for use in `l1_provider.commit_block`

Only EXTRACT + getter, otherwise no logic changes.