### PR TITLE
chore(papyrus_base_layer): change `MessageToL2CancellationStarted` inner

### DIFF
--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -192,8 +192,8 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
                     .map_err(L1ScraperError::HashCalculationError)?;
                 Event::L1HandlerTransaction(tx)
             }
-            L1Event::MessageToL2CancellationStarted(event_data) => {
-                Event::TransactionCancellationStarted(event_data)
+            L1Event::MessageToL2CancellationStarted { .. } => {
+                todo!()
             }
             L1Event::MessageToL2Canceled(event_data) => Event::TransactionCanceled(event_data),
             L1Event::ConsumedMessageToL2(event_data) => Event::TransactionConsumed(event_data),


### PR DESCRIPTION
`MessageToL2CancellationStarted` is mapped to a corresponding
SendMessageToL2 transaction (L1HandlerTransaction) by calculating the tx
hash. This is done later down the pipeline when we convert the current
L1 type into an L2 type. For now lets convert the type to a Starknet API
L1HandlerTransaction, which represents an "external" transaction, and
add the tx_hash calculation when converting into an inner type later on.