### PR TITLE
fix: make `secp` module and `SecpGetPointFromXRequest` fields public

### DIFF
--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -52,7 +52,7 @@ use crate::transaction::objects::{
 };
 
 pub mod hint_processor;
-mod secp;
+pub mod secp;
 pub mod syscall_base;
 
 #[cfg(test)]

--- a/crates/blockifier/src/execution/syscalls/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/secp.rs
@@ -169,10 +169,10 @@ pub fn secp256r1_add(
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct SecpGetPointFromXRequest {
-    x: BigUint,
+    pub x: BigUint,
     // The parity of the y coordinate, assuming a point with the given x coordinate exists.
     // True means the y coordinate is odd.
-    y_parity: bool,
+    pub y_parity: bool,
 }
 
 impl SyscallRequest for SecpGetPointFromXRequest {


### PR DESCRIPTION
This PR sets to public some required modules and fields, allowing usage on [snos](https://github.com/keep-starknet-strange/snos) and conformity with other modules and types