### PR TITLE
refactor(consensus): begin rewriting tests for the stream handler

### DIFF
--- a/crates/starknet_consensus/src/stream_handler_test.rs
+++ b/crates/starknet_consensus/src/stream_handler_test.rs
@@ -547,3 +547,196 @@ mod tests {
         );
     }
 }
+
+mod tests_v2 {
+    use std::collections::BTreeSet;
+
+    use futures::channel::mpsc::{self, Receiver, SendError, Sender};
+    use futures::{FutureExt, SinkExt, StreamExt};
+    use papyrus_network::network_manager::{BroadcastTopicClientTrait, ReceivedBroadcastedMessage};
+    use papyrus_network_types::network_types::BroadcastedMessageMetadata;
+    use papyrus_protobuf::consensus::{ProposalInit, ProposalPart, StreamMessageBody};
+
+    use super::{TestStreamId, CHANNEL_SIZE};
+    use crate::stream_handler::StreamHandler;
+
+    type StreamMessage = papyrus_protobuf::consensus::StreamMessage<ProposalPart, TestStreamId>;
+
+    struct FakeBroadcastClient {
+        sender: Sender<StreamMessage>,
+    }
+
+    #[async_trait::async_trait]
+    impl BroadcastTopicClientTrait<StreamMessage> for FakeBroadcastClient {
+        async fn broadcast_message(&mut self, message: StreamMessage) -> Result<(), SendError> {
+            self.sender.send(message).await
+        }
+
+        async fn report_peer(&mut self, _: BroadcastedMessageMetadata) -> Result<(), SendError> {
+            todo!()
+        }
+
+        async fn continue_propagation(
+            &mut self,
+            _: &BroadcastedMessageMetadata,
+        ) -> Result<(), SendError> {
+            todo!()
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn setup() -> (
+        StreamHandler<
+            ProposalPart,
+            TestStreamId,
+            Receiver<ReceivedBroadcastedMessage<StreamMessage>>,
+            FakeBroadcastClient,
+        >,
+        Sender<ReceivedBroadcastedMessage<StreamMessage>>,
+        Receiver<Receiver<ProposalPart>>,
+        Sender<(TestStreamId, Receiver<ProposalPart>)>,
+        Receiver<StreamMessage>,
+    ) {
+        let (inbound_internal_sender, inbound_internal_receiver) = mpsc::channel(CHANNEL_SIZE);
+        let (inbound_network_sender, inbound_network_receiver) = mpsc::channel(CHANNEL_SIZE);
+        let (outbound_internal_sender, outbound_internal_receiver) = mpsc::channel(CHANNEL_SIZE);
+        let (outbound_network_sender, outbound_network_receiver) = mpsc::channel(CHANNEL_SIZE);
+        let outbound_network_sender = FakeBroadcastClient { sender: outbound_network_sender };
+        let stream_handler = StreamHandler::new(
+            inbound_internal_sender,
+            inbound_network_receiver,
+            outbound_internal_receiver,
+            outbound_network_sender,
+        );
+
+        (
+            stream_handler,
+            inbound_network_sender,
+            inbound_internal_receiver,
+            outbound_internal_sender,
+            outbound_network_receiver,
+        )
+    }
+
+    fn build_init_message(round: u32, stream_id: u64, message_id: u32) -> StreamMessage {
+        StreamMessage {
+            message: StreamMessageBody::Content(ProposalPart::Init(ProposalInit {
+                round,
+                ..Default::default()
+            })),
+            stream_id: TestStreamId(stream_id),
+            message_id: message_id.into(),
+        }
+    }
+
+    fn build_fin_message(stream_id: u64, message_id: u32) -> StreamMessage {
+        StreamMessage {
+            message: StreamMessageBody::Fin,
+            stream_id: TestStreamId(stream_id),
+            message_id: message_id.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn outbound_single() {
+        let num_messages = 5;
+        let stream_id = 1;
+        let (
+            mut stream_handler,
+            _,
+            _,
+            mut client_to_streamhandler_sender,
+            mut streamhandler_to_network_receiver,
+        ) = setup();
+
+        // Create a new stream to send.
+        let (mut sender, stream_receiver) = mpsc::channel(CHANNEL_SIZE);
+        client_to_streamhandler_sender
+            .send((TestStreamId(stream_id), stream_receiver))
+            .await
+            .unwrap();
+        stream_handler.handle_next_msg().await;
+
+        // Send the content of the stream.
+        for i in 0..num_messages {
+            let init = ProposalPart::Init(ProposalInit { round: i, ..Default::default() });
+            sender.send(init).await.unwrap();
+        }
+
+        // Check the content is sent to the network in order.
+        for i in 0..num_messages {
+            stream_handler.handle_next_msg().await;
+            let actual = streamhandler_to_network_receiver.next().now_or_never().unwrap().unwrap();
+            assert_eq!(actual, build_init_message(i, stream_id, i));
+        }
+
+        // Close the stream and check that a Fin is sent to the network.
+        sender.close_channel();
+        stream_handler.handle_next_msg().await;
+        assert_eq!(
+            streamhandler_to_network_receiver.next().now_or_never().unwrap().unwrap(),
+            build_fin_message(stream_id, num_messages)
+        );
+    }
+
+    #[tokio::test]
+    async fn outbound_multiple() {
+        let num_messages = 5;
+        let num_streams = 3;
+        let (
+            mut stream_handler,
+            _,
+            _,
+            mut client_to_streamhandler_sender,
+            mut streamhandler_to_network_receiver,
+        ) = setup();
+
+        // client opens up multiple outbound streams.
+        let mut stream_senders = Vec::new();
+        for stream_id in 0..num_streams {
+            let (sender, stream_receiver) = mpsc::channel(CHANNEL_SIZE);
+            stream_senders.push(sender);
+            client_to_streamhandler_sender
+                .send((TestStreamId(stream_id), stream_receiver))
+                .await
+                .unwrap();
+            stream_handler.handle_next_msg().await;
+        }
+
+        // Send messages on all of the streams.
+        for stream_id in 0..num_streams {
+            let sender =
+                stream_senders.get_mut(TryInto::<usize>::try_into(stream_id).unwrap()).unwrap();
+            for i in 0..num_messages {
+                let init = ProposalPart::Init(ProposalInit { round: i, ..Default::default() });
+                sender.send(init).await.unwrap();
+            }
+        }
+
+        // {StreamId : [Msgs]} - asserts order received matches expected order per stream.
+        let mut expected_msgs = (0..num_streams).map(|_| Vec::new()).collect::<Vec<_>>();
+        let mut actual_msgs = expected_msgs.clone();
+        for stream_id in 0..num_streams {
+            for i in 0..num_messages {
+                // The order the stream handler selects from among multiple streams is undefined.
+                stream_handler.handle_next_msg().await;
+                let msg = streamhandler_to_network_receiver.next().now_or_never().unwrap().unwrap();
+                actual_msgs[TryInto::<usize>::try_into(msg.stream_id.0).unwrap()].push(msg);
+                expected_msgs[TryInto::<usize>::try_into(stream_id).unwrap()]
+                    .push(build_init_message(i, stream_id, i));
+            }
+        }
+        assert_eq!(actual_msgs, expected_msgs);
+
+        // Drop all the senders and check Fins are sent.
+        stream_senders.clear();
+        let mut stream_ids = (0..num_streams).collect::<BTreeSet<_>>();
+        for _ in 0..num_streams {
+            stream_handler.handle_next_msg().await;
+            let fin = streamhandler_to_network_receiver.next().now_or_never().unwrap().unwrap();
+            assert_eq!(fin.message, StreamMessageBody::Fin);
+            assert_eq!(fin.message_id, u64::from(num_messages));
+            assert!(stream_ids.remove(&fin.stream_id.0));
+        }
+    }
+}


### PR DESCRIPTION
Goals:
1. Utilize new genericiy to just use simple channels instead of using mock_register_broadcast_topic
2. Tests should try to use only the public API (ie messages in and out)
    - This may be broken later when testing how malicious cases are defended