### PR TITLE
chore(consensus): add dumping functionality to manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "papyrus_common",
  "prost",
  "serde",
+ "serde_json",
  "starknet-types-core",
  "starknet_api",
  "strum 0.25.0",

--- a/crates/apollo_consensus/Cargo.toml
+++ b/crates/apollo_consensus/Cargo.toml
@@ -26,6 +26,7 @@ nix.workspace = true
 papyrus_common.workspace = true
 prost.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 strum.workspace = true

--- a/crates/apollo_consensus/src/single_height_consensus.rs
+++ b/crates/apollo_consensus/src/single_height_consensus.rs
@@ -18,6 +18,7 @@ use apollo_protobuf::consensus::{ProposalFin, ProposalInit, Vote, VoteType};
 #[cfg(test)]
 use enum_as_inner::EnumAsInner;
 use futures::channel::{mpsc, oneshot};
+use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use tracing::{debug, info, instrument, trace, warn};
 
@@ -171,6 +172,7 @@ impl ShcTask {
 ///
 /// SHC is not a top level task, it is called directly and returns values (doesn't directly run sub
 /// tasks). SHC does have side effects, such as sending messages to the network via the context.
+#[derive(Serialize, Deserialize)]
 pub(crate) struct SingleHeightConsensus {
     height: BlockNumber,
     validators: Vec<ValidatorId>,

--- a/crates/apollo_consensus/src/single_height_consensus.rs
+++ b/crates/apollo_consensus/src/single_height_consensus.rs
@@ -172,7 +172,7 @@ impl ShcTask {
 ///
 /// SHC is not a top level task, it is called directly and returns values (doesn't directly run sub
 /// tasks). SHC does have side effects, such as sending messages to the network via the context.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct SingleHeightConsensus {
     height: BlockNumber,
     validators: Vec<ValidatorId>,

--- a/crates/apollo_consensus/src/state_machine.rs
+++ b/crates/apollo_consensus/src/state_machine.rs
@@ -9,13 +9,14 @@ mod state_machine_test;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use serde::{Deserialize, Serialize};
 use tracing::{info, trace};
 
 use crate::metrics::{CONSENSUS_HELD_LOCKS, CONSENSUS_NEW_VALUE_LOCKS, CONSENSUS_ROUND};
 use crate::types::{ProposalCommitment, Round, ValidatorId};
 
 /// Events which the state machine sends/receives.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum StateMachineEvent {
     /// Sent by the state machine when a block is required to propose (ProposalCommitment is always
     /// None). While waiting for the response of GetProposal, the state machine will buffer all
@@ -41,7 +42,7 @@ pub enum StateMachineEvent {
     TimeoutPrecommit(Round),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Step {
     Propose,
     Prevote,
@@ -53,6 +54,7 @@ pub enum Step {
 /// 2. SM must handle "out of order" messages (E.g. vote arrives before proposal).
 ///
 /// Each height is begun with a call to `start`, with no further calls to it.
+#[derive(Serialize, Deserialize)]
 pub struct StateMachine {
     id: ValidatorId,
     round: Round,

--- a/crates/apollo_consensus/src/state_machine.rs
+++ b/crates/apollo_consensus/src/state_machine.rs
@@ -54,7 +54,7 @@ pub enum Step {
 /// 2. SM must handle "out of order" messages (E.g. vote arrives before proposal).
 ///
 /// Each height is begun with a call to `start`, with no further calls to it.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StateMachine {
     id: ValidatorId,
     round: Round,

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -159,6 +159,8 @@ impl ConsensusManager {
 
         let network_task = tokio::spawn(network_manager.run());
         let stream_handler_task = tokio::spawn(stream_handler.run());
+        // Dummy channels until the infra is set up for this.
+        let (_debug_sender, debug_receiver) = mpsc::channel(CHANNEL_BUFFER_LENGTH);
         let consensus_fut = apollo_consensus::run_consensus(
             context,
             active_height,
@@ -169,6 +171,7 @@ impl ConsensusManager {
             self.config.consensus_config.sync_retry_interval,
             votes_broadcast_channels.into(),
             inbound_internal_receiver,
+            debug_receiver,
         );
 
         tokio::select! {

--- a/crates/apollo_protobuf/src/consensus.rs
+++ b/crates/apollo_protobuf/src/consensus.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 
 use bytes::{Buf, BufMut};
 use prost::DecodeError;
+use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::ContractAddress;
@@ -19,14 +20,14 @@ impl<T> IntoFromProto for T where
 {
 }
 
-#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum VoteType {
     Prevote,
     #[default]
     Precommit,
 }
 
-#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Vote {
     pub vote_type: VoteType,
     pub height: u64,


### PR DESCRIPTION
Currently main creates an unused sender while we wait for infra implementation.