### PR TITLE
apollo_dashboard: refactor consensus panels from consts to fns

### DIFF
--- a/crates/apollo_dashboard/src/panels/gateway.rs
+++ b/crates/apollo_dashboard/src/panels/gateway.rs
@@ -20,102 +20,123 @@ use const_format::formatcp;
 
 use crate::dashboard::{Panel, PanelType, Row};
 
-const PANEL_GATEWAY_TRANSACTIONS_RECEIVED_BY_TYPE: Panel = Panel::new(
-    GATEWAY_TRANSACTIONS_RECEIVED.get_name(),
-    GATEWAY_TRANSACTIONS_RECEIVED.get_description(),
-    formatcp!(
-        "sum  by ({}) ({}) ",
-        GATEWAY_LABEL_NAME_TX_TYPE,
-        GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter()
-    ),
-    PanelType::Stat,
-);
+fn get_panel_gateway_transactions_received_by_type() -> Panel {
+    Panel::new(
+        GATEWAY_TRANSACTIONS_RECEIVED.get_name(),
+        GATEWAY_TRANSACTIONS_RECEIVED.get_description(),
+        formatcp!(
+            "sum  by ({}) ({}) ",
+            GATEWAY_LABEL_NAME_TX_TYPE,
+            GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter()
+        ),
+        PanelType::Stat,
+    )
+}
 
