### PR TITLE
fix(apollo_state_reader): fix the query definition

### DIFF
--- a/Monitoring/sequencer/dev_grafana.json
+++ b/Monitoring/sequencer/dev_grafana.json
@@ -392,14 +392,14 @@
         "title": "class_cache_miss_ratio",
         "description": "The ratio of cache misses when requesting compiled classes from the apollo state reader",
         "type": "graph",
-        "expr": "100 * (class_cache_misses / max((class_cache_misses + class_cache_hits), 1))",
+        "expr": "100 * (rate(class_cache_misses[5m]) / (rate(class_cache_misses[5m]) + rate(class_cache_hits[5m])))",
         "extra_params": {}
       },
       {
         "title": "native_class_returned_ratio",
         "description": "The ratio of Native classes returned by the apollo state reader",
         "type": "graph",
-        "expr": "100 * (native_class_returned / max((class_cache_hits + class_cache_misses), 1))",
+        "expr": "100 * (rate(native_class_returned[5m]) / (rate(class_cache_hits[5m]) + rate(class_cache_misses[5m])))",
         "extra_params": {}
       }
     ],

--- a/crates/apollo_dashboard/src/dashboard_definitions.rs
+++ b/crates/apollo_dashboard/src/dashboard_definitions.rs
@@ -120,7 +120,12 @@ use apollo_mempool_p2p::metrics::{
     MEMPOOL_P2P_NUM_RECEIVED_MESSAGES,
     MEMPOOL_P2P_NUM_SENT_MESSAGES,
 };
-use apollo_state_reader::metrics::{CLASS_CACHE_HITS, CLASS_CACHE_MISSES, NATIVE_CLASS_RETURNED};
+use apollo_state_reader::metrics::{
+    CLASS_CACHE_HITS,
+    CLASS_CACHE_MISSES,
+    NATIVE_CLASS_RETURNED,
+    STATE_READER_METRIC_RATE_DURATION,
+};
 use apollo_state_sync::metrics::{
     STATE_SYNC_P2P_NUM_ACTIVE_INBOUND_SESSIONS,
     STATE_SYNC_P2P_NUM_ACTIVE_OUTBOUND_SESSIONS,
@@ -467,10 +472,13 @@ const PANEL_APOLLO_STATE_READER_CLASS_CACHE_MISS_RATIO: Panel = Panel::new(
     "class_cache_miss_ratio",
     "The ratio of cache misses when requesting compiled classes from the apollo state reader",
     formatcp!(
-        "100 * ({} / max(({} + {}), 1))",
+        "100 * (rate({}[{}]) / (rate({}[{}]) + rate({}[{}])))",
         CLASS_CACHE_MISSES.get_name(),
+        STATE_READER_METRIC_RATE_DURATION,
         CLASS_CACHE_MISSES.get_name(),
-        CLASS_CACHE_HITS.get_name()
+        STATE_READER_METRIC_RATE_DURATION,
+        CLASS_CACHE_HITS.get_name(),
+        STATE_READER_METRIC_RATE_DURATION
     ),
     PanelType::Graph,
 );
@@ -478,10 +486,13 @@ const PANEL_APOLLO_STATE_READER_NATIVE_CLASS_RETURNED_RATIO: Panel = Panel::new(
     "native_class_returned_ratio",
     "The ratio of Native classes returned by the apollo state reader",
     formatcp!(
-        "100 * ({} / max(({} + {}), 1))",
+        "100 * (rate({}[{}]) / (rate({}[{}]) + rate({}[{}])))",
         NATIVE_CLASS_RETURNED.get_name(),
+        STATE_READER_METRIC_RATE_DURATION,
         CLASS_CACHE_HITS.get_name(),
-        CLASS_CACHE_MISSES.get_name()
+        STATE_READER_METRIC_RATE_DURATION,
+        CLASS_CACHE_MISSES.get_name(),
+        STATE_READER_METRIC_RATE_DURATION,
     ),
     PanelType::Graph,
 );

--- a/crates/apollo_state_reader/src/metrics.rs
+++ b/crates/apollo_state_reader/src/metrics.rs
@@ -12,3 +12,5 @@ define_metrics!(
             init=0}
     }
 );
+
+pub const STATE_READER_METRIC_RATE_DURATION: &str = "5m";


### PR DESCRIPTION
clamp_min()
clamp_min(v instant-vector, min scalar) clamps the sample values of all elements in v to have a lower limit of min.

while max(v instant-vector)  returns the max value of v.

I noticed the problem in the Grafana Itai sent


[![???](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/default-memes/questionmarks.gif)](https://app.graphite.dev//settings/meme-library?org=starkware-libs)


