### PR TITLE
starknet_api: using internal implementation of sizeof part2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.4",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.4",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -1353,7 +1353,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "toml",
+ "toml 0.8.20",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3648,7 +3648,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "smol_str",
- "toml",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -3765,7 +3765,7 @@ dependencies = [
  "cairo-lang-utils",
  "serde",
  "thiserror 2.0.12",
- "toml",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -3840,7 +3840,7 @@ dependencies = [
  "rust-analyzer-salsa",
  "sha3",
  "smol_str",
- "toml",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -5590,7 +5590,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.100",
- "toml",
+ "toml 0.8.20",
  "walkdir",
 ]
 
@@ -11621,6 +11621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11845,10 +11854,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sizeof"
+version = "0.15.0-rc.2"
+dependencies = [
+ "size-of",
+ "sizeof_internal",
+ "sizeof_macro",
+ "trybuild",
+]
+
+[[package]]
 name = "sizeof_internal"
 version = "0.15.0-rc.2"
 dependencies = [
  "starknet-types-core",
+]
+
+[[package]]
+name = "sizeof_macro"
+version = "0.15.0-rc.2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -12535,6 +12563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "tblgen"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12940,9 +12974,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
  "toml_edit 0.22.24",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -12955,13 +13004,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.9.0",
- "toml_datetime",
+ "toml_datetime 0.6.8",
  "winnow 0.5.40",
 ]
 
@@ -12973,9 +13031,18 @@ checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.7.4",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
+ "winnow 0.7.12",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -12983,8 +13050,14 @@ name = "toml_test_utils"
 version = "0.15.0-rc.2"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.8.20",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -13158,6 +13231,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.2",
+]
 
 [[package]]
 name = "tungstenite"
