### PR TITLE
feat(blockifier): move end-chunk logic from scheduler.rs to worker_logic.rs (#6670)

### DIFF
--- a/crates/blockifier/src/concurrency/flow_test.rs
+++ b/crates/blockifier/src/concurrency/flow_test.rs
@@ -53,6 +53,10 @@ fn scheduler_flow_test(
                             state_proxy.apply_writes(&new_writes, &ContractClassMapping::default());
                             scheduler.finish_execution_during_commit(tx_index);
                         }
+                        if tx_index == DEFAULT_CHUNK_SIZE - 1 {
+                            scheduler.halt();
+                            break;
+                        }
                     }
                 }
                 task = match task {

--- a/crates/blockifier/src/concurrency/scheduler.rs
+++ b/crates/blockifier/src/concurrency/scheduler.rs
@@ -42,9 +42,6 @@ impl<'a> TransactionCommitter<'a> {
         }
         *status = TransactionStatus::Committed;
         *self.commit_index_guard += 1;
-        if *self.commit_index_guard == self.scheduler.chunk_size {
-            self.scheduler.done_marker.store(true, Ordering::Release);
-        }
         Some(*self.commit_index_guard - 1)
     }
 
@@ -64,8 +61,7 @@ pub struct Scheduler {
     commit_index: Mutex<usize>,
     chunk_size: usize,
     tx_statuses: DashMap<TxIndex, TransactionStatus>,
-    /// Set to true when all transactions have been committed, or when calling `halt()`,
-    /// providing a cheap way for all threads to exit their main loops.
+    /// Set to true when calling `halt()`. This will cause all threads to exit their main loops.
     done_marker: AtomicBool,
 }
 

--- a/crates/blockifier/src/concurrency/scheduler_test.rs
+++ b/crates/blockifier/src/concurrency/scheduler_test.rs
@@ -102,10 +102,6 @@ fn test_commit_flow(
             *scheduler.commit_index.lock().unwrap(),
             if should_halt { commit_index } else { commit_index + 1 }
         );
-        assert_eq!(
-            scheduler.done_marker.load(Ordering::Acquire),
-            commit_index + 1 == DEFAULT_CHUNK_SIZE || should_halt
-        );
     } else {
         assert_eq!(*scheduler.lock_tx_status(commit_index), commit_index_tx_status);
         assert_eq!(*scheduler.commit_index.lock().unwrap(), commit_index);

--- a/crates/blockifier/src/concurrency/worker_logic.rs
+++ b/crates/blockifier/src/concurrency/worker_logic.rs
@@ -175,7 +175,11 @@ impl<S: StateReader> WorkerExecutor<S> {
                     panic!("Commit transaction should not be called after clearing the state.");
                 });
                 match commit_result {
-                    CommitResult::Success => {}
+                    CommitResult::Success => {
+                        if tx_index == self.chunk.len() - 1 {
+                            self.scheduler.halt();
+                        }
+                    }
                     CommitResult::NoRoomInBlock => {
                         tx_committer.uncommit();
                         self.scheduler.halt();


### PR DESCRIPTION
**Stack**:
- #6747
- #6746
- #6745
- #6744
- #6743
- #6742
- #6741
- #6740
- #6739 ⬅
- #6738
- #6737
- #6736
- #6735
- #6734
- #6733
- #6732


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*