### PR TITLE
papyrus_base_layer: add timestamp to message cancellation raw events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "apollo_l1_provider_types",
  "apollo_metrics",
  "apollo_state_sync_types",
+ "apollo_time",
  "assert_matches",
  "async-trait",
  "hex",

--- a/crates/apollo_l1_provider/Cargo.toml
+++ b/crates/apollo_l1_provider/Cargo.toml
@@ -15,6 +15,7 @@ apollo_infra.workspace = true
 apollo_l1_provider_types.workspace = true
 apollo_metrics.workspace = true
 apollo_state_sync_types.workspace = true
+apollo_time.workspace = true
 async-trait.workspace = true
 hex.workspace = true
 indexmap.workspace = true
@@ -33,6 +34,7 @@ alloy.workspace = true
 apollo_batcher_types = { workspace = true, features = ["testing"] }
 apollo_l1_provider_types = { workspace = true, features = ["testing"] }
 apollo_state_sync_types = { workspace = true, features = ["testing"] }
+apollo_time = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 itertools.workspace = true
 papyrus_base_layer = { workspace = true, features = ["testing"] }

--- a/crates/apollo_l1_provider/src/l1_provider_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_provider_tests.rs
@@ -10,6 +10,7 @@ use apollo_l1_provider_types::SessionState::{
 };
 use apollo_l1_provider_types::{Event, InvalidValidationStatus, ValidationStatus};
 use apollo_state_sync_types::communication::MockStateSyncClient;
+use apollo_time::time::MockClock;
 use assert_matches::assert_matches;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
@@ -22,7 +23,7 @@ use starknet_api::tx_hash;
 use crate::bootstrapper::{Bootstrapper, CommitBlockBacklog, SyncTaskHandle};
 use crate::l1_provider::L1Provider;
 use crate::test_utils::{l1_handler, FakeL1ProviderClient, L1ProviderContentBuilder};
-use crate::ProviderState;
+use crate::{L1ProviderConfig, ProviderState};
 
 fn commit_block_no_rejected(
     l1_provider: &mut L1Provider,
@@ -581,4 +582,129 @@ fn get_txs_same_timestamp_returns_in_arrival_order() {
         expected,
         "Transactions with the same timestamp must be returned in order of arrival"
     );
+}
+
+#[test]
+fn get_txs_identical_timestamps() {
+    let tx_1 = l1_handler(1);
+    let tx_2 = l1_handler(2);
+    let tx_3 = l1_handler(3);
+    let timestamp_1 = 1;
+    let timestamp_2 = timestamp_1; // Transaction 2 has the same timestamp as 1.
+    let timestamp_3 = 2;
+
+    let l1_provider_builder = L1ProviderContentBuilder::new()
+        .with_timed_txs([
+            (tx_1.clone(), timestamp_1),
+            (tx_2.clone(), timestamp_2),
+            (tx_3.clone(), timestamp_3),
+        ])
+        .with_state(ProviderState::Propose);
+
+    // Can get only one tx out of the two with the same timestamp.
+    assert_eq!(
+        l1_provider_builder.clone().build_into_l1_provider().get_txs(1, BlockNumber(0)).unwrap(),
+        [tx_1.clone()]
+    );
+
+    assert_eq!(
+        l1_provider_builder.build_into_l1_provider().get_txs(3, BlockNumber(0)).unwrap(),
+        [tx_1, tx_2, tx_3]
+    );
+}
+
+#[test]
+fn get_txs_timestamp_cutoff_some_eligible() {
+    let tx_1 = l1_handler(1);
+    let tx_2 = l1_handler(2);
+    let tx_3 = l1_handler(3);
+    let timestamp_1 = 10;
+    let timestamp_2 = 20;
+    let timestamp_3 = 30;
+    let now = 35u64;
+    let cooldown = 20; // cutoff = now - cooldown = 35 - 20 = 15.
+    // Only tx_1 (timestamp_1=10) is eligible (10 < 15).
+
+    let mut mock_clock = MockClock::new();
+    mock_clock.expect_unix_now().return_const(now);
+
+    let config = L1ProviderConfig {
+        new_l1_handler_cooldown_seconds: Duration::from_secs(cooldown),
+        ..Default::default()
+    };
+    let mut l1_provider = L1ProviderContentBuilder::new()
+        .with_config(config)
+        .with_clock(Arc::new(mock_clock))
+        .with_timed_txs([
+            (tx_1.clone(), timestamp_1),
+            (tx_2.clone(), timestamp_2),
+            (tx_3.clone(), timestamp_3),
+        ])
+        .with_state(ProviderState::Propose)
+        .build_into_l1_provider();
+
+    let result = l1_provider.get_txs(10, BlockNumber(0)).unwrap();
+    assert_eq!(result, vec![tx_1.clone()]);
+}
+
+#[test]
+fn get_txs_timestamp_cutoff_none_eligible() {
+    let tx_1 = l1_handler(1);
+    let tx_2 = l1_handler(2);
+    let timestamp_1 = 10;
+    let timestamp_2 = 20;
+    let now = 30u64;
+    let cooldown = 21; // cutoff = now - cooldown = 30 - 21 = 9.
+    // No txs have timestamp < cutoff (10,20 >= 9).
+
+    let mut mock_clock = MockClock::new();
+    mock_clock.expect_unix_now().return_const(now);
+
+    let config = L1ProviderConfig {
+        new_l1_handler_cooldown_seconds: Duration::from_secs(cooldown),
+        ..Default::default()
+    };
+    let mut l1_provider = L1ProviderContentBuilder::new()
+        .with_config(config)
+        .with_clock(Arc::new(mock_clock))
+        .with_timed_txs([(tx_1.clone(), timestamp_1), (tx_2.clone(), timestamp_2)])
+        .with_state(ProviderState::Propose)
+        .build_into_l1_provider();
+
+    let result = l1_provider.get_txs(10, BlockNumber(0)).unwrap();
+    assert_eq!(result, vec![]);
+}
+
+#[test]
+fn get_txs_timestamp_cutoff_edge_case_at_cutoff() {
+    let tx_1 = l1_handler(1);
+    let tx_2 = l1_handler(2);
+    let tx_3 = l1_handler(3);
+    let timestamp_1 = 10;
+    let timestamp_2 = 11;
+    let timestamp_3 = 9;
+    let now = 30u64;
+    let cooldown = 20; // cutoff = now - cooldown = 30 - 20 = 10
+    // Only tx_3 is eligible (timestamp_3 = 9 < 10).
+
+    let mut mock_clock = MockClock::new();
+    mock_clock.expect_unix_now().return_const(now);
+
+    let config = L1ProviderConfig {
+        new_l1_handler_cooldown_seconds: Duration::from_secs(cooldown),
+        ..Default::default()
+    };
+    let mut l1_provider = L1ProviderContentBuilder::new()
+        .with_config(config)
+        .with_clock(Arc::new(mock_clock))
+        .with_timed_txs([
+            (tx_1.clone(), timestamp_1),
+            (tx_2.clone(), timestamp_2),
+            (tx_3.clone(), timestamp_3),
+        ])
+        .with_state(ProviderState::Propose)
+        .build_into_l1_provider();
+
+    let result = l1_provider.get_txs(10, BlockNumber(0)).unwrap();
+    assert_eq!(result, vec![tx_3.clone()]);
 }

