### PR TITLE
batcher: fix missing expectation in `failed_l1_handler_transaction_consumed`

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -35,8 +35,6 @@ use blockifier::state::state_reader_and_contract_manager::StateReaderAndContract
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use blockifier::transaction::transaction_execution::Transaction as BlockifierTransaction;
 use indexmap::{IndexMap, IndexSet};
-#[cfg(test)]
-use mockall::automock;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHashAndNumber, BlockInfo};
 use starknet_api::block_hash::state_diff_hash::calculate_state_diff_hash;
@@ -148,7 +146,7 @@ impl BlockExecutionArtifacts {
 /// The BlockBuilderTrait is responsible for building a new block from transactions provided by the
 /// tx_provider. The block building will stop at time deadline.
 /// The transactions that were added to the block will be streamed to the output_content_sender.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait BlockBuilderTrait: Send {
     async fn build_block(&mut self) -> BlockBuilderResult<BlockExecutionArtifacts>;
@@ -565,7 +563,7 @@ pub type BatcherWorkerPool =
     Arc<WorkerPool<CachedState<StateReaderAndContractManager<PapyrusReader>>>>;
 
 /// The BlockBuilderFactoryTrait is responsible for creating a new block builder.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 pub trait BlockBuilderFactoryTrait: Send + Sync {
     // TODO(noamsp): Investigate and remove this clippy warning.
     #[allow(clippy::result_large_err, clippy::too_many_arguments)]

--- a/crates/apollo_batcher/src/block_builder_test.rs
+++ b/crates/apollo_batcher/src/block_builder_test.rs
@@ -915,6 +915,7 @@ async fn failed_l1_handler_transaction_consumed() {
         Ok((execution_info(), StateMaps::default())),
     ]);
     helper.expect_is_done(true);
+    helper.expect_successful_get_new_results(0);
 
     helper.mock_transaction_executor.expect_close_block().times(1).return_once(|_| {
         Ok(BlockExecutionSummary {


### PR DESCRIPTION
The change in the mockall imports is unrelated, added only to trigger the block builder tests, which seemed to not be triggered if only the test file is changed :(

