### PR TITLE
apollo_integration_tests: generate empty contract declare tx

### DIFF
--- a/crates/apollo_gateway/src/config.rs
+++ b/crates/apollo_gateway/src/config.rs
@@ -130,7 +130,7 @@ impl Default for StatelessTransactionValidatorConfig {
             max_contract_bytecode_size: 81920,
             max_contract_class_object_size: 4089446,
             min_sierra_version: VersionId::new(1, 1, 0),
-            max_sierra_version: VersionId::new(1, 5, usize::MAX),
+            max_sierra_version: VersionId::new(1, 7, usize::MAX),
         }
     }
 }

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -128,7 +128,8 @@ impl TestScenario for DeclareTx {
         tx_generator: &mut MultiAccountTransactionGenerator,
         account_id: AccountId,
     ) -> (Vec<RpcTransaction>, Vec<L1HandlerTransaction>) {
-        let declare_tx = tx_generator.account_with_id_mut(account_id).generate_declare();
+        let declare_tx =
+            tx_generator.account_with_id_mut(account_id).generate_declare_of_contract_class();
         (vec![declare_tx], vec![])
     }
 

--- a/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
@@ -119,6 +119,6 @@ fn test_two_txs(tx_hashes: &[TransactionHash]) -> Vec<TransactionHash> {
 
 fn create_declare_tx(tx_generator: &mut MultiAccountTransactionGenerator) -> Vec<RpcTransaction> {
     let account_tx_generator = tx_generator.account_with_id_mut(ACCOUNT_ID_0);
-    let declare_tx = account_tx_generator.generate_declare();
+    let declare_tx = account_tx_generator.generate_declare_of_contract_class();
     vec![declare_tx]
 }

--- a/crates/apollo_integration_tests/tests/test_custom_syscall_invoke_txs.rs
+++ b/crates/apollo_integration_tests/tests/test_custom_syscall_invoke_txs.rs
@@ -7,6 +7,7 @@ use mempool_test_utils::starknet_api_test_utils::{
     AccountTransactionGenerator,
     MultiAccountTransactionGenerator,
 };
+use starknet_api::core::CompiledClassHash;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::felt;
 use starknet_api::rpc_transaction::RpcTransaction;
@@ -16,7 +17,7 @@ use crate::common::{end_to_end_flow, validate_tx_count, TestScenario};
 mod common;
 
 const DEFAULT_TIP: u64 = 1_u64;
-const CUSTOM_INVOKE_TX_COUNT: usize = 5;
+const CUSTOM_INVOKE_TX_COUNT: usize = 6;
 
 /// Test a wide range of different kinds of invoke transactions.
 #[tokio::test]
@@ -46,6 +47,7 @@ fn create_cairo_1_syscall_test_txs(
 ) -> Vec<RpcTransaction> {
     let account_tx_generator = tx_generator.account_with_id_mut(CAIRO1_ACCOUNT_ID);
     let mut txs = vec![];
+    txs.push(generate_empty_contract_declare_tx(account_tx_generator));
     txs.extend(generate_nested_library_call_invoke_txs(account_tx_generator));
     txs.extend(generate_direct_test_contract_invoke_txs(account_tx_generator));
 
@@ -105,4 +107,18 @@ fn generate_nested_library_call_invoke_txs(
             )
         })
         .collect()
+}
+
+pub fn generate_empty_contract_declare_tx(
+    account_tx_generator: &mut AccountTransactionGenerator,
+) -> RpcTransaction {
+    let empty_contract = FeatureContract::Empty(account_tx_generator.account.cairo_version());
+    // Hard coded class hash for empty contract. See example in https://github.com/starkware-libs/sequencer/blob/main-v0.14.0/crates/mempool_test_utils/src/starknet_api_test_utils.rs#L92
+    // TODO(Itamar): Move compiled hash to the blockifier constants file as optional trait for
+    // FeatureContract.
+    let empty_compiled_class_hash = CompiledClassHash(felt!(
+        "0x6EE46561691E785D643A8296B9BF08008E432DF405A1A4BEB6ED784541B571C"
+    ));
+
+    account_tx_generator.generate_declare_tx(empty_compiled_class_hash, empty_contract.get_sierra())
 }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -1742,7 +1742,7 @@
   "gateway_config.stateless_tx_validator_config.max_sierra_version.minor": {
     "description": "The minor version of the configuration.",
     "privacy": "Public",
-    "value": 5
+    "value": 7
   },
   "gateway_config.stateless_tx_validator_config.max_sierra_version.patch": {
     "description": "The patch version of the configuration.",

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -435,6 +435,21 @@ impl AccountTransactionGenerator {
         self.generate_rpc_invoke_tx(tip, calldata)
     }
 
+    pub fn generate_declare_tx(
+        &mut self,
+        compiled_class_hash: CompiledClassHash,
+        contract_class: SierraContractClass,
+    ) -> RpcTransaction {
+        let nonce = self.next_nonce();
+        let declare_args = declare_tx_args!(
+            sender_address: self.sender_address(),
+            resource_bounds: test_valid_resource_bounds(),
+            nonce,
+            compiled_class_hash,
+        );
+        rpc_declare_tx(declare_args, contract_class)
+    }
+
     pub fn generate_trivial_executable_invoke_tx(&mut self) -> AccountTransaction {
         let test_contract = FeatureContract::TestContract(self.account.cairo_version());
         let calldata = create_trivial_calldata(test_contract.get_instance_address(0));
@@ -495,17 +510,9 @@ impl AccountTransactionGenerator {
         rpc_deploy_account_tx(deploy_account_args)
     }
 
-    pub fn generate_declare(&mut self) -> RpcTransaction {
-        let nonce = self.next_nonce();
-        let declare_args = declare_tx_args!(
-            signature: TransactionSignature(vec![Felt::ZERO].into()),
-            sender_address: self.sender_address(),
-            resource_bounds: test_valid_resource_bounds(),
-            nonce,
-            compiled_class_hash: *COMPILED_CLASS_HASH,
-        );
-        let contract_class = contract_class();
-        rpc_declare_tx(declare_args, contract_class)
+    /// Generates a declare transaction for the ContractClass in contract_class.cairo file.
+    pub fn generate_declare_of_contract_class(&mut self) -> RpcTransaction {
+        self.generate_declare_tx(*COMPILED_CLASS_HASH, contract_class())
     }
 
     pub fn sender_address(&self) -> ContractAddress {


### PR DESCRIPTION
We will use the empty contract in the following PR's so we declare it now.