### PR TITLE
demo(starknet_integration_tests): when the integration test fails - instance of the anvil is still running

### DIFF
--- a/crates/starknet_integration_tests/src/node_component_configs.rs
+++ b/crates/starknet_integration_tests/src/node_component_configs.rs
@@ -414,7 +414,7 @@ fn get_l1_provider_config(
         l1_provider_socket.ip(),
         l1_provider_socket.port(),
     );
-    config.l1_scraper = ActiveComponentExecutionConfig::enabled();
+    config.l1_scraper = ActiveComponentExecutionConfig::disabled();
     config.state_sync = state_sync_remote_config;
     config.monitoring_endpoint = ActiveComponentExecutionConfig::enabled();
     config


### PR DESCRIPTION
This Branch is used to demonstrate the scenario of the integration test running and the anvil instance not being dropped when the test fails.