### PR TITLE
feat(apollo_l1_provider): save committed txs in sidebuffer

### DIFF
--- a/crates/apollo_l1_provider/src/l1_provider_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_provider_tests.rs
@@ -105,7 +105,7 @@ fn validate_happy_flow() {
     // Setup.
     let mut l1_provider = L1ProviderContentBuilder::new()
         .with_txs([l1_handler(1)])
-        .with_committed_hashes([tx_hash!(2)])
+        .with_committed([l1_handler(2)])
         .with_state(ProviderState::Validate)
         .build_into_l1_provider();
 
@@ -166,7 +166,7 @@ fn process_events_committed_txs() {
     // Setup.
     let mut l1_provider = L1ProviderContentBuilder::new()
         .with_txs([l1_handler(1)])
-        .with_committed_hashes([tx_hash!(2)])
+        .with_committed(vec![l1_handler(2)])
         .with_state(ProviderState::Pending)
         .build_into_l1_provider();
 
@@ -335,15 +335,15 @@ fn commit_block_backlog() {
 #[test]
 fn tx_in_commit_block_before_processed_is_skipped() {
     // Setup
-    let mut l1_provider = L1ProviderContentBuilder::new()
-        .with_committed_hashes([tx_hash!(1)])
-        .build_into_l1_provider();
+    let mut l1_provider =
+        L1ProviderContentBuilder::new().with_committed([l1_handler(1)]).build_into_l1_provider();
 
     // Transactions unknown yet.
     commit_block_no_rejected(&mut l1_provider, &[tx_hash!(2), tx_hash!(3)], BlockNumber(0));
     let expected_l1_provider = L1ProviderContentBuilder::new()
         .with_txs([])
-        .with_committed_hashes([tx_hash!(1), tx_hash!(2), tx_hash!(3)])
+        .with_committed([l1_handler(1)])
+        .with_committed_hashes([tx_hash!(2), tx_hash!(3)])
         .build();
     expected_l1_provider.assert_eq(&l1_provider);
 
@@ -412,7 +412,7 @@ fn commit_block_rejected_transactions() {
     let expected_l1_provider = L1ProviderContentBuilder::new()
         .with_txs([l1_handler(3)])
         .with_rejected([l1_handler(1)])
-        .with_committed_hashes([tx_hash!(2)])
+        .with_committed([l1_handler(2)])
         .with_height(BlockNumber(1))
         .build();
     expected_l1_provider.assert_eq(&l1_provider);
@@ -474,7 +474,7 @@ fn add_new_transaction_not_added_if_rejected() {
     let expected_l1_provider = L1ProviderContentBuilder::new()
         .with_txs([l1_handler(3)])
         .with_rejected([l1_handler(1)])
-        .with_committed_hashes([tx_hash!(2)])
+        .with_committed([l1_handler(2)])
         .with_height(BlockNumber(1))
         .build();
     expected_l1_provider.assert_eq(&l1_provider);

--- a/crates/apollo_l1_provider/src/test_utils.rs
+++ b/crates/apollo_l1_provider/src/test_utils.rs
@@ -103,6 +103,14 @@ impl L1ProviderContentBuilder {
         self
     }
 
+    pub fn with_committed(
+        mut self,
+        committed: impl IntoIterator<Item = L1HandlerTransaction>,
+    ) -> Self {
+        self.tx_manager_content_builder = self.tx_manager_content_builder.with_committed(committed);
+        self
+    }
+
     pub fn with_committed_hashes(
         mut self,
         tx_hashes: impl IntoIterator<Item = TransactionHash>,
@@ -183,6 +191,13 @@ impl TransactionManagerContentBuilder {
 
     fn with_rejected(mut self, rejected: impl IntoIterator<Item = L1HandlerTransaction>) -> Self {
         self.rejected = Some(rejected.into_iter().collect());
+        self
+    }
+
+    fn with_committed(mut self, committed: impl IntoIterator<Item = L1HandlerTransaction>) -> Self {
+        self.committed
+            .get_or_insert_default()
+            .extend(committed.into_iter().map(|tx| (tx.tx_hash, tx.into())));
         self
     }
 

--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -68,7 +68,7 @@ impl TransactionManager {
 
         let mut uncommitted = IndexMap::new();
         let mut rejected = IndexMap::new();
-        let committed: IndexMap<_, _> = committed_txs
+        let mut committed: IndexMap<_, _> = committed_txs
             .iter()
             .copied()
             .map(|tx_hash| (tx_hash, TransactionPayload::HashOnly))
@@ -79,7 +79,9 @@ impl TransactionManager {
             // Each rejected transaction is added to the rejected pool.
             if rejected_txs.contains(&hash) {
                 rejected.insert(hash, entry);
-            } else if !committed_txs.contains(&hash) {
+            } else if committed.contains_key(&hash) {
+                committed.get_mut(&hash).unwrap().set(entry.transaction);
+            } else {
                 // If a transaction is not committed or rejected, it is added back to the
                 // uncommitted pool.
                 uncommitted.insert(hash, entry);
@@ -117,4 +119,16 @@ pub enum TransactionPayload {
     #[default]
     HashOnly,
     Full(L1HandlerTransaction),
+}
+
+impl TransactionPayload {
+    pub fn set(&mut self, tx: L1HandlerTransaction) {
+        *self = tx.into();
+    }
+}
+
+impl From<L1HandlerTransaction> for TransactionPayload {
+    fn from(tx: L1HandlerTransaction) -> Self {
+        TransactionPayload::Full(tx)
+    }
 }


### PR DESCRIPTION
Whenever we see a tx hash in commit-block for a tx we already scraped,
save it in a side buffer instead of deleting it and only storing its
hash (the current behavior).
Initial support for this was added in previous commits, where the
commited-txs collection was changed from hashset of tx_hashes into a map,
that until now only had tx-hash keys without any values (through a
dedicated enum representing this state).

Next commit will add support for the flow in which we see a tx hash in
commit-block and only afterwards scrape the tx.