### PR TITLE
apollo_deployments: fix stress test chain id to E2E_TESTNET

### DIFF
--- a/crates/apollo_deployments/resources/deployments/stress_test/deployment_config_override.json
+++ b/crates/apollo_deployments/resources/deployments/stress_test/deployment_config_override.json
@@ -1,6 +1,6 @@
 {
   "base_layer_config.starknet_contract_address": "0x4fA369fEBf0C574ea05EC12bC0e1Bc9Cd461Dd0f",
-  "chain_id": "INTERNAL_STRESS_TEST",
+  "chain_id": "E2E_TESTNET",
   "consensus_manager_config.context_config.num_validators": 3,
   "eth_fee_token_address": "0x7e813ecf3e7b3e14f07bd2f68cb4a3d12110e3c75ec5a63de3d2dacf1852904",
   "l1_provider_config.provider_startup_height_override": 0,

--- a/crates/apollo_deployments/src/deployment_definitions/stress_test.rs
+++ b/crates/apollo_deployments/src/deployment_definitions/stress_test.rs
@@ -23,7 +23,7 @@ pub(crate) fn stress_test_hybrid_deployments() -> Vec<Deployment> {
 fn stress_test_deployment_config_override() -> DeploymentConfigOverride {
     DeploymentConfigOverride::new(
         "0x4fA369fEBf0C574ea05EC12bC0e1Bc9Cd461Dd0f",
-        "INTERNAL_STRESS_TEST",
+        "E2E_TESTNET",
         "0x7e813ecf3e7b3e14f07bd2f68cb4a3d12110e3c75ec5a63de3d2dacf1852904",
         Url::parse("http://feeder-gateway.starknet-0-14-0-stress-test-03:9713/")
             .expect("Invalid URL"),


### PR DESCRIPTION
- **apollo_deployments: update stress test parameters for env restart**
- **apollo_deployments: fix stress test chain id to E2E_TESTNET**
