### PR TITLE
chore(ci): use our own fork of moonrepo/setup-rust. This should solve…

### DIFF
--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -13,6 +13,7 @@ runs:
       name: Install Rust toolchain and binaries
       with:
         # cache-base: main(-v[0-9].*)?
+        cache-restore-keys: true
         inherit-toolchain: true
         bins: taplo-cli@0.9.3, cargo-machete
         # Install additional non-default toolchains (for rustfmt for example), NOP if input omitted.

--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: moonrepo/setup-rust@v1
+    - uses: starkware-libs/setup-rust@v2
       name: Install Rust toolchain and binaries
       with:
         cache-base: main(-v[0-9].*)?

--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -12,7 +12,7 @@ runs:
     - uses: starkware-libs/setup-rust@v2
       name: Install Rust toolchain and binaries
       with:
-        cache-base: main(-v[0-9].*)?
+        # cache-base: main(-v[0-9].*)?
         inherit-toolchain: true
         bins: taplo-cli@0.9.3, cargo-machete
         # Install additional non-default toolchains (for rustfmt for example), NOP if input omitted.


### PR DESCRIPTION
… a cache mismatch issue