### PR TITLE
feat(starknet_os): implement LoadCairoObject trait for DeprecatedContractClass

### DIFF
--- a/crates/starknet_os/src/hints/hint_implementation/deprecated_compiled_class/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/deprecated_compiled_class/utils.rs
@@ -1,145 +1,123 @@
 use std::collections::HashMap;
 
-use blockifier::state::state_api::StateReader;
+use cairo_vm::serde::deserialize_program::deserialize_array_of_bigint_hex;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::deprecated_contract_class::{ContractClass, EntryPointV0};
 use starknet_types_core::felt::Felt;
 
-use crate::hints::error::OsHintResult;
-use crate::hints::vars::CairoStruct;
-use crate::hint_processor::snos_hint_processor::SnosHintProcessor;
-use crate::vm_utils::{insert_values_to_fields ,insert_value_to_nested_field, IdentifierGetter, LoadCairoObject};
+use crate::hints::class_hash::hinted_class_hash::{
+    compute_cairo_hinted_class_hash,
+    CairoContractDefinition,
+};
+use crate::hints::error::{OsHintError, OsHintResult};
+use crate::hints::vars::{CairoStruct, Const};
+use crate::vm_utils::{insert_values_to_fields, CairoSized, IdentifierGetter, LoadCairoObject};
 