-const PANEL_GATEWAY_LOCAL_MSGS_RECEIVED: Panel =
-    Panel::from_counter(GATEWAY_LOCAL_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_GATEWAY_LOCAL_MSGS_PROCESSED: Panel =
-    Panel::from_counter(GATEWAY_LOCAL_MSGS_PROCESSED, PanelType::Graph);
-const PANEL_GATEWAY_REMOTE_MSGS_RECEIVED: Panel =
-    Panel::from_counter(GATEWAY_REMOTE_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_GATEWAY_REMOTE_VALID_MSGS_RECEIVED: Panel =
-    Panel::from_counter(GATEWAY_REMOTE_VALID_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_GATEWAY_REMOTE_MSGS_PROCESSED: Panel =
-    Panel::from_counter(GATEWAY_REMOTE_MSGS_PROCESSED, PanelType::Graph);
-const PANEL_GATEWAY_LOCAL_QUEUE_DEPTH: Panel =
-    Panel::from_gauge(GATEWAY_LOCAL_QUEUE_DEPTH, PanelType::Graph);
-const PANEL_GATEWAY_REMOTE_CLIENT_SEND_ATTEMPTS: Panel =
-    Panel::from_hist(GATEWAY_REMOTE_CLIENT_SEND_ATTEMPTS, PanelType::Graph);
+fn get_panel_gateway_local_msgs_received() -> Panel {
+    Panel::from_counter(GATEWAY_LOCAL_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_gateway_local_msgs_processed() -> Panel {
+    Panel::from_counter(GATEWAY_LOCAL_MSGS_PROCESSED, PanelType::Graph)
+}
+fn get_panel_gateway_remote_msgs_received() -> Panel {
+    Panel::from_counter(GATEWAY_REMOTE_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_gateway_remote_valid_msgs_received() -> Panel {
+    Panel::from_counter(GATEWAY_REMOTE_VALID_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_gateway_remote_msgs_processed() -> Panel {
+    Panel::from_counter(GATEWAY_REMOTE_MSGS_PROCESSED, PanelType::Graph)
+}
+fn get_panel_gateway_local_queue_depth() -> Panel {
+    Panel::from_gauge(GATEWAY_LOCAL_QUEUE_DEPTH, PanelType::Graph)
+}
+fn get_panel_gateway_remote_client_send_attempts() -> Panel {
+    Panel::from_hist(GATEWAY_REMOTE_CLIENT_SEND_ATTEMPTS, PanelType::Graph)
+}
 
-const PANEL_GATEWAY_TRANSACTIONS_RECEIVED_BY_SOURCE: Panel = Panel::new(
-    GATEWAY_TRANSACTIONS_RECEIVED.get_name(),
-    GATEWAY_TRANSACTIONS_RECEIVED.get_description(),
-    formatcp!(
-        "sum  by ({}) ({}) ",
-        LABEL_NAME_SOURCE,
-        GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter()
-    ),
-    PanelType::Stat,
-);
+fn get_panel_gateway_transactions_received_by_source() -> Panel {
+    Panel::new(
+        GATEWAY_TRANSACTIONS_RECEIVED.get_name(),
+        GATEWAY_TRANSACTIONS_RECEIVED.get_description(),
+        formatcp!(
+            "sum  by ({}) ({}) ",
+            LABEL_NAME_SOURCE,
+            GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter()
+        ),
+        PanelType::Stat,
+    )
+}
 
-const PANEL_GATEWAY_TRANSACTIONS_RECEIVED_RATE: Panel = Panel::new(
-    "gateway_transactions_received_rate (TPS)",
-    "The rate of transactions received by the gateway during the last 20 minutes",
-    formatcp!(
-        "sum(rate({}[20m])) or vector(0)",
-        GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter()
-    ),
-    PanelType::Graph,
-);
+fn get_panel_gateway_transactions_received_rate() -> Panel {
+    Panel::new(
+        "gateway_transactions_received_rate (TPS)",
+        "The rate of transactions received by the gateway during the last 20 minutes",
+        formatcp!(
+            "sum(rate({}[20m])) or vector(0)",
+            GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter()
+        ),
+        PanelType::Graph,
+    )
+}
 
-const PANEL_GATEWAY_ADD_TX_LATENCY: Panel = Panel::new(
-    GATEWAY_ADD_TX_LATENCY.get_name(),
-    GATEWAY_ADD_TX_LATENCY.get_description(),
-    // TODO(Tsabary): revisit this panel, it used to be defined with "avg_over_time({}[2m])".
-    GATEWAY_ADD_TX_LATENCY.get_name_with_filter(),
-    PanelType::Graph,
-);
+fn get_panel_gateway_add_tx_latency() -> Panel {
+    Panel::new(
+        GATEWAY_ADD_TX_LATENCY.get_name(),
+        GATEWAY_ADD_TX_LATENCY.get_description(),
+        // TODO(Tsabary): revisit this panel, it used to be defined with "avg_over_time({}[2m])".
+        GATEWAY_ADD_TX_LATENCY.get_name_with_filter(),
+        PanelType::Graph,
+    )
+}
 
-const PANEL_GATEWAY_VALIDATE_TX_LATENCY: Panel = Panel::new(
-    GATEWAY_VALIDATE_TX_LATENCY.get_name(),
-    GATEWAY_VALIDATE_TX_LATENCY.get_description(),
-    // TODO(Tsabary): revisit this panel, it used to be defined with "avg_over_time({}[2m])".
-    GATEWAY_VALIDATE_TX_LATENCY.get_name_with_filter(),
-    PanelType::Graph,
-);
+fn get_panel_gateway_validate_tx_latency() -> Panel {
+    Panel::new(
+        GATEWAY_VALIDATE_TX_LATENCY.get_name(),
+        GATEWAY_VALIDATE_TX_LATENCY.get_description(),
+        // TODO(Tsabary): revisit this panel, it used to be defined with "avg_over_time({}[2m])".
+        GATEWAY_VALIDATE_TX_LATENCY.get_name_with_filter(),
+        PanelType::Graph,
+    )
+}
 
-const PANEL_GATEWAY_TRANSACTIONS_FAILED: Panel = Panel::new(
-    GATEWAY_TRANSACTIONS_FAILED.get_name(),
-    GATEWAY_TRANSACTIONS_FAILED.get_description(),
-    formatcp!(
-        "sum  by ({}) ({})",
-        GATEWAY_LABEL_NAME_TX_TYPE,
-        GATEWAY_TRANSACTIONS_FAILED.get_name_with_filter()
-    ),
-    PanelType::Stat,
-);
+fn get_panel_gateway_transactions_failed() -> Panel {
+    Panel::new(
+        GATEWAY_TRANSACTIONS_FAILED.get_name(),
+        GATEWAY_TRANSACTIONS_FAILED.get_description(),
+        formatcp!(
+            "sum  by ({}) ({})",
+            GATEWAY_LABEL_NAME_TX_TYPE,
+            GATEWAY_TRANSACTIONS_FAILED.get_name_with_filter()
+        ),
+        PanelType::Stat,
+    )
+}
 
-const PANEL_GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL: Panel = Panel::new(
-    GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL.get_name(),
-    GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL.get_description(),
-    formatcp!(
-        "sum  by ({}) ({})",
-        GATEWAY_LABEL_NAME_TX_TYPE,
-        GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL.get_name_with_filter()
-    ),
-    PanelType::Stat,
-);
+fn get_panel_gateway_transactions_sent_to_mempool() -> Panel {
+    Panel::new(
+        GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL.get_name(),
+        GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL.get_description(),
+        formatcp!(
+            "sum  by ({}) ({})",
+            GATEWAY_LABEL_NAME_TX_TYPE,
+            GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL.get_name_with_filter()
+        ),
+        PanelType::Stat,
+    )
+}
 
 pub(crate) fn get_gateway_row() -> Row {
     Row::new(
         "Gateway",
         vec![
-            PANEL_GATEWAY_TRANSACTIONS_RECEIVED_BY_TYPE,
-            PANEL_GATEWAY_TRANSACTIONS_RECEIVED_BY_SOURCE,
-            PANEL_GATEWAY_TRANSACTIONS_RECEIVED_RATE,
-            PANEL_GATEWAY_ADD_TX_LATENCY,
-            PANEL_GATEWAY_VALIDATE_TX_LATENCY,
-            PANEL_GATEWAY_TRANSACTIONS_FAILED,
-            PANEL_GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL,
+            get_panel_gateway_transactions_received_by_type(),
+            get_panel_gateway_transactions_received_by_source(),
+            get_panel_gateway_transactions_received_rate(),
+            get_panel_gateway_add_tx_latency(),
+            get_panel_gateway_validate_tx_latency(),
+            get_panel_gateway_transactions_failed(),
+            get_panel_gateway_transactions_sent_to_mempool(),
         ],
     )
 }
@@ -124,13 +145,13 @@ pub(crate) fn get_gateway_infra_row() -> Row {
     Row::new(
         "Gateway Infra",
         vec![
-            PANEL_GATEWAY_LOCAL_MSGS_RECEIVED,
-            PANEL_GATEWAY_LOCAL_MSGS_PROCESSED,
-            PANEL_GATEWAY_LOCAL_QUEUE_DEPTH,
-            PANEL_GATEWAY_REMOTE_MSGS_RECEIVED,
-            PANEL_GATEWAY_REMOTE_VALID_MSGS_RECEIVED,
-            PANEL_GATEWAY_REMOTE_MSGS_PROCESSED,
-            PANEL_GATEWAY_REMOTE_CLIENT_SEND_ATTEMPTS,
+            get_panel_gateway_local_msgs_received(),
+            get_panel_gateway_local_msgs_processed(),
+            get_panel_gateway_local_queue_depth(),
+            get_panel_gateway_remote_msgs_received(),
+            get_panel_gateway_remote_valid_msgs_received(),
+            get_panel_gateway_remote_msgs_processed(),
+            get_panel_gateway_remote_client_send_attempts(),
         ],
     )
 }

--- a/crates/apollo_dashboard/src/panels/http_server.rs
+++ b/crates/apollo_dashboard/src/panels/http_server.rs
@@ -2,9 +2,10 @@ use apollo_http_server::metrics::ADDED_TRANSACTIONS_TOTAL;
 
 use crate::dashboard::{Panel, PanelType, Row};
 
-const PANEL_ADDED_TRANSACTIONS_TOTAL: Panel =
-    Panel::from_counter(ADDED_TRANSACTIONS_TOTAL, PanelType::Graph);
+fn get_panel_added_transactions_total() -> Panel {
+    Panel::from_counter(ADDED_TRANSACTIONS_TOTAL, PanelType::Graph)
+}
 
 pub(crate) fn get_http_server_row() -> Row {
-    Row::new("Http Server", vec![PANEL_ADDED_TRANSACTIONS_TOTAL])
+    Row::new("Http Server", vec![get_panel_added_transactions_total()])
 }

--- a/crates/apollo_dashboard/src/panels/l1_gas_price.rs
+++ b/crates/apollo_dashboard/src/panels/l1_gas_price.rs
@@ -16,38 +16,49 @@ use apollo_l1_gas_price::metrics::{
 
 use crate::dashboard::{Panel, PanelType, Row};
 
-const PANEL_L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_RECEIVED: Panel =
-    Panel::from_counter(L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_PROCESSED: Panel =
-    Panel::from_counter(L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_PROCESSED, PanelType::Graph);
-const PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_RECEIVED: Panel =
-    Panel::from_counter(L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_VALID_MSGS_RECEIVED: Panel =
-    Panel::from_counter(L1_GAS_PRICE_PROVIDER_REMOTE_VALID_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_PROCESSED: Panel =
-    Panel::from_counter(L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_PROCESSED, PanelType::Graph);
-const PANEL_L1_GAS_PRICE_PROVIDER_LOCAL_QUEUE_DEPTH: Panel =
-    Panel::from_gauge(L1_GAS_PRICE_PROVIDER_LOCAL_QUEUE_DEPTH, PanelType::Graph);
-const PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS: Panel =
-    Panel::from_hist(L1_GAS_PRICE_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS, PanelType::Graph);
+fn get_panel_l1_gas_price_provider_local_msgs_received() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_l1_gas_price_provider_local_msgs_processed() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_PROCESSED, PanelType::Graph)
+}
+fn get_panel_l1_gas_price_provider_remote_msgs_received() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_l1_gas_price_provider_remote_valid_msgs_received() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_PROVIDER_REMOTE_VALID_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_l1_gas_price_provider_remote_msgs_processed() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_PROCESSED, PanelType::Graph)
+}
+fn get_panel_l1_gas_price_provider_local_queue_depth() -> Panel {
+    Panel::from_gauge(L1_GAS_PRICE_PROVIDER_LOCAL_QUEUE_DEPTH, PanelType::Graph)
+}
+fn get_panel_l1_gas_price_provider_remote_client_send_attempts() -> Panel {
+    Panel::from_hist(L1_GAS_PRICE_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS, PanelType::Graph)
+}
 
-const PANEL_L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY: Panel =
-    Panel::from_counter(L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY, PanelType::Stat);
-const PANEL_L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT: Panel =
-    Panel::from_counter(L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT, PanelType::Stat);
-const PANEL_L1_GAS_PRICE_SCRAPER_REORG_DETECTED: Panel =
-    Panel::from_counter(L1_GAS_PRICE_SCRAPER_REORG_DETECTED, PanelType::Stat);
-const PANEL_ETH_TO_STRK_ERROR_COUNT: Panel =
-    Panel::from_counter(ETH_TO_STRK_ERROR_COUNT, PanelType::Stat);
+fn get_panel_l1_gas_price_provider_insufficient_history() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY, PanelType::Stat)
+}
+fn get_panel_l1_gas_price_scraper_baselayer_error_count() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT, PanelType::Stat)
+}
+fn get_panel_l1_gas_price_scraper_reorg_detected() -> Panel {
+    Panel::from_counter(L1_GAS_PRICE_SCRAPER_REORG_DETECTED, PanelType::Stat)
+}
+fn get_panel_eth_to_strk_error_count() -> Panel {
+    Panel::from_counter(ETH_TO_STRK_ERROR_COUNT, PanelType::Stat)
+}
 
 pub(crate) fn get_l1_gas_price_row() -> Row {
     Row::new(
         "L1 Gas Price",
         vec![
-            PANEL_ETH_TO_STRK_ERROR_COUNT,
-            PANEL_L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
-            PANEL_L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT,
-            PANEL_L1_GAS_PRICE_SCRAPER_REORG_DETECTED,
+            get_panel_eth_to_strk_error_count(),
+            get_panel_l1_gas_price_provider_insufficient_history(),
+            get_panel_l1_gas_price_scraper_baselayer_error_count(),
+            get_panel_l1_gas_price_scraper_reorg_detected(),
         ],
     )
 }
@@ -56,13 +67,13 @@ pub(crate) fn get_l1_gas_price_infra_row() -> Row {
     Row::new(
         "L1 Gas Price Infra",
         vec![
-            PANEL_L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_RECEIVED,
-            PANEL_L1_GAS_PRICE_PROVIDER_LOCAL_MSGS_PROCESSED,
-            PANEL_L1_GAS_PRICE_PROVIDER_LOCAL_QUEUE_DEPTH,
-            PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_RECEIVED,
-            PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_VALID_MSGS_RECEIVED,
-            PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_MSGS_PROCESSED,
-            PANEL_L1_GAS_PRICE_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS,
+            get_panel_l1_gas_price_provider_local_msgs_received(),
+            get_panel_l1_gas_price_provider_local_msgs_processed(),
+            get_panel_l1_gas_price_provider_local_queue_depth(),
+            get_panel_l1_gas_price_provider_remote_msgs_received(),
+            get_panel_l1_gas_price_provider_remote_valid_msgs_received(),
+            get_panel_l1_gas_price_provider_remote_msgs_processed(),
+            get_panel_l1_gas_price_provider_remote_client_send_attempts(),
         ],
     )
 }

--- a/crates/apollo_dashboard/src/panels/l1_provider.rs
+++ b/crates/apollo_dashboard/src/panels/l1_provider.rs
@@ -14,31 +14,40 @@ use apollo_l1_provider::metrics::{
 
 use crate::dashboard::{Panel, PanelType, Row};
 
-const PANEL_L1_PROVIDER_LOCAL_MSGS_RECEIVED: Panel =
-    Panel::from_counter(L1_PROVIDER_LOCAL_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_L1_PROVIDER_LOCAL_MSGS_PROCESSED: Panel =
-    Panel::from_counter(L1_PROVIDER_LOCAL_MSGS_PROCESSED, PanelType::Graph);
-const PANEL_L1_PROVIDER_REMOTE_MSGS_RECEIVED: Panel =
-    Panel::from_counter(L1_PROVIDER_REMOTE_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_L1_PROVIDER_REMOTE_VALID_MSGS_RECEIVED: Panel =
-    Panel::from_counter(L1_PROVIDER_REMOTE_VALID_MSGS_RECEIVED, PanelType::Graph);
-const PANEL_L1_PROVIDER_REMOTE_MSGS_PROCESSED: Panel =
-    Panel::from_counter(L1_PROVIDER_REMOTE_MSGS_PROCESSED, PanelType::Graph);
-const PANEL_L1_PROVIDER_LOCAL_QUEUE_DEPTH: Panel =
-    Panel::from_gauge(L1_PROVIDER_LOCAL_QUEUE_DEPTH, PanelType::Graph);
-const PANEL_L1_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS: Panel =
-    Panel::from_hist(L1_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS, PanelType::Graph);
-const PANEL_L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT: Panel =
-    Panel::from_counter(L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT, PanelType::Graph);
-const PANEL_L1_MESSAGE_SCRAPER_REORG_DETECTED: Panel =
-    Panel::from_counter(L1_MESSAGE_SCRAPER_REORG_DETECTED, PanelType::Graph);
+fn get_panel_l1_provider_local_msgs_received() -> Panel {
+    Panel::from_counter(L1_PROVIDER_LOCAL_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_l1_provider_local_msgs_processed() -> Panel {
+    Panel::from_counter(L1_PROVIDER_LOCAL_MSGS_PROCESSED, PanelType::Graph)
+}
+fn get_panel_l1_provider_remote_msgs_received() -> Panel {
+    Panel::from_counter(L1_PROVIDER_REMOTE_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_l1_provider_remote_valid_msgs_received() -> Panel {
+    Panel::from_counter(L1_PROVIDER_REMOTE_VALID_MSGS_RECEIVED, PanelType::Graph)
+}
+fn get_panel_l1_provider_remote_msgs_processed() -> Panel {
+    Panel::from_counter(L1_PROVIDER_REMOTE_MSGS_PROCESSED, PanelType::Graph)
+}
+fn get_panel_l1_provider_local_queue_depth() -> Panel {
+    Panel::from_gauge(L1_PROVIDER_LOCAL_QUEUE_DEPTH, PanelType::Graph)
+}
+fn get_panel_l1_provider_remote_client_send_attempts() -> Panel {
+    Panel::from_hist(L1_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS, PanelType::Graph)
+}
+fn get_panel_l1_message_scraper_baselayer_error_count() -> Panel {
+    Panel::from_counter(L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT, PanelType::Graph)
+}
+fn get_panel_l1_message_scraper_reorg_detected() -> Panel {
+    Panel::from_counter(L1_MESSAGE_SCRAPER_REORG_DETECTED, PanelType::Graph)
+}
 
 pub(crate) fn get_l1_provider_row() -> Row {
     Row::new(
         "L1 Provider",
         vec![
-            PANEL_L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT,
-            PANEL_L1_MESSAGE_SCRAPER_REORG_DETECTED,
+            get_panel_l1_message_scraper_baselayer_error_count(),
+            get_panel_l1_message_scraper_reorg_detected(),
         ],
     )
 }
@@ -47,13 +56,13 @@ pub(crate) fn get_l1_provider_infra_row() -> Row {
     Row::new(
         "L1 Provider Infra",
         vec![
-            PANEL_L1_PROVIDER_LOCAL_MSGS_RECEIVED,
-            PANEL_L1_PROVIDER_LOCAL_MSGS_PROCESSED,
-            PANEL_L1_PROVIDER_LOCAL_QUEUE_DEPTH,
-            PANEL_L1_PROVIDER_REMOTE_MSGS_RECEIVED,
-            PANEL_L1_PROVIDER_REMOTE_VALID_MSGS_RECEIVED,
-            PANEL_L1_PROVIDER_REMOTE_MSGS_PROCESSED,
-            PANEL_L1_PROVIDER_REMOTE_CLIENT_SEND_ATTEMPTS,
+            get_panel_l1_provider_local_msgs_received(),
+            get_panel_l1_provider_local_msgs_processed(),
+            get_panel_l1_provider_local_queue_depth(),
+            get_panel_l1_provider_remote_msgs_received(),
+            get_panel_l1_provider_remote_valid_msgs_received(),
+            get_panel_l1_provider_remote_msgs_processed(),
+            get_panel_l1_provider_remote_client_send_attempts(),
         ],
     )
 }


### PR DESCRIPTION
apollo_dashboard: refactor consensus panels from consts to fns

apollo_dashboard: delete empty lines in consensus panels

apollo_dashboard: delete empty lines in mempool panels

apollo_dashboard: refactor mempool p2p panels from consts to fns

apollo_dashboard: refactor sierra compiler and state reader panels from consts to fns

apollo_dashboard: refactor state sync panels from consts to fns

apollo_dashboard: completion of panels const to fn refactor