### PR TITLE
refactor(starknet_l1_provider): rename for readability

### DIFF
--- a/crates/starknet_batcher/src/batcher.rs
+++ b/crates/starknet_batcher/src/batcher.rs
@@ -572,13 +572,13 @@ impl Batcher {
             .await;
         l1_provider_result.unwrap_or_else(|err| match err {
             L1ProviderClientError::L1ProviderError(L1ProviderError::UnexpectedHeight {
-                expected,
+                expected_height,
                 got,
             }) => {
                 error!(
                     "Unexpected height while committing block in L1 provider: expected={:?}, \
                      got={:?}",
-                    expected, got
+                    expected_height, got
                 );
             }
             other_err => {

--- a/crates/starknet_batcher/src/batcher_test.rs
+++ b/crates/starknet_batcher/src/batcher_test.rs
@@ -394,8 +394,10 @@ async fn l1_handler_provider_not_ready(#[case] proposer: bool) {
     let mut deps = MockDependencies::default();
     deps.l1_provider_client.expect_start_block().returning(|_, _| {
         // The heights are not important for the test.
-        let err =
-            L1ProviderError::UnexpectedHeight { expected: INITIAL_HEIGHT, got: INITIAL_HEIGHT };
+        let err = L1ProviderError::UnexpectedHeight {
+            expected_height: INITIAL_HEIGHT,
+            got: INITIAL_HEIGHT,
+        };
         Err(err.into())
     });
     let mut batcher = create_batcher(deps).await;
@@ -771,7 +773,7 @@ async fn proposal_startup_failure_allows_new_proposals() {
     );
     let mut l1_provider_client = MockL1ProviderClient::new();
     let error = L1ProviderClientError::L1ProviderError(L1ProviderError::UnexpectedHeight {
-        expected: BlockNumber(1),
+        expected_height: BlockNumber(1),
         got: BlockNumber(0),
     });
     l1_provider_client.expect_start_block().once().return_once(|_, _| Err(error));

--- a/crates/starknet_l1_provider_types/src/errors.rs
+++ b/crates/starknet_l1_provider_types/src/errors.rs
@@ -15,8 +15,8 @@ pub enum L1ProviderError {
     // This is likely due to a crash, restart block proposal.
     #[error("`validate` called when provider is not in proposer state")]
     OutOfSessionValidate,
-    #[error("Unexpected height: expected {expected}, got {got}")]
-    UnexpectedHeight { expected: BlockNumber, got: BlockNumber },
+    #[error("Unexpected height: expected {expected_height}, got {got}")]
+    UnexpectedHeight { expected_height: BlockNumber, got: BlockNumber },
     #[error("Cannot transition from {from} to {to}")]
     UnexpectedProviderStateTransition { from: String, to: String },
     #[error("`validate` called while in `Propose` state")]


### PR DESCRIPTION
Also ONE unpacking change in the definition of current_height var