### PR TITLE
time: revert timekeeper struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,7 +2109,6 @@ dependencies = [
 name = "apollo_time"
 version = "0.15.0-rc.2"
 dependencies = [
- "async-trait",
  "chrono",
  "mockall",
  "tokio",

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -26,7 +26,7 @@ use apollo_network::network_manager::{BroadcastTopicChannels, NetworkManager};
 use apollo_protobuf::consensus::{HeightAndRound, ProposalPart, StreamMessage, Vote};
 use apollo_reverts::revert_blocks_and_eternal_pending;
 use apollo_state_sync_types::communication::SharedStateSyncClient;
-use apollo_time::time_keeper::TimeKeeper;
+use apollo_time::time_keeper::DefaultClock;
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use starknet_api::block::BlockNumber;
@@ -161,7 +161,7 @@ impl ConsensusManager {
                     self.config.eth_to_strk_oracle_config.clone(),
                 )),
                 l1_gas_price_provider: self.l1_gas_price_provider.clone(),
-                time: TimeKeeper::default(),
+                clock: Arc::new(DefaultClock()),
                 outbound_proposal_sender: outbound_internal_sender,
                 vote_broadcast_client: votes_broadcast_channels.broadcast_topic_client.clone(),
             },

--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -109,7 +109,7 @@ pub(crate) async fn build_proposal(mut args: ProposalBuildArguments) {
 async fn initiate_build(args: &ProposalBuildArguments) -> ProposalResult<ConsensusBlockInfo> {
     let batcher_timeout = chrono::Duration::from_std(args.batcher_timeout)
         .expect("Can't convert timeout to chrono::Duration");
-    let timestamp = args.deps.time.unix_now();
+    let timestamp = args.deps.clock.unix_now();
     let (eth_to_fri_rate, l1_prices) = get_oracle_rate_and_prices(
         args.deps.eth_to_strk_oracle_client.clone(),
         args.deps.l1_gas_price_provider.clone(),
@@ -134,7 +134,7 @@ async fn initiate_build(args: &ProposalBuildArguments) -> ProposalResult<Consens
         retrospective_block_hash(args.deps.state_sync_client.clone(), &block_info).await?;
     let build_proposal_input = ProposeBlockInput {
         proposal_id: args.proposal_id,
-        deadline: args.deps.time.now() + batcher_timeout,
+        deadline: args.deps.clock.now() + batcher_timeout,
         retrospective_block_hash,
         block_info: convert_to_sn_api_block_info(&block_info),
         proposal_round: args.proposal_round,

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -44,7 +44,7 @@ use apollo_protobuf::consensus::{
 };
 use apollo_state_sync_types::communication::{StateSyncClient, StateSyncClientError};
 use apollo_state_sync_types::state_sync_types::SyncBlock;
-use apollo_time::time_keeper::{DateTime, Sleeper, TimeKeeper};
+use apollo_time::time_keeper::{sleep_until, Clock, DateTime};
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
@@ -212,7 +212,7 @@ pub struct SequencerConsensusContextDeps {
     pub eth_to_strk_oracle_client: Arc<dyn EthToStrkOracleClientTrait>,
     pub l1_gas_price_provider: Arc<dyn L1GasPriceProviderClient>,
     /// Use DefaultClock if you don't want to inject timestamps.
-    pub time: TimeKeeper,
+    pub clock: Arc<dyn Clock>,
     // Used to initiate new outbound proposal streams.
     pub outbound_proposal_sender: mpsc::Sender<(HeightAndRound, mpsc::Receiver<ProposalPart>)>,
     // Used to broadcast votes to other consensus nodes.
@@ -601,7 +601,7 @@ impl ConsensusContext for SequencerConsensusContext {
         let timestamp = sync_block.block_header_without_hash.timestamp;
         let last_block_timestamp =
             self.previous_block_info.as_ref().map_or(0, |info| info.timestamp);
-        let now: u64 = self.deps.time.unix_now();
+        let now: u64 = self.deps.clock.unix_now();
         if !(block_number == height
             && timestamp.0 >= last_block_timestamp
             && timestamp.0 <= now + self.config.block_timestamp_window_seconds)
@@ -767,7 +767,7 @@ impl SequencerConsensusContext {
 
 async fn validate_proposal(mut args: ProposalValidateArguments) {
     let mut content = Vec::new();
-    let now = args.deps.time.now();
+    let now = args.deps.clock.now();
 
     let Some(deadline) = now.checked_add_signed(chrono::TimeDelta::from_std(args.timeout).unwrap())
     else {
@@ -780,7 +780,7 @@ async fn validate_proposal(mut args: ProposalValidateArguments) {
         deadline,
         &mut args.content_receiver,
         args.fin_sender,
-        &args.deps.time,
+        args.deps.clock.as_ref(),
     )
     .await
     else {
@@ -790,7 +790,7 @@ async fn validate_proposal(mut args: ProposalValidateArguments) {
         args.block_info_validation.clone(),
         block_info.clone(),
         args.deps.eth_to_strk_oracle_client,
-        &args.deps.time,
+        args.deps.clock.as_ref(),
         args.deps.l1_gas_price_provider,
         &args.gas_price_params,
     )
@@ -804,7 +804,7 @@ async fn validate_proposal(mut args: ProposalValidateArguments) {
         block_info.clone(),
         args.proposal_id,
         args.timeout + args.batcher_timeout_margin,
-        &args.deps.time,
+        args.deps.clock.as_ref(),
     )
     .await
     {
@@ -819,7 +819,7 @@ async fn validate_proposal(mut args: ProposalValidateArguments) {
                 batcher_abort_proposal(args.deps.batcher.as_ref(), args.proposal_id).await;
                 return;
             }
-            _ = args.deps.time.sleep_until(deadline) => {
+            _ = sleep_until(deadline, args.deps.clock.as_ref()) => {
                 warn!("Validation timed out.");
                 batcher_abort_proposal(args.deps.batcher.as_ref(), args.proposal_id).await;
                 return;
@@ -883,11 +883,11 @@ async fn is_block_info_valid(
     block_info_validation: BlockInfoValidation,
     block_info_proposed: ConsensusBlockInfo,
     eth_to_strk_oracle_client: Arc<dyn EthToStrkOracleClientTrait>,
-    time: &TimeKeeper,
+    clock: &dyn Clock,
     l1_gas_price_provider: Arc<dyn L1GasPriceProviderClient>,
     gas_price_params: &GasPriceParams,
 ) -> bool {
-    let now: u64 = time.unix_now();
+    let now: u64 = clock.unix_now();
     let last_block_timestamp =
         block_info_validation.previous_block_info.as_ref().map_or(0, |info| info.timestamp);
     if !(block_info_proposed.height == block_info_validation.height
@@ -957,14 +957,14 @@ async fn await_second_proposal_part(
     deadline: DateTime,
     content_receiver: &mut mpsc::Receiver<ProposalPart>,
     fin_sender: oneshot::Sender<ProposalCommitment>,
-    time: &TimeKeeper,
+    clock: &dyn Clock,
 ) -> Option<(ConsensusBlockInfo, oneshot::Sender<ProposalCommitment>)> {
     tokio::select! {
         _ = cancel_token.cancelled() => {
             warn!("Proposal interrupted");
             None
         }
-        _ = time.sleep_until(deadline) => {
+        _ = sleep_until(deadline, clock) => {
             warn!("Validation timed out.");
             None
         }
@@ -999,14 +999,14 @@ async fn initiate_validation(
     block_info: ConsensusBlockInfo,
     proposal_id: ProposalId,
     timeout_plus_margin: Duration,
-    time: &TimeKeeper,
+    clock: &dyn Clock,
 ) -> ProposalResult<()> {
     let chrono_timeout = chrono::Duration::from_std(timeout_plus_margin)
         .expect("Can't convert timeout to chrono::Duration");
 
     let input = ValidateBlockInput {
         proposal_id,
-        deadline: time.now() + chrono_timeout,
+        deadline: clock.now() + chrono_timeout,
         retrospective_block_hash: retrospective_block_hash(state_sync_client, &block_info).await?,
         block_info: convert_to_sn_api_block_info(&block_info),
     };

--- a/crates/apollo_time/Cargo.toml
+++ b/crates/apollo_time/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 testing = ["mockall"]
 
 [dependencies]
-async-trait.workspace = true
 chrono.workspace = true
 mockall = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["time"] }

--- a/crates/apollo_time/src/time_keeper.rs
+++ b/crates/apollo_time/src/time_keeper.rs
@@ -1,8 +1,3 @@
-use std::ops::Deref;
-use std::sync::Arc;
-
-use async_trait::async_trait;
-
 pub type DateTime = chrono::DateTime<chrono::Utc>;
 
 // TODO(Gilad): add fake clock with fixed time + advance(), instead of mockall, easier to use.
@@ -21,43 +16,19 @@ pub trait Clock: Send + Sync {
     }
 }
 
-/// Contains sleep logic, in order to decouple from std/tokio constraints.
-// Consider adding a wrapper around tokio sleep, to decouple from global tokio sleep.
-#[async_trait]
-pub trait Sleeper: Send + Sync {
-    async fn sleep_until(&self, deadline: DateTime);
+/// Free function to sleep until a given deadline using a provided clock.
+pub async fn sleep_until(deadline: DateTime, clock: &dyn Clock) {
+    // Calculate how much time is left until the deadline.
+    // If the deadline has already passed, this will be a negative duration.
+    let time_delta = deadline - clock.now();
+    // Convert to `std::time::Duration`, clamping any negative value to zero.
+    // A zero-duration sleep is effectively a no-op.
+    let duration_to_sleep = time_delta.to_std().unwrap_or_default();
+    // Sleep for the computed duration (or return immediately if zero).
+    tokio::time::sleep(duration_to_sleep).await;
 }
 
 #[derive(Clone, Default)]
 pub struct DefaultClock();
 
 impl Clock for DefaultClock {}
-
-#[derive(Clone)]
-pub struct TimeKeeper {
-    pub clock: Arc<dyn Clock>,
-}
-
-#[async_trait]
-impl Sleeper for TimeKeeper {
-    // From Tokio maintainer: https://github.com/tokio-rs/tokio/issues/3918#issuecomment-896192957.
-    async fn sleep_until(&self, deadline: DateTime) {
-        let time_delta = deadline - self.clock.now(); // can represent negative duration.
-        let duration_to_sleep = time_delta.to_std().unwrap_or_default(); // nonzero duration.
-        // Note: this is a NOP on `Duration::ZERO`.
-        tokio::time::sleep(duration_to_sleep).await;
-    }
-}
-
-impl Deref for TimeKeeper {
-    type Target = dyn Clock;
-    fn deref(&self) -> &Self::Target {
-        self.clock.as_ref()
-    }
-}
-
-impl Default for TimeKeeper {
-    fn default() -> Self {
-        Self { clock: Arc::new(DefaultClock::default()) }
-    }
-}


### PR DESCRIPTION
Sleeper trait isn't useful + improve documentation for `sleep_until`.
Next pr will also rename time_keeper.rs -> time.rs