### PR TITLE
fix(apollo_integration_tests): allow L1 gas price provider to run without scraper in the tests

### DIFF
--- a/crates/apollo_sequencer_node/src/components.rs
+++ b/crates/apollo_sequencer_node/src/components.rs
@@ -275,7 +275,20 @@ pub async fn create_node_components(
     let l1_gas_price_provider = match config.components.l1_gas_price_provider.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-            Some(L1GasPriceProvider::new(config.l1_gas_price_provider_config.clone()))
+            match config.components.l1_gas_price_scraper.execution_mode {
+                ActiveComponentExecutionMode::Disabled => {
+                    // TODO(guyn, matan): remove this once proper dependency injection is in place.
+                    warn!(
+                        "L1 gas price provider is running in local mode, but L1 gas price scraper \
+                         is disabled. This may lead to unexpected behavior. Consider enabling the \
+                         L1 gas price scraper."
+                    );
+                    Some(L1GasPriceProvider::make_new_provider_with_fake_data(
+                        config.l1_gas_price_provider_config.clone(),
+                    ))
+                }
+                _ => Some(L1GasPriceProvider::new(config.l1_gas_price_provider_config.clone())),
+            }
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
     };


### PR DESCRIPTION
This allows integration tests to pass until we add Anvil transactions that the scraper can use in the tests. 