### PR TITLE
apollo_mempool: migrate to apollo_time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,6 +1541,7 @@ dependencies = [
  "apollo_network",
  "apollo_network_types",
  "apollo_test_utils",
+ "apollo_time",
  "assert_matches",
  "async-trait",
  "derive_more 0.99.18",

--- a/crates/apollo_mempool/Cargo.toml
+++ b/crates/apollo_mempool/Cargo.toml
@@ -11,6 +11,7 @@ testing = [
   "apollo_metrics/testing",
   "apollo_network/testing",
   "apollo_network_types/testing",
+  "apollo_time/testing",
   "starknet_api/testing",
 ]
 
@@ -24,6 +25,7 @@ apollo_mempool_p2p_types.workspace = true
 apollo_mempool_types.workspace = true
 apollo_metrics.workspace = true
 apollo_network_types.workspace = true
+apollo_time = { workspace = true }
 async-trait.workspace = true
 derive_more.workspace = true
 indexmap.workspace = true
@@ -41,6 +43,7 @@ apollo_metrics = { workspace = true, features = ["testing"] }
 apollo_network = { workspace = true, features = ["testing"] }
 apollo_network_types = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
+apollo_time = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 itertools.workspace = true
 mempool_test_utils.workspace = true

--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -11,6 +11,7 @@ use apollo_mempool_types::communication::{
 use apollo_mempool_types::errors::MempoolError;
 use apollo_mempool_types::mempool_types::{CommitBlockArgs, MempoolResult, MempoolSnapshot};
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
+use apollo_time::time::DefaultClock;
 use async_trait::async_trait;
 use starknet_api::block::GasPrice;
 use starknet_api::core::ContractAddress;
@@ -20,7 +21,6 @@ use tracing::warn;
 use crate::config::MempoolConfig;
 use crate::mempool::Mempool;
 use crate::metrics::register_metrics;
-use crate::utils::InstantClock;
 
 pub type LocalMempoolServer =
     LocalComponentServer<MempoolCommunicationWrapper, MempoolRequest, MempoolResponse>;
@@ -31,7 +31,7 @@ pub fn create_mempool(
     mempool_p2p_propagator_client: SharedMempoolP2pPropagatorClient,
 ) -> MempoolCommunicationWrapper {
     MempoolCommunicationWrapper::new(
-        Mempool::new(config, Arc::new(InstantClock)),
+        Mempool::new(config, Arc::new(DefaultClock)),
         mempool_p2p_propagator_client,
     )
 }

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::Instant;
 
 use apollo_mempool_types::errors::MempoolError;
 use apollo_mempool_types::mempool_types::{
@@ -11,6 +10,7 @@ use apollo_mempool_types::mempool_types::{
     MempoolSnapshot,
     MempoolStateSnapshot,
 };
+use apollo_time::time::{Clock, DateTime};
 use indexmap::IndexSet;
 use rand::{thread_rng, Rng};
 use starknet_api::block::GasPrice;
@@ -35,7 +35,7 @@ use crate::metrics::{
 };
 use crate::transaction_pool::TransactionPool;
 use crate::transaction_queue::TransactionQueue;
-use crate::utils::{try_increment_nonce, Clock};
+use crate::utils::try_increment_nonce;
 
 #[cfg(test)]
 #[path = "mempool_test.rs"]
@@ -182,7 +182,7 @@ impl MempoolState {
 
 // A queue to hold transactions that are waiting to be added to the tx pool.
 struct AddTransactionQueue {
-    elements: VecDeque<(Instant, AddTransactionArgs)>,
+    elements: VecDeque<(DateTime, AddTransactionArgs)>,
     // Keeps track of the total size of the transactions in this queue.
     size_in_bytes: u64,
 }
@@ -192,7 +192,7 @@ impl AddTransactionQueue {
         AddTransactionQueue { elements: VecDeque::new(), size_in_bytes: 0 }
     }
 
-    fn push_back(&mut self, submission_time: Instant, args: AddTransactionArgs) {
+    fn push_back(&mut self, submission_time: DateTime, args: AddTransactionArgs) {
         self.size_in_bytes = self
             .size_in_bytes
             .checked_add(args.tx.total_bytes())
@@ -200,7 +200,7 @@ impl AddTransactionQueue {
         self.elements.push_back((submission_time, args));
     }
 
-    fn pop_front(&mut self) -> Option<(Instant, AddTransactionArgs)> {
+    fn pop_front(&mut self) -> Option<(DateTime, AddTransactionArgs)> {
         let removed_element = self.elements.pop_front();
         if let Some((_, args)) = &removed_element {
             self.size_in_bytes = self
@@ -211,7 +211,7 @@ impl AddTransactionQueue {
         removed_element
     }
 
-    fn front(&self) -> Option<&(Instant, AddTransactionArgs)> {
+    fn front(&self) -> Option<&(DateTime, AddTransactionArgs)> {
         self.elements.front()
     }
 
@@ -393,7 +393,7 @@ impl Mempool {
     fn add_ready_declares(&mut self) {
         let now = self.clock.now();
         while let Some((submission_time, _args)) = self.delayed_declares.front() {
-            if now - *submission_time < self.config.declare_delay {
+            if now - self.config.declare_delay < *submission_time {
                 break;
             }
             let (_submission_time, args) =

--- a/crates/apollo_mempool/src/mempool_flow_tests.rs
+++ b/crates/apollo_mempool/src/mempool_flow_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use apollo_mempool_types::errors::MempoolError;
+use apollo_time::test_utils::FakeClock;
 use rstest::{fixture, rstest};
 use starknet_api::block::GasPrice;
 use starknet_api::{contract_address, nonce};
@@ -8,13 +9,7 @@ use starknet_api::{contract_address, nonce};
 use crate::add_tx_input;
 use crate::config::MempoolConfig;
 use crate::mempool::Mempool;
-use crate::test_utils::{
-    add_tx,
-    add_tx_expect_error,
-    commit_block,
-    get_txs_and_assert_expected,
-    FakeClock,
-};
+use crate::test_utils::{add_tx, add_tx_expect_error, commit_block, get_txs_and_assert_expected};
 
 // Fixtures.
 

--- a/crates/apollo_mempool/src/mempool_test.rs
+++ b/crates/apollo_mempool/src/mempool_test.rs
@@ -13,6 +13,7 @@ use apollo_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
 use apollo_metrics::metrics::HistogramValue;
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
 use apollo_test_utils::{get_rng, GetTestInstance};
+use apollo_time::test_utils::FakeClock;
 use mempool_test_utils::starknet_api_test_utils::test_valid_resource_bounds;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use mockall::predicate::eq;
@@ -42,7 +43,6 @@ use crate::test_utils::{
     add_tx_expect_error,
     commit_block,
     get_txs_and_assert_expected,
-    FakeClock,
     MempoolMetrics,
 };
 use crate::transaction_pool::TransactionPool;

--- a/crates/apollo_mempool/src/test_utils.rs
+++ b/crates/apollo_mempool/src/test_utils.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
-use std::time::Instant;
 
 use apollo_mempool_types::errors::MempoolError;
 use apollo_mempool_types::mempool_types::{AddTransactionArgs, CommitBlockArgs};
@@ -27,7 +25,6 @@ use crate::metrics::{
     MEMPOOL_TRANSACTIONS_RECEIVED,
     TRANSACTION_TIME_SPENT_IN_MEMPOOL,
 };
-use crate::utils::Clock;
 
 /// Creates an executable invoke transaction with the given field subset (the rest receive default
 /// values).
@@ -280,28 +277,6 @@ pub fn get_txs_and_assert_expected(
 ) {
     let txs = mempool.get_txs(n_txs).unwrap();
     assert_eq!(txs, expected_txs);
-}
-
-pub struct FakeClock {
-    pub now: Mutex<Instant>,
-}
-
-impl Default for FakeClock {
-    fn default() -> Self {
-        FakeClock { now: Mutex::new(Instant::now()) }
-    }
-}
-
-impl FakeClock {
-    pub fn advance(&self, duration: std::time::Duration) {
-        *self.now.lock().unwrap() += duration;
-    }
-}
-
-impl Clock for FakeClock {
-    fn now(&self) -> Instant {
-        *self.now.lock().unwrap()
-    }
 }
 
 #[derive(Default)]

--- a/crates/apollo_mempool/src/transaction_pool_test.rs
+++ b/crates/apollo_mempool/src/transaction_pool_test.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use apollo_time::test_utils::FakeClock;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::{contract_address, nonce, tx_hash};
 
-use crate::test_utils::FakeClock;
 use crate::transaction_pool::TransactionPool;
 use crate::tx;
 

--- a/crates/apollo_mempool/src/utils.rs
+++ b/crates/apollo_mempool/src/utils.rs
@@ -1,22 +1,7 @@
-use std::time::Instant;
-
 use apollo_mempool_types::communication::MempoolResult;
 use apollo_mempool_types::errors::MempoolError;
 use starknet_api::core::Nonce;
 
 pub fn try_increment_nonce(nonce: Nonce) -> MempoolResult<Nonce> {
     nonce.try_increment().map_err(|_| MempoolError::NonceTooLarge(nonce))
-}
-
-// TODO(dafna, 01/03/2025): Move to a common utils crate.
-pub trait Clock: Send + Sync {
-    fn now(&self) -> Instant;
-}
-
-pub struct InstantClock;
-
-impl Clock for InstantClock {
-    fn now(&self) -> Instant {
-        Instant::now()
-    }
 }


### PR DESCRIPTION
API is the same only using realclock instead of instant under the hood.
Realclock is sufficiently accurate (and monotone) for our usage, and
unlike `Instant` can be debugged in a human-readable way (Lior requested
we migrate to this type).

All changes are just changing the types to apollo_time.