### PR TITLE
feat(apollo_signature_manager): define a local key store service variant

### DIFF
--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -1,2 +1,26 @@
 pub mod communication;
 pub mod signature_manager;
+
+use crate::signature_manager::{LocalKeyStore, SignatureManager as GenericSignatureManager};
+
+pub struct LocalKeyStoreSignatureManager(pub GenericSignatureManager<LocalKeyStore>);
+
+impl LocalKeyStoreSignatureManager {
+    pub fn new() -> Self {
+        Self(GenericSignatureManager::new(LocalKeyStore::new_for_testing()))
+    }
+}
+
+impl Default for LocalKeyStoreSignatureManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub use LocalKeyStoreSignatureManager as SignatureManager;
+
+// TODO(Elin): understand how key store would look in production and better define the way the
+// signature manager is created.
+pub fn create_signature_manager() -> SignatureManager {
+    SignatureManager::new()
+}

--- a/crates/apollo_signature_manager/src/signature_manager.rs
+++ b/crates/apollo_signature_manager/src/signature_manager.rs
@@ -89,8 +89,7 @@ impl LocalKeyStore {
         Self { private_key, public_key }
     }
 
-    #[cfg(test)]
-    const fn new_for_testing() -> Self {
+    pub(crate) const fn new_for_testing() -> Self {
         // Created using `cairo-lang`.
         const PRIVATE_KEY: PrivateKey = PrivateKey(Felt::from_hex_unchecked(
             "0x608bf2cdb1ad4138e72d2f82b8c5db9fa182d1883868ae582ed373429b7a133",


### PR DESCRIPTION
This is supposed to be used in all test types (unit through
system/integration), not in prod.

In the effort of prep.-ing the service as a node component, and since
design is still missing re how would this service be built with a remote
KMS (and also no adequate infra. support of dependency injection yet) --
I chose to temporarily use this (local KMS) variant across the node.