### PR TITLE
feat(apollo_signature_manager): add nonce to `identify` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,6 +1906,7 @@ dependencies = [
  "pretty_assertions",
  "rstest",
  "starknet-core",
+ "starknet-types-core",
  "starknet_api",
  "tokio",
 ]

--- a/crates/apollo_signature_manager/Cargo.toml
+++ b/crates/apollo_signature_manager/Cargo.toml
@@ -19,6 +19,7 @@ async-trait.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 starknet-core.workspace = true
+starknet-types-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 tokio.workspace = true
 

--- a/crates/apollo_signature_manager/src/communication.rs
+++ b/crates/apollo_signature_manager/src/communication.rs
@@ -22,8 +22,8 @@ impl<KS: KeyStore> ComponentRequestHandler<SignatureManagerRequest, SignatureMan
         request: SignatureManagerRequest,
     ) -> SignatureManagerResponse {
         match request {
-            SignatureManagerRequest::Identify(peer_id, _nonce) => {
-                SignatureManagerResponse::Identify(self.identify(peer_id).await)
+            SignatureManagerRequest::Identify(peer_id, nonce) => {
+                SignatureManagerResponse::Identify(self.identify(peer_id, nonce).await)
             }
             SignatureManagerRequest::SignPrecommitVote(block_hash) => {
                 SignatureManagerResponse::SignPrecommitVote(


### PR DESCRIPTION
Peers challenge identify signature.