### PR TITLE
refactor(papyrus_network): shrink test buffer size from 10k to 1k

### DIFF
--- a/crates/papyrus_network/src/network_manager/test_utils.rs
+++ b/crates/papyrus_network/src/network_manager/test_utils.rs
@@ -85,7 +85,7 @@ where
     )
 }
 
-const CHANNEL_BUFFER_SIZE: usize = 10000;
+const CHANNEL_BUFFER_SIZE: usize = 1000;
 
 /// Mock register subscriber for a given topic. BroadcastNetworkMock is used to send and catch
 /// messages broadcasted by and to the subscriber respectively.


### PR DESCRIPTION
Should be large enough for tests. I want this smaller in order to fill it up for a test
(next PR)