### PR TITLE
chore(papyrus_base_layer): add "PartialEq" to base layer error

### DIFF
--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -267,6 +267,24 @@ pub enum L1ScraperError<T: BaseLayerContract + Send + Sync> {
     NeedsRestart,
 }
 
+impl<B: BaseLayerContract + Send + Sync> PartialEq for L1ScraperError<B> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::BaseLayerError(e1), Self::BaseLayerError(e2)) => e1 == e2,
+            (this @ Self::FinalityTooHigh { .. }, other @ Self::FinalityTooHigh { .. }) => {
+                this == other
+            }
+            (Self::HashCalculationError(e1), Self::HashCalculationError(e2)) => e1 == e2,
+            (Self::NetworkError(e1), Self::NetworkError(e2)) => e1 == e2,
+            (this @ Self::L1ReorgDetected { .. }, other @ Self::L1ReorgDetected { .. }) => {
+                this == other
+            }
+            (Self::NeedsRestart, Self::NeedsRestart) => true,
+            _ => false,
+        }
+    }
+}
+
 impl<B: BaseLayerContract + Send + Sync> L1ScraperError<B> {
     pub async fn finality_too_high(finality: u64, base_layer: &B) -> L1ScraperError<B> {
         let latest_l1_block_number_no_finality = base_layer.latest_l1_block_number(0).await;

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -200,6 +200,21 @@ pub enum EthereumBaseLayerError {
     UnhandledL1Event(alloy::primitives::Log),
 }
 
+impl PartialEq for EthereumBaseLayerError {
+    fn eq(&self, other: &Self) -> bool {
+        use EthereumBaseLayerError::*;
+        match (self, other) {
+            (Contract(this), Contract(other)) => this.to_string() == other.to_string(),
+            (FeeOutOfRange(this), FeeOutOfRange(other)) => this == other,
+            (RpcError(this), RpcError(other)) => this.to_string() == other.to_string(),
+            (StarknetApiParsingError(this), StarknetApiParsingError(other)) => this == other,
+            (TypeError(this), TypeError(other)) => this == other,
+            (UnhandledL1Event(this), UnhandledL1Event(other)) => this == other,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]
 pub struct EthereumBaseLayerConfig {
     pub node_url: Url,

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -25,14 +25,14 @@ mod base_layer_test;
 
 pub type L1BlockNumber = u64;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum MockError {}
 
 /// Interface for getting data from the Starknet base contract.
 #[cfg_attr(any(feature = "testing", test), automock(type Error = MockError;))]
 #[async_trait]
 pub trait BaseLayerContract {
-    type Error: Error + Display + Debug;
+    type Error: Error + PartialEq + Display + Debug;
 
     /// Get the latest Starknet block that is proved on the base layer at a specific L1 block
     /// number. If the number is too low, return an error.


### PR DESCRIPTION
Add manual `PartialEq` + `to_string` for external non-`PartialEq` types.