### PR TITLE
chore(blockifier): create log compatible execution error display

### DIFF
--- a/crates/apollo_batcher/Cargo.toml
+++ b/crates/apollo_batcher/Cargo.toml
@@ -17,6 +17,7 @@ apollo_batcher_types.workspace = true
 apollo_class_manager_types.workspace = true
 apollo_config.workspace = true
 apollo_infra.workspace = true
+apollo_infra_utils.workspace = true
 apollo_l1_provider_types.workspace = true
 apollo_mempool_types.workspace = true
 apollo_metrics.workspace = true

--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -11,6 +11,7 @@ use apollo_class_manager_types::transaction_converter::{
 use apollo_class_manager_types::SharedClassManagerClient;
 use apollo_config::dumping::{append_sub_config_name, ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use apollo_infra_utils::tracing::LogCompatibleToStringExt;
 use apollo_state_reader::papyrus_state::{ClassReader, PapyrusReader};
 use apollo_storage::StorageReader;
 use async_trait::async_trait;
@@ -330,7 +331,11 @@ async fn collect_execution_results_and_stream_txs(
             // TODO(yael 18/9/2024): add timeout error handling here once this
             // feature is added.
             Err(err) => {
-                debug!("Transaction {} failed with error: {}.", tx_hash, err);
+                debug!(
+                    "Transaction {} failed with error: {}.",
+                    tx_hash,
+                    err.log_compatible_to_string()
+                );
                 if fail_on_err {
                     return Err(BlockBuilderError::FailOnError(
                         FailOnErrorCause::TransactionFailed(err),

--- a/crates/apollo_infra_utils/src/tracing.rs
+++ b/crates/apollo_infra_utils/src/tracing.rs
@@ -42,3 +42,9 @@ pub enum TraceLevel {
     Warn,
     Error,
 }
+
+pub trait LogCompatibleToStringExt: std::fmt::Display {
+    fn log_compatible_to_string(&self) -> String {
+        self.to_string().replace('\n', "\t")
+    }
+}

--- a/crates/blockifier/src/blockifier/transaction_executor.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor.rs
@@ -1,6 +1,7 @@
 use std::panic::{self, catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, Mutex};
 
+use apollo_infra_utils::tracing::LogCompatibleToStringExt;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
 use starknet_api::block::BlockHashAndNumber;
@@ -40,6 +41,8 @@ pub enum TransactionExecutorError {
     #[error(transparent)]
     CompressionError(#[from] CompressionError),
 }
+
+impl LogCompatibleToStringExt for TransactionExecutorError {}
 
 pub type TransactionExecutorResult<T> = Result<T, TransactionExecutorError>;
 


### PR DESCRIPTION
Before:
three lines:

```
Transaction execution has failed:
0: Error in the called contract (contract address: 0x0000000000000000000000000000000000000000000000000000000000000000, class hash: 0x0000000000000000000000000000000000000000000000000000000000000000, selector: 0x0000000000000000000000000000000000000000000000000000000000000000):
Execution failed due to recursion depth exceeded.
```

After:
One line:
```
Transaction execution has failed:       0: Error in the called contract (contract address: 0x0000000000000000000000000000000000000000000000000000000000000000, class hash: 0x0000000000000000000000000000000000000000000000000000000000000000, selector: 0x0000000000000000000000000000000000000000000000000000000000000000):     Execution failed due to recursion depth exceeded.
```

Also, note that the reason the error displays on multiple lines is this `\n` symbol:
https://github.com/starkware-libs/sequencer/blob/93c3ef696614b0d5f58574c6b411c0a0881cec00/crates/blockifier/src/execution/stack_trace.rs#L161
