### PR TITLE
chore(blockifier): remove deprecated resources from VC

### DIFF
--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_0.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_0.json
@@ -441,131 +441,63 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 15,
-                            "range_check_builtin": 63
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 2711
+                "constant": {
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 15,
+                        "range_check_builtin": 63
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0,
+                    "n_steps": 2711
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 15,
-                            "range_check_builtin": 63
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 2711
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 83
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 3628
+                "constant": {
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 83
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0,
+                    "n_steps": 3628
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 83
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 3628
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 80
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 3382
+                "constant": {
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 80
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0,
+                    "n_steps": 3382
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 80
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 3382
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 17
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 1069
+                "constant": {
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 17
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0,
+                    "n_steps": 1069
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 17
-                        },
-                        "n_memory_holes": 0,
-                        "n_steps": 1069
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_1.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_1.json
@@ -465,143 +465,69 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 2839,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 63
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 2839,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 63
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 2839,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 63
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 3792,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 83
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3792,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 83
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3792,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 83
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 3546,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 80
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3546,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 80
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3546,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 80
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 1146,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 17
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1146,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 17
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1146,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 17
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_1_1.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_1_1.json
@@ -465,143 +465,69 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 2839,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 63
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 2839,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 63
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 2839,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 63
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 3792,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 83
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3792,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 83
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3792,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 83
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 3546,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 80
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3546,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 80
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3546,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 80
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "resources": {
-                    "constant": {
-                        "n_steps": 1146,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 17
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1146,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 17
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1146,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 17
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_2.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_2.json
@@ -469,143 +469,69 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 2973,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 53
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 2973,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 53
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3079,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 58,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 4015,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 72
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 4015,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 72
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4137,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 77,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3763,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 69
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3763,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 69
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3904,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 74,
-                            "poseidon_builtin": 11
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1233,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 16
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1233,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 16
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_2_1.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_2_1.json
@@ -469,143 +469,69 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 2973,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 53
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 2973,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 53
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3079,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 58,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 4015,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 72
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 4015,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 72
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4137,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 77,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3763,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 69
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3763,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 69
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3904,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 74,
-                            "poseidon_builtin": 11
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1233,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 16
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1233,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 16
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_3.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_3.json
@@ -469,143 +469,69 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 2973,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 53
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 2973,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 53
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3079,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 58,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 4015,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 72
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 4015,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 72
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4137,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 77,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3763,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 69
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3763,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 69
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3904,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 74,
-                            "poseidon_builtin": 11
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1233,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 16
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1233,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 16
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_4.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_4.json
@@ -365,144 +365,70 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3203,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 56,
-                            "poseidon_builtin": 4
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3203,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 56,
+                        "poseidon_builtin": 4
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3346,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 64,
-                            "poseidon_builtin": 14
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 4161,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 72
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 4161,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 72
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4321,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 80,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3918,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 69
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3918,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 69
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4102,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 77,
-                            "poseidon_builtin": 11
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1279,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 16
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1279,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 16
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_5.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_5.json
@@ -369,144 +369,70 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3203,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 56,
-                            "poseidon_builtin": 4
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3203,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 16,
+                        "range_check_builtin": 56,
+                        "poseidon_builtin": 4
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3346,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 64,
-                            "poseidon_builtin": 14
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 4161,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 72
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 4161,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 23,
+                        "range_check_builtin": 72
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4321,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 80,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3918,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 69
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3918,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 14,
+                        "range_check_builtin": 69
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4102,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 77,
-                            "poseidon_builtin": 11
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1279,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 16
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1279,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 16
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_14_0.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_14_0.json
@@ -379,144 +379,72 @@
         },
         "execute_txs_inner": {
             "Declare": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3203,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 16,
-                            "range_check_builtin": 56,
-                            "poseidon_builtin": 4
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 3346,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 64,
+                        "poseidon_builtin": 14
                     },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 3346,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 64,
-                            "poseidon_builtin": 14
-                        },
-                        "n_memory_holes": 0
-                    },
-                    "calldata_factor": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
-                    }
+                "calldata_factor": {
+                    "n_steps": 0,
+                    "builtin_instance_counter": {},
+                    "n_memory_holes": 0
                 }
             },
             "DeployAccount": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 4161,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 23,
-                            "range_check_builtin": 72
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 4321,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 80,
+                        "poseidon_builtin": 10
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4321,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 80,
-                            "poseidon_builtin": 10
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 21,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 2
                     },
