### PR TITLE
signature: use `libp2p::PeerId` in sig. manager API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,9 +1967,11 @@ name = "apollo_signature_manager"
 version = "0.0.0"
 dependencies = [
  "apollo_infra",
+ "apollo_network_types",
  "apollo_signature_manager_types",
  "async-trait",
  "blake2s",
+ "hex",
  "pretty_assertions",
  "rstest",
  "starknet-core",
@@ -1984,9 +1986,9 @@ name = "apollo_signature_manager_types"
 version = "0.0.0"
 dependencies = [
  "apollo_infra",
+ "apollo_network_types",
  "apollo_proc_macros",
  "async-trait",
- "derive_more 0.99.18",
  "mockall",
  "serde",
  "starknet_api",

--- a/crates/apollo_network_types/src/network_types.rs
+++ b/crates/apollo_network_types/src/network_types.rs
@@ -1,5 +1,6 @@
-use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
+
+pub type PeerId = libp2p::PeerId;
 
 // TODO(alonl): remove clone
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/crates/apollo_signature_manager/Cargo.toml
+++ b/crates/apollo_signature_manager/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 apollo_infra.workspace = true
+apollo_network_types.workspace = true
 apollo_signature_manager_types.workspace = true
 async-trait.workspace = true
 blake2s.workspace = true
@@ -15,7 +16,9 @@ starknet-crypto.workspace = true
 starknet_api.workspace = true
 
 [dev-dependencies]
+apollo_network_types.workspace = true
 apollo_signature_manager_types.workspace = true
+hex.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 starknet-core.workspace = true

--- a/crates/apollo_signature_manager/src/signature_manager.rs
+++ b/crates/apollo_signature_manager/src/signature_manager.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
 use apollo_infra::component_definitions::ComponentStarter;
+use apollo_network_types::network_types::PeerId;
 use apollo_signature_manager_types::{
     KeyStore,
     KeyStoreResult,
-    PeerId,
     SignatureManagerError,
     SignatureManagerResult,
 };
@@ -113,6 +113,7 @@ impl KeyStore for LocalKeyStore {
 
 fn build_peer_identity_message_digest(peer_id: PeerId, nonce: Nonce) -> MessageDigest {
     let nonce = nonce.to_bytes_be();
+    let peer_id = peer_id.to_bytes();
     let mut message = Vec::with_capacity(INIT_PEER_ID.len() + peer_id.len() + nonce.len());
     message.extend_from_slice(INIT_PEER_ID);
     message.extend_from_slice(&peer_id);

--- a/crates/apollo_signature_manager/src/signature_manager_test.rs
+++ b/crates/apollo_signature_manager/src/signature_manager_test.rs
@@ -1,4 +1,5 @@
-use apollo_signature_manager_types::PeerId;
+use apollo_network_types::network_types::PeerId;
+use hex::FromHex;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::block::BlockHash;
@@ -16,10 +17,10 @@ use crate::signature_manager::{
 
 const ALICE_IDENTITY_SIGNATURE: Signature = Signature {
     r: Felt::from_hex_unchecked(
-        "0x7687c83bdfa7474518c585f1b58a028b939764f1d2721e63bf821c4c8987299",
+        "0x7a8dd91774e806fa5e0880c77d61ccb40fc33fcb5db00fdc5585758cf95f79d",
     ),
     s: Felt::from_hex_unchecked(
-        "0x7e05746545ed1fe24fec988341d2452a4bbcebec26d73f9ee9bdc9426a372a5",
+        "0x5bdd4ddd34e2708c03c14d5872de1d541476f4af9f92f48a3d77d5ea3e16cc0",
     ),
 };
 
@@ -38,7 +39,12 @@ struct PeerIdentity {
 
 impl PeerIdentity {
     pub fn new() -> Self {
-        Self { peer_id: PeerId(b"alice".to_vec()), nonce: nonce!(0x1234) }
+        // TODO(Elin): use a test util once it's merged.
+        let peer_id =
+            Vec::from_hex("00205cccc292b9dcc77610797e5f47b23d2b0fb7b77010d76481fc2c0652f6ca2fc2")
+                .unwrap();
+
+        Self { peer_id: PeerId::from_bytes(&peer_id).unwrap(), nonce: nonce!(0x1234) }
     }
 }
 
@@ -79,7 +85,7 @@ async fn test_identify() {
     let signature_manager = SignatureManager::new(key_store);
 
     let PeerIdentity { peer_id, nonce } = PeerIdentity::new();
-    let signature = signature_manager.identify(peer_id.clone(), nonce).await;
+    let signature = signature_manager.identify(peer_id, nonce).await;
 
     assert_eq!(signature, Ok(ALICE_IDENTITY_SIGNATURE.into()));
 

--- a/crates/apollo_signature_manager_types/Cargo.toml
+++ b/crates/apollo_signature_manager_types/Cargo.toml
@@ -10,9 +10,9 @@ testing = []
 
 [dependencies]
 apollo_infra.workspace = true
+apollo_network_types.workspace = true
 apollo_proc_macros.workspace = true
 async-trait.workspace = true
-derive_more.workspace = true
 mockall.workspace = true
 serde.workspace = true
 starknet_api.workspace = true

--- a/crates/apollo_signature_manager_types/src/lib.rs
+++ b/crates/apollo_signature_manager_types/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use apollo_infra::component_client::{ClientError, LocalComponentClient, RemoteComponentClient};
 use apollo_infra::component_definitions::{ComponentClient, ComponentRequestAndResponseSender};
 use apollo_infra::impl_debug_for_infra_requests_and_responses;
+use apollo_network_types::network_types::PeerId;
 use apollo_proc_macros::handle_all_response_variants;
 use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
@@ -38,17 +39,6 @@ pub trait KeyStore: Clone + Send + Sync {
 pub enum KeyStoreError {
     #[error("Failed to fetch key: {0}")]
     Custom(String),
-}
-
-#[derive(
-    Clone, Debug, Default, derive_more::Deref, Eq, PartialEq, Hash, Serialize, Deserialize,
-)]
-pub struct PeerId(pub Vec<u8>);
-
-impl From<Vec<u8>> for PeerId {
-    fn from(value: Vec<u8>) -> Self {
-        Self(value)
-    }
 }
 
 /// Serves as the signature manager's shared interface.


### PR DESCRIPTION
The `libp2p` peer ID has a specific format, and only legal ones can be
built. Used a constant value for tests (generated through
`libp2p::PeerId::random()`.