### PR TITLE
apollo_integration_tests: create genereic rpc invoke tx

### DIFF
--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -450,7 +450,7 @@ pub fn create_deploy_account_tx_and_invoke_tx(
     let undeployed_account_tx_generator = tx_generator.account_with_id_mut(account_id);
     assert!(!undeployed_account_tx_generator.is_deployed());
     let deploy_tx = undeployed_account_tx_generator.generate_deploy_account();
-    let invoke_tx = undeployed_account_tx_generator.generate_invoke_with_tip(1);
+    let invoke_tx = undeployed_account_tx_generator.generate_trivial_rpc_invoke_tx(1);
     vec![deploy_tx, invoke_tx]
 }
 
@@ -460,7 +460,7 @@ pub fn create_invoke_txs(
     n_txs: usize,
 ) -> Vec<RpcTransaction> {
     (0..n_txs)
-        .map(|_| tx_generator.account_with_id_mut(account_id).generate_invoke_with_tip(1))
+        .map(|_| tx_generator.account_with_id_mut(account_id).generate_trivial_rpc_invoke_tx(1))
         .collect()
 }
 

--- a/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
@@ -72,11 +72,11 @@ fn create_multiple_account_txs(
 ) -> Vec<RpcTransaction> {
     // Create RPC transactions.
     let account0_invoke_nonce1 =
-        tx_generator.account_with_id_mut(ACCOUNT_ID_0).generate_invoke_with_tip(2);
+        tx_generator.account_with_id_mut(ACCOUNT_ID_0).generate_trivial_rpc_invoke_tx(2);
     let account0_invoke_nonce2 =
-        tx_generator.account_with_id_mut(ACCOUNT_ID_0).generate_invoke_with_tip(3);
+        tx_generator.account_with_id_mut(ACCOUNT_ID_0).generate_trivial_rpc_invoke_tx(3);
     let account1_invoke_nonce1 =
-        tx_generator.account_with_id_mut(ACCOUNT_ID_1).generate_invoke_with_tip(4);
+        tx_generator.account_with_id_mut(ACCOUNT_ID_1).generate_trivial_rpc_invoke_tx(4);
 
     vec![account0_invoke_nonce1, account0_invoke_nonce2, account1_invoke_nonce1]
 }

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -24,6 +24,7 @@ use starknet_api::test_utils::{NonceManager, TEST_ERC20_CONTRACT_ADDRESS2};
 use starknet_api::transaction::constants::TRANSFER_ENTRY_POINT_NAME;
 use starknet_api::transaction::fields::{
     AllResourceBounds,
+    Calldata,
     ContractAddressSalt,
     Fee,
     ResourceBounds,
@@ -132,7 +133,7 @@ pub fn executable_invoke_tx(cairo_version: CairoVersion) -> AccountTransaction {
 
     let mut tx_generator = MultiAccountTransactionGenerator::new();
     tx_generator.register_deployed_account(default_account);
-    tx_generator.account_with_id_mut(0).generate_executable_invoke()
+    tx_generator.account_with_id_mut(0).generate_trivial_executable_invoke_tx()
 }
 
 pub fn deploy_account_tx() -> RpcTransaction {
@@ -223,9 +224,12 @@ impl L1HandlerTransactionGenerator {
 /// tx_generator.register_deployed_account(some_account_type.clone());
 /// tx_generator.register_deployed_account(some_account_type.clone());
 ///
-/// let account_0_tx_with_nonce_0 = tx_generator.account_with_id_mut(0).generate_invoke_with_tip(1);
-/// let account_1_tx_with_nonce_0 = tx_generator.account_with_id_mut(1).generate_invoke_with_tip(3);
-/// let account_0_tx_with_nonce_1 = tx_generator.account_with_id_mut(0).generate_invoke_with_tip(1);
+/// let account_0_tx_with_nonce_0 =
+///     tx_generator.account_with_id_mut(0).generate_trivial_rpc_invoke_tx(1);
+/// let account_1_tx_with_nonce_0 =
+///     tx_generator.account_with_id_mut(1).generate_trivial_rpc_invoke_tx(3);
+/// let account_0_tx_with_nonce_1 =
+///     tx_generator.account_with_id_mut(0).generate_trivial_rpc_invoke_tx(1);
 ///
 /// // Initialize an undeployed account.
 /// let salt = ContractAddressSalt(123_u64.into());
@@ -376,8 +380,7 @@ impl AccountTransactionGenerator {
         self.nonce_manager.borrow().get(self.sender_address()) != nonce!(0)
     }
 
-    /// Generate a valid `RpcTransaction` with default parameters.
-    pub fn generate_invoke_with_tip(&mut self, tip: u64) -> RpcTransaction {
+    fn build_invoke_tx_args(&mut self, tip: u64, calldata: Calldata) -> InvokeTxArgs {
         assert!(
             self.is_deployed(),
             "Cannot invoke on behalf of an undeployed account: the first transaction of every \
@@ -386,29 +389,27 @@ impl AccountTransactionGenerator {
         let nonce = self.next_nonce();
         let invoke_args = invoke_tx_args!(
             nonce,
-            tip : Tip(tip),
+            tip: Tip(tip),
             sender_address: self.sender_address(),
             resource_bounds: test_valid_resource_bounds(),
-            calldata: create_trivial_calldata(self.sender_address()),
+            calldata,
         );
+        invoke_args
+    }
+
+    pub fn generate_rpc_invoke_tx(&mut self, tip: u64, calldata: Calldata) -> RpcTransaction {
+        let invoke_args = self.build_invoke_tx_args(tip, calldata);
         rpc_invoke_tx(invoke_args)
     }
 
-    pub fn generate_executable_invoke(&mut self) -> AccountTransaction {
-        assert!(
-            self.is_deployed(),
-            "Cannot invoke on behalf of an undeployed account: the first transaction of every \
-             account must be a deploy account transaction."
-        );
-        let nonce = self.next_nonce();
+    pub fn generate_trivial_rpc_invoke_tx(&mut self, tip: u64) -> RpcTransaction {
+        let calldata = create_trivial_calldata(self.sender_address());
+        self.generate_rpc_invoke_tx(tip, calldata)
+    }
 
-        let invoke_args = invoke_tx_args!(
-            sender_address: self.sender_address(),
-            resource_bounds: test_valid_resource_bounds(),
-            nonce,
-            calldata: create_trivial_calldata(self.sender_address()),
-        );
-
+    pub fn generate_trivial_executable_invoke_tx(&mut self) -> AccountTransaction {
+        let calldata = create_trivial_calldata(self.sender_address());
+        let invoke_args = self.build_invoke_tx_args(Tip::default().0, calldata);
         starknet_api::test_utils::invoke::executable_invoke_tx(invoke_args)
     }
 
@@ -416,8 +417,8 @@ impl AccountTransactionGenerator {
     ///
     /// Caller must manually handle bumping nonce and fetching the correct sender address via
     /// [AccountTransactionGenerator::next_nonce] and [AccountTransactionGenerator::sender_address].
-    /// See [AccountTransactionGenerator::generate_invoke_with_tip] to have these filled up by
-    /// default.
+    /// See [AccountTransactionGenerator::generate_trivial_rpc_invoke_tx] to have these
+    /// filled up by default.
     ///
     /// Note: This is a best effort attempt to make the API more useful; amend or add new methods
     /// as needed.


### PR DESCRIPTION
Simplify the creation of rpc invoke txs by creating generic rpc invoke txs function.
The functions which creates trivial invoke txs uses the generic one.