### PR TITLE
chore(apollo_l1_provider): panic on double commit

### DIFF
--- a/crates/apollo_l1_provider/src/l1_provider_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_provider_tests.rs
@@ -489,3 +489,14 @@ fn add_new_transaction_not_added_if_rejected() {
     l1_provider.add_events(vec![l1_handler_event(rejected_tx_id)]).unwrap();
     expected_l1_provider.assert_eq(&l1_provider);
 }
+
+#[test]
+#[should_panic(expected = "committed twice")]
+fn commit_block_twice_panics() {
+    // Setup.
+    let mut l1_provider =
+        L1ProviderContentBuilder::new().with_committed([l1_handler(1)]).build_into_l1_provider();
+
+    // Test.
+    l1_provider.commit_block([tx_hash!(1)].into(), [].into(), BlockNumber(0)).unwrap();
+}

--- a/crates/apollo_l1_provider/src/test_utils.rs
+++ b/crates/apollo_l1_provider/src/test_utils.rs
@@ -210,7 +210,9 @@ impl TransactionManagerContentBuilder {
         committed_hashes: impl IntoIterator<Item = TransactionHash>,
     ) -> Self {
         self.committed.get_or_insert_default().extend(
-            committed_hashes.into_iter().map(|tx_hash| (tx_hash, TransactionPayload::HashOnly)),
+            committed_hashes
+                .into_iter()
+                .map(|tx_hash| (tx_hash, TransactionPayload::HashOnly(tx_hash))),
         );
         self
     }

--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -75,7 +75,7 @@ impl TransactionManager {
         let mut committed: IndexMap<_, _> = committed_txs
             .iter()
             .copied()
-            .map(|tx_hash| (tx_hash, TransactionPayload::HashOnly))
+            .map(|tx_hash| (tx_hash, TransactionPayload::HashOnly(tx_hash)))
             .collect();
 
         // Iterate over the uncommitted transactions and check if they are committed or rejected.
@@ -154,16 +154,28 @@ impl TransactionManager {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TransactionPayload {
-    #[default]
-    HashOnly,
+    HashOnly(TransactionHash),
     Full(L1HandlerTransaction),
 }
 
 impl TransactionPayload {
     pub fn set(&mut self, tx: L1HandlerTransaction) {
         *self = tx.into();
+    }
+
+    pub fn tx_hash(&self) -> TransactionHash {
+        match self {
+            TransactionPayload::HashOnly(hash) => *hash,
+            TransactionPayload::Full(tx) => tx.tx_hash,
+        }
+    }
+}
+
+impl Default for TransactionPayload {
+    fn default() -> Self {
+        TransactionPayload::HashOnly(TransactionHash::default())
     }
 }
 
@@ -202,6 +214,14 @@ pub struct TransactionRecord {
 
 impl TransactionRecord {
     pub fn mark_committed(&mut self) {
+        // Can't return error because committing only part of a block leaves the provider in an
+        // undetermined state.
+        assert!(
+            !self.committed,
+            "L1 handler transaction {} committed twice, this may lead to l2 reorgs,",
+            self.tx.tx_hash()
+        );
+
         self.state = TransactionState::Committed;
         self.committed = true;
     }


### PR DESCRIPTION
Unlikely that the batcher can do anything with "double commit" error
anyway besides panicking as well.