### PR TITLE
refactor(starknet_class_manager): move metric code to its own module

### DIFF
--- a/crates/starknet_class_manager/src/class_storage.rs
+++ b/crates/starknet_class_manager/src/class_storage.rs
@@ -16,8 +16,8 @@ use starknet_sierra_multicompile_types::{RawClass, RawClassError, RawExecutableC
 use thiserror::Error;
 use tracing::instrument;
 
-use crate::class_manager::{increment_n_classes, CairoClassType};
 use crate::config::{ClassHashStorageConfig, FsClassStorageConfig};
+use crate::metrics::{increment_n_classes, CairoClassType};
 
 #[cfg(test)]
 #[path = "class_storage_test.rs"]

--- a/crates/starknet_class_manager/src/lib.rs
+++ b/crates/starknet_class_manager/src/lib.rs
@@ -2,6 +2,7 @@ pub mod class_manager;
 pub mod class_storage;
 pub mod communication;
 pub mod config;
+pub mod metrics;
 
 use crate::class_manager::ClassManager as GenericClassManager;
 use crate::class_storage::FsClassStorage;

--- a/crates/starknet_class_manager/src/metrics.rs
+++ b/crates/starknet_class_manager/src/metrics.rs
@@ -1,0 +1,36 @@
+use starknet_sequencer_metrics::metrics::LabeledMetricCounter;
+use starknet_sequencer_metrics::{define_metrics, generate_permutation_labels};
+use strum::VariantNames;
+
+const CAIRO_CLASS_TYPE_LABEL: &str = "class_type";
+
+#[derive(strum_macros::EnumVariantNames, strum_macros::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum CairoClassType {
+    Regular,
+    Deprecated,
+}
+
+generate_permutation_labels! {
+    CAIRO_CLASS_TYPE_LABELS,
+    (CAIRO_CLASS_TYPE_LABEL, CairoClassType),
+}
+
+define_metrics!(
+    ClassManager => {
+        LabeledMetricCounter {
+            N_CLASSES,
+            "class_manager_n_classes", "Number of classes, by label (regular, deprecated)",
+            init = 0 ,
+            labels = CAIRO_CLASS_TYPE_LABELS
+        },
+    },
+);
+
+pub(crate) fn increment_n_classes(cls_type: CairoClassType) {
+    N_CLASSES.increment(1, &[(CAIRO_CLASS_TYPE_LABEL, cls_type.into())]);
+}
+
+pub(crate) fn register_metrics() {
+    N_CLASSES.register();
+}


### PR DESCRIPTION
No changes, only move.