### PR TITLE
Refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x

### DIFF
--- a/crates/blockifier_reexecution/src/main.rs
+++ b/crates/blockifier_reexecution/src/main.rs
@@ -26,16 +26,16 @@ const OFFLINE_PREFIX_FILE: &str = "/offline_reexecution_files_prefix";
 
 /// BlockifierReexecution CLI.
 #[derive(Debug, Parser)]
-#[clap(name = "blockifier-reexecution-cli", version)]
+#[command(name = "blockifier-reexecution-cli", version)]
 pub struct BlockifierReexecutionCliArgs {
-    #[clap(flatten)]
+    #[command(flatten)]
     global_options: GlobalOptions,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
-#[derive(clap::ValueEnum, Clone, Debug)]
+#[derive(ValueEnum, Clone, Debug)]
 enum SupportedChainId {
     Mainnet,
     Testnet,
@@ -52,14 +52,14 @@ impl From<SupportedChainId> for ChainId {
     }
 }
 
-#[derive(Clone, Debug, Args)]
+#[derive(Clone, Debug, Parser)]
 struct RpcArgs {
     /// Node url.
-    #[clap(long, short = 'n')]
+    #[arg(long, short = 'n')]
     node_url: String,
 
     /// Optional chain ID (if not provided, it will be guessed from the node url).
-    #[clap(long, short = 'c')]
+    #[arg(long, short = 'c')]
     chain_id: Option<SupportedChainId>,
 }
 
@@ -76,68 +76,68 @@ impl RpcArgs {
 enum Command {
     /// Runs the RPC test.
     RpcTest {
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc_args: RpcArgs,
 
         /// Block number.
-        #[clap(long, short = 'b')]
+        #[arg(long, short = 'b')]
         block_number: u64,
     },
 
     /// Writes the RPC queries of all (selected) blocks to json files.
     WriteToFile {
-        #[clap(flatten)]
+        #[command(flatten)]
         rpc_args: RpcArgs,
 
         /// Block numbers. If not specified, blocks are retrieved from
         /// get_block_numbers_for_reexecution().
-        #[clap(long, short = 'b', num_args = 1.., default_value = None)]
+        #[arg(long, short = 'b', num_args = 1.., default_value = None)]
         block_numbers: Option<Vec<u64>>,
 
-        // Directory path to json files directory. Default:
-        // "./crates/blockifier_reexecution/resources".
-        // TODO(Aner): add possibility to retrieve files from gc bucket.
-        #[clap(long, short = 'd', default_value = None)]
+        /// Directory path to json files directory. Default:
+        /// "./crates/blockifier_reexecution/resources".
+        /// TODO(Aner): add possibility to retrieve files from gc bucket.
+        #[arg(long, short = 'd', default_value = None)]
         directory_path: Option<String>,
     },
 
-    // Reexecute all (selected) blocks
+    /// Reexecute all (selected) blocks.
     Reexecute {
         /// Block numbers. If not specified, blocks are retrieved from
         /// get_block_numbers_for_reexecution().
-        #[clap(long, short = 'b', num_args = 1.., default_value = None)]
+        #[arg(long, short = 'b', num_args = 1.., default_value = None)]
         block_numbers: Option<Vec<u64>>,
 
-        // Directory path to json files directory. Default:
-        // "./crates/blockifier_reexecution/resources".
-        // TODO(Aner): add possibility to retrieve files from gc bucket.
-        #[clap(long, short = 'd', default_value = None)]
+        /// Directory path to json files directory. Default:
+        /// "./crates/blockifier_reexecution/resources".
+        /// TODO(Aner): add possibility to retrieve files from gc bucket.
+        #[arg(long, short = 'd', default_value = None)]
         directory_path: Option<String>,
     },
 
-    // Upload all (selected) blocks to the gc bucket.
+    /// Upload all (selected) blocks to the gc bucket.
     UploadFiles {
         /// Block numbers. If not specified, blocks are retrieved from
         /// get_block_numbers_for_reexecution().
-        #[clap(long, short = 'b', num_args = 1.., default_value = None)]
+        #[arg(long, short = 'b', num_args = 1.., default_value = None)]
         block_numbers: Option<Vec<u64>>,
 
-        // Directory path to json files directory. Default:
-        // "./crates/blockifier_reexecution/resources".
-        #[clap(long, short = 'd', default_value = None)]
+        /// Directory path to json files directory. Default:
+        /// "./crates/blockifier_reexecution/resources".
+        #[arg(long, short = 'd', default_value = None)]
         directory_path: Option<String>,
     },
 
-    // Download all (selected) blocks from the gc bucket.
+    /// Download all (selected) blocks from the gc bucket.
     DownloadFiles {
         /// Block numbers. If not specified, blocks are retrieved from
         /// get_block_numbers_for_reexecution().
-        #[clap(long, short = 'b', num_args = 1.., default_value = None)]
+        #[arg(long, short = 'b', num_args = 1.., default_value = None)]
         block_numbers: Option<Vec<u64>>,
 
-        // Directory path to json files directory. Default:
-        // "./crates/blockifier_reexecution/resources".
-        #[clap(long, short = 'd', default_value = None)]
+        /// Directory path to json files directory. Default:
+        /// "./crates/blockifier_reexecution/resources".
+        #[arg(long, short = 'd', default_value = None)]
         directory_path: Option<String>,
     },
 }

--- a/crates/starknet_committer_and_os_cli/src/block_hash_cli/run_block_hash_cli.rs
+++ b/crates/starknet_committer_and_os_cli/src/block_hash_cli/run_block_hash_cli.rs
@@ -12,12 +12,6 @@ use crate::shared_utils::types::{run_python_test, IoArgs, PythonTestArg};
 
 #[derive(Parser, Debug)]
 pub struct BlockHashCliCommand {
-    #[clap(subcommand)]
-    command: Command,
-}
-
-#[derive(Parser, Debug)]
-pub struct BlockHashCliCommand {
     #[command(subcommand)]
     command: Command,
 }

--- a/crates/starknet_committer_and_os_cli/src/block_hash_cli/run_block_hash_cli.rs
+++ b/crates/starknet_committer_and_os_cli/src/block_hash_cli/run_block_hash_cli.rs
@@ -16,16 +16,22 @@ pub struct BlockHashCliCommand {
     command: Command,
 }
 
+#[derive(Parser, Debug)]
+pub struct BlockHashCliCommand {
+    #[command(subcommand)]
+    command: Command,
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Calculates the block hash.
     BlockHash {
-        #[clap(flatten)]
+        #[command(flatten)]
         io_args: IoArgs,
     },
     /// Calculates commitments needed for the block hash.
     BlockHashCommitments {
-        #[clap(flatten)]
+        #[command(flatten)]
         io_args: IoArgs,
     },
     PythonTest(PythonTestArg),

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/run_committer_cli.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/run_committer_cli.rs
@@ -10,7 +10,7 @@ use crate::shared_utils::types::{run_python_test, IoArgs, PythonTestArg};
 
 #[derive(Parser, Debug)]
 pub struct CommitterCliCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
@@ -18,7 +18,7 @@ pub struct CommitterCliCommand {
 enum Command {
     /// Given previous state tree skeleton and a state diff, computes the new commitment.
     Commit {
-        #[clap(flatten)]
+        #[command(flatten)]
         io_args: IoArgs,
     },
     PythonTest(PythonTestArg),

--- a/crates/starknet_committer_and_os_cli/src/main.rs
+++ b/crates/starknet_committer_and_os_cli/src/main.rs
@@ -13,12 +13,12 @@ use tracing::info;
 
 /// Committer and OS CLI.
 #[derive(Debug, Parser)]
-#[clap(name = "committer-and-os-cli", version)]
+#[command(name = "committer-and-os-cli", version)]
 struct CliArgs {
-    #[clap(flatten)]
+    #[command(flatten)]
     global_options: GlobalOptions,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: CommitterOrOsCommand,
 }
 

--- a/crates/starknet_committer_and_os_cli/src/os_cli/run_os_cli.rs
+++ b/crates/starknet_committer_and_os_cli/src/os_cli/run_os_cli.rs
@@ -10,7 +10,7 @@ use crate::shared_utils::types::{run_python_test, IoArgs, PythonTestArg};
 
 #[derive(Parser, Debug)]
 pub struct OsCliCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
@@ -18,7 +18,7 @@ pub struct OsCliCommand {
 enum Command {
     PythonTest(PythonTestArg),
     RunOsStateless {
-        #[clap(flatten)]
+        #[command(flatten)]
         io_args: IoArgs,
     },
 }

--- a/crates/starknet_committer_and_os_cli/src/shared_utils/types.rs
+++ b/crates/starknet_committer_and_os_cli/src/shared_utils/types.rs
@@ -9,22 +9,22 @@ pub(crate) type PythonTestResult<E> = Result<String, PythonTestError<E>>;
 #[derive(Debug, Args)]
 pub(crate) struct IoArgs {
     /// File path to input.
-    #[clap(long, short = 'i')]
+    #[arg(long, short = 'i')]
     pub(crate) input_path: String,
 
     /// File path to output.
-    #[clap(long, short = 'o', default_value = "stdout")]
+    #[arg(long, short = 'o', default_value = "stdout")]
     pub(crate) output_path: String,
 }
 
 #[derive(Debug, Args)]
 pub(crate) struct PythonTestArg {
     // TODO(Amos): Make this optional.
-    #[clap(flatten)]
+    #[command(flatten)]
     pub(crate) io_args: IoArgs,
 
     /// Test name.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) test_name: String,
 }
 


### PR DESCRIPTION
This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.
