### PR TITLE
refactor(apollo_signature_manager): create `PeerIdentity` test util

### DIFF
--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -128,7 +128,7 @@ mod tests {
         false
     )]
     fn test_verify_identity(#[case] signature: Signature, #[case] expected: bool) {
-        let peer_id = PeerId(b"alice".to_vec());
+        let peer_id = PeerIdentity::new().peer_id;
         let public_key =
             PublicKey(felt!("0x125d56b1fbba593f1dd215b7c55e384acd838cad549c4a2b9c6d32d264f4e2a"));
 
@@ -156,6 +156,18 @@ mod tests {
             verify_precommit_vote_signature(block_hash, signature.into(), public_key),
             Ok(expected)
         );
+    }
+
+    // TODO: add identification nonce.
+    #[derive(Clone, Debug)]
+    struct PeerIdentity {
+        pub peer_id: PeerId,
+    }
+
+    impl PeerIdentity {
+        pub fn new() -> Self {
+            Self { peer_id: PeerId(b"alice".to_vec()) }
+        }
     }
 
     /// Simple in-memory KeyStore implementation for testing
@@ -195,7 +207,7 @@ mod tests {
         let key_store = TestKeyStore::new();
         let signature_manager = SignatureManager::new(key_store);
 
-        let peer_id = PeerId(b"alice".to_vec());
+        let peer_id = PeerIdentity::new().peer_id;
         let signature = signature_manager.identify(peer_id.clone()).await;
 
         assert_eq!(signature, Ok(ALICE_IDENTITY_SIGNATURE.into()));


### PR DESCRIPTION
Will soon add nonce to it.