### PR TITLE
chore(apollo_l1_endpoint_monitor): add client boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,13 @@ dependencies = [
 [[package]]
 name = "apollo_l1_endpoint_monitor"
 version = "0.0.0"
+dependencies = [
+ "apollo_infra",
+ "apollo_l1_endpoint_monitor_types",
+ "async-trait",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "apollo_l1_endpoint_monitor_types"

--- a/crates/apollo_l1_endpoint_monitor/Cargo.toml
+++ b/crates/apollo_l1_endpoint_monitor/Cargo.toml
@@ -6,6 +6,11 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+apollo_infra.workspace = true
+apollo_l1_endpoint_monitor_types.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 

--- a/crates/apollo_l1_endpoint_monitor/src/communication.rs
+++ b/crates/apollo_l1_endpoint_monitor/src/communication.rs
@@ -1,0 +1,41 @@
+use apollo_infra::component_client::{LocalComponentClient, RemoteComponentClient};
+use apollo_infra::component_definitions::{
+    ComponentRequestAndResponseSender,
+    ComponentRequestHandler,
+};
+use apollo_infra::component_server::{LocalComponentServer, RemoteComponentServer};
+use apollo_l1_endpoint_monitor_types::{L1EndpointMonitorRequest, L1EndpointMonitorResponse};
+use async_trait::async_trait;
+use tracing::instrument;
+
+use crate::monitor::L1EndpointMonitor;
+
+pub type LocalL1EndpointMonitorServer =
+    LocalComponentServer<L1EndpointMonitor, L1EndpointMonitorRequest, L1EndpointMonitorResponse>;
+pub type RemoteL1EndpointMonitorServer =
+    RemoteComponentServer<L1EndpointMonitorRequest, L1EndpointMonitorResponse>;
+pub type L1EndpointMonitorRequestAndResponseSender =
+    ComponentRequestAndResponseSender<L1EndpointMonitorRequest, L1EndpointMonitorResponse>;
+pub type LocalL1EndpointMonitorClient =
+    LocalComponentClient<L1EndpointMonitorRequest, L1EndpointMonitorResponse>;
+pub type RemoteL1EndpointMonitorClient =
+    RemoteComponentClient<L1EndpointMonitorRequest, L1EndpointMonitorResponse>;
+
+#[async_trait]
+impl ComponentRequestHandler<L1EndpointMonitorRequest, L1EndpointMonitorResponse>
+    for L1EndpointMonitor
+{
+    #[instrument(skip(self))]
+    async fn handle_request(
+        &mut self,
+        request: L1EndpointMonitorRequest,
+    ) -> L1EndpointMonitorResponse {
+        match request {
+            L1EndpointMonitorRequest::EnsureOperational(node_url) => {
+                L1EndpointMonitorResponse::EnsureOperational(
+                    self.ensure_operational(node_url).await,
+                )
+            }
+        }
+    }
+}

--- a/crates/apollo_l1_endpoint_monitor/src/lib.rs
+++ b/crates/apollo_l1_endpoint_monitor/src/lib.rs
@@ -1,1 +1,2 @@
-
+pub mod communication;
+pub mod monitor;

--- a/crates/apollo_l1_endpoint_monitor/src/monitor.rs
+++ b/crates/apollo_l1_endpoint_monitor/src/monitor.rs
@@ -1,0 +1,14 @@
+use apollo_l1_endpoint_monitor_types::{L1EndpointMonitorResult, L1EndpointOperationalStatus};
+use url::Url;
+
+pub struct L1EndpointMonitor;
+
+impl L1EndpointMonitor {
+    pub async fn ensure_operational(
+        &mut self,
+        _node_url: Url,
+    ) -> L1EndpointMonitorResult<L1EndpointOperationalStatus> {
+        // TODO(Gilad): will be added soon.
+        Ok(L1EndpointOperationalStatus::Operational)
+    }
+}

--- a/crates/apollo_l1_endpoint_monitor_types/src/lib.rs
+++ b/crates/apollo_l1_endpoint_monitor_types/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use apollo_infra::component_client::ClientError;
 use apollo_infra::component_definitions::ComponentClient;
 use apollo_infra::impl_debug_for_infra_requests_and_responses;
@@ -10,6 +12,7 @@ use url::Url;
 
 pub type L1EndpointMonitorResult<T> = Result<T, L1EndpointMonitorError>;
 pub type L1EndpointMonitorClientResult<T> = Result<T, L1EndpointMonitorClientError>;
+pub type SharedL1EndpointMonitorClient = Arc<dyn L1EndpointMonitorClient>;
 
 #[async_trait]
 impl<ComponentClientType> L1EndpointMonitorClient for ComponentClientType


### PR DESCRIPTION
Client boilerplate + dummy monitor struct added in order to satisfy the
boilerplate client.