### PR TITLE
chore(apollo_l1_provider): optimize commit-check

### DIFF
--- a/crates/apollo_l1_provider/src/soft_delete_index_map.rs
+++ b/crates/apollo_l1_provider/src/soft_delete_index_map.rs
@@ -24,7 +24,7 @@ impl SoftDeleteIndexMap {
         let tx_hash = tx.tx_hash;
         match self.txs.entry(tx_hash) {
             Entry::Occupied(entry) => {
-                assert_eq!(entry.get().transaction, tx);
+                assert_eq!(entry.get().tx, tx);
                 false
             }
             Entry::Vacant(entry) => {
@@ -54,11 +54,11 @@ impl SoftDeleteIndexMap {
         entry.set_state(TxState::Staged);
         self.staged_txs.insert(tx_hash);
 
-        Some(&entry.transaction)
+        Some(&entry.tx)
     }
 
     pub fn get_transaction(&self, tx_hash: &TransactionHash) -> Option<&L1HandlerTransaction> {
-        self.txs.get(tx_hash).map(|entry| &entry.transaction)
+        self.txs.get(tx_hash).map(|entry| &entry.tx)
     }
 
     /// Rolls back all staged transactions, converting them to unstaged.
@@ -91,13 +91,13 @@ pub enum TxState {
 /// and provides convenience methods for stage/unstage.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionEntry {
-    pub transaction: L1HandlerTransaction,
+    pub tx: L1HandlerTransaction,
     pub state: TxState,
 }
 
 impl TransactionEntry {
-    pub fn new(transaction: L1HandlerTransaction) -> Self {
-        Self { transaction, state: TxState::Unstaged }
+    pub fn new(tx: L1HandlerTransaction) -> Self {
+        Self { tx, state: TxState::Unstaged }
     }
 
     pub fn set_state(&mut self, state: TxState) {

--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -80,7 +80,7 @@ impl TransactionManager {
             if rejected_txs.contains(&hash) {
                 rejected.insert(hash, entry);
             } else if committed.contains_key(&hash) {
-                committed.get_mut(&hash).unwrap().set(entry.transaction);
+                committed.get_mut(&hash).unwrap().set(entry.tx);
             } else {
                 // If a transaction is not committed or rejected, it is added back to the
                 // uncommitted pool.

--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -1,5 +1,5 @@
 use apollo_l1_provider_types::{InvalidValidationStatus, ValidationStatus};
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use starknet_api::executable_transaction::L1HandlerTransaction;
 use starknet_api::transaction::TransactionHash;
 
@@ -31,7 +31,7 @@ impl TransactionManager {
     }
 
     pub fn validate_tx(&mut self, tx_hash: TransactionHash) -> ValidationStatus {
-        if self.committed.contains_key(&tx_hash) {
+        if self.is_committed(tx_hash) {
             return ValidationStatus::Invalid(InvalidValidationStatus::AlreadyIncludedOnL2);
         }
 
@@ -116,8 +116,8 @@ impl TransactionManager {
         self.uncommitted.insert(tx)
     }
 
-    pub fn committed_tx_hashes(&self) -> IndexSet<TransactionHash> {
-        self.committed.keys().copied().collect()
+    pub fn is_committed(&self, tx_hash: TransactionHash) -> bool {
+        self.committed.contains_key(&tx_hash)
     }
 
     pub(crate) fn snapshot(&self) -> TransactionManagerSnapshot {


### PR DESCRIPTION
Add `is_committed`, which will:
1. Better encapsulate access to committed (will also assist the upcoming refactor).
2. reduce unnecessary allocation and iteration in the now removed `committed_tx_hashes()`.
