### PR TITLE
papyrus_base_layer: implement core of monitored base layer

### DIFF
--- a/crates/papyrus_base_layer/src/monitored_base_layer.rs
+++ b/crates/papyrus_base_layer/src/monitored_base_layer.rs
@@ -1,5 +1,10 @@
-use apollo_l1_endpoint_monitor_types::SharedL1EndpointMonitorClient;
+use apollo_l1_endpoint_monitor_types::{
+    L1EndpointMonitorClientError,
+    L1EndpointMonitorError,
+    SharedL1EndpointMonitorClient,
+};
 use tokio::sync::Mutex;
+use tracing::{error, info};
 use url::Url;
 
 use crate::BaseLayerContract;
@@ -13,14 +18,37 @@ pub struct MonitoredBaseLayer<B: BaseLayerContract + Send + Sync> {
 }
 
 impl<B: BaseLayerContract + Send + Sync> MonitoredBaseLayer<B> {
-    // Ensures that the inner base layer remains operational (hot-swapping the inner node_url if
-    // needed), and yields the inner base layer.
-    pub async fn ensure_operational(&self) -> Result<(), MonitoredBaseLayerError> {
-        todo!(
-            "Asks the monitor what the current active L1 endpoint is (that is synced with the \
-             rest of the base layers), and modifies the inner base layer to use it if it's using \
-             a different one. "
-        )
+    /// Ensures that the inner base layer remains operational (hot-swapping the inner node_url if
+    /// needed), and yields the inner base layer.
+    /// Note: the monitor has to do a liveness check with the l1 client here, so this has overhead
+    /// of an external HTTP call.
+    async fn _ensure_operational(&self) -> Result<(), MonitoredBaseLayerError<B>> {
+        let active_l1_endpoint = self.monitor.get_active_l1_endpoint().await;
+        match active_l1_endpoint {
+            Ok(new_node_url) if new_node_url != *self.current_node_url.lock().await => {
+                info!(
+                    "L1 endpoint {} is no longer operational, switching to new operational L1 \
+                     endpoint: {}",
+                    self.current_node_url.lock().await,
+                    &new_node_url
+                );
+
+                let mut base_layer = self.base_layer.lock().await;
+                base_layer
+                    .set_provider_url(new_node_url.clone())
+                    .await
+                    .map_err(|err| MonitoredBaseLayerError::BaseLayerContractError(err))?;
+
+                *self.current_node_url.lock().await = new_node_url;
+            }
+            Ok(_) => (), // Noop; the current node URL is still operational.
+            Err(L1EndpointMonitorClientError::L1EndpointMonitorError(err)) => Err(err)?,
+            Err(L1EndpointMonitorClientError::ClientError(err)) => {
+                panic!("Unhandled client error: {err}")
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -38,5 +66,33 @@ impl<B: BaseLayerContract + Send + Sync + std::fmt::Debug> std::fmt::Debug
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum MonitoredBaseLayerError {}
+#[derive(thiserror::Error)]
+pub enum MonitoredBaseLayerError<B: BaseLayerContract + Send + Sync> {
+    #[error("{0}")]
+    L1EndpointMonitorError(#[from] L1EndpointMonitorError),
+    #[error("{0}")]
+    BaseLayerContractError(B::Error),
+}
+
+impl<B: BaseLayerContract + Send + Sync> PartialEq for MonitoredBaseLayerError<B> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::L1EndpointMonitorError(left), Self::L1EndpointMonitorError(right)) => {
+                left == right
+            }
+            (Self::BaseLayerContractError(left), Self::BaseLayerContractError(right)) => {
+                left == right
+            }
+            _ => false,
+        }
+    }
+}
+
+impl<B: BaseLayerContract + Send + Sync> std::fmt::Debug for MonitoredBaseLayerError<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MonitoredBaseLayerError::L1EndpointMonitorError(err) => write!(f, "{:?}", err),
+            MonitoredBaseLayerError::BaseLayerContractError(err) => write!(f, "{:?}", err),
+        }
+    }
+}


### PR DESCRIPTION
This is the main API for this wrapper: it checks liveness of the l1
client and updates the inner "real" base layer with the result.

Subsequent commits will make this wrapper implement the base layer trait
through delegation to the inner base layer.