### PR TITLE
starknet_api: internal implementation of sizeof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared_execution_objects",
+ "sizeof",
  "starknet-types-core",
  "starknet_api",
  "strum 0.25.0",
@@ -11839,6 +11840,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sizeof"
+version = "0.15.0-rc.2"
+dependencies = [
+ "size-of",
+ "sizeof_internal",
+ "sizeof_macro",
+ "starknet-types-core",
+ "trybuild",
+]
+
+[[package]]
+name = "sizeof_internal"
+version = "0.15.0-rc.2"
+dependencies = [
+ "starknet-types-core",
+]
+
+[[package]]
+name = "sizeof_macro"
+version = "0.15.0-rc.2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12115,7 +12143,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "size-of",
+ "sizeof",
  "starknet-crypto",
  "starknet-types-core",
  "strum 0.25.0",
@@ -12518,6 +12546,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tblgen"
@@ -13143,6 +13177,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,9 @@ members = [
   "crates/papyrus_monitoring_gateway",
   "crates/papyrus_node",
   "crates/shared_execution_objects",
+  "crates/sizeof",
+  "crates/sizeof/sizeof_internal",
+  "crates/sizeof/sizeof_macro",
   "crates/starknet_api",
   "crates/starknet_committer",
   "crates/starknet_committer_and_os_cli",
@@ -281,7 +284,9 @@ sha2 = "0.10.8"
 sha3 = "0.10.8"
 shared_execution_objects.path = "crates/shared_execution_objects"
 simple_logger = "4.0.0"
-size-of = "0.1.5"
+sizeof = { path = "crates/sizeof", version = "0.15.0-rc.2" }
+sizeof_internal = { path = "crates/sizeof/sizeof_internal", version = "0.15.0-rc.2" }
+sizeof_macro = { path = "crates/sizeof/sizeof_macro", version = "0.15.0-rc.2" }
 socket2 = "0.5.8"
 starknet-core = "0.12.1"
 starknet-crypto = "0.7.1"

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 shared_execution_objects.workspace = true
+sizeof.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 strum.workspace = true

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -65,6 +65,7 @@ use num_bigint::BigUint;
 use rstest::rstest;
 use serde::Serialize;
 use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
+use sizeof::SizeOf;
 use starknet_api::block::{
     BlockHash,
     BlockInfo,
@@ -967,4 +968,67 @@ fn serialize_central_objects(#[case] rust_obj: impl Serialize, #[case] python_js
     let rust_json = serde_json::to_value(rust_obj).unwrap();
 
     assert_json_eq(&rust_json, &python_json, "Json Comparison failed".to_string());
+}
+
+// Check size of internal transactions.
+#[test]
+fn test_deploy_account_tx_size_of() {
+    let deploy_account_tx = deploy_account_tx();
+
+    let RpcDeployAccountTransaction::V3(internal_deploy_account_tx) = &deploy_account_tx.tx;
+
+    let expected_size = std::mem::size_of::<InternalRpcDeployAccountTransaction>()
+        + internal_deploy_account_tx.class_hash.dynamic_size()
+        + internal_deploy_account_tx.constructor_calldata.dynamic_size()
+        + internal_deploy_account_tx.contract_address_salt.dynamic_size()
+        + internal_deploy_account_tx.fee_data_availability_mode.dynamic_size()
+        + internal_deploy_account_tx.nonce.dynamic_size()
+        + internal_deploy_account_tx.nonce_data_availability_mode.dynamic_size()
+        + internal_deploy_account_tx.paymaster_data.dynamic_size()
+        + internal_deploy_account_tx.resource_bounds.dynamic_size()
+        + internal_deploy_account_tx.signature.dynamic_size()
+        + internal_deploy_account_tx.tip.dynamic_size()
+        + deploy_account_tx.contract_address.dynamic_size();
+
+    assert_eq!(deploy_account_tx.size_bytes(), expected_size);
+}
+
+#[test]
+fn test_declare_account_tx_size_of() {
+    let declare_tx = declare_transaction();
+
+    let expected_size = std::mem::size_of::<InternalRpcDeclareTransactionV3>()
+        + declare_tx.class_hash.dynamic_size()
+        + declare_tx.compiled_class_hash.dynamic_size()
+        + declare_tx.fee_data_availability_mode.dynamic_size()
+        + declare_tx.nonce.dynamic_size()
+        + declare_tx.nonce_data_availability_mode.dynamic_size()
+        + declare_tx.paymaster_data.dynamic_size()
+        + declare_tx.resource_bounds.dynamic_size()
+        + declare_tx.sender_address.dynamic_size()
+        + declare_tx.signature.dynamic_size()
+        + declare_tx.tip.dynamic_size();
+
+    assert_eq!(declare_tx.size_bytes(), expected_size);
+}
+
+#[test]
+fn test_invoke_tx_size_of() {
+    let invoke_tx = invoke_transaction();
+
+    let RpcInvokeTransaction::V3(internal_invoke_tx) = &invoke_tx;
+
+    let expected_size = std::mem::size_of::<RpcInvokeTransaction>()
+        + internal_invoke_tx.account_deployment_data.dynamic_size()
+        + internal_invoke_tx.calldata.dynamic_size()
+        + internal_invoke_tx.fee_data_availability_mode.dynamic_size()
+        + internal_invoke_tx.nonce.dynamic_size()
+        + internal_invoke_tx.nonce_data_availability_mode.dynamic_size()
+        + internal_invoke_tx.paymaster_data.dynamic_size()
+        + internal_invoke_tx.resource_bounds.dynamic_size()
+        + internal_invoke_tx.sender_address.dynamic_size()
+        + internal_invoke_tx.signature.dynamic_size()
+        + internal_invoke_tx.tip.dynamic_size();
+
+    assert_eq!(invoke_tx.size_bytes(), expected_size);
 }

--- a/crates/sizeof/Cargo.toml
+++ b/crates/sizeof/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sizeof"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "compute size of types in memory"
+
+[dependencies]
+sizeof_internal.workspace = true
+sizeof_macro.workspace = true
+starknet-types-core.workspace = true
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+size-of = "0.1.5"
+trybuild = "1.0.105"

--- a/crates/sizeof/negative_tests/notgeneric.rs
+++ b/crates/sizeof/negative_tests/notgeneric.rs
@@ -1,0 +1,20 @@
+use sizeof::SizeOf;
+struct NotSizeOf {
+    a: u32,
+    b: String,
+}
+#[derive(SizeOf)]
+struct ShouldNotCompile {
+    a: u32,
+    b: Vec<NotSizeOf>,
+}
+
+fn main() {
+    // This test is expected to fail because `NotSizeOf` (a member of the vector) does not implement `SizeOf`.
+    // The macro should not compile.
+
+    let _ = ShouldNotCompile { a: 42, b: vec![NotSizeOf { a: 1, b: String::from("test") }] };
+    println!(
+        "This is a negative test for the SizeOf macro. It should not compile if the macro is working correctly. You can find the expected error in notgeneric.stderr"
+    );
+}

--- a/crates/sizeof/negative_tests/notgeneric.stderr
+++ b/crates/sizeof/negative_tests/notgeneric.stderr
@@ -1,0 +1,22 @@
+error[E0599]: the method `dynamic_size` exists for struct `Vec<NotSizeOf>`, but its trait bounds were not satisfied
+ --> negative_tests/notgeneric.rs:9:5
+  |
+2 | struct NotSizeOf {
+  | ---------------- doesn't satisfy `NotSizeOf: SizeOf`
+...
+9 |     b: Vec<NotSizeOf>,
+  |     ^ method cannot be called on `Vec<NotSizeOf>` due to unsatisfied trait bounds
+  |
+ ::: $RUST/alloc/src/vec/mod.rs
+  |
+  | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+  | ------------------------------------------------------------------------------------------------ doesn't satisfy `Vec<NotSizeOf>: SizeOf`
+  |
+  = note: the following trait bounds were not satisfied:
+          `NotSizeOf: SizeOf`
+          which is required by `Vec<NotSizeOf>: SizeOf`
+note: the trait `SizeOf` must be implemented
+ --> sizeof_internal/src/lib.rs
+  |
+  | pub trait SizeOf {
+  | ^^^^^^^^^^^^^^^^

--- a/crates/sizeof/negative_tests/notsizeof.rs
+++ b/crates/sizeof/negative_tests/notsizeof.rs
@@ -1,0 +1,20 @@
+use sizeof::SizeOf;
+struct NotSizeOf {
+    a: u32,
+    b: String,
+}
+#[derive(SizeOf)]
+struct ShouldNotCompile {
+    a: u32,
+    b: NotSizeOf,
+}
+
+fn main() {
+    // This test is expected to fail because `NotSizeOf` does not implement `SizeOf`.
+    // The macro should not compile.
+
+    let _ = ShouldNotCompile { a: 42, b: NotSizeOf { a: 1, b: String::from("test") } };
+    println!(
+        "This is a negative test for the SizeOf macro. It should not compile if the macro is working correctly. You can find the expected error in notsizeof.stderr"
+    );
+}

--- a/crates/sizeof/negative_tests/notsizeof.stderr
+++ b/crates/sizeof/negative_tests/notsizeof.stderr
@@ -1,0 +1,18 @@
+error[E0599]: no method named `dynamic_size` found for struct `NotSizeOf` in the current scope
+ --> negative_tests/notsizeof.rs:9:5
+  |
+2 | struct NotSizeOf {
+  | ---------------- method `dynamic_size` not found for this struct
+...
+9 |     b: NotSizeOf,
+  |     ^ method not found in `NotSizeOf`
+  |
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following trait defines an item `dynamic_size`, perhaps you need to implement it:
+          candidate #1: `SizeOf`
+help: some of the expressions' fields have a method of the same name
+  |
+9 |     a.b: NotSizeOf,
+  |     ++
+9 |     b.b: NotSizeOf,
+  |     ++

--- a/crates/sizeof/sizeof_internal/Cargo.toml
+++ b/crates/sizeof/sizeof_internal/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sizeof_internal"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "compute size of types in memory"
+
+[lints]
+workspace = true
+
+[dependencies]
+starknet-types-core.workspace = true

--- a/crates/sizeof/sizeof_internal/src/lib.rs
+++ b/crates/sizeof/sizeof_internal/src/lib.rs
@@ -1,0 +1,96 @@
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex, RwLock};
+
+use starknet_types_core::felt::Felt;
+
+/// Trait for types that can report their size in bytes.
+/// There are two methods:
+/// - `dynamic_size`: returns the size of the heap part of the type.
+/// - `size_bytes`: returns the total size of the type, including both stack and heap parts.
+///
+/// This trait is useful for calculating the size of types in memory, especially when dealing with
+/// dynamic data structures like `Vec<T>` or `String`.
+pub trait SizeOf {
+    /// Returns the heap size of the type in bytes.
+    fn dynamic_size(&self) -> usize;
+
+    /// Returns the total size of the type in bytes, including both stack and heap parts.
+    fn size_bytes(&self) -> usize
+    where
+        Self: Sized,
+    {
+        std::mem::size_of::<Self>() + self.dynamic_size()
+    }
+}
+
+#[macro_export]
+macro_rules! default_primitive_sizeof {
+    ($($type:ty),*) => {
+        $(
+            impl SizeOf for $type {
+                fn dynamic_size(&self) -> usize {
+                    0
+                }
+            }
+        )*
+    };
+}
+
+default_primitive_sizeof! {
+    bool, u8, i8, u16, i16, u32, i32, u64, i64, u128, i128,
+    f32, f64,
+    usize, isize,
+    Felt
+}
+
+impl SizeOf for String {
+    fn dynamic_size(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl<T: SizeOf> SizeOf for Vec<T> {
+    fn dynamic_size(&self) -> usize {
+        self.iter().map(|x| x.size_bytes()).sum::<usize>()
+    }
+}
+
+#[macro_export]
+macro_rules! default_pointer_sizeof {
+    ($($name:ident < $($generic_params:ident $(: $bounds:path)*),* >),*) => {
+        $(
+             impl < $($generic_params : $crate::SizeOf $(+ $bounds)* ),* > $crate::SizeOf for $name < $($generic_params),* >  {
+                fn dynamic_size(&self) -> usize {
+                    self.deref().size_bytes()
+                }
+            }
+        )*
+    };
+}
+
+default_pointer_sizeof! { Box<T>, Rc<T>, Arc<T>, RefCell<T>, Mutex<T>, RwLock<T> }
+
+#[test]
+fn test_size_of() {
+    assert_eq!(17_u8.size_bytes(), 1);
+    assert_eq!(
+        String::from("Hello").size_bytes(),
+        std::mem::size_of::<String>() + String::from("Hello").capacity()
+    );
+    assert_eq!(
+        vec![1_u8, 2_u8, 3_u8].size_bytes(),
+        std::mem::size_of::<Vec<u8>>() + std::mem::size_of::<u8>() * 3
+    );
+}
+
+#[test]
+fn test_felt_size_of() {
+    assert_eq!(Felt::ZERO.size_bytes(), 32);
+    assert_eq!(Felt::ONE.size_bytes(), 32);
+    assert_eq!(Felt::from(1600000000).size_bytes(), 32);
+    assert_eq!(Felt::MAX.size_bytes(), 32);
+}
+
+

--- a/crates/sizeof/sizeof_macro/Cargo.toml
+++ b/crates/sizeof/sizeof_macro/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sizeof_macro"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "compute size of types in memory"
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote.workspace = true
+syn = { workspace = true, features = ["full"] }

--- a/crates/sizeof/sizeof_macro/src/lib.rs
+++ b/crates/sizeof/sizeof_macro/src/lib.rs
@@ -1,0 +1,160 @@
+// The code in this file uses code from and inspired by https://github.com/dtolnay/syn/tree/master/examples/heapsize and https://github.com/Kixiron/size-of
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{
+    parse_macro_input,
+    parse_quote,
+    Data,
+    DataEnum,
+    DataStruct,
+    DeriveInput,
+    Fields,
+    GenericParam,
+    Generics,
+};
+
+/// This macro derives the `SizeOf` trait for structs and enums, allowing them to calculate
+/// their dynamic size and total size in bytes.
+///
+/// Use `size_bytes()` to get the total size of the type, which includes both stack and heap parts.
+/// Use `dynamic_size()` to get the heap size of the type.
+///
+/// `WARNING`: It is `DANGEROUS` to use this macro on types with children that implement `Deref`,
+/// for two reasons (the first leading to under-counting and the second to over-counting):
+/// 1. If a type `P<T>` does not explicitly implement `SizeOf`, calling `P<T>.size_bytes()` will
+///    implicitly call `T.size_bytes()` (due to `Deref coercion`), which will neglect counting the
+///    stack size taken by `P<T>` itself. Currently, this macro is only implemented for the
+///    following `Deref` types: `Box<T>, Rc<T>, Arc<T>, RefCell<T>, Mutex<T>, RwLock<T>`. If your
+///    `Deref` type is not on this list, refrain from using this macro.
+/// 2. Even if a pointer type `P<T>` implements `SizeOf` (for example `Rc<T>` or `Arc<T>`), it is
+///    possible to count the same memory location twice if multiple pointers point to the same data.
+///    In such cases it is recommended to implement `SizeOf` manually for the type.
+#[proc_macro_derive(SizeOf)]
+pub fn derive_dynamic_size(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident; // The name of the struct or enum being derived.
+    let generics = add_trait_bounds(input.generics); // Add the SizeOf trait bound
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl(); // Split the generics into parts for the impl block.
+
+    let gen = match input.data {
+        Data::Struct(data_struct) => derive_macro_for_struct(data_struct),
+        Data::Enum(data_enum) => derive_macro_for_enum(data_enum),
+        Data::Union(_) => unimplemented!("SizeOf can only be derived for structs and enums."),
+    };
+
+    // Create the implementation block for the SizeOf trait.
+    // The `impl_generics`, `ty_generics`, and `where_clause` are used to ensure the T: SizeOf bound
+    // is enforced on all generic types.
+    quote! {
+        impl #impl_generics SizeOf for #name #ty_generics #where_clause {
+            fn dynamic_size(&self) -> usize {
+                #gen
+            }
+        }
+    }
+    .into()
+}
+
+// Helper function to derive dynamic_size() for structs.
+fn derive_macro_for_struct(data_struct: DataStruct) -> TokenStream2 {
+    // Generate expressions for each field in the struct to calculate their sizes.
+    let field_exprs = match data_struct.fields {
+        Fields::Named(ref fields) => fields
+            .named
+            .iter()
+            .map(|f| {
+                let ident = f.ident.as_ref().unwrap(); // Get the name of the field.
+                quote_spanned! {f.span()=>
+                    size += self.#ident.dynamic_size();
+                }
+            })
+            .collect::<Vec<_>>(),
+        Fields::Unnamed(ref fields) => fields
+            .unnamed
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let idx = syn::Index::from(i); // Create an index for unnamed fields.
+                quote_spanned! {f.span()=>
+                    size += self.#idx.dynamic_size();
+                }
+            })
+            .collect(),
+        Fields::Unit => vec![],
+    };
+    quote! {
+       let mut size = 0;
+       // Calculate the size of each field in the struct.
+        #(#field_exprs)*
+         size
+    }
+}
+
+// Helper functions to derive dynamic_size() for enums.
+fn derive_macro_for_enum(data_enum: DataEnum) -> TokenStream2 {
+    // Generate match arms for each variant of the enum.
+    let variant_matches = data_enum.variants.iter().map(|variant| {
+        let vname = &variant.ident;
+
+        // Match arms for each variant, calculating the size based on its fields.
+        match &variant.fields {
+            Fields::Named(ref fields) => {
+                let idents: Vec<_> =
+                    fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+                let bindings: Vec<_> = idents.iter().map(|id| quote! { #id }).collect();
+                let sizes: Vec<_> = idents
+                    .iter()
+                    .map(|id| quote_spanned! { id.span() => size += #id.dynamic_size(); })
+                    .collect();
+                quote! {
+                    Self::#vname { #(#bindings),* } => {
+                        let mut size = 0;
+                        #(#sizes)*
+                        size
+                    }
+                }
+            }
+            Fields::Unnamed(ref fields) => {
+                let bindings: Vec<syn::Ident> = (0..fields.unnamed.len())
+                    .map(|i| syn::Ident::new(&format!("f{}", i), vname.span()))
+                    .collect();
+                let sizes: Vec<_> = bindings
+                    .iter()
+                    .map(|b| quote_spanned! { b.span() => size += #b.dynamic_size(); })
+                    .collect();
+                quote! {
+                    Self::#vname( #(#bindings),* ) => {
+                        let mut size = 0;
+                        #(#sizes)*
+                        size
+                    }
+                }
+            }
+            Fields::Unit => {
+                quote! {
+                    Self::#vname => 0
+                }
+            }
+        }
+    });
+    quote! {
+        // Match on the enum variants and calculate their dynamic sizes.
+        match self {
+            // Each variant match arm will calculate its dynamic size.
+            #(#variant_matches),*
+        }
+    }
+}
+
+// Add a bound `T: SizeOf` to every type parameter T.
+fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(parse_quote!(sizeof::SizeOf));
+        }
+    }
+    generics
+}

--- a/crates/sizeof/src/lib.rs
+++ b/crates/sizeof/src/lib.rs
@@ -1,0 +1,142 @@
+pub use sizeof_internal::SizeOf;
+pub use sizeof_macro::SizeOf;
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use size_of::SizeOf as OldSizeOf;
+
+    use super::SizeOf;
+
+    #[test]
+    fn test_equality_with_old_size_of() {
+        // Ensure that the SizeOf trait from this crate is equivalent to the one from the old crate.
+        // TODO(victorkstarkware): Remove this test once the old crate is no longer used.
+        assert_eq!(17_u8.size_of().total_bytes(), 17_u8.size_bytes());
+        assert_eq!(
+            String::from("Hello").size_of().total_bytes(),
+            String::from("Hello").size_bytes()
+        );
+        assert_eq!(
+            vec![1_u8, 2_u8, 3_u8].size_of().total_bytes(),
+            vec![1_u8, 2_u8, 3_u8].size_bytes()
+        );
+
+        // Test struct
+        #[derive(OldSizeOf, SizeOf)]
+        struct MyStruct {
+            a: u32,
+            b: String,
+            c: Vec<u8>,
+        }
+        let strct = MyStruct { a: 42, b: String::from("Hello"), c: vec![1, 2, 3, 4, 5] };
+        assert_eq!(strct.size_of().total_bytes(), strct.size_bytes());
+
+        // Test enum
+        #[derive(OldSizeOf, SizeOf)]
+        enum MyEnum {
+            VariantA(u32),
+            VariantB { x: u64, y: String },
+        }
+        let my_enum_a = MyEnum::VariantA(42);
+        let my_enum_b = MyEnum::VariantB { x: 100, y: String::from("World") };
+        assert_eq!(my_enum_a.size_of().total_bytes(), my_enum_a.size_bytes());
+        assert_eq!(my_enum_b.size_of().total_bytes(), my_enum_b.size_bytes());
+
+        // Test complicated enum
+        #[derive(OldSizeOf, SizeOf)]
+        enum MyComplicatedEnum {
+            VariantA(MyStruct),
+            VariantB(Vec<MyEnum>),
+        }
+        let my_complicated_enum_a = MyComplicatedEnum::VariantA(MyStruct {
+            a: 42,
+            b: String::from("Hello"),
+            c: vec![1, 2, 3],
+        });
+        let my_complicated_enum_b = MyComplicatedEnum::VariantB(vec![
+            MyEnum::VariantA(42),
+            MyEnum::VariantB { x: 100, y: String::from("World") },
+            MyEnum::VariantB { x: 66, y: String::from("Starknet") },
+        ]);
+        assert_eq!(
+            my_complicated_enum_a.size_of().total_bytes(),
+            my_complicated_enum_a.size_bytes()
+        );
+        assert_eq!(
+            my_complicated_enum_b.size_of().total_bytes(),
+            my_complicated_enum_b.size_bytes()
+        );
+    }
+
+    #[test]
+    fn test_size_of_struct() {
+        #[derive(SizeOf)]
+        struct MyStruct {
+            a: u32,
+            b: String,
+            c: Vec<u8>,
+        }
+        let my_struct = MyStruct { a: 42, b: String::from("Hello"), c: vec![1, 2, 3, 4, 5] };
+        assert_eq!(my_struct.size_bytes(), std::mem::size_of::<MyStruct>() + 5 + 5);
+    }
+
+    #[test]
+    fn test_size_of_enum() {
+        #[derive(SizeOf)]
+        enum MyEnum {
+            VariantA(u32),
+            VariantB { x: u64, y: String },
+        }
+        let my_enum_a = MyEnum::VariantA(42);
+        let my_enum_b = MyEnum::VariantB { x: 100, y: String::from("World!") };
+        assert_eq!(my_enum_a.size_bytes(), std::mem::size_of::<MyEnum>());
+        assert_eq!(my_enum_b.size_bytes(), std::mem::size_of::<MyEnum>() + 6);
+    }
+
+    #[test]
+    fn test_size_of_complicated_enum() {
+        #[derive(SizeOf)]
+        enum MyEnum {
+            VariantA(u32),
+            VariantB { x: u64, y: String },
+        }
+        #[derive(SizeOf)]
+        struct MyStruct {
+            a: u32,
+            b: String,
+            c: Vec<u8>,
+        }
+        #[derive(SizeOf)]
+        enum MyComplicatedEnum {
+            VariantA(MyStruct),
+            VariantB { vec: Vec<MyEnum> },
+        }
+        let my_complicated_enum_a = MyComplicatedEnum::VariantA(MyStruct {
+            a: 42,
+            b: String::from("Hello"),
+            c: vec![1, 2, 3],
+        });
+        let my_complicated_enum_b = MyComplicatedEnum::VariantB {
+            vec: vec![MyEnum::VariantA(42), MyEnum::VariantB { x: 100, y: String::from("World!") }],
+        };
+        assert_eq!(
+            my_complicated_enum_a.size_bytes(),
+            std::mem::size_of::<MyComplicatedEnum>() + 5 + 3
+        );
+        assert_eq!(
+            my_complicated_enum_b.size_bytes(),
+            std::mem::size_of::<MyComplicatedEnum>() + 2 * std::mem::size_of::<MyEnum>() + 6
+        );
+    }
+
+    #[test]
+    fn test_should_not_compile() {
+        // Note: this sets the TRYBUILD=overwrite env variable globally. If used elsewhere in the
+        // future, consider changing this or removing this test.
+        env::set_var("TRYBUILD", "overwrite");
+        let t = trybuild::TestCases::new();
+        t.compile_fail("negative_tests/*.rs");
+    }
+}

--- a/crates/starknet_api/Cargo.toml
+++ b/crates/starknet_api/Cargo.toml
@@ -31,7 +31,7 @@ semver.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 sha3.workspace = true
-size-of.workspace = true
+sizeof.workspace = true
 starknet-crypto.workspace = true
 starknet-types-core = { workspace = true, features = ["hash"] }
 strum = { workspace = true, features = ["derive"] }

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Poseidon, StarkHash as CoreStarkHash};
 use strum_macros::EnumIter;

--- a/crates/starknet_api/src/core.rs
+++ b/crates/starknet_api/src/core.rs
@@ -9,7 +9,7 @@ use num_traits::ToPrimitive;
 use primitive_types::H160;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::{Felt, NonZeroFelt};
 use starknet_types_core::hash::{Pedersen, StarkHash as CoreStarkHash};
 

--- a/crates/starknet_api/src/data_availability.rs
+++ b/crates/starknet_api/src/data_availability.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 
 use crate::StarknetApiError;

--- a/crates/starknet_api/src/execution_resources.rs
+++ b/crates/starknet_api/src/execution_resources.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 use strum_macros::EnumIter;
 

--- a/crates/starknet_api/src/rpc_transaction.rs
+++ b/crates/starknet_api/src/rpc_transaction.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use cairo_lang_starknet_classes::contract_class::ContractEntryPoints as CairoLangContractEntryPoints;
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use strum::EnumVariantNames;
 use strum_macros::{EnumDiscriminants, EnumIter, IntoStaticStr};
 
@@ -230,8 +230,7 @@ impl InternalRpcTransaction {
     }
 
     pub fn total_bytes(&self) -> u64 {
-        self.size_of()
-            .total_bytes()
+        self.size_bytes()
             .try_into()
             .expect("The transaction size in bytes should fit in a u64 value.")
     }

--- a/crates/starknet_api/src/rpc_transaction_test.rs
+++ b/crates/starknet_api/src/rpc_transaction_test.rs
@@ -1,10 +1,18 @@
 use rstest::rstest;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 
 use crate::block::GasPrice;
 use crate::core::CompiledClassHash;
 use crate::execution_resources::GasAmount;
-use crate::rpc_transaction::{DataAvailabilityMode, RpcTransaction};
+use crate::rpc_transaction::{
+    DataAvailabilityMode,
+    RpcDeployAccountTransaction,
+    RpcDeployAccountTransactionV3,
+    RpcInvokeTransaction,
+    RpcInvokeTransactionV3,
+    RpcTransaction,
+};
 use crate::state::SierraContractClass;
 use crate::test_utils::declare::{rpc_declare_tx, DeclareTxArgs};
 use crate::test_utils::deploy_account::{rpc_deploy_account_tx, DeployAccountTxArgs};
@@ -84,4 +92,67 @@ fn test_rpc_transactions(#[case] tx: RpcTransaction) {
     let serialized = serde_json::to_string(&tx).unwrap();
     let deserialized: RpcTransaction = serde_json::from_str(&serialized).unwrap();
     assert_eq!(tx, deserialized);
+}
+
+// Check size of RPC transactions.
+#[test]
+fn test_deploy_account_tx_size_of() {
+    let tx = create_deploy_account_tx();
+    if let RpcTransaction::DeployAccount(deploy_tx) = tx {
+        let RpcDeployAccountTransaction::V3(tx_v3) = deploy_tx;
+
+        // Calculate the expected size of the V3 deploy account transaction.
+        let expected_size = std::mem::size_of::<RpcDeployAccountTransactionV3>()
+            + tx_v3.resource_bounds.l1_gas.max_amount.dynamic_size()
+            + tx_v3.resource_bounds.l1_gas.max_price_per_unit.dynamic_size()
+            + tx_v3.resource_bounds.l2_gas.max_amount.dynamic_size()
+            + tx_v3.resource_bounds.l2_gas.max_price_per_unit.dynamic_size()
+            + tx_v3.resource_bounds.l1_data_gas.max_amount.dynamic_size()
+            + tx_v3.resource_bounds.l1_data_gas.max_price_per_unit.dynamic_size()
+            + tx_v3.tip.dynamic_size()
+            + tx_v3.contract_address_salt.dynamic_size()
+            + tx_v3.class_hash.dynamic_size()
+            + tx_v3.constructor_calldata.dynamic_size()
+            + tx_v3.nonce.dynamic_size()
+            + tx_v3.signature.dynamic_size()
+            + tx_v3.nonce_data_availability_mode.dynamic_size()
+            + tx_v3.fee_data_availability_mode.dynamic_size()
+            + tx_v3.paymaster_data.dynamic_size();
+
+        // Check the size of the V3 deploy account transaction.
+        assert_eq!(tx_v3.size_bytes(), expected_size);
+    } else {
+        panic!("Expected RpcTransaction::DeployAccount");
+    }
+}
+
+#[test]
+fn test_invoke_tx_size_of() {
+    let tx = create_invoke_tx();
+    if let RpcTransaction::Invoke(invoke_tx) = tx {
+        let RpcInvokeTransaction::V3(tx_v3) = invoke_tx;
+
+        // Calculate the expected size of the V3 invoke transaction.
+        let expected_size = std::mem::size_of::<RpcInvokeTransactionV3>()
+            + tx_v3.resource_bounds.l1_gas.max_amount.dynamic_size()
+            + tx_v3.resource_bounds.l1_gas.max_price_per_unit.dynamic_size()
+            + tx_v3.resource_bounds.l2_gas.max_amount.dynamic_size()
+            + tx_v3.resource_bounds.l2_gas.max_price_per_unit.dynamic_size()
+            + tx_v3.resource_bounds.l1_data_gas.max_amount.dynamic_size()
+            + tx_v3.resource_bounds.l1_data_gas.max_price_per_unit.dynamic_size()
+            + tx_v3.tip.dynamic_size()
+            + tx_v3.calldata.dynamic_size()
+            + tx_v3.sender_address.dynamic_size()
+            + tx_v3.nonce.dynamic_size()
+            + tx_v3.signature.dynamic_size()
+            + tx_v3.nonce_data_availability_mode.dynamic_size()
+            + tx_v3.fee_data_availability_mode.dynamic_size()
+            + tx_v3.paymaster_data.dynamic_size()
+            + tx_v3.account_deployment_data.dynamic_size();
+
+        // Check the size of the V3 invoke transaction.
+        assert_eq!(tx_v3.size_bytes(), expected_size);
+    } else {
+        panic!("Expected RpcTransaction::Invoke");
+    }
 }

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 
 use crate::block::{BlockHash, BlockNumber};

--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 use strum_macros::EnumIter;
 


### PR DESCRIPTION
### TL;DR

Added a new `sizeof` crate to replace the external `size-of` dependency

### What changed?

- Created a new `sizeof` crate with three components:
  - `sizeof_internal`: Core trait definition and implementations for primitive types
  - `sizeof_macro`: Procedural macro for deriving `SizeOf` on structs and enums
  - Main `sizeof` crate: Re-exports and tests

- Implemented the `SizeOf` trait with two methods:
  - `dynamic_size()`: Returns the heap size of a type
  - `size_bytes()`: Returns the total size (stack + heap)

- Added tests to verify size calculations for various types including Starknet-specific types

- Updated dependencies across the codebase to use the new `sizeof` crate instead of the external `size-of` dependency

- Added negative tests to ensure proper compile-time errors when the trait is not implemented correctly

### How to test?

- Run the test suite with `cargo test` to verify the new `sizeof` crate works correctly
- Check the negative tests in `negative_tests/` directory to ensure proper compile-time errors
- Verify size calculations for Starknet types in the added tests in `apollo_consensus_orchestrator/src/cende/central_objects_test.rs` and `starknet_api/src/rpc_transaction_test.rs`
