### PR TITLE
signature: use local signature manager as server

### DIFF
--- a/crates/apollo_signature_manager/src/communication.rs
+++ b/crates/apollo_signature_manager/src/communication.rs
@@ -1,12 +1,12 @@
 use apollo_infra::component_definitions::ComponentRequestHandler;
 use apollo_infra::component_server::{ConcurrentLocalComponentServer, RemoteComponentServer};
-use apollo_signature_manager_types::{KeyStore, SignatureManagerRequest, SignatureManagerResponse};
+use apollo_signature_manager_types::{SignatureManagerRequest, SignatureManagerResponse};
 use async_trait::async_trait;
 
-use crate::signature_manager::SignatureManager;
+use crate::SignatureManager;
 
-pub type LocalSignatureManagerServer<KS> = ConcurrentLocalComponentServer<
-    SignatureManager<KS>,
+pub type LocalSignatureManagerServer = ConcurrentLocalComponentServer<
+    SignatureManager,
     SignatureManagerRequest,
     SignatureManagerResponse,
 >;
@@ -14,8 +14,8 @@ pub type RemoteSignatureManagerServer =
     RemoteComponentServer<SignatureManagerRequest, SignatureManagerResponse>;
 
 #[async_trait]
-impl<KS: KeyStore> ComponentRequestHandler<SignatureManagerRequest, SignatureManagerResponse>
-    for SignatureManager<KS>
+impl ComponentRequestHandler<SignatureManagerRequest, SignatureManagerResponse>
+    for SignatureManager
 {
     async fn handle_request(
         &mut self,

--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod communication;
 pub mod signature_manager;
 
+use std::ops::Deref;
+
 use crate::signature_manager::{LocalKeyStore, SignatureManager as GenericSignatureManager};
 
 pub struct LocalKeyStoreSignatureManager(pub GenericSignatureManager<LocalKeyStore>);
@@ -14,6 +16,14 @@ impl LocalKeyStoreSignatureManager {
 impl Default for LocalKeyStoreSignatureManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Deref for LocalKeyStoreSignatureManager {
+    type Target = GenericSignatureManager<LocalKeyStore>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 


### PR DESCRIPTION
I intend integration to node to be done with the local veriant E2E (the
existing generic server was merged previous to this decision).
Additional thought is needed re using (at least) two types of server:
one with local key store for testing, and the other with a remote
(secure) one for production; or, in other words: for the server to be
generic in key store.