### PR TITLE
refactor(starknet_client): change fee market input types

### DIFF
--- a/crates/starknet_consensus_orchestrator/resources/orchestrator_versioned_constants_0_14_0.json
+++ b/crates/starknet_consensus_orchestrator/resources/orchestrator_versioned_constants_0_14_0.json
@@ -2,6 +2,6 @@
     "gas_price_max_change_denominator": 48,
     "gas_target": 2000000000,
     "max_block_size": 4000000000,
-    "min_gas_price": 100000,
+    "min_gas_price": "0x186a0",
     "l1_gas_price_margin_percent": 10
 }

--- a/crates/starknet_consensus_orchestrator/src/cende/central_objects.rs
+++ b/crates/starknet_consensus_orchestrator/src/cende/central_objects.rs
@@ -58,7 +58,6 @@ use crate::fee_market::FeeMarketInfo;
 mod central_objects_test;
 
 pub(crate) type CentralBouncerWeights = BouncerWeights;
-pub(crate) type CentralFeeMarketInfo = FeeMarketInfo;
 pub(crate) type CentralCompressedStateDiff = CentralStateDiff;
 pub(crate) type CentralSierraContractClassEntry = (ClassHash, CentralSierraContractClass);
 pub(crate) type CentralCasmContractClassEntry = (CompiledClassHash, CentralCasmContractClass);
@@ -437,6 +436,21 @@ impl From<CasmContractClass> for CentralCasmContractClass {
                 pythonic_hints: Some(compiled_class.pythonic_hints.unwrap_or_default()),
                 ..compiled_class
             },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CentralFeeMarketInfo {
+    pub l2_gas_consumed: u64,
+    pub next_l2_gas_price: u128,
+}
+
+impl From<FeeMarketInfo> for CentralFeeMarketInfo {
+    fn from(fee_market_info: FeeMarketInfo) -> CentralFeeMarketInfo {
+        CentralFeeMarketInfo {
+            l2_gas_consumed: fee_market_info.l2_gas_consumed.0,
+            next_l2_gas_price: fee_market_info.next_l2_gas_price.0,
         }
     }
 }

--- a/crates/starknet_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/starknet_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -120,6 +120,7 @@ use super::{
 };
 use crate::cende::central_objects::CentralCasmContractClass;
 use crate::cende::{AerospikeBlob, BlobParameters};
+use crate::fee_market::FeeMarketInfo;
 
 // TODO(yael, dvir): add default object serialization tests.
 
@@ -193,6 +194,10 @@ fn block_info() -> BlockInfo {
         },
         use_kzg_da: true,
     }
