### PR TITLE
starknet_api: using internal implementation of sizeof part3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared_execution_objects",
+ "sizeof",
  "starknet-types-core",
  "starknet_api",
  "strum 0.25.0",
@@ -11699,7 +11700,7 @@ dependencies = [
 
 [[package]]
 name = "sizeof"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.4"
 dependencies = [
  "size-of",
  "sizeof_internal",
@@ -11716,7 +11717,7 @@ dependencies = [
 
 [[package]]
 name = "sizeof_macro"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11983,7 +11984,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "size-of",
+ "sizeof",
  "starknet-crypto",
  "starknet-types-core",
  "strum 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,9 +293,9 @@ sha3 = "0.10.8"
 shared_execution_objects.path = "crates/shared_execution_objects"
 simple_logger = "4.0.0"
 size-of = "0.1.5"
-sizeof = { path = "crates/sizeof" }
-sizeof_internal = { path = "crates/sizeof/sizeof_internal" }
-sizeof_macro = { path = "crates/sizeof/sizeof_macro" }
+sizeof = { path = "crates/sizeof", version = "0.15.0-rc.4" }
+sizeof_internal = { path = "crates/sizeof/sizeof_internal", version = "0.15.0-rc.4" }
+sizeof_macro = { path = "crates/sizeof/sizeof_macro", version = "0.15.0-rc.4" }
 socket2 = "0.5.8"
 starknet-core = "0.12.1"
 starknet-crypto = "0.7.1"

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 shared_execution_objects.workspace = true
+sizeof.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 strum.workspace = true

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -65,6 +65,7 @@ use num_bigint::BigUint;
 use rstest::rstest;
 use serde::Serialize;
 use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
+use sizeof::SizeOf;
 use starknet_api::block::{
     BlockHash,
     BlockInfo,
@@ -967,4 +968,73 @@ fn serialize_central_objects(#[case] rust_obj: impl Serialize, #[case] python_js
     let rust_json = serde_json::to_value(rust_obj).unwrap();
 
     assert_json_eq(&rust_json, &python_json, "Json Comparison failed".to_string());
+}
+
+// Check size of internal transactions.
+#[test]
+fn test_deploy_account_tx_size_of() {
+    let deploy_account_tx = deploy_account_tx();
+
+    // hardcoded number was generated using:
+    //
+    // let RpcDeployAccountTransaction::V3(internal_deploy_account_tx) = &deploy_account_tx.tx;
+    //
+    // let expected_size = std::mem::size_of::<InternalRpcDeployAccountTransaction>()
+    // + internal_deploy_account_tx.class_hash.dynamic_size()
+    // + internal_deploy_account_tx.constructor_calldata.dynamic_size()
+    // + internal_deploy_account_tx.contract_address_salt.dynamic_size()
+    // + internal_deploy_account_tx.fee_data_availability_mode.dynamic_size()
+    // + internal_deploy_account_tx.nonce.dynamic_size()
+    // + internal_deploy_account_tx.nonce_data_availability_mode.dynamic_size()
+    // + internal_deploy_account_tx.paymaster_data.dynamic_size()
+    // + internal_deploy_account_tx.resource_bounds.dynamic_size()
+    // + internal_deploy_account_tx.signature.dynamic_size()
+    // + internal_deploy_account_tx.tip.dynamic_size()
+    // + deploy_account_tx.contract_address.dynamic_size();
+
+    assert_eq!(deploy_account_tx.size_bytes(), 528);
+}
+
+#[test]
+fn test_declare_account_tx_size_of() {
+    let declare_tx = declare_transaction();
+
+    // hardcoded number was generated using:
+    //
+    // let expected_size = std::mem::size_of::<InternalRpcDeclareTransactionV3>()
+    // + declare_tx.class_hash.dynamic_size()
+    // + declare_tx.compiled_class_hash.dynamic_size()
+    // + declare_tx.fee_data_availability_mode.dynamic_size()
+    // + declare_tx.nonce.dynamic_size()
+    // + declare_tx.nonce_data_availability_mode.dynamic_size()
+    // + declare_tx.paymaster_data.dynamic_size()
+    // + declare_tx.resource_bounds.dynamic_size()
+    // + declare_tx.sender_address.dynamic_size()
+    // + declare_tx.signature.dynamic_size()
+    // + declare_tx.tip.dynamic_size();
+
+    assert_eq!(declare_tx.size_bytes(), 424);
+}
+
+#[test]
+fn test_invoke_tx_size_of() {
+    let invoke_tx = invoke_transaction();
+
+    // hardcoded number was generated using:
+    //
+    // let RpcInvokeTransaction::V3(internal_invoke_tx) = &invoke_tx;
+    //
+    // let expected_size = std::mem::size_of::<RpcInvokeTransaction>()
+    // + internal_invoke_tx.account_deployment_data.dynamic_size()
+    // + internal_invoke_tx.calldata.dynamic_size()
+    // + internal_invoke_tx.fee_data_availability_mode.dynamic_size()
+    // + internal_invoke_tx.nonce.dynamic_size()
+    // + internal_invoke_tx.nonce_data_availability_mode.dynamic_size()
+    // + internal_invoke_tx.paymaster_data.dynamic_size()
+    // + internal_invoke_tx.resource_bounds.dynamic_size()
+    // + internal_invoke_tx.sender_address.dynamic_size()
+    // + internal_invoke_tx.signature.dynamic_size()
+    // + internal_invoke_tx.tip.dynamic_size();
+
+    assert_eq!(invoke_tx.size_bytes(), 448);
 }

--- a/crates/starknet_api/Cargo.toml
+++ b/crates/starknet_api/Cargo.toml
@@ -31,7 +31,7 @@ semver.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 sha3.workspace = true
-size-of.workspace = true
+sizeof.workspace = true
 starknet-crypto.workspace = true
 starknet-types-core = { workspace = true, features = ["hash"] }
 strum = { workspace = true, features = ["derive"] }

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Poseidon, StarkHash as CoreStarkHash};
 use strum_macros::EnumIter;

--- a/crates/starknet_api/src/core.rs
+++ b/crates/starknet_api/src/core.rs
@@ -9,7 +9,7 @@ use num_traits::ToPrimitive;
 use primitive_types::H160;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::{Felt, NonZeroFelt};
 use starknet_types_core::hash::{Pedersen, StarkHash as CoreStarkHash};
 

--- a/crates/starknet_api/src/data_availability.rs
+++ b/crates/starknet_api/src/data_availability.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 
 use crate::StarknetApiError;

--- a/crates/starknet_api/src/execution_resources.rs
+++ b/crates/starknet_api/src/execution_resources.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 use strum_macros::EnumIter;
 

--- a/crates/starknet_api/src/rpc_transaction.rs
+++ b/crates/starknet_api/src/rpc_transaction.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use cairo_lang_starknet_classes::contract_class::ContractEntryPoints as CairoLangContractEntryPoints;
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use strum::EnumVariantNames;
 use strum_macros::{EnumDiscriminants, EnumIter, IntoStaticStr};
 
@@ -230,8 +230,7 @@ impl InternalRpcTransaction {
     }
 
     pub fn total_bytes(&self) -> u64 {
-        self.size_of()
-            .total_bytes()
+        self.size_bytes()
             .try_into()
             .expect("The transaction size in bytes should fit in a u64 value.")
     }

--- a/crates/starknet_api/src/rpc_transaction_test.rs
+++ b/crates/starknet_api/src/rpc_transaction_test.rs
@@ -1,10 +1,16 @@
 use rstest::rstest;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 
 use crate::block::GasPrice;
 use crate::core::CompiledClassHash;
 use crate::execution_resources::GasAmount;
-use crate::rpc_transaction::{DataAvailabilityMode, RpcTransaction};
+use crate::rpc_transaction::{
+    DataAvailabilityMode,
+    RpcDeployAccountTransaction,
+    RpcInvokeTransaction,
+    RpcTransaction,
+};
 use crate::state::SierraContractClass;
 use crate::test_utils::declare::{rpc_declare_tx, DeclareTxArgs};
 use crate::test_utils::deploy_account::{rpc_deploy_account_tx, DeployAccountTxArgs};
@@ -84,4 +90,69 @@ fn test_rpc_transactions(#[case] tx: RpcTransaction) {
     let serialized = serde_json::to_string(&tx).unwrap();
     let deserialized: RpcTransaction = serde_json::from_str(&serialized).unwrap();
     assert_eq!(tx, deserialized);
+}
+
+// Check size of RPC transactions.
+#[test]
+fn test_deploy_account_tx_size_of() {
+    let tx = create_deploy_account_tx();
+    if let RpcTransaction::DeployAccount(deploy_tx) = tx {
+        let RpcDeployAccountTransaction::V3(tx_v3) = deploy_tx;
+
+        // hardcoded number was generated using:
+        //
+        // let expected_size = std::mem::size_of::<RpcDeployAccountTransactionV3>()
+        // + tx_v3.resource_bounds.l1_gas.max_amount.dynamic_size()
+        // + tx_v3.resource_bounds.l1_gas.max_price_per_unit.dynamic_size()
+        // + tx_v3.resource_bounds.l2_gas.max_amount.dynamic_size()
+        // + tx_v3.resource_bounds.l2_gas.max_price_per_unit.dynamic_size()
+        // + tx_v3.resource_bounds.l1_data_gas.max_amount.dynamic_size()
+        // + tx_v3.resource_bounds.l1_data_gas.max_price_per_unit.dynamic_size()
+        // + tx_v3.tip.dynamic_size()
+        // + tx_v3.contract_address_salt.dynamic_size()
+        // + tx_v3.class_hash.dynamic_size()
+        // + tx_v3.constructor_calldata.dynamic_size()
+        // + tx_v3.nonce.dynamic_size()
+        // + tx_v3.signature.dynamic_size()
+        // + tx_v3.nonce_data_availability_mode.dynamic_size()
+        // + tx_v3.fee_data_availability_mode.dynamic_size()
+        // + tx_v3.paymaster_data.dynamic_size();
+
+        // Check the size of the V3 deploy account transaction.
+        assert_eq!(tx_v3.size_bytes(), 432);
+    } else {
+        panic!("Expected RpcTransaction::DeployAccount");
+    }
+}
+
+#[test]
+fn test_invoke_tx_size_of() {
+    let tx = create_invoke_tx();
+    if let RpcTransaction::Invoke(invoke_tx) = tx {
+        let RpcInvokeTransaction::V3(tx_v3) = invoke_tx;
+
+        // hardcoded number was generated using:
+        //
+        // let expected_size = std::mem::size_of::<RpcInvokeTransactionV3>()
+        // + tx_v3.resource_bounds.l1_gas.max_amount.dynamic_size()
+        // + tx_v3.resource_bounds.l1_gas.max_price_per_unit.dynamic_size()
+        // + tx_v3.resource_bounds.l2_gas.max_amount.dynamic_size()
+        // + tx_v3.resource_bounds.l2_gas.max_price_per_unit.dynamic_size()
+        // + tx_v3.resource_bounds.l1_data_gas.max_amount.dynamic_size()
+        // + tx_v3.resource_bounds.l1_data_gas.max_price_per_unit.dynamic_size()
+        // + tx_v3.tip.dynamic_size()
+        // + tx_v3.calldata.dynamic_size()
+        // + tx_v3.sender_address.dynamic_size()
+        // + tx_v3.nonce.dynamic_size()
+        // + tx_v3.signature.dynamic_size()
+        // + tx_v3.nonce_data_availability_mode.dynamic_size()
+        // + tx_v3.fee_data_availability_mode.dynamic_size()
+        // + tx_v3.paymaster_data.dynamic_size()
+        // + tx_v3.account_deployment_data.dynamic_size();
+
+        // Check the size of the V3 invoke transaction.
+        assert_eq!(tx_v3.size_bytes(), 448);
+    } else {
+        panic!("Expected RpcTransaction::Invoke");
+    }
 }

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -2,7 +2,7 @@ use std::sync::LazyLock;
 
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 
 use crate::block::{BlockHash, BlockNumber};

--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use size_of::SizeOf;
+use sizeof::SizeOf;
 use starknet_types_core::felt::Felt;
 use strum_macros::EnumIter;
 


### PR DESCRIPTION
### TL;DR

Replace `size-of` crate with our own `sizeof` crate for memory usage tracking.

### What changed?

- Replaced the external `size-of` dependency with our internal `sizeof` crate
- Updated imports from `size_of::SizeOf` to `sizeof::SizeOf` across the codebase
- Added version information (`0.15.0-rc.2`) to the `sizeof` crate and its internal components
- Added `sizeof` as a dependency to the `apollo_consensus_orchestrator` crate
- Added tests for transaction size calculations in `central_objects_test.rs` and `rpc_transaction_test.rs`
- Updated the method call from `size_of().total_bytes()` to `size_bytes()` in the `total_bytes()` method

### How to test?

- Run the new size calculation tests in `central_objects_test.rs` and `rpc_transaction_test.rs`
- Verify that all existing code that used the `size-of` crate continues to work with the new `sizeof` crate
- Check that the memory usage calculations are accurate for the transaction types

### Why make this change?

This should replace the size-of crate currently in use down the line, as it uses code that will be deprecated in Rust 1.88. This specific PR replaces the `size-of` crate with our own `sizeof` crate for memory usage tracking.

We only use `size-of` as a dev dependency to ensure consistency in its memory size calculation.