### PR TITLE
fix(apollo_l1_provider): don't scrape unsupported events

### DIFF
--- a/crates/apollo_l1_provider/src/lib.rs
+++ b/crates/apollo_l1_provider/src/lib.rs
@@ -17,13 +17,7 @@ use std::time::Duration;
 use apollo_config::dumping::{ser_optional_param, ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use apollo_l1_provider_types::SessionState;
-use papyrus_base_layer::constants::{
-    EventIdentifier,
-    CONSUMED_MESSAGE_TO_L1_EVENT_IDENTIFIER,
-    LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER,
-    MESSAGE_TO_L2_CANCELED_EVENT_IDENTIFIER,
-    MESSAGE_TO_L2_CANCELLATION_STARTED_EVENT_IDENTIFIER,
-};
+use papyrus_base_layer::constants::{EventIdentifier, LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER};
 use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use validator::Validate;
@@ -138,10 +132,5 @@ impl SerializeConfig for L1ProviderConfig {
 }
 
 pub const fn event_identifiers_to_track() -> &'static [EventIdentifier] {
-    &[
-        LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER,
-        CONSUMED_MESSAGE_TO_L1_EVENT_IDENTIFIER,
-        MESSAGE_TO_L2_CANCELLATION_STARTED_EVENT_IDENTIFIER,
-        MESSAGE_TO_L2_CANCELED_EVENT_IDENTIFIER,
-    ]
+    &[LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER]
 }


### PR DESCRIPTION
Only `SendMessageToL2` is supported at the moment, no need to scrape it.