+}
+
+fn fee_market_info() -> FeeMarketInfo {
+    FeeMarketInfo { l2_gas_consumed: GasAmount(150000), next_l2_gas_price: GasPrice(100000) }
 }
 
 fn central_state_diff() -> CentralStateDiff {
@@ -607,7 +612,7 @@ fn central_blob() -> AerospikeBlob {
         compressed_state_diff: Some(commitment_state_diff()),
         transactions: input_txs,
         bouncer_weights: central_bouncer_weights(),
-        fee_market_info: central_fee_market_info(),
+        fee_market_info: fee_market_info(),
         execution_infos: vec![transaction_execution_info()],
     };
 

--- a/crates/starknet_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/starknet_consensus_orchestrator/src/cende/mod.rs
@@ -310,7 +310,7 @@ impl AerospikeBlob {
             state_diff,
             compressed_state_diff,
             bouncer_weights: blob_parameters.bouncer_weights,
-            fee_market_info: blob_parameters.fee_market_info,
+            fee_market_info: blob_parameters.fee_market_info.into(),
             transactions: central_transactions,
             execution_infos,
             contract_classes,

--- a/crates/starknet_consensus_orchestrator/src/fee_market/mod.rs
+++ b/crates/starknet_consensus_orchestrator/src/fee_market/mod.rs
@@ -1,6 +1,8 @@
 use std::cmp::max;
 
 use serde::Serialize;
+use starknet_api::block::GasPrice;
+use starknet_api::execution_resources::GasAmount;
 
 use crate::orchestrator_versioned_constants;
 
@@ -11,9 +13,9 @@ mod test;
 #[derive(Debug, Default, Serialize)]
 pub struct FeeMarketInfo {
     /// Total gas consumed in the current block.
-    pub l2_gas_consumed: u64,
+    pub l2_gas_consumed: GasAmount,
     /// Gas price for the next block.
-    pub next_l2_gas_price: u64,
+    pub next_l2_gas_price: GasPrice,
 }
 
 /// Calculate the base gas price for the next block according to EIP-1559.
@@ -22,7 +24,11 @@ pub struct FeeMarketInfo {
 /// - `price`: The base gas price per unit (in fri) of the current block.
 /// - `gas_used`: The total gas used in the current block.
 /// - `gas_target`: The target gas usage per block (usually half of a block's gas limit).
-pub fn calculate_next_base_gas_price(price: u64, gas_used: u64, gas_target: u64) -> u64 {
+pub fn calculate_next_base_gas_price(
+    price: GasPrice,
+    gas_used: GasAmount,
+    gas_target: GasAmount,
+) -> GasPrice {
     let versioned_constants =
         orchestrator_versioned_constants::VersionedConstants::latest_constants();
     // Setting the target at 50% of the max block size balances the rate of gas price changes,
@@ -47,35 +53,27 @@ pub fn calculate_next_base_gas_price(price: u64, gas_used: u64, gas_target: u64)
     // all inputs using u128 for intermediate calculations.
 
     // The absolute difference between gas_used and gas_target is always u64.
-    let gas_delta = gas_used.abs_diff(gas_target);
+    let gas_delta = gas_used.0.abs_diff(gas_target.0);
     // Convert to u128 to prevent overflow, as a product of two u64 fits inside a u128.
-    let price_u128 = u128::from(price);
-    let gas_delta_u128 = u128::from(gas_delta);
-    let gas_target_u128 = u128::from(gas_target);
+    let gas_delta_u128 = gas_delta.into();
+    let gas_target_u128: u128 = gas_target.0.into();
 
-    // Calculate the gas change as u128 to handle potential overflow during multiplication.
     let gas_delta_cost =
-        price_u128.checked_mul(gas_delta_u128).expect("Both variables originate from u64");
+        price.0.checked_mul(gas_delta_u128).expect("Multiplication overflow detected");
     // Calculate the price change, maintaining precision by dividing after scaling up.
     // This avoids significant precision loss that would occur if dividing before
     // multiplication.
-    let price_change_u128 =
-        gas_delta_cost / (gas_target_u128 * versioned_constants.gas_price_max_change_denominator);
-
-    // Convert back to u64, as the price change should fit within the u64 range.
-    // Since the target is half the maximum block size (which fits within a u64), the gas delta
-    // is bounded by half the maximum block size. Therefore, after dividing by the gas target
-    // (which is half the maximum block size), the result is guaranteed to fit within a u64.
-    let price_change = u64::try_from(price_change_u128)
-        .expect("Result fits u64 after division of a bounded gas delta");
+    let price_change = gas_delta_cost
+        .checked_div(gas_target_u128 * versioned_constants.gas_price_max_change_denominator)
+        .expect("Division error, denominator must be nonzero");
 
     let adjusted_price =
-        if gas_used > gas_target { price + price_change } else { price - price_change };
+        if gas_used > gas_target { price.0 + price_change } else { price.0 - price_change };
 
     assert!(
-        gas_used > gas_target && adjusted_price >= price
-            || gas_used <= gas_target && adjusted_price <= price
+        gas_used > gas_target && adjusted_price >= price.0
+            || gas_used <= gas_target && adjusted_price <= price.0
     );
 
-    max(adjusted_price, versioned_constants.min_gas_price)
+    GasPrice(max(adjusted_price, versioned_constants.min_gas_price.0))
 }

--- a/crates/starknet_consensus_orchestrator/src/orchestrator_versioned_constants.rs
+++ b/crates/starknet_consensus_orchestrator/src/orchestrator_versioned_constants.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
-use starknet_api::block::StarknetVersion;
+use starknet_api::block::{GasPrice, StarknetVersion};
 use starknet_api::define_versioned_constants;
+use starknet_api::execution_resources::GasAmount;
 use thiserror::Error;
 
 /// Versioned constants for the Consensus.
@@ -10,12 +11,12 @@ pub struct VersionedConstants {
     /// serves as a sensitivity parameter that limits the maximum rate of change of the gas price
     /// between consecutive blocks.
     pub gas_price_max_change_denominator: u128,
-    /// The minimum gas price in fri.
-    pub min_gas_price: u64,
+    /// The minimum gas price in fri (set to 100,000).
+    pub min_gas_price: GasPrice,
     /// The maximum block size in gas units.
-    pub max_block_size: u64,
+    pub max_block_size: GasAmount,
     /// The target gas usage per block (usually half of a block's gas limit).
-    pub gas_target: u64,
+    pub gas_target: GasAmount,
     /// The margin for the eth to fri rate disagreement, expressed as a percentage (parts per
     /// hundred).
     pub l1_gas_price_margin_percent: u32,

--- a/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/starknet_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -175,7 +175,7 @@ pub struct SequencerConsensusContext {
     // The next block's l2 gas price, calculated based on EIP-1559, used for building and
     // validating proposals.
     _l1_gas_price_provider: Arc<dyn L1GasPriceProviderClient>,
-    l2_gas_price: u64,
+    l2_gas_price: GasPrice,
     l1_da_mode: L1DataAvailabilityMode,
     last_block_timestamp: Option<u64>,
 }
@@ -229,7 +229,7 @@ impl SequencerConsensusContext {
     fn gas_prices(&self) -> GasPrices {
         GasPrices {
             strk_gas_prices: GasPriceVector {
-                l2_gas_price: NonzeroGasPrice::new(self.l2_gas_price.into())
+                l2_gas_price: NonzeroGasPrice::new(self.l2_gas_price)
                     .expect("Failed to convert l2_gas_price to NonzeroGasPrice, should not be 0."),
                 ..TEMPORARY_GAS_PRICES.strk_gas_prices
             },
@@ -496,7 +496,7 @@ impl ConsensusContext for SequencerConsensusContext {
 
         let next_l2_gas_price = calculate_next_base_gas_price(
             self.l2_gas_price,
-            l2_gas_used.0,
+            l2_gas_used,
             VersionedConstants::latest_constants().max_block_size / 2,
         );
 
@@ -519,13 +519,13 @@ impl ConsensusContext for SequencerConsensusContext {
             l1_gas_price,
             l1_data_gas_price,
             l2_gas_price: GasPricePerToken {
-                price_in_fri: GasPrice(__self.l2_gas_price.into()),
+                price_in_fri: self.l2_gas_price,
                 // TODO(guy.f): We shouldn't be sending price_in_wei for l2, should we remove
                 // it from the Token or not use GasPriceToken here.
                 price_in_wei: GasPrice(1),
             },
             l2_gas_consumed: GasAmount(l2_gas_used.0),
-            next_l2_gas_price: GasPrice(next_l2_gas_price.into()),
+            next_l2_gas_price,
             sequencer,
             timestamp: BlockTimestamp(block_info.timestamp),
             l1_da_mode: block_info.l1_da_mode,
@@ -558,7 +558,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 execution_infos: central_objects.execution_infos,
                 bouncer_weights: central_objects.bouncer_weights,
                 fee_market_info: FeeMarketInfo {
-                    l2_gas_consumed: l2_gas_used.0,
+                    l2_gas_consumed: l2_gas_used,
                     next_l2_gas_price: self.l2_gas_price,
                 },
             })
@@ -580,13 +580,10 @@ impl ConsensusContext for SequencerConsensusContext {
             Ok(Some(block)) => block,
         };
         // May be default for blocks older than 0.14.0, ensure min gas price is met.
-        // TODO(Ayelet): Change min_gas_price to GasPrice.
         self.l2_gas_price = max(
-            sync_block.block_header_without_hash.next_l2_gas_price.0,
-            VersionedConstants::latest_constants().min_gas_price.into(),
-        )
-        .try_into()
-        .unwrap();
+            sync_block.block_header_without_hash.next_l2_gas_price,
+            VersionedConstants::latest_constants().min_gas_price,
+        );
         // TODO(Asmaa): validate starknet_version and parent_hash when they are stored.
         let block_number = sync_block.block_header_without_hash.block_number;
         let timestamp = sync_block.block_header_without_hash.timestamp;


### PR DESCRIPTION
After refactoring gas price to u128, there were two options for this calculation:
1. Use u256 to eliminate any risk of overflow.
2. Use u128 with overflow checks, assuming realistic values won't overflow.

I chose the second option because the worst-case values are well within safe bounds:
**Case 1:** Multiplication `gas_delta_cost = price × gas_delta`
- Max price: ~10¹⁸ (1 ETH in wei)
- Max gas delta: 2,000,000,000 (`gas_target = max_block_size / 2`)
Result: 10¹⁸ × 2 × 10⁹ = 2 × 10²⁷
u128::MAX ≈ 3.4 × 10³⁸ → ✅ no overflow

**Case 2:** Division `gas_delta_cost / (gas_target × gas_price_max_change_denominator)`
- Denominator: 2,000,000,000 × 48 = 96 × 10⁹
- Max gas delta: 2,000,000,000 (`gas_target = max_block_size / 2`)
Result: 2 × 10²⁷ / 96 × 10⁹ = 2.08 × 10¹⁶
✅ safely fits in u128

Using u128 keeps the code simple and efficient, and overflow is prevented with checked_* methods.