-                    "calldata_factor": {
-                        "n_steps": 21,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 2
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "InvokeFunction": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 3918,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 14,
-                            "range_check_builtin": 69
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 4102,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 77,
+                        "poseidon_builtin": 11
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 4102,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 4,
-                            "range_check_builtin": 77,
-                            "poseidon_builtin": 11
-                        },
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 8,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             },
             "L1Handler": {
-                "deprecated_resources": {
-                    "constant": {
-                        "n_steps": 1279,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 11,
-                            "range_check_builtin": 16
-                        },
-                        "n_memory_holes": 0
+                "constant": {
+                    "n_steps": 1279,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 11,
+                        "range_check_builtin": 16
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 },
-                "resources": {
-                    "constant": {
-                        "n_steps": 0,
-                        "builtin_instance_counter": {},
-                        "n_memory_holes": 0
+                "calldata_factor": {
+                    "n_steps": 13,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
                     },
-                    "calldata_factor": {
-                        "n_steps": 13,
-                        "builtin_instance_counter": {
-                            "pedersen_builtin": 1
-                        },
-                        "n_memory_holes": 0
-                    }
+                    "n_memory_holes": 0
                 }
             }
         },

--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -472,7 +472,7 @@ pub struct OsResources {
     // i.e., resources that don't count during the execution itself.
     // For each transaction the OS uses a constant amount of VM resources, and an
     // additional variable amount that depends on the calldata length.
-    execute_txs_inner: HashMap<TransactionType, ResourcesByVersion>,
+    execute_txs_inner: HashMap<TransactionType, ResourcesParams>,
 
     // Resources needed for the OS to compute the KZG commitment info, as a factor of the data
     // segment length. Does not include poseidon_hash_many cost.
@@ -519,11 +519,8 @@ impl OsResources {
         let execution_resources = self
             .execute_txs_inner
             .values()
-            .flat_map(|resources_vector| {
-                [
-                    &resources_vector.deprecated_resources.constant,
-                    &resources_vector.deprecated_resources.calldata_factor,
-                ]
+            .flat_map(|resources_params| {
+                [&resources_params.constant, &resources_params.calldata_factor]
             })
             .chain(self.execute_syscalls.values().flat_map(|resources_params| {
                 [&resources_params.constant, &resources_params.calldata_factor]
@@ -592,11 +589,9 @@ impl OsResources {
     }
 
     fn resources_params_for_tx_type(&self, tx_type: &TransactionType) -> &ResourcesParams {
-        &(self
-            .execute_txs_inner
+        self.execute_txs_inner
             .get(tx_type)
             .unwrap_or_else(|| panic!("should contain transaction type '{tx_type:?}'."))
-            .deprecated_resources)
     }
 
     fn resources_for_tx_type(
@@ -1211,12 +1206,6 @@ impl Default for ValidateRoundingConsts {
     fn default() -> Self {
         Self { validate_block_number_rounding: 1, validate_timestamp_rounding: 1 }
     }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct ResourcesByVersion {
-    pub resources: ResourcesParams,
-    pub deprecated_resources: ResourcesParams,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -409,7 +409,7 @@ fn test_infinite_recursion(
     resource_bounds: ValidResourceBounds,
 ) {
     // Limit the number of execution steps (so we quickly hit the limit).
-    block_context.versioned_constants.invoke_tx_max_n_steps = 4200;
+    block_context.versioned_constants.invoke_tx_max_n_steps = 4500;
 
     let TestInitData { mut state, account_address, contract_address, mut nonce_manager } =
         create_test_init_data(&block_context.chain_info, CairoVersion::Cairo0);

--- a/crates/blockifier/src/transaction/execution_flavors_test.rs
+++ b/crates/blockifier/src/transaction/execution_flavors_test.rs
@@ -638,10 +638,10 @@ fn test_simulate_validate_charge_fee_mid_execution(
 
     // Second scenario: limit resources via sender bounds. Should revert if and only if step limit
     // is derived from sender bounds (`charge_fee` mode).
-    let (gas_bound, fee_bound) = gas_and_fee(6111_u32.into(), validate, &fee_type);
+    let (gas_bound, fee_bound) = gas_and_fee(6295_u32.into(), validate, &fee_type);
     // If `charge_fee` is true, execution is limited by sender bounds, so less resources will be
     // used. Otherwise, execution is limited by block bounds, so more resources will be used.
-    let (limited_gas_used, limited_fee) = gas_and_fee(7763_u32.into(), validate, &fee_type);
+    let (limited_gas_used, limited_fee) = gas_and_fee(7947_u32.into(), validate, &fee_type);
     let (unlimited_gas_used, unlimited_fee) = gas_and_fee(
         u64_from_usize(
             get_syscall_resources(SyscallSelector::CallContract).n_steps
@@ -777,7 +777,7 @@ fn test_simulate_validate_charge_fee_post_execution(
     // If `charge_fee` is false - we do not revert, and simply report the fee and resources as used.
     // If `charge_fee` is true, we revert, charge the maximal allowed fee (derived from sender
     // bounds), and report resources base on execution steps reverted + other overhead.
-    let base_gas_bound = 8010_u32.into();
+    let base_gas_bound = 8210_u32.into();
     let (just_not_enough_gas_bound, just_not_enough_fee_bound) =
         gas_and_fee(base_gas_bound, validate, &fee_type);
     // `__validate__` and overhead resources + number of reverted steps, comes out slightly more

--- a/crates/starknet_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/starknet_integration_tests/tests/end_to_end_flow_test.rs
@@ -214,7 +214,7 @@ fn create_test_blocks() -> Vec<TestBlockScenario> {
             vec![],
             test_two_txs,
             ExpectedContentId::from_hex_unchecked(
-                "0x4f290184c08e4d9dcc529e369050c15f4ecff67402141e8efe6d3daa59200f6",
+                "0x7d740c26e2c198f74f1622ac7049a1ec536fc98c3a498f4b4b5f3f4f93f372",
             ),
         ),
         (
@@ -222,7 +222,7 @@ fn create_test_blocks() -> Vec<TestBlockScenario> {
             vec![],
             test_single_tx,
             ExpectedContentId::from_hex_unchecked(
-                "0x5441d6244e9187f9552df5bbc5dbfefcf827b191b6ad82039dd7be35562a3d6",
+                "0x7cc6ffd93db0aa36c4008d45403da1f421cd63dda0fb2cc8dfc7fd65a4b78b1",
             ),
         ),
     ];


### PR DESCRIPTION
All VC should take the deprecated resources, except 0.14.0