--- a/crates/apollo_l1_provider/src/transaction_record.rs
+++ b/crates/apollo_l1_provider/src/transaction_record.rs
@@ -91,7 +91,7 @@ impl TransactionRecord {
     /// in all states in its lifecycle, except after it had already been added to block, or (to be
     /// implemented) a short time after it's cancellation was requested on L1.
     /// In particular, this includes states like: a rejected transaction, a new timelocked
-    /// transaction (to be implemented), a transaction whose cancellation was requested on L1 too
+    /// transaction, a transaction whose cancellation was requested on L1 too
     /// recently (there will be a timelock for this).
     pub fn is_validatable(&self) -> bool {
         !self.is_committed()

--- a/crates/apollo_l1_provider_types/src/lib.rs
+++ b/crates/apollo_l1_provider_types/src/lib.rs
@@ -240,7 +240,10 @@ impl Event {
                 let tx = ExecutableL1HandlerTransaction::create(tx, chain_id, fee)?;
                 Self::L1HandlerTransaction { l1_handler_tx: tx, timestamp }
             }
-            L1Event::MessageToL2CancellationStarted { cancelled_tx } => {
+            L1Event::MessageToL2CancellationStarted {
+                cancelled_tx,
+                cancellation_request_timestamp: _not_used_yet,
+            } => {
                 let tx_hash =
                     cancelled_tx.calculate_transaction_hash(chain_id, &cancelled_tx.version)?;
 

--- a/crates/apollo_time/src/time.rs
+++ b/crates/apollo_time/src/time.rs
@@ -1,8 +1,10 @@
+use std::fmt::Debug;
+
 pub type DateTime = chrono::DateTime<chrono::Utc>;
 
 // TODO(Gilad): add fake clock with fixed time + advance(), instead of mockall, easier to use.
 #[cfg_attr(any(test, feature = "testing"), mockall::automock)]
-pub trait Clock: Send + Sync {
+pub trait Clock: Send + Sync + Debug {
     /// Human readable representation of unix time (uses duration from epoch under the hood).
     // Note: chrono is used here since it wraps unix time and allows it to be printed in datetime
     // format, since it is otherwise not human readable.
@@ -28,7 +30,7 @@ pub async fn sleep_until(deadline: DateTime, clock: &dyn Clock) {
     tokio::time::sleep(duration_to_sleep).await;
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DefaultClock;
 
 impl Clock for DefaultClock {}

--- a/crates/papyrus_base_layer/src/eth_events.rs
+++ b/crates/papyrus_base_layer/src/eth_events.rs
@@ -40,6 +40,7 @@ pub fn parse_event(log: Log, block_timestamp: BlockTimestamp) -> EthereumBaseLay
         Starknet::StarknetEvents::MessageToL2CancellationStarted(event) => {
             Ok(L1Event::MessageToL2CancellationStarted {
                 cancelled_tx: EventData::try_from(event)?.into(),
+                cancellation_request_timestamp: block_timestamp,
             })
         }
         _ => Err(EthereumBaseLayerError::UnhandledL1Event(log)),

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -108,6 +108,9 @@ pub enum L1Event {
     },
     MessageToL2CancellationStarted {
         cancelled_tx: L1HandlerTransaction,
+        // To clarify, this is the timestamp of the cancellation request, not the timestamp of the
+        // cancellation itself, nor is it the timestamp of the transaction that was cancelled.
+        cancellation_request_timestamp: BlockTimestamp,
     },
     MessageToL2Canceled(EventData),
 }


### PR DESCRIPTION
Note that this is the timestamp of the cancellation-started event, not
the original l1 handler's timestamp