### PR TITLE
signature: add sig. verification error enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,7 @@ dependencies = [
  "starknet-crypto",
  "starknet-types-core",
  "starknet_api",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/crates/apollo_signature_manager/Cargo.toml
+++ b/crates/apollo_signature_manager/Cargo.toml
@@ -14,6 +14,7 @@ blake2s.workspace = true
 starknet-core.workspace = true
 starknet-crypto.workspace = true
 starknet_api.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 apollo_network_types.workspace = true

--- a/crates/apollo_signature_manager/src/signature_manager_test.rs
+++ b/crates/apollo_signature_manager/src/signature_manager_test.rs
@@ -58,7 +58,7 @@ fn test_verify_identity(#[case] signature: Signature, #[case] expected: bool) {
     let PeerIdentity { peer_id, nonce } = PeerIdentity::new();
     let public_key = LocalKeyStore::new_for_testing().public_key;
 
-    assert_eq!(verify_identity(peer_id, nonce, signature.into(), public_key), Ok(expected));
+    assert_eq!(verify_identity(peer_id, nonce, signature.into(), public_key).unwrap(), expected);
 }
 
 #[rstest]
@@ -74,8 +74,8 @@ fn test_verify_precommit_vote_signature(#[case] signature: Signature, #[case] ex
     let public_key = LocalKeyStore::new_for_testing().public_key;
 
     assert_eq!(
-        verify_precommit_vote_signature(block_hash, signature.into(), public_key),
-        Ok(expected)
+        verify_precommit_vote_signature(block_hash, signature.into(), public_key).unwrap(),
+        expected
     );
 }
 
@@ -90,7 +90,10 @@ async fn test_identify() {
     assert_eq!(signature, Ok(ALICE_IDENTITY_SIGNATURE.into()));
 
     // Test alignment with verification function.
-    assert_eq!(verify_identity(peer_id, nonce, signature.unwrap(), key_store.public_key), Ok(true));
+    assert_eq!(
+        verify_identity(peer_id, nonce, signature.unwrap(), key_store.public_key).unwrap(),
+        true
+    );
 }
 
 #[tokio::test]
@@ -105,7 +108,8 @@ async fn test_sign_precommit_vote() {
 
     // Test alignment with verification function.
     assert_eq!(
-        verify_precommit_vote_signature(block_hash, signature.unwrap(), key_store.public_key),
-        Ok(true)
+        verify_precommit_vote_signature(block_hash, signature.unwrap(), key_store.public_key)
+            .unwrap(),
+        true
     );
 }

--- a/crates/apollo_signature_manager_types/src/lib.rs
+++ b/crates/apollo_signature_manager_types/src/lib.rs
@@ -69,8 +69,6 @@ pub enum SignatureManagerError {
     Sign(String),
     #[error(transparent)]
     SignatureConversion(#[from] SignatureConversionError),
-    #[error("Failed to verify: {0}")]
-    Verify(String),
 }
 
 #[derive(Clone, Debug, Error)]


### PR DESCRIPTION
Verification is not part of the signature manager, it is provided as
library functions (will probably be wrapped by a verifier trait later);
those two flows are separate, hence their error enums ought to be too.