### PR TITLE
apollo_batcher: compute l2_gas_used at the end of the block, to exlude irrelevant txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "chrono",
  "futures",
  "indexmap 2.9.0",
+ "itertools 0.12.1",
  "mempool_test_utils",
  "metrics 0.24.1",
  "metrics-exporter-prometheus",

--- a/crates/apollo_batcher/Cargo.toml
+++ b/crates/apollo_batcher/Cargo.toml
@@ -52,6 +52,7 @@ assert_matches.workspace = true
 blockifier = { workspace = true, features = ["testing"] }
 cairo-lang-starknet-classes.workspace = true
 chrono = { workspace = true }
+itertools.workspace = true
 mempool_test_utils.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true

--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -173,7 +173,6 @@ pub struct BlockBuilder {
     /// The transactions whose execution started.
     block_txs: Vec<InternalConsensusTransaction>,
     execution_data: BlockTransactionExecutionData,
-    l2_gas_used: GasAmount,
 
     /// Parameters to configure the block builder behavior.
     n_concurrent_txs: usize,
@@ -209,7 +208,6 @@ impl BlockBuilder {
             n_executed_txs: 0,
             block_txs: Vec::new(),
             execution_data: BlockTransactionExecutionData::default(),
-            l2_gas_used: GasAmount::ZERO,
             n_concurrent_txs,
             tx_polling_interval_millis,
             execution_params,
@@ -308,12 +306,13 @@ impl BlockBuilder {
                 self.block_txs[n_txs_in_block..].iter().map(|tx| tx.tx_hash()).collect();
             execution_data.remove_last_txs(&remove_tx_hashes);
         }
+        let l2_gas_used = execution_data.l2_gas_used();
         Ok(BlockExecutionArtifacts {
             execution_data,
             commitment_state_diff: state_diff,
             compressed_state_diff,
             bouncer_weights,
-            l2_gas_used: self.l2_gas_used,
+            l2_gas_used,
             casm_hash_computation_data,
         })
     }
@@ -405,7 +404,6 @@ impl BlockBuilder {
         collect_execution_results_and_stream_txs(
             &self.block_txs[old_n_executed_txs..self.n_executed_txs],
             results,
-            &mut self.l2_gas_used,
             &mut self.execution_data,
             &self.output_content_sender,
             self.execution_params.fail_on_err,
@@ -473,7 +471,6 @@ async fn convert_to_executable_blockifier_tx(
 async fn collect_execution_results_and_stream_txs(
     tx_chunk: &[InternalConsensusTransaction],
     results: Vec<TransactionExecutorResult<TransactionExecutionOutput>>,
-    l2_gas_used: &mut GasAmount,
     execution_data: &mut BlockTransactionExecutionData,
     output_content_sender: &Option<
         tokio::sync::mpsc::UnboundedSender<InternalConsensusTransaction>,
@@ -499,10 +496,6 @@ async fn collect_execution_results_and_stream_txs(
 
         match result {
             Ok((tx_execution_info, state_maps)) => {
-                *l2_gas_used = l2_gas_used
-                    .checked_add(tx_execution_info.receipt.gas.l2_gas)
-                    .expect("Total L2 gas overflow.");
-
                 let (tx_index, duplicate_tx_hash) =
                     execution_data.execution_infos.insert_full(tx_hash, tx_execution_info);
                 assert_eq!(duplicate_tx_hash, None, "Duplicate transaction: {tx_hash}.");
@@ -739,6 +732,16 @@ impl BlockTransactionExecutionData {
             remove_last_set(&mut self.rejected_tx_hashes, tx_hash);
             remove_last_set(&mut self.consumed_l1_handler_tx_hashes, tx_hash);
         }
+    }
+
+    fn l2_gas_used(&self) -> GasAmount {
+        let mut res = GasAmount::ZERO;
+        for execution_info in self.execution_infos.values() {
+            res =
+                res.checked_add(execution_info.receipt.gas.l2_gas).expect("Total L2 gas overflow.");
+        }
+
+        res
     }
 }
 

--- a/crates/apollo_batcher/src/block_builder_test.rs
+++ b/crates/apollo_batcher/src/block_builder_test.rs
@@ -23,6 +23,7 @@ use blockifier::state::errors::StateError;
 use blockifier::transaction::objects::{RevertError, TransactionExecutionInfo};
 use blockifier::transaction::transaction_execution::Transaction as BlockifierTransaction;
 use indexmap::{IndexMap, IndexSet};
+use itertools::chain;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use mockall::predicate::eq;
 use mockall::Sequence;
@@ -200,11 +201,14 @@ fn one_chunk_mock_executor(
     (helper.mock_transaction_executor, expected_block_artifacts)
 }
 
-fn two_chunks_test_expectations() -> TestExpectations {
+fn two_chunks_mock_executor() -> (
+    Vec<InternalConsensusTransaction>,
+    Vec<InternalConsensusTransaction>,
+    MockTransactionExecutorTrait,
+) {
     let input_txs = test_txs(0..6);
     let first_chunk = input_txs[..N_CONCURRENT_TXS].to_vec();
     let second_chunk = input_txs[N_CONCURRENT_TXS..].to_vec();
-    let block_size = input_txs.len();
 
     let mut helper = ExpectationHelper::new();
 
@@ -218,16 +222,24 @@ fn two_chunks_test_expectations() -> TestExpectations {
     helper.expect_is_done(false);
     helper.deadline_expectations();
 
-    let expected_block_artifacts =
-        set_close_block_expectations(&mut helper.mock_transaction_executor, block_size);
+    (first_chunk, second_chunk, helper.mock_transaction_executor)
+}
 
-    let mock_tx_provider = mock_tx_provider_limitless_calls(vec![first_chunk, second_chunk]);
+fn two_chunks_test_expectations() -> TestExpectations {
+    let (first_chunk, second_chunk, mut mock_transaction_executor) = two_chunks_mock_executor();
+    let block_size = first_chunk.len() + second_chunk.len();
+
+    let expected_block_artifacts =
+        set_close_block_expectations(&mut mock_transaction_executor, block_size);
+
+    let mock_tx_provider =
+        mock_tx_provider_limitless_calls(vec![first_chunk.clone(), second_chunk.clone()]);
 
     TestExpectations {
-        mock_transaction_executor: helper.mock_transaction_executor,
+        mock_transaction_executor,
         mock_tx_provider,
         expected_block_artifacts,
-        expected_txs_output: input_txs,
+        expected_txs_output: chain!(first_chunk.iter(), second_chunk.iter()).cloned().collect(),
         expected_full_blocks_metric: 0,
     }
 }
@@ -452,6 +464,14 @@ fn set_close_block_expectations(
 fn mock_tx_provider_limited_calls(
     input_chunks: Vec<Vec<InternalConsensusTransaction>>,
 ) -> MockTransactionProvider {
+    mock_tx_provider_limited_calls_ex(input_chunks, None)
+}
+
+/// Create a mock tx provider that will return the input chunks for number of chunks queries.
+fn mock_tx_provider_limited_calls_ex(
+    input_chunks: Vec<Vec<InternalConsensusTransaction>>,
+    n_txs_in_block: Option<usize>,
+) -> MockTransactionProvider {
     let mut mock_tx_provider = MockTransactionProvider::new();
     let mut seq = Sequence::new();
     for input_chunk in input_chunks {
@@ -467,7 +487,7 @@ fn mock_tx_provider_limited_calls(
             .in_sequence(&mut seq)
             .returning(move |_n_txs| Ok(NextTxs::Txs(input_chunk.clone())));
     }
-    mock_tx_provider.expect_get_n_txs_in_block().return_const(None);
+    mock_tx_provider.expect_get_n_txs_in_block().return_const(n_txs_in_block);
     mock_tx_provider
 }
 
@@ -628,6 +648,37 @@ async fn test_validate_block() {
     let (mock_transaction_executor, expected_block_artifacts) =
         one_chunk_mock_executor(&input_txs, input_txs.len());
     let mock_tx_provider = mock_tx_provider_stream_done(input_txs);
+
+    let (_abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
+    let result_block_artifacts = run_build_block(
+        mock_transaction_executor,
+        mock_tx_provider,
+        None,
+        true,
+        abort_receiver,
+        BLOCK_GENERATION_DEADLINE_SECS,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result_block_artifacts, expected_block_artifacts);
+}
+
+/// Tests the case where the final number of transactions in the block is smaller than the number
+/// of transactions that were executed.
+#[tokio::test]
+async fn test_validate_block_excluded_txs() {
+    let (first_chunk, second_chunk, mut mock_transaction_executor) = two_chunks_mock_executor();
+    let n_executed_txs = first_chunk.len() + second_chunk.len();
+    let n_txs_in_block = n_executed_txs - 1;
+
+    let expected_block_artifacts =
+        set_close_block_expectations(&mut mock_transaction_executor, n_txs_in_block);
+
+    let mut mock_tx_provider =
+        mock_tx_provider_limited_calls_ex(vec![first_chunk, second_chunk], Some(n_txs_in_block));
+
+    mock_tx_provider.expect_get_txs().returning(move |_n_txs| Ok(NextTxs::Txs(vec![])));
 
     let (_abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
     let result_block_artifacts = run_build_block(


### PR DESCRIPTION
**Stack**:
- #7266
- #7265
- #7252
- #7250 ⬅
- #7209


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*