### PR TITLE
fix(apollo_compile_to_casm,apollo_compile_to_native): small cleanup

### DIFF
--- a/crates/apollo_compile_to_casm/src/constants.rs
+++ b/crates/apollo_compile_to_casm/src/constants.rs
@@ -4,6 +4,4 @@
 
 pub(crate) const CAIRO_LANG_BINARY_NAME: &str = "starknet-sierra-compile";
 
-#[allow(dead_code)]
-pub(crate) const REQUIRED_CAIRO_LANG_VERSION: &str = "2.11.2";
-// TODO(Elin): test version alignment with Cargo.
+pub const REQUIRED_CAIRO_LANG_VERSION: &str = "2.11.2";

--- a/crates/apollo_compile_to_native/src/constants.rs
+++ b/crates/apollo_compile_to_native/src/constants.rs
@@ -4,5 +4,4 @@
 
 pub(crate) const CAIRO_NATIVE_BINARY_NAME: &str = "starknet-native-compile";
 
-#[allow(dead_code)]
-pub(crate) const REQUIRED_CAIRO_NATIVE_VERSION: &str = "0.4.0";
+pub const REQUIRED_CAIRO_NATIVE_VERSION: &str = "0.4.0";


### PR DESCRIPTION
Deleted unnecessary comment (version is tested).
Made version constants `pub`lic; better than marking them as dead code. Both are used in build scripts and unit test, so to the compiler they seem unused.