### PR TITLE
fix(starknet_l1_provider): flow test consistency

### DIFF
--- a/crates/starknet_l1_provider/tests/startup_flows.rs
+++ b/crates/starknet_l1_provider/tests/startup_flows.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use itertools::Itertools;
 use mempool_test_utils::in_ci;
 use starknet_api::block::BlockNumber;
+use starknet_l1_provider::bootstrapper::CommitBlockBacklog;
 use starknet_l1_provider::l1_provider::create_l1_provider;
 use starknet_l1_provider::test_utils::FakeL1ProviderClient;
 use starknet_l1_provider::L1ProviderConfig;
@@ -174,10 +175,19 @@ async fn bootstrap_delayed_sync_state_with_trivial_catch_up() {
     // is a trivial catchup scenario (nothing to catch up).
     // This checks that the trivial catch_up_height doesn't mess up this flow.
     let no_txs_committed = []; // Not testing txs in this test.
-    l1_provider.commit_block(&no_txs_committed, startup_height).unwrap();
-    tokio::time::sleep(config.startup_sync_sleep_retry_interval).await;
-    l1_provider.commit_block(&no_txs_committed, startup_height.unchecked_next()).unwrap();
-    tokio::time::sleep(config.startup_sync_sleep_retry_interval).await;
+    l1_provider_client.commit_block(no_txs_committed.to_vec(), startup_height).await.unwrap();
+    l1_provider_client
+        .commit_block(no_txs_committed.to_vec(), startup_height.unchecked_next())
+        .await
+        .unwrap();
+
+    // Flush txs from the fake client to the provider, acts like the `recv()` in a channel.
+    let commit_blocks =
+        l1_provider_client.commit_blocks_received.lock().unwrap().drain(..).collect_vec();
+    for CommitBlockBacklog { height, committed_txs } in commit_blocks {
+        l1_provider.commit_block(&committed_txs, height).unwrap();
+    }
+
     // Commit blocks should have been applied.
     let start_height_plus_2 = startup_height.unchecked_next().unchecked_next();
     assert_eq!(l1_provider.current_height, start_height_plus_2);
@@ -196,9 +206,7 @@ async fn bootstrap_delayed_sync_state_with_trivial_catch_up() {
     // state.
     l1_provider.commit_block(&no_txs_committed, start_height_plus_2).unwrap();
     assert_eq!(l1_provider.current_height, start_height_plus_2.unchecked_next());
-    // Should still be bootstrapping, since catchup height isn't determined yet.
-    // Technically we could end bootstrapping at this point, but its simpler to let it
-    // terminate gracefully once the the sync is ready.
+    // The new commit block triggered the catch-up check, which ended the bootstrapping phase.
     assert!(!l1_provider.state.is_bootstrapping());
 }
 


### PR DESCRIPTION
Use the client, rather than direct l1_provider calls.
This is relevant here because the async task is already using the
(mock) client, and making the test use the provider directly while the
sync task is using the client will be too different from prod code.

Also fixed an incorrect copy-paste code remark.