@@ -14031,9 +14119,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,9 @@ members = [
   "crates/papyrus_monitoring_gateway",
   "crates/papyrus_node",
   "crates/shared_execution_objects",
+  "crates/sizeof",
   "crates/sizeof/sizeof_internal",
+  "crates/sizeof/sizeof_macro",
   "crates/starknet_api",
   "crates/starknet_committer",
   "crates/starknet_committer_and_os_cli",
@@ -283,7 +285,9 @@ sha3 = "0.10.8"
 shared_execution_objects.path = "crates/shared_execution_objects"
 simple_logger = "4.0.0"
 size-of = "0.1.5"
+sizeof = { path = "crates/sizeof" }
 sizeof_internal = { path = "crates/sizeof/sizeof_internal" }
+sizeof_macro = { path = "crates/sizeof/sizeof_macro" }
 socket2 = "0.5.8"
 starknet-core = "0.12.1"
 starknet-crypto = "0.7.1"

--- a/crates/sizeof/Cargo.toml
+++ b/crates/sizeof/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sizeof"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "compute size of types in memory"
+
+[dependencies]
+sizeof_internal.workspace = true
+sizeof_macro.workspace = true
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+size-of = "0.1.5"
+trybuild = "1.0.105"

--- a/crates/sizeof/negative_tests/notgeneric.rs
+++ b/crates/sizeof/negative_tests/notgeneric.rs
@@ -1,0 +1,20 @@
+use sizeof::SizeOf;
+struct NotSizeOf {
+    a: u32,
+    b: String,
+}
+#[derive(SizeOf)]
+struct ShouldNotCompile {
+    a: u32,
+    b: Vec<NotSizeOf>,
+}
+
+fn main() {
+    // This test is expected to fail because `NotSizeOf` (a member of the vector) does not implement `SizeOf`.
+    // The macro should not compile.
+
+    let _ = ShouldNotCompile { a: 42, b: vec![NotSizeOf { a: 1, b: String::from("test") }] };
+    println!(
+        "This is a negative test for the SizeOf macro. It should not compile if the macro is working correctly. You can find the expected error in notgeneric.stderr"
+    );
+}

--- a/crates/sizeof/negative_tests/notgeneric.stderr
+++ b/crates/sizeof/negative_tests/notgeneric.stderr
@@ -1,0 +1,22 @@
+error[E0599]: the method `dynamic_size` exists for struct `Vec<NotSizeOf>`, but its trait bounds were not satisfied
+ --> negative_tests/notgeneric.rs:9:5
+  |
+2 | struct NotSizeOf {
+  | ---------------- doesn't satisfy `NotSizeOf: SizeOf`
+...
+9 |     b: Vec<NotSizeOf>,
+  |     ^ method cannot be called on `Vec<NotSizeOf>` due to unsatisfied trait bounds
+  |
+ ::: $RUST/alloc/src/vec/mod.rs
+  |
+  | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+  | ------------------------------------------------------------------------------------------------ doesn't satisfy `Vec<NotSizeOf>: SizeOf`
+  |
+  = note: the following trait bounds were not satisfied:
+          `NotSizeOf: SizeOf`
+          which is required by `Vec<NotSizeOf>: SizeOf`
+note: the trait `SizeOf` must be implemented
+ --> sizeof_internal/src/lib.rs
+  |
+  | pub trait SizeOf {
+  | ^^^^^^^^^^^^^^^^

--- a/crates/sizeof/negative_tests/notsizeof.rs
+++ b/crates/sizeof/negative_tests/notsizeof.rs
@@ -1,0 +1,20 @@
+use sizeof::SizeOf;
+struct NotSizeOf {
+    a: u32,
+    b: String,
+}
+#[derive(SizeOf)]
+struct ShouldNotCompile {
+    a: u32,
+    b: NotSizeOf,
+}
+
+fn main() {
+    // This test is expected to fail because `NotSizeOf` does not implement `SizeOf`.
+    // The macro should not compile.
+
+    let _ = ShouldNotCompile { a: 42, b: NotSizeOf { a: 1, b: String::from("test") } };
+    println!(
+        "This is a negative test for the SizeOf macro. It should not compile if the macro is working correctly. You can find the expected error in notsizeof.stderr"
+    );
+}

--- a/crates/sizeof/negative_tests/notsizeof.stderr
+++ b/crates/sizeof/negative_tests/notsizeof.stderr
@@ -1,0 +1,18 @@
+error[E0599]: no method named `dynamic_size` found for struct `NotSizeOf` in the current scope
+ --> negative_tests/notsizeof.rs:9:5
+  |
+2 | struct NotSizeOf {
+  | ---------------- method `dynamic_size` not found for this struct
+...
+9 |     b: NotSizeOf,
+  |     ^ method not found in `NotSizeOf`
+  |
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following trait defines an item `dynamic_size`, perhaps you need to implement it:
+          candidate #1: `SizeOf`
+help: some of the expressions' fields have a method of the same name
+  |
+9 |     a.b: NotSizeOf,
+  |     ++
+9 |     b.b: NotSizeOf,
+  |     ++

--- a/crates/sizeof/sizeof_internal/Cargo.toml
+++ b/crates/sizeof/sizeof_internal/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "sizeof_internal"
-version.workspace = true
-edition.workspace = true
-repository.workspace = true
-license-file.workspace = true
 description = "compute size of types in memory"
+edition.workspace = true
+license-file.workspace = true
+name = "sizeof_internal"
+repository.workspace = true
+version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sizeof/sizeof_macro/Cargo.toml
+++ b/crates/sizeof/sizeof_macro/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sizeof_macro"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "compute size of types in memory"
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote.workspace = true
+syn = { workspace = true, features = ["full"] }

--- a/crates/sizeof/sizeof_macro/src/lib.rs
+++ b/crates/sizeof/sizeof_macro/src/lib.rs
@@ -1,0 +1,160 @@
+// The code in this file uses code from and inspired by https://github.com/dtolnay/syn/tree/master/examples/heapsize and https://github.com/Kixiron/size-of
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{
+    parse_macro_input,
+    parse_quote,
+    Data,
+    DataEnum,
+    DataStruct,
+    DeriveInput,
+    Fields,
+    GenericParam,
+    Generics,
+};
+
+/// This macro derives the `SizeOf` trait for structs and enums, allowing them to calculate
+/// their dynamic size and total size in bytes.
+///
+/// Use `size_bytes()` to get the total size of the type, which includes both stack and heap parts.
+/// Use `dynamic_size()` to get the heap size of the type.
+///
+/// `WARNING`: It is `DANGEROUS` to use this macro on types with children that implement `Deref`,
+/// for two reasons (the first leading to under-counting and the second to over-counting):
+/// 1. If a type `P<T>` does not explicitly implement `SizeOf`, calling `P<T>.size_bytes()` will
+///    implicitly call `T.size_bytes()` (due to `Deref coercion`), which will neglect counting the
+///    stack size taken by `P<T>` itself. Currently, this macro is only implemented for the
+///    following `Deref` types: `Box<T>, Rc<T>, Arc<T>`. If your `Deref` type is not on this list,
+///    refrain from using this macro.
+/// 2. Even if a pointer type `P<T>` implements `SizeOf` (for example `Rc<T>` or `Arc<T>`), it is
+///    possible to count the same memory location twice if multiple pointers point to the same data.
+///    In such cases it is recommended to implement `SizeOf` manually for the type.
+#[proc_macro_derive(SizeOf)]
+pub fn derive_dynamic_size(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident; // The name of the struct or enum being derived.
+    let generics = add_trait_bounds(input.generics); // Add the SizeOf trait bound
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl(); // Split the generics into parts for the impl block.
+
+    let gen = match input.data {
+        Data::Struct(data_struct) => derive_macro_for_struct(data_struct),
+        Data::Enum(data_enum) => derive_macro_for_enum(data_enum),
+        Data::Union(_) => unimplemented!("SizeOf can only be derived for structs and enums."),
+    };
+
+    // Create the implementation block for the SizeOf trait.
+    // The `impl_generics`, `ty_generics`, and `where_clause` are used to ensure the T: SizeOf bound
+    // is enforced on all generic types.
+    quote! {
+        impl #impl_generics SizeOf for #name #ty_generics #where_clause {
+            fn dynamic_size(&self) -> usize {
+                #gen
+            }
+        }
+    }
+    .into()
+}
+
+// Helper function to derive dynamic_size() for structs.
+fn derive_macro_for_struct(data_struct: DataStruct) -> TokenStream2 {
+    // Generate expressions for each field in the struct to calculate their sizes.
+    let field_exprs = match data_struct.fields {
+        Fields::Named(ref fields) => fields
+            .named
+            .iter()
+            .map(|f| {
+                let ident = f.ident.as_ref().unwrap(); // Get the name of the field.
+                quote_spanned! {f.span()=>
+                    size += self.#ident.dynamic_size();
+                }
+            })
+            .collect::<Vec<_>>(),
+        Fields::Unnamed(ref fields) => fields
+            .unnamed
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let idx = syn::Index::from(i); // Create an index for unnamed fields.
+                quote_spanned! {f.span()=>
+                    size += self.#idx.dynamic_size();
+                }
+            })
+            .collect(),
+        Fields::Unit => vec![],
+    };
+    quote! {
+       let mut size = 0;
+       // Calculate the size of each field in the struct.
+        #(#field_exprs)*
+         size
+    }
+}
+
+// Helper functions to derive dynamic_size() for enums.
+fn derive_macro_for_enum(data_enum: DataEnum) -> TokenStream2 {
+    // Generate match arms for each variant of the enum.
+    let variant_matches = data_enum.variants.iter().map(|variant| {
+        let vname = &variant.ident;
+
+        // Match arms for each variant, calculating the size based on its fields.
+        match &variant.fields {
+            Fields::Named(ref fields) => {
+                let idents: Vec<_> =
+                    fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+                let bindings: Vec<_> = idents.iter().map(|id| quote! { #id }).collect();
+                let sizes: Vec<_> = idents
+                    .iter()
+                    .map(|id| quote_spanned! { id.span() => size += #id.dynamic_size(); })
+                    .collect();
+                quote! {
+                    Self::#vname { #(#bindings),* } => {
+                        let mut size = 0;
+                        #(#sizes)*
+                        size
+                    }
+                }
+            }
+            Fields::Unnamed(ref fields) => {
+                let bindings: Vec<syn::Ident> = (0..fields.unnamed.len())
+                    .map(|i| syn::Ident::new(&format!("f{}", i), vname.span()))
+                    .collect();
+                let sizes: Vec<_> = bindings
+                    .iter()
+                    .map(|b| quote_spanned! { b.span() => size += #b.dynamic_size(); })
+                    .collect();
+                quote! {
+                    Self::#vname( #(#bindings),* ) => {
+                        let mut size = 0;
+                        #(#sizes)*
+                        size
+                    }
+                }
+            }
+            Fields::Unit => {
+                quote! {
+                    Self::#vname => 0
+                }
+            }
+        }
+    });
+    quote! {
+        // Match on the enum variants and calculate their dynamic sizes.
+        match self {
+            // Each variant match arm will calculate its dynamic size.
+            #(#variant_matches),*
+        }
+    }
+}
+
+// Add a bound `T: SizeOf` to every type parameter T.
+fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(parse_quote!(sizeof::SizeOf));
+        }
+    }
+    generics
+}

--- a/crates/sizeof/src/lib.rs
+++ b/crates/sizeof/src/lib.rs
@@ -1,0 +1,142 @@
+pub use sizeof_internal::SizeOf;
+pub use sizeof_macro::SizeOf;
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use size_of::SizeOf as OldSizeOf;
+
+    use super::SizeOf;
+
+    #[test]
+    fn test_equality_with_old_size_of() {
+        // Ensure that the SizeOf trait from this crate is equivalent to the one from the old crate.
+        // TODO(victorkstarkware): Remove this test once the old crate is no longer used.
+        assert_eq!(17_u8.size_of().total_bytes(), 17_u8.size_bytes());
+        assert_eq!(
+            String::from("Hello").size_of().total_bytes(),
+            String::from("Hello").size_bytes()
+        );
+        assert_eq!(
+            vec![1_u8, 2_u8, 3_u8].size_of().total_bytes(),
+            vec![1_u8, 2_u8, 3_u8].size_bytes()
+        );
+
+        // Test struct
+        #[derive(OldSizeOf, SizeOf)]
+        struct MyStruct {
+            a: u32,
+            b: String,
+            c: Vec<u8>,
+        }
+        let strct = MyStruct { a: 42, b: String::from("Hello"), c: vec![1, 2, 3, 4, 5] };
+        assert_eq!(strct.size_of().total_bytes(), strct.size_bytes());
+
+        // Test enum
+        #[derive(OldSizeOf, SizeOf)]
+        enum MyEnum {
+            VariantA(u32),
+            VariantB { x: u64, y: String },
+        }
+        let my_enum_a = MyEnum::VariantA(42);
+        let my_enum_b = MyEnum::VariantB { x: 100, y: String::from("World") };
+        assert_eq!(my_enum_a.size_of().total_bytes(), my_enum_a.size_bytes());
+        assert_eq!(my_enum_b.size_of().total_bytes(), my_enum_b.size_bytes());
+
+        // Test complicated enum
+        #[derive(OldSizeOf, SizeOf)]
+        enum MyComplicatedEnum {
+            VariantA(MyStruct),
+            VariantB(Vec<MyEnum>),
+        }
+        let my_complicated_enum_a = MyComplicatedEnum::VariantA(MyStruct {
+            a: 42,
+            b: String::from("Hello"),
+            c: vec![1, 2, 3],
+        });
+        let my_complicated_enum_b = MyComplicatedEnum::VariantB(vec![
+            MyEnum::VariantA(42),
+            MyEnum::VariantB { x: 100, y: String::from("World") },
+            MyEnum::VariantB { x: 66, y: String::from("Starknet") },
+        ]);
+        assert_eq!(
+            my_complicated_enum_a.size_of().total_bytes(),
+            my_complicated_enum_a.size_bytes()
+        );
+        assert_eq!(
+            my_complicated_enum_b.size_of().total_bytes(),
+            my_complicated_enum_b.size_bytes()
+        );
+    }
+
+    #[test]
+    fn test_size_of_struct() {
+        #[derive(SizeOf)]
+        struct MyStruct {
+            a: u32,
+            b: String,
+            c: Vec<u8>,
+        }
+        let my_struct = MyStruct { a: 42, b: String::from("Hello"), c: vec![1, 2, 3, 4, 5] };
+        assert_eq!(my_struct.size_bytes(), std::mem::size_of::<MyStruct>() + 5 + 5);
+    }
+
+    #[test]
+    fn test_size_of_enum() {
+        #[derive(SizeOf)]
+        enum MyEnum {
+            VariantA(u32),
+            VariantB { x: u64, y: String },
+        }
+        let my_enum_a = MyEnum::VariantA(42);
+        let my_enum_b = MyEnum::VariantB { x: 100, y: String::from("World!") };
+        assert_eq!(my_enum_a.size_bytes(), std::mem::size_of::<MyEnum>());
+        assert_eq!(my_enum_b.size_bytes(), std::mem::size_of::<MyEnum>() + 6);
+    }
+
+    #[test]
+    fn test_size_of_complicated_enum() {
+        #[derive(SizeOf)]
+        enum MyEnum {
+            VariantA(u32),
+            VariantB { x: u64, y: String },
+        }
+        #[derive(SizeOf)]
+        struct MyStruct {
+            a: u32,
+            b: String,
+            c: Vec<u8>,
+        }
+        #[derive(SizeOf)]
+        enum MyComplicatedEnum {
+            VariantA(MyStruct),
+            VariantB { vec: Vec<MyEnum> },
+        }
+        let my_complicated_enum_a = MyComplicatedEnum::VariantA(MyStruct {
+            a: 42,
+            b: String::from("Hello"),
+            c: vec![1, 2, 3],
+        });
+        let my_complicated_enum_b = MyComplicatedEnum::VariantB {
+            vec: vec![MyEnum::VariantA(42), MyEnum::VariantB { x: 100, y: String::from("World!") }],
+        };
+        assert_eq!(
+            my_complicated_enum_a.size_bytes(),
+            std::mem::size_of::<MyComplicatedEnum>() + 5 + 3
+        );
+        assert_eq!(
+            my_complicated_enum_b.size_bytes(),
+            std::mem::size_of::<MyComplicatedEnum>() + 2 * std::mem::size_of::<MyEnum>() + 6
+        );
+    }
+
+    #[test]
+    fn test_should_not_compile() {
+        // Note: this sets the TRYBUILD=overwrite env variable globally. If used elsewhere in the
+        // future, consider changing this or removing this test.
+        env::set_var("TRYBUILD", "overwrite");
+        let t = trybuild::TestCases::new();
+        t.compile_fail("negative_tests/*.rs");
+    }
+}


### PR DESCRIPTION
### TL;DR

Add a new `sizeof` crate with a derive macro for calculating memory size of types. We're using the "3 crate design pattern" since a procedural macro needs to be in its own crate.

### What changed?

- Added a new `sizeof` crate with three components:
  - `sizeof`: Main crate that re-exports the trait and derive macro
  - `sizeof_internal`: Contains the `SizeOf` trait definition
  - `sizeof_macro`: Implements the derive macro for `SizeOf`

- The `SizeOf` trait provides methods to calculate:
  - `dynamic_size()`: Size of heap-allocated memory
  - `size_bytes()`: Total size including both stack and heap parts

- Added negative tests to ensure proper compile-time errors when the macro is used incorrectly

- Added tests that compare with the old `size-of` crate to make sure we're making the same exact calculation.

- Updated dependencies in Cargo.toml to include the new crates

### How to test?

- Run the test suite which includes:
  - Tests comparing with the existing `size-of` crate
  - Tests for structs, enums, and complex nested types
  - Negative tests that verify compile-time errors

```bash
cargo test -p sizeof
```

### Why make this change?

This should replace the `size-of` crate currently in use down the line, as it uses code that will be deprecated in Rust 1.88. This specific PR includes a similar `derive` macro as in the `size-of` crate, that allows automatic computation of the `SizeOf` trait.

`WARNING:` When using the macro with structs that have smart pointers (or `Deref` types), there could be two problems:
- Overcounting: The macro assumes all pointers use disjoint memory space. Violating this assumption could lead to double-counting of memory space.
- Undercounting: Due to Rust's `Deref coercion`, if the trait `SizeOf` is not implemented on some `Deref` type (commonly smart pointers), it will simply execute the `size_bytes()` call on the internal type, excluding the space the pointer itself uses on stack. Thus, care should be taken to always implement the `SizeOf` trait for all `Deref` types before using this macro.