### PR TITLE
chore(starknet_api): add trait for stateless tx validations to be shared by rpc_tx and blockifier_tx

### DIFF
--- a/crates/starknet_api/src/lib.rs
+++ b/crates/starknet_api/src/lib.rs
@@ -24,6 +24,7 @@ pub mod state;
 pub mod test_utils;
 pub mod transaction;
 pub mod transaction_hash;
+pub mod transaction_stateless_validation;
 pub mod type_utils;
 pub mod versioned_constants_logic;
 

--- a/crates/starknet_api/src/transaction_stateless_validation.rs
+++ b/crates/starknet_api/src/transaction_stateless_validation.rs
@@ -1,0 +1,17 @@
+use crate::data_availability::DataAvailabilityMode;
+use crate::state::SierraContractClass;
+use crate::transaction::fields::AllResourceBounds;
+use crate::StarknetApiError;
+
+pub trait TransactionStatelessValidation {
+    fn validate_contract_address(&self) -> Result<(), StarknetApiError>;
+    fn account_deployment_data_is_empty(&self) -> bool;
+    fn paymaster_data_is_empty(&self) -> bool;
+    fn resource_bounds(&self) -> &AllResourceBounds;
+    fn calldata_length(&self) -> Option<usize>;
+    fn signature_length(&self) -> usize;
+    fn nonce_data_availability_mode(&self) -> &DataAvailabilityMode;
+    fn fee_data_availability_mode(&self) -> &DataAvailabilityMode;
+    fn is_declare(&self) -> bool;
+    fn contract_class(&self) -> Option<&SierraContractClass>;
+}


### PR DESCRIPTION
be shared by rpc_tx and blockifier_tx