### PR TITLE
refactor(mempool_test_utils): remove `in_ci`

### DIFF
--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -26,6 +26,10 @@ pub fn in_ci() -> bool {
     std::env::var("CI").is_ok()
 }
 
+fn in_ci() -> bool {
+    std::env::var("CI").is_ok()
+}
+
 #[tokio::test]
 // Note: the test requires ganache-cli installed, otherwise it is ignored.
 async fn latest_proved_block_ethereum() {


### PR DESCRIPTION
It isn't used in that crate.
It's fine to duplicate this util, its simple enough.