### PR TITLE
apollo_network: increase gossipsub max message size to 10gb

### DIFF
--- a/crates/apollo_network/src/mixed_behaviour.rs
+++ b/crates/apollo_network/src/mixed_behaviour.rs
@@ -117,7 +117,7 @@ impl MixedBehaviour {
                 gossipsub::MessageAuthenticity::Signed(keypair),
                 gossipsub::ConfigBuilder::default()
                     // TODO(shahak): try to reduce this bound.
-                    .max_transmit_size(100 * ONE_MEGA)
+                    .max_transmit_size(10000 * ONE_MEGA)
                     .build()
                     .expect("Failed to build gossipsub config"),
             )


### PR DESCRIPTION
- **apollo_deployments: fix l1 handler cooldown to be bigger than scraping interval (#7870)**
- **apollo_dashboard: fix consensus_round_above_zero_ratio alert (#7827) (#7865)**
- **apollo_dashboard: remove duplicate alert http_server idle (#7871)**
- **apollo_dashboard: fix alerts having no data (#7849)**
- **apollo_dashboard: fixed cende_latency alert and make block_number alert trigger (#7859) (#7867)**
- **apollo_consensus_orchestrator: move cende latency metric to correct function (#7854) (#7868)**
- **apollo_network: increase gossipsub max message size to 100mb (#7900)**
- **apollo_deployments: increase gas price lag margin to 300 (#7901)**
- **apollo_network: increase gossipsub max message size to 10gb**
