### PR TITLE
fix: fix type of `base_command` in `run_test` function

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -93,7 +93,7 @@ def test_crates(crates: Set[str], base_command: BaseCommand):
 
 
 def run_test(
-    changes_only: bool, commit_id: Optional[str], base_command: bool, include_dependencies: bool
+    changes_only: bool, commit_id: Optional[str], base_command: BaseCommand, include_dependencies: bool
 ):
     """
     Runs tests.


### PR DESCRIPTION
I've corrected the type of `base_command` in the `run_test` function. It should be `BaseCommand`, not `bool`, as the function is intended to work with values from this enumeration.
This change ensures the correct behavior of the function as it was originally intended.