### PR TITLE
l1: return OK on commit-block for height < start_height

### DIFF
--- a/crates/apollo_l1_provider/src/l1_provider_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_provider_tests.rs
@@ -956,3 +956,43 @@ fn validate_tx_unknown_returns_invalid_consumed_or_unknown() {
     let status = l1_provider.validate(tx_hash!(1), l1_provider.current_height).unwrap();
     assert_eq!(status, InvalidValidationStatus::ConsumedOnL1OrUnknown.into());
 }
+
+#[test]
+fn commit_block_historical_height_short_circuits_non_bootstrap() {
+    // Setup.
+    let l1_provider_builder = L1ProviderContentBuilder::new()
+        .with_height(BlockNumber(5))
+        .with_txs([l1_handler(1)])
+        .with_state(ProviderState::Propose);
+
+    // Test.
+    let mut l1_provider = l1_provider_builder.clone().build_into_l1_provider();
+    let old_height = BlockNumber(4);
+    l1_provider.commit_block([tx_hash!(1)].into(), [].into(), old_height).unwrap();
+
+    let expected_unchanged = l1_provider_builder.build();
+    expected_unchanged.assert_eq(&l1_provider);
+}
+
+#[test]
+fn commit_block_historical_height_short_circuits_bootstrap() {
+    // Setup.
+    let batcher_height_old = 4;
+    let initial_bootstrap_state = ProviderState::Bootstrap(bootstrapper!(
+        backlog: [],
+        catch_up: batcher_height_old
+    ));
+    let l1_provider_builder = L1ProviderContentBuilder::new()
+        .with_height(BlockNumber(5))
+        .with_txs([l1_handler(1)])
+        .with_state(initial_bootstrap_state);
+
+    // Test.
+    let mut l1_provider = l1_provider_builder.clone().build_into_l1_provider();
+    l1_provider
+        .commit_block([tx_hash!(1)].into(), [].into(), BlockNumber(batcher_height_old))
+        .unwrap();
+
+    let expected_unchanged = l1_provider_builder.build();
+    expected_unchanged.assert_eq(&l1_provider);
+}

--- a/crates/apollo_l1_provider/src/test_utils.rs
+++ b/crates/apollo_l1_provider/src/test_utils.rs
@@ -74,6 +74,7 @@ impl From<L1ProviderContent> for L1Provider {
             // is functionally equivalent to Pending for testing purposes.
             state: content.state.unwrap_or(ProviderState::Pending),
             current_height: content.current_height.unwrap_or_default(),
+            start_height: content.current_height.unwrap_or_default(),
             clock: content.clock.unwrap_or_else(|| Arc::new(DefaultClock)),
         }
     }

--- a/crates/apollo_l1_provider/tests/reexecution_flow.rs
+++ b/crates/apollo_l1_provider/tests/reexecution_flow.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use apollo_batcher_types::communication::MockBatcherClient;
+use apollo_l1_provider::l1_provider::L1ProviderBuilder;
+use apollo_l1_provider::{L1ProviderConfig, ProviderState};
+use apollo_l1_provider_types::MockL1ProviderClient;
+use apollo_state_sync_types::communication::MockStateSyncClient;
+use apollo_time::test_utils::FakeClock;
+use pretty_assertions::assert_eq;
+use starknet_api::block::BlockNumber;
+use starknet_api::tx_hash;
+
+#[tokio::test]
+async fn reexecution_flow_historical_blocks_ignored() {
+    // Setup: Provider starts at height 5, but catch-up height is 3 (2 blocks _behind_)
+    let start_height = BlockNumber(5);
+    let catch_up_height = BlockNumber(3);
+    let mut l1_provider = L1ProviderBuilder::new(
+        L1ProviderConfig::default(),
+        Arc::new(MockL1ProviderClient::default()),
+        Arc::new(MockBatcherClient::default()),
+        Arc::new(MockStateSyncClient::default()),
+    )
+    .startup_height(start_height)
+    .catchup_height(catch_up_height)
+    .clock(Arc::new(FakeClock::new(0)))
+    .build();
+
+    // Initialize the provider
+    l1_provider.initialize(vec![]).await.unwrap();
+
+    let unchanged_l1_provider = l1_provider.clone();
+    for historical_height in catch_up_height.iter_up_to(start_height) {
+        let arbitrary_unknown_tx_hashes = [tx_hash!(1), tx_hash!(2)];
+        l1_provider
+            .commit_block(arbitrary_unknown_tx_hashes.into(), [].into(), historical_height)
+            .unwrap();
+
+        // Verify the provider state is unchanged
+        assert_eq!(l1_provider, unchanged_l1_provider);
+    }
+
+    // Test: Commit block with correct height (5) should bump the height
+    l1_provider.commit_block([].into(), [].into(), start_height).unwrap();
+
+    assert_eq!(l1_provider.current_height, start_height.unchecked_next());
+    assert_eq!(l1_provider.state, ProviderState::Pending);
+}


### PR DESCRIPTION
To accommodate state sync flow from genesis in the batcher, which will
send a bunch of historical blocks to the provider (but no
validate/get/start_block).