### PR TITLE
refactor(starknet_batcher): move execution info into execution data

### DIFF
--- a/crates/starknet_batcher/src/batcher_test.rs
+++ b/crates/starknet_batcher/src/batcher_test.rs
@@ -276,7 +276,7 @@ fn verify_decision_reached_response(
     assert_eq!(response.central_objects.bouncer_weights, expected_artifacts.bouncer_weights);
     assert_eq!(
         response.central_objects.execution_infos,
-        expected_artifacts.execution_infos.values().cloned().collect::<Vec<_>>()
+        expected_artifacts.execution_data.execution_infos.values().cloned().collect::<Vec<_>>()
     );
 }
 
@@ -1000,7 +1000,7 @@ async fn decision_reached() {
     );
     assert_eq!(
         BATCHED_TRANSACTIONS.parse_numeric_metric::<usize>(&metrics),
-        Some(expected_artifacts.execution_infos.len())
+        Some(expected_artifacts.execution_data.execution_infos.len())
     );
     assert_eq!(
         REJECTED_TRANSACTIONS.parse_numeric_metric::<usize>(&metrics),
@@ -1035,7 +1035,7 @@ async fn test_execution_info_order_is_kept() {
 
     let block_builder_result = BlockExecutionArtifacts::create_for_testing();
     // Check that the execution_infos were initiated properly for this test.
-    verify_indexed_execution_infos(&block_builder_result.execution_infos);
+    verify_indexed_execution_infos(&block_builder_result.execution_data.execution_infos);
 
     mock_create_builder_for_propose_block(
         &mut mock_dependencies.block_builder_factory,
@@ -1047,7 +1047,7 @@ async fn test_execution_info_order_is_kept() {
 
     // Verify that the execution_infos are in the same order as returned from the block_builder.
     let expected_execution_infos: Vec<TransactionExecutionInfo> =
-        block_builder_result.execution_infos.into_values().collect();
+        block_builder_result.execution_data.execution_infos.into_values().collect();
     assert_eq!(decision_reached_response.central_objects.execution_infos, expected_execution_infos);
 }
 

--- a/crates/starknet_batcher/src/block_builder_test.rs
+++ b/crates/starknet_batcher/src/block_builder_test.rs
@@ -66,8 +66,8 @@ fn block_execution_artifacts(
 ) -> BlockExecutionArtifacts {
     let l2_gas_used = GasAmount(execution_infos.len().try_into().unwrap());
     BlockExecutionArtifacts {
-        execution_infos,
         execution_data: BlockTransactionExecutionData {
+            execution_infos,
             rejected_tx_hashes,
             accepted_l1_handler_tx_hashes,
         },
@@ -655,7 +655,7 @@ async fn test_execution_info_order() {
     .unwrap();
 
     // Verify that the execution_infos are ordered in the same order as the input_txs.
-    result_block_artifacts.execution_infos.iter().zip(&input_txs).for_each(
+    result_block_artifacts.execution_data.execution_infos.iter().zip(&input_txs).for_each(
         |((tx_hash, _execution_info), tx)| {
             assert_eq!(tx_hash, &tx.tx_hash());
         },

--- a/crates/starknet_batcher/src/test_utils.rs
+++ b/crates/starknet_batcher/src/test_utils.rs
@@ -125,8 +125,8 @@ impl BlockExecutionArtifacts {
     pub fn create_for_testing() -> Self {
         // Use a non-empty commitment_state_diff to get a valuable test verification of the result.
         Self {
-            execution_infos: indexed_execution_infos(),
             execution_data: BlockTransactionExecutionData {
+                execution_infos: indexed_execution_infos(),
                 rejected_tx_hashes: test_txs(10..15).iter().map(|tx| tx.tx_hash()).collect(),
                 accepted_l1_handler_tx_hashes: Default::default(),
             },


### PR DESCRIPTION
- Removed Eq because `TransactionExecutionInfo` doesn't support it
  recursively into inner types for some reason.
- No longer passing the entire metadata object into `commit_proposal_and_block`
due to ownership issues since execinfo isn't used there and is used
afterwards.