### PR TITLE
feat(apollo_l1_provider): dummy mode


### DIFF
--- a/crates/apollo_l1_provider/src/l1_scraper_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper_tests.rs
@@ -27,7 +27,7 @@ use starknet_api::transaction::fields::{Calldata, Fee};
 use starknet_api::transaction::{L1HandlerTransaction, TransactionHasher, TransactionVersion};
 
 use crate::bootstrapper::Bootstrapper;
-use crate::l1_provider::create_l1_provider;
+use crate::l1_provider::L1ProviderBuilder;
 use crate::l1_scraper::{L1Scraper, L1ScraperConfig};
 use crate::test_utils::FakeL1ProviderClient;
 use crate::{event_identifiers_to_track, L1ProviderConfig};
@@ -170,13 +170,10 @@ async fn bootstrap_e2e() {
         startup_sync_sleep_retry_interval_seconds: Duration::from_millis(10),
         ..Default::default()
     };
-    let mut l1_provider = create_l1_provider(
-        config,
-        l1_provider_client.clone(),
-        Arc::new(sync_client),
-        STARTUP_HEIGHT,
-        None,
-    );
+    let mut l1_provider =
+        L1ProviderBuilder::new(config, l1_provider_client.clone(), Arc::new(sync_client))
+            .startup_height(STARTUP_HEIGHT)
+            .build();
 
     // Test.
 
@@ -288,13 +285,10 @@ async fn bootstrap_delayed_sync_state_with_trivial_catch_up() {
         startup_sync_sleep_retry_interval_seconds: Duration::from_millis(10),
         ..Default::default()
     };
-    let mut l1_provider = create_l1_provider(
-        config,
-        l1_provider_client.clone(),
-        Arc::new(sync_client),
-        STARTUP_HEIGHT,
-        None,
-    );
+    let mut l1_provider =
+        L1ProviderBuilder::new(config, l1_provider_client.clone(), Arc::new(sync_client))
+            .startup_height(STARTUP_HEIGHT)
+            .build();
 
     // Test.
 
@@ -364,13 +358,10 @@ async fn bootstrap_delayed_sync_state_with_sync_behind_batcher() {
         startup_sync_sleep_retry_interval_seconds: Duration::from_millis(10),
         ..Default::default()
     };
-    let mut l1_provider = create_l1_provider(
-        config,
-        l1_provider_client.clone(),
-        Arc::new(sync_client),
-        startup_height,
-        None,
-    );
+    let mut l1_provider =
+        L1ProviderBuilder::new(config, l1_provider_client.clone(), Arc::new(sync_client))
+            .startup_height(startup_height)
+            .build();
 
     // Test.
 
