### PR TITLE
feat(consensus): querys are spawned into a side task and we attempt to eagerly query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "starknet_api",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "validator",
@@ -1375,6 +1376,7 @@ dependencies = [
  "starknet_api",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/apollo_l1_gas_price/Cargo.toml
+++ b/crates/apollo_l1_gas_price/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 url.workspace = true
 validator.workspace = true

--- a/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
@@ -10,8 +10,10 @@ use apollo_l1_gas_price_types::EthToStrkOracleClientTrait;
 use async_trait::async_trait;
 use lru::LruCache;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::Response;
 use serde::{Deserialize, Serialize};
 use serde_json;
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, info};
 use url::Url;
 
@@ -22,6 +24,11 @@ pub mod eth_to_strk_oracle_test;
 // TODO(Asmaa): Move to config.
 pub const ETH_TO_STRK_QUANTIZATION: u64 = 18;
 pub const MAX_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).expect("Invalid cache size");
+
+pub enum Query {
+    Resolved(u128),
+    Unresolved(AbortOnDropHandle<Result<Response, reqwest::Error>>),
+}
 
 fn hashmap_to_headermap(hash_map: Option<HashMap<String, String>>) -> HeaderMap {
     let mut header_map = HeaderMap::new();
@@ -92,7 +99,7 @@ pub struct EthToStrkOracleClient {
     headers: HeaderMap,
     lag_interval_seconds: u64,
     client: reqwest::Client,
-    cached_prices: Mutex<LruCache<u64, u128>>,
+    cached_prices: Mutex<LruCache<u64, Query>>,
 }
 
 impl EthToStrkOracleClient {
@@ -113,27 +120,28 @@ impl EthToStrkOracleClient {
             cached_prices: Mutex::new(LruCache::new(MAX_CACHE_SIZE)),
         }
     }
-}
 
-#[async_trait]
-impl EthToStrkOracleClientTrait for EthToStrkOracleClient {
-    /// The HTTP response must include the following fields:
-    /// - `price`: a hexadecimal string representing the price.
-    /// - `decimals`: a `u64` value, must be equal to `ETH_TO_STRK_QUANTIZATION`.
-    async fn eth_to_fri_rate(&self, timestamp: u64) -> Result<u128, EthToStrkOracleClientError> {
-        let quantized_timestamp =
-            (timestamp - self.lag_interval_seconds) / self.lag_interval_seconds;
-        if let Some(rate) =
-            self.cached_prices.lock().expect("Lock poisoned").peek(&quantized_timestamp)
-        {
-            return Ok(*rate);
-        }
-
+    fn spawn_query(
+        &self,
+        quantized_timestamp: u64,
+    ) -> AbortOnDropHandle<Result<Response, reqwest::Error>> {
         let adjusted_timestamp = quantized_timestamp * self.lag_interval_seconds;
         let url = format!("{}{}", self.base_url, adjusted_timestamp);
-        let response = self.client.get(&url).headers(self.headers.clone()).send().await?;
-        let body = response.text().await?;
+        let request = self.client.get(&url).headers(self.headers.clone()).send();
+        AbortOnDropHandle::new(tokio::spawn(request))
+    }
 
+    async fn resolve_query(
+        &self,
+        quantized_timestamp: u64,
+    ) -> Result<u128, EthToStrkOracleClientError> {
+        let Some(Query::Unresolved(handle)) =
+            self.cached_prices.lock().expect("Lock poisoned").pop(&quantized_timestamp)
+        else {
+            panic!("Entry must exist")
+        };
+        assert!(handle.is_finished(), "Should only be called once the query completes");
+        let body = handle.await??.text().await?;
         let json: serde_json::Value = serde_json::from_str(&body)?;
         let price = json
             .get("price")
@@ -153,8 +161,47 @@ impl EthToStrkOracleClientTrait for EthToStrkOracleClient {
                 decimals,
             ));
         }
+        Ok(rate)
+    }
+}
 
-        self.cached_prices.lock().expect("Lock poisoned").push(quantized_timestamp, rate);
+#[async_trait]
+impl EthToStrkOracleClientTrait for EthToStrkOracleClient {
+    /// The HTTP response must include the following fields:
+    /// - `price`: a hexadecimal string representing the price.
+    /// - `decimals`: a `u64` value, must be equal to `ETH_TO_STRK_QUANTIZATION`.
+    async fn eth_to_fri_rate(&self, timestamp: u64) -> Result<u128, EthToStrkOracleClientError> {
+        let quantized_timestamp =
+            (timestamp - self.lag_interval_seconds) / self.lag_interval_seconds;
+        // Scope is to make sure the MutexGuard is dropped before the await.
+        {
+            let mut cached_prices = self.cached_prices.lock().expect("Lock poisoned");
+            let Some(query) = cached_prices.get_mut(&quantized_timestamp) else {
+                cached_prices.push(
+                    quantized_timestamp,
+                    Query::Unresolved(self.spawn_query(quantized_timestamp)),
+                );
+                return Err(EthToStrkOracleClientError::TimeoutError(timestamp));
+            };
+
+            match query {
+                Query::Resolved(rate) => {
+                    debug!("Cached conversion rate for timestamp {timestamp} is {rate}");
+                    return Ok(*rate);
+                }
+                Query::Unresolved(handle) => {
+                    if !handle.is_finished() {
+                        return Err(EthToStrkOracleClientError::TimeoutError(timestamp));
+                    }
+                }
+            };
+        }
+
+        let rate = self.resolve_query(quantized_timestamp).await?;
+        self.cached_prices
+            .lock()
+            .expect("Lock poisoned")
+            .push(quantized_timestamp, Query::Resolved(rate));
         debug!("Conversion rate for timestamp {timestamp} is {rate}");
         Ok(rate)
     }

--- a/crates/apollo_l1_gas_price_types/Cargo.toml
+++ b/crates/apollo_l1_gas_price_types/Cargo.toml
@@ -17,6 +17,7 @@ serde_json.workspace = true
 starknet_api.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/apollo_l1_gas_price_types/src/errors.rs
+++ b/crates/apollo_l1_gas_price_types/src/errors.rs
@@ -23,6 +23,8 @@ pub enum L1GasPriceClientError {
 #[derive(Debug, Error)]
 pub enum EthToStrkOracleClientError {
     #[error(transparent)]
+    JoinError(#[from] tokio::task::JoinError),
+    #[error(transparent)]
     RequestError(#[from] reqwest::Error),
     #[error(transparent)]
     ParseError(#[from] serde_json::Error),
@@ -30,4 +32,6 @@ pub enum EthToStrkOracleClientError {
     MissingFieldError(&'static str),
     #[error("Invalid decimals value: expected {0}, got {1}")]
     InvalidDecimalsError(u64, u64),
+    #[error("Timed out waiting for a response: timestamp={0}")]
+    TimeoutError(u64),
 }


### PR DESCRIPTION
I am very skeptical that eagerly querying provides any benefit. This would only be helpful
if the timestamp being sent was itself not basically equal to now