### PR TITLE
chore(starknet_l1_provider): save committed txs

### DIFF
--- a/crates/starknet_l1_provider/src/test_utils.rs
+++ b/crates/starknet_l1_provider/src/test_utils.rs
@@ -132,12 +132,16 @@ impl TransactionManagerContent {
                 &tx_manager.txs.txs.values().map(|tx| tx.transaction.clone()).collect_vec()
             );
         }
+
+        if let Some(committed) = &self.committed {
+            assert_eq!(committed, &tx_manager.committed);
+        }
     }
 }
 
 impl From<TransactionManagerContent> for TransactionManager {
     fn from(mut content: TransactionManagerContent) -> TransactionManager {
-        let txs: Vec<_> = mem::take(&mut content.txs).unwrap();
+        let txs: Vec<_> = mem::take(&mut content.txs).unwrap_or_default();
         TransactionManager {
             txs: SoftDeleteIndexMap::from(txs),
             committed: content.committed.unwrap_or_default(),

--- a/crates/starknet_l1_provider/src/transaction_manager.rs
+++ b/crates/starknet_l1_provider/src/transaction_manager.rs
@@ -44,7 +44,11 @@ impl TransactionManager {
     }
 
     pub fn commit_txs(&mut self, committed_txs: &[TransactionHash]) {
+        // Committed L1 transactions are dropped here, do we need to them for anything?
         self.txs.commit(committed_txs);
+        // Add all committed tx hashes to the committed buffer, regardless of if they're known or
+        // not, in case we haven't scraped them yet and another node did.
+        self.committed.extend(committed_txs)
     }
 
     /// Adds a transaction to the transaction manager, return false iff the transaction already


### PR DESCRIPTION
Saving the committed txs on commit was missing, added a test for the
race between a tx coming from another node before it was received from
the scraper.