### PR TITLE
fix(starknet_l1_provider): off-by-one flow test

### DIFF
--- a/crates/starknet_l1_provider/tests/startup_flows.rs
+++ b/crates/starknet_l1_provider/tests/startup_flows.rs
@@ -142,7 +142,7 @@ async fn bootstrap_delayed_sync_state_with_trivial_catch_up() {
     // Setup.
 
     let l1_provider_client = Arc::new(FakeL1ProviderClient::default());
-    let startup_height = BlockNumber(2);
+    let startup_height = BlockNumber(3);
 
     let mut sync_client = MockStateSyncClient::default();
     // Mock sync response for an arbitrary number of calls to get_latest_block_number.


### PR DESCRIPTION
This didn't fail the test since the sync task panicked in an async task,
the panic was that the sync tried to sync on an extra block, which
didn't have a mockall expectation on.
Error on the spawned task is currently not tracked: a health check for the
async task is a pending task, added it to the board.