### PR TITLE
fix(starknet_l1_provider): fix dependencies for l1 handler

### DIFF
--- a/crates/starknet_l1_provider/Cargo.toml
+++ b/crates/starknet_l1_provider/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-testing = ["itertools", "pretty_assertions"]
+testing = ["itertools", "pretty_assertions", "starknet_api/testing"]
 
 [dependencies]
 async-trait.workspace = true


### PR DESCRIPTION
We activated starkent_api's testing flag under dev-dependencies which takes effect
for test, but was not activated under the testing flag