### PR TITLE
Make `starknet_sierra_multicompile` an optional dependency

### DIFF
--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -10,7 +10,7 @@ description = "The transaction-executing component in the Starknet sequencer."
 workspace = true
 
 [features]
-cairo_native = ["dep:cairo-native", "starknet_sierra_multicompile/cairo_native"]
+cairo_native = ["dep:cairo-native", "starknet_sierra_multicompile/cairo_native", "dep:starknet_sierra_multicompile", ]
 jemalloc = ["dep:tikv-jemallocator"]
 native_blockifier = []
 node_api = []
@@ -54,7 +54,7 @@ sha2.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_infra_utils.workspace = true
-starknet_sierra_multicompile.workspace = true
+starknet_sierra_multicompile = { workspace = true, optional = true}
 strum.workspace = true
 strum_macros.workspace = true
 tempfile.workspace = true

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -10,7 +10,9 @@ description = "The transaction-executing component in the Starknet sequencer."
 workspace = true
 
 [features]
-cairo_native = ["dep:cairo-native", "starknet_sierra_multicompile/cairo_native", "dep:starknet_sierra_multicompile", ]
+default = ["sierra_multicompile"]
+sierra_multicompile = ["dep:starknet_sierra_multicompile"]
+cairo_native = ["dep:cairo-native", "starknet_sierra_multicompile/cairo_native", "sierra_multicompile"]
 jemalloc = ["dep:tikv-jemallocator"]
 native_blockifier = []
 node_api = []
@@ -54,7 +56,7 @@ sha2.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_infra_utils.workspace = true
-starknet_sierra_multicompile = { workspace = true, optional = true}
+starknet_sierra_multicompile = { workspace = true, optional = true }
 strum.workspace = true
 strum_macros.workspace = true
 tempfile.workspace = true

--- a/crates/blockifier/src/blockifier/config.rs
+++ b/crates/blockifier/src/blockifier/config.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use papyrus_config::dumping::{SerializeConfig, append_sub_config_name, ser_param};
+use papyrus_config::dumping::{append_sub_config_name, ser_param, SerializeConfig};
 use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "cairo_native")]

--- a/crates/blockifier/src/blockifier/config.rs
+++ b/crates/blockifier/src/blockifier/config.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
-use papyrus_config::dumping::{append_sub_config_name, ser_param, SerializeConfig};
+use papyrus_config::dumping::{SerializeConfig, append_sub_config_name, ser_param};
 use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "cairo_native")]
 use starknet_sierra_multicompile::config::SierraCompilationConfig;
 
 use crate::blockifier::transaction_executor::DEFAULT_STACK_SIZE;
@@ -88,6 +89,7 @@ impl SerializeConfig for ConcurrencyConfig {
 pub struct ContractClassManagerConfig {
     pub cairo_native_run_config: CairoNativeRunConfig,
     pub contract_cache_size: usize,
+    #[cfg(feature = "cairo_native")]
     pub native_compiler_config: SierraCompilationConfig,
 }
 
@@ -96,6 +98,7 @@ impl Default for ContractClassManagerConfig {
         Self {
             cairo_native_run_config: CairoNativeRunConfig::default(),
             contract_cache_size: GLOBAL_CONTRACT_CACHE_SIZE_FOR_TEST,
+            #[cfg(feature = "cairo_native")]
             native_compiler_config: SierraCompilationConfig::default(),
         }
     }
@@ -125,10 +128,13 @@ impl SerializeConfig for ContractClassManagerConfig {
             self.cairo_native_run_config.dump(),
             "cairo_native_run_config",
         ));
-        dump.append(&mut append_sub_config_name(
-            self.native_compiler_config.dump(),
-            "native_compiler_config",
-        ));
+        #[cfg(feature = "cairo_native")]
+        {
+            dump.append(&mut append_sub_config_name(
+                self.native_compiler_config.dump(),
+                "native_compiler_config",
+            ));
+        }
         dump
     }
 }

--- a/crates/blockifier/src/blockifier/config.rs
+++ b/crates/blockifier/src/blockifier/config.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use papyrus_config::dumping::{append_sub_config_name, ser_param, SerializeConfig};
 use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "cairo_native")]
+#[cfg(feature = "sierra_multicompile")]
 use starknet_sierra_multicompile::config::SierraCompilationConfig;
 
 use crate::blockifier::transaction_executor::DEFAULT_STACK_SIZE;
@@ -89,7 +89,7 @@ impl SerializeConfig for ConcurrencyConfig {
 pub struct ContractClassManagerConfig {
     pub cairo_native_run_config: CairoNativeRunConfig,
     pub contract_cache_size: usize,
-    #[cfg(feature = "cairo_native")]
+    #[cfg(feature = "sierra_multicompile")]
     pub native_compiler_config: SierraCompilationConfig,
 }
 
@@ -98,7 +98,7 @@ impl Default for ContractClassManagerConfig {
         Self {
             cairo_native_run_config: CairoNativeRunConfig::default(),
             contract_cache_size: GLOBAL_CONTRACT_CACHE_SIZE_FOR_TEST,
-            #[cfg(feature = "cairo_native")]
+            #[cfg(feature = "sierra_multicompile")]
             native_compiler_config: SierraCompilationConfig::default(),
         }
     }
@@ -128,7 +128,7 @@ impl SerializeConfig for ContractClassManagerConfig {
             self.cairo_native_run_config.dump(),
             "cairo_native_run_config",
         ));
-        #[cfg(feature = "cairo_native")]
+        #[cfg(feature = "sierra_multicompile")]
         {
             dump.append(&mut append_sub_config_name(
                 self.native_compiler_config.dump(),


### PR DESCRIPTION
This PR makes the `starknet_sierra_multicompile` dependency entirely optional. `config.rs` file was updated so that code from this package is hidden behind a feature flag.

Motivation: `starknet_sierra_multicompile` depends on `std::os::unix` which breaks compatibility with Windows.

I've run blockifier crate tests and they seemed to pass locally but I wasn't able to setup the whole dev environment correctly so it needs double checking.