### PR TITLE
chore: fixed broktn links docs

### DIFF
--- a/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
@@ -73,7 +73,7 @@ impl SerializeConfig for L1GasPriceScraperConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id",
+                "The chain to follow. For more details see https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#chain-id",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -241,7 +241,7 @@ impl SerializeConfig for L1ScraperConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#chain-id.",
                 ParamPrivacyInput::Public,
             ),
         ])

--- a/crates/apollo_rpc/src/lib.rs
+++ b/crates/apollo_rpc/src/lib.rs
@@ -105,7 +105,7 @@ impl SerializeConfig for RpcConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#chain-id.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/papyrus_node/src/config/pointers.rs
+++ b/crates/papyrus_node/src/config/pointers.rs
@@ -55,7 +55,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
             ser_pointer_target_required_param(
                 "chain_id",
                 SerializationType::String,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/architecture-and-concepts/network-architecture/transactions/#chain-id.",
             ),
             set_pointing_param_paths(&[
                 "context.chain_id",


### PR DESCRIPTION
Hi! I updated old StarkNet docs URLs to new format:
  - From: `documentation/architecture_and_concepts/Blocks/transactions`
  - To: `architecture-and-concepts/network-architecture/transactions`