### PR TITLE
Revert "chore(blockifier): limit casm compilation memory usage (#5426)"

### DIFF
--- a/crates/apollo_sierra_multicompile/src/command_line_compiler.rs
+++ b/crates/apollo_sierra_multicompile/src/command_line_compiler.rs
@@ -58,7 +58,8 @@ impl SierraToCasmCompiler for CommandLineCompiler {
             "--max-bytecode-size",
             &self.config.max_casm_bytecode_size.to_string(),
         ];
-        let resource_limits = ResourceLimits::new(None, None, Some(self.config.max_memory_usage));
+        let resource_limits = ResourceLimits::new(None, None, None);
+
         let stdout = compile_with_args(
             compiler_binary_path,
             contract_class,


### PR DESCRIPTION
This reverts commit 9dec00c0377a8c02c235b9652065d729c6aaaa9f.