### PR TITLE
fix(consensus): add TODO to fn proposer in the context

### DIFF
--- a/crates/starknet_consensus/src/types.rs
+++ b/crates/starknet_consensus/src/types.rs
@@ -97,6 +97,7 @@ pub trait ConsensusContext {
     async fn validators(&self, height: BlockNumber) -> Vec<ValidatorId>;
 
     /// Calculates the ID of the Proposer based on the inputs.
+    // TODO(matan): Consider passing the validator set in order to keep this sync.
     fn proposer(&self, height: BlockNumber, round: Round) -> ValidatorId;
 
     async fn broadcast(&mut self, message: Vote) -> Result<(), ConsensusError>;


### PR DESCRIPTION
This will likely be relevant when the validator set can change and retrieving it is
an async process.