### PR TITLE
apollo_node: fix sequencer image to allow cairo_native compilation

### DIFF
--- a/deployments/images/sequencer/Dockerfile
+++ b/deployments/images/sequencer/Dockerfile
@@ -37,7 +37,7 @@ RUN BUILD_FLAGS=""; \
     cargo build $BUILD_FLAGS --bin apollo_node --features cairo_native
 
 
-FROM ubuntu:24.04 AS final_stage
+FROM base AS final_stage
 
 ARG BUILD_MODE=release
 ENV BUILD_MODE=${BUILD_MODE}


### PR DESCRIPTION
This commit fixes the the sequencer image to include all Ubuntu packages installed in the base
image. The fix is to deploy the final_stage of the image `FROM base` instead of `FROM ubuntu:24.04`
(which is a blank Ubuntu image with a minimal installation).
