### PR TITLE
l1: rename only

### DIFF
--- a/crates/apollo_l1_provider/src/l1_scraper_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper_tests.rs
@@ -144,7 +144,7 @@ async fn txs_happy_flow() {
         .timestamp;
 
     const EXPECTED_VERSION: TransactionVersion = TransactionVersion(StarkHash::ZERO);
-    let expected_internal_l1_tx = L1HandlerTransaction {
+    let expected_l1_handler_0 = L1HandlerTransaction {
         version: EXPECTED_VERSION,
         nonce: Nonce(StarkHash::ZERO),
         contract_address: contract_address!(l2_contract_address),
@@ -154,18 +154,18 @@ async fn txs_happy_flow() {
         ),
     };
     let default_chain_id = L1ScraperConfig::default().chain_id;
-    let tx_hash_first_tx = expected_internal_l1_tx
+    let tx_hash_first_tx = expected_l1_handler_0
         .calculate_transaction_hash(&default_chain_id, &EXPECTED_VERSION)
         .unwrap();
     let tx = ExecutableL1HandlerTransaction {
         tx_hash: tx_hash_first_tx,
-        tx: expected_internal_l1_tx,
+        tx: expected_l1_handler_0,
         paid_fee_on_l1: Fee(0),
     };
     let first_expected_log =
         Event::L1HandlerTransaction { l1_handler_tx: tx.clone(), timestamp: block_timestamps[0] };
 
-    let expected_internal_l1_tx_2 = L1HandlerTransaction {
+    let expected_l1_handler_1 = L1HandlerTransaction {
         nonce: Nonce(StarkHash::ONE),
         calldata: Calldata(
             vec![DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS, StarkHash::from(3), StarkHash::from(4)].into(),
@@ -173,10 +173,10 @@ async fn txs_happy_flow() {
         ..tx.tx
     };
     let tx_2 = ExecutableL1HandlerTransaction {
-        tx_hash: expected_internal_l1_tx_2
+        tx_hash: expected_l1_handler_1
             .calculate_transaction_hash(&default_chain_id, &EXPECTED_VERSION)
             .unwrap(),
-        tx: expected_internal_l1_tx_2,
+        tx: expected_l1_handler_1,
         ..tx
     };
     let second_expected_log =


### PR DESCRIPTION
The name is wrong, it's not internal, it's external.
Internal will be renamed next, into "executable" by convention.