### PR TITLE
chore(apollo_integration_tests): async creator for simulator

### DIFF
--- a/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_flow.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_flow.rs
@@ -74,7 +74,7 @@ async fn main() {
         integration_test_manager.get_num_accepted_txs_on_all_running_nodes().await;
 
     // Create a simulator for sustained transaction sending.
-    let simulator = integration_test_manager.create_simulator();
+    let simulator = integration_test_manager.create_simulator().await;
     let mut tx_generator = integration_test_manager.tx_generator().snapshot();
     let test_scenario = ConsensusTxs {
         n_invoke_txs: TOTAL_INVOKE_TXS.try_into().expect("Failed to convert TPS to usize"),

--- a/crates/apollo_integration_tests/src/bin/sequencer_simulator.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_simulator.rs
@@ -122,7 +122,8 @@ async fn main() -> anyhow::Result<()> {
     let (http_port, monitoring_port) = get_ports(&args);
 
     let sequencer_simulator =
-        SequencerSimulator::new(args.http_url, http_port, args.monitoring_url, monitoring_port);
+        SequencerSimulator::create(args.http_url, http_port, args.monitoring_url, monitoring_port)
+            .await;
 
     info!("Sending deploy and invoke txs");
     sequencer_simulator.send_txs(&mut tx_generator, &DeployAndInvokeTxs, ACCOUNT_ID_0).await;

--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -501,7 +501,7 @@ impl IntegrationTestManager {
     }
 
     /// Create a simulator that's connected to the http server of Node 0.
-    pub fn create_simulator(&self) -> SequencerSimulator {
+    pub async fn create_simulator(&self) -> SequencerSimulator {
         let node_0_setup = self
             .running_nodes
             .get(&0)
@@ -514,12 +514,13 @@ impl IntegrationTestManager {
             .get_config();
 
         let localhost_url = format!("http://{}", Ipv4Addr::LOCALHOST);
-        SequencerSimulator::new(
+        SequencerSimulator::create(
             localhost_url.clone(),
             config.http_server_config.port,
             localhost_url,
             config.monitoring_endpoint_config.port,
         )
+        .await
     }
 
     #[instrument(skip(self))]

--- a/crates/apollo_integration_tests/src/sequencer_simulator_utils.rs
+++ b/crates/apollo_integration_tests/src/sequencer_simulator_utils.rs
@@ -12,13 +12,14 @@ use crate::integration_test_manager::nonce_to_usize;
 use crate::monitoring_utils;
 use crate::utils::{send_consensus_txs, TestScenario};
 
+// TODO(Arni): Add the Starknet L1 contract handler.
 pub struct SequencerSimulator {
     monitoring_client: MonitoringClient,
     http_client: HttpTestClient,
 }
 
 impl SequencerSimulator {
-    pub fn new(
+    pub async fn create(
         http_url: String,
         http_port: u16,
         monitoring_url: String,


### PR DESCRIPTION
In the following PR, we add the deployment of a Starknet L1 contract to the simulator initiation. This action is async, so the create function needs to be async.