-/// Returns the serialization of a contract as a list of field elements.
-fn get_deprecated_contract_class_struct<S: StateReader>(
-    hint_processor: &mut SnosHintProcessor<S>,
-    vm: &mut VirtualMachine,
-    class_base: Relocatable,
-    deprecated_class: ContractClass,
-) -> OsHintResult {
-    vm.insert_value(class_base, Felt::from(0))?; // DEPRECATED_COMPILED_CLASS_VERSION = 0
+impl<IG: IdentifierGetter> LoadCairoObject<IG> for ContractClass {
+    fn load_into(
+        &self,
+        vm: &mut VirtualMachine,
+        identifier_getter: &IG,
+        address: Relocatable,
+        constants: &HashMap<String, Felt>,
+    ) -> OsHintResult {
+        // Insert compiled class version field.
+        let compiled_class_version = Const::DeprecatedCompiledClassVersion.fetch(constants)?;
 
-    let mut externals: Vec<MaybeRelocatable> = Vec::new();
-    for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::External).unwrap().iter() {
-        externals.push(MaybeRelocatable::from(elem.selector.0));
-        externals.push(MaybeRelocatable::from(Felt::from(elem.offset.0)));
+        // Insert external entry points.
+        let (externals_list_base, externals_len) =
+            insert_entry_points(self, vm, identifier_getter, constants, &EntryPointType::External)?;
+
+        // Insert l1 handler entry points.
+        let (l1_handlers_list_base, l1_handlers_len) = insert_entry_points(
+            self,
+            vm,
+            identifier_getter,
+            constants,
+            &EntryPointType::L1Handler,
+        )?;
+
+        // Insert constructor entry points.
+        let (constructors_list_base, constructors_len) = insert_entry_points(
+            self,
+            vm,
+            identifier_getter,
+            constants,
+            &EntryPointType::Constructor,
+        )?;
+
+        // Insert builtins.
+        let builtins: Vec<String> =
+            serde_json::from_value(self.program.builtins.clone()).map_err(|e| {
+                OsHintError::SerdeJsonDeserialize { error: e, value: self.program.builtins.clone() }
+            })?;
+        let builtins: Vec<MaybeRelocatable> = builtins
+            .into_iter()
+            .map(|bi| (Felt::from_bytes_be_slice(bi.as_bytes())).into())
+            .collect();
+
+        let builtin_list_base = vm.add_memory_segment();
+        vm.load_data(builtin_list_base, &builtins)?;
+
+        // Insert hinted class hash.
+        let contract_definition_vec = serde_json::to_vec(&self)?;
+        let contract_definition: CairoContractDefinition<'_> =
+            serde_json::from_slice(&contract_definition_vec).map_err(OsHintError::SerdeJson)?;
+
+        let hinted_class_hash = compute_cairo_hinted_class_hash(&contract_definition)?;
+
+        // Insert bytecode_ptr.
+        let bytecode_ptr = deserialize_array_of_bigint_hex(&self.program.data)?;
+
+        let bytecode_ptr_base = vm.add_memory_segment();
+        vm.load_data(bytecode_ptr_base, &bytecode_ptr)?;
+
+        // Insert the fields.
+        let nested_fields_and_value = [
+            ("compiled_class_version", compiled_class_version.into()),
+            ("n_external_functions", Felt::from(externals_len).into()),
+            ("external_functions", externals_list_base.into()),
+            ("n_l1_handlers", Felt::from(l1_handlers_len).into()),
+            ("l1_handlers", l1_handlers_list_base.into()),
+            ("n_constructors", Felt::from(constructors_len).into()),
+            ("constructors", constructors_list_base.into()),
+            ("n_builtins", Felt::from(builtins.len()).into()),
+            ("builtin_list", builtin_list_base.into()),
+            ("hinted_class_hash", hinted_class_hash.into()),
+            ("bytecode_length", Felt::from(bytecode_ptr.len()).into()),
+            ("bytecode_ptr", bytecode_ptr_base.into()),
+        ];
+        insert_values_to_fields(
+            address,
+            CairoStruct::DeprecatedCompiledClass,
+            vm,
+            nested_fields_and_value.as_slice(),
+            identifier_getter,
+        )?;
+
+        Ok(())
     }
-    vm.insert_value((class_base + 1)?, Felt::from(externals.len() / 2))?;
-    let externals_base = vm.add_memory_segment();
-    vm.load_data(externals_base, &externals)?;
-
-    vm.insert_value((class_base + 2)?, externals_base)?;
-
-    let mut l1_handlers: Vec<MaybeRelocatable> = Vec::new();
-    for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::L1Handler).unwrap().iter() {
-        l1_handlers.push(MaybeRelocatable::from(elem.selector.0));
-        l1_handlers.push(MaybeRelocatable::from(Felt::from(elem.offset.0)));
-    }
-    vm.insert_value((class_base + 3)?, Felt::from(l1_handlers.len() / 2))?;
-    let l1_handlers_base = vm.add_memory_segment();
-    vm.load_data(l1_handlers_base, &l1_handlers)?;
-
-    vm.insert_value((class_base + 4)?, l1_handlers_base)?;
-
-    let mut constructors: Vec<MaybeRelocatable> = Vec::new();
-    for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::Constructor).unwrap().iter() {
-        constructors.push(MaybeRelocatable::from(elem.selector.0));
-        constructors.push(MaybeRelocatable::from(Felt::from(elem.offset.0)));
-    }
-    vm.insert_value((class_base + 5)?, Felt::from(constructors.len() / 2))?;
-    let constructors_base = vm.add_memory_segment();
-    vm.load_data(constructors_base, &constructors)?;
-
-    vm.insert_value((class_base + 6)?, constructors_base)?;
-
-    let builtins: Vec<String> = serde_json::from_value(deprecated_class.clone().program.builtins).unwrap();
-    let builtins: Vec<MaybeRelocatable> =
-        builtins.into_iter().map(|bi| MaybeRelocatable::from(Felt::from_bytes_be_slice(bi.as_bytes()))).collect();
-
-    vm.insert_value((class_base + 7)?, Felt::from(builtins.len()))?;
-    let builtins_base = vm.add_memory_segment();
-    vm.load_data(builtins_base, &builtins)?;
-    vm.insert_value((class_base + 8)?, builtins_base)?;
-
-    let contract_definition_dump = serde_json::to_vec(&deprecated_class).expect("Serialization should not fail");
-    let mut cairo_contract_class_json =
-        serde_json::from_slice::<json::CairoContractDefinition<'_>>(&contract_definition_dump)
-            .expect("Deserialization should not fail");
-
-    // This functions perform some tweaks for old Cairo contracts in order to keep backward compatibility and compute the right hash
-    prepare_json_contract_definition(&mut cairo_contract_class_json)
-        .map_err(|_| custom_hint_error("Processing Cairo contracts for backward compatibility failed"))?;
-
-    let hinted_class_hash = {
-        let class_hash =
-            compute_cairo_hinted_class_hash(&cairo_contract_class_json).expect("Hashing should not fail here");
-        Felt::from_bytes_be(&class_hash.to_be_bytes())
-    };
-
-    vm.insert_value((class_base + 9)?, hinted_class_hash)?;
-
-    let data: Vec<String> = serde_json::from_value(deprecated_class.program.data).unwrap();
-    let data: Vec<MaybeRelocatable> =
-        data.into_iter().map(|datum| MaybeRelocatable::from(Felt::from_hex(&datum).unwrap())).collect();
-    vm.insert_value((class_base + 10)?, Felt::from(data.len()))?;
-    let data_base = vm.add_memory_segment();
-    vm.load_data(data_base, &data)?;
-
-    vm.insert_value((class_base + 11)?, data_base)?;
-
-    Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-/// Loads the entry points of a deprecated contract class to a contract class struct, given a
-/// specific entry point type.
-fn load_entry_points_to_contract_class_struct<IG: IdentifierGetter>(
-    deprecated_class: &ContractClass,
-    entry_point_type: &EntryPointType,
-    class_base: Relocatable,
-    var_type: CairoStruct,
+fn insert_entry_points<IG: IdentifierGetter>(
+    dep_contract_class: &ContractClass,
     vm: &mut VirtualMachine,
     identifier_getter: &IG,
-    entry_points_field: &str,
-    num_entry_points_field: &str,
-) -> OsHintResult {
-    let empty_vec = Vec::new();
-    let entry_points =
-        deprecated_class.entry_points_by_type.get(entry_point_type).unwrap_or(&empty_vec);
+    constants: &HashMap<String, Felt>,
+    entry_point_type: &EntryPointType,
+) -> Result<(Relocatable, usize), OsHintError> {
+    let list_base = vm.add_memory_segment();
+    let n_entry_points = match dep_contract_class.entry_points_by_type.get(entry_point_type) {
+        Some(entry_points) => {
+            entry_points.load_into(vm, identifier_getter, list_base, constants)?;
+            entry_points.len()
+        }
+        None => 0,
+    };
 
-    let flat_entry_point_data: Vec<MaybeRelocatable> = entry_points
-        .iter()
-        .flat_map(|entry_point| {
-            vec![
-                MaybeRelocatable::from(entry_point.selector.0),
-                MaybeRelocatable::from(Felt::from(entry_point.offset.0)),
-            ]
-        })
-        .collect();
-
-    insert_value_to_nested_field(
-        class_base,
-        var_type,
-        vm,
-        &[num_entry_points_field],
-        identifier_getter,
-        Felt::from(entry_points.len()),
-    )?;
-
-    let flat_entry_point_data_base = vm.add_memory_segment();
-    vm.load_data(flat_entry_point_data_base, &flat_entry_point_data)?;
-    insert_value_to_nested_field(
-        class_base,
-        var_type,
-        vm,
-        &[entry_points_field],
-        identifier_getter,
-        flat_entry_point_data_base,
-    )?;
-
-    Ok(())
+    Ok((list_base, n_entry_points))
 }
 
 impl<IG: IdentifierGetter> LoadCairoObject<IG> for EntryPointV0 {
@@ -162,5 +140,12 @@ impl<IG: IdentifierGetter> LoadCairoObject<IG> for EntryPointV0 {
         )?;
 
         Ok(())
+    }
+}
+
+impl<IG: IdentifierGetter> CairoSized<IG> for EntryPointV0 {
+    fn size(_identifier_getter: &IG) -> usize {
+        // TODO(Rotem): Fetch from IG after we upgrade the VM.
+        2
     }
 }

