### PR TITLE
refactor(apollo_l1_provider): convert method to function

### DIFF
--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -16,8 +16,6 @@ use papyrus_base_layer::constants::EventIdentifier;
 use papyrus_base_layer::{BaseLayerContract, L1BlockNumber, L1BlockReference, L1Event};
 use serde::{Deserialize, Serialize};
 use starknet_api::core::ChainId;
-use starknet_api::executable_transaction::L1HandlerTransaction as ExecutableL1HandlerTransaction;
-use starknet_api::transaction::TransactionHasher;
 use starknet_api::StarknetApiError;
 use thiserror::Error;
 use tokio::time::sleep;
@@ -136,7 +134,10 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
 
         let events = l1_events
             .into_iter()
-            .map(|event| self.event_from_raw_l1_event(event))
+            .map(|event| {
+                Event::from_l1_event(&self.config.chain_id, event)
+                    .map_err(L1ScraperError::HashCalculationError)
+            })
             .collect::<L1ScraperResult<Vec<_>, _>>()?;
 
         // Used for debug.
@@ -183,26 +184,6 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
                 Err(e) => return Err(e),
             }
         }
-    }
-
-    fn event_from_raw_l1_event(&self, l1_event: L1Event) -> L1ScraperResult<Event, B> {
-        let chain_id = &self.config.chain_id;
-        Ok(match l1_event {
-            L1Event::LogMessageToL2 { tx, fee, .. } => {
-                let tx = ExecutableL1HandlerTransaction::create(tx, chain_id, fee)
-                    .map_err(L1ScraperError::HashCalculationError)?;
-                Event::L1HandlerTransaction(tx)
-            }
-            L1Event::MessageToL2CancellationStarted { cancelled_tx } => {
-                let tx_hash = cancelled_tx
-                    .calculate_transaction_hash(chain_id, &cancelled_tx.version)
-                    .map_err(L1ScraperError::HashCalculationError)?;
-
-                Event::TransactionCancellationStarted(tx_hash)
-            }
-            L1Event::MessageToL2Canceled(event_data) => Event::TransactionCanceled(event_data),
-            L1Event::ConsumedMessageToL2(event_data) => Event::TransactionConsumed(event_data),
-        })
     }
 
     async fn assert_no_l1_reorgs(&self) -> L1ScraperResult<(), B> {


### PR DESCRIPTION
Only MOVE, no logic changes.
Made into a function for testability later, also this is general enough
in order to be decoupled -- from the scraper itself.