### PR TITLE
fix(apollo_l1_provider): wrap records with dedicated type

### DIFF
--- a/crates/apollo_l1_provider/src/test_utils.rs
+++ b/crates/apollo_l1_provider/src/test_utils.rs
@@ -195,7 +195,7 @@ impl From<TransactionManagerContent> for TransactionManager {
             .filter_map(|(&tx_hash, record)| record.is_proposable().then_some(tx_hash))
             .collect();
         let current_epoch = StagingEpoch::new();
-        TransactionManager::create_for_testing(records, proposable_index, current_epoch)
+        TransactionManager::create_for_testing(records.into(), proposable_index, current_epoch)
     }
 }
 

--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -9,7 +9,7 @@ use starknet_api::transaction::TransactionHash;
 pub struct TransactionManager {
     /// Storage of all l1 handler transactions --- keeps transactions until they can be safely
     /// removed, like when they are consumed on L1, or fully cancelled on L1.
-    pub records: IndexMap<TransactionHash, TransactionRecord>,
+    pub records: Records,
     /// Invariant: contains all hashes of transactions that are proposable, and only them.
     /// Structure: [staged_tx1, staged_tx2, ..., staged_txN, unstaged_tx1, unstaged_tx2, ...]
     proposable_index: IndexSet<TransactionHash>,
@@ -26,7 +26,7 @@ pub struct TransactionManager {
 impl TransactionManager {
     pub fn new() -> Self {
         Self {
-            records: IndexMap::default(),
+            records: Records::default(),
             proposable_index: IndexSet::default(),
             current_staging_epoch: StagingEpoch::new(),
         }
@@ -137,7 +137,7 @@ impl TransactionManager {
     pub(crate) fn snapshot(&self) -> TransactionManagerSnapshot {
         let mut snapshot = TransactionManagerSnapshot::default();
 
-        for (&tx_hash, record) in &self.records {
+        for (&tx_hash, record) in self.records.iter() {
             match record.state {
                 TransactionState::Rejected => {
                     snapshot.rejected.push(tx_hash);
@@ -164,7 +164,7 @@ impl TransactionManager {
     where
         F: FnOnce(&mut TransactionRecord) -> R,
     {
-        let record = self.records.get_mut(&hash)?;
+        let record = self.records.get_mut_unchecked(hash)?;
         let result = f(record);
         self.maintain_index(hash);
         Some(result)
@@ -203,7 +203,7 @@ impl TransactionManager {
 
     #[cfg(any(feature = "testing", test))]
     pub fn create_for_testing(
-        records: IndexMap<TransactionHash, TransactionRecord>,
+        records: Records,
         proposable_index: IndexSet<TransactionHash>,
         current_epoch: StagingEpoch,
     ) -> Self {
@@ -421,5 +421,34 @@ impl Sub<u128> for StagingEpoch {
 
     fn sub(self, rhs: u128) -> Self::Output {
         Self(self.0 - rhs)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Records(IndexMap<TransactionHash, TransactionRecord>);
+
+impl Records {
+    /// Warning: this is not a safe method to use outside of the transaction managers's
+    /// `with_record`.
+    pub fn get_mut_unchecked(&mut self, hash: TransactionHash) -> Option<&mut TransactionRecord> {
+        self.0.get_mut(&hash)
+    }
+
+    pub fn insert(&mut self, hash: TransactionHash, record: TransactionRecord) {
+        self.0.insert(hash, record);
+    }
+}
+
+impl Deref for Records {
+    type Target = IndexMap<TransactionHash, TransactionRecord>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<IndexMap<TransactionHash, TransactionRecord>> for Records {
+    fn from(map: IndexMap<TransactionHash, TransactionRecord>) -> Self {
+        Self(map)
     }
 }


### PR DESCRIPTION
Soon will be moved out of file, thus preventing access of records
not through `Records#with_record()`.