### PR TITLE
fix(ci): trigger compatibility test on Cairo compiler version update

### DIFF
--- a/.github/workflows/blockifier_compiled_cairo.yml
+++ b/.github/workflows/blockifier_compiled_cairo.yml
@@ -7,8 +7,8 @@ on:
       - reopened
       - synchronize
     paths:
-      - 'Cargo.toml'
       - '.github/workflows/blockifier_compiled_cairo.yml'
+      - 'crates/apollo_sierra_multicompile/src/constants.rs' # Contains the compiler version.
       - 'crates/blockifier_test_utils/cairo_compile.rs'
       - 'crates/blockifier_test_utils/resources/feature_contracts/**'
       - 'crates/blockifier_test_utils/tests/feature_contracts_compatibility_test.rs'


### PR DESCRIPTION
Ensure the compatibility test runs when the Cairo compiler is upgraded. A new lightweight file now holds the compiler version (along with a check for alignment with `Cargo.toml`). The workflow is updated to trigger on changes to this file instead of the full `Cargo.toml`.