### PR TITLE
chore(papyrus_base_layer): remove ganache usage from test

### DIFF
--- a/crates/papyrus_base_layer/src/test_utils.rs
+++ b/crates/papyrus_base_layer/src/test_utils.rs
@@ -40,6 +40,10 @@ pub const DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS: StarkHash =
     StarkHash::from_hex_unchecked("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 pub const DEFAULT_ANVIL_ADDITIONAL_ADDRESS_INDEX: usize = 3;
 
+// ***
+// DEPRECATED: Use the anvil constructor, this constructor is deprecated as it uses ganache.
+// ***
+//
 // Returns a Ganache instance, preset with a Starknet core contract and some state updates:
 // Starknet contract address: 0xe2aF2c1AE11fE13aFDb7598D0836398108a4db0A
 //     Ethereum block number   starknet block number   starknet block hash
@@ -49,8 +53,10 @@ pub const DEFAULT_ANVIL_ADDITIONAL_ADDRESS_INDEX: usize = 3;
 // The blockchain is at Ethereum block number 31.
 // Note: Requires Ganache@7.4.3 installed.
 // TODO(Gilad): `Ganache` and `ethers` have both been deprecated. Also, `ethers`s' replacement,
-// `alloy`, no longer supports `Ganache`. Once we decide on a Ganache replacement, fix this test and
-// fully remove `ethers`.
+// `alloy`, no longer supports `Ganache`. Once we fully support anvil, remove this util, `ganache`
+// and `ethers``.
+#[deprecated(note = "Ganache is dead and will be removed soon, use Anvil instead, unless you \
+                     need something we don't support on anvil yet.")]
 pub fn get_test_ethereum_node() -> (TestEthereumNodeHandle, EthereumContractAddress) {
     const SN_CONTRACT_ADDR: &str = "0xe2aF2c1AE11fE13aFDb7598D0836398108a4db0A";
     // Verify correct Ganache version.


### PR DESCRIPTION
* Use mocked anvil, no need to do IO here.
* Deprecate ganache through cargo to prevent future usage

Note: the existing test is basically testing that the configs are mapped
correctly to the correct computations, it's blurring the line between
testing the eip.