### PR TITLE
chore(apollo_http_server): try from deprecated gateway declare tx

### DIFF
--- a/crates/apollo_http_server/src/errors.rs
+++ b/crates/apollo_http_server/src/errors.rs
@@ -2,6 +2,7 @@ use apollo_gateway_types::communication::GatewayClientError;
 use apollo_gateway_types::errors::GatewayError;
 use axum::response::{IntoResponse, Response};
 use jsonrpsee::types::error::ErrorCode;
+use starknet_api::compression_utils::CompressionError;
 use thiserror::Error;
 use tracing::{debug, error};
 
@@ -12,13 +13,15 @@ pub enum HttpServerRunError {
     ServerStartupError(#[from] hyper::Error),
 }
 
-/// Errors that may occure during the runtime of the HTTP server.
+/// Errors that may occur during the runtime of the HTTP server.
 #[derive(Error, Debug)]
 pub enum HttpServerError {
     #[error(transparent)]
     GatewayClientError(#[from] GatewayClientError),
     #[error(transparent)]
     DeserializationError(#[from] serde_json::Error),
+    #[error(transparent)]
+    DecompressionError(#[from] CompressionError),
 }
 
 impl IntoResponse for HttpServerError {
@@ -26,8 +29,19 @@ impl IntoResponse for HttpServerError {
         match self {
             HttpServerError::GatewayClientError(e) => gw_client_err_into_response(e),
             HttpServerError::DeserializationError(e) => serde_error_into_response(e),
+            HttpServerError::DecompressionError(e) => compression_error_into_response(e),
         }
     }
+}
+
+fn compression_error_into_response(err: CompressionError) -> Response {
+    debug!("Failed to decompress the transaction: {}", err);
+    let parse_error = jsonrpsee::types::ErrorObject::owned(
+        ErrorCode::InvalidParams.code(),
+        "Failed to decompress the provided Sierra program.",
+        None::<()>,
+    );
+    serde_json::to_vec(&parse_error).expect("Expecting a serializable error.").into_response()
 }
 
 fn serde_error_into_response(err: serde_json::Error) -> Response {

--- a/crates/apollo_http_server/src/http_server.rs
+++ b/crates/apollo_http_server/src/http_server.rs
@@ -89,7 +89,11 @@ async fn add_tx(
     // TODO(Yael): increment the failure metric for parsing error.
     let tx: DeprecatedGatewayTransactionV3 = serde_json::from_str(&tx)
         .inspect_err(|e| debug!("Error while parsing transaction: {}", e))?;
-    add_tx_inner(app_state, headers, tx.into()).await
+    let rpc_tx = tx.try_into().inspect_err(|e| {
+        debug!("Error while converting deprecated gateway transaction into RPC transaction: {}", e);
+    })?;
+
+    add_tx_inner(app_state, headers, rpc_tx).await
 }
 
 async fn add_tx_inner(

--- a/crates/starknet_api/src/compression_utils.rs
+++ b/crates/starknet_api/src/compression_utils.rs
@@ -22,6 +22,7 @@ pub fn compress_and_encode(value: serde_json::Value) -> Result<String, std::io::
     Ok(base64::encode(compressed_data))
 }
 
+// TODO(Arni): Refactor this function so it returns a generic T where T: DeserializeOwned.
 // Decompress the value from base64 and gzip.
 pub fn decode_and_decompress(value: &str) -> Result<serde_json::Value, CompressionError> {
     let decoded_data = base64::decode(value)?;


### PR DESCRIPTION
Note:
The base branch for this PR was `yael/support_rest_api` when it was created.
Now it is over main

This PR no longer contains the code of #5325.