### PR TITLE
l1: return dummy answers on height < start_height

### DIFF
--- a/crates/apollo_l1_provider/src/test_utils.rs
+++ b/crates/apollo_l1_provider/src/test_utils.rs
@@ -74,6 +74,7 @@ impl From<L1ProviderContent> for L1Provider {
             // is functionally equivalent to Pending for testing purposes.
             state: content.state.unwrap_or(ProviderState::Pending),
             current_height: content.current_height.unwrap_or_default(),
+            start_height: content.current_height.unwrap_or_default(),
             clock: content.clock.unwrap_or_else(|| Arc::new(DefaultClock)),
         }
     }


### PR DESCRIPTION
This is introduced in order to tighten the coupling with the batcher, to
accommodate its re-execution-from-genesis state, which ignores l1
interaction.
Note that this will hide batcher startup errors, for example off-by-one
errors.

Suggested alternative: return a dedicated error and let the Batcher
decide if this is an Error or not, based on whatever special state _it_
is in.