### PR TITLE
l1: consolidate Ethereum contract address re-export

### DIFF
--- a/crates/papyrus_base_layer/src/eth_events.rs
+++ b/crates/papyrus_base_layer/src/eth_events.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy::primitives::{Address as EthereumContractAddress, U256};
+use alloy::primitives::U256;
 use alloy::rpc::types::Log;
 use alloy::sol_types::SolEventInterface;
 use starknet_api::block::BlockTimestamp;
@@ -12,6 +12,7 @@ use starknet_types_core::felt::Felt;
 use crate::ethereum_base_layer_contract::{
     EthereumBaseLayerError,
     EthereumBaseLayerResult,
+    EthereumContractAddress,
     Starknet,
 };
 use crate::{EventData, L1Event};

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use alloy::dyn_abi::SolType;
 use alloy::eips::eip7840;
-use alloy::primitives::Address as EthereumContractAddress;
+use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder, RootProvider};
 use alloy::rpc::json_rpc::RpcError;
 use alloy::rpc::types::eth::Filter as EthEventFilter;
@@ -29,6 +29,7 @@ use crate::eth_events::parse_event;
 use crate::{BaseLayerContract, L1BlockHeader, L1BlockNumber, L1BlockReference, L1Event};
 
 pub type EthereumBaseLayerResult<T> = Result<T, EthereumBaseLayerError>;
+pub type EthereumContractAddress = Address;
 
 // Wraps the Starknet contract with a type that implements its interface, and is aware of its
 // events.

--- a/crates/papyrus_base_layer/src/test_utils.rs
+++ b/crates/papyrus_base_layer/src/test_utils.rs
@@ -3,8 +3,7 @@ use std::process::Command;
 
 use alloy::network::TransactionBuilder;
 use alloy::node_bindings::{Anvil, AnvilInstance, NodeError as AnvilError};
-pub(crate) use alloy::primitives::Address as EthereumContractAddress;
-use alloy::primitives::{Address, U256};
+use alloy::primitives::U256;
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use colored::*;
@@ -18,6 +17,7 @@ use url::Url;
 use crate::ethereum_base_layer_contract::{
     EthereumBaseLayerConfig,
     EthereumBaseLayerContract,
+    EthereumContractAddress,
     Starknet,
     StarknetL1Contract,
 };
@@ -154,8 +154,8 @@ pub async fn deploy_starknet_l1_contract(config: EthereumBaseLayerConfig) -> Sta
 }
 
 pub async fn make_block_history_on_anvil(
-    sender_address: Address,
-    receiver_address: Address,
+    sender_address: EthereumContractAddress,
+    receiver_address: EthereumContractAddress,
     base_layer_config: EthereumBaseLayerConfig,
     num_blocks: usize,
 ) {


### PR DESCRIPTION
Removes `alloy` type from the API of `papyrus_base_layer` and define in
the proper place, which is `ethereum_base_layer`.