### PR TITLE
apollo_l1_gas_price: make some config items public

### DIFF
--- a/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
@@ -82,19 +82,19 @@ impl SerializeConfig for EthToStrkOracleConfig {
                  lag refers to the fact that the interval `[T, T+k)` contains the conversion rate \
                  for queries in the interval `[T+k, T+2k)`. Should be configured in alignment \
                  with relevant query parameters in `base_url`, if required.",
-                ParamPrivacyInput::Private,
+                ParamPrivacyInput::Public,
             ),
             ser_param(
                 "max_cache_size",
                 &self.max_cache_size,
                 "The maximum number of cached conversion rates.",
-                ParamPrivacyInput::Private,
+                ParamPrivacyInput::Public,
             ),
             ser_param(
                 "query_timeout_sec",
                 &self.query_timeout_sec,
                 "The timeout (seconds) for the query to the eth to strk oracle.",
-                ParamPrivacyInput::Private,
+                ParamPrivacyInput::Public,
             ),
         ])
     }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -1076,17 +1076,17 @@
   },
   "consensus_manager_config.eth_to_strk_oracle_config.lag_interval_seconds": {
     "description": "The size of the interval (seconds) that the eth to strk rate is taken on. The lag refers to the fact that the interval `[T, T+k)` contains the conversion rate for queries in the interval `[T+k, T+2k)`. Should be configured in alignment with relevant query parameters in `base_url`, if required.",
-    "privacy": "Private",
+    "privacy": "Public",
     "value": 1
   },
   "consensus_manager_config.eth_to_strk_oracle_config.max_cache_size": {
     "description": "The maximum number of cached conversion rates.",
-    "privacy": "Private",
+    "privacy": "Public",
     "value": 100
   },
   "consensus_manager_config.eth_to_strk_oracle_config.query_timeout_sec": {
     "description": "The timeout (seconds) for the query to the eth to strk oracle.",
-    "privacy": "Private",
+    "privacy": "Public",
     "value": 3
   },
   "consensus_manager_config.immediate_active_height": {


### PR DESCRIPTION
The config parameters `lag_interval_seconds`, `max_cache_size` and `query_timeout_sec` of the eth to strk rate oracle were private, but should be public. 