### PR TITLE
feat(blockifier): move end-chunk logic from scheduler.rs to worker_logic.rs

### DIFF
--- a/crates/blockifier/src/blockifier/transaction_executor.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor.rs
@@ -315,9 +315,8 @@ impl<S: StateReader + Send + Sync> TransactionExecutor<S> {
                         let abort_guard = AbortIfPanic;
                         // If a panic is not handled or the handling logic itself panics, then we
                         // abort the program.
-                        if let Err(err) = catch_unwind(AssertUnwindSafe(|| {
-                            worker_executor.run();
-                        })) {
+                        let res = catch_unwind(AssertUnwindSafe(|| { worker_executor.run(); }));
+                        if let Err(err) = res {
                             // If the program panics here, the abort guard will exit the program.
                             // In this case, no panic message will be logged. Add the cargo flag
                             // --nocapture to log the panic message.

--- a/crates/blockifier/src/concurrency/flow_test.rs
+++ b/crates/blockifier/src/concurrency/flow_test.rs
@@ -25,7 +25,7 @@ fn scheduler_flow_test(
     // transactions with multiple threads, where every transaction depends on its predecessor. Each
     // transaction sequentially advances a counter by reading the previous value and bumping it by
     // 1.
-    let scheduler = Arc::new(Scheduler::new(DEFAULT_CHUNK_SIZE));
+    let scheduler = Arc::new(Scheduler::new());
     let versioned_state =
         safe_versioned_state_for_testing(CachedState::from(DictStateReader::default()));
     let mut handles = vec![];
@@ -50,6 +50,10 @@ fn scheduler_flow_test(
                             );
                             state_proxy.apply_writes(&new_writes, &ContractClassMapping::default());
                             scheduler.finish_execution_during_commit(tx_index);
+                        }
+                        if tx_index == DEFAULT_CHUNK_SIZE - 1 {
+                            scheduler.halt();
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
**Stack**:
- #6519 ⬅
- #6490
- #6489


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*