### PR TITLE
refactor(apollo_integration_tests): only EXTRACT, to run flow tests sequentially

### DIFF
--- a/crates/apollo_integration_tests/tests/common/mod.rs
+++ b/crates/apollo_integration_tests/tests/common/mod.rs
@@ -1,0 +1,141 @@
+use std::time::Duration;
+
+use apollo_infra::trace_util::configure_tracing;
+use apollo_infra_utils::test_utils::TestIdentifier;
+use apollo_integration_tests::flow_test_setup::{FlowSequencerSetup, FlowTestSetup};
+use apollo_integration_tests::utils::{
+    create_flow_test_tx_generator,
+    run_test_scenario,
+    CreateL1ToL2MessagesArgsFn,
+    CreateRpcTxsFn,
+    TestTxHashesFn,
+};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusRecorder};
+use pretty_assertions::assert_eq;
+use starknet_api::execution_resources::GasAmount;
+use starknet_api::transaction::TransactionHash;
+use tracing::info;
+
+// Note: run integration/flow tests from separate files in `tests/`, which helps cargo ensure
+// isolation (prevent cross-contamination of services/resources) and that these tests won't be
+// parallelized (which won't work with fixed ports).
+pub async fn end_to_end_flow(
+    test_identifier: TestIdentifier,
+    test_blocks_scenarios: Vec<TestScenario>,
+    block_max_capacity_sierra_gas: GasAmount,
+    expecting_full_blocks: bool,
+) {
+    configure_tracing().await;
+
+    let mut tx_generator = create_flow_test_tx_generator();
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+    const TEST_SCENARIO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(50);
+    // Setup.
+    let mock_running_system = FlowTestSetup::new_from_tx_generator(
+        &tx_generator,
+        test_identifier.into(),
+        block_max_capacity_sierra_gas,
+    )
+    .await;
+
+    tokio::join!(
+        wait_for_sequencer_node(&mock_running_system.sequencer_0),
+        wait_for_sequencer_node(&mock_running_system.sequencer_1),
+    );
+
+    let sequencers = [&mock_running_system.sequencer_0, &mock_running_system.sequencer_1];
+    // We use only the first sequencer's gateway to test that the mempools are syncing.
+    let sequencer_to_add_txs = *sequencers.first().unwrap();
+    let mut expected_proposer_iter = sequencers.iter().cycle();
+    // We start at height 1, so we need to skip the proposer of the initial height.
+    expected_proposer_iter.next().unwrap();
+    let chain_id = mock_running_system.chain_id().clone();
+    let mut send_rpc_tx_fn = |tx| sequencer_to_add_txs.assert_add_tx_success(tx);
+    let mut total_expected_txs = vec![];
+
+    // Build multiple heights to ensure heights are committed.
+    for (
+        i,
+        TestScenario { create_rpc_txs_fn, create_l1_to_l2_messages_args_fn, test_tx_hashes_fn },
+    ) in test_blocks_scenarios.into_iter().enumerate()
+    {
+        info!("Starting scenario {i}.");
+        // Create and send transactions.
+        // TODO(Arni): move send messages to l2 into [run_test_scenario].
+        let l1_to_l2_messages_args = create_l1_to_l2_messages_args_fn(&mut tx_generator);
+        mock_running_system.send_messages_to_l2(&l1_to_l2_messages_args).await;
+        let mut expected_batched_tx_hashes = run_test_scenario(
+            &mut tx_generator,
+            create_rpc_txs_fn,
+            l1_to_l2_messages_args,
+            &mut send_rpc_tx_fn,
+            test_tx_hashes_fn,
+            &chain_id,
+        )
+        .await;
+        total_expected_txs.append(&mut expected_batched_tx_hashes.clone());
+
+        tokio::time::timeout(TEST_SCENARIO_TIMEOUT, async {
+            loop {
+                info!(
+                    "Waiting for sent txs to be included in a block: {:#?}",
+                    expected_batched_tx_hashes
+                );
+
+                let batched_txs =
+                    &mock_running_system.accumulated_txs.lock().await.accumulated_tx_hashes;
+                expected_batched_tx_hashes.retain(|tx| !batched_txs.contains(tx));
+                if expected_batched_tx_hashes.is_empty() {
+                    break;
+                }
+
+                tokio::time::sleep(Duration::from_millis(2000)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "Scenario {i}: Expected transactions should be included in a block by now, \
+                 remaining txs: {expected_batched_tx_hashes:#?}"
+            )
+        });
+    }
+
+    assert_only_expected_txs(
+        total_expected_txs,
+        mock_running_system.accumulated_txs.lock().await.accumulated_tx_hashes.clone(),
+    );
+    assert_full_blocks_flow(&recorder, expecting_full_blocks);
+}
+
+pub struct TestScenario {
+    pub create_rpc_txs_fn: CreateRpcTxsFn,
+    pub create_l1_to_l2_messages_args_fn: CreateL1ToL2MessagesArgsFn,
+    pub test_tx_hashes_fn: TestTxHashesFn,
+}
+
+fn assert_only_expected_txs(
+    mut total_expected_txs: Vec<TransactionHash>,
+    mut batched_txs: Vec<TransactionHash>,
+) {
+    total_expected_txs.sort();
+    batched_txs.sort();
+    assert_eq!(total_expected_txs, batched_txs);
+}
+
+fn assert_full_blocks_flow(recorder: &PrometheusRecorder, expecting_full_blocks: bool) {
+    let metrics = recorder.handle().render();
+    let full_blocks_metric =
+        apollo_batcher::metrics::FULL_BLOCKS.parse_numeric_metric::<u64>(&metrics).unwrap();
+    if expecting_full_blocks {
+        assert!(full_blocks_metric > 0);
+    } else {
+        assert_eq!(full_blocks_metric, 0);
+    }
+}
+
+async fn wait_for_sequencer_node(sequencer: &FlowSequencerSetup) {
+    sequencer.monitoring_client.await_alive(5000, 50).await.expect("Node should be alive.");
+}

--- a/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
@@ -1,169 +1,35 @@
-use std::time::Duration;
-
-use apollo_infra::trace_util::configure_tracing;
 use apollo_infra_utils::test_utils::TestIdentifier;
-use apollo_integration_tests::flow_test_setup::{FlowSequencerSetup, FlowTestSetup};
 use apollo_integration_tests::utils::{
     create_deploy_account_tx_and_invoke_tx,
-    create_flow_test_tx_generator,
-    create_funding_txs,
-    create_l1_to_l2_message_args,
-    create_many_invoke_txs,
-    create_multiple_account_txs,
-    run_test_scenario,
-    test_many_invoke_txs,
-    test_multiple_account_txs,
-    CreateL1ToL2MessagesArgsFn,
-    CreateRpcTxsFn,
-    TestTxHashesFn,
+    create_l1_to_l2_messages_args,
     ACCOUNT_ID_0,
+    ACCOUNT_ID_1,
     UNDEPLOYED_ACCOUNT_ID,
 };
-use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerator;
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusRecorder};
-use pretty_assertions::assert_eq;
-use rstest::{fixture, rstest};
+use mempool_test_utils::starknet_api_test_utils::{
+    L1ToL2MessageArgs,
+    MultiAccountTransactionGenerator,
+};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::transaction::TransactionHash;
-use tracing::info;
 
