### PR TITLE
papyrus_base_layer: monitor baselayer health through wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9389,6 +9389,7 @@ version = "0.15.0-rc.2"
 dependencies = [
  "alloy",
  "apollo_config",
+ "apollo_l1_endpoint_monitor_types",
  "assert_matches",
  "async-trait",
  "colored 3.0.0",

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -14,6 +14,7 @@ testing = ["alloy/node-bindings", "colored", "tar", "tempfile"]
 [dependencies]
 alloy = { workspace = true, features = ["contract", "json-rpc", "rpc-types"] }
 apollo_config.workspace = true
+apollo_l1_endpoint_monitor_types.workspace = true
 async-trait.workspace = true
 colored = { workspace = true, optional = true }
 ethers.workspace = true

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -15,6 +15,7 @@ use starknet_api::transaction::L1HandlerTransaction;
 
 pub mod constants;
 pub mod ethereum_base_layer_contract;
+pub mod monitored_base_layer;
 
 pub(crate) mod eth_events;
 

--- a/crates/papyrus_base_layer/src/monitored_base_layer.rs
+++ b/crates/papyrus_base_layer/src/monitored_base_layer.rs
@@ -1,0 +1,42 @@
+use apollo_l1_endpoint_monitor_types::SharedL1EndpointMonitorClient;
+use tokio::sync::Mutex;
+use url::Url;
+
+use crate::BaseLayerContract;
+
+// Using interior mutability for modifiable fields in order to comply with the base layer's
+// largely immutable API.
+pub struct MonitoredBaseLayer<B: BaseLayerContract + Send + Sync> {
+    pub monitor: SharedL1EndpointMonitorClient,
+    current_node_url: Mutex<Url>,
+    base_layer: Mutex<B>,
+}
+
+impl<B: BaseLayerContract + Send + Sync> MonitoredBaseLayer<B> {
+    // Ensures that the inner base layer remains operational (hot-swapping the inner node_url if
+    // needed), and yields the inner base layer.
+    pub async fn ensure_operational(&self) -> Result<(), MonitoredBaseLayerError> {
+        todo!(
+            "Asks the monitor what the current active L1 endpoint is (that is synced with the \
+             rest of the base layers), and modifies the inner base layer to use it if it's using \
+             a different one. "
+        )
+    }
+}
+
+// TODO(Gilad): implement BaseLayerContract for MonitoredBaseLayer so it'll be a proper wrapper for
+// the inner base_layer.
+
+impl<B: BaseLayerContract + Send + Sync + std::fmt::Debug> std::fmt::Debug
+    for MonitoredBaseLayer<B>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MonitoredBaseLayer")
+            .field("current_node_url", &self.current_node_url)
+            .field("base_layer", &self.base_layer)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MonitoredBaseLayerError {}


### PR DESCRIPTION
This wrapper is intended to wrap `EthereumBaseLayer`, so that all of its
API calls will be preempted by a health check (`ensure_operational`) of the underlying L1 node
url, hot swapping the base_layer's L1 node if the `L1EndpointMonitor`
has decided to start using a separate L1 Endpoint (e.g. infra vs
alchemy).

Requirement 1: since this health check can modify
the inner L1 node, it must only be done once, at the onset of every API
call.
In particular, inner calls of the base layer API that the base-layer calls by
itself should not trigger the health check --- otherwise, we might have a
single base-layer API call using different L1 nodes internally in
different stages of the call.
This requirement implies a wrapper, since adhering to it internally
inside the `BaseLayerContract` will complicate things too much.

Requirement 2: All base layers that subscribe to this monitoring service
(by using the wrapper instead of the raw base layer type) must agree on
a single L1 Endpoint (up to a short sync delay). Therefore, if the
monitor says that the current active L1 endpoint is different from the
one used in a given base-layer, the base layer should switch to what the
monitor stated.
In order to ensure this happens, it is handled in the wrapper logic,
making the base layer itself largely oblivious to this logic.