### PR TITLE
chore(blockifier): change bootstrap declare address to BOOTSTRAP (#5662)

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -42,6 +42,7 @@ use crate::fee_market::FeeMarketInfo;
 
 // TODO(dvir): add metrics when the infra side will be completed.
 
+#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
 #[derive(thiserror::Error, Debug)]
 pub enum CendeAmbassadorError {
     #[error(transparent)]

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -46,8 +46,8 @@ use apollo_protobuf::consensus::{
 };
 use apollo_state_sync_types::communication::MockStateSyncClient;
 use chrono::{TimeZone, Utc};
+use futures::channel::mpsc;
 use futures::channel::oneshot::Canceled;
-use futures::channel::{mpsc, oneshot};
 use futures::executor::block_on;
 use futures::future::pending;
 use futures::{FutureExt, SinkExt, StreamExt};
@@ -169,10 +169,8 @@ fn setup_with_custom_mocks(
     )
 }
 
-// Setup for test of the `build_proposal` function.
-async fn build_proposal_setup(
-    mock_cende_context: MockCendeContext,
-) -> (oneshot::Receiver<BlockHash>, SequencerConsensusContext, NetworkDependencies) {
+// Setup batcher client for proposal building flow.
+async fn setup_batcher_for_build(block_number: BlockNumber) -> MockBatcherClient {
     let mut batcher = MockBatcherClient::new();
     let proposal_id = Arc::new(OnceLock::new());
     let proposal_id_clone = Arc::clone(&proposal_id);
@@ -183,7 +181,7 @@ async fn build_proposal_setup(
     batcher
         .expect_start_height()
         .times(1)
-        .withf(|input| input.height == BlockNumber(0))
+        .withf(move |input| input.height == block_number)
         .return_once(|_| Ok(()));
     let proposal_id_clone = Arc::clone(&proposal_id);
     batcher.expect_get_proposal_content().times(1).returning(move |input| {
@@ -201,16 +199,7 @@ async fn build_proposal_setup(
             }),
         })
     });
-    let (default_deps, _network) = default_context_dependencies();
-    let context_deps = SequencerConsensusContextDeps {
-        batcher: Arc::new(batcher),
-        cende_ambassador: Arc::new(mock_cende_context),
-        ..default_deps
-    };
-    let mut context = setup_with_custom_mocks(context_deps);
-    let init = ProposalInit::default();
-
-    (context.build_proposal(init, TIMEOUT).await, context, _network)
+    batcher
 }
 
 // Returns a mock CendeContext that will return a successful write_prev_height_blob.
