### PR TITLE
fix(starknet_class_manager): small fixes to class manager (#4299)

### DIFF
--- a/config/sequencer/default_config.json
+++ b/config/sequencer/default_config.json
@@ -287,7 +287,7 @@
   "class_manager_config.class_storage_config.class_hash_storage_config.path_prefix": {
     "description": "Prefix of the path of class hash storage directory.",
     "privacy": "Public",
-    "value": "/data/persistent_root"
+    "value": "/data/class_hash_storage"
   },
   "class_manager_config.class_storage_config.persistent_root": {
     "description": "Path to the node's class storage directory.",

--- a/crates/starknet_class_manager/src/config.rs
+++ b/crates/starknet_class_manager/src/config.rs
@@ -18,7 +18,7 @@ pub struct ClassHashStorageConfig {
 impl Default for ClassHashStorageConfig {
     fn default() -> Self {
         Self {
-            path_prefix: "/data/persistent_root".into(),
+            path_prefix: "/data/class_hash_storage".into(),
             enforce_file_exists: false,
             max_size: 1 << 20, // 1MB.
         }

--- a/crates/starknet_integration_tests/src/state_reader.rs
+++ b/crates/starknet_integration_tests/src/state_reader.rs
@@ -106,7 +106,7 @@ impl StorageTestSetup {
         let mut fs_class_storage_builder = FsClassStorageBuilderForTesting::default();
         if let Some(class_manager_path) = fs_class_storage_db_path.as_ref() {
             let class_hash_storage_path_prefix = class_manager_path.join("class_hash_storage");
-            let persistent_root = class_manager_path.join("persistent_root");
+            let persistent_root = class_manager_path.join("classes");
             // The paths will be created in the first time the storage is opened (passing
             // `enforce_file_exists: false`).
             fs_class_storage_builder = fs_class_storage_builder

--- a/crates/starknet_sierra_multicompile/src/lib.rs
+++ b/crates/starknet_sierra_multicompile/src/lib.rs
@@ -97,7 +97,6 @@ impl SierraCompiler {
 }
 
 pub fn create_sierra_compiler(config: SierraCompilationConfig) -> SierraCompiler {
-    // TODO(Elin): rewrite this function
     let compiler = CommandLineCompiler::new(config);
     SierraCompiler::new(compiler)
 }

--- a/crates/starknet_sierra_multicompile_types/src/lib.rs
+++ b/crates/starknet_sierra_multicompile_types/src/lib.rs
@@ -91,7 +91,7 @@ impl<T> SerializedClass<T> {
             .expect("Failing to open file with given options is impossible");
 
         let writer = BufWriter::new(file);
-        serde_json::to_writer(writer, &self.into_value())?;
+        serde_json::to_writer_pretty(writer, &self.into_value())?;
 
         Ok(())
     }


### PR DESCRIPTION
Improved storage directory names
Used JSON writer with whitespaces for easy class (human) read; the JSON
format is quite heavy as it is, I prefer for those files to be readable
for debugging if necessary