### PR TITLE
Make `starknet_sierra_multicompile` an optional dependency

### DIFF
--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 cairo_native = [
   "blockifier_test_utils/cairo_native",
   "dep:cairo-native",
-  "starknet_sierra_multicompile/cairo_native",
+  "dep:starknet_sierra_multicompile",
 ]
 native_blockifier = []
 reexecution = ["transaction_serde"]
@@ -58,7 +58,7 @@ sha2.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_infra_utils.workspace = true
-starknet_sierra_multicompile.workspace = true
+starknet_sierra_multicompile = { workspace = true, optional = true}
 strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true

--- a/crates/blockifier/src/blockifier/config.rs
+++ b/crates/blockifier/src/blockifier/config.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
-use papyrus_config::dumping::{append_sub_config_name, ser_param, SerializeConfig};
+use papyrus_config::dumping::{SerializeConfig, append_sub_config_name, ser_param};
 use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "cairo_native")]
 use starknet_sierra_multicompile::config::SierraCompilationConfig;
 
 use crate::blockifier::transaction_executor::DEFAULT_STACK_SIZE;
@@ -88,6 +89,7 @@ impl SerializeConfig for ConcurrencyConfig {
 pub struct ContractClassManagerConfig {
     pub cairo_native_run_config: CairoNativeRunConfig,
     pub contract_cache_size: usize,
+    #[cfg(feature = "cairo_native")]
     pub native_compiler_config: SierraCompilationConfig,
 }
 
@@ -96,6 +98,7 @@ impl Default for ContractClassManagerConfig {
         Self {
             cairo_native_run_config: CairoNativeRunConfig::default(),
             contract_cache_size: GLOBAL_CONTRACT_CACHE_SIZE_FOR_TEST,
+            #[cfg(feature = "cairo_native")]
             native_compiler_config: SierraCompilationConfig::default(),
         }
     }
@@ -125,10 +128,13 @@ impl SerializeConfig for ContractClassManagerConfig {
             self.cairo_native_run_config.dump(),
             "cairo_native_run_config",
         ));
-        dump.append(&mut append_sub_config_name(
-            self.native_compiler_config.dump(),
-            "native_compiler_config",
-        ));
+        #[cfg(feature = "cairo_native")]
+        {
+            dump.append(&mut append_sub_config_name(
+                self.native_compiler_config.dump(),
+                "native_compiler_config",
+            ));
+        }
         dump
     }
 }


### PR DESCRIPTION
This PR makes the `starknet_sierra_multicompile` dependency entirely optional. `config.rs` file was updated so that code from this package is hidden behind a feature flag.

Motivation: `starknet_sierra_multicompile` depends on `std::os::unix` which breaks compatibility with Windows.