### PR TITLE
feat(blockifier): add TransactionExecutorTrait::abort_block

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -192,6 +192,16 @@ impl BlockBuilder {
 #[async_trait]
 impl BlockBuilderTrait for BlockBuilder {
     async fn build_block(&mut self) -> BlockBuilderResult<BlockExecutionArtifacts> {
+        let res = self.build_block_inner().await;
+        if res.is_err() {
+            self.executor.lock().await.abort_block();
+        }
+        res
+    }
+}
+
+impl BlockBuilder {
+    async fn build_block_inner(&mut self) -> BlockBuilderResult<BlockExecutionArtifacts> {
         let mut block_is_full = false;
         let mut l2_gas_used = GasAmount::ZERO;
         let mut execution_data = BlockTransactionExecutionData::default();

--- a/crates/apollo_batcher/src/block_builder_test.rs
+++ b/crates/apollo_batcher/src/block_builder_test.rs
@@ -567,6 +567,7 @@ async fn test_validate_block_with_error(
     #[case] expected_error: FailOnErrorCause,
 ) {
     mock_transaction_executor.expect_close_block().times(0);
+    mock_transaction_executor.expect_abort_block().times(1).return_once(|| ());
 
     let mock_tx_provider = mock_tx_provider_limited_calls(1, vec![input_txs]);
 
@@ -600,8 +601,12 @@ async fn test_validate_block_l1_handler_validation_error(#[case] status: Invalid
     });
 
     let (_abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
+
+    let mut mock_transaction_executor = MockTransactionExecutorTrait::new();
+    mock_transaction_executor.expect_abort_block().times(1).return_once(|| ());
+
     let result = run_build_block(
-        MockTransactionExecutorTrait::new(),
+        mock_transaction_executor,
         tx_provider,
         None,
         true,
@@ -632,6 +637,7 @@ async fn test_build_block_abort() {
         .expect_add_txs_to_block()
         .return_once(|_, _| (0..3).map(|_| Ok(execution_info())).collect());
     mock_transaction_executor.expect_close_block().times(0);
+    mock_transaction_executor.expect_abort_block().times(1).return_once(|| ());
 
     let (output_tx_sender, mut output_tx_receiver) = output_channel();
     let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
@@ -665,6 +671,7 @@ async fn test_build_block_abort_immediately() {
     let mut mock_transaction_executor = MockTransactionExecutorTrait::new();
     mock_transaction_executor.expect_add_txs_to_block().times(0);
     mock_transaction_executor.expect_close_block().times(0);
+    mock_transaction_executor.expect_abort_block().times(1).return_once(|| ());
 
     let (output_tx_sender, _output_tx_receiver) = output_channel();
     let (abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
@@ -837,6 +844,8 @@ async fn partial_chunk_execution_with_fail_on_error_flag() {
         .expect_add_txs_to_block()
         .times(1)
         .return_once(move |_, _| executed_txs.iter().map(|_| Ok(execution_info())).collect()); // We return only 2 txs, simulating a partial chunk execution.
+    mock_transaction_executor.expect_close_block().times(0);
+    mock_transaction_executor.expect_abort_block().times(1).return_once(|| ());
 
     let mock_tx_provider = mock_tx_provider_limited_calls(1, vec![input_txs.clone()]);
     let (_abort_sender, abort_receiver) = tokio::sync::oneshot::channel();

--- a/crates/apollo_batcher/src/transaction_executor.rs
+++ b/crates/apollo_batcher/src/transaction_executor.rs
@@ -17,8 +17,16 @@ pub trait TransactionExecutorTrait: Send {
         txs: &[BlockifierTransaction],
         block_timeout: Instant,
     ) -> Vec<TransactionExecutorResult<TransactionExecutionInfo>>;
+
+    /// Finalizes the block creation and returns the commitment state diff, visited
+    /// segments mapping and bouncer.
+    ///
+    /// Every block must be closed with either `close_block` or `abort_block`.
     #[allow(clippy::result_large_err)]
     fn close_block(&mut self) -> TransactionExecutorResult<BlockExecutionSummary>;
+
+    /// Marks the block as aborted.
+    fn abort_block(&mut self);
 }
 
 impl<S: StateReader + Send + Sync + 'static> TransactionExecutorTrait for TransactionExecutor<S> {
@@ -33,10 +41,14 @@ impl<S: StateReader + Send + Sync + 'static> TransactionExecutorTrait for Transa
             .map(|res| res.map(|(tx_execution_info, _state_diff)| tx_execution_info))
             .collect()
     }
+
     /// Finalizes the block creation and returns the commitment state diff, visited
     /// segments mapping and bouncer.
     #[allow(clippy::result_large_err)]
     fn close_block(&mut self) -> TransactionExecutorResult<BlockExecutionSummary> {
         self.finalize()
     }
+
+    /// Marks the block as aborted.
+    fn abort_block(&mut self) {}
 }


### PR DESCRIPTION
Preparation for using one WorkerExecutor per block

---

**Stack**:
- #6872
- #6871
- #6825
- #6824 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*