### PR TITLE
chore(apollo_l1_provider): add `UnsupportedL1Event` error

### DIFF
--- a/crates/apollo_l1_provider/src/l1_provider.rs
+++ b/crates/apollo_l1_provider/src/l1_provider.rs
@@ -223,10 +223,7 @@ impl L1Provider {
                     // TODO(Gilad): can we ignore this silently?
                     let _is_known_or_committed = self.tx_manager.add_tx(l1_handler_tx);
                 }
-                _ => {
-                    // TODO(Gilad): Properly handle all events.
-                    error!("Unsupported event type {:?}", event)
-                }
+                _ => return Err(L1ProviderError::unsupported_l1_event(event)),
             }
         }
         Ok(())

--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -336,6 +336,13 @@ fn handle_client_error<B: BaseLayerContract + Send + Sync>(
         L1ProviderClientError::L1ProviderError(L1ProviderError::Uninitialized) => {
             Err(L1ScraperError::NeedsRestart)
         }
+        L1ProviderClientError::L1ProviderError(L1ProviderError::UnsupportedL1Event(event)) => {
+            panic!(
+                "Scraper-->Provider consistency error: the event {event} is not supported by the \
+                 provider, but has been scraped and sent to it nonetheless. Check the list of \
+                 tracked events in the scraper and compare to the provider's."
+            )
+        }
         error => panic!("Unexpected error: {error}"),
     }
 }

--- a/crates/apollo_l1_provider_types/src/errors.rs
+++ b/crates/apollo_l1_provider_types/src/errors.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use thiserror::Error;
 
+use crate::Event;
+
 #[derive(Clone, Debug, Error, PartialEq, Eq, Serialize, Deserialize)]
 pub enum L1ProviderError {
     #[error("`get_txs` while in `Validate` state")]
@@ -24,6 +26,8 @@ pub enum L1ProviderError {
     UnexpectedHeight { expected_height: BlockNumber, got: BlockNumber },
     #[error("Cannot transition from {from} to {to}")]
     UnexpectedProviderStateTransition { from: String, to: String },
+    #[error("L1 event not supported: {0}")]
+    UnsupportedL1Event(String),
     #[error("`validate` called while in `Propose` state")]
     ValidateTransactionConsensusBug,
 }
@@ -31,6 +35,10 @@ pub enum L1ProviderError {
 impl L1ProviderError {
     pub fn unexpected_transition(from: impl ToString, to: impl ToString) -> Self {
         Self::UnexpectedProviderStateTransition { from: from.to_string(), to: to.to_string() }
+    }
+
+    pub fn unsupported_l1_event(event: Event) -> Self {
+        Self::UnsupportedL1Event(format!("{event:?}"))
     }
 }
 


### PR DESCRIPTION
Currently the scraper only scraper `SendMessageToL2` events, so this
shouldn't occur until we start supporting them.
However, this constitutes an input error until then.

Using a constructor type because `Event` is a big obj and makes the
enum too fat