### PR TITLE
feat(apollo_signature_manager): add derive `Clone`

### DIFF
--- a/crates/apollo_signature_manager/src/signature_manager.rs
+++ b/crates/apollo_signature_manager/src/signature_manager.rs
@@ -37,6 +37,7 @@ impl Deref for MessageDigest {
 }
 
 /// Provides signing and signature verification functionality.
+#[derive(Clone, Debug)]
 pub struct SignatureManager<KS: KeyStore> {
     pub keystore: KS,
 }

--- a/crates/apollo_signature_manager_types/src/lib.rs
+++ b/crates/apollo_signature_manager_types/src/lib.rs
@@ -18,9 +18,9 @@ pub type SignatureManagerClientResult<T> = Result<T, SignatureManagerClientError
 
 pub type SharedSignatureManagerClient = Arc<dyn SignatureManagerClient>;
 
-/// A read-only keystore that contains exactly one key.
+/// A read-only key store that contains exactly one key.
 #[async_trait]
-pub trait KeyStore: Send + Sync {
+pub trait KeyStore: Clone + Send + Sync {
     /// Retrieve a reference to the contained private key.
     async fn get_key(&self) -> KeyStoreResult<PrivateKey>;
 }


### PR DESCRIPTION
For `KeyStore` and `SignatureManager`.
This is an infra. requirement to be able to serve requests concurrently.
It is okay for this service, since it is currently stateless and
lightweight.