### PR TITLE
blockifier: Time transaction and entrypoint executions.

### DIFF
--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign};
+use std::time::Duration;
 
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use serde::Serialize;
@@ -211,6 +212,9 @@ pub struct CallInfo {
     pub accessed_storage_keys: HashSet<StorageKey>,
     pub read_class_hash_values: Vec<ClassHash>,
     pub accessed_contract_addresses: HashSet<ContractAddress>,
+    /// Execution time of the contract call.
+    /// None implies that the time was not measured.
+    pub time: Option<Duration>,
 }
 
 impl CallInfo {

--- a/crates/blockifier/src/execution/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/entry_point_execution.rs
@@ -431,6 +431,7 @@ pub fn finalize_execution(
         accessed_storage_keys: syscall_handler_base.accessed_keys,
         read_class_hash_values: syscall_handler_base.read_class_hash_values,
         accessed_contract_addresses: syscall_handler_base.accessed_contract_addresses,
+        time: None,
     })
 }
 

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Instant;
 
 use cairo_vm::serde::deserialize_program::{
     deserialize_array_of_bigint_hex,
@@ -115,7 +116,9 @@ pub fn execute_entry_point_call(
     state: &mut dyn State,
     context: &mut EntryPointExecutionContext,
 ) -> EntryPointExecutionResult<CallInfo> {
-    match compiled_class {
+    let pre_execution_instant = Instant::now();
+
+    let mut call_info = match compiled_class {
         RunnableCompiledClass::V0(compiled_class) => {
             deprecated_entry_point_execution::execute_entry_point_call(
                 call,
@@ -147,7 +150,10 @@ pub fn execute_entry_point_call(
                 )
             }
         }
-    }
+    }?;
+
+    call_info.time = Some(pre_execution_instant.elapsed());
+    Ok(call_info)
 }
 
 pub fn update_remaining_gas(remaining_gas: &mut u64, call_info: &CallInfo) {

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::block::GasPriceVector;
@@ -796,6 +797,8 @@ impl<U: UpdatableState> ExecutableTransaction<U> for AccountTransaction {
         block_context: &BlockContext,
         concurrency_mode: bool,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
+        let pre_execution_instant = Instant::now();
+
         let tx_context = Arc::new(block_context.to_tx_context(self));
         self.verify_tx_version(tx_context.tx_info.version())?;
 
@@ -836,6 +839,7 @@ impl<U: UpdatableState> ExecutableTransaction<U> for AccountTransaction {
                 gas: total_gas,
             },
             revert_error,
+            time: Some(pre_execution_instant.elapsed()),
         };
         Ok(tx_execution_info)
     }

--- a/crates/blockifier/src/transaction/objects.rs
+++ b/crates/blockifier/src/transaction/objects.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
@@ -210,6 +211,9 @@ pub struct TransactionExecutionInfo {
     /// (including L1 gas and additional OS resources estimation),
     /// and total gas consumed.
     pub receipt: TransactionReceipt,
+    /// Total execution time of the transaction.
+    /// None implies that the time was not measured.
+    pub time: Option<Duration>,
 }
 
 impl TransactionExecutionInfo {

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use starknet_api::contract_class::ClassInfo;
 use starknet_api::core::{calculate_contract_address, ContractAddress, Nonce};
@@ -142,6 +143,8 @@ impl<U: UpdatableState> ExecutableTransaction<U> for L1HandlerTransaction {
         block_context: &BlockContext,
         _concurrency_mode: bool,
     ) -> TransactionExecutionResult<TransactionExecutionInfo> {
+        let pre_execution_instant = Instant::now();
+
         let tx_context = Arc::new(block_context.to_tx_context(self));
         let limit_steps_by_resources = false;
         // The Sierra gas limit for L1 handler transaction is set to max_execute_sierra_gas.
@@ -184,6 +187,7 @@ impl<U: UpdatableState> ExecutableTransaction<U> for L1HandlerTransaction {
                 gas: total_gas,
             },
             revert_error: None,
+            time: Some(pre_execution_instant.elapsed()),
         })
     }
 }


### PR DESCRIPTION
This PR adds logic for measuring the execution time of both:

- A whole transaction execution.
- An individual entrypoint call.

The measured time is then stored as a field of the execution result.

As both `TransactionExecutionInfo` and `CallInfo` implement the trait `Default`, I'm using `Option<Duration>` to differentiate between zero time, and the default value (no measurement).