### PR TITLE
apollo_consensus: extract consensus clock into `apollo_time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "apollo_protobuf",
  "apollo_reverts",
  "apollo_state_sync_types",
+ "apollo_time",
  "async-trait",
  "futures",
  "mockall",
@@ -1111,6 +1112,7 @@ dependencies = [
  "apollo_state_sync_types",
  "apollo_storage",
  "apollo_test_utils",
+ "apollo_time",
  "async-trait",
  "blockifier",
  "cairo-lang-casm",
@@ -2106,6 +2108,12 @@ dependencies = [
 [[package]]
 name = "apollo_time"
 version = "0.15.0-rc.2"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "mockall",
+ "tokio",
+]
 
 [[package]]
 name = "aquamarine"

--- a/crates/apollo_consensus_manager/Cargo.toml
+++ b/crates/apollo_consensus_manager/Cargo.toml
@@ -26,6 +26,7 @@ apollo_network.workspace = true
 apollo_protobuf.workspace = true
 apollo_reverts.workspace = true
 apollo_state_sync_types.workspace = true
+apollo_time.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 serde.workspace = true

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -15,7 +15,6 @@ use apollo_consensus_orchestrator::cende::CendeAmbassador;
 use apollo_consensus_orchestrator::sequencer_consensus_context::{
     SequencerConsensusContext,
     SequencerConsensusContextDeps,
-    TimeKeeper,
 };
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_infra_utils::type_name::short_type_name;
@@ -27,6 +26,7 @@ use apollo_network::network_manager::{BroadcastTopicChannels, NetworkManager};
 use apollo_protobuf::consensus::{HeightAndRound, ProposalPart, StreamMessage, Vote};
 use apollo_reverts::revert_blocks_and_eternal_pending;
 use apollo_state_sync_types::communication::SharedStateSyncClient;
+use apollo_time::time_keeper::TimeKeeper;
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use starknet_api::block::BlockNumber;

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -18,6 +18,7 @@ apollo_network.workspace = true
 apollo_proc_macros.workspace = true
 apollo_protobuf.workspace = true
 apollo_state_sync_types.workspace = true
+apollo_time.workspace = true
 async-trait.workspace = true
 blockifier.workspace = true
 cairo-lang-starknet-classes.workspace = true
@@ -25,7 +26,6 @@ chrono.workspace = true
 ethnum.workspace = true
 futures.workspace = true
 indexmap.workspace = true
-mockall.workspace = true
 num-rational.workspace = true
 paste.workspace = true
 reqwest = { workspace = true, features = ["json"] }
@@ -54,6 +54,7 @@ apollo_network = { workspace = true, features = ["testing"] }
 apollo_state_sync_types = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
+apollo_time = { workspace = true, features = ["testing"] }
 cairo-lang-casm.workspace = true
 cairo-lang-utils.workspace = true
 cairo-vm.workspace = true

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -7,7 +7,6 @@ mod sequencer_consensus_context_test;
 
 use std::cmp::max;
 use std::collections::BTreeMap;
-use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -48,13 +47,12 @@ use apollo_protobuf::consensus::{
 };
 use apollo_state_sync_types::communication::{StateSyncClient, StateSyncClientError};
 use apollo_state_sync_types::state_sync_types::SyncBlock;
+use apollo_time::time_keeper::{DateTime, Sleeper, TimeKeeper};
 use async_trait::async_trait;
 // TODO(Gilad): Define in consensus, either pass to blockifier as config or keep the dup.
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 use futures::channel::{mpsc, oneshot};
 use futures::{FutureExt, SinkExt, StreamExt};
-#[cfg(any(feature = "testing", test))]
-use mockall::automock;
 use num_rational::Ratio;
 use starknet_api::block::{
     BlockHash,
@@ -125,66 +123,6 @@ enum BuildProposalError {
     EthToStrkOracle(#[from] EthToStrkOracleClientError),
     #[error("L1GasPriceProvider error: {0}")]
     L1GasPriceProvider(#[from] L1GasPriceClientError),
-}
-
-type DateTime = chrono::DateTime<chrono::Utc>;
-
-// TODO(guy.f): Times are probably used in other crates which would benefit from this. Move this to
-// a common mod that can be used across crates.
-#[cfg_attr(any(test, feature = "testing"), automock)]
-pub trait Clock: Send + Sync {
-    /// Human readable representation of unix time (uses duration from epoch under the hood).
-    // Note: chrono iix time and allows it to be printed in datetime
-    // format, since it is otherwise not human readable.
-    fn now(&self) -> DateTime {
-        chrono::Utc::now()
-    }
-
-    /// Seconds from epoch.
-    fn unix_now(&self) -> u64 {
-        self.now().timestamp().try_into().expect("We shouldn't have dates before the unix epoch")
-    }
-}
-
-/// Contains sleep logic, in order to decouple from std/tokio constraints.
-// Consider adding a wrapper around tokio sleep, to decouple from global tokio sleep.
-#[async_trait]
-pub trait Sleeper: Send + Sync {
-    async fn sleep_until(&self, deadline: DateTime);
-}
-
-#[derive(Clone, Default)]
-pub struct DefaultClock();
-
-impl Clock for DefaultClock {}
-
-#[derive(Clone)]
-pub struct TimeKeeper {
-    clock: Arc<dyn Clock>,
-}
-
-#[async_trait]
-impl Sleeper for TimeKeeper {
-    // From Tokio maintainer: https://github.com/tokio-rs/tokio/issues/3918#issuecomment-896192957
-    async fn sleep_until(&self, deadline: DateTime) {
-        let time_delta = deadline - self.clock.now(); // can represent negative duration.
-        let duration_to_sleep = time_delta.to_std().unwrap_or_default(); // nonzero duration.
-        // Note: this is a NOP on `Duration::ZERO`.
-        tokio::time::sleep(duration_to_sleep).await;
-    }
-}
-
-impl Deref for TimeKeeper {
-    type Target = dyn Clock;
-    fn deref(&self) -> &Self::Target {
-        self.clock.as_ref()
-    }
-}
-
-impl Default for TimeKeeper {
-    fn default() -> Self {
-        Self { clock: Arc::new(DefaultClock::default()) }
-    }
 }
 
 type HeightToIdToContent = BTreeMap<

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -52,6 +52,7 @@ use apollo_protobuf::consensus::{
     Vote,
 };
 use apollo_state_sync_types::communication::MockStateSyncClient;
+use apollo_time::time_keeper::MockClock;
 use chrono::{TimeZone, Utc};
 use futures::channel::mpsc;
 use futures::channel::oneshot::Canceled;
@@ -82,7 +83,7 @@ use crate::cende::MockCendeContext;
 use crate::config::ContextConfig;
 use crate::metrics::CONSENSUS_L2_GAS_PRICE;
 use crate::orchestrator_versioned_constants::VersionedConstants;
-use crate::sequencer_consensus_context::{MockClock, SequencerConsensusContext, TimeKeeper};
+use crate::sequencer_consensus_context::{SequencerConsensusContext, TimeKeeper};
 
 const TIMEOUT: Duration = Duration::from_millis(1200);
 const CHANNEL_SIZE: usize = 5000;

--- a/crates/apollo_time/Cargo.toml
+++ b/crates/apollo_time/Cargo.toml
@@ -5,10 +5,18 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[features]
+testing = ["mockall"]
 
 [dependencies]
+async-trait.workspace = true
+chrono.workspace = true
+mockall = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["time"] }
+
 
 [dev-dependencies]
+mockall.workspace = true
 
 [lints]
 workspace = true

--- a/crates/apollo_time/src/lib.rs
+++ b/crates/apollo_time/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod time_keeper;

--- a/crates/apollo_time/src/time_keeper.rs
+++ b/crates/apollo_time/src/time_keeper.rs
@@ -1,0 +1,63 @@
+use std::ops::Deref;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+pub type DateTime = chrono::DateTime<chrono::Utc>;
+
+// TODO(Gilad): add fake clock with fixed time + advance(), instead of mockall, easier to use.
+#[cfg_attr(any(test, feature = "testing"), mockall::automock)]
+pub trait Clock: Send + Sync {
+    /// Human readable representation of unix time (uses duration from epoch under the hood).
+    // Note: chrono is used here since it wraps unix time and allows it to be printed in datetime
+    // format, since it is otherwise not human readable.
+    fn now(&self) -> DateTime {
+        chrono::Utc::now()
+    }
+
+    /// Seconds from epoch.
+    fn unix_now(&self) -> u64 {
+        self.now().timestamp().try_into().expect("We shouldn't have dates before the unix epoch")
+    }
+}
+
+/// Contains sleep logic, in order to decouple from std/tokio constraints.
+// Consider adding a wrapper around tokio sleep, to decouple from global tokio sleep.
+#[async_trait]
+pub trait Sleeper: Send + Sync {
+    async fn sleep_until(&self, deadline: DateTime);
+}
+
+#[derive(Clone, Default)]
+pub struct DefaultClock();
+
+impl Clock for DefaultClock {}
+
+#[derive(Clone)]
+pub struct TimeKeeper {
+    pub clock: Arc<dyn Clock>,
+}
+
+#[async_trait]
+impl Sleeper for TimeKeeper {
+    // From Tokio maintainer: https://github.com/tokio-rs/tokio/issues/3918#issuecomment-896192957.
+    async fn sleep_until(&self, deadline: DateTime) {
+        let time_delta = deadline - self.clock.now(); // can represent negative duration.
+        let duration_to_sleep = time_delta.to_std().unwrap_or_default(); // nonzero duration.
+        // Note: this is a NOP on `Duration::ZERO`.
+        tokio::time::sleep(duration_to_sleep).await;
+    }
+}
+
+impl Deref for TimeKeeper {
+    type Target = dyn Clock;
+    fn deref(&self) -> &Self::Target {
+        self.clock.as_ref()
+    }
+}
+
+impl Default for TimeKeeper {
+    fn default() -> Self {
+        Self { clock: Arc::new(DefaultClock::default()) }
+    }
+}


### PR DESCRIPTION
TODO(gilad): use everywhere (will be implemented after we finish the
milestone).
Also add `FakeClock` instead of mockall: impl is similar to
the mempool's clock, which will also be converted to use this clock
rather than instants.