### PR TITLE
l1: once cancellation requests pass timelock, ban validations

### DIFF
--- a/crates/apollo_l1_provider_types/src/lib.rs
+++ b/crates/apollo_l1_provider_types/src/lib.rs
@@ -46,6 +46,7 @@ impl From<InvalidValidationStatus> for ValidationStatus {
 pub enum InvalidValidationStatus {
     AlreadyIncludedInProposedBlock,
     AlreadyIncludedOnL2,
+    CancelledOnL2,
     ConsumedOnL1OrUnknown,
 }
 

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -548,6 +548,10 @@ impl GasPrices {
 pub struct BlockTimestamp(pub u64);
 
 impl BlockTimestamp {
+    pub fn saturating_add(self, rhs: &u64) -> Self {
+        Self(self.0.saturating_add(*rhs))
+    }
+
     pub fn saturating_sub(self, rhs: &u64) -> Self {
         Self(self.0.saturating_sub(*rhs))
     }


### PR DESCRIPTION
We are already banning proposals for transactions that have a pending
cancellation request. This change compares the cancellation's
block_timestamp with now(), and if the difference is larger than the
config'ed timelock, that record transitions to "cancelled" state, which
also doesn't allow validations on it (but commit_block overrides this
state, in case another node happened to add that tx anyway).

Note that the state transition of a record into cancelled state is
_lazy_, and occures only upon receiving a validation request for it.