@@ -430,13 +421,10 @@ async fn test_stuck_sync() {
 
     let l1_provider_client = Arc::new(FakeL1ProviderClient::default());
     let config = Default::default();
-    let mut l1_provider = create_l1_provider(
-        config,
-        l1_provider_client.clone(),
-        Arc::new(sync_client),
-        STARTUP_HEIGHT,
-        None,
-    );
+    let mut l1_provider =
+        L1ProviderBuilder::new(config, l1_provider_client.clone(), Arc::new(sync_client))
+            .startup_height(STARTUP_HEIGHT)
+            .build();
 
     // Test.
 

--- a/crates/apollo_l1_provider/src/l1_scraper_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper_tests.rs
@@ -175,6 +175,7 @@ async fn bootstrap_e2e() {
         l1_provider_client.clone(),
         Arc::new(sync_client),
         STARTUP_HEIGHT,
+        None,
     );
 
     // Test.
@@ -292,6 +293,7 @@ async fn bootstrap_delayed_sync_state_with_trivial_catch_up() {
         l1_provider_client.clone(),
         Arc::new(sync_client),
         STARTUP_HEIGHT,
+        None,
     );
 
     // Test.
@@ -367,6 +369,7 @@ async fn bootstrap_delayed_sync_state_with_sync_behind_batcher() {
         l1_provider_client.clone(),
         Arc::new(sync_client),
         startup_height,
+        None,
     );
 
     // Test.
@@ -432,6 +435,7 @@ async fn test_stuck_sync() {
         l1_provider_client.clone(),
         Arc::new(sync_client),
         STARTUP_HEIGHT,
+        None,
     );
 
     // Test.

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -6,9 +6,9 @@ use apollo_gateway::gateway::{create_gateway, Gateway};
 use apollo_http_server::http_server::{create_http_server, HttpServer};
 use apollo_l1_gas_price::l1_gas_price_provider::L1GasPriceProvider;
 use apollo_l1_gas_price::l1_gas_price_scraper::L1GasPriceScraper;
-use apollo_l1_provider::event_identifiers_to_track;
 use apollo_l1_provider::l1_provider::{create_l1_provider, L1Provider};
 use apollo_l1_provider::l1_scraper::L1Scraper;
+use apollo_l1_provider::{event_identifiers_to_track, L1ProviderConfig};
 use apollo_mempool::communication::{create_mempool, MempoolCommunicationWrapper};
 use apollo_mempool_p2p::create_p2p_propagator_and_runner;
 use apollo_mempool_p2p::propagator::MempoolP2pPropagator;
@@ -241,11 +241,11 @@ pub async fn create_node_components(
     let l1_provider = match config.components.l1_provider.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-            let provider_startup_height = match &l1_scraper {
+            let (provider_startup_height, catch_up_height) = match &l1_scraper {
                 Some(l1_scraper) => {
                     let (base_layer, l1_scraper_start_l1_height) =
-                        (l1_scraper.base_layer.clone(), l1_scraper.last_l1_block_processed.number);
-                    base_layer
+                        (&l1_scraper.base_layer, l1_scraper.last_l1_block_processed.number);
+                    let startup_height = base_layer
                         .get_proved_block_at(l1_scraper_start_l1_height)
                         .await
                         .map(|block| block.number)
@@ -258,15 +258,53 @@ pub async fn create_node_components(
                             faulty Anvil state, or if the scraper was initialized too far back.
                             Attempting to use provider startup height override (read its docstring
                             before using!).\n {err}")})
-                        .ok().or(config.l1_provider_config.provider_startup_height_override)
+                        .ok().or(config.l1_provider_config.provider_startup_height_override);
+
+                    // Let catchup_height be set dynamically unless overridden later.
+                    let catch_up_height = None;
+
+                    (startup_height, catch_up_height)
                 }
                 None => {
                     warn!(
-                        "L1 Scraper is disabled, attempting to use provider startup height \
-                         override in order to find L1 Provider startup height (read its docstring \
-                         before using!)"
+                        "L1 Scraper is disabled, attempting to initialize the L1Provider from \
+                         overridden config values."
                     );
-                    config.l1_provider_config.provider_startup_height_override
+                    let L1ProviderConfig {
+                        provider_startup_height_override: startup_height_override,
+                        bootstrap_catch_up_height_override: catch_up_height_override,
+                        ..
+                    } = config.l1_provider_config;
+
+                    match (startup_height_override, catch_up_height_override) {
+                        (Some(startup_height), Some(catchup_height)) => {
+                            warn!(
+                                "Set up the L1 provider with startup and catchup height from the \
+                                 provided overrides."
+                            );
+                            (Some(startup_height), Some(catchup_height))
+                        }
+                        (None, None) => {
+                            warn!(
+                                "Explicit overrides for the startup and catchup height of the L1 \
+                                 Provider were not provided. Initializing in Dummy Mode by \
+                                 setting both of these values as the current batcher height."
+                            );
+                            let startup_height =
+                                batcher.as_ref().unwrap().get_height().await.unwrap().height;
+                            let catch_up_height = startup_height;
+                            (Some(startup_height), Some(catch_up_height))
+                        }
+                        _ => panic!(
+                            "Configuration error: overriding only one of \
+                             startup_height={startup:?} or catchup_height={catchup:?} is not \
+                             supported in l1 provider's dummy mode. Either set neither (this is \
+                             the preferred way) which sets both values to the batcher height, or \
+                             set both if you have a specific startup flow in mind.",
+                            startup = config.l1_provider_config.provider_startup_height_override,
+                            catchup = config.l1_provider_config.bootstrap_catch_up_height_override
+                        ),
+                    }
                 }
             };
             let provider_startup_height = provider_startup_height.expect(
@@ -280,6 +318,7 @@ pub async fn create_node_components(
                 clients.get_l1_provider_shared_client().unwrap(),
                 clients.get_state_sync_shared_client().unwrap(),
                 provider_startup_height,
+                catch_up_height,
             ))
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -6,9 +6,9 @@ use apollo_gateway::gateway::{create_gateway, Gateway};
 use apollo_http_server::http_server::{create_http_server, HttpServer};
 use apollo_l1_gas_price::l1_gas_price_provider::L1GasPriceProvider;
 use apollo_l1_gas_price::l1_gas_price_scraper::L1GasPriceScraper;
-use apollo_l1_provider::l1_provider::{create_l1_provider, L1Provider};
+use apollo_l1_provider::event_identifiers_to_track;
+use apollo_l1_provider::l1_provider::{L1Provider, L1ProviderBuilder};
 use apollo_l1_provider::l1_scraper::L1Scraper;
-use apollo_l1_provider::{event_identifiers_to_track, L1ProviderConfig};
 use apollo_mempool::communication::{create_mempool, MempoolCommunicationWrapper};
 use apollo_mempool_p2p::create_p2p_propagator_and_runner;
 use apollo_mempool_p2p::propagator::MempoolP2pPropagator;
@@ -22,7 +22,7 @@ use apollo_state_sync::runner::StateSyncRunner;
 use apollo_state_sync::{create_state_sync_and_runner, StateSync};
 use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerContract;
 use papyrus_base_layer::BaseLayerContract;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::clients::SequencerNodeClients;
 use crate::config::component_execution_config::{
@@ -241,11 +241,15 @@ pub async fn create_node_components(
     let l1_provider = match config.components.l1_provider.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-            let (provider_startup_height, catch_up_height) = match &l1_scraper {
+            let mut l1_provider_builder = L1ProviderBuilder::new(
+                config.l1_provider_config,
+                clients.get_l1_provider_shared_client().unwrap(),
+                clients.get_state_sync_shared_client().unwrap(),
+            );
+            match &l1_scraper {
                 Some(l1_scraper) => {
-                    let (base_layer, l1_scraper_start_l1_height) =
-                        (&l1_scraper.base_layer, l1_scraper.last_l1_block_processed.number);
-                    let startup_height = base_layer
+                    let l1_scraper_start_l1_height = l1_scraper.last_l1_block_processed.number;
+                    let scraper_synced_startup_height = l1_scraper.base_layer
                         .get_proved_block_at(l1_scraper_start_l1_height)
                         .await
                         .map(|block| block.number)
@@ -253,73 +257,59 @@ pub async fn create_node_components(
                         // genesis. The former should override the height, or setup Anvil accordingly, and
                         // the latter should use the correct L1 height.
                         .inspect_err(|err|{
-                            warn!("Error while attempting to get the L2 block at the L1 height the
-                            scraper was initialized on. This is either due to running a test with
-                            faulty Anvil state, or if the scraper was initialized too far back.
-                            Attempting to use provider startup height override (read its docstring
-                            before using!).\n {err}")})
-                        .ok().or(config.l1_provider_config.provider_startup_height_override);
+                            warn!("Error while attempting to get the L2 block at the L1 height \
+                            the scraper was initialized on. This is either due to running a \
+                            test with faulty Anvil state, or if the scraper was initialized too \
+                            far back.  Will attempt to use provider startup height override \
+                            instead (read its docstring before using!).\n {err}")})
+                        .ok();
 
-                    // Let catchup_height be set dynamically unless overridden later.
-                    let catch_up_height = None;
+                    if let Some(height) = scraper_synced_startup_height {
+                        l1_provider_builder = l1_provider_builder.startup_height(height);
+                    }
 
-                    (startup_height, catch_up_height)
+                    Some(l1_provider_builder.build())
                 }
                 None => {
-                    warn!(
-                        "L1 Scraper is disabled, attempting to initialize the L1Provider from \
-                         overridden config values."
+                    warn!("L1 Scraper is disabled, initialize L1 provider in dummy mode");
+                    let batcher_height = batcher
+                        .as_ref()
+                        .expect(
+                            "L1 provider's dummy mode initialization requires the batcher to be \
+                             set up in order to align to its height",
+                        )
+                        .get_height()
+                        .await
+                        .unwrap()
+                        .height;
+                    info!(
+                        "L1 provider dummy mode startup height set at batcher height: \
+                         {batcher_height}"
                     );
-                    let L1ProviderConfig {
-                        provider_startup_height_override: startup_height_override,
-                        bootstrap_catch_up_height_override: catch_up_height_override,
-                        ..
-                    } = config.l1_provider_config;
 
-                    match (startup_height_override, catch_up_height_override) {
-                        (Some(startup_height), Some(catchup_height)) => {
-                            warn!(
-                                "Set up the L1 provider with startup and catchup height from the \
-                                 provided overrides."
-                            );
-                            (Some(startup_height), Some(catchup_height))
-                        }
-                        (None, None) => {
-                            warn!(
-                                "Explicit overrides for the startup and catchup height of the L1 \
-                                 Provider were not provided. Initializing in Dummy Mode by \
-                                 setting both of these values as the current batcher height."
-                            );
-                            let startup_height =
-                                batcher.as_ref().unwrap().get_height().await.unwrap().height;
-                            let catch_up_height = startup_height;
-                            (Some(startup_height), Some(catch_up_height))
-                        }
-                        _ => panic!(
-                            "Configuration error: overriding only one of \
-                             startup_height={startup:?} or catchup_height={catchup:?} is not \
-                             supported in l1 provider's dummy mode. Either set neither (this is \
-                             the preferred way) which sets both values to the batcher height, or \
-                             set both if you have a specific startup flow in mind.",
-                            startup = config.l1_provider_config.provider_startup_height_override,
-                            catchup = config.l1_provider_config.bootstrap_catch_up_height_override
-                        ),
-                    }
+                    // Helps keep override use more structured, prevents bugs.
+                    assert!(
+                        config
+                            .l1_provider_config
+                            .provider_startup_height_override
+                            .xor(config.l1_provider_config.bootstrap_catch_up_height_override)
+                            .is_none(),
+                        "Configuration error: overriding only one of startup_height={startup:?} \
+                         or catchup_height={catchup:?} is not supported in l1 provider's dummy \
+                         mode. Either set neither (this is the preferred way) which sets both \
+                         values to the batcher height, or set both if you have a specific startup \
+                         flow in mind.",
+                        startup = config.l1_provider_config.provider_startup_height_override,
+                        catchup = config.l1_provider_config.bootstrap_catch_up_height_override
+                    );
+                    Some(
+                        l1_provider_builder
+                            .startup_height(batcher_height)
+                            .catchup_height(batcher_height)
+                            .build(),
+                    )
                 }
-            };
-            let provider_startup_height = provider_startup_height.expect(
-                "Cannot determine L1 Provider startup height. Either enable the L1 Scraper on \
-                 height that is at least as old as L2 genesis, or override provider startup \
-                 height (read its docstring before using)",
-            );
-
-            Some(create_l1_provider(
-                config.l1_provider_config,
-                clients.get_l1_provider_shared_client().unwrap(),
-                clients.get_state_sync_shared_client().unwrap(),
-                provider_startup_height,
-                catch_up_height,
-            ))
+            }
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
     };

--- a/deployments/monitoring/local/docker-compose.yml
+++ b/deployments/monitoring/local/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       jq '.\"http_server_config.port\" = ${SEQUENCER_HTTP_PORT}' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       jq '.\"monitoring_endpoint_config.port\" = ${SEQUENCER_MONITORING_PORT}' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       jq '.\"components.l1_scraper.execution_mode\" = \"Disabled\"' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
-      jq '.\"l1_provider_config.provider_startup_height_override\" = 0' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
+      jq '.\"l1_provider_config.provider_startup_height_override.#is_none\" = true' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       jq '.\"components.l1_gas_price_scraper.execution_mode\" = \"Disabled\"' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       echo 'Done'"
     volumes:

--- a/deployments/monitoring/local/docker-compose.yml
+++ b/deployments/monitoring/local/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       jq '.\"http_server_config.port\" = ${SEQUENCER_HTTP_PORT}' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       jq '.\"monitoring_endpoint_config.port\" = ${SEQUENCER_MONITORING_PORT}' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       jq '.\"components.l1_scraper.execution_mode\" = \"Disabled\"' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
+      jq '.\"l1_provider_config.provider_startup_height_override\" = 0' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       jq '.\"components.l1_gas_price_scraper.execution_mode\" = \"Disabled\"' ${SEQUENCER_CONFIG_PATH} | sponge ${SEQUENCER_CONFIG_PATH} && \
       echo 'Done'"
     volumes:


### PR DESCRIPTION
In order to startup the provider in dummy mode, disable the scraper in
the infra configs.
This will initialize the provider at the batcher height (unless given
explicit overrides for both startupheight and bootstrap height), which
short-circuits the bootstrapper and effectively makes the provider a
dummy: get_txs will be [] because it has no txs, and validate is false
for the same reason.

Note: Construction has become complex, use builder to streamline it.
