### PR TITLE
l1: extract constructor into function

### DIFF
--- a/crates/apollo_l1_endpoint_monitor/src/l1_endpoint_monitor_tests.rs
+++ b/crates/apollo_l1_endpoint_monitor/src/l1_endpoint_monitor_tests.rs
@@ -135,7 +135,12 @@ async fn all_down_fails() {
     assert_eq!(monitor.current_l1_endpoint_index, 0);
 }
 
-#[test]
-#[ignore = "Enable once we add a constructor to the monitor (soon) which asserts correct index and \
-            returns an error otherwise"]
-fn initialized_with_index_out_of_bounds() {}
+#[tokio::test]
+async fn initialized_with_unknown_url_returns_error() {
+    let some_valid_endpoint = mock_working_l1_endpoint().await;
+    let config =
+        L1EndpointMonitorConfig { ordered_l1_endpoint_urls: vec![some_valid_endpoint.url] };
+    let unknown_url = url(BAD_ENDPOINT_1);
+    let result = L1EndpointMonitor::new(config.clone(), &unknown_url);
+    assert_eq!(result, Err(L1EndpointMonitorError::InitializationError { unknown_url }));
+}

--- a/crates/apollo_l1_endpoint_monitor/src/monitor.rs
+++ b/crates/apollo_l1_endpoint_monitor/src/monitor.rs
@@ -14,13 +14,27 @@ pub mod l1_endpoint_monitor_tests;
 // a bug in infura where the connectivity was fine, but get_block_number() failed.
 pub const HEALTH_CHECK_RPC_METHOD: &str = "eth_blockNumber";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct L1EndpointMonitor {
     pub current_l1_endpoint_index: usize,
     pub config: L1EndpointMonitorConfig,
 }
 
 impl L1EndpointMonitor {
+    pub fn new(
+        config: L1EndpointMonitorConfig,
+        initial_node_url: &Url,
+    ) -> L1EndpointMonitorResult<Self> {
+        let starting_l1_endpoint_index =
+            config.ordered_l1_endpoint_urls.iter().position(|url| url == initial_node_url).ok_or(
+                L1EndpointMonitorError::InitializationError {
+                    unknown_url: initial_node_url.clone(),
+                },
+            )?;
+
+        Ok(Self { current_l1_endpoint_index: starting_l1_endpoint_index, config })
+    }
+
     /// Returns a functional L1 endpoint, or fails if all configured endpoints are non-operational.
     /// The method cycles through the configured endpoints, starting from the currently selected one
     /// and returns the first one that is operational.

--- a/crates/apollo_l1_endpoint_monitor_types/src/lib.rs
+++ b/crates/apollo_l1_endpoint_monitor_types/src/lib.rs
@@ -29,6 +29,8 @@ pub enum L1EndpointMonitorResponse {
 
 #[derive(Debug, Clone, Error, Serialize, Deserialize, PartialEq, Eq)]
 pub enum L1EndpointMonitorError {
+    #[error("Unknown initial L1 endpoint URL not present in the config: {unknown_url}")]
+    InitializationError { unknown_url: Url },
     #[error("All L1 endpoints are non-operational")]
     NoActiveL1Endpoint,
 }

--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -53,27 +53,14 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
         base_layer: B,
         events_identifiers_to_track: &[EventIdentifier],
     ) -> L1ScraperResult<Self, B> {
-        let latest_l1_block = get_latest_l1_block_number(config.finality, &base_layer).await?;
-        // Estimate the number of blocks in the interval, to rewind from the latest block.
-        let blocks_in_interval = config.startup_rewind_time_seconds.as_secs() / L1_BLOCK_TIME;
-        // Add 50% safety margin.
-        let safe_blocks_in_interval = blocks_in_interval + blocks_in_interval / 2;
-
-        let l1_block_number_rewind = latest_l1_block.saturating_sub(safe_blocks_in_interval);
-
-        let block_reference_rewind = base_layer
-            .l1_block_at(l1_block_number_rewind)
+        let l1_start_block = fetch_start_block(&base_layer, &config)
             .await
-            .map_err(L1ScraperError::BaseLayerError)?
-            .expect(
-                "Rewound L1 block number is between 0 and the verified latest L1 block, so should \
-                 exist",
-            );
+            .unwrap_or_else(|err| panic!("Error while initializing the L1 scraper: {err}"));
 
         Ok(Self {
             l1_provider_client,
             base_layer,
-            last_l1_block_processed: block_reference_rewind,
+            last_l1_block_processed: l1_start_block,
             config,
             tracked_event_identifiers: events_identifiers_to_track.to_vec(),
         })
@@ -226,6 +213,39 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
     }
 }
 
