### PR TITLE
chore(blockifier): create a file dedicated to l1 handler txs

### DIFF
--- a/crates/blockifier/src/transaction.rs
+++ b/crates/blockifier/src/transaction.rs
@@ -2,6 +2,7 @@ pub mod account_transaction;
 #[cfg(test)]
 pub mod error_format_test;
 pub mod errors;
+pub mod l1_handler_transaction;
 pub mod objects;
 #[cfg(any(feature = "testing", test))]
 pub mod test_utils;

--- a/crates/blockifier/src/transaction/l1_handler_transaction.rs
+++ b/crates/blockifier/src/transaction/l1_handler_transaction.rs
@@ -1,0 +1,37 @@
+use starknet_api::executable_transaction::L1HandlerTransaction;
+use starknet_api::transaction::fields::{Fee, TransactionSignature};
+use starknet_api::transaction::TransactionVersion;
+
+use crate::transaction::objects::{
+    CommonAccountFields,
+    DeprecatedTransactionInfo,
+    HasRelatedFeeType,
+    TransactionInfo,
+    TransactionInfoCreator,
+};
+
+impl HasRelatedFeeType for L1HandlerTransaction {
+    fn version(&self) -> TransactionVersion {
+        self.tx.version
+    }
+
+    fn is_l1_handler(&self) -> bool {
+        true
+    }
+}
+
+impl TransactionInfoCreator for L1HandlerTransaction {
+    fn create_tx_info(&self) -> TransactionInfo {
+        TransactionInfo::Deprecated(DeprecatedTransactionInfo {
+            common_fields: CommonAccountFields {
+                transaction_hash: self.tx_hash,
+                version: self.tx.version,
+                signature: TransactionSignature::default(),
+                nonce: self.tx.nonce,
+                sender_address: self.tx.contract_address,
+                only_query: false,
+            },
+            max_fee: Fee::default(),
+        })
+    }
+}

--- a/crates/blockifier/src/transaction/transactions.rs
+++ b/crates/blockifier/src/transaction/transactions.rs
@@ -10,18 +10,8 @@ use starknet_api::executable_transaction::{
     InvokeTransaction,
     L1HandlerTransaction,
 };
-use starknet_api::transaction::fields::{
-    AccountDeploymentData,
-    Calldata,
-    Fee,
-    TransactionSignature,
-};
-use starknet_api::transaction::{
-    constants,
-    DeclareTransactionV2,
-    DeclareTransactionV3,
-    TransactionVersion,
-};
+use starknet_api::transaction::fields::{AccountDeploymentData, Calldata};
+use starknet_api::transaction::{constants, DeclareTransactionV2, DeclareTransactionV3};
 
 use crate::context::{BlockContext, GasCounter, TransactionContext};
 use crate::execution::call_info::CallInfo;
@@ -40,11 +30,9 @@ use crate::transaction::objects::{
     CommonAccountFields,
     CurrentTransactionInfo,
     DeprecatedTransactionInfo,
-    HasRelatedFeeType,
     TransactionExecutionInfo,
     TransactionExecutionResult,
     TransactionInfo,
-    TransactionInfoCreator,
     TransactionInfoCreatorInner,
 };
 #[cfg(test)]
@@ -115,16 +103,6 @@ pub trait ValidatableTransaction {
     ) -> TransactionExecutionResult<Option<CallInfo>>;
 }
 
-impl HasRelatedFeeType for L1HandlerTransaction {
-    fn version(&self) -> TransactionVersion {
-        self.tx.version
-    }
-
-    fn is_l1_handler(&self) -> bool {
-        true
-    }
-}
-
 impl<S: State> Executable<S> for L1HandlerTransaction {
     fn run_execute(
         &self,
@@ -156,22 +134,6 @@ impl<S: State> Executable<S> for L1HandlerTransaction {
                 selector,
             },
         )
-    }
-}
-
-impl TransactionInfoCreator for L1HandlerTransaction {
-    fn create_tx_info(&self) -> TransactionInfo {
-        TransactionInfo::Deprecated(DeprecatedTransactionInfo {
-            common_fields: CommonAccountFields {
-                transaction_hash: self.tx_hash,
-                version: self.tx.version,
-                signature: TransactionSignature::default(),
-                nonce: self.tx.nonce,
-                sender_address: self.tx.contract_address,
-                only_query: false,
-            },
-            max_fee: Fee::default(),
-        })
     }
 }
 


### PR DESCRIPTION
In this PR, we create a file called `l1_handler_transaction.rs`. This file should be parallel to `account_transaction.rs` in the same path.
In this PR we create the file and move some functions to that file.

This is towards a greater goal of creating a complete parallel between the files, and moving code out of `transactions.rs`, and later changing some business logic of L1 handler transactions.