### PR TITLE
chore(apollo_consensus_orchestrator): print the tx hashes for each batch when validating

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1384,7 +1384,10 @@ async fn handle_proposal_part(
                     ));
                 }
             };
-            debug!("Converted transactions to internal representation.");
+            debug!(
+                "Converted transactions to internal representation. hashes={:?}",
+                txs.iter().map(|tx| tx.tx_hash()).collect::<Vec<TransactionHash>>()
+            );
 
             content.push(txs.clone());
             let input =


### PR DESCRIPTION
We already do this when proposing