### PR TITLE
apollo_dashboard: alert for high gw add tx latency

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -568,6 +568,60 @@
       "severity": "p2"
     },
     {
+      "name": "gateway_avg_add_tx_latency",
+      "title": "High gateway average add_tx latency",
+      "ruleGroup": "gateway",
+      "expr": "sum(rate(gateway_add_tx_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) / sum(rate(gateway_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]))",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              2.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2"
+    },
+    {
+      "name": "gateway_p95_add_tx_latency",
+      "title": "High gateway P95 add_tx latency",
+      "ruleGroup": "gateway",
+      "expr": "histogram_quantile(0.95, sum(rate(gateway_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) by (le, instance))",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              2.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2"
+    },
+    {
       "name": "http_server_idle",
       "title": "http server idle",
       "ruleGroup": "http_server",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -20,7 +20,7 @@ use apollo_consensus_orchestrator::metrics::{
     CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY,
     CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR,
 };
-use apollo_gateway::metrics::GATEWAY_TRANSACTIONS_RECEIVED;
+use apollo_gateway::metrics::{GATEWAY_ADD_TX_LATENCY, GATEWAY_TRANSACTIONS_RECEIVED};
 use apollo_http_server::metrics::{
     ADDED_TRANSACTIONS_FAILURE,
     ADDED_TRANSACTIONS_INTERNAL_ERROR,
@@ -346,7 +346,49 @@ fn get_gateway_add_tx_idle() -> Alert {
     }
 }
 
-// TODO(shahak): add gateway latency alert
+/// Triggers if the average latency of `add_tx` calls, across all gateways, exceeds 2 seconds over a
+/// 5-minute window.
+fn get_gateway_avg_add_tx_latency_alert() -> Alert {
+    let sum_metric = GATEWAY_ADD_TX_LATENCY.get_name_sum_with_filter();
+    let count_metric = GATEWAY_ADD_TX_LATENCY.get_name_count_with_filter();
+
+    Alert {
+        name: "gateway_avg_add_tx_latency",
+        title: "High gateway average add_tx latency",
+        alert_group: AlertGroup::Gateway,
+        expr: format!("sum(rate({sum_metric}[5m])) / sum(rate({count_metric}[5m]))"),
+        conditions: &[AlertCondition {
+            comparison_op: AlertComparisonOp::GreaterThan,
+            comparison_value: 2.0,
+            logical_op: AlertLogicalOp::And,
+        }],
+        pending_duration: PENDING_DURATION_DEFAULT,
+        evaluation_interval_sec: EVALUATION_INTERVAL_SEC_DEFAULT,
+        severity: AlertSeverity::Regular,
+    }
+}
+
+/// Triggers when the slowest 5% of transactions for a specific gateway are taking longer than 2
+/// seconds over a 5-minute window.
+fn get_gateway_p95_add_tx_latency_alert() -> Alert {
+    Alert {
+        name: "gateway_p95_add_tx_latency",
+        title: "High gateway P95 add_tx latency",
+        alert_group: AlertGroup::Gateway,
+        expr: format!(
+            "histogram_quantile(0.95, sum(rate({}[5m])) by (le, instance))",
+            GATEWAY_ADD_TX_LATENCY.get_name_with_filter()
+        ),
+        conditions: &[AlertCondition {
+            comparison_op: AlertComparisonOp::GreaterThan,
+            comparison_value: 2.0,
+            logical_op: AlertLogicalOp::And,
+        }],
+        pending_duration: PENDING_DURATION_DEFAULT,
+        evaluation_interval_sec: EVALUATION_INTERVAL_SEC_DEFAULT,
+        severity: AlertSeverity::Regular,
+    }
+}
 
 fn get_mempool_add_tx_idle() -> Alert {
     Alert {
@@ -984,6 +1026,8 @@ pub fn get_apollo_alerts() -> Alerts {
         get_consensus_validate_proposal_failed_alert(),
         get_consensus_votes_num_sent_messages_alert(),
         get_gateway_add_tx_idle(),
+        get_gateway_avg_add_tx_latency_alert(),
+        get_gateway_p95_add_tx_latency_alert(),
         get_http_server_idle(),
         get_http_server_add_tx_idle(),
         get_http_server_high_transaction_failure_ratio(),


### PR DESCRIPTION
This PR adds two per-gateway latency alerts for the `add_tx` endpoint, both triggered when latency goes over 2 seconds, but each catching a different issue:
* P95 latency alert: fires if the 95th percentile latency exceeds 2s.
example: most transactions are fast, but a few are slow — this catches the bad experience for some users.
* Average latency alert: fires if the overall average exceeds 2s.
example: almost all transactions are fast, but one is extremely slow — this catches that outlier.

Together, these alerts help us spot both consistent slowness and rare spikes. 
If the P95 alert proves sufficient, we can consider removing the average one later (or now).