### PR TITLE
apollo_l1_gas_price: cherrypick scraper baselayer errors do not cause crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5413,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
@@ -178,28 +178,12 @@ impl<B: BaseLayerContract + Send + Sync + Debug> L1GasPriceScraper<B> {
             // Not enough blocks under current finality. Try again later.
             return Ok(());
         };
-<<<<<<< HEAD
-        trace!(
-            "Scraping gas prices starting from block {start_block_number} to {last_block_number}."
-        );
+        trace!("Scraping gas prices starting from block {} to {last_block_number}.", *block_number);
         // TODO(guy.f): Replace with info_every_n_sec once implemented.
         info_every_n!(
             100,
-            "Scraping gas prices starting from block {start_block_number} to {last_block_number}."
-||||||| parent of 0912d8a47 (apollo_l1_gas_price: scraper baselayer errors do not cause crash)
-        trace!(
-            "Scraping gas prices starting from block {start_block_number} to {last_block_number}."
-        );
-        info_every_n_sec!(
-            1,
-            "Scraping gas prices starting from block {start_block_number} to {last_block_number}."
-=======
-        trace!("Scraping gas prices starting from block {} to {last_block_number}.", *block_number,);
-        info_every_n_sec!(
-            1,
             "Scraping gas prices starting from block {} to {last_block_number}.",
             *block_number,
->>>>>>> 0912d8a47 (apollo_l1_gas_price: scraper baselayer errors do not cause crash)
         );
         while *block_number <= last_block_number {
             let header = match self.base_layer.get_block_header(*block_number).await {


### PR DESCRIPTION
- **apollo_deployments: fix l1 handler cooldown to be bigger than scraping interval (#7870)**
- **apollo_dashboard: fix consensus_round_above_zero_ratio alert (#7827) (#7865)**
- **apollo_dashboard: remove duplicate alert http_server idle (#7871)**
- **apollo_dashboard: fix alerts having no data (#7849)**
- **apollo_dashboard: fixed cende_latency alert and make block_number alert trigger (#7859) (#7867)**
- **apollo_consensus_orchestrator: move cende latency metric to correct function (#7854) (#7868)**
- **apollo_l1_gas_price: scraper baselayer errors do not cause crash (cherrypick with conflicts)**
- **apollo_l1_gas_price: fix conflicts**
