### PR TITLE
refactor(consensus): check sync before running consensus

### DIFF
--- a/crates/starknet_consensus/src/manager.rs
+++ b/crates/starknet_consensus/src/manager.rs
@@ -156,7 +156,6 @@ impl<ContextT: ConsensusContext> MultiHeightManager<ContextT> {
     /// - `must_observer`: Whether the node must observe or if it is allowed to be active (assuming
     ///   it is in the validator set).
     #[instrument(skip_all, fields(height=%height.0), level = "error")]
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn run_height(
         &mut self,
         context: &mut ContextT,
@@ -166,6 +165,10 @@ impl<ContextT: ConsensusContext> MultiHeightManager<ContextT> {
         broadcast_channels: &mut BroadcastVoteChannel,
         proposal_receiver: &mut mpsc::Receiver<mpsc::Receiver<ContextT::ProposalPart>>,
     ) -> Result<RunHeightRes, ConsensusError> {
+        if context.try_sync(height).await {
+            return Ok(RunHeightRes::Sync);
+        }
+
         let validators = context.validators(height).await;
         let is_observer = must_observer || !validators.contains(&self.validator_id);
         info!(

--- a/crates/starknet_consensus/src/manager_test.rs
+++ b/crates/starknet_consensus/src/manager_test.rs
@@ -103,6 +103,7 @@ async fn manager_multiple_heights_unordered() {
 
     let mut context = MockTestContext::new();
     // Run the manager for height 1.
+    context.expect_try_sync().returning(|_| false);
     expect_validate_proposal(&mut context, Felt::ONE, 1);
     context.expect_validators().returning(move |_| vec![*PROPOSER_ID, *VALIDATOR_ID]);
     context.expect_proposer().returning(move |_, _| *PROPOSER_ID);


### PR DESCRIPTION
Avoid wasting time when we are lagging and sync already knows the decision