### PR TITLE
fix(apollo_compile_to_casm,papyrus_node): do not change current dir

### DIFF
--- a/crates/apollo_compile_to_casm/src/compile_test.rs
+++ b/crates/apollo_compile_to_casm/src/compile_test.rs
@@ -1,6 +1,3 @@
-use std::env;
-use std::path::Path;
-
 use apollo_compilation_utils::errors::CompilationUtilError;
 use apollo_compilation_utils::test_utils::contract_class_from_file;
 use apollo_infra_utils::path::resolve_project_relative_path;
@@ -22,9 +19,8 @@ fn compiler() -> SierraToCasmCompiler {
 }
 
 fn get_test_contract() -> CairoLangContractClass {
-    env::set_current_dir(resolve_project_relative_path(TEST_FILES_FOLDER).unwrap())
-        .expect("Failed to set current dir.");
-    let sierra_path = Path::new(FAULTY_ACCOUNT_CLASS_FILE);
+    let sierra_path =
+        resolve_project_relative_path(TEST_FILES_FOLDER).unwrap().join(FAULTY_ACCOUNT_CLASS_FILE);
     contract_class_from_file(sierra_path)
 }
 

--- a/crates/apollo_compile_to_native/src/compile_test.rs
+++ b/crates/apollo_compile_to_native/src/compile_test.rs
@@ -1,6 +1,3 @@
-use std::env;
-use std::path::Path;
-
 use apollo_compilation_utils::errors::CompilationUtilError;
 use apollo_compilation_utils::test_utils::contract_class_from_file;
 use apollo_infra_utils::path::resolve_project_relative_path;
@@ -30,9 +27,8 @@ fn compiler() -> SierraToNativeCompiler {
 }
 
 fn get_test_contract() -> ContractClass {
-    env::set_current_dir(resolve_project_relative_path(TEST_FILES_FOLDER).unwrap())
-        .expect("Failed to set current dir.");
-    let sierra_path = Path::new(FAULTY_ACCOUNT_CLASS_FILE);
+    let sierra_path =
+        resolve_project_relative_path(TEST_FILES_FOLDER).unwrap().join(FAULTY_ACCOUNT_CLASS_FILE);
     contract_class_from_file(sierra_path)
 }
 

--- a/crates/apollo_infra_utils/src/dumping.rs
+++ b/crates/apollo_infra_utils/src/dumping.rs
@@ -1,5 +1,3 @@
-#[cfg(any(feature = "testing", test))]
-use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
@@ -18,9 +16,7 @@ use crate::test_utils::assert_json_eq;
 
 #[cfg(any(feature = "testing", test))]
 pub fn serialize_to_file_test<T: Serialize>(data: T, file_path: &str, fix_binary_name: &str) {
-    env::set_current_dir(resolve_project_relative_path("").unwrap())
-        .expect("Couldn't set working dir.");
-
+    let file_path = resolve_project_relative_path("").unwrap().join(file_path);
     let loaded_data: Value = from_reader(File::open(file_path).unwrap()).unwrap();
 
     let serialized_data =

--- a/crates/apollo_node/src/config/config_test.rs
+++ b/crates/apollo_node/src/config/config_test.rs
@@ -91,10 +91,9 @@ fn valid_component_execution_config(
 /// cargo run --bin sequencer_dump_config -q
 #[test]
 fn default_config_file_is_up_to_date() {
-    env::set_current_dir(resolve_project_relative_path("").unwrap())
-        .expect("Couldn't set working dir.");
+    let config_path = resolve_project_relative_path("").unwrap().join(DEFAULT_CONFIG_PATH);
     let from_default_config_file: serde_json::Value =
-        serde_json::from_reader(File::open(DEFAULT_CONFIG_PATH).unwrap()).unwrap();
+        serde_json::from_reader(File::open(config_path).unwrap()).unwrap();
 
     // Create a temporary file and dump the default config to it.
     let mut tmp_file_path = env::temp_dir();

--- a/crates/papyrus_node/src/config/config_test.rs
+++ b/crates/papyrus_node/src/config/config_test.rs
@@ -104,8 +104,6 @@ fn load_http_headers() {
 // Regression test which checks that the default config dumping hasn't changed.
 fn test_dump_default_config() {
     let mut default_config = NodeConfig::default();
-    env::set_current_dir(resolve_project_relative_path("").unwrap())
-        .expect("Couldn't set working dir.");
     let dumped_default_config = default_config.dump();
     insta::assert_json_snapshot!(dumped_default_config);
 
@@ -148,10 +146,9 @@ fn test_update_dumped_config_by_command() {
 #[cfg(feature = "rpc")]
 #[test]
 fn default_config_file_is_up_to_date() {
-    env::set_current_dir(resolve_project_relative_path("").unwrap())
-        .expect("Couldn't set working dir.");
+    let config_path = resolve_project_relative_path("").unwrap().join(DEFAULT_CONFIG_PATH);
     let from_default_config_file: serde_json::Value =
-        serde_json::from_reader(File::open(DEFAULT_CONFIG_PATH).unwrap()).unwrap();
+        serde_json::from_reader(File::open(config_path).unwrap()).unwrap();
 
     // Create a temporary file and dump the default config to it.
     let mut tmp_file_path = env::temp_dir();


### PR DESCRIPTION
No need to do this in the fied tests; or at all (it's a persistent change throughtout the program).
There are additional usages, which are less trivial to fix.