### PR TITLE
refactor(starknet_infra_utils): move `cairo1_compiler_version` and it…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,12 +1900,10 @@ dependencies = [
 name = "blockifier_test_utils"
 version = "0.0.0"
 dependencies = [
- "cached",
  "cairo-lang-starknet-classes",
  "itertools 0.12.1",
  "pretty_assertions",
  "rstest",
- "serde",
  "serde_json",
  "starknet-types-core",
  "starknet_api",
@@ -1914,7 +1912,6 @@ dependencies = [
  "strum_macros 0.25.3",
  "tempfile",
  "tokio",
- "toml",
  "tracing",
  "tracing-test",
 ]
@@ -11250,6 +11247,7 @@ name = "starknet_infra_utils"
 version = "0.0.0"
 dependencies = [
  "assert-json-diff",
+ "cached",
  "colored 3.0.0",
  "nix 0.20.2",
  "pretty_assertions",
@@ -11257,6 +11255,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/blockifier_test_utils/Cargo.toml
+++ b/crates/blockifier_test_utils/Cargo.toml
@@ -10,21 +10,18 @@ description = "Test utilities for the blockifier."
 cairo_native = []
 
 [dependencies]
-cached.workspace = true
 cairo-lang-starknet-classes.workspace = true
 itertools.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 starknet-types-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
-starknet_infra_utils.workspace = true
+starknet_infra_utils = { workspace = true, features = ["testing"] }
 strum.workspace = true
 strum_macros.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-toml.workspace = true
 tracing.workspace = true
 tracing-test.workspace = true
 

--- a/crates/blockifier_test_utils/src/cairo_compile.rs
+++ b/crates/blockifier_test_utils/src/cairo_compile.rs
@@ -3,8 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::{env, fs};
 
-use cached::proc_macro::cached;
-use serde::{Deserialize, Serialize};
+use starknet_infra_utils::cairo_compiler_version::cairo1_compiler_version;
 use starknet_infra_utils::compile_time_cargo_manifest_dir;
 use tempfile::NamedTempFile;
 
@@ -14,58 +13,9 @@ const CAIRO0_PIP_REQUIREMENTS_FILE: &str = "tests/requirements.txt";
 const CAIRO1_REPO_RELATIVE_PATH_OVERRIDE_ENV_VAR: &str = "CAIRO1_REPO_RELATIVE_PATH";
 const DEFAULT_CAIRO1_REPO_RELATIVE_PATH: &str = "../../../cairo";
 
-/// Objects for simple deserialization of Cargo.toml to fetch the Cairo1 compiler version.
-/// The compiler itself isn't actually a dependency, so we compile by using the version of the
-/// cairo-lang-casm crate.
-/// The choice of cairo-lang-casm is arbitrary, as all compiler crate dependencies should have the
-/// same version.
-/// Deserializes:
-/// """
-/// ...
-/// [workspace.dependencies]
-/// ...
-/// cairo-lang-casm = VERSION
-/// ...
-/// """
-/// where `VERSION` can be a simple "x.y.z" version string or an object with a "version" field.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-enum DependencyValue {
-    // cairo-lang-casm = "x.y.z".
-    String(String),
-    // cairo-lang-casm = { version = "x.y.z", .. }.
-    Object { version: String },
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct CairoLangCasmDependency {
-    #[serde(rename = "cairo-lang-casm")]
-    cairo_lang_casm: DependencyValue,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct WorkspaceFields {
-    dependencies: CairoLangCasmDependency,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct CargoToml {
-    workspace: WorkspaceFields,
-}
-
 pub enum CompilationArtifacts {
     Cairo0 { casm: Vec<u8> },
     Cairo1 { casm: Vec<u8>, sierra: Vec<u8> },
-}
-
-#[cached]
-/// Returns the version of the Cairo1 compiler defined in the root Cargo.toml (by checking the
-/// package version of one of the crates from the compiler in the dependencies).
-pub fn cairo1_compiler_version() -> String {
-    let cargo_toml: CargoToml = toml::from_str(include_str!("../../../Cargo.toml")).unwrap();
-    match cargo_toml.workspace.dependencies.cairo_lang_casm {
-        DependencyValue::String(version) | DependencyValue::Object { version } => version.clone(),
-    }
 }
 
 pub fn cairo1_compiler_tag() -> String {

--- a/crates/starknet_infra_utils/Cargo.toml
+++ b/crates/starknet_infra_utils/Cargo.toml
@@ -14,10 +14,12 @@ workspace = true
 
 [dependencies]
 assert-json-diff = { workspace = true, optional = true }
+cached.workspace = true
 colored = { workspace = true, optional = true }
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["process", "rt", "time"] }
+toml.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/starknet_infra_utils/src/cairo_compiler_version.rs
+++ b/crates/starknet_infra_utils/src/cairo_compiler_version.rs
@@ -1,0 +1,51 @@
+use cached::proc_macro::cached;
+use serde::{Deserialize, Serialize};
+
+/// Objects for simple deserialization of `Cargo.toml`, to fetch the Cairo1 compiler version.
+/// The compiler itself isn't actually a dependency, so we compile by using the version of the
+/// `cairo-lang-casm` crate.
+/// The choice of this crate is arbitrary, as all compiler crate dependencies should have the
+/// same version.
+/// Deserializes:
+/// """
+/// ...
+/// [workspace.dependencies]
+/// ...
+/// cairo-lang-casm = VERSION
+/// ...
+/// """
+/// where `VERSION` can be a simple "x.y.z" version string or an object with a "version" field.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum DependencyValue {
+    // cairo-lang-casm = "x.y.z".
+    String(String),
+    // cairo-lang-casm = { version = "x.y.z", .. }.
+    Object { version: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CairoLangCasmDependency {
+    #[serde(rename = "cairo-lang-casm")]
+    cairo_lang_casm: DependencyValue,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WorkspaceFields {
+    dependencies: CairoLangCasmDependency,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CargoToml {
+    workspace: WorkspaceFields,
+}
+
+#[cached]
+/// Returns the version of the Cairo1 compiler defined in the root Cargo.toml (by checking the
+/// package version of one of the crates from the compiler in the dependencies).
+pub fn cairo1_compiler_version() -> String {
+    let cargo_toml: CargoToml = toml::from_str(include_str!("../../../Cargo.toml")).unwrap();
+    match cargo_toml.workspace.dependencies.cairo_lang_casm {
+        DependencyValue::String(version) | DependencyValue::Object { version } => version.clone(),
+    }
+}

--- a/crates/starknet_infra_utils/src/lib.rs
+++ b/crates/starknet_infra_utils/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "testing", test))]
+pub mod cairo_compiler_version;
 pub mod command;
 pub mod dumping;
 pub mod global_allocator;


### PR DESCRIPTION
…s transitive closure

Few remarks:
- No code change, only move.
- I put the new file under "testing" feature since `Cargo.toml`-parsing code should not be ran in production.
- This is prep. for testing compiler version alignment between `Cargo.toml` and `build.rs`; should also be done for `cairo-native`compiler.