@@ -563,7 +552,11 @@ async fn interrupt_active_proposal() {
 async fn build_proposal() {
     let before: u64 =
         chrono::Utc::now().timestamp().try_into().expect("Timestamp conversion failed");
-    let (fin_receiver, _, mut network) = build_proposal_setup(success_cende_ammbassador()).await;
+    let batcher = setup_batcher_for_build(BlockNumber(0)).await;
+    let (default_deps, mut network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
+    let fin_receiver = context.build_proposal(ProposalInit::default(), TIMEOUT).await;
     // Test proposal parts.
     let (_, mut receiver) = network.outbound_proposal_receiver.next().await.unwrap();
     assert_eq!(receiver.next().await.unwrap(), ProposalPart::Init(ProposalInit::default()));
@@ -596,9 +589,16 @@ async fn build_proposal_cende_failure() {
         .expect_write_prev_height_blob()
         .times(1)
         .return_once(|_height| tokio::spawn(ready(false)));
+    let batcher = setup_batcher_for_build(BlockNumber(0)).await;
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps {
+        batcher: Arc::new(batcher),
+        cende_ambassador: Arc::new(mock_cende_context),
+        ..default_deps
+    };
+    let mut context = setup_with_custom_mocks(context_deps);
 
-    let (fin_receiver, _, _network) = build_proposal_setup(mock_cende_context).await;
-
+    let fin_receiver = context.build_proposal(ProposalInit::default(), TIMEOUT).await;
     assert_eq!(fin_receiver.await, Err(Canceled));
 }
 
@@ -610,8 +610,16 @@ async fn build_proposal_cende_incomplete() {
         .times(1)
         .return_once(|_height| tokio::spawn(pending()));
 
-    let (fin_receiver, _, _network) = build_proposal_setup(mock_cende_context).await;
+    let batcher = setup_batcher_for_build(BlockNumber(0)).await;
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps {
+        batcher: Arc::new(batcher),
+        cende_ambassador: Arc::new(mock_cende_context),
+        ..default_deps
+    };
+    let mut context = setup_with_custom_mocks(context_deps);
 
+    let fin_receiver = context.build_proposal(ProposalInit::default(), TIMEOUT).await;
     assert_eq!(fin_receiver.await, Err(Canceled));
 }
 
@@ -654,9 +662,12 @@ async fn batcher_not_ready(#[case] proposer: bool) {
 
 #[tokio::test]
 async fn propose_then_repropose() {
+    let batcher = setup_batcher_for_build(BlockNumber(0)).await;
+    let (default_deps, mut network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
     // Build proposal.
-    let (fin_receiver, mut context, mut network) =
-        build_proposal_setup(success_cende_ammbassador()).await;
+    let fin_receiver = context.build_proposal(ProposalInit::default(), TIMEOUT).await;
     let (_, mut receiver) = network.outbound_proposal_receiver.next().await.unwrap();
     // Receive the proposal parts.
     let _init = receiver.next().await.unwrap();
@@ -711,26 +722,7 @@ async fn decision_reached_sends_correct_values() {
     // We need to create a valid proposal to call decision_reached on.
     //
     // 1. Build proposal setup starts.
-    let mut batcher = MockBatcherClient::new();
-
-    batcher.expect_propose_block().times(1).returning(|_| Ok(()));
-
-    batcher
-        .expect_start_height()
-        .withf(|input| input.height == BlockNumber(0))
-        .return_once(|_| Ok(()));
-    batcher.expect_get_proposal_content().times(1).returning(move |_| {
-        Ok(GetProposalContentResponse {
-            content: GetProposalContent::Txs(INTERNAL_TX_BATCH.clone()),
-        })
-    });
-    batcher.expect_get_proposal_content().times(1).returning(move |_| {
-        Ok(GetProposalContentResponse {
-            content: GetProposalContent::Finished(ProposalCommitment {
-                state_diff_commitment: STATE_DIFF_COMMITMENT,
-            }),
-        })
-    });
+    let mut batcher = setup_batcher_for_build(BlockNumber(0)).await;
 
     const BLOCK_TIME_STAMP_SECONDS: u64 = 123456;
     let mut clock = MockClock::new();

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -202,6 +202,46 @@ async fn setup_batcher_for_build(block_number: BlockNumber) -> MockBatcherClient
     batcher
 }
 
+// Setup batcher client for proposal validation flow.
+async fn setup_batcher_for_validate(block_number: BlockNumber) -> MockBatcherClient {
+    let mut batcher = MockBatcherClient::new();
+    let proposal_id: Arc<OnceLock<ProposalId>> = Arc::new(OnceLock::new());
+    let proposal_id_clone = Arc::clone(&proposal_id);
+    batcher.expect_validate_block().times(1).returning(move |input: ValidateBlockInput| {
+        proposal_id_clone.set(input.proposal_id).unwrap();
+        Ok(())
+    });
+    batcher
+        .expect_start_height()
+        .times(1)
+        .withf(move |input| input.height == block_number)
+        .return_once(|_| Ok(()));
+    let proposal_id_clone = Arc::clone(&proposal_id);
+    batcher.expect_send_proposal_content().times(1).returning(
+        move |input: SendProposalContentInput| {
+            assert_eq!(input.proposal_id, *proposal_id_clone.get().unwrap());
+            let SendProposalContent::Txs(txs) = input.content else {
+                panic!("Expected SendProposalContent::Txs, got {:?}", input.content);
+            };
+            assert_eq!(txs, *INTERNAL_TX_BATCH);
+            Ok(SendProposalContentResponse { response: ProposalStatus::Processing })
+        },
+    );
+    let proposal_id_clone = Arc::clone(&proposal_id);
+    batcher.expect_send_proposal_content().times(1).returning(
+        move |input: SendProposalContentInput| {
+            assert_eq!(input.proposal_id, *proposal_id_clone.get().unwrap());
+            assert!(matches!(input.content, SendProposalContent::Finish));
+            Ok(SendProposalContentResponse {
+                response: ProposalStatus::Finished(ProposalCommitment {
+                    state_diff_commitment: STATE_DIFF_COMMITMENT,
+                }),
+            })
+        },
+    );
+    batcher
+}
+
 // Returns a mock CendeContext that will return a successful write_prev_height_blob.
 fn success_cende_ammbassador() -> MockCendeContext {
     let mut mock_cende = MockCendeContext::new();
@@ -241,41 +281,7 @@ async fn cancelled_proposal_aborts() {
 
 #[tokio::test]
 async fn validate_proposal_success() {
-    let mut batcher = MockBatcherClient::new();
-    let proposal_id: Arc<OnceLock<ProposalId>> = Arc::new(OnceLock::new());
-    let proposal_id_clone = Arc::clone(&proposal_id);
-    batcher.expect_validate_block().times(1).returning(move |input: ValidateBlockInput| {
-        proposal_id_clone.set(input.proposal_id).unwrap();
-        Ok(())
-    });
-    batcher
-        .expect_start_height()
-        .times(1)
-        .withf(|input| input.height == BlockNumber(0))
-        .return_once(|_| Ok(()));
-    let proposal_id_clone = Arc::clone(&proposal_id);
-    batcher.expect_send_proposal_content().times(1).returning(
-        move |input: SendProposalContentInput| {
-            assert_eq!(input.proposal_id, *proposal_id_clone.get().unwrap());
-            let SendProposalContent::Txs(txs) = input.content else {
-                panic!("Expected SendProposalContent::Txs, got {:?}", input.content);
-            };
-            assert_eq!(txs, *INTERNAL_TX_BATCH);
-            Ok(SendProposalContentResponse { response: ProposalStatus::Processing })
-        },
-    );
-    let proposal_id_clone = Arc::clone(&proposal_id);
-    batcher.expect_send_proposal_content().times(1).returning(
-        move |input: SendProposalContentInput| {
-            assert_eq!(input.proposal_id, *proposal_id_clone.get().unwrap());
-            assert!(matches!(input.content, SendProposalContent::Finish));
-            Ok(SendProposalContentResponse {
-                response: ProposalStatus::Finished(ProposalCommitment {
-                    state_diff_commitment: STATE_DIFF_COMMITMENT,
-                }),
-            })
-        },
-    );
+    let batcher = setup_batcher_for_validate(BlockNumber(0)).await;
     let (default_deps, _network) = default_context_dependencies();
     let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
     let mut context = setup_with_custom_mocks(context_deps);
@@ -327,29 +333,7 @@ async fn dont_send_block_info() {
 #[tokio::test]
 async fn repropose() {
     // Receive a proposal. Then re-retrieve it.
-    let mut batcher = MockBatcherClient::new();
-    batcher.expect_validate_block().times(1).returning(move |_| Ok(()));
-    batcher
-        .expect_start_height()
-        .times(1)
-        .withf(|input| input.height == BlockNumber(0))
-        .return_once(|_| Ok(()));
-    batcher.expect_send_proposal_content().times(1).returning(
-        move |input: SendProposalContentInput| {
-            assert!(matches!(input.content, SendProposalContent::Txs(_)));
-            Ok(SendProposalContentResponse { response: ProposalStatus::Processing })
-        },
-    );
-    batcher.expect_send_proposal_content().times(1).returning(
-        move |input: SendProposalContentInput| {
-            assert!(matches!(input.content, SendProposalContent::Finish));
-            Ok(SendProposalContentResponse {
-                response: ProposalStatus::Finished(ProposalCommitment {
-                    state_diff_commitment: STATE_DIFF_COMMITMENT,
-                }),
-            })
-        },
-    );
+    let batcher = setup_batcher_for_validate(BlockNumber(0)).await;
     let (default_deps, mut network) = default_context_dependencies();
     let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
     let mut context = setup_with_custom_mocks(context_deps);
@@ -362,7 +346,7 @@ async fn repropose() {
     let block_info = ProposalPart::BlockInfo(block_info(BlockNumber(0)));
     content_sender.send(block_info.clone()).await.unwrap();
     let transactions =
-        ProposalPart::Transactions(TransactionBatch { transactions: vec![generate_invoke_tx(2)] });
+        ProposalPart::Transactions(TransactionBatch { transactions: TX_BATCH.to_vec() });
     content_sender.send(transactions.clone()).await.unwrap();
     let fin = ProposalPart::Fin(ProposalFin {
         proposal_commitment: BlockHash(STATE_DIFF_COMMITMENT.0.0),
@@ -385,41 +369,7 @@ async fn repropose() {
 
 #[tokio::test]
 async fn proposals_from_different_rounds() {
-    let mut batcher = MockBatcherClient::new();
-    let proposal_id: Arc<OnceLock<ProposalId>> = Arc::new(OnceLock::new());
-    let proposal_id_clone = Arc::clone(&proposal_id);
-    batcher.expect_validate_block().times(1).returning(move |input: ValidateBlockInput| {
-        proposal_id_clone.set(input.proposal_id).unwrap();
-        Ok(())
-    });
-    batcher
-        .expect_start_height()
-        .times(1)
-        .withf(|input| input.height == BlockNumber(0))
-        .return_once(|_| Ok(()));
-    let proposal_id_clone = Arc::clone(&proposal_id);
-    batcher.expect_send_proposal_content().times(1).returning(
-        move |input: SendProposalContentInput| {
-            assert_eq!(input.proposal_id, *proposal_id_clone.get().unwrap());
-            let SendProposalContent::Txs(txs) = input.content else {
-                panic!("Expected SendProposalContent::Txs, got {:?}", input.content);
-            };
-            assert_eq!(txs, *INTERNAL_TX_BATCH);
-            Ok(SendProposalContentResponse { response: ProposalStatus::Processing })
-        },
-    );
-    let proposal_id_clone = Arc::clone(&proposal_id);
-    batcher.expect_send_proposal_content().times(1).returning(
-        move |input: SendProposalContentInput| {
-            assert_eq!(input.proposal_id, *proposal_id_clone.get().unwrap());
-            assert!(matches!(input.content, SendProposalContent::Finish));
-            Ok(SendProposalContentResponse {
-                response: ProposalStatus::Finished(ProposalCommitment {
-                    state_diff_commitment: STATE_DIFF_COMMITMENT,
-                }),
-            })
-        },
-    );
+    let batcher = setup_batcher_for_validate(BlockNumber(0)).await;
     let (default_deps, _network) = default_context_dependencies();
     let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
     let mut context = setup_with_custom_mocks(context_deps);
@@ -472,41 +422,7 @@ async fn proposals_from_different_rounds() {
 
 #[tokio::test]
 async fn interrupt_active_proposal() {
-    let mut batcher = MockBatcherClient::new();
-    batcher
-        .expect_start_height()
-        .times(1)
-        .withf(|input| input.height == BlockNumber(0))
-        .return_once(|_| Ok(()));
-    batcher
-        .expect_validate_block()
-        .times(1)
-        .withf(|input| input.proposal_id == ProposalId(1))
-        .returning(|_| Ok(()));
-    batcher
-        .expect_send_proposal_content()
-        .withf(|input| {
-            input.proposal_id == ProposalId(1)
-                && input.content == SendProposalContent::Txs(INTERNAL_TX_BATCH.clone())
-        })
-        .times(1)
-        .returning(move |_| {
-            Ok(SendProposalContentResponse { response: ProposalStatus::Processing })
-        });
-    batcher
-        .expect_send_proposal_content()
-        .withf(|input| {
-            input.proposal_id == ProposalId(1)
-                && matches!(input.content, SendProposalContent::Finish)
-        })
-        .times(1)
-        .returning(move |_| {
-            Ok(SendProposalContentResponse {
-                response: ProposalStatus::Finished(ProposalCommitment {
-                    state_diff_commitment: STATE_DIFF_COMMITMENT,
-                }),
-            })
-        });
+    let batcher = setup_batcher_for_validate(BlockNumber(0)).await;
     let (default_deps, _network) = default_context_dependencies();
     let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
     let mut context = setup_with_custom_mocks(context_deps);

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -145,7 +145,7 @@ fn default_context_dependencies() -> (SequencerConsensusContextDeps, NetworkDepe
         vote_broadcast_client: votes_topic_client,
         cende_ambassador: Arc::new(success_cende_ammbassador()),
         eth_to_strk_oracle_client: Arc::new(eth_to_strk_oracle_client),
-        l1_gas_price_provider: Arc::new(MockL1GasPriceProviderClient::new()),
+        l1_gas_price_provider: Arc::new(dummy_gas_price_provider()),
         clock: Arc::new(DefaultClock::default()),
     };
 
@@ -167,23 +167,6 @@ fn setup_with_custom_mocks(
         },
         context_deps,
     )
-}
-
-// TODO(guy.f): Remove this method and rename `setup_with_custom_mocks` to `setup`, replace
-// all calls to pass in a `SequencerConsensusContextDeps` object.
-fn setup(
-    batcher: MockBatcherClient,
-    cende_ambassador: MockCendeContext,
-) -> (SequencerConsensusContext, NetworkDependencies) {
-    let (default_deps, network_dependencies) = default_context_dependencies();
-    let context_deps = SequencerConsensusContextDeps {
-        batcher: Arc::new(batcher),
-        cende_ambassador: Arc::new(cende_ambassador),
-        l1_gas_price_provider: Arc::new(dummy_gas_price_provider()),
-        ..default_deps
-    };
-
-    (setup_with_custom_mocks(context_deps), network_dependencies)
 }
 
 // Setup for test of the `build_proposal` function.
@@ -218,8 +201,13 @@ async fn build_proposal_setup(
             }),
         })
     });
-
-    let (mut context, _network) = setup(batcher, mock_cende_context);
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps {
+        batcher: Arc::new(batcher),
+        cende_ambassador: Arc::new(mock_cende_context),
+        ..default_deps
+    };
+    let mut context = setup_with_custom_mocks(context_deps);
     let init = ProposalInit::default();
 
     (context.build_proposal(init, TIMEOUT).await, context, _network)
@@ -250,8 +238,9 @@ async fn cancelled_proposal_aborts() {
     batcher.expect_propose_block().times(1).return_once(|_| Ok(()));
 
     batcher.expect_start_height().times(1).return_once(|_| Ok(()));
-
-    let (mut context, _network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
 
     let fin_receiver = context.build_proposal(ProposalInit::default(), TIMEOUT).await;
 
@@ -298,7 +287,9 @@ async fn validate_proposal_success() {
             })
         },
     );
-    let (mut context, _network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
 
     // Initialize the context for a specific height, starting with round 0.
     context.set_height_and_round(BlockNumber(0), 0).await;
@@ -329,7 +320,9 @@ async fn dont_send_block_info() {
         .times(1)
         .withf(|input| input.height == BlockNumber(0))
         .return_once(|_| Ok(()));
-    let (mut context, _network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
 
     // Initialize the context for a specific height, starting with round 0.
     context.set_height_and_round(BlockNumber(0), 0).await;
@@ -368,7 +361,9 @@ async fn repropose() {
             })
         },
     );
-    let (mut context, mut network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, mut network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
 
     // Initialize the context for a specific height, starting with round 0.
     context.set_height_and_round(BlockNumber(0), 0).await;
@@ -436,7 +431,9 @@ async fn proposals_from_different_rounds() {
             })
         },
     );
-    let (mut context, _network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
     // Initialize the context for a specific height, starting with round 0.
     context.set_height_and_round(BlockNumber(0), 0).await;
     context.set_height_and_round(BlockNumber(0), 1).await;
@@ -521,7 +518,9 @@ async fn interrupt_active_proposal() {
                 }),
             })
         });
-    let (mut context, _network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
     // Initialize the context for a specific height, starting with round 0.
     context.set_height_and_round(BlockNumber(0), 0).await;
 
@@ -634,7 +633,9 @@ async fn batcher_not_ready(#[case] proposer: bool) {
             .times(1)
             .returning(move |_| Err(BatcherClientError::BatcherError(BatcherError::NotReady)));
     }
-    let (mut context, _network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
     context.set_height_and_round(BlockNumber::default(), Round::default()).await;
 
     if proposer {
@@ -689,8 +690,9 @@ async fn eth_to_fri_rate_out_of_range() {
         .times(1)
         .withf(|input| input.height == BlockNumber(0))
         .return_once(|_| Ok(()));
-
-    let (mut context, _network) = setup(batcher, success_cende_ammbassador());
+    let (default_deps, _network) = default_context_dependencies();
+    let context_deps = SequencerConsensusContextDeps { batcher: Arc::new(batcher), ..default_deps };
+    let mut context = setup_with_custom_mocks(context_deps);
     context.set_height_and_round(BlockNumber(0), 0).await;
     let (mut content_sender, content_receiver) = mpsc::channel(context.config.proposal_buffer_size);
     // Send a block info with an eth_to_fri_rate that is outside the margin of error.
@@ -765,7 +767,6 @@ async fn decision_reached_sends_correct_values() {
         cende_ambassador: Arc::new(cende_ammbassador),
         state_sync_client: Arc::new(mock_sync_client),
         clock: Arc::new(clock),
-        l1_gas_price_provider: Arc::new(dummy_gas_price_provider()),
         ..default_deps
     };
 

--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -180,7 +180,6 @@ impl From<FeeCheckError> for RevertError {
 }
 
 /// Contains the information gathered by the execution of a transaction.
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
 #[cfg_attr(feature = "transaction_serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Default, PartialEq)]
 pub struct TransactionExecutionInfo {


### PR DESCRIPTION
chore(blockifier): change bootstrap declare address to BOOTSTRAP (#5662)

feat(starknet_os): implement n_blocks hint (#5660)

chore(apollo_deployments): include env in deployment (#5663)

feat(starknet_os): define StateUpdatePointers struct (#5668)

fix(deployment): enforce strings in array and at least 1 element (#5671)

feat(deployment): add prometheus scrap annotations (#5673)

chore(apollo_consensus_manager): log component  name in network crate logs (#5606)

chore(apollo_deployments): add env for component config gen fn (#5664)

* chore(apollo_deployments): include env in deployment

* chore(apollo_deployments): add env for component config gen fn

chore(apollo_mempool_p2p): log component  name in network crate logs (#5607)

chore(apollo_state_sync): log component  name in network crate logs (#5608)

fix(starknet_os): insert ids vars from hint (#5678)

chore(apollo_deployments): deployment component config based on env (#5665)

fix(apollo_l1_provider): sleep and retry on BaseLayerError (#5626)

This is an incomplete solution, as it is possible for a query itself to be problematic
(e.g. too large)

feat(starknet_os): impl init_state_update_pointer hint (#5670)

* fix(starknet_os): insert ids vars from hint

* feat(starknet_os): impl init_state_update_pointer hint

fix(apollo_l1_gas_price): support retry if the base layer query fails (#5681)

fix(deployment): fix schema validation (#5680)

chore(apollo_deployments): add hybrid integration deployment + make ingress optional (#5676)

feat(blockifier): make into_executable public (#5682)

Signed-off-by: Dori Medini <dori@starkware.co>

chore(apollo_deployments): update config values (#5683)

feat(apollo_gateway_types): copy error type from writer client (#5540)

chore(apollo_consensus_orchestrator): remove stale TODOs from the context (#5677)

chore(ci): disable integration test flows (#5689)

feat(apollo_mempool,apollo_mempool_types): return expected nonce (#5555)

* feat(apollo_gateway_types): copy error type from writer client

* feat(apollo_mempool,apollo_mempool_types): return expected nonce

test(apollo_gateway): added Declare transactions to unit tests (#5464)

fix(papyrus_base_layer): clarify log message in L1 setup (#5688)

chore(apollo_deployments): edit deployment configs (#5687)

chore(cairo_native): update cairo native version to 0.4.0 (#5613)

* chore(cairo_native): update cairo native version to 0.4.0

* fix(cairo_native): fix all cairo contracts according to the new compiler

* fix(cairo_native): fix test magic numbers after the contracts update

* fix(cairo_native): fix the serialization test accourding to the new cairo version

refactor(blockifier): add fn entry_point_for_deploy for code share (#5659)

test(apollo_consensus_orchestrator): add a test that checks decision_reached (#5397)

fix(apollo_deployments): add remote server for sierra compiler (#5699)

fix(blockifier): change compilation signal info (#5696)

fix(blockifier): the order of calldata factor resources (#5686)

feat(apollo_network): bin for private key to peer id (#5694)

fix(starknet_os): remove duplicated def of state update pointers (#5675)

fix(deployment): fix schema validation (#5706)

fix(apollo_infra): remove verbose logging (#5709)

chore(apollo_deployments): add deployment backend (#5707)

fix(papyrus_base_layer): log base layer error (#5710)

feat(deployment): add pod-monitoring resource (#5711)

feat(starknet_os): add use_kzg_da as a field of os hints config (#5702)

feat(blockifier): gas capping in validate now part of ValidatableTransaction (#5714)

* feat(blockifier): gas capping in validate now part of ValidatableTransaction

Signed-off-by: Dori Medini <dori@starkware.co>

* refactor(blockifier): delete handle_validate_tx

Signed-off-by: Dori Medini <dori@starkware.co>

---------

Signed-off-by: Dori Medini <dori@starkware.co>

feat(starknet_api, apollo_gateway): get compiled class hashes (#5559)

* feat(apollo_gateway_types): copy error type from writer client

* feat(apollo_mempool,apollo_mempool_types): return expected nonce

* feat(starknet_api, apollo_gateway): get compiled class hashes

fix(ci): trigger compatibility test on Cairo compiler version update (#5721)

Ensure the compatibility test runs when the Cairo compiler is upgraded.
A new lightweight file now holds the compiler version
(along with a check for alignment with `Cargo.toml`).
The workflow is updated to trigger on changes to this file instead of the full `Cargo.toml`.

chore(papyrus_base_layer): add "PartialEq" to base layer error (#5634)

Add manual `PartialEq` + `to_string` for external non-`PartialEq` types.

Co-authored-by: Gilad Chase <gilad@starkware.com>

fix(apollo_infra): use non-ephemeral ports for fixed ports (#5536)

On most linux ephemeral ports are 32768-60999. These are meant as
short-term port bindings and cannt function reliably as fixed endoints,
for those one should use any port range included in 1025-32767.
They are typically free on linux, so on CI/deployments this will fine.
For local devs, users can use ports as they like, and if they happen to
bind these ports differently, they should fix their env, or run the node
with a different port config. Either way, it's the user's responsibility
to fix non-ephemeral port clashes, unless we pick a port that is already
used by one of the 3rd party deps we use.

References:
1 list of commonly bound ports:
https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Registered_ports
2. `cat /etc/services` for a list of existing bound ports in a given
   machine.

Co-authored-by: Gilad Chase <gilad@starkware.com>

feat(deployment): add pod-monitoring resource (#5719)

feat(starknet_os): impl create_block_additional_hints hint (#5730)

refactor(apollo_consensus_orchestrator): enable modifying the default context deps in tests

refactor(apollo_consensus_orchestrator): setup_batcher_for_build in context tests

refactor(apollo_consensus_orchestrator): setup_batcher_for_validate in context tests

refactor(apollo_consensus_orchestrator): replace returning with return_const when posisble