### PR TITLE
chore(apollo_l1_provider): switch committed `HashSet`->`IndexSet`

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -578,11 +578,7 @@ impl Batcher {
 
         let l1_provider_result = self
             .l1_provider_client
-            .commit_block(
-                consumed_l1_handler_tx_hashes.iter().copied().collect(),
-                rejected_l1_handler_tx_hashes,
-                height,
-            )
+            .commit_block(consumed_l1_handler_tx_hashes, rejected_l1_handler_tx_hashes, height)
             .await;
 
         // Return error if the commit to the L1 provider failed.

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use apollo_batcher_types::batcher_types::{
@@ -236,7 +236,7 @@ async fn start_batcher_with_active_validate(
     batcher
 }
 
-fn test_tx_hashes() -> HashSet<TransactionHash> {
+fn test_tx_hashes() -> IndexSet<TransactionHash> {
     (0..5u8).map(|i| tx_hash!(i + 12)).collect()
 }
 
@@ -819,7 +819,7 @@ async fn proposal_startup_failure_allows_new_proposals() {
 async fn add_sync_block() {
     let recorder = PrometheusBuilder::new().build_recorder();
     let _recorder_guard = metrics::set_default_local_recorder(&recorder);
-    let l1_transaction_hashes: Vec<_> = test_tx_hashes().into_iter().collect();
+    let l1_transaction_hashes = test_tx_hashes();
     let mut mock_dependencies = MockDependencies::default();
 
     mock_dependencies
@@ -856,7 +856,7 @@ async fn add_sync_block() {
             ..Default::default()
         },
         state_diff: test_state_diff(),
-        l1_transaction_hashes,
+        l1_transaction_hashes: l1_transaction_hashes.into_iter().collect(),
         ..Default::default()
     };
     batcher.add_sync_block(sync_block).await.unwrap();
@@ -984,7 +984,7 @@ async fn decision_reached() {
         .l1_provider_client
         .expect_commit_block()
         .times(1)
-        .with(eq(vec![]), eq(IndexSet::new()), eq(INITIAL_HEIGHT))
+        .with(eq(IndexSet::new()), eq(IndexSet::new()), eq(INITIAL_HEIGHT))
         .returning(|_, _, _| Ok(()));
 
     mock_dependencies

--- a/crates/apollo_l1_provider/src/bootstrapper.rs
+++ b/crates/apollo_l1_provider/src/bootstrapper.rs
@@ -6,6 +6,7 @@ use apollo_batcher_types::batcher_types::GetHeightResponse;
 use apollo_batcher_types::communication::SharedBatcherClient;
 use apollo_l1_provider_types::SharedL1ProviderClient;
 use apollo_state_sync_types::communication::SharedStateSyncClient;
+use indexmap::IndexSet;
 use starknet_api::block::BlockNumber;
 use starknet_api::transaction::TransactionHash;
 use tokio::sync::OnceCell;
@@ -70,7 +71,7 @@ impl Bootstrapper {
 
     pub fn add_commit_block_to_backlog(
         &mut self,
-        committed_txs: &[TransactionHash],
+        committed_txs: &IndexSet<TransactionHash>,
         height: BlockNumber,
     ) {
         assert!(
@@ -81,7 +82,7 @@ impl Bootstrapper {
         );
 
         self.commit_block_backlog
-            .push(CommitBlockBacklog { height, committed_txs: committed_txs.to_vec() });
+            .push(CommitBlockBacklog { height, committed_txs: committed_txs.clone() });
     }
 
     /// Spawns async task that produces and sends commit block messages to the provider, according
@@ -194,7 +195,7 @@ async fn l2_sync_task(
 
                 l1_provider_client
                     .commit_block(
-                        block.l1_transaction_hashes,
+                        block.l1_transaction_hashes.into_iter().collect(),
                         l1_handler_rejected_tx_hashes,
                         current_height,
                     )
@@ -210,7 +211,7 @@ async fn l2_sync_task(
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CommitBlockBacklog {
     pub height: BlockNumber,
-    pub committed_txs: Vec<TransactionHash>,
+    pub committed_txs: IndexSet<TransactionHash>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/apollo_l1_provider/src/l1_provider_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_provider_tests.rs
@@ -29,7 +29,7 @@ fn commit_block_no_rejected(
     txs: &[TransactionHash],
     block_number: BlockNumber,
 ) {
-    l1_provider.commit_block(txs, &[].into(), block_number).unwrap();
+    l1_provider.commit_block(&txs.iter().copied().collect(), &[].into(), block_number).unwrap();
 }
 
 fn setup_rejected_transactions() -> L1Provider {
@@ -50,7 +50,9 @@ fn setup_rejected_transactions() -> L1Provider {
     // Commit block with rejected transactions.
     let consumed_txs = [tx1, tx2];
     let rejected_txs = [tx1];
-    l1_provider.commit_block(&consumed_txs, &rejected_txs.into(), first_block_number).unwrap();
+    l1_provider
+        .commit_block(&consumed_txs.into(), &rejected_txs.into(), first_block_number)
+        .unwrap();
 
     // Set the state to Validate for the validation tests.
     l1_provider.state = ProviderState::Validate;
@@ -63,7 +65,7 @@ macro_rules! bootstrapper {
             commit_block_backlog: vec![
                 $(CommitBlockBacklog {
                     height: BlockNumber($height),
-                    committed_txs: vec![$(tx_hash!($tx)),*]
+                    committed_txs: [$(tx_hash!($tx)),*].into()
                 }),*
             ].into_iter().collect(),
             catch_up_height: Arc::new(BlockNumber($catch).into()),
@@ -385,7 +387,7 @@ fn bootstrap_commit_block_received_twice_error_if_new_uncommitted_txs() {
     // Error, since the new tx hash is not known to be committed.
     assert_matches!(
         l1_provider
-            .commit_block(&[tx_hash!(1), tx_hash!(3)], &[].into(), BlockNumber(0))
+            .commit_block(&[tx_hash!(1), tx_hash!(3)].into(), &[].into(), BlockNumber(0))
             .unwrap_err(),
         L1ProviderError::UnexpectedHeight { expected_height: BlockNumber(1), got: BlockNumber(0) }
     );

--- a/crates/apollo_l1_provider/src/test_utils.rs
+++ b/crates/apollo_l1_provider/src/test_utils.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::mem;
 use std::sync::Mutex;
 
@@ -128,7 +127,7 @@ impl L1ProviderContentBuilder {
 struct TransactionManagerContent {
     pub uncommitted: Option<Vec<L1HandlerTransaction>>,
     pub rejected: Option<Vec<L1HandlerTransaction>>,
-    pub committed: Option<HashSet<TransactionHash>>,
+    pub committed: Option<IndexSet<TransactionHash>>,
 }
 
 impl TransactionManagerContent {
@@ -169,7 +168,7 @@ impl From<TransactionManagerContent> for TransactionManager {
 struct TransactionManagerContentBuilder {
     uncommitted: Option<Vec<L1HandlerTransaction>>,
     rejected: Option<Vec<L1HandlerTransaction>>,
-    committed: Option<HashSet<TransactionHash>>,
+    committed: Option<IndexSet<TransactionHash>>,
 }
 
 impl TransactionManagerContentBuilder {
@@ -258,7 +257,7 @@ impl L1ProviderClient for FakeL1ProviderClient {
 
     async fn commit_block(
         &self,
-        l1_handler_tx_hashes: Vec<TransactionHash>,
+        l1_handler_tx_hashes: IndexSet<TransactionHash>,
         _rejected_l1_handler_tx_hashes: IndexSet<TransactionHash>,
         height: BlockNumber,
     ) -> L1ProviderClientResult<()> {

--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -1,7 +1,5 @@
-use std::collections::HashSet;
-
 use apollo_l1_provider_types::{InvalidValidationStatus, ValidationStatus};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use starknet_api::executable_transaction::L1HandlerTransaction;
 use starknet_api::transaction::TransactionHash;
 
@@ -11,7 +9,7 @@ use crate::soft_delete_index_map::SoftDeleteIndexMap;
 pub struct TransactionManager {
     pub uncommitted: SoftDeleteIndexMap,
     pub rejected: SoftDeleteIndexMap,
-    pub committed: HashSet<TransactionHash>,
+    pub committed: IndexSet<TransactionHash>,
 }
 
 impl TransactionManager {
@@ -103,7 +101,7 @@ impl TransactionManager {
         self.uncommitted.insert(tx)
     }
 
-    pub fn committed_includes(&self, tx_hashes: &[TransactionHash]) -> bool {
-        tx_hashes.iter().all(|tx| self.committed.contains(tx))
+    pub fn committed_includes(&self, tx_hashes: &IndexSet<TransactionHash>) -> bool {
+        self.committed.is_superset(tx_hashes)
     }
 }

--- a/crates/apollo_l1_provider_types/src/lib.rs
+++ b/crates/apollo_l1_provider_types/src/lib.rs
@@ -47,7 +47,7 @@ pub enum InvalidValidationStatus {
 pub enum L1ProviderRequest {
     AddEvents(Vec<Event>),
     CommitBlock {
-        l1_handler_tx_hashes: Vec<TransactionHash>,
+        l1_handler_tx_hashes: IndexSet<TransactionHash>,
         rejected_tx_hashes: IndexSet<TransactionHash>,
         height: BlockNumber,
     },
@@ -105,7 +105,7 @@ pub trait L1ProviderClient: Send + Sync {
 
     async fn commit_block(
         &self,
-        l1_handler_consumed_tx_hashes: Vec<TransactionHash>,
+        l1_handler_consumed_tx_hashes: IndexSet<TransactionHash>,
         l1_handler_rejected_tx_hashes: IndexSet<TransactionHash>,
         height: BlockNumber,
     ) -> L1ProviderClientResult<()>;
@@ -169,7 +169,7 @@ where
 
     async fn commit_block(
         &self,
-        l1_handler_tx_hashes: Vec<TransactionHash>,
+        l1_handler_tx_hashes: IndexSet<TransactionHash>,
         rejected_tx_hashes: IndexSet<TransactionHash>,
         height: BlockNumber,
     ) -> L1ProviderClientResult<()> {


### PR DESCRIPTION
For consistency with rejected hashes.

Note: batcher treats both committed and rejected as a Set, whereas
SyncBlocks consider committed as a list (like committed used to be in
the provider/batcher).

Note: It no longer makes sense to pass this with a reference, since
there is no deref. Currently keeping it for consistency with rejected.
Will both have their refs removed soon.