### PR TITLE
l1: get l1 scraper starting height at callsite

### DIFF
--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -52,11 +52,8 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
         l1_provider_client: SharedL1ProviderClient,
         base_layer: B,
         events_identifiers_to_track: &[EventIdentifier],
+        l1_start_block: L1BlockReference,
     ) -> L1ScraperResult<Self, B> {
-        let l1_start_block = fetch_start_block(&base_layer, &config)
-            .await
-            .unwrap_or_else(|err| panic!("Error while initializing the L1 scraper: {err}"));
-
         Ok(Self {
             l1_provider_client,
             base_layer,

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -10,7 +10,7 @@ use apollo_l1_gas_price::l1_gas_price_provider::L1GasPriceProvider;
 use apollo_l1_gas_price::l1_gas_price_scraper::L1GasPriceScraper;
 use apollo_l1_provider::event_identifiers_to_track;
 use apollo_l1_provider::l1_provider::{L1Provider, L1ProviderBuilder};
-use apollo_l1_provider::l1_scraper::L1Scraper;
+use apollo_l1_provider::l1_scraper::{fetch_start_block, L1Scraper};
 use apollo_mempool::communication::{create_mempool, MempoolCommunicationWrapper};
 use apollo_mempool_p2p::create_p2p_propagator_and_runner;
 use apollo_mempool_p2p::propagator::MempoolP2pPropagator;
@@ -242,12 +242,17 @@ pub async fn create_node_components(
             let l1_provider_client = clients.get_l1_provider_shared_client().unwrap();
             let l1_scraper_config = config.l1_scraper_config.clone();
             let base_layer = EthereumBaseLayerContract::new(config.base_layer_config.clone());
+            let l1_start_block = fetch_start_block(&base_layer, &l1_scraper_config)
+                .await
+                .unwrap_or_else(|err| panic!("Error while initializing the L1 scraper: {err}"));
+
             Some(
                 L1Scraper::new(
                     l1_scraper_config,
                     l1_provider_client,
                     base_layer,
                     event_identifiers_to_track(),
+                    l1_start_block,
                 )
                 .await
                 .unwrap(),


### PR DESCRIPTION
This must be called outside of the scraper, since soon the scraper will
be initialized with a liveness-proxy over the baselayer (L1EndpointMonitor),
rather than the actual `EthereumBaseLayerContract`.
Due to a known limitation of components.rs, sending messages between
services is not possible during initailization, hence we need to do the
raw query using the baselayer at the callsite.

This will be clearer in upcoming commits.