### PR TITLE
chore(starknet_l1_provider): make committed hashset

### DIFF
--- a/crates/starknet_l1_provider/src/test_utils.rs
+++ b/crates/starknet_l1_provider/src/test_utils.rs
@@ -136,12 +136,7 @@ impl From<TransactionManagerContent> for TransactionManager {
         let txs: Vec<_> = mem::take(&mut content.txs).unwrap();
         TransactionManager {
             txs: SoftDeleteIndexMap::from(txs),
-            committed: content
-                .committed
-                .unwrap_or_default()
-                .into_iter()
-                .map(|tx_hash| (tx_hash, None))
-                .collect(),
+            committed: content.committed.unwrap_or_default(),
         }
     }
 }

--- a/crates/starknet_l1_provider/src/transaction_manager.rs
+++ b/crates/starknet_l1_provider/src/transaction_manager.rs
@@ -1,4 +1,5 @@
-use indexmap::IndexMap;
+use std::collections::HashSet;
+
 use starknet_api::executable_transaction::L1HandlerTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_l1_provider_types::{InvalidValidationStatus, ValidationStatus};
@@ -8,7 +9,7 @@ use crate::soft_delete_index_map::SoftDeleteIndexMap;
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TransactionManager {
     pub txs: SoftDeleteIndexMap,
-    pub committed: IndexMap<TransactionHash, Option<L1HandlerTransaction>>,
+    pub committed: HashSet<TransactionHash>,
 }
 
 impl TransactionManager {
@@ -29,7 +30,7 @@ impl TransactionManager {
     }
 
     pub fn validate_tx(&mut self, tx_hash: TransactionHash) -> ValidationStatus {
-        if self.committed.contains_key(&tx_hash) {
+        if self.committed.contains(&tx_hash) {
             return ValidationStatus::Invalid(InvalidValidationStatus::AlreadyIncludedOnL2);
         }
 
@@ -49,6 +50,6 @@ impl TransactionManager {
     /// Adds a transaction to the transaction manager, return false iff the transaction already
     /// existed.
     pub fn add_tx(&mut self, tx: L1HandlerTransaction) -> bool {
-        self.committed.contains_key(&tx.tx_hash) || self.txs.insert(tx)
+        self.committed.contains(&tx.tx_hash) || self.txs.insert(tx)
     }
 }


### PR DESCRIPTION
No need to save the transaction itself
Note: insertion to this collection hasn't been added yet, will be added
in the next PR.