### PR TITLE
apollo_deployments: increase gas price lag margin to 300

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -165,7 +165,6 @@ impl SerializeConfig for CendeConfig {
 
 #[async_trait]
 impl CendeContext for CendeAmbassador {
-    #[sequencer_latency_histogram(CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY, false)]
     fn write_prev_height_blob(&self, current_height: BlockNumber) -> JoinHandle<bool> {
         info!("Start writing to Aerospike previous height blob for height {current_height}.");
 
@@ -241,6 +240,7 @@ impl CendeContext for CendeAmbassador {
     }
 }
 
+#[sequencer_latency_histogram(CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY, false)]
 async fn send_write_blob(request_builder: RequestBuilder, blob: &AerospikeBlob) -> bool {
     // TODO(dvir): use compression to reduce the size of the blob in the network.
     match request_builder.json(blob).send().await {

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -85,7 +85,7 @@
       "name": "cende_write_prev_height_blob_latency_too_high",
       "title": "Cende write prev height blob latency too high",
       "ruleGroup": "consensus",
-      "expr": "avg_over_time(cende_write_prev_height_blob_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])",
+      "expr": "rate(cende_write_prev_height_blob_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) / clamp_min(rate(cende_write_prev_height_blob_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]), 0.0000001)",
       "conditions": [
         {
           "evaluator": {
@@ -112,7 +112,7 @@
       "name": "consensus_block_number_stuck",
       "title": "Consensus block number stuck",
       "ruleGroup": "consensus",
-      "expr": "increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])",
+      "expr": "sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -544,7 +544,7 @@
       "name": "gateway_add_tx_idle",
       "title": "Gateway add_tx idle",
       "ruleGroup": "gateway",
-      "expr": "increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)",
+      "expr": "sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)",
       "conditions": [
         {
           "evaluator": {
@@ -571,7 +571,7 @@
       "name": "http_server_add_tx_idle",
       "title": "HTTP Server add_tx idle",
       "ruleGroup": "http_server",
-      "expr": "increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)",
+      "expr": "sum(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)",
       "conditions": [
         {
           "evaluator": {
@@ -679,7 +679,7 @@
       "name": "http_server_no_successful_transactions",
       "title": "http server no successful transactions",
       "ruleGroup": "http_server",
-      "expr": "increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) or vector(0)",
+      "expr": "sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
       "conditions": [
         {
           "evaluator": {
@@ -1003,7 +1003,7 @@
       "name": "mempool_add_tx_idle",
       "title": "Mempool add_tx idle",
       "ruleGroup": "mempool",
-      "expr": "increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)",
+      "expr": "sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -436,7 +436,7 @@
       "name": "consensus_round_above_zero_ratio",
       "title": "Consensus round above zero ratio",
       "ruleGroup": "consensus",
-      "expr": "count_over_time((consensus_round{cluster=~\"$cluster\", namespace=~\"$namespace\"} > 0)[1h]) / count_over_time(consensus_round{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
+      "expr": "increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -568,33 +568,6 @@
       "severity": "p2"
     },
     {
-      "name": "http_server_idle",
-      "title": "http server idle",
-      "ruleGroup": "http_server",
-      "expr": "increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2"
-    },
-    {
       "name": "http_server_add_tx_idle",
       "title": "HTTP Server add_tx idle",
       "ruleGroup": "http_server",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -334,7 +334,7 @@ fn get_gateway_add_tx_idle() -> Alert {
         title: "Gateway add_tx idle",
         alert_group: AlertGroup::Gateway,
         expr: format!(
-            "increase({}[20m]) or vector(0)",
+            "sum(increase({}[20m])) or vector(0)",
             GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter()
         ),
         conditions: &[AlertCondition {
@@ -356,7 +356,7 @@ fn get_mempool_add_tx_idle() -> Alert {
         title: "Mempool add_tx idle",
         alert_group: AlertGroup::Mempool,
         expr: format!(
-            "increase({}[20m]) or vector(0)",
+            "sum(increase({}[20m])) or vector(0)",
             MEMPOOL_TRANSACTIONS_RECEIVED.get_name_with_filter()
         ),
         conditions: &[AlertCondition {
@@ -376,7 +376,7 @@ fn get_http_server_add_tx_idle() -> Alert {
         title: "HTTP Server add_tx idle",
         alert_group: AlertGroup::HttpServer,
         expr: format!(
-            "increase({}[20m]) or vector(0)",
+            "sum(increase({}[20m])) or vector(0)",
             ADDED_TRANSACTIONS_TOTAL.get_name_with_filter()
         ),
         conditions: &[AlertCondition {
@@ -491,7 +491,7 @@ fn get_http_server_no_successful_transactions() -> Alert {
         title: "http server no successful transactions",
         alert_group: AlertGroup::HttpServer,
         expr: format!(
-            "increase({}[1h]) or vector(0)",
+            "sum(increase({}[1h])) or vector(0)",
             ADDED_TRANSACTIONS_SUCCESS.get_name_with_filter()
         ),
         conditions: &[AlertCondition {

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -390,26 +390,6 @@ fn get_http_server_add_tx_idle() -> Alert {
     }
 }
 
-fn get_http_server_idle() -> Alert {
-    Alert {
-        name: "http_server_idle",
-        title: "http server idle",
-        alert_group: AlertGroup::HttpServer,
-        expr: format!(
-            "increase({}[20m]) or vector(0)",
-            ADDED_TRANSACTIONS_TOTAL.get_name_with_filter()
-        ),
-        conditions: &[AlertCondition {
-            comparison_op: AlertComparisonOp::LessThan,
-            comparison_value: 1.0,
-            logical_op: AlertLogicalOp::And,
-        }],
-        pending_duration: PENDING_DURATION_DEFAULT,
-        evaluation_interval_sec: EVALUATION_INTERVAL_SEC_DEFAULT,
-        severity: AlertSeverity::Regular,
-    }
-}
-
 fn get_http_server_internal_error_ratio() -> Alert {
     Alert {
         name: "http_server_internal_error_ratio",
@@ -1031,7 +1011,6 @@ pub fn get_apollo_alerts() -> Alerts {
         get_consensus_validate_proposal_failed_alert(),
         get_consensus_votes_num_sent_messages_alert(),
         get_gateway_add_tx_idle(),
-        get_http_server_idle(),
         get_http_server_add_tx_idle(),
         get_http_server_high_transaction_failure_ratio(),
         get_http_server_internal_error_ratio(),

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -74,7 +74,10 @@ fn get_consensus_block_number_stuck() -> Alert {
         name: "consensus_block_number_stuck",
         title: "Consensus block number stuck",
         alert_group: AlertGroup::Consensus,
-        expr: format!("increase({}[5m])", CONSENSUS_BLOCK_NUMBER.get_name_with_filter()),
+        expr: format!(
+            "sum(increase({}[5m])) or vector(0)",
+            CONSENSUS_BLOCK_NUMBER.get_name_with_filter()
+        ),
         conditions: &[AlertCondition {
             comparison_op: AlertComparisonOp::LessThan,
             comparison_value: 10.0,
@@ -204,8 +207,9 @@ fn get_cende_write_prev_height_blob_latency_too_high() -> Alert {
         title: "Cende write prev height blob latency too high",
         alert_group: AlertGroup::Consensus,
         expr: format!(
-            "avg_over_time({}[20m])",
-            CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY.get_name_with_filter()
+            "rate({}[20m]) / clamp_min(rate({}[20m]), 0.0000001)",
+            CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY.get_name_sum_with_filter(),
+            CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY.get_name_count_with_filter(),
         ),
         conditions: &[AlertCondition {
             comparison_op: AlertComparisonOp::GreaterThan,

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -10,6 +10,7 @@ use apollo_consensus::metrics::{
     CONSENSUS_INBOUND_STREAM_EVICTED,
     CONSENSUS_PROPOSALS_INVALID,
     CONSENSUS_ROUND,
+    CONSENSUS_ROUND_ABOVE_ZERO,
 };
 use apollo_consensus_manager::metrics::{
     CONSENSUS_NUM_CONNECTED_PEERS,
@@ -767,8 +768,9 @@ fn get_consensus_round_above_zero_ratio() -> Alert {
         title: "Consensus round above zero ratio",
         alert_group: AlertGroup::Consensus,
         expr: format!(
-            "count_over_time(({metric} > 0)[1h]) / count_over_time({metric}[1h])",
-            metric = CONSENSUS_ROUND.get_name_with_filter()
+            "increase({}[1h]) / clamp_min(increase({}[1h]), 1)",
+            CONSENSUS_ROUND_ABOVE_ZERO.get_name_with_filter(),
+            CONSENSUS_BLOCK_NUMBER.get_name_with_filter(),
         ),
         conditions: &[AlertCondition {
             comparison_op: AlertComparisonOp::GreaterThan,

--- a/crates/apollo_deployments/resources/base_app_config.json
+++ b/crates/apollo_deployments/resources/base_app_config.json
@@ -145,7 +145,7 @@
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2.0,
   "l1_provider_config.l1_handler_cancellation_timelock_seconds": 300.0,
-  "l1_provider_config.new_l1_handler_cooldown_seconds": 30.0,
+  "l1_provider_config.new_l1_handler_cooldown_seconds": 135.0,
   "l1_scraper_config.finality": 10,
   "l1_scraper_config.polling_interval_seconds": 120,
   "l1_scraper_config.startup_rewind_time_seconds": 3600,

--- a/crates/apollo_deployments/resources/base_app_config.json
+++ b/crates/apollo_deployments/resources/base_app_config.json
@@ -131,7 +131,7 @@
   "gateway_config.stateless_tx_validator_config.validate_non_zero_resource_bounds": true,
   "http_server_config.ip": "0.0.0.0",
   "http_server_config.port": 8080,
-  "l1_gas_price_provider_config.lag_margin_seconds": 60,
+  "l1_gas_price_provider_config.lag_margin_seconds": 300,
   "l1_gas_price_provider_config.number_of_blocks_for_mean": 300,
   "l1_gas_price_provider_config.storage_limit": 3000,
   "l1_gas_price_provider_config.max_time_gap_seconds": 900,


### PR DESCRIPTION
- **apollo_deployments: fix l1 handler cooldown to be bigger than scraping interval (#7870)**
- **apollo_dashboard: fix consensus_round_above_zero_ratio alert (#7827) (#7865)**
- **apollo_dashboard: remove duplicate alert http_server idle (#7871)**
- **apollo_dashboard: fix alerts having no data (#7849)**
- **apollo_dashboard: fixed cende_latency alert and make block_number alert trigger (#7859) (#7867)**
- **apollo_consensus_orchestrator: move cende latency metric to correct function (#7854) (#7868)**
- **apollo_deployments: increase gas price lag margin to 300**
