### PR TITLE
refactor(blockifier): make into_executable public

### DIFF
--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -238,7 +238,7 @@ impl CallEntryPoint {
         execution_result
     }
 
-    fn into_executable(self, class_hash: ClassHash) -> ExecutableCallEntryPoint {
+    pub fn into_executable(self, class_hash: ClassHash) -> ExecutableCallEntryPoint {
         ExecutableCallEntryPoint {
             class_hash,
             code_address: self.code_address,


### PR DESCRIPTION
Having this method public would be useful for Starknet Foundry.