### PR TITLE
fix(apollo_network): improve peer connection metrics accuracy

### DIFF
--- a/crates/apollo_network/src/network_manager/mod.rs
+++ b/crates/apollo_network/src/network_manager/mod.rs
@@ -269,13 +269,22 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         event: SwarmEvent<mixed_behaviour::Event>,
     ) -> Result<(), NetworkError> {
         match event {
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+            SwarmEvent::ConnectionEstablished { peer_id, num_established, .. } => {
                 debug!("Connected to peer id: {peer_id:?}");
                 if let Some(metrics) = self.metrics.as_ref() {
-                    metrics.num_connected_peers.increment(1);
+                    // We increment the count of connected peers only if this is the first
+                    // connection with the peer.
+                    if num_established.get() == 1 {
+                        metrics.num_connected_peers.increment(1);
+                    }
                 }
             }
-            SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+            SwarmEvent::ConnectionClosed {
+                peer_id,
+                cause,
+                num_established: num_remaining_connections,
+                ..
+            } => {
                 match cause {
                     Some(connection_error) => {
                         debug!("Connection to {peer_id:?} closed due to {connection_error:?}.")
@@ -283,7 +292,11 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
                     None => debug!("Connection to {peer_id:?} closed."),
                 }
                 if let Some(metrics) = self.metrics.as_ref() {
-                    metrics.num_connected_peers.decrement(1);
+                    // We decrement the count of connected peers only if there are no more
+                    // connections with the peer.
+                    if num_remaining_connections == 0 {
+                        metrics.num_connected_peers.decrement(1);
+                    }
                 }
             }
             SwarmEvent::Behaviour(event) => {


### PR DESCRIPTION
Updates connection event handling to increment or decrement the connected peers metric only when the first connection is established or the last connection is closed with a peer.