### PR TITLE
ci: increase gatekeeper timeout to 1 hour

### DIFF
--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -59,7 +59,7 @@ jobs:
         uses: upsidr/merge-gatekeeper@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: 2100
+          timeout: 3600
           interval: 30
           ignored: "code-review/reviewable"
 


### PR DESCRIPTION
Not sure why this action is necessary, but its 2100 timeout is strictly smaller than our longest test.
