### PR TITLE
feat(blockifier): add a cairo native flag to call info

### DIFF
--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -61,6 +61,7 @@ pub struct CallExecution {
     pub retdata: Retdata,
     pub events: Vec<OrderedEvent>,
     pub l2_to_l1_messages: Vec<OrderedL2ToL1Message>,
+    pub cairo_native: bool,
     pub failed: bool,
     pub gas_consumed: u64,
 }

--- a/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
+++ b/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
@@ -263,6 +263,7 @@ pub fn finalize_execution(
             retdata: read_execution_retdata(&runner, retdata_size, &retdata_ptr)?,
             events: syscall_handler.events,
             l2_to_l1_messages: syscall_handler.l2_to_l1_messages,
+            cairo_native: false,
             failed: false,
             gas_consumed: 0,
         },

--- a/crates/blockifier/src/execution/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/entry_point_execution.rs
@@ -420,6 +420,7 @@ pub fn finalize_execution(
             retdata: call_result.retdata,
             events: syscall_handler_base.events,
             l2_to_l1_messages: syscall_handler_base.l2_to_l1_messages,
+            cairo_native: false,
             failed: call_result.failed,
             gas_consumed: call_result.gas_consumed,
         },

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -96,6 +96,7 @@ pub fn execute_entry_point_call_wrapper(
                 call: orig_call.into(),
                 execution: CallExecution {
                     retdata: Retdata(vec![Felt::from_hex(error_code).unwrap()]),
+                    // FIXME: Should we get the `is_cairo_native` bool?
                     failed: true,
                     gas_consumed: 0,
                     ..CallExecution::default()

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -93,6 +93,7 @@ fn create_callinfo(
         execution: CallExecution {
             retdata: Retdata(call_result.return_values),
             events: syscall_handler.base.events,
+            cairo_native: true,
             l2_to_l1_messages: syscall_handler.base.l2_to_l1_messages,
             failed: call_result.failure_flag,
             gas_consumed,

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
@@ -26,6 +26,7 @@ fn no_constructor(runnable_version: RunnableCairo1) {
     let deployer_contract = FeatureContract::TestContract(CairoVersion::Cairo1(runnable_version));
     let empty_contract = FeatureContract::Empty(CairoVersion::Cairo1(runnable_version));
     let class_hash = empty_contract.get_class_hash();
+    let cairo_native = runnable_version.is_cairo_native();
 
     let mut state = test_state(
         &ChainInfo::create_for_testing(),
@@ -43,7 +44,12 @@ fn no_constructor(runnable_version: RunnableCairo1) {
     let deploy_call = &entry_point_call.execute_directly(&mut state).unwrap();
     assert_eq!(
         deploy_call.execution,
-        CallExecution { retdata: retdata![], gas_consumed: 154430, ..CallExecution::default() }
+        CallExecution {
+            retdata: retdata![],
+            gas_consumed: 154430,
+            cairo_native,
+            ..CallExecution::default()
+        }
     );
 
     let deployed_contract_address = calculate_contract_address(
@@ -97,6 +103,7 @@ fn no_constructor_nonempty_calldata(runnable_version: RunnableCairo1) {
 fn with_constructor(runnable_version: RunnableCairo1) {
     let deployer_contract = FeatureContract::TestContract(CairoVersion::Cairo1(runnable_version));
     let mut state = test_state(&ChainInfo::create_for_testing(), Fee(0), &[(deployer_contract, 1)]);
+    let cairo_native = runnable_version.is_cairo_native();
 
     let class_hash = deployer_contract.get_class_hash();
     let constructor_calldata = vec![
@@ -125,7 +132,12 @@ fn with_constructor(runnable_version: RunnableCairo1) {
 
     assert_eq!(
         deploy_call.execution,
-        CallExecution { retdata: retdata![], gas_consumed: 184610, ..CallExecution::default() }
+        CallExecution {
+            retdata: retdata![],
+            gas_consumed: 184610,
+            cairo_native,
+            ..CallExecution::default()
+        }
     );
 
     let constructor_call = &deploy_call.inner_calls[0];
@@ -138,6 +150,7 @@ fn with_constructor(runnable_version: RunnableCairo1) {
             retdata: retdata![constructor_calldata[0]],
             // This reflects the gas cost of storage write syscall.
             gas_consumed: 15140,
+            cairo_native,
             ..CallExecution::default()
         }
     );

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/emit_event.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/emit_event.rs
@@ -42,6 +42,7 @@ fn positive_flow(runnable_version: RunnableCairo1) {
         CallExecution {
             events: vec![OrderedEvent { order: 0, event }],
             gas_consumed: 41880,
+            cairo_native: runnable_version.is_cairo_native(),
             ..Default::default()
         }
     );

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_block_hash.rs
@@ -58,6 +58,7 @@ fn positive_flow(runnable_version: RunnableCairo1) {
         entry_point_call.clone().execute_directly(&mut state).unwrap().execution,
         CallExecution {
             gas_consumed: REQUIRED_GAS_GET_BLOCK_HASH_TEST,
+            cairo_native: runnable_version.is_cairo_native(),
             ..CallExecution::from_retdata(retdata![block_hash])
         }
     );

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_class_hash_at.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_class_hash_at.rs
@@ -43,6 +43,7 @@ fn test_get_class_hash_at(runnable_version: RunnableCairo1) {
         CallExecution {
             retdata: retdata!(),
             gas_consumed: REQUIRED_GAS_GET_CLASS_HASH_AT_TEST + redeposit_gas,
+            cairo_native: runnable_version.is_cairo_native(),
             failed: false,
             ..CallExecution::default()
         }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/keccak.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/keccak.rs
@@ -26,6 +26,10 @@ fn test_keccak(runnable_version: RunnableCairo1) {
 
     pretty_assertions::assert_eq!(
         entry_point_call.execute_directly(&mut state).unwrap().execution,
-        CallExecution { gas_consumed: 245767, ..CallExecution::from_retdata(retdata![]) }
+        CallExecution {
+            gas_consumed: 245767,
+            cairo_native: runnable_version.is_cairo_native(),
+            ..CallExecution::from_retdata(retdata![])
+        }
     );
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/library_call.rs
@@ -47,6 +47,7 @@ fn test_library_call(runnable_version: RunnableCairo1) {
         CallExecution {
             retdata: retdata![felt!(91_u16)],
             gas_consumed: REQUIRED_GAS_LIBRARY_CALL_TEST,
+            cairo_native: runnable_version.is_cairo_native(),
             ..Default::default()
         }
     );
@@ -85,6 +86,7 @@ fn test_library_call_assert_fails(runnable_version: RunnableCairo1) {
                 felt!("0x454e545259504f494e545f4641494c4544")
             ]),
             gas_consumed: 105050,
+            cairo_native: runnable_version.is_cairo_native(),
             failed: true,
             ..Default::default()
         }
@@ -159,6 +161,7 @@ fn test_nested_library_call(runnable_version: RunnableCairo1) {
         execution: CallExecution {
             retdata: retdata![felt!(value + 1)],
             gas_consumed: REQUIRED_GAS_STORAGE_READ_WRITE_TEST,
+            cairo_native: runnable_version.is_cairo_native(),
             ..CallExecution::default()
         },
         tracked_resource,
@@ -175,6 +178,7 @@ fn test_nested_library_call(runnable_version: RunnableCairo1) {
         execution: CallExecution {
             retdata: retdata![felt!(value + 1)],
             gas_consumed: REQUIRED_GAS_LIBRARY_CALL_TEST,
+            cairo_native: runnable_version.is_cairo_native(),
             ..CallExecution::default()
         },
         inner_calls: vec![nested_storage_call_info],
@@ -190,6 +194,7 @@ fn test_nested_library_call(runnable_version: RunnableCairo1) {
         execution: CallExecution {
             retdata: retdata![felt!(value)],
             gas_consumed: REQUIRED_GAS_STORAGE_READ_WRITE_TEST,
+            cairo_native: runnable_version.is_cairo_native(),
             ..CallExecution::default()
         },
         storage_read_values: vec![felt!(value)],
@@ -207,6 +212,7 @@ fn test_nested_library_call(runnable_version: RunnableCairo1) {
         execution: CallExecution {
             retdata: retdata![felt!(value)],
             gas_consumed: main_gas_consumed,
+            cairo_native: runnable_version.is_cairo_native(),
             ..CallExecution::default()
         },
         inner_calls: vec![library_call_info, storage_call_info],

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/out_of_gas.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/out_of_gas.rs
@@ -44,6 +44,7 @@ fn test_out_of_gas(runnable_version: RunnableCairo1) {
             gas_consumed: constants::REQUIRED_GAS_GET_BLOCK_HASH_TEST
                 - syscall_required_gas
                 - redeposit_gas,
+            cairo_native: runnable_version.is_cairo_native(),
             failed: true,
             ..Default::default()
         }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/replace_class.rs
@@ -74,7 +74,11 @@ fn positive_flow(runnable_version: RunnableCairo1) {
     };
     assert_eq!(
         entry_point_call.execute_directly(&mut state).unwrap().execution,
-        CallExecution { gas_consumed: 15920, ..Default::default() }
+        CallExecution {
+            gas_consumed: 15920,
+            cairo_native: runnable_version.is_cairo_native(),
+            ..Default::default()
+        }
     );
     assert_eq!(state.get_class_hash_at(contract_address).unwrap(), new_class_hash);
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/secp.rs
@@ -25,7 +25,11 @@ fn test_secp256k1(runnable_version: RunnableCairo1) {
 
     pretty_assertions::assert_eq!(
         entry_point_call.execute_directly(&mut state).unwrap().execution,
-        CallExecution { gas_consumed: 17011779, ..Default::default() }
+        CallExecution {
+            gas_consumed: 17011779,
+            cairo_native: runnable_version.is_cairo_native(),
+            ..Default::default()
+        }
     );
 }
 
@@ -45,6 +49,10 @@ fn test_secp256r1(runnable_version: RunnableCairo1) {
 
     pretty_assertions::assert_eq!(
         entry_point_call.execute_directly(&mut state).unwrap().execution,
-        CallExecution { gas_consumed: 27571210, ..Default::default() }
+        CallExecution {
+            gas_consumed: 27571210,
+            cairo_native: runnable_version.is_cairo_native(),
+            ..Default::default()
+        }
     );
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/send_message_to_l1.rs
@@ -48,6 +48,7 @@ fn test_send_message_to_l1(runnable_version: RunnableCairo1) {
         CallExecution {
             l2_to_l1_messages: vec![OrderedL2ToL1Message { order: 0, message }],
             gas_consumed: 30190,
+            cairo_native: runnable_version.is_cairo_native(),
             ..Default::default()
         }
     );

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/sha256.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/sha256.rs
@@ -26,6 +26,10 @@ fn test_sha256(runnable_version: RunnableCairo1) {
 
     pretty_assertions::assert_eq!(
         entry_point_call.execute_directly(&mut state).unwrap().execution,
-        CallExecution { gas_consumed: 870855, ..CallExecution::from_retdata(retdata![]) }
+        CallExecution {
+            gas_consumed: 870855,
+            cairo_native: runnable_version.is_cairo_native(),
+            ..CallExecution::from_retdata(retdata![])
+        }
     );
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/storage_read_write.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/storage_read_write.rs
@@ -34,6 +34,7 @@ fn test_storage_read_write(runnable_version: RunnableCairo1) {
         CallExecution {
             retdata: retdata![value],
             gas_consumed: REQUIRED_GAS_STORAGE_READ_WRITE_TEST,
+            cairo_native: runnable_version.is_cairo_native(),
             ..CallExecution::default()
         }
     );

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -78,6 +78,16 @@ impl Default for RunnableCairo1 {
     }
 }
 
+impl RunnableCairo1 {
+    pub fn is_cairo_native(&self) -> bool {
+        match self {
+            Self::Casm => false,
+            #[cfg(feature = "cairo_native")]
+            Self::Native => true,
+        }
+    }
+}
+
 // TODO(Aviv, 14/7/2024): Move from test utils module, and use it in ContractClassVersionMismatch
 // error.
 #[derive(Clone, Hash, PartialEq, Eq, Copy, Debug)]
@@ -110,6 +120,13 @@ impl CairoVersion {
         match self {
             Self::Cairo0 => true,
             Self::Cairo1(_) => false,
+        }
+    }
+
+    pub fn is_cairo_native(&self) -> bool {
+        match self {
+            Self::Cairo0 => false,
+            Self::Cairo1(runnable_cairo1) => runnable_cairo1.is_cairo_native(),
         }
     }
 }
@@ -157,6 +174,13 @@ impl CompilerBasedVersion {
             CompilerBasedVersion::CairoVersion(CairoVersion::Cairo1(RunnableCairo1::Casm)),
         ];
         VERSIONS.iter()
+    }
+
+    pub fn is_cairo_native(&self) -> bool {
+        match self {
+            Self::CairoVersion(version) => version.is_cairo_native(),
+            Self::OldCairo1 => false,
+        }
     }
 }
 


### PR DESCRIPTION
This commit adds a boolean flag "cairo_native" to call info. This flag is true for any entry
point executed with Cairo Native. Note that when the function `execute_entry_point_call` returns
an error there is currently no way to distinguish between Cairo VM execution and Cairo Native
execution, hence the function `execute_entry_point_call_wrapper` - which handles these cases -
applies the default value to the flag "cairo_native" setting it to false.
