### PR TITLE
apollo_l1_provider: add timestamp to the got messages to l2 log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12134,6 +12134,7 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -116,10 +116,12 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
 
         let l1_events = scraping_result.map_err(L1ScraperError::BaseLayerError)?;
         // Used for debug.
-        let l1_hashes = l1_events
+        let l1_messages_info = l1_events
             .iter()
             .filter_map(|event| match event {
-                L1Event::LogMessageToL2 { l1_tx_hash, .. } => Some(*l1_tx_hash),
+                L1Event::LogMessageToL2 { l1_tx_hash, timestamp, .. } => {
+                    Some((*l1_tx_hash, *timestamp))
+                }
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -138,11 +140,14 @@ impl<B: BaseLayerContract + Send + Sync> L1Scraper<B> {
             _ => None,
         });
 
-        let formatted_pairs = zip_eq(l1_hashes, l2_hashes)
-            .map(|(l1_hash, l2_hash)| format!("L1 hash: {:?}, L2 hash: {}", l1_hash, l2_hash))
+        let formatted_pairs = zip_eq(l1_messages_info, l2_hashes)
+            .map(|((l1_hash, timestamp), l2_hash)| {
+                format!("L1 hash: {l1_hash:?}, L1 timestamp: {timestamp}, L2 hash: {l2_hash}")
+            })
             .collect::<Vec<_>>();
-        debug!("Got Messages to L2: {:?}", formatted_pairs);
-
+        if !formatted_pairs.is_empty() {
+            debug!("Got Messages to L2: {formatted_pairs:?}");
+        }
         Ok((latest_l1_block, events))
     }
 

--- a/crates/starknet_api/Cargo.toml
+++ b/crates/starknet_api/Cargo.toml
@@ -37,6 +37,7 @@ starknet-types-core = { workspace = true, features = ["hash"] }
 strum = { workspace = true, features = ["derive"] }
 strum_macros.workspace = true
 thiserror.workspace = true
+time.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -11,6 +11,7 @@ use size_of::SizeOf;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Poseidon, StarkHash as CoreStarkHash};
 use strum_macros::EnumIter;
+use time::OffsetDateTime;
 
 use crate::core::{
     ContractAddress,
@@ -582,7 +583,10 @@ impl From<u64> for BlockTimestamp {
 
 impl Display for BlockTimestamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        let seconds_from_epoch = i64::try_from(self.0).map_err(|_| std::fmt::Error)?;
+        let time_in_range =
+            OffsetDateTime::from_unix_timestamp(seconds_from_epoch).map_err(|_| std::fmt::Error)?;
+        write!(f, "{}", time_in_range)
     }
 }
 

--- a/crates/starknet_api/src/block_test.rs
+++ b/crates/starknet_api/src/block_test.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 use strum::IntoEnumIterator;
 
 use super::{verify_block_signature, StarknetVersion};
-use crate::block::{BlockHash, BlockNumber, BlockSignature};
+use crate::block::{BlockHash, BlockNumber, BlockSignature, BlockTimestamp};
 use crate::core::{GlobalRoot, SequencerPublicKey};
 use crate::crypto::utils::{PublicKey, Signature};
 use crate::felt;
@@ -79,4 +79,12 @@ fn test_latest_version() {
     for version in StarknetVersion::iter() {
         assert!(version <= latest);
     }
+}
+
+#[test]
+fn test_block_timestamp_display() {
+    let timestamp = BlockTimestamp(1_752_482_544);
+    let expected = "2025-07-14 8:42:24.0 +00:00:00";
+
+    assert_eq!(timestamp.to_string(), expected);
 }


### PR DESCRIPTION
During the manual test for the `new_l1_handler_cooldown_seconds` feature, we found a gap in the information provided by the L1 provider's logs.