-struct TestScenario {
-    create_rpc_txs_fn: CreateRpcTxsFn,
-    create_l1_to_l2_messages_args_fn: CreateL1ToL2MessagesArgsFn,
-    test_tx_hashes_fn: TestTxHashesFn,
-}
+use crate::common::{end_to_end_flow, TestScenario};
 
-#[fixture]
-fn tx_generator() -> MultiAccountTransactionGenerator {
-    create_flow_test_tx_generator()
-}
+mod common;
 
-#[rstest]
-#[case::end_to_end_flow(
-    TestIdentifier::EndToEndFlowTest,
-    create_test_scenarios(),
-    GasAmount(29000000),
-    false
-)]
-#[case::many_txs_scenario(
-    TestIdentifier::EndToEndFlowTestManyTxs,
-    create_many_txs_scenario(),
-    GasAmount(17500000),
-    true
-)]
 #[tokio::test]
-async fn end_to_end_flow(
-    mut tx_generator: MultiAccountTransactionGenerator,
-    #[case] test_identifier: TestIdentifier,
-    #[case] test_blocks_scenarios: Vec<TestScenario>,
-    #[case] block_max_capacity_sierra_gas: GasAmount,
-    #[case] expecting_full_blocks: bool,
-) {
-    configure_tracing().await;
-    let recorder = PrometheusBuilder::new().build_recorder();
-    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
-
-    const TEST_SCENARIO_TIMOUT: std::time::Duration = std::time::Duration::from_secs(50);
-    // Setup.
-    let mock_running_system = FlowTestSetup::new_from_tx_generator(
-        &tx_generator,
-        test_identifier.into(),
-        block_max_capacity_sierra_gas,
+async fn test_end_to_end_flow() {
+    end_to_end_flow(
+        TestIdentifier::EndToEndFlowTest,
+        create_test_scenarios(),
+        GasAmount(29000000),
+        false,
     )
-    .await;
-
-    tokio::join!(
-        wait_for_sequencer_node(&mock_running_system.sequencer_0),
-        wait_for_sequencer_node(&mock_running_system.sequencer_1),
-    );
-
-    let sequencers = [&mock_running_system.sequencer_0, &mock_running_system.sequencer_1];
-    // We use only the first sequencer's gateway to test that the mempools are syncing.
-    let sequencer_to_add_txs = *sequencers.first().unwrap();
-    let mut expected_proposer_iter = sequencers.iter().cycle();
-    // We start at height 1, so we need to skip the proposer of the initial height.
-    expected_proposer_iter.next().unwrap();
-    let chain_id = mock_running_system.chain_id().clone();
-    let mut send_rpc_tx_fn = |tx| sequencer_to_add_txs.assert_add_tx_success(tx);
-    let mut total_expected_txs = vec![];
-
-    // Build multiple heights to ensure heights are committed.
-    for (
-        i,
-        TestScenario { create_rpc_txs_fn, create_l1_to_l2_messages_args_fn, test_tx_hashes_fn },
-    ) in test_blocks_scenarios.into_iter().enumerate()
-    {
-        info!("Starting scenario {i}.");
-        // Create and send transactions.
-        // TODO(Arni): move send messages to l2 into [run_test_scenario].
-        let l1_to_l2_messages_args = create_l1_to_l2_messages_args_fn(&mut tx_generator);
-        mock_running_system.send_messages_to_l2(&l1_to_l2_messages_args).await;
-        let mut expected_batched_tx_hashes = run_test_scenario(
-            &mut tx_generator,
-            create_rpc_txs_fn,
-            l1_to_l2_messages_args,
-            &mut send_rpc_tx_fn,
-            test_tx_hashes_fn,
-            &chain_id,
-        )
-        .await;
-        total_expected_txs.append(&mut expected_batched_tx_hashes.clone());
-
-        tokio::time::timeout(TEST_SCENARIO_TIMOUT, async {
-            loop {
-                info!(
-                    "Waiting for sent txs to be included in a block: {:#?}",
-                    expected_batched_tx_hashes
-                );
-
-                let batched_txs =
-                    &mock_running_system.accumulated_txs.lock().await.accumulated_tx_hashes;
-                expected_batched_tx_hashes.retain(|tx| !batched_txs.contains(tx));
-                if expected_batched_tx_hashes.is_empty() {
-                    break;
-                }
-
-                tokio::time::sleep(Duration::from_millis(2000)).await;
-            }
-        })
-        .await
-        .unwrap_or_else(|_| {
-            panic!(
-                "Scenario {i}: Expected transactions should be included in a block by now, \
-                 remaining txs: {expected_batched_tx_hashes:#?}"
-            )
-        });
-    }
-
-    assert_only_expected_txs(
-        total_expected_txs,
-        mock_running_system.accumulated_txs.lock().await.accumulated_tx_hashes.clone(),
-    );
-    assert_full_blocks_flow(&recorder, expecting_full_blocks);
+    .await
 }
 
-fn assert_only_expected_txs(
-    mut total_expected_txs: Vec<TransactionHash>,
-    mut batched_txs: Vec<TransactionHash>,
-) {
-    total_expected_txs.sort();
-    batched_txs.sort();
-    assert_eq!(total_expected_txs, batched_txs);
-}
-
-fn assert_full_blocks_flow(recorder: &PrometheusRecorder, expecting_full_blocks: bool) {
-    let metrics = recorder.handle().render();
-    let full_blocks_metric =
-        apollo_batcher::metrics::FULL_BLOCKS.parse_numeric_metric::<u64>(&metrics).unwrap();
-    if expecting_full_blocks {
-        assert!(full_blocks_metric > 0);
-    } else {
-        assert_eq!(full_blocks_metric, 0);
-    }
-}
-
-fn create_test_scenarios() -> Vec<TestScenario> {
+pub fn create_test_scenarios() -> Vec<TestScenario> {
     vec![
         // This block should be the first to be tested, as the addition of L1 handler transaction
         // does not work smoothly with the current architecture of the test.
@@ -196,16 +62,53 @@ fn create_test_scenarios() -> Vec<TestScenario> {
     ]
 }
 
-fn create_many_txs_scenario() -> Vec<TestScenario> {
-    vec![TestScenario {
-        create_rpc_txs_fn: create_many_invoke_txs,
-        create_l1_to_l2_messages_args_fn: |_| vec![],
-        test_tx_hashes_fn: test_many_invoke_txs,
-    }]
+fn create_l1_to_l2_message_args(
+    tx_generator: &mut MultiAccountTransactionGenerator,
+) -> Vec<L1ToL2MessageArgs> {
+    const N_TXS: usize = 1;
+    create_l1_to_l2_messages_args(tx_generator, N_TXS)
 }
 
-async fn wait_for_sequencer_node(sequencer: &FlowSequencerSetup) {
-    sequencer.monitoring_client.await_alive(5000, 50).await.expect("Node should be alive.");
+fn create_multiple_account_txs(
+    tx_generator: &mut MultiAccountTransactionGenerator,
+) -> Vec<RpcTransaction> {
+    // Create RPC transactions.
+    let account0_invoke_nonce1 =
+        tx_generator.account_with_id_mut(ACCOUNT_ID_0).generate_invoke_with_tip(2);
+    let account0_invoke_nonce2 =
+        tx_generator.account_with_id_mut(ACCOUNT_ID_0).generate_invoke_with_tip(3);
+    let account1_invoke_nonce1 =
+        tx_generator.account_with_id_mut(ACCOUNT_ID_1).generate_invoke_with_tip(4);
+
+    vec![account0_invoke_nonce1, account0_invoke_nonce2, account1_invoke_nonce1]
+}
+
+fn test_single_tx(tx_hashes: &[TransactionHash]) -> Vec<TransactionHash> {
+    assert_eq!(tx_hashes.len(), 1, "Expected a single transaction");
+    tx_hashes.to_vec()
+}
+
+fn test_multiple_account_txs(tx_hashes: &[TransactionHash]) -> Vec<TransactionHash> {
+    // Return the transaction hashes in the order they should be given by the mempool:
+    // Transactions from the same account are ordered by nonce; otherwise, higher tips are given
+    // priority.
+    assert!(
+        tx_hashes.len() == 3,
+        "Unexpected number of transactions sent in the test scenario. Found {} transactions",
+        tx_hashes.len()
+    );
+    vec![tx_hashes[2], tx_hashes[0], tx_hashes[1]]
+}
+
+fn create_funding_txs(tx_generator: &mut MultiAccountTransactionGenerator) -> Vec<RpcTransaction> {
+    // TODO(yair): Register the undeployed account here instead of in the test setup
+    // once funding is implemented.
+    let undeployed_account = tx_generator.account_with_id(UNDEPLOYED_ACCOUNT_ID).account;
+    assert!(tx_generator.undeployed_accounts().contains(&undeployed_account));
+
+    let funding_tx =
+        tx_generator.account_with_id_mut(ACCOUNT_ID_0).generate_transfer(&undeployed_account);
+    vec![funding_tx]
 }
 
 /// Generates a deploy account transaction followed by an invoke transaction from the same deployed
@@ -214,11 +117,6 @@ fn deploy_account_and_invoke(
     tx_generator: &mut MultiAccountTransactionGenerator,
 ) -> Vec<RpcTransaction> {
     create_deploy_account_tx_and_invoke_tx(tx_generator, UNDEPLOYED_ACCOUNT_ID)
-}
-
-fn test_single_tx(tx_hashes: &[TransactionHash]) -> Vec<TransactionHash> {
-    assert_eq!(tx_hashes.len(), 1, "Expected a single transaction");
-    tx_hashes.to_vec()
 }
 
 fn test_two_txs(tx_hashes: &[TransactionHash]) -> Vec<TransactionHash> {

--- a/crates/apollo_integration_tests/tests/test_many.rs
+++ b/crates/apollo_integration_tests/tests/test_many.rs
@@ -1,0 +1,46 @@
+use apollo_infra_utils::test_utils::TestIdentifier;
+use apollo_integration_tests::utils::{create_invoke_txs, ACCOUNT_ID_1};
+use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerator;
+use starknet_api::execution_resources::GasAmount;
+use starknet_api::rpc_transaction::RpcTransaction;
+use starknet_api::transaction::TransactionHash;
+
+use crate::common::{end_to_end_flow, TestScenario};
+
+mod common;
+
+#[tokio::test]
+async fn many_txs() {
+    end_to_end_flow(
+        TestIdentifier::EndToEndFlowTestManyTxs,
+        create_many_txs_scenario(),
+        GasAmount(17500000),
+        true,
+    )
+    .await
+}
+
+fn create_many_txs_scenario() -> Vec<TestScenario> {
+    vec![TestScenario {
+        create_rpc_txs_fn: create_many_invoke_txs,
+        create_l1_to_l2_messages_args_fn: |_| vec![],
+        test_tx_hashes_fn: test_many_invoke_txs,
+    }]
+}
+
+pub fn test_many_invoke_txs(tx_hashes: &[TransactionHash]) -> Vec<TransactionHash> {
+    assert!(
+        tx_hashes.len() == 15,
+        "Unexpected number of transactions sent in the test scenario. Found {} transactions",
+        tx_hashes.len()
+    );
+    tx_hashes.to_vec()
+}
+
+/// Creates and sends more transactions than can fit in a block.
+pub fn create_many_invoke_txs(
+    tx_generator: &mut MultiAccountTransactionGenerator,
+) -> Vec<RpcTransaction> {
+    const N_TXS: usize = 15;
+    create_invoke_txs(tx_generator, ACCOUNT_ID_1, N_TXS)
+}


### PR DESCRIPTION
    Changes:
    ONLY MOVE, no logic changes. Break up the rstest
    parameterization into two separate files inside `tests/`, which
    corresponds to two `cargo`-style integration tests.
    Also moved a bunch of _single-use_ functions from utils.rs into the
    corresponding test file.

    Motivation:
    * https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html#integration-testing.
    Every file in `tests/` is run as a separate binary by cargo, without
    parallelization.
    However, multiple tests in the same file in `tests/` are still parallelized by cargo,
    which is what `rstest` parametrization generates.

    * This is the best way to run flow tests (and also integration) for
    a bunch of reasons: we don't want stuff in one test contaminating the
    other, we want to use fixed (configurable) ports for things (there is no
    requirement to do otherwise and dynamic ports adds complexity to the
    setup).

    * Clarifying note: in the future, we want the _integration tests_ to become tests
      inside `tests/` inside `apollo_node`, for somewhat similar reasons,
      plus they will spare us from using the bash script instead of `cargo test`,
      but this is unrelated to this commit.

