### PR TITLE
fix(starknet_batcher): track accepted l1 tx hashes and pass to `L1Pro…

### DIFF
--- a/crates/starknet_batcher/src/batcher.rs
+++ b/crates/starknet_batcher/src/batcher.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use apollo_reverts::revert_block;
@@ -11,7 +11,6 @@ use starknet_api::block::{BlockHeaderWithoutHash, BlockNumber};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::state::ThinStateDiff;
-use starknet_api::transaction::TransactionHash;
 use starknet_batcher_types::batcher_types::{
     BatcherResult,
     CentralObjects,
@@ -59,6 +58,7 @@ use crate::block_builder::{
     BlockBuilderFactoryTrait,
     BlockBuilderTrait,
     BlockExecutionArtifacts,
+    BlockExecutionMetadata,
     BlockMetadata,
 };
 use crate::config::BatcherConfig;
@@ -461,7 +461,8 @@ impl Batcher {
         }
 
         let address_to_nonce = state_diff.nonces.iter().map(|(k, v)| (*k, *v)).collect();
-        self.commit_proposal_and_block(height, state_diff, address_to_nonce, [].into()).await
+        self.commit_proposal_and_block(height, state_diff, address_to_nonce, Default::default())
+            .await
     }
 
     #[instrument(skip(self), err)]
@@ -486,7 +487,7 @@ impl Batcher {
             height,
             state_diff.clone(),
             block_execution_artifacts.address_to_nonce(),
-            block_execution_artifacts.metadata.rejected_tx_hashes,
+            block_execution_artifacts.metadata,
         )
         .await?;
         let execution_infos: Vec<_> =
@@ -511,8 +512,9 @@ impl Batcher {
         height: BlockNumber,
         state_diff: ThinStateDiff,
         address_to_nonce: HashMap<ContractAddress, Nonce>,
-        rejected_tx_hashes: HashSet<TransactionHash>,
+        metadata: BlockExecutionMetadata,
     ) -> BatcherResult<()> {
+        let rejected_tx_hashes = metadata.rejected_tx_hashes;
         info!("Committing block at height {} and notifying mempool of the block.", height);
         trace!("Rejected transactions: {:#?}, State diff: {:#?}.", rejected_tx_hashes, state_diff);
 
@@ -532,7 +534,10 @@ impl Batcher {
             // TODO(AlonH): Should we rollback the state diff and return an error?
         };
 
-        let l1_provider_result = self.l1_provider_client.commit_block(vec![], height).await;
+        let l1_provider_result = self
+            .l1_provider_client
+            .commit_block(metadata.accepted_l1_handler_tx_hashes.iter().copied().collect(), height)
+            .await;
         l1_provider_result.unwrap_or_else(|err| match err {
             L1ProviderClientError::L1ProviderError(L1ProviderError::UnexpectedHeight {
                 expected,

--- a/crates/starknet_batcher/src/block_builder.rs
+++ b/crates/starknet_batcher/src/block_builder.rs
@@ -17,7 +17,7 @@ use blockifier::state::contract_class_manager::ContractClassManager;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use blockifier::transaction::transaction_execution::Transaction as BlockifierTransaction;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 #[cfg(test)]
 use mockall::automock;
 use papyrus_config::dumping::{append_sub_config_name, ser_param, SerializeConfig};
@@ -185,7 +185,7 @@ impl BlockBuilderTrait for BlockBuilder {
         let mut block_is_full = false;
         let mut execution_infos = IndexMap::new();
         let mut l2_gas_used = GasAmount::ZERO;
-        let mut rejected_tx_hashes = HashSet::new();
+        let mut metadata = BlockExecutionMetadata::default();
         // TODO(yael 6/10/2024): delete the timeout condition once the executor has a timeout
         while !block_is_full {
             if tokio::time::Instant::now() >= self.execution_params.deadline {
@@ -247,7 +247,7 @@ impl BlockBuilderTrait for BlockBuilder {
                 results,
                 &mut l2_gas_used,
                 &mut execution_infos,
-                &mut rejected_tx_hashes,
+                &mut metadata,
                 &self.output_content_sender,
                 self.execution_params.fail_on_err,
             )
@@ -257,7 +257,7 @@ impl BlockBuilderTrait for BlockBuilder {
             self.executor.lock().await.close_block()?;
         Ok(BlockExecutionArtifacts {
             execution_infos,
-            metadata: BlockExecutionMetadata { rejected_tx_hashes },
+            metadata,
             commitment_state_diff: state_diff,
             compressed_state_diff,
             bouncer_weights,
@@ -272,7 +272,7 @@ async fn collect_execution_results_and_stream_txs(
     results: Vec<TransactionExecutorResult<TransactionExecutionInfo>>,
     l2_gas_used: &mut GasAmount,
     execution_infos: &mut IndexMap<TransactionHash, TransactionExecutionInfo>,
-    rejected_tx_hashes: &mut HashSet<TransactionHash>,
+    metadata: &mut BlockExecutionMetadata,
     output_content_sender: &Option<
         tokio::sync::mpsc::UnboundedSender<InternalConsensusTransaction>,
     >,
@@ -300,7 +300,13 @@ async fn collect_execution_results_and_stream_txs(
                 *l2_gas_used = l2_gas_used
                     .checked_add(tx_execution_info.receipt.gas.l2_gas)
                     .expect("Total L2 gas overflow.");
-                execution_infos.insert(input_tx.tx_hash(), tx_execution_info);
+
+                let tx_hash = input_tx.tx_hash();
+                execution_infos.insert(tx_hash, tx_execution_info);
+                if let InternalConsensusTransaction::L1Handler(_) = input_tx {
+                    metadata.accepted_l1_handler_tx_hashes.insert(tx_hash);
+                }
+
                 if let Some(output_content_sender) = output_content_sender {
                     output_content_sender.send(input_tx)?;
                 }
@@ -314,7 +320,7 @@ async fn collect_execution_results_and_stream_txs(
                         FailOnErrorCause::TransactionFailed(err),
                     ));
                 }
-                rejected_tx_hashes.insert(input_tx.tx_hash());
+                metadata.rejected_tx_hashes.insert(input_tx.tx_hash());
             }
         }
     }
@@ -471,4 +477,5 @@ impl BlockBuilderFactoryTrait for BlockBuilderFactory {
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct BlockExecutionMetadata {
     pub rejected_tx_hashes: HashSet<TransactionHash>,
+    pub accepted_l1_handler_tx_hashes: IndexSet<TransactionHash>,
 }

--- a/crates/starknet_batcher/src/block_builder_test.rs
+++ b/crates/starknet_batcher/src/block_builder_test.rs
@@ -65,7 +65,7 @@ fn block_execution_artifacts(
     let l2_gas_used = GasAmount(execution_infos.len().try_into().unwrap());
     BlockExecutionArtifacts {
         execution_infos,
-        metadata: BlockExecutionMetadata { rejected_tx_hashes },
+        metadata: BlockExecutionMetadata { rejected_tx_hashes, ..Default::default() },
         commitment_state_diff: Default::default(),
         compressed_state_diff: Default::default(),
         bouncer_weights: BouncerWeights { l1_gas: 100, ..BouncerWeights::empty() },

--- a/crates/starknet_batcher/src/test_utils.rs
+++ b/crates/starknet_batcher/src/test_utils.rs
@@ -116,6 +116,7 @@ impl BlockExecutionArtifacts {
             execution_infos: indexed_execution_infos(),
             metadata: BlockExecutionMetadata {
                 rejected_tx_hashes: test_txs(10..15).iter().map(|tx| tx.tx_hash()).collect(),
+                accepted_l1_handler_tx_hashes: Default::default(),
             },
             commitment_state_diff: CommitmentStateDiff {
                 address_to_class_hash: IndexMap::from_iter([(


### PR DESCRIPTION
…vider`

Replaces the placeholder used in commit_block previously. Also started passing the metadata obj whenever possible.