### PR TITLE
chore(apollo_l1_provider): add config for cancellation timelock

### DIFF
--- a/config/sequencer/base_app_config.json
+++ b/config/sequencer/base_app_config.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 1,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/default_config.json
+++ b/config/sequencer/default_config.json
@@ -1249,6 +1249,11 @@
     "privacy": "TemporaryValue",
     "value": true
   },
+  "l1_provider_config.cancellation_timelock_in_blocks": {
+    "description": "How many blocks the provider should wait before attempting to cancel a message.",
+    "privacy": "Public",
+    "value": 0
+  },
   "l1_provider_config.provider_startup_height_override": {
     "description": "Override height at which the provider should start",
     "privacy": "Public",

--- a/config/sequencer/presets/system_test_presets/single_node/node_0/executable_0/node_config.json
+++ b/config/sequencer/presets/system_test_presets/single_node/node_0/executable_0/node_config.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 0,
   "l1_provider_config.provider_startup_height_override": 1,
   "l1_provider_config.provider_startup_height_override.#is_none": false,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 0.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/core.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/gateway.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/http_server.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/mempool.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/sierra_compiler.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_0/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/core.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/gateway.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/http_server.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/mempool.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/sierra_compiler.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_1/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/core.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/gateway.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/http_server.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/mempool.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/sierra_compiler.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_2/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/core.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/gateway.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/http_server.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/mempool.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/sierra_compiler.json
+++ b/config/sequencer/sepolia_integration/app_configs/hybrid/integration_hybrid_node_3/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/consolidated/deployment_test_consolidated/node.json
+++ b/config/sequencer/testing/app_configs/consolidated/deployment_test_consolidated/node.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/batcher.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/batcher.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/class_manager.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/class_manager.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/consensus_manager.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/consensus_manager.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/gateway.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/http_server.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/l1.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/l1.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/mempool.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/sierra_compiler.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/state_sync.json
+++ b/config/sequencer/testing/app_configs/distributed/deployment_test_distributed/state_sync.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/core.json
+++ b/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/gateway.json
+++ b/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/http_server.json
+++ b/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/mempool.json
+++ b/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/sierra_compiler.json
+++ b/config/sequencer/testing/app_configs/hybrid/deployment_test_hybrid/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/core.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/gateway.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/http_server.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/mempool.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/sierra_compiler.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_0/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/core.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/gateway.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/http_server.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/mempool.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/sierra_compiler.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_1/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/core.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/gateway.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/http_server.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/mempool.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/sierra_compiler.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_2/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/core.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/gateway.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/http_server.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/mempool.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/sierra_compiler.json
+++ b/config/sequencer/testing_env_2/app_configs/hybrid/integration_hybrid_node_3/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/core.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/gateway.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/http_server.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/mempool.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/sierra_compiler.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_0/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/core.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/gateway.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/http_server.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/mempool.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/sierra_compiler.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_1/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/core.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/gateway.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/http_server.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/mempool.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/sierra_compiler.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_2/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/core.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/core.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/gateway.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/gateway.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/http_server.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/http_server.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/mempool.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/mempool.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/sierra_compiler.json
+++ b/config/sequencer/testing_env_3/app_configs/hybrid/integration_hybrid_node_3/sierra_compiler.json
@@ -227,6 +227,7 @@
   "l1_gas_price_scraper_config.starting_block.#is_none": true,
   "l1_provider_config.bootstrap_catch_up_height_override": 0,
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
+  "l1_provider_config.cancellation_timelock_in_blocks": 150,
   "l1_provider_config.provider_startup_height_override": 0,
   "l1_provider_config.provider_startup_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,

--- a/crates/apollo_l1_provider/src/lib.rs
+++ b/crates/apollo_l1_provider/src/lib.rs
@@ -106,16 +106,26 @@ pub struct L1ProviderConfig {
     pub bootstrap_catch_up_height_override: Option<BlockNumber>,
     #[serde(deserialize_with = "deserialize_float_seconds_to_duration")]
     pub startup_sync_sleep_retry_interval_seconds: Duration,
+    /// How many blocks the provider should wait before attempting to cancel a message.
+    pub cancellation_timelock_in_blocks: BlockNumber,
 }
 
 impl SerializeConfig for L1ProviderConfig {
     fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
-        let mut dump = BTreeMap::from([ser_param(
-            "startup_sync_sleep_retry_interval_seconds",
-            &self.startup_sync_sleep_retry_interval_seconds.as_secs_f64(),
-            "Interval in seconds between each retry of syncing with L2 during startup.",
-            ParamPrivacyInput::Public,
-        )]);
+        let mut dump = BTreeMap::from([
+            ser_param(
+                "startup_sync_sleep_retry_interval_seconds",
+                &self.startup_sync_sleep_retry_interval_seconds.as_secs_f64(),
+                "Interval in seconds between each retry of syncing with L2 during startup.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "cancellation_timelock_in_blocks",
+                &self.cancellation_timelock_in_blocks,
+                "How many blocks the provider should wait before attempting to cancel a message.",
+                ParamPrivacyInput::Public,
+            ),
+        ]);
 
         dump.extend(ser_optional_param(
             &self.provider_startup_height_override,


### PR DESCRIPTION
Cancellation requests (which we'll add later) are timelocked in the
provider for what will likely be ~5 minutes, in order to ensure all
nodes have ample time to process the cancellation.
(This timelock is applied independently from the 5 _day_ timelock
applied on L1 for cancellation requests, which is done to prevent DOS
attacks.)
