### PR TITLE
feat(starknet_consensus_orchestrator): move ContextConfig to config module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8013,6 +8013,7 @@ dependencies = [
  "starknet_class_manager_types",
  "starknet_client",
  "starknet_consensus",
+ "starknet_consensus_orchestrator",
  "starknet_infra_utils",
  "strum 0.25.0",
  "tempfile",
@@ -11127,6 +11128,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "validator",
 ]
 
 [[package]]

--- a/crates/papyrus_node/Cargo.toml
+++ b/crates/papyrus_node/Cargo.toml
@@ -39,6 +39,7 @@ starknet_api.workspace = true
 starknet_class_manager_types.workspace = true
 starknet_client.workspace = true
 starknet_consensus.workspace = true
+starknet_consensus_orchestrator.workspace = true
 strum.workspace = true
 tokio = { workspace = true, features = ["full", "sync"] }
 tracing.workspace = true

--- a/crates/papyrus_node/src/config/mod.rs
+++ b/crates/papyrus_node/src/config/mod.rs
@@ -39,7 +39,7 @@ use serde_json::{Map, Value};
 use starknet_api::core::ChainId;
 use starknet_client::RetryConfig;
 use starknet_consensus::config::ConsensusConfig;
-use starknet_consensus::types::ContextConfig;
+use starknet_consensus_orchestrator::config::ContextConfig;
 use validator::Validate;
 
 use crate::version::VERSION_FULL;

--- a/crates/starknet_consensus/src/types.rs
+++ b/crates/starknet_consensus/src/types.rs
@@ -1,13 +1,9 @@
 //! Types for interfacing between consensus and the node.
-
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
-use papyrus_config::dumping::{ser_param, SerializeConfig};
-use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use papyrus_network::network_manager::{
     BroadcastTopicChannels,
     BroadcastTopicClient,
@@ -16,10 +12,8 @@ use papyrus_network::network_manager::{
 use papyrus_network_types::network_types::BroadcastedMessageMetadata;
 use papyrus_protobuf::consensus::{ProposalFin, ProposalInit, Vote};
 use papyrus_protobuf::converters::ProtobufConversionError;
-use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockNumber};
-use starknet_api::core::{ChainId, ContractAddress};
-use validator::Validate;
+use starknet_api::core::ContractAddress;
 
 /// Used to identify the node by consensus.
 /// 1. This ID is derived from the id registered with Starknet's L2 staking contract.
@@ -29,72 +23,6 @@ use validator::Validate;
 pub type ValidatorId = ContractAddress;
 pub type Round = u32;
 pub type ProposalCommitment = BlockHash;
-
-// TODO(guyn): move this to another file.
-/// Configuration for the Context struct.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Validate)]
-pub struct ContextConfig {
-    /// The buffer size for streaming outbound proposals.
-    pub proposal_buffer_size: usize,
-    /// The number of validators.
-    pub num_validators: u64,
-    /// The chain id of the Starknet chain.
-    pub chain_id: ChainId,
-    /// Maximum allowed deviation (seconds) of a proposed block's timestamp from the current time.
-    pub block_timestamp_window: u64,
-    /// The data availability mode, true: Blob, false: Calldata.
-    pub l1_da_mode: bool,
-}
-
-impl SerializeConfig for ContextConfig {
-    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
-        BTreeMap::from_iter([
-            ser_param(
-                "proposal_buffer_size",
-                &self.proposal_buffer_size,
-                "The buffer size for streaming outbound proposals.",
-                ParamPrivacyInput::Public,
-            ),
-            ser_param(
-                "num_validators",
-                &self.num_validators,
-                "The number of validators.",
-                ParamPrivacyInput::Public,
-            ),
-            ser_param(
-                "chain_id",
-                &self.chain_id,
-                "The chain id of the Starknet chain.",
-                ParamPrivacyInput::Public,
-            ),
-            ser_param(
-                "block_timestamp_window",
-                &self.block_timestamp_window,
-                "Maximum allowed deviation (seconds) of a proposed block's timestamp from the \
-                 current time.",
-                ParamPrivacyInput::Public,
-            ),
-            ser_param(
-                "l1_da_mode",
-                &self.l1_da_mode,
-                "The data availability mode, true: Blob, false: Calldata.",
-                ParamPrivacyInput::Public,
-            ),
-        ])
-    }
-}
-
-impl Default for ContextConfig {
-    fn default() -> Self {
-        Self {
-            proposal_buffer_size: 100,
-            num_validators: 1,
-            chain_id: ChainId::Mainnet,
-            block_timestamp_window: 1,
-            l1_da_mode: true,
-        }
-    }
-}
 
 /// Interface for consensus to call out to the node.
 ///

--- a/crates/starknet_consensus_manager/src/config.rs
+++ b/crates/starknet_consensus_manager/src/config.rs
@@ -7,8 +7,8 @@ use papyrus_network::NetworkConfig;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_consensus::config::ConsensusConfig;
-use starknet_consensus::types::ContextConfig;
 use starknet_consensus_orchestrator::cende::CendeConfig;
