### PR TITLE
refactor(blockifier): invalid syscall selector depracted base error

### DIFF
--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscall_executor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscall_executor.rs
@@ -13,7 +13,6 @@ use num_bigint::{BigUint, TryFromBigIntError};
 use starknet_api::StarknetApiError;
 use starknet_types_core::felt::Felt;
 
-use crate::execution::common_hints::HintExecutionResult;
 use crate::execution::deprecated_syscalls::{
     CallContractRequest,
     CallContractResponse,
@@ -21,7 +20,6 @@ use crate::execution::deprecated_syscalls::{
     DelegateCallResponse,
     DeployRequest,
     DeployResponse,
-    DeprecatedSyscallResult,
     DeprecatedSyscallSelector,
     EmitEventRequest,
     EmitEventResponse,
@@ -55,18 +53,20 @@ use crate::execution::deprecated_syscalls::{
 use crate::execution::execution_utils::felt_from_ptr;
 
 pub trait DeprecatedSyscallExecutor {
+    type Error: From<DeprecatedSyscallExecutorBaseError>;
+
     #[allow(clippy::result_large_err)]
     fn read_next_syscall_selector(
         &mut self,
         vm: &mut VirtualMachine,
-    ) -> DeprecatedSyscallResult<Felt> {
+    ) -> DeprecatedSyscallExecutorBaseResult<Felt> {
         Ok(felt_from_ptr(vm, self.get_mut_syscall_ptr())?)
     }
 
     fn increment_syscall_count(&mut self, selector: &DeprecatedSyscallSelector);
 
     #[allow(clippy::result_large_err)]
-    fn verify_syscall_ptr(&self, actual_ptr: Relocatable) -> DeprecatedSyscallResult<()>;
+    fn verify_syscall_ptr(&self, actual_ptr: Relocatable) -> Result<(), Self::Error>;
 
     fn get_mut_syscall_ptr(&mut self) -> &mut Relocatable;
 
@@ -75,133 +75,133 @@ pub trait DeprecatedSyscallExecutor {
         request: CallContractRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<CallContractResponse>;
+    ) -> Result<CallContractResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn delegate_call(
         request: DelegateCallRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<DelegateCallResponse>;
+    ) -> Result<DelegateCallResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn delegate_l1_handler(
         request: DelegateCallRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<DelegateCallResponse>;
+    ) -> Result<DelegateCallResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn deploy(
         request: DeployRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<DeployResponse>;
+    ) -> Result<DeployResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn emit_event(
         request: EmitEventRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<EmitEventResponse>;
+    ) -> Result<EmitEventResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn get_block_number(
         request: GetBlockNumberRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<GetBlockNumberResponse>;
+    ) -> Result<GetBlockNumberResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn get_block_timestamp(
         request: GetBlockTimestampRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<GetBlockTimestampResponse>;
+    ) -> Result<GetBlockTimestampResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn get_caller_address(
         request: GetCallerAddressRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<GetCallerAddressResponse>;
+    ) -> Result<GetCallerAddressResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn get_contract_address(
         request: GetContractAddressRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<GetContractAddressResponse>;
+    ) -> Result<GetContractAddressResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn get_sequencer_address(
         request: GetSequencerAddressRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<GetSequencerAddressResponse>;
+    ) -> Result<GetSequencerAddressResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn get_tx_info(
         request: GetTxInfoRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<GetTxInfoResponse>;
+    ) -> Result<GetTxInfoResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn get_tx_signature(
         request: GetTxSignatureRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<GetTxSignatureResponse>;
+    ) -> Result<GetTxSignatureResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn library_call(
         request: LibraryCallRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<LibraryCallResponse>;
+    ) -> Result<LibraryCallResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn library_call_l1_handler(
         request: LibraryCallRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<LibraryCallResponse>;
+    ) -> Result<LibraryCallResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn replace_class(
         request: ReplaceClassRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<ReplaceClassResponse>;
+    ) -> Result<ReplaceClassResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn send_message_to_l1(
         request: SendMessageToL1Request,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<SendMessageToL1Response>;
+    ) -> Result<SendMessageToL1Response, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn storage_read(
         request: StorageReadRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<StorageReadResponse>;
+    ) -> Result<StorageReadResponse, Self::Error>;
 
     #[allow(clippy::result_large_err)]
     fn storage_write(
         request: StorageWriteRequest,
         vm: &mut VirtualMachine,
         syscall_handler: &mut Self,
-    ) -> DeprecatedSyscallResult<StorageWriteResponse>;
+    ) -> Result<StorageWriteResponse, Self::Error>;
 }
 
 pub fn execute_deprecated_syscall_from_selector<T: DeprecatedSyscallExecutor>(
     deprecated_syscall_executor: &mut T,
     vm: &mut VirtualMachine,
     selector: DeprecatedSyscallSelector,
-) -> HintExecutionResult {
+) -> Result<(), T::Error> {
     match selector {
         DeprecatedSyscallSelector::CallContract => {
             execute_deprecated_syscall(deprecated_syscall_executor, vm, T::call_contract)
@@ -274,9 +274,11 @@ pub fn execute_deprecated_syscall_from_selector<T: DeprecatedSyscallExecutor>(
         | DeprecatedSyscallSelector::Secp256r1GetPointFromX
         | DeprecatedSyscallSelector::Secp256r1GetXy
         | DeprecatedSyscallSelector::Secp256r1Mul
-        | DeprecatedSyscallSelector::Secp256r1New => Err(HintError::UnknownHint(
-            format!("Unsupported syscall selector {selector:?}.").into(),
-        )),
+        | DeprecatedSyscallSelector::Secp256r1New => {
+            Err(DeprecatedSyscallExecutorBaseError::from(HintError::UnknownHint(
+                format!("Unsupported syscall selector {selector:?}.").into(),
+            )))?
+        }
     }
 }
 
@@ -284,13 +286,13 @@ fn execute_deprecated_syscall<Request, Response, ExecuteCallback, Executor>(
     deprecated_syscall_executor: &mut Executor,
     vm: &mut VirtualMachine,
     execute_callback: ExecuteCallback,
-) -> HintExecutionResult
+) -> Result<(), Executor::Error>
 where
     Executor: DeprecatedSyscallExecutor,
     Request: SyscallRequest,
     Response: SyscallResponse,
     ExecuteCallback:
-        FnOnce(Request, &mut VirtualMachine, &mut Executor) -> DeprecatedSyscallResult<Response>,
+        FnOnce(Request, &mut VirtualMachine, &mut Executor) -> Result<Response, Executor::Error>,
 {
     let request = Request::read(vm, deprecated_syscall_executor.get_mut_syscall_ptr())?;
 
@@ -307,8 +309,9 @@ pub fn execute_next_deprecated_syscall<T: DeprecatedSyscallExecutor>(
     vm: &mut VirtualMachine,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> HintExecutionResult {
-    let initial_syscall_ptr = get_ptr_from_var_name("syscall_ptr", vm, ids_data, ap_tracking)?;
+) -> Result<(), T::Error> {
+    let initial_syscall_ptr = get_ptr_from_var_name("syscall_ptr", vm, ids_data, ap_tracking)
+        .map_err(DeprecatedSyscallExecutorBaseError::from)?;
     deprecated_syscall_executor.verify_syscall_ptr(initial_syscall_ptr)?;
 
     let selector = DeprecatedSyscallSelector::try_from(

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -451,7 +451,12 @@ impl HintProcessorLogic for DeprecatedSyscallHintProcessor<'_> {
     ) -> HintExecutionResult {
         let hint = hint_data.downcast_ref::<HintProcessorData>().ok_or(HintError::WrongHintData)?;
         if hint_code::SYSCALL_HINTS.contains(hint.code.as_str()) {
-            return execute_next_deprecated_syscall(self, vm, &hint.ids_data, &hint.ap_tracking);
+            return Ok(execute_next_deprecated_syscall(
+                self,
+                vm,
+                &hint.ids_data,
+                &hint.ap_tracking,
+            )?);
         }
 
         self.builtin_hint_processor.execute_hint(vm, exec_scopes, hint_data, constants)
@@ -459,6 +464,8 @@ impl HintProcessorLogic for DeprecatedSyscallHintProcessor<'_> {
 }
 
 impl DeprecatedSyscallExecutor for DeprecatedSyscallHintProcessor<'_> {
+    type Error = DeprecatedSyscallExecutionError;
+
     #[allow(clippy::result_large_err)]
     fn verify_syscall_ptr(&self, actual_ptr: Relocatable) -> DeprecatedSyscallResult<()> {
         if actual_ptr != self.syscall_ptr {

--- a/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
@@ -95,7 +95,7 @@ impl DeprecatedSyscallSelector {
 }
 
 impl TryFrom<Felt> for DeprecatedSyscallSelector {
-    type Error = DeprecatedSyscallExecutionError;
+    type Error = DeprecatedSyscallExecutorBaseError;
     fn try_from(raw_selector: Felt) -> Result<Self, Self::Error> {
         // Remove leading zero bytes from selector.
         let selector_bytes = raw_selector.to_bytes_be();
@@ -136,8 +136,8 @@ impl TryFrom<Felt> for DeprecatedSyscallSelector {
             b"SendMessageToL1" => Ok(Self::SendMessageToL1),
             b"StorageRead" => Ok(Self::StorageRead),
             b"StorageWrite" => Ok(Self::StorageWrite),
-            _ => Err(Self::Error::from(
-                DeprecatedSyscallExecutorBaseError::InvalidDeprecatedSyscallSelector(raw_selector),
+            _ => Err(DeprecatedSyscallExecutorBaseError::InvalidDeprecatedSyscallSelector(
+                raw_selector,
             )),
         }
     }

--- a/crates/blockifier/src/execution/syscalls/vm_syscall_utils.rs
+++ b/crates/blockifier/src/execution/syscalls/vm_syscall_utils.rs
@@ -21,7 +21,7 @@ use crate::abi::sierra_types::SierraTypeError;
 use crate::blockifier_versioned_constants::{EventLimits, GasCostsError, VersionedConstants};
 use crate::execution::call_info::MessageToL1;
 use crate::execution::common_hints::ExecutionMode;
-use crate::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallExecutionError;
+use crate::execution::deprecated_syscalls::deprecated_syscall_executor::DeprecatedSyscallExecutorBaseError;
 use crate::execution::deprecated_syscalls::DeprecatedSyscallSelector;
 use crate::execution::execution_utils::{
     felt_from_ptr,
@@ -811,7 +811,7 @@ pub trait TryExtractRevert {
 #[derive(Debug, thiserror::Error)]
 pub enum SyscallExecutorBaseError {
     #[error(transparent)]
-    DeprecatedSyscallExecution(#[from] DeprecatedSyscallExecutionError),
+    DeprecatedSyscallExecutorBase(#[from] DeprecatedSyscallExecutorBaseError),
     #[error(transparent)]
     FromStr(#[from] FromStrError),
     #[error("Failed to get gas cost for syscall selector {selector:?}. Error: {error:?}")]

--- a/crates/starknet_os/src/hints/error.rs
+++ b/crates/starknet_os/src/hints/error.rs
@@ -1,3 +1,4 @@
+use blockifier::execution::deprecated_syscalls::deprecated_syscall_executor::DeprecatedSyscallExecutorBaseError;
 use blockifier::execution::deprecated_syscalls::hint_processor::DeprecatedSyscallExecutionError;
 use blockifier::state::errors::StateError;
 use cairo_vm::hint_processor::hint_processor_definition::HintExtension;
@@ -22,6 +23,7 @@ use starknet_types_core::felt::Felt;
 
 use crate::hint_processor::execution_helper::ExecutionHelperError;
 use crate::hint_processor::os_logger::OsLoggerError;
+use crate::hint_processor::snos_deprecated_syscall_executor::DeprecatedSnosSyscallError;
 use crate::hints::enum_definition::AllHints;
 use crate::hints::hint_implementation::kzg::utils::FftError;
 use crate::hints::hint_implementation::patricia::error::PatriciaError;
@@ -40,6 +42,10 @@ pub enum OsHintError {
     BooleanIdExpected { id: Ids, felt: Felt },
     #[error("Failed to convert {variant:?} felt value {felt:?} to type {ty}: {reason:?}.")]
     ConstConversion { variant: Const, felt: Felt, ty: String, reason: String },
+    #[error(transparent)]
+    DeprecatedBaseSyscall(#[from] DeprecatedSyscallExecutorBaseError),
+    #[error(transparent)]
+    DeprecatedSnosSyscall(#[from] DeprecatedSnosSyscallError),
     #[error(transparent)]
     DeprecatedSyscallExecution(#[from] DeprecatedSyscallExecutionError),
     #[error("Tried to iterate past the end of {item_type}.")]


### PR DESCRIPTION
refactor(blockifier): invalid syscall selector depracted base error

feat(blockifier, starknet_os): associated basic deprecated syscall error type