### PR TITLE
refactor(apollo_signature_manager): move peer ID type to types create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,7 @@ dependencies = [
  "apollo_infra",
  "apollo_proc_macros",
  "async-trait",
+ "derive_more 0.99.18",
  "serde",
  "starknet_api",
  "strum_macros 0.25.3",

--- a/crates/apollo_signature_manager_types/Cargo.toml
+++ b/crates/apollo_signature_manager_types/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 apollo_infra.workspace = true
 apollo_proc_macros.workspace = true
 async-trait.workspace = true
+derive_more.workspace = true
 serde.workspace = true
 starknet_api.workspace = true
 strum_macros.workspace = true

--- a/crates/apollo_signature_manager_types/src/lib.rs
+++ b/crates/apollo_signature_manager_types/src/lib.rs
@@ -35,6 +35,17 @@ pub enum KeyStoreError {
     Custom(String),
 }
 
+#[derive(
+    Clone, Debug, Default, derive_more::Deref, Eq, PartialEq, Hash, Serialize, Deserialize,
+)]
+pub struct PeerId(pub Vec<u8>);
+
+impl From<Vec<u8>> for PeerId {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
 /// Serves as the signature manager's shared interface.
 /// Requires `Send + Sync` to allow transferring and sharing resources (inputs, futures) across
 /// threads.


### PR DESCRIPTION
To be used in the `SignatureManagerClient` trait, which appears in the
types crate.

Also:
- Rename to `PeerId` with a lowercase `d`.
- Add c-tor from inner value type `impl From<Vec<u8>>`.