### PR TITLE
refactor(apollo_l1_provider): use Display instead of Debug in error

### DIFF
--- a/crates/apollo_l1_provider_types/src/errors.rs
+++ b/crates/apollo_l1_provider_types/src/errors.rs
@@ -38,7 +38,7 @@ impl L1ProviderError {
     }
 
     pub fn unsupported_l1_event(event: Event) -> Self {
-        Self::UnsupportedL1Event(format!("{event:?}"))
+        Self::UnsupportedL1Event(event.to_string())
     }
 }
 

--- a/crates/apollo_l1_provider_types/src/lib.rs
+++ b/crates/apollo_l1_provider_types/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod errors;
 
+use std::fmt::Display;
 use std::sync::Arc;
 
 use apollo_infra::component_client::ClientError;
@@ -188,6 +189,21 @@ pub enum Event {
     TransactionCanceled(EventData),
     TransactionCancellationStarted(EventData),
     TransactionConsumed(EventData),
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::L1HandlerTransaction(tx) => {
+                write!(f, "L1HandlerTransaction(tx_hash={})", tx.tx_hash)
+            }
+            Event::TransactionCanceled(data) => write!(f, "TransactionCanceled({})", data),
+            Event::TransactionCancellationStarted(data) => {
+                write!(f, "TransactionCancellationStarted({})", data)
+            }
+            Event::TransactionConsumed(data) => write!(f, "TransactionConsumed({})", data),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -108,3 +108,14 @@ pub struct EventData {
     pub payload: Calldata,
     pub nonce: Nonce,
 }
+
+impl Display for EventData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "EventData {{ from_address: {:?}, to_address: {:?}, calldata: <omitted>, \
+             entry_point_selector: {}, nonce: {} }}",
+            self.from_address, self.to_address, self.entry_point_selector, self.nonce
+        )
+    }
+}

--- a/crates/starknet_api/src/core.rs
+++ b/crates/starknet_api/src/core.rs
@@ -257,7 +257,18 @@ impl Nonce {
 
 /// The selector of an [EntryPoint](`crate::state::EntryPoint`).
 #[derive(
-    Debug, Copy, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord,
+    Debug,
+    Copy,
+    Clone,
+    Default,
+    Eq,
+    PartialEq,
+    Hash,
+    Deserialize,
+    Serialize,
+    PartialOrd,
+    Ord,
+    derive_more::Display,
 )]
 pub struct EntryPointSelector(pub StarkHash);
 


### PR DESCRIPTION
Debug is spammy, especially in objects with dynamic fields like
`calldata` which is omitted from Display.