### PR TITLE
chore(blockifier): readablity refactor in receipt creation in l1 handler

### DIFF
--- a/crates/blockifier/src/transaction/l1_handler_transaction.rs
+++ b/crates/blockifier/src/transaction/l1_handler_transaction.rs
@@ -70,7 +70,7 @@ impl<U: UpdatableState> ExecutableTransaction<U> for L1HandlerTransaction {
         );
         let execute_call_info = self.run_execute(state, &mut context, &mut remaining_gas)?;
         let l1_handler_payload_size = self.payload_size();
-        let receipt = TransactionReceipt::from_l1_handler(
+        let mut receipt = TransactionReceipt::from_l1_handler(
             &tx_context,
             l1_handler_payload_size,
             CallInfo::summarize_many(execute_call_info.iter(), &block_context.versioned_constants),
@@ -89,16 +89,12 @@ impl<U: UpdatableState> ExecutableTransaction<U> for L1HandlerTransaction {
             ));
         }
 
+        receipt.fee = Fee(0);
         Ok(TransactionExecutionInfo {
             validate_call_info: None,
             execute_call_info,
             fee_transfer_call_info: None,
-            receipt: TransactionReceipt {
-                fee: Fee::default(),
-                da_gas: receipt.da_gas,
-                resources: receipt.resources,
-                gas: receipt.gas,
-            },
+            receipt,
             revert_error: None,
         })
     }


### PR DESCRIPTION
I looked at the history. There is no reason not to clean this up a bit:
I got back into looking in the [blockfier repo](https://github.com/starkware-libs/blockifier/commit/99527a30202264556d100fd41589a1f22f4abdb4)