### PR TITLE
apollo_metrics: add a struct that increments a metric counter when it goes out of scope

### DIFF
--- a/crates/apollo_metrics/src/lib.rs
+++ b/crates/apollo_metrics/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod label_utils;
 pub mod metric_definitions;
 pub mod metrics;
+pub mod utils;
 
 // Its being exported here to be used in define_metrics macro.
 pub use paste;

--- a/crates/apollo_metrics/src/utils.rs
+++ b/crates/apollo_metrics/src/utils.rs
@@ -1,0 +1,35 @@
+use crate::metrics::MetricCounter;
+
+/// Holds a `MetricCounter`, and when dropped, increments the counter by 1.
+/// To prevent the increment, call `defuse`.
+/// This is useful for scenarios where you want to ensure a metric is incremented
+/// only if certain conditions are met, such as when a task completes successfully.
+/// Example usage:
+/// ```rust
+/// let mut bomb = MetricCounterBomb::new(MY_METRIC_COUNTER);
+/// // ... some complicated logic that may return an error or panic...
+/// bomb.defuse(); // Prevent the metric from being incremented
+/// retrun Ok(());
+/// ```
+pub struct MetricCounterBomb {
+    pub metric: MetricCounter,
+    pub primed: bool,
+}
+
+impl MetricCounterBomb {
+    pub fn new(metric: MetricCounter) -> Self {
+        Self { metric, primed: true }
+    }
+
+    pub fn defuse(&mut self) {
+        self.primed = false;
+    }
+}
+
+impl Drop for MetricCounterBomb {
+    fn drop(&mut self) {
+        if self.primed {
+            self.metric.increment(1);
+        }
+    }
+}


### PR DESCRIPTION
This is useful when you have a complicated function that has many ways to return an error or panic, and you'd like to increment an error counter in all cases except when the function returns successfully in the end. 