### PR TITLE
apollo_l1_provider: simplify record constructor

### DIFF
--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -157,10 +157,7 @@ impl TransactionManager {
     }
 
     fn create_record_if_not_exist(&mut self, hash: TransactionHash) -> bool {
-        self.records.insert(
-            hash,
-            TransactionRecord::new(hash.into(), self.current_staging_epoch.decrement()),
-        )
+        self.records.insert(hash, TransactionRecord::new(hash.into()))
     }
 
     fn is_staged(&self, tx_hash: TransactionHash) -> bool {

--- a/crates/apollo_l1_provider/src/transaction_record.rs
+++ b/crates/apollo_l1_provider/src/transaction_record.rs
@@ -27,8 +27,10 @@ pub struct TransactionRecord {
 }
 
 impl TransactionRecord {
-    pub fn new(payload: TransactionPayload, staged_epoch: StagingEpoch) -> Self {
-        Self { staged_epoch, ..Self::from(payload) }
+    /// Create a new transaction record from a transaction payload, epoch is 0 by default, allowing
+    /// the transaction to always be stageable, since the transaction manager's epoch starts at one.
+    pub fn new(payload: TransactionPayload) -> Self {
+        Self::from(payload)
     }
 
     pub fn get_unchecked(&self) -> &L1HandlerTransaction {


### PR DESCRIPTION
Note: soon we'll add timestamps to records, then the `new` won't be so
trivial.