### PR TITLE
fix(starknet_api): remove starknet_infra_utils from testing feature and optional dependencies

### DIFF
--- a/crates/starknet_api/Cargo.toml
+++ b/crates/starknet_api/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "Starknet Rust types related to computation and execution."
 
 [features]
-testing = ["starknet_infra_utils"]
+testing = []
 
 [dependencies]
 bitvec.workspace = true
@@ -28,7 +28,7 @@ serde_json.workspace = true
 sha3.workspace = true
 starknet-crypto.workspace = true
 starknet-types-core = { workspace = true, features = ["hash"] }
-starknet_infra_utils = { workspace = true, optional = true }
+starknet_infra_utils.workspace = true
 strum = { workspace = true, features = ["derive"] }
 strum_macros.workspace = true
 thiserror.workspace = true
@@ -36,7 +36,6 @@ thiserror.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 rstest.workspace = true
-starknet_infra_utils.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
`starknet_infra_utils` should not be optional.
It was mistakenly marked as optional and only enabled via the `testing` feature, causing missing dependency issues. Now it's always included to prevent build failures.  