### PR TITLE
starknet_api: using internal implementation of sizeof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11845,6 +11845,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "sizeof_internal"
+version = "0.15.0-rc.2"
+dependencies = [
+ "starknet-types-core",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
   "crates/papyrus_monitoring_gateway",
   "crates/papyrus_node",
   "crates/shared_execution_objects",
+  "crates/sizeof/sizeof_internal",
   "crates/starknet_api",
   "crates/starknet_committer",
   "crates/starknet_committer_and_os_cli",
@@ -282,6 +283,7 @@ sha3 = "0.10.8"
 shared_execution_objects.path = "crates/shared_execution_objects"
 simple_logger = "4.0.0"
 size-of = "0.1.5"
+sizeof_internal = { path = "crates/sizeof/sizeof_internal" }
 socket2 = "0.5.8"
 starknet-core = "0.12.1"
 starknet-crypto = "0.7.1"

--- a/crates/sizeof/sizeof_internal/Cargo.toml
+++ b/crates/sizeof/sizeof_internal/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sizeof_internal"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "compute size of types in memory"
+
+[lints]
+workspace = true
+
+[dependencies]
+starknet-types-core.workspace = true

--- a/crates/sizeof/sizeof_internal/src/lib.rs
+++ b/crates/sizeof/sizeof_internal/src/lib.rs
@@ -1,0 +1,207 @@
+use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use starknet_types_core::felt::Felt;
+
+/// Trait for types that can report their size in bytes.
+/// There are two methods:
+/// - `dynamic_size`: returns the size of the heap part of the type.
+/// - `size_bytes`: returns the total size of the type, including both stack and heap parts.
+///
+/// This trait is useful for calculating the size of types in memory, especially when dealing with
+/// dynamic data structures like `Vec<T>` or `String`.
+pub trait SizeOf {
+    /// Returns the heap size of the type in bytes.
+    ///
+    /// `WARNING`: It is `DANGEROUS` to use this function on types that implement `Deref`, since
+    /// `Deref coercion` will neglect counting the    stack size taken by the original type
+    /// itself. Currently, this trait is only implemented for the    following `Deref` types:
+    /// `Box<T>, Rc<T>, Arc<T>`. If your `Deref` type is not on this list, refrain from using
+    /// this method.
+    fn dynamic_size(&self) -> usize;
+
+    /// Returns the total size of the type in bytes, including both stack and heap parts.
+    ///
+    /// `WARNING`: It is `DANGEROUS` to use this function on types that implement `Deref`, since
+    /// `Deref coercion` will neglect counting the    stack size taken by the original type
+    /// itself. Currently, this trait is only implemented for the    following `Deref` types:
+    /// `Box<T>, Rc<T>, Arc<T>`. If your `Deref` type is not on this list, refrain from using
+    /// this method.
+    fn size_bytes(&self) -> usize
+    where
+        Self: Sized,
+    {
+        std::mem::size_of::<Self>() + self.dynamic_size()
+    }
+}
+
+#[macro_export]
+macro_rules! default_primitive_sizeof {
+    ($($type:ty),*) => {
+        $(
+            impl SizeOf for $type {
+                fn dynamic_size(&self) -> usize {
+                    0
+                }
+            }
+        )*
+    };
+}
+
+default_primitive_sizeof! {
+    bool, u8, i8, u16, i16, u32, i32, u64, i64, u128, i128,
+    f32, f64,
+    usize, isize,
+    Felt
+}
+
+impl SizeOf for String {
+    fn dynamic_size(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl<T: SizeOf> SizeOf for Vec<T> {
+    fn dynamic_size(&self) -> usize {
+        let used = self.iter().map(|x| x.size_bytes()).sum::<usize>();
+        let excess = (self.capacity() - self.len()) * std::mem::size_of::<T>();
+
+        used + excess
+    }
+}
+
+#[macro_export]
+macro_rules! default_deref_sizeof {
+    ($($name:ident < $($generic_params:ident $(: $bounds:path)*),* >),*) => {
+        $(
+             impl < $($generic_params : $crate::SizeOf $(+ $bounds)* ),* > $crate::SizeOf for $name < $($generic_params),* >  {
+                fn dynamic_size(&self) -> usize {
+                    self.deref().size_bytes()
+                }
+            }
+        )*
+    };
+}
+
+default_deref_sizeof! { Box<T>, Rc<T>, Arc<T> }
+
+#[test]
+fn test_size_of() {
+    assert_eq!(17_u8.size_bytes(), 1);
+    assert_eq!(
+        String::from("Hello").size_bytes(),
+        std::mem::size_of::<String>() + String::from("Hello").capacity()
+    );
+    assert_eq!(
+        vec![1_u8, 2_u8, 3_u8].size_bytes(),
+        std::mem::size_of::<Vec<u8>>() + std::mem::size_of::<u8>() * 3
+    );
+}
+
+#[test]
+fn test_felt_size_of() {
+    assert_eq!(Felt::ZERO.size_bytes(), 32);
+    assert_eq!(Felt::ONE.size_bytes(), 32);
+    assert_eq!(Felt::from(1600000000).size_bytes(), 32);
+    assert_eq!(Felt::MAX.size_bytes(), 32);
+}
+
+#[test]
+fn test_vec_string_sizeof() {
+    let mut vec_string = Vec::with_capacity(17);
+    vec_string.push(String::from("Hello"));
+    vec_string.push(String::from("World!"));
+    let size = vec_string.size_bytes();
+    assert_eq!(
+        size,
+        vec_string[0].size_bytes()
+            + vec_string[1].size_bytes()
+            + (vec_string.capacity() - vec_string.len()) * std::mem::size_of::<String>()
+            + std::mem::size_of::<Vec<String>>()
+    );
+    assert_eq!(vec_string[0].size_bytes(), std::mem::size_of::<String>() + 5);
+    assert_eq!(vec_string[1].size_bytes(), std::mem::size_of::<String>() + 6);
+}
+
+#[test]
+fn test_arc_vec_string_sizeof() {
+    let mut vec_string = Vec::with_capacity(35);
+    vec_string.push(String::from("Starknet"));
+    vec_string.push(String::from("Cairo"));
+
+    let vec_string = Arc::new(vec_string);
+
+    let size = vec_string.size_bytes();
+    assert_eq!(
+        size,
+        vec_string[0].size_bytes()
+            + vec_string[1].size_bytes()
+            + (vec_string.capacity() - vec_string.len()) * std::mem::size_of::<String>()
+            + std::mem::size_of::<Vec<String>>()
+            + std::mem::size_of::<Arc<Vec<String>>>()
+    );
+    assert_eq!(
+        vec_string.deref().size_bytes(),
+        vec_string[0].size_bytes()
+            + vec_string[1].size_bytes()
+            + (vec_string.capacity() - vec_string.len()) * std::mem::size_of::<String>()
+            + std::mem::size_of::<Vec<String>>()
+    );
+    assert_eq!(vec_string[0].size_bytes(), std::mem::size_of::<String>() + 8);
+    assert_eq!(vec_string[1].size_bytes(), std::mem::size_of::<String>() + 5);
+}
+
+#[test]
+fn test_rc_vec_string_sizeof() {
+    let mut vec_string = Vec::with_capacity(25);
+    vec_string.push(String::from("Pip"));
+    vec_string.push(String::from("Install"));
+
+    let vec_string = Rc::new(vec_string);
+
+    let size = vec_string.size_bytes();
+    assert_eq!(
+        size,
+        vec_string[0].size_bytes()
+            + vec_string[1].size_bytes()
+            + (vec_string.capacity() - vec_string.len()) * std::mem::size_of::<String>()
+            + std::mem::size_of::<Vec<String>>()
+            + std::mem::size_of::<Rc<Vec<String>>>()
+    );
+    assert_eq!(
+        vec_string.deref().size_bytes(),
+        vec_string[0].size_bytes()
+            + vec_string[1].size_bytes()
+            + (vec_string.capacity() - vec_string.len()) * std::mem::size_of::<String>()
+            + std::mem::size_of::<Vec<String>>()
+    );
+    assert_eq!(vec_string[0].size_bytes(), std::mem::size_of::<String>() + 3);
+    assert_eq!(vec_string[1].size_bytes(), std::mem::size_of::<String>() + 7);
+}
+
+#[test]
+fn test_box_vec_string_sizeof() {
+    let mut vec_string = Vec::with_capacity(20);
+    vec_string.push(String::from("Rust"));
+    vec_string.push(String::from("Programming"));
+    let vec_string = Box::new(vec_string);
+    let size = vec_string.size_bytes();
+    assert_eq!(
+        size,
+        vec_string[0].size_bytes()
+            + vec_string[1].size_bytes()
+            + (vec_string.capacity() - vec_string.len()) * std::mem::size_of::<String>()
+            + std::mem::size_of::<Vec<String>>()
+            + std::mem::size_of::<Box<Vec<String>>>()
+    );
+    assert_eq!(
+        vec_string.deref().size_bytes(),
+        vec_string[0].size_bytes()
+            + vec_string[1].size_bytes()
+            + (vec_string.capacity() - vec_string.len()) * std::mem::size_of::<String>()
+            + std::mem::size_of::<Vec<String>>()
+    );
+    assert_eq!(vec_string[0].size_bytes(), std::mem::size_of::<String>() + 4);
+    assert_eq!(vec_string[1].size_bytes(), std::mem::size_of::<String>() + 11);
+}


### PR DESCRIPTION
### TL;DR

Added a new `sizeof_internal` crate to compute the size of types in memory.

### What changed?

- Created a new crate `sizeof_internal` with a `SizeOf` trait that provides two methods:
  - `dynamic_size()`: returns the heap size of a type in bytes
  - `size_bytes()`: returns the total size (stack + heap) of a type in bytes
- Implemented the trait for primitive types, `String`, `Vec<T>`, and pointer types like `Box<T>`, `Rc<T>`, etc.
- Added macros `default_primitive_sizeof!` and `default_pointer_sizeof!` to simplify trait implementation
- Included tests to verify the functionality for basic types and `Felt`

### How to test?

Run the tests in the crate:
```bash
cargo test -p sizeof_internal
```

The tests verify size calculations for primitive types, strings, vectors, and Felt values.

### Why make this change?

This should replace the `size-of` crate currently in use down the line, as it uses code that will be deprecated in Rust 1.88. This specific PR includes just the trait definition and implementations for primitive types.