### PR TITLE
feat(apollo_consensus_orchestrator): add logs for building / validating empty proposals

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1021,6 +1021,9 @@ async fn get_proposal_content(
                 let proposal_commitment = BlockHash(id.state_diff_commitment.0.0);
                 let num_txs: usize = content.iter().map(|batch| batch.len()).sum();
                 info!(?proposal_commitment, num_txs = num_txs, "Finished building proposal",);
+                if num_txs == 0 {
+                    warn!("Built an empty proposal.");
+                }
 
                 // If the blob writing operation to Aerospike doesn't return a success status, we
                 // can't finish the proposal.
@@ -1373,6 +1376,9 @@ async fn handle_proposal_part(
                 num_txs,
                 "Finished validating proposal."
             );
+            if num_txs == 0 {
+                warn!("Validated empty proposal.");
+            }
             HandledProposalPart::Finished(batcher_block_id, ProposalFin { proposal_commitment: id })
         }
         Some(ProposalPart::Transactions(TransactionBatch { transactions: txs })) => {


### PR DESCRIPTION
Examples of both logs:

Node id 2 part 0: 2025-04-29T08:36:57.764Z  WARN run_consensus:run_height:consensus_build_proposal: crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs:1025: Built an empty proposal. validator_id=0x0000000000000000000000000000000000000000000000000000000000000066 height=2 proposal_id=1 round=0

Node id 1 part 0: 2025-04-29T08:36:57.775Z  WARN run_consensus:run_height:consensus_validate_proposal: crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs:1380: Validated empty proposal. validator_id=0x0000000000000000000000000000000000000000000000000000000000000065 height=2 proposal_id=1 round=0