### PR TITLE
feat(blockifier): remove lifetime from WorkerExecutor

### DIFF
--- a/crates/blockifier/src/blockifier/transaction_executor.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor.rs
@@ -1,6 +1,6 @@
 use std::mem;
 use std::panic::{self, catch_unwind, AssertUnwindSafe};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
 
 use apollo_infra_utils::tracing::LogCompatibleToStringExt;
@@ -58,8 +58,8 @@ pub struct BlockExecutionSummary {
 
 /// A transaction executor, used for building a single block.
 pub struct TransactionExecutor<S: StateReader> {
-    pub block_context: BlockContext,
-    pub bouncer: Bouncer,
+    pub block_context: Arc<BlockContext>,
+    pub bouncer: Arc<Mutex<Bouncer>>,
     // Note: this config must not affect the execution result (e.g. state diff and traces).
     pub config: TransactionExecutorConfig,
 
@@ -99,8 +99,8 @@ impl<S: StateReader> TransactionExecutor<S> {
         // Note: the state might not be empty even at this point; it is the creator's
         // responsibility to tune the bouncer according to pre and post block process.
         Self {
-            block_context,
-            bouncer: Bouncer::new(bouncer_config),
+            block_context: block_context.into(),
+            bouncer: Mutex::new(Bouncer::new(bouncer_config)).into(),
             config,
             block_state: Some(block_state),
         }
@@ -125,7 +125,7 @@ impl<S: StateReader> TransactionExecutor<S> {
             Ok(tx_execution_info) => {
                 let state_diff = transactional_state.to_state_diff()?.state_maps;
                 let tx_state_changes_keys = state_diff.keys();
-                self.bouncer.try_update(
+                lock_bouncer(&mut self.bouncer).try_update(
                     &transactional_state,
                     &tx_state_changes_keys,
                     &tx_execution_info.summarize(&self.block_context.versioned_constants),
@@ -179,7 +179,10 @@ impl<S: StateReader> TransactionExecutor<S> {
     }
 
     fn internal_finalize(&mut self) -> TransactionExecutorResult<BlockExecutionSummary> {
-        log::debug!("Final block weights: {:?}.", self.bouncer.get_accumulated_weights());
+        log::debug!(
+            "Final block weights: {:?}.",
+            lock_bouncer(&mut self.bouncer).get_accumulated_weights()
+        );
         let block_state = self.block_state.as_mut().expect(BLOCK_STATE_ACCESS_ERR);
         let alias_contract_address = self
             .block_context
@@ -197,13 +200,19 @@ impl<S: StateReader> TransactionExecutor<S> {
             } else {
                 None
             };
+
+        let mut bouncer = lock_bouncer(&mut self.bouncer);
         Ok(BlockExecutionSummary {
             state_diff: state_diff.into(),
             compressed_state_diff,
-            bouncer_weights: *self.bouncer.get_accumulated_weights(),
-            casm_hash_computation_data: mem::take(&mut self.bouncer.casm_hash_computation_data),
+            bouncer_weights: *bouncer.get_accumulated_weights(),
+            casm_hash_computation_data: mem::take(&mut bouncer.casm_hash_computation_data),
         })
     }
+}
+
+fn lock_bouncer(bouncer: &mut Arc<Mutex<Bouncer>>) -> MutexGuard<'_, Bouncer> {
+    bouncer.lock().expect("Bouncer lock failed.")
 }
 
 impl<S: StateReader + Send + Sync> TransactionExecutor<S> {
@@ -300,9 +309,12 @@ impl<S: StateReader + Send + Sync> TransactionExecutor<S> {
 
         let worker_executor = Arc::new(WorkerExecutor::initialize(
             block_state,
-            chunk,
-            &self.block_context,
-            Mutex::new(&mut self.bouncer),
+            // We need to clone the transactions so that ownership can be shared between threads,
+            // that will live longer than the current function.
+            // TODO(lior): Move the transactions instead of cloning them.
+            chunk.to_vec(),
+            self.block_context.clone(),
+            self.bouncer.clone(),
             execution_deadline,
         ));
 

--- a/crates/blockifier/src/blockifier/transaction_executor_test.rs
+++ b/crates/blockifier/src/blockifier/transaction_executor_test.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use assert_matches::assert_matches;
 use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
 use blockifier_test_utils::calldata::create_calldata;
@@ -58,7 +60,8 @@ fn tx_executor_test_body<S: StateReader>(
     // should not be added, rename the test to `test_bouncer_info`.
     // TODO(Arni, 30/03/2024): Test all bouncer weights.
     let _tx_execution_output = tx_executor.execute(&tx).unwrap();
-    let bouncer_weights = tx_executor.bouncer.get_accumulated_weights();
+    let bouncer = tx_executor.bouncer.lock().unwrap();
+    let bouncer_weights = bouncer.get_accumulated_weights();
     assert_eq!(bouncer_weights.state_diff_size, expected_bouncer_weights.state_diff_size);
     assert_eq!(
         bouncer_weights.message_segment_length,
@@ -280,7 +283,7 @@ fn test_bouncing(#[case] initial_bouncer_weights: BouncerWeights, #[case] n_even
     let mut tx_executor =
         TransactionExecutor::new(state, block_context, TransactionExecutorConfig::default());
 
-    tx_executor.bouncer.set_accumulated_weights(initial_bouncer_weights);
+    tx_executor.bouncer.lock().unwrap().set_accumulated_weights(initial_bouncer_weights);
 
     tx_executor
         .execute(
@@ -361,7 +364,8 @@ fn test_execute_txs_bouncing(#[values(true, false)] concurrency_enabled: bool) {
     assert_eq!(remaining_tx_results.len(), 0);
 
     // Reset the bouncer and add the remaining transactions.
-    tx_executor.bouncer = Bouncer::new(tx_executor.block_context.bouncer_config.clone());
+    tx_executor.bouncer =
+        Mutex::new(Bouncer::new(tx_executor.block_context.bouncer_config.clone())).into();
     let remaining_tx_results = tx_executor.execute_txs(remaining_txs, None);
 
     assert_eq!(remaining_tx_results.len(), 2);

--- a/crates/blockifier/src/concurrency/worker_logic_test.rs
+++ b/crates/blockifier/src/concurrency/worker_logic_test.rs
@@ -98,12 +98,16 @@ pub fn test_commit_tx() {
     .into_iter()
     .map(Transaction::Account)
     .collect::<Vec<Transaction>>();
-    let mut bouncer = Bouncer::new(block_context.bouncer_config.clone());
+    let bouncer = Bouncer::new(block_context.bouncer_config.clone());
     let cached_state =
         test_state(&block_context.chain_info, BALANCE, &[(account, 1), (test_contract, 1)]);
     let versioned_state = safe_versioned_state_for_testing(cached_state);
-    let executor =
-        WorkerExecutor::new(versioned_state, &txs, &block_context, Mutex::new(&mut bouncer));
+    let executor = WorkerExecutor::new(
+        versioned_state,
+        txs.to_vec(),
+        block_context.into(),
+        Mutex::new(bouncer).into(),
+    );
 
     // Execute transactions.
     // Simulate a concurrent run by executing tx1 before tx0.
@@ -200,15 +204,15 @@ fn test_commit_tx_when_sender_is_sequencer() {
         nonce!(0_u8),
     ))];
 
-    let mut bouncer = Bouncer::new(block_context.bouncer_config.clone());
+    let bouncer = Bouncer::new(block_context.bouncer_config.clone());
 
     let state = test_state(&block_context.chain_info, BALANCE, &[(account, 1), (test_contract, 1)]);
     let versioned_state = safe_versioned_state_for_testing(state);
     let executor = WorkerExecutor::new(
         versioned_state,
-        &sequencer_tx,
-        &block_context,
-        Mutex::new(&mut bouncer),
+        sequencer_tx.to_vec(),
+        block_context.into(),
+        Mutex::new(bouncer).into(),
     );
     let tx_index = 0;
     let tx_versioned_state = executor.state.pin_version(tx_index);
@@ -315,12 +319,12 @@ fn test_worker_execute(default_all_resource_bounds: ValidResourceBounds) {
         .map(Transaction::Account)
         .collect::<Vec<Transaction>>();
 
-    let mut bouncer = Bouncer::new(block_context.bouncer_config.clone());
+    let bouncer = Bouncer::new(block_context.bouncer_config.clone());
     let worker_executor = WorkerExecutor::new(
         safe_versioned_state.clone(),
-        &txs,
-        &block_context,
-        Mutex::new(&mut bouncer),
+        txs.to_vec(),
+        block_context.into(),
+        Mutex::new(bouncer).into(),
     );
 
     // Creates 3 execution active tasks.
@@ -475,12 +479,12 @@ fn test_worker_validate(default_all_resource_bounds: ValidResourceBounds) {
         .map(Transaction::Account)
         .collect::<Vec<Transaction>>();
 
-    let mut bouncer = Bouncer::new(block_context.bouncer_config.clone());
+    let bouncer = Bouncer::new(block_context.bouncer_config.clone());
     let worker_executor = WorkerExecutor::new(
         safe_versioned_state.clone(),
-        &txs,
-        &block_context,
-        Mutex::new(&mut bouncer),
+        txs.to_vec(),
+        block_context.into(),
+        Mutex::new(bouncer).into(),
     );
 
     // Creates 2 active tasks.
@@ -587,9 +591,13 @@ fn test_deploy_before_declare(
     let txs =
         [declare_tx, invoke_tx].into_iter().map(Transaction::Account).collect::<Vec<Transaction>>();
 
-    let mut bouncer = Bouncer::new(block_context.bouncer_config.clone());
-    let worker_executor =
-        WorkerExecutor::new(safe_versioned_state, &txs, &block_context, Mutex::new(&mut bouncer));
+    let bouncer = Bouncer::new(block_context.bouncer_config.clone());
+    let worker_executor = WorkerExecutor::new(
+        safe_versioned_state,
+        txs.to_vec(),
+        block_context.into(),
+        Mutex::new(bouncer).into(),
+    );
 
     // Creates 2 active tasks.
     worker_executor.scheduler.next_task();
@@ -660,9 +668,13 @@ fn test_worker_commit_phase(default_all_resource_bounds: ValidResourceBounds) {
         })
         .collect::<Vec<Transaction>>();
 
-    let mut bouncer = Bouncer::new(block_context.bouncer_config.clone());
-    let worker_executor =
-        WorkerExecutor::new(safe_versioned_state, &txs, &block_context, Mutex::new(&mut bouncer));
+    let bouncer = Bouncer::new(block_context.bouncer_config.clone());
+    let worker_executor = WorkerExecutor::new(
+        safe_versioned_state,
+        txs.to_vec(),
+        block_context.into(),
+        Mutex::new(bouncer).into(),
+    );
 
     // Try to commit before any transaction is ready.
     worker_executor.commit_while_possible();
@@ -751,9 +763,13 @@ fn test_worker_commit_phase_with_halt() {
         })
         .collect::<Vec<Transaction>>();
 
-    let mut bouncer = Bouncer::new(block_context.bouncer_config.clone());
-    let worker_executor =
-        WorkerExecutor::new(safe_versioned_state, &txs, &block_context, Mutex::new(&mut bouncer));
+    let bouncer = Bouncer::new(block_context.bouncer_config.clone());
+    let worker_executor = WorkerExecutor::new(
+        safe_versioned_state,
+        txs.to_vec(),
+        block_context.into(),
+        Mutex::new(bouncer).into(),
+    );
 
     // Creates 2 active tasks.
     // Creating these tasks changes the status of both transactions to `Executing`. If we skip this


### PR DESCRIPTION
This will allow using it in threads that will live longer than the block.

---

**Stack**:
- #6569
- #6564
- #6603
- #6563
- #6562
- #6544 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*