### PR TITLE
feat(ci): update rust toolchain version to `1.86`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85"
+channel = "1.86"
 components = ["rustc-dev"]
 profile = "default"
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
The latest stable one.
Needed for upgrading `cairo` compiler to `v2.12.0-dev.1` (together with `cairo_native` to `v0.5.0-rc.5`).