### PR TITLE
apollo_p2p_sync: add timeout when awaiting sync response

### DIFF
--- a/crates/apollo_p2p_sync/src/client/block_data_stream_builder.rs
+++ b/crates/apollo_p2p_sync/src/client/block_data_stream_builder.rs
@@ -271,6 +271,8 @@ pub(crate) enum BadPeerError {
     ClassNotInStateDiff { class_hash: ClassHash },
     #[error("Received two classes with the same hash: {class_hash}.")]
     DuplicateClass { class_hash: ClassHash },
+    #[error("Response timeout while waiting for data from the network.")]
+    ResponseTimeout,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/apollo_p2p_sync/src/client/class.rs
+++ b/crates/apollo_p2p_sync/src/client/class.rs
@@ -24,6 +24,7 @@ use super::block_data_stream_builder::{
     ParseDataError,
 };
 use super::P2pSyncClientError;
+use crate::client::RESPONSE_TIMEOUT;
 
 impl BlockData for (DeclaredClasses, DeprecatedDeclaredClasses, BlockNumber) {
     fn write_to_storage<'a>(
@@ -111,11 +112,13 @@ impl BlockDataStreamBuilder<(ApiContractClass, ClassHash)> for ClassStreamBuilde
             ) = (0, DeclaredClasses::new(), DeprecatedDeclaredClasses::new());
 
             while current_class_len < target_class_len {
-                let maybe_contract_class = classes_response_manager.next().await.ok_or(
-                    ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
-                        type_description: Self::TYPE_DESCRIPTION,
-                    }),
-                )?;
+                let maybe_contract_class =
+                    tokio::time::timeout(RESPONSE_TIMEOUT, classes_response_manager.next())
+                        .await
+                        .map_err(|_| ParseDataError::BadPeer(BadPeerError::ResponseTimeout))?
+                        .ok_or(ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
+                            type_description: Self::TYPE_DESCRIPTION,
+                        }))?;
                 let Some((api_contract_class, class_hash)) = maybe_contract_class?.0 else {
                     if current_class_len == 0 {
                         return Ok(None);

--- a/crates/apollo_p2p_sync/src/client/header.rs
+++ b/crates/apollo_p2p_sync/src/client/header.rs
@@ -20,6 +20,7 @@ use super::block_data_stream_builder::{
     ParseDataError,
 };
 use super::{P2pSyncClientError, ALLOWED_SIGNATURES_LENGTH};
+use crate::client::RESPONSE_TIMEOUT;
 
 impl BlockData for SignedBlockHeader {
     #[allow(clippy::as_conversions)] // FIXME: use int metrics so `as f64` may be removed.
@@ -85,11 +86,13 @@ impl BlockDataStreamBuilder<SignedBlockHeader> for HeaderStreamBuilder {
         _storage_reader: &'a StorageReader,
     ) -> BoxFuture<'a, Result<Option<Self::Output>, ParseDataError>> {
         async move {
-            let maybe_signed_header = signed_headers_response_manager.next().await.ok_or(
-                ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
-                    type_description: Self::TYPE_DESCRIPTION,
-                }),
-            )?;
+            let maybe_signed_header =
+                tokio::time::timeout(RESPONSE_TIMEOUT, signed_headers_response_manager.next())
+                    .await
+                    .map_err(|_| ParseDataError::BadPeer(BadPeerError::ResponseTimeout))?
+                    .ok_or(ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
+                        type_description: Self::TYPE_DESCRIPTION,
+                    }))?;
             let Some(signed_block_header) = maybe_signed_header?.0 else {
                 return Ok(None);
             };

--- a/crates/apollo_p2p_sync/src/client/mod.rs
+++ b/crates/apollo_p2p_sync/src/client/mod.rs
@@ -55,6 +55,8 @@ use validator::Validate;
 
 const STEP: u64 = 1;
 const ALLOWED_SIGNATURES_LENGTH: usize = 1;
+// TODO(noamsp): remove usage of this constant once network session timeout is configured properly.
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Validate)]
 pub struct P2pSyncClientConfig {

--- a/crates/apollo_p2p_sync/src/client/state_diff.rs
+++ b/crates/apollo_p2p_sync/src/client/state_diff.rs
@@ -21,7 +21,7 @@ use crate::client::block_data_stream_builder::{
     BlockNumberLimit,
     ParseDataError,
 };
-use crate::client::P2pSyncClientError;
+use crate::client::{P2pSyncClientError, RESPONSE_TIMEOUT};
 
 impl BlockData for (ThinStateDiff, BlockNumber) {
     #[latency_histogram("p2p_sync_state_diff_write_to_storage_latency_seconds", true)]
@@ -70,12 +70,17 @@ impl BlockDataStreamBuilder<StateDiffChunk> for StateDiffStreamBuilder {
                 })?;
 
             while current_state_diff_len < target_state_diff_len {
-                let maybe_state_diff_chunk = state_diff_chunks_response_manager
-                    .next()
-                    .await
-                    .ok_or(ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
+                let maybe_state_diff_chunk = tokio::time::timeout(
+                    RESPONSE_TIMEOUT,
+                    state_diff_chunks_response_manager.next(),
+                )
+                .await
+                .map_err(|_| ParseDataError::BadPeer(BadPeerError::ResponseTimeout))?
+                .ok_or(ParseDataError::BadPeer(
+                    BadPeerError::SessionEndedWithoutFin {
                         type_description: Self::TYPE_DESCRIPTION,
-                    }))?;
+                    },
+                ))?;
                 let Some(state_diff_chunk) = maybe_state_diff_chunk?.0 else {
                     if current_state_diff_len == 0 {
                         return Ok(None);

--- a/crates/apollo_p2p_sync/src/client/transaction.rs
+++ b/crates/apollo_p2p_sync/src/client/transaction.rs
@@ -23,6 +23,7 @@ use super::block_data_stream_builder::{
     ParseDataError,
 };
 use super::P2pSyncClientError;
+use crate::client::RESPONSE_TIMEOUT;
 
 impl BlockData for (BlockBody, BlockNumber) {
     fn write_to_storage<'a>(
@@ -65,11 +66,13 @@ impl BlockDataStreamBuilder<FullTransaction> for TransactionStreamFactory {
                 .expect("A header with number lower than the header marker is missing")
                 .n_transactions;
             while current_transaction_len < target_transaction_len {
-                let maybe_transaction = transactions_response_manager.next().await.ok_or(
-                    ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
-                        type_description: Self::TYPE_DESCRIPTION,
-                    }),
-                )?;
+                let maybe_transaction =
+                    tokio::time::timeout(RESPONSE_TIMEOUT, transactions_response_manager.next())
+                        .await
+                        .map_err(|_| ParseDataError::BadPeer(BadPeerError::ResponseTimeout))?
+                        .ok_or(ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
+                            type_description: Self::TYPE_DESCRIPTION,
+                        }))?;
                 let Some(FullTransaction { transaction, transaction_output, transaction_hash }) =
                     maybe_transaction?.0
                 else {


### PR DESCRIPTION
This commit was added as a temporary fix to the bug found in the restart integration test.
During header sync at 50% hit-rate the restarted node would await endlessly for the peer to sync it up.
The problem probably originates from long session timeouts;
TODO: fix the network configs and make sure restart test passes consistently
after removing the changes introduced in this commit.