### PR TITLE
apollo_batcher: use feeder state diff in preconf

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -50,7 +50,7 @@ use tokio::sync::{Mutex, MutexGuard};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::block_builder::FailOnErrorCause::L1HandlerTransactionValidationFailed;
-use crate::cende_client_types::StarknetClientTransactionReceipt;
+use crate::cende_client_types::{StarknetClientStateDiff, StarknetClientTransactionReceipt};
 use crate::metrics::FULL_BLOCKS;
 use crate::pre_confirmed_block_writer::{ExecutedTxSender, PreConfirmedTxSender};
 use crate::transaction_executor::TransactionExecutorTrait;
@@ -491,7 +491,7 @@ async fn collect_execution_results_and_stream_txs(
                         &execution_data.execution_infos[&tx_hash],
                     ));
 
-                    let tx_state_diff = ThinStateDiff::from(state_maps);
+                    let tx_state_diff = StarknetClientStateDiff::from(state_maps).0;
 
                     let result =
                         executed_tx_sender.try_send((input_tx.clone(), tx_receipt, tx_state_diff));

--- a/crates/apollo_batcher/src/pre_confirmed_block_writer.rs
+++ b/crates/apollo_batcher/src/pre_confirmed_block_writer.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use apollo_batcher_types::batcher_types::Round;
 use apollo_config::dumping::{ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use apollo_starknet_client::reader::StateDiff;
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -15,7 +16,6 @@ use mockall::automock;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
-use starknet_api::state::ThinStateDiff;
 use starknet_api::transaction::TransactionHash;
 use thiserror::Error;
 use tracing::info;
@@ -46,12 +46,12 @@ pub type PreConfirmedTxSender = tokio::sync::mpsc::Sender<Vec<InternalConsensusT
 pub type ExecutedTxReceiver = tokio::sync::mpsc::Receiver<(
     InternalConsensusTransaction,
     StarknetClientTransactionReceipt,
-    ThinStateDiff,
+    StateDiff,
 )>;
 pub type ExecutedTxSender = tokio::sync::mpsc::Sender<(
     InternalConsensusTransaction,
     StarknetClientTransactionReceipt,
-    ThinStateDiff,
+    StateDiff,
 )>;
 
 /// Coordinates the flow of pre-confirmed block data during block proposal.
@@ -95,7 +95,7 @@ impl PreConfirmedBlockWriter {
             (
                 CendePreConfirmedTransaction,
                 Option<StarknetClientTransactionReceipt>,
-                Option<ThinStateDiff>,
+                Option<StateDiff>,
             ),
         >,
         write_iteration: u64,
@@ -134,7 +134,7 @@ impl PreConfirmedBlockWriterTrait for PreConfirmedBlockWriter {
             (
                 CendePreConfirmedTransaction,
                 Option<StarknetClientTransactionReceipt>,
-                Option<ThinStateDiff>,
+                Option<StateDiff>,
             ),
         > = IndexMap::new();
 

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use indexmap::IndexMap;
 use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
-use starknet_api::state::{StorageKey, ThinStateDiff};
+use starknet_api::state::StorageKey;
 use starknet_types_core::felt::Felt;
 
 use crate::context::TransactionContext;
@@ -366,18 +366,6 @@ impl StateMaps {
             class_hash_keys: self.class_hashes.keys().cloned().collect(),
             storage_keys: self.storage.keys().cloned().collect(),
             compiled_class_hash_keys: self.compiled_class_hashes.keys().cloned().collect(),
-        }
-    }
-}
-
-impl From<StateMaps> for ThinStateDiff {
-    fn from(maps: StateMaps) -> Self {
-        Self {
-            deployed_contracts: IndexMap::from_iter(maps.class_hashes),
-            storage_diffs: StorageDiff::from(StorageView(maps.storage)),
-            declared_classes: IndexMap::from_iter(maps.compiled_class_hashes),
-            deprecated_declared_classes: Vec::new(),
-            nonces: IndexMap::from_iter(maps.nonces),
         }
     }
 }


### PR DESCRIPTION
- **apollo_batcher: change pre confirmed write API from tx to block**
- **apollo_batcher: stream executed tx receipts**
- **apollo_batcher: change channel types for new block writer API**
- **apollo_batcher: implement pre confirmed writer run**
- **apollo_batcher: implement client write pre confirmed block**
- **apollo_batcher: make pre confirmed block write interval configurable**
- **apollo_batcher: add CendeBlockMetadata constructor**
- **apollo_batcher: preconfirmed block - collect the data and send to cende**
- **apollo_batcher: ci fixes**
- **apollo_batcher: remove parent block hash from cende block**
- **apollo_batcher: use feeder state diff in preconf**
