### PR TITLE
feat(starknet_api): allow randomly generated tx hashes for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10843,6 +10843,7 @@ dependencies = [
  "num-traits",
  "pretty_assertions",
  "primitive-types",
+ "rand 0.8.5",
  "rstest",
  "semver 1.0.24",
  "serde",

--- a/crates/papyrus_p2p_sync/src/client/test.rs
+++ b/crates/papyrus_p2p_sync/src/client/test.rs
@@ -255,11 +255,7 @@ fn create_random_sync_block(
 
     let mut transaction_hashes = vec![];
     for _ in 0..transaction_hashes_len {
-        let mut transaction_hash = vec![];
-        for _ in 0..32 {
-            transaction_hash.push(rng.gen::<u8>());
-        }
-        transaction_hashes.push(TransactionHash::from(transaction_hash));
+        transaction_hashes.push(TransactionHash::random(&mut rng));
     }
     let BlockHeaderWithoutHash {
         block_number: _,

--- a/crates/starknet_api/Cargo.toml
+++ b/crates/starknet_api/Cargo.toml
@@ -23,6 +23,7 @@ num-bigint.workspace = true
 num-traits.workspace = true
 pretty_assertions.workspace = true
 primitive-types = { workspace = true, features = ["serde"] }
+rand.workspace = true
 semver.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -891,6 +891,20 @@ impl std::fmt::Display for TransactionHash {
     }
 }
 
+// Use this in tests to get a randomly generate transaction hash.
+// Note that get_test_instance uses StarkHash::default, not a random value.
+#[cfg(any(feature = "testing", test))]
+impl TransactionHash {
+    pub fn random(rng: &mut impl rand::Rng) -> Self {
+        let mut byte_vec = vec![];
+        for _ in 0..32 {
+            byte_vec.push(rng.gen::<u8>());
+        }
+        let byte_array = byte_vec.try_into().expect("Expected a Vec of length 32");
+        TransactionHash(StarkHash::from_bytes_be(&byte_array))
+    }
+}
+
 // TODO(guyn): this is only used for conversion of transactions->executable transactions
 // It should be removed once we integrate a proper way to calculate executable transaction hashes
 impl From<TransactionHash> for Vec<u8> {


### PR DESCRIPTION
This also allows me to remove the into/from Vec<u8> of TransactionHash (the next PR). 