### PR TITLE
feat(starknet_sequencer_infra): add file and line number to log format

### DIFF
--- a/crates/starknet_sequencer_infra/src/trace_util.rs
+++ b/crates/starknet_sequencer_infra/src/trace_util.rs
@@ -20,7 +20,14 @@ pub async fn configure_tracing() {
             );
             let timer = UtcTime::new(time_format);
 
-            let fmt_layer = fmt::layer().compact().with_target(true).with_timer(timer);
+            let fmt_layer = fmt::layer()
+                .compact()
+                .with_timer(timer)
+                .with_target(false) // No module name.
+                // Instead, file name and line number.
+                .with_file(true)
+                .with_line_number(true);
+
             let level_filter_layer = EnvFilter::builder()
                 .with_default_directive(DEFAULT_LEVEL.into())
                 .from_env_lossy()


### PR DESCRIPTION
File comes instead of module name, which is less informative. Goal is to trivially find the line logging came from.

Changes from:
`2025-03-30T10:53:27.018Z  INFO starknet_sequencer_infra::trace_util: Tracing has been successfully initialized.`

To:
`2025-03-30T10:53:27.018Z  INFO crates/starknet_sequencer_infra/src/trace_util.rs:37: Tracing has been successfully initialized.`