### PR TITLE
fix(starknet_l1_gas_price): allow gas price provider to start at any height

### DIFF
--- a/crates/starknet_l1_gas_price/src/l1_gas_price_provider.rs
+++ b/crates/starknet_l1_gas_price/src/l1_gas_price_provider.rs
@@ -78,13 +78,13 @@ impl L1GasPriceProvider {
         height: L1BlockNumber,
         sample: PriceSample,
     ) -> L1GasPriceProviderResult<()> {
-        let last_plus_one =
-            self.price_samples_by_block.back().map(|data| data.height + 1).unwrap_or(0);
-        if height != last_plus_one {
-            return Err(L1GasPriceProviderError::UnexpectedHeightError {
-                expected: last_plus_one,
-                found: height,
-            });
+        if let Some(data) = self.price_samples_by_block.back() {
+            if height != data.height + 1 {
+                return Err(L1GasPriceProviderError::UnexpectedHeightError {
+                    expected: data.height + 1,
+                    found: height,
+                });
+            }
         }
         self.price_samples_by_block.push(GasPriceData { height, sample });
         Ok(())

--- a/crates/starknet_l1_gas_price/src/l1_gas_price_provider_test.rs
+++ b/crates/starknet_l1_gas_price/src/l1_gas_price_provider_test.rs
@@ -81,6 +81,7 @@ fn gas_price_provider_adding_samples() {
     let ret = provider.get_price_info(BlockTimestamp(final_timestamp + lag));
     matches!(ret, Result::Err(L1GasPriceProviderError::MissingDataError { .. }));
 }
+
 #[test]
 fn gas_price_provider_timestamp_changes_mean() {
     let (provider, samples) = make_provider();
@@ -96,4 +97,14 @@ fn gas_price_provider_timestamp_changes_mean() {
         provider.get_price_info(BlockTimestamp(final_timestamp + lag * 2)).unwrap();
     assert_ne!(gas_price_new, gas_price);
     assert_ne!(data_gas_price_new, data_gas_price);
+}
+
+#[test]
+fn gas_price_provider_can_start_at_nonzero_height() {
+    let mut provider = L1GasPriceProvider::new(L1GasPriceProviderConfig {
+        number_of_blocks_for_mean: 3,
+        ..Default::default()
+    });
+    let sample = PriceSample { timestamp: 0, base_fee_per_gas: 0, blob_fee: 0 };
+    provider.add_price_info(42, sample.clone()).unwrap();
 }


### PR DESCRIPTION
Fix a bug where the provider would crash if the first block number it got was not zero. 