### PR TITLE
chore(apollo_integration_tests): remove killall

### DIFF
--- a/scripts/sequencer_integration_test.sh
+++ b/scripts/sequencer_integration_test.sh
@@ -40,12 +40,6 @@ TEST="${1:-positive}"
 echo "Running integration test alias: $TEST"
 
 SEQUENCER_BINARY="apollo_node"
-ANVIL_PROCESS_NAME="anvil"
-
-# Stop any running instances of SEQUENCER_BINARY (ignore error if not found)
-killall "$SEQUENCER_BINARY" 2>/dev/null
-# Stop any running instances of Anvil (ignore error if not found)
-killall "$ANVIL_PROCESS_NAME" 2>/dev/null
 
 # Build the main node binary (if required)
 cargo build --bin "$SEQUENCER_BINARY"


### PR DESCRIPTION
    No longer necessary as of: 75705a572214e1712f28ac6b1b69d33edd6d2f5c,
    since the exit only applies to node code, but not test code, which now
    is dropped gracefully.
    The anvil error was carried over due to the sequencer not terminating
    (once it did, so did anvil which terminates on drop).

    Note that the hook in the above commit still requires to be removed at
    some point and replaced by explicit handling of `JoinHandle`s, since it
    currently prevents destructors in the node from being run on panic
    (which can leak resources).
