### PR TITLE
chore: fix regex to support package names with hyphens

### DIFF
--- a/scripts/tests_utils.py
+++ b/scripts/tests_utils.py
@@ -7,7 +7,7 @@ import os
 from typing import Dict, List, Set, Optional
 from git import Repo
 
-PATTERN = r"(\w+)\s*v([\d.]*.*)\((.*?)\)"
+PATTERN = r"([a-zA-Z0-9_-]+)\s*v([\d.]*.*)\((.*?)\)"
 
 # Pattern to match the dependency tree output (`cargo tree -i` output).
 # First match group is the dependent crate name; second match group is the local path to the


### PR DESCRIPTION
the `PATTERN` regex was updated to handle package names with hyphens and other characters, replacing `(\w+)` with `([a-zA-Z0-9_-]+)`. 

this ensures correct matching of all valid package names.