### PR TITLE
chore(starknet_sequencer_metrics): update dashboard dump binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11506,7 +11506,6 @@ dependencies = [
 name = "starknet_sequencer_metrics"
 version = "0.0.0"
 dependencies = [
- "clap",
  "metrics 0.24.1",
  "num-traits",
  "regex",

--- a/crates/starknet_sequencer_metrics/Cargo.toml
+++ b/crates/starknet_sequencer_metrics/Cargo.toml
@@ -13,7 +13,6 @@ testing = []
 workspace = true
 
 [dependencies]
-clap.workspace = true
 metrics.workspace = true
 num-traits.workspace = true
 regex.workspace = true

--- a/crates/starknet_sequencer_metrics/src/dashboard_definitions.rs
+++ b/crates/starknet_sequencer_metrics/src/dashboard_definitions.rs
@@ -16,6 +16,8 @@ use crate::metric_definitions::{
     STATE_SYNC_P2P_NUM_CONNECTED_PEERS,
 };
 
+pub const DEV_JSON_PATH: &str = "Monitoring/sequencer/dev_grafana.json";
+
 const PANEL_ADDED_TRANSACTIONS_TOTAL: Panel = Panel::new(
     ADDED_TRANSACTIONS_TOTAL.get_name(),
     ADDED_TRANSACTIONS_TOTAL.get_description(),


### PR DESCRIPTION
**Stack**:
- chore(starknet_sequencer_metrics): add dashboard dump test #4285
- chore(starknet_sequencer_metrics): update dashboard serde #4284
- chore(starknet_sequencer_metrics): update dashboard dump binary #4283 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*