### PR TITLE
papyrus_base_layer: parse event block timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9372,6 +9372,7 @@ dependencies = [
  "colored 3.0.0",
  "ethers",
  "ethers-core",
+ "futures",
  "mockall",
  "pretty_assertions",
  "serde",

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -17,6 +17,7 @@ apollo_config.workspace = true
 async-trait.workspace = true
 colored = { workspace = true, optional = true }
 ethers.workspace = true
+futures.workspace = true
 mockall.workspace = true
 serde.workspace = true
 starknet-types-core.workspace = true

--- a/crates/papyrus_base_layer/src/eth_events.rs
+++ b/crates/papyrus_base_layer/src/eth_events.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use alloy::primitives::{Address as EthereumContractAddress, U256};
 use alloy::rpc::types::Log;
 use alloy::sol_types::SolEventInterface;
+use starknet_api::block::BlockTimestamp;
 use starknet_api::core::{EntryPointSelector, Nonce};
 use starknet_api::transaction::fields::{Calldata, Fee};
 use starknet_api::transaction::L1HandlerTransaction;
@@ -15,36 +16,33 @@ use crate::ethereum_base_layer_contract::{
 };
 use crate::{EventData, L1Event};
 
-impl TryFrom<Log> for L1Event {
-    type Error = EthereumBaseLayerError;
+// Note: don't move as method for L1Event, we don't want to expose alloy's inner type Log to our
+// base layer's API.
+pub fn parse_event(log: Log, block_timestamp: BlockTimestamp) -> EthereumBaseLayerResult<L1Event> {
+    let validate = true;
+    let l1_tx_hash = log.transaction_hash;
+    let log = log.inner;
 
-    fn try_from(log: Log) -> EthereumBaseLayerResult<Self> {
-        let validate = true;
-        let l1_tx_hash = log.transaction_hash;
-        let log = log.inner;
-
-        let event = Starknet::StarknetEvents::decode_log(&log, validate)?.data;
-        match event {
-            Starknet::StarknetEvents::LogMessageToL2(event) => {
-                let fee =
-                    Fee(event.fee.try_into().map_err(EthereumBaseLayerError::FeeOutOfRange)?);
-                let event_data = EventData::try_from(event)?;
-                let tx = L1HandlerTransaction::from(event_data);
-                Ok(L1Event::LogMessageToL2 { tx, fee, l1_tx_hash })
-            }
-            Starknet::StarknetEvents::ConsumedMessageToL2(event) => {
-                Ok(L1Event::ConsumedMessageToL2(event.try_into()?))
-            }
-            Starknet::StarknetEvents::MessageToL2Canceled(event) => {
-                Ok(L1Event::MessageToL2Canceled(event.try_into()?))
-            }
-            Starknet::StarknetEvents::MessageToL2CancellationStarted(event) => {
-                Ok(L1Event::MessageToL2CancellationStarted {
-                    cancelled_tx: EventData::try_from(event)?.into(),
-                })
-            }
-            _ => Err(EthereumBaseLayerError::UnhandledL1Event(log)),
+    let event = Starknet::StarknetEvents::decode_log(&log, validate)?.data;
+    match event {
+        Starknet::StarknetEvents::LogMessageToL2(event) => {
+            let fee = Fee(event.fee.try_into().map_err(EthereumBaseLayerError::FeeOutOfRange)?);
+            let event_data = EventData::try_from(event)?;
+            let tx = L1HandlerTransaction::from(event_data);
+            Ok(L1Event::LogMessageToL2 { tx, fee, l1_tx_hash, timestamp: block_timestamp })
         }
+        Starknet::StarknetEvents::ConsumedMessageToL2(event) => {
+            Ok(L1Event::ConsumedMessageToL2(event.try_into()?))
+        }
+        Starknet::StarknetEvents::MessageToL2Canceled(event) => {
+            Ok(L1Event::MessageToL2Canceled(event.try_into()?))
+        }
+        Starknet::StarknetEvents::MessageToL2CancellationStarted(event) => {
+            Ok(L1Event::MessageToL2CancellationStarted {
+                cancelled_tx: EventData::try_from(event)?.into(),
+            })
+        }
+        _ => Err(EthereumBaseLayerError::UnhandledL1Event(log)),
     }
 }
 

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -25,6 +25,7 @@ use tracing::{debug, error, instrument};
 use url::Url;
 use validator::Validate;
 
+use crate::eth_events::parse_event;
 use crate::{BaseLayerContract, L1BlockHeader, L1BlockNumber, L1BlockReference, L1Event};
 
 pub type EthereumBaseLayerResult<T> = Result<T, EthereumBaseLayerError>;
@@ -159,13 +160,20 @@ impl BaseLayerContract for EthereumBaseLayerContract {
             self.contract.provider().get_logs(&filter),
         )
         .await??;
-        let received_tx_hashes: Vec<_> =
-            matching_logs.iter().map(|log| log.transaction_hash).collect();
-        debug!(
-            "Got events of blocks in range {:?} with transaction hash: {:?}",
-            block_range, received_tx_hashes
-        );
-        matching_logs.into_iter().map(L1Event::try_from).collect()
+
+        // Debugging.
+        let hashes: Vec<_> = matching_logs.iter().filter_map(|log| log.transaction_hash).collect();
+        debug!("Got events in {:?}, transaction hashes: {:?}", block_range, hashes);
+
+        let block_header_futures = matching_logs.into_iter().map(|log| {
+            let block_number = log.block_number.unwrap();
+            async move {
+                let header = self.get_block_header(block_number).await?.unwrap();
+                parse_event(log, header.timestamp)
+            }
+        });
+
+        futures::future::join_all(block_header_futures).await.into_iter().collect()
     }
 
     #[instrument(skip(self), err)]

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -100,8 +100,15 @@ pub struct L1BlockHeader {
 pub enum L1Event {
     ConsumedMessageToL2(EventData),
     // TODO(Arni): Consider adding the l1_tx_hash to all variants of L1 Event.
-    LogMessageToL2 { tx: L1HandlerTransaction, fee: Fee, l1_tx_hash: Option<FixedBytes<32>> },
-    MessageToL2CancellationStarted { cancelled_tx: L1HandlerTransaction },
+    LogMessageToL2 {
+        tx: L1HandlerTransaction,
+        fee: Fee,
+        l1_tx_hash: Option<FixedBytes<32>>,
+        timestamp: BlockTimestamp,
+    },
+    MessageToL2CancellationStarted {
+        cancelled_tx: L1HandlerTransaction,
+    },
     MessageToL2Canceled(EventData),
 }
 


### PR DESCRIPTION
Note that the log object has a block_timestamp field on alloy, but that
isn't guaranteed to be filled and isn't supported yet by infura and
others (it's a new feature on ethereum). Hence using the traditional way
of fetching the block header itself and grabbing the time from it, which
is guaranteed to exist.

Note that this does n_logs rpc calls to infura, one per log, but this is
probably unavoidable at the moment, and also isn't that large given the
small number of l1 handlers we get.