+pub async fn fetch_start_block<B: BaseLayerContract + Send + Sync>(
+    base_layer: &B,
+    config: &L1ScraperConfig,
+) -> Result<L1BlockReference, L1ScraperError<B>> {
+    let finality = config.finality;
+    let latest_l1_block_number = base_layer
+        .latest_l1_block_number(finality)
+        .await
+        .map_err(L1ScraperError::BaseLayerError)?;
+
+    let latest_l1_block = match latest_l1_block_number {
+        Some(latest_l1_block_number) => Ok(latest_l1_block_number),
+        None => Err(L1ScraperError::finality_too_high(finality, base_layer).await),
+    }?;
+
+    // Estimate the number of blocks in the interval, to rewind from the latest block.
+    let blocks_in_interval = config.startup_rewind_time_seconds.as_secs() / L1_BLOCK_TIME;
+    // Add 50% safety margin.
+    let safe_blocks_in_interval = blocks_in_interval + blocks_in_interval / 2;
+
+    let l1_block_number_rewind = latest_l1_block.saturating_sub(safe_blocks_in_interval);
+
+    let block_reference_rewind = base_layer
+        .l1_block_at(l1_block_number_rewind)
+        .await
+        .map_err(L1ScraperError::BaseLayerError)?
+        .expect(
+            "Rewound L1 block number is between 0 and the verified latest L1 block, so should \
+             exist",
+        );
+    Ok(block_reference_rewind)
+}
+
 #[async_trait]
 impl<B: BaseLayerContract + Send + Sync> ComponentStarter for L1Scraper<B> {
     async fn start(&mut self) {
@@ -360,20 +380,5 @@ fn handle_client_error<B: BaseLayerContract + Send + Sync>(
             )
         }
         error => panic!("Unexpected error: {error}"),
-    }
-}
-
-async fn get_latest_l1_block_number<B: BaseLayerContract + Send + Sync>(
-    finality: u64,
-    base_layer: &B,
-) -> Result<L1BlockNumber, L1ScraperError<B>> {
-    let latest_l1_block_number = base_layer
-        .latest_l1_block_number(finality)
-        .await
-        .map_err(L1ScraperError::BaseLayerError)?;
-
-    match latest_l1_block_number {
-        Some(latest_l1_block_number) => Ok(latest_l1_block_number),
-        None => Err(L1ScraperError::finality_too_high(finality, base_layer).await),
     }
 }

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -37,7 +37,7 @@ pub enum MockError {}
 #[cfg_attr(any(feature = "testing", test), automock(type Error = MockError;))]
 #[async_trait]
 pub trait BaseLayerContract {
-    type Error: Error + PartialEq + Display + Debug;
+    type Error: Error + PartialEq + Display + Debug + Send + Sync;
 
     /// Get the latest Starknet block that is proved on the base layer at a specific L1 block
     /// number. If the number is too low, return an error.


### PR DESCRIPTION
EXTRACT more of the scraper's startup logic for deciding which l1 block to start
scraping from into a function and rename it.

NO logic changes, just extract.

Motivation: soon the base layer queries will have to use the monitored base layer,
instead of the raw base layer, meaning they need the service to be
running in order to succeed. This hits the known issue of not being able
to depend on external services during construction in components.rs.
Hence, the next commit will make the callsite call this function and
pass the resulting start_block to the scarper's constructor.