### PR TITLE
feat(apollo_l1_provider): force provider/scraper mutual restart

### DIFF
--- a/crates/apollo_l1_provider/src/bootstrapper.rs
+++ b/crates/apollo_l1_provider/src/bootstrapper.rs
@@ -100,6 +100,10 @@ impl Bootstrapper {
         self.catch_up_height.get().copied()
     }
 
+    pub fn sync_started(&self) -> bool {
+        matches!(self.sync_task_handle, SyncTaskHandle::Started(_))
+    }
+
     fn sync_task_health_check(&self, is_caught_up: bool) {
         let SyncTaskHandle::Started(sync_task) = &self.sync_task_handle else {
             return;

--- a/crates/apollo_l1_provider/src/lib.rs
+++ b/crates/apollo_l1_provider/src/lib.rs
@@ -48,6 +48,13 @@ impl ProviderState {
         }
     }
 
+    /// Checks if the provider is in its uninitialized state. In this state, the provider has
+    /// started, but its startup sequence, triggered via the initialization API, has not yet
+    /// begun.
+    pub fn uninitialized(&mut self) -> bool {
+        self.get_bootstrapper().is_some_and(|bootstrapper| !bootstrapper.sync_started())
+    }
+
     pub fn is_bootstrapping(&self) -> bool {
         if let ProviderState::Bootstrap { .. } = self {
             return true;

--- a/crates/apollo_l1_provider_types/src/errors.rs
+++ b/crates/apollo_l1_provider_types/src/errors.rs
@@ -15,6 +15,11 @@ pub enum L1ProviderError {
     // This is likely due to a crash, restart block proposal.
     #[error("`validate` called when provider is not in proposer state")]
     OutOfSessionValidate,
+    // This error indicates that the provider is uninitialized.
+    // It likely occurs if the provider restarted while the scraper remained active.
+    // In that case, the scraper's restart logic will automatically reinitialize the provider.
+    #[error("The provider hasn't been initialized yet, call its initialization API.")]
+    Uninitialized,
     #[error("Unexpected height: expected {expected_height}, got {got}")]
     UnexpectedHeight { expected_height: BlockNumber, got: BlockNumber },
     #[error("Cannot transition from {from} to {to}")]


### PR DESCRIPTION
Incomplete, still needs infra to be able to respawn on fail.
Also needs infra to be able to process fatal errors, instead of
panicking.