+use starknet_consensus_orchestrator::config::ContextConfig;
 use validator::Validate;
 
 /// The consensus manager related configuration.

--- a/crates/starknet_consensus_orchestrator/Cargo.toml
+++ b/crates/starknet_consensus_orchestrator/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
+validator.workspace = true
 
 [dev-dependencies]
 cairo-lang-casm.workspace = true

--- a/crates/starknet_consensus_orchestrator/src/config.rs
+++ b/crates/starknet_consensus_orchestrator/src/config.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use papyrus_config::dumping::{ser_param, SerializeConfig};
+use papyrus_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use serde::{Deserialize, Serialize};
+use starknet_api::core::ChainId;
+use validator::Validate;
+
+/// Configuration for the Context struct.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Validate)]
+pub struct ContextConfig {
+    /// The buffer size for streaming outbound proposals.
+    pub proposal_buffer_size: usize,
+    /// The number of validators.
+    pub num_validators: u64,
+    /// The chain id of the Starknet chain.
+    pub chain_id: ChainId,
+    /// Maximum allowed deviation (seconds) of a proposed block's timestamp from the current time.
+    pub block_timestamp_window: u64,
+    /// The data availability mode, true: Blob, false: Calldata.
+    pub l1_da_mode: bool,
+}
+
+impl SerializeConfig for ContextConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
+            ser_param(
+                "proposal_buffer_size",
+                &self.proposal_buffer_size,
+                "The buffer size for streaming outbound proposals.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "num_validators",
+                &self.num_validators,
+                "The number of validators.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "chain_id",
+                &self.chain_id,
+                "The chain id of the Starknet chain.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "block_timestamp_window",
+                &self.block_timestamp_window,
+                "Maximum allowed deviation (seconds) of a proposed block's timestamp from the \
+                 current time.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "l1_da_mode",
+                &self.l1_da_mode,
+                "The data availability mode, true: Blob, false: Calldata.",
+                ParamPrivacyInput::Public,
+            ),
+        ])
+    }
+}
+
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self {
+            proposal_buffer_size: 100,
+            num_validators: 1,
+            chain_id: ChainId::Mainnet,
+            block_timestamp_window: 1,
+            l1_da_mode: true,
+        }
+    }
+}

--- a/crates/starknet_consensus_orchestrator/src/lib.rs
+++ b/crates/starknet_consensus_orchestrator/src/lib.rs
@@ -14,3 +14,6 @@ pub mod fee_market;
 
 /// Consensus' versioned constants.
 pub mod orchestrator_versioned_constants;
+
+/// The orchestrator's configuration.
+pub mod config;

--- a/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -61,7 +61,6 @@ use starknet_class_manager_types::SharedClassManagerClient;
 use starknet_consensus::types::{
     ConsensusContext,
     ConsensusError,
-    ContextConfig,
     ProposalCommitment,
     Round,
     ValidatorId,
@@ -76,6 +75,7 @@ use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error, error_span, info, instrument, trace, warn, Instrument};
 
 use crate::cende::{BlobParameters, CendeContext};
+use crate::config::ContextConfig;
 use crate::fee_market::{calculate_next_base_gas_price, FeeMarketInfo};
 use crate::orchestrator_versioned_constants::VersionedConstants;
 

--- a/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -51,11 +51,12 @@ use starknet_class_manager_types::transaction_converter::{
     TransactionConverterTrait,
 };
 use starknet_class_manager_types::EmptyClassManagerClient;
-use starknet_consensus::types::{ConsensusContext, ContextConfig, Round};
+use starknet_consensus::types::{ConsensusContext, Round};
 use starknet_state_sync_types::communication::MockStateSyncClient;
 use starknet_types_core::felt::Felt;
 
 use crate::cende::MockCendeContext;
+use crate::config::ContextConfig;
 use crate::sequencer_consensus_context::SequencerConsensusContext;
 
 const TIMEOUT: Duration = Duration::from_millis(1200);

--- a/crates/starknet_integration_tests/src/utils.rs
+++ b/crates/starknet_integration_tests/src/utils.rs
@@ -34,9 +34,10 @@ use starknet_class_manager::config::{
     FsClassStorageConfig,
 };
 use starknet_consensus::config::{ConsensusConfig, TimeoutsConfig};
-use starknet_consensus::types::{ContextConfig, ValidatorId};
+use starknet_consensus::types::ValidatorId;
 use starknet_consensus_manager::config::ConsensusManagerConfig;
 use starknet_consensus_orchestrator::cende::{CendeConfig, RECORDER_WRITE_BLOB_PATH};
+use starknet_consensus_orchestrator::config::ContextConfig;
 use starknet_gateway::config::{
     GatewayConfig,
     StatefulTransactionValidatorConfig,


### PR DESCRIPTION
It was previously in `starknet_consensus/src/types.rs` which is where the ConsensusContext definition lives. But it is a specific implementation and should go in the orchestrator crate. 