--- a/crates/starknet_os/src/hints/hint_implementation/deprecated_compiled_class/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/deprecated_compiled_class/utils.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use blockifier::state::state_api::StateReader;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_api::contract_class::EntryPointType;
@@ -8,12 +9,88 @@ use starknet_types_core::felt::Felt;
 
 use crate::hints::error::OsHintResult;
 use crate::hints::vars::CairoStruct;
-use crate::vm_utils::{
-    insert_value_to_nested_field,
-    insert_values_to_fields,
-    IdentifierGetter,
-    LoadCairoObject,
-};
+use crate::hint_processor::snos_hint_processor::SnosHintProcessor;
+use crate::vm_utils::{insert_values_to_fields ,insert_value_to_nested_field, IdentifierGetter, LoadCairoObject};
+
+/// Returns the serialization of a contract as a list of field elements.
+fn get_deprecated_contract_class_struct<S: StateReader>(
+    hint_processor: &mut SnosHintProcessor<S>,
+    vm: &mut VirtualMachine,
+    class_base: Relocatable,
+    deprecated_class: ContractClass,
+) -> OsHintResult {
+    vm.insert_value(class_base, Felt::from(0))?; // DEPRECATED_COMPILED_CLASS_VERSION = 0
+
+    let mut externals: Vec<MaybeRelocatable> = Vec::new();
+    for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::External).unwrap().iter() {
+        externals.push(MaybeRelocatable::from(elem.selector.0));
+        externals.push(MaybeRelocatable::from(Felt::from(elem.offset.0)));
+    }
+    vm.insert_value((class_base + 1)?, Felt::from(externals.len() / 2))?;
+    let externals_base = vm.add_memory_segment();
+    vm.load_data(externals_base, &externals)?;
+
+    vm.insert_value((class_base + 2)?, externals_base)?;
+
+    let mut l1_handlers: Vec<MaybeRelocatable> = Vec::new();
+    for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::L1Handler).unwrap().iter() {
+        l1_handlers.push(MaybeRelocatable::from(elem.selector.0));
+        l1_handlers.push(MaybeRelocatable::from(Felt::from(elem.offset.0)));
+    }
+    vm.insert_value((class_base + 3)?, Felt::from(l1_handlers.len() / 2))?;
+    let l1_handlers_base = vm.add_memory_segment();
+    vm.load_data(l1_handlers_base, &l1_handlers)?;
+
+    vm.insert_value((class_base + 4)?, l1_handlers_base)?;
+
+    let mut constructors: Vec<MaybeRelocatable> = Vec::new();
+    for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::Constructor).unwrap().iter() {
+        constructors.push(MaybeRelocatable::from(elem.selector.0));
+        constructors.push(MaybeRelocatable::from(Felt::from(elem.offset.0)));
+    }
+    vm.insert_value((class_base + 5)?, Felt::from(constructors.len() / 2))?;
+    let constructors_base = vm.add_memory_segment();
+    vm.load_data(constructors_base, &constructors)?;
+
+    vm.insert_value((class_base + 6)?, constructors_base)?;
+
+    let builtins: Vec<String> = serde_json::from_value(deprecated_class.clone().program.builtins).unwrap();
+    let builtins: Vec<MaybeRelocatable> =
+        builtins.into_iter().map(|bi| MaybeRelocatable::from(Felt::from_bytes_be_slice(bi.as_bytes()))).collect();
+
+    vm.insert_value((class_base + 7)?, Felt::from(builtins.len()))?;
+    let builtins_base = vm.add_memory_segment();
+    vm.load_data(builtins_base, &builtins)?;
+    vm.insert_value((class_base + 8)?, builtins_base)?;
+
+    let contract_definition_dump = serde_json::to_vec(&deprecated_class).expect("Serialization should not fail");
+    let mut cairo_contract_class_json =
+        serde_json::from_slice::<json::CairoContractDefinition<'_>>(&contract_definition_dump)
+            .expect("Deserialization should not fail");
+
+    // This functions perform some tweaks for old Cairo contracts in order to keep backward compatibility and compute the right hash
+    prepare_json_contract_definition(&mut cairo_contract_class_json)
+        .map_err(|_| custom_hint_error("Processing Cairo contracts for backward compatibility failed"))?;
+
+    let hinted_class_hash = {
+        let class_hash =
+            compute_cairo_hinted_class_hash(&cairo_contract_class_json).expect("Hashing should not fail here");
+        Felt::from_bytes_be(&class_hash.to_be_bytes())
+    };
+
+    vm.insert_value((class_base + 9)?, hinted_class_hash)?;
+
+    let data: Vec<String> = serde_json::from_value(deprecated_class.program.data).unwrap();
+    let data: Vec<MaybeRelocatable> =
+        data.into_iter().map(|datum| MaybeRelocatable::from(Felt::from_hex(&datum).unwrap())).collect();
+    vm.insert_value((class_base + 10)?, Felt::from(data.len()))?;
+    let data_base = vm.add_memory_segment();
+    vm.load_data(data_base, &data)?;
+
+    vm.insert_value((class_base + 11)?, data_base)?;
+
+    Ok(())
+}
 
 #[allow(clippy::too_many_arguments)]
 /// Loads the entry points of a deprecated contract class to a contract class struct, given a

--- a/crates/starknet_os/src/hints/vars.rs
+++ b/crates/starknet_os/src/hints/vars.rs
@@ -201,6 +201,7 @@ pub enum Const {
     BlobLength,
     BlockHashContractAddress,
     CompiledClassVersion,
+    DeprecatedCompiledClassVersion,
     EntryPointInitialBudget,
     InitialAvailableAlias,
     MerkleHeight,
@@ -225,6 +226,10 @@ impl From<Const> for &'static str {
             }
             Const::CompiledClassVersion => {
                 "starkware.starknet.core.os.contract_class.compiled_class.COMPILED_CLASS_VERSION"
+            }
+            Const::DeprecatedCompiledClassVersion => {
+                "starkware.starknet.core.os.contract_class.deprecated_compiled_class.\
+                 DEPRECATED_COMPILED_CLASS_VERSION"
             }
             Const::InitialAvailableAlias => {
                 "starkware.starknet.core.os.state.aliases.INITIAL_AVAILABLE_ALIAS"


### PR DESCRIPTION
feat(starknet_os): copy get_deprecated_contract_class_struct from moonsong's repo

feat(starknet_os): implement LoadCairoObject trait for DeprecatedContractClass