### PR TITLE
Make all `ArchivalDataResources` fields public

### DIFF
--- a/crates/blockifier/src/fee/resources.rs
+++ b/crates/blockifier/src/fee/resources.rs
@@ -238,8 +238,8 @@ impl StateResources {
 pub struct ArchivalDataResources {
     pub event_summary: EventSummary,
     pub calldata_length: usize,
-    signature_length: usize,
-    code_size: usize,
+    pub signature_length: usize,
+    pub code_size: usize,
 }
 
 impl ArchivalDataResources {


### PR DESCRIPTION
Made all `ArchivalDataResources` fields public. We need to create this struct directly in Starknet Foundry.