### PR TITLE
refactor(apollo_mempool): extract Clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "apollo_network",
  "apollo_network_types",
  "apollo_test_utils",
+ "apollo_time",
  "assert_matches",
  "async-trait",
  "derive_more 0.99.18",

--- a/crates/apollo_mempool/Cargo.toml
+++ b/crates/apollo_mempool/Cargo.toml
@@ -20,6 +20,7 @@ apollo_metrics.workspace = true
 apollo_network_types.workspace = true
 async-trait.workspace = true
 derive_more.workspace = true
+apollo_time.workspace = true
 serde.workspace = true
 starknet_api.workspace = true
 strum.workspace = true
@@ -34,6 +35,7 @@ apollo_metrics = { workspace = true, features = ["testing"] }
 apollo_network = { workspace = true, features = ["testing"] }
 apollo_network_types = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
+apollo_time = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 itertools.workspace = true
 mempool_test_utils.workspace = true

--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -11,6 +11,7 @@ use apollo_mempool_types::communication::{
 use apollo_mempool_types::errors::MempoolError;
 use apollo_mempool_types::mempool_types::{CommitBlockArgs, MempoolResult, MempoolSnapshot};
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
+use apollo_time::system::SystemClock;
 use async_trait::async_trait;
 use starknet_api::block::GasPrice;
 use starknet_api::core::ContractAddress;
@@ -20,7 +21,6 @@ use tracing::warn;
 use crate::config::MempoolConfig;
 use crate::mempool::Mempool;
 use crate::metrics::register_metrics;
-use crate::utils::InstantClock;
 
 pub type LocalMempoolServer =
     LocalComponentServer<MempoolCommunicationWrapper, MempoolRequest, MempoolResponse>;
@@ -31,7 +31,7 @@ pub fn create_mempool(
     mempool_p2p_propagator_client: SharedMempoolP2pPropagatorClient,
 ) -> MempoolCommunicationWrapper {
     MempoolCommunicationWrapper::new(
-        Mempool::new(config, Arc::new(InstantClock)),
+        Mempool::new(config, Arc::new(SystemClock)),
         mempool_p2p_propagator_client,
     )
 }

--- a/crates/apollo_mempool/src/mempool_flow_tests.rs
+++ b/crates/apollo_mempool/src/mempool_flow_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use apollo_mempool_types::errors::MempoolError;
+use apollo_time::test_utils::FakeClock;
 use rstest::{fixture, rstest};
 use starknet_api::block::GasPrice;
 use starknet_api::{contract_address, nonce};
@@ -8,13 +9,7 @@ use starknet_api::{contract_address, nonce};
 use crate::add_tx_input;
 use crate::config::MempoolConfig;
 use crate::mempool::Mempool;
-use crate::test_utils::{
-    add_tx,
-    add_tx_expect_error,
-    commit_block,
-    get_txs_and_assert_expected,
-    FakeClock,
-};
+use crate::test_utils::{add_tx, add_tx_expect_error, commit_block, get_txs_and_assert_expected};
 
 // Fixtures.
 

--- a/crates/apollo_mempool/src/mempool_test.rs
+++ b/crates/apollo_mempool/src/mempool_test.rs
@@ -13,6 +13,7 @@ use apollo_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
 use apollo_metrics::metrics::HistogramValue;
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
 use apollo_test_utils::{get_rng, GetTestInstance};
+use apollo_time::test_utils::FakeClock;
 use mempool_test_utils::starknet_api_test_utils::test_valid_resource_bounds;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use mockall::predicate::eq;
@@ -33,7 +34,6 @@ use crate::test_utils::{
     add_tx_expect_error,
     commit_block,
     get_txs_and_assert_expected,
-    FakeClock,
     MempoolMetrics,
 };
 use crate::transaction_pool::TransactionPool;

--- a/crates/apollo_mempool/src/test_utils.rs
+++ b/crates/apollo_mempool/src/test_utils.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
-use std::time::Instant;
 
 use apollo_mempool_types::errors::MempoolError;
 use apollo_mempool_types::mempool_types::{AddTransactionArgs, CommitBlockArgs};
@@ -27,7 +25,6 @@ use crate::metrics::{
     MEMPOOL_TRANSACTIONS_RECEIVED,
     TRANSACTION_TIME_SPENT_IN_MEMPOOL,
 };
-use crate::utils::Clock;
 
 /// Creates an executable invoke transaction with the given field subset (the rest receive default
 /// values).
@@ -280,28 +277,6 @@ pub fn get_txs_and_assert_expected(
 ) {
     let txs = mempool.get_txs(n_txs).unwrap();
     assert_eq!(txs, expected_txs);
-}
-
-pub struct FakeClock {
-    pub now: Mutex<Instant>,
-}
-
-impl Default for FakeClock {
-    fn default() -> Self {
-        FakeClock { now: Mutex::new(Instant::now()) }
-    }
-}
-
-impl FakeClock {
-    pub fn advance(&self, duration: std::time::Duration) {
-        *self.now.lock().unwrap() += duration;
-    }
-}
-
-impl Clock for FakeClock {
-    fn now(&self) -> Instant {
-        *self.now.lock().unwrap()
-    }
 }
 
 #[derive(Default)]

--- a/crates/apollo_mempool/src/utils.rs
+++ b/crates/apollo_mempool/src/utils.rs
@@ -1,22 +1,7 @@
-use std::time::Instant;
-
 use apollo_mempool_types::communication::MempoolResult;
 use apollo_mempool_types::errors::MempoolError;
 use starknet_api::core::Nonce;
 
 pub fn try_increment_nonce(nonce: Nonce) -> MempoolResult<Nonce> {
     nonce.try_increment().map_err(|_| MempoolError::NonceTooLarge(nonce))
-}
-
-// TODO(dafna, 01/03/2025): Move to a common utils crate.
-pub trait Clock: Send + Sync {
-    fn now(&self) -> Instant;
-}
-
-pub struct InstantClock;
-
-impl Clock for InstantClock {
-    fn now(&self) -> Instant {
-        Instant::now()
-    }
 }

--- a/crates/apollo_time/Cargo.toml
+++ b/crates/apollo_time/Cargo.toml
@@ -6,6 +6,7 @@ repository.workspace = true
 license-file.workspace = true
 
 [features]
+testing = []
 
 [dependencies]
 

--- a/crates/apollo_time/src/clock.rs
+++ b/crates/apollo_time/src/clock.rs
@@ -1,0 +1,10 @@
+use std::ops::Add;
+use std::time::Duration;
+
+/// Provides an `Instant` type for relative timing operations (deadlines, intervals).
+/// The associated `Instant` type will likely be a `std::time::Instant` or a `tokio::time::Instant`,
+/// see individual implementations for details.
+pub trait InstantClock: Send + Sync {
+    type Instant: Copy + Add<Duration, Output = Self::Instant>;
+    fn now(&self) -> Self::Instant;
+}

--- a/crates/apollo_time/src/lib.rs
+++ b/crates/apollo_time/src/lib.rs
@@ -1,1 +1,5 @@
+pub mod clock;
+pub mod system;
 
+#[cfg(any(feature = "testing", test))]
+pub mod test_utils;

--- a/crates/apollo_time/src/system.rs
+++ b/crates/apollo_time/src/system.rs
@@ -1,0 +1,16 @@
+use std::time::Instant as StdInstant;
+
+use crate::clock::InstantClock;
+
+/// A clock that relies on the the internal OS clock (CLOCK_MONOTONIC) for relative timing.
+/// Use this when you need real-world timing without interfacing with tokio Instance (don't mix the
+/// two in a single flow, as this violates some assumptions tokio makes on timing).
+pub struct SystemClock;
+
+impl InstantClock for SystemClock {
+    type Instant = StdInstant;
+
+    fn now(&self) -> Self::Instant {
+        StdInstant::now()
+    }
+}

--- a/crates/apollo_time/src/test_utils.rs
+++ b/crates/apollo_time/src/test_utils.rs
@@ -1,0 +1,40 @@
+use std::ops::Add;
+use std::sync::Mutex;
+use std::time::{Duration, Instant as StdInstant};
+
+use crate::clock::InstantClock;
+
+#[derive(Debug)]
+pub struct FakeClock<I: Copy + Add<Duration, Output = I> + Send + Sync> {
+    offset: Mutex<Duration>,
+    base_instant: I,
+}
+
+impl<I: Copy + Add<Duration, Output = I> + Send + Sync> FakeClock<I> {
+    pub fn new(base_instant: I) -> Self {
+        FakeClock { offset: Mutex::new(Duration::ZERO), base_instant }
+    }
+
+    pub fn advance(&self, duration: Duration) {
+        let mut off = self.offset.lock().unwrap();
+        *off = off.saturating_add(duration);
+    }
+}
+
+impl<I: Copy + Add<Duration, Output = I> + Send + Sync> InstantClock for FakeClock<I>
+where
+    I: Copy + Add<Duration, Output = I> + Send + Sync,
+{
+    type Instant = I;
+
+    fn now(&self) -> I {
+        let off = *self.offset.lock().unwrap();
+        self.base_instant + off
+    }
+}
+
+impl Default for FakeClock<StdInstant> {
+    fn default() -> Self {
+        FakeClock { offset: Mutex::new(Duration::ZERO), base_instant: StdInstant::now() }
+    }
+}


### PR DESCRIPTION
For the MEMPOOL: only a move, no changes in logic.

Implementation notes: the implementation of Clock is generic on instant to accommodate
next use cases, which use a TokioInstant. Also `FakeClock`'s `advance()` now
maintains the `advance`d offset in order to support unix time fakes later on.