### PR TITLE
refactor(apollo_consensus): extract `Clock` into `apollo_time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,7 @@ dependencies = [
  "apollo_protobuf",
  "apollo_reverts",
  "apollo_state_sync_types",
+ "apollo_time",
  "async-trait",
  "futures",
  "mockall",
@@ -1108,6 +1109,7 @@ dependencies = [
  "apollo_state_sync_types",
  "apollo_storage",
  "apollo_test_utils",
+ "apollo_time",
  "async-trait",
  "blockifier",
  "cairo-lang-casm",
@@ -2093,6 +2095,10 @@ dependencies = [
 [[package]]
 name = "apollo_time"
 version = "0.0.0"
+dependencies = [
+ "chrono",
+ "tokio",
+]
 
 [[package]]
 name = "aquamarine"

--- a/crates/apollo_consensus_manager/Cargo.toml
+++ b/crates/apollo_consensus_manager/Cargo.toml
@@ -26,6 +26,7 @@ apollo_network.workspace = true
 apollo_protobuf.workspace = true
 apollo_reverts.workspace = true
 apollo_state_sync_types.workspace = true
+apollo_time = { workspace = true, features = ["chrono", "tokio"] }
 async-trait.workspace = true
 futures.workspace = true
 serde.workspace = true

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -12,7 +12,6 @@ use apollo_consensus::stream_handler::StreamHandler;
 use apollo_consensus::types::ConsensusError;
 use apollo_consensus_orchestrator::cende::CendeAmbassador;
 use apollo_consensus_orchestrator::sequencer_consensus_context::{
-    DefaultClock,
     SequencerConsensusContext,
     SequencerConsensusContextDeps,
 };
@@ -26,6 +25,7 @@ use apollo_network::network_manager::{BroadcastTopicChannels, NetworkManager};
 use apollo_protobuf::consensus::{HeightAndRound, ProposalPart, StreamMessage, Vote};
 use apollo_reverts::revert_blocks_and_eternal_pending;
 use apollo_state_sync_types::communication::SharedStateSyncClient;
+use apollo_time::tokio_clock::TokioClock;
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use starknet_api::block::BlockNumber;
@@ -161,7 +161,7 @@ impl ConsensusManager {
                     self.config.eth_to_strk_oracle_config.lag_interval_seconds,
                 )),
                 l1_gas_price_provider: self.l1_gas_price_provider.clone(),
-                clock: Arc::new(DefaultClock::default()),
+                clock: Arc::new(TokioClock),
             },
         );
 

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -7,6 +7,7 @@ license-file.workspace = true
 description = "Implements the consensus context and orchestrates the node's components accordingly"
 
 [dependencies]
+apollo_time = { workspace = true, features = ["chrono", "tokio"] }
 apollo_batcher_types.workspace = true
 apollo_class_manager_types.workspace = true
 apollo_config.workspace = true
@@ -45,6 +46,7 @@ validator.workspace = true
 
 [dev-dependencies]
 apollo_batcher.workspace = true
+apollo_time = { workspace = true, features = ["chrono", "testing", "tokio"] }
 apollo_batcher_types = { workspace = true, features = ["testing"] }
 apollo_class_manager_types = { workspace = true, features = ["testing"] }
 apollo_infra_utils = { workspace = true, features = ["testing"] }

--- a/crates/apollo_time/Cargo.toml
+++ b/crates/apollo_time/Cargo.toml
@@ -6,9 +6,13 @@ repository.workspace = true
 license-file.workspace = true
 
 [features]
+chrono = ["dep:chrono"]
 testing = []
+tokio = ["dep:tokio"]
 
 [dependencies]
+chrono = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["time"], optional = true }
 
 [dev-dependencies]
 

--- a/crates/apollo_time/src/clock.rs
+++ b/crates/apollo_time/src/clock.rs
@@ -1,5 +1,5 @@
 use std::ops::Add;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Provides an `Instant` type for relative timing operations (deadlines, intervals).
 /// The associated `Instant` type will likely be a `std::time::Instant` or a `tokio::time::Instant`,
@@ -8,3 +8,26 @@ pub trait InstantClock: Send + Sync {
     type Instant: Copy + Add<Duration, Output = Self::Instant>;
     fn now(&self) -> Self::Instant;
 }
+
+/// UnixClock provides absolute wall-clock time since the UNIX epoch.
+/// Use `unix_now()` for subsecond durations and `unix_now_secs()` for whole seconds.
+/// When the `chrono` feature is enabled, `chrono_unix_now()` returns a `DateTime<Utc>`.
+pub trait UnixClock {
+    fn unix_now(&self) -> Duration {
+        SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+    }
+
+    fn unix_now_secs(&self) -> u64 {
+        self.unix_now().as_secs()
+    }
+
+    // Legacy: we are using chrono in some places just to use unix time, these places can all be
+    // replaced to use unix time method above and save the extra dependency.
+    #[cfg(feature = "chrono")]
+    fn chrono_unix_now(&self) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::<chrono::Utc>::from(UNIX_EPOCH + self.unix_now())
+    }
+}
+
+pub trait Clock: InstantClock + UnixClock {}
+impl<T: InstantClock + UnixClock> Clock for T {}

--- a/crates/apollo_time/src/lib.rs
+++ b/crates/apollo_time/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod clock;
 pub mod system;
+#[cfg(feature = "tokio")]
+pub mod tokio_clock;
 
 #[cfg(any(feature = "testing", test))]
 pub mod test_utils;

--- a/crates/apollo_time/src/tokio_clock.rs
+++ b/crates/apollo_time/src/tokio_clock.rs
@@ -1,0 +1,18 @@
+use tokio::time::Instant as TokioInstant;
+
+use crate::clock::{InstantClock, UnixClock};
+
+/// Clock that relies on the tokio runtime for relative timing, which wraps STD `Instant` and allows
+/// for better global control during tests, like `pause` and `advance`, which halts the clock
+/// globally.
+#[derive(Debug, Default)]
+pub struct TokioClock;
+
+impl InstantClock for TokioClock {
+    type Instant = TokioInstant;
+    fn now(&self) -> TokioInstant {
+        TokioInstant::now()
+    }
+}
+
+impl UnixClock for TokioClock {}


### PR DESCRIPTION
- Only MOVE, no logic changes.
- The `InstantClock` trait in apollo time is generic over instant, so we added a
  TokioClock struct that uses the tokio instant + unix time.
- Note that chrono's now() is just a wrapper around the `unix_now()`
  method in apollo_time, so we prefer that in order to make it easier to
  dump chrono (which is only used for unix time anyway).
- The consensus test can now be simplified using apollo_time's FakeClock
  abstraction, which defaults to a frozen `Self::Instant::now()` unless
  advanced manually.
- tokio and chrono are feature gated since other users of the clock
  don't need either (and arguably no one really NEEDS chrono).