### PR TITLE
Fix Typos in Documentation and Cairo Test Resources

### DIFF
--- a/crates/blockifier_reexecution/README.md
+++ b/crates/blockifier_reexecution/README.md
@@ -111,7 +111,7 @@ Therefore, when changing the files format, do these 4 steps in order:
 ```
 cargo run --bin blockifier_reexecution write-to-file -n <node_url>
 ```
-Make sure reexecution of all the blocks succeeded; if neccessary, rerun the command with the block numbers that failed.
+Make sure reexecution of all the blocks succeeded; if necessary, rerun the command with the block numbers that failed.
 
 - 3. Verify that offline reexecution succeeds by running
 ```

--- a/crates/blockifier_test_utils/resources/ERC20/ERC20_Cairo1/ERC20_cairo1.cairo
+++ b/crates/blockifier_test_utils/resources/ERC20/ERC20_Cairo1/ERC20_cairo1.cairo
@@ -314,7 +314,7 @@ mod ERC20 {
             // Handle EIC.
             match implementation_data.eic_data {
                 Option::Some(eic_data) => {
-                    // Wrap the calldata as a span, as preperation for the library_call_syscall
+                    // Wrap the calldata as a span, as preparation for the library_call_syscall
                     // invocation.
                     let mut calldata_wrapper = ArrayTrait::new();
                     eic_data.eic_init_data.serialize(ref calldata_wrapper);

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo0/account_faulty.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo0/account_faulty.cairo
@@ -62,7 +62,7 @@ func __validate__{syscall_ptr: felt*}(
     contract_address: felt, selector: felt, calldata_len: felt, calldata: felt*
 ) {
     let to_address = 0;
-    // By calling the `send_message_to_l1` function in validation and exeution, tests can now verify
+    // By calling the `send_message_to_l1` function in validation and execution, tests can now verify
     // the functionality of entry point counters.
     send_message_to_l1(to_address, calldata_len, calldata);
     faulty_validate();

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo1/account_faulty.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo1/account_faulty.cairo
@@ -68,7 +68,7 @@ mod Account {
         calldata: Array<felt252>
     ) -> felt252 {
         let to_address = 0;
-        // By calling the `send_message_to_l1` function in validation and exeution, tests can now verify
+        // By calling the `send_message_to_l1` function in validation and execution, tests can now verify
         // the functionality of entry point counters.
         send_message_to_l1_syscall(
             to_address: to_address,


### PR DESCRIPTION


---



**Description:**  
This pull request corrects several minor typos in documentation and Cairo test resource files:
- Fixes spelling errors such as "neccessary" → "necessary", "preperation" → "preparation", and "exeution" → "execution".
- Updates comments and documentation for improved clarity and consistency.



---