### PR TITLE
apollo_l1_provider: add validation to the l1 provider cooldown

### DIFF
--- a/crates/apollo_l1_provider/src/config.rs
+++ b/crates/apollo_l1_provider/src/config.rs
@@ -13,11 +13,17 @@ use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::ChainId;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 
+use crate::l1_scraper::L1_BLOCK_TIME;
 use crate::transaction_manager::TransactionManagerConfig;
 
+#[cfg(test)]
+#[path = "config_test.rs"]
+pub mod config_test;
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Validate, PartialEq)]
+#[validate(schema(function = "validate_cooldown"))]
 pub struct L1MessageProviderConfig {
     pub l1_provider_config: L1ProviderConfig,
     pub l1_scraper_config: L1ScraperConfig,
@@ -180,5 +186,33 @@ impl SerializeConfig for L1ScraperConfig {
                 ParamPrivacyInput::Public,
             ),
         ])
+    }
+}
+
+pub fn validate_cooldown(config: &L1MessageProviderConfig) -> Result<(), ValidationError> {
+    let message_to_scrape_time_diff_lowerbound =
+        Duration::from_secs(L1_BLOCK_TIME * config.l1_scraper_config.finality)
+            + config.l1_scraper_config.polling_interval_seconds;
+    if message_to_scrape_time_diff_lowerbound
+        <= config.l1_provider_config.new_l1_handler_cooldown_seconds
+    {
+        Ok(())
+    } else {
+        let mut error = ValidationError::new("L1 handler cooldown validation failed.");
+        error.message = Some(
+            format!(
+                "L1 provider's new L1 handler cooldown must be greater than the lower bound on \
+                 the time between when a transaction is accepted on L1 and when it is scraped. \
+                 Otherwise, the cooldown might not be effective: a transaction could be provided \
+                 to the proposer before it is scraped by a validator.\nRelevant parameters:\n- L1 \
+                 scraper finality: {}.\n- L1 scraper polling interval (seconds): {}.\n- L1 \
+                 provider's new L1 handler cooldown (seconds): {}.",
+                config.l1_scraper_config.finality,
+                config.l1_scraper_config.polling_interval_seconds.as_secs(),
+                config.l1_provider_config.new_l1_handler_cooldown_seconds.as_secs()
+            )
+            .into(),
+        );
+        Err(error)
     }
 }

--- a/crates/apollo_l1_provider/src/config_test.rs
+++ b/crates/apollo_l1_provider/src/config_test.rs
@@ -1,0 +1,84 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use rstest::rstest;
+use validator::Validate;
+
+use super::{L1ProviderConfig, L1ScraperConfig};
+use crate::config::L1MessageProviderConfig;
+use crate::l1_scraper::L1_BLOCK_TIME;
+
+#[rstest]
+#[case::polling_interval(
+    L1ScraperConfig {
+        polling_interval_seconds: Duration::from_secs(2),
+        finality: 0,
+        ..L1ScraperConfig::default()
+    }
+)]
+#[case::finality(
+    L1ScraperConfig {
+        polling_interval_seconds: Duration::from_secs(0),
+        finality: 1,
+        ..L1ScraperConfig::default()
+    }
+)]
+#[case::polling_interval_and_finality(
+    L1ScraperConfig {
+        polling_interval_seconds: Duration::from_secs(1),
+        finality: 1,
+        ..L1ScraperConfig::default()
+    }
+)]
+fn validate_l1_handler_cooldown_failure(#[case] l1_scraper_config: L1ScraperConfig) {
+    let config = L1MessageProviderConfig {
+        l1_scraper_config,
+        l1_provider_config: L1ProviderConfig {
+            new_l1_handler_cooldown_seconds: Duration::from_secs(1),
+            ..L1ProviderConfig::default()
+        },
+    };
+
+    assert_matches!(
+        config.validate(),
+        Err(e) if e.to_string().contains("L1 handler cooldown validation failed.")
+    );
+}
+
+#[rstest]
+#[case::polling_interval(
+    L1ScraperConfig {
+        polling_interval_seconds: Duration::from_secs(2),
+        finality: 0,
+        ..L1ScraperConfig::default()
+    }
+)]
+#[case::finality(
+    L1ScraperConfig {
+        polling_interval_seconds: Duration::from_secs(0),
+        finality: 1,
+        ..L1ScraperConfig::default()
+    }
+)]
+#[case::polling_interval_and_finality(
+    L1ScraperConfig {
+        polling_interval_seconds: Duration::from_secs(1),
+        finality: 1,
+        ..L1ScraperConfig::default()
+    }
+)]
+fn validate_l1_handler_cooldown_success(#[case] l1_scraper_config: L1ScraperConfig) {
+    let new_l1_handler_cooldown_seconds = l1_scraper_config.polling_interval_seconds
+        + Duration::from_secs(L1_BLOCK_TIME * l1_scraper_config.finality)
+        + Duration::from_secs(1);
+
+    let config = L1MessageProviderConfig {
+        l1_scraper_config,
+        l1_provider_config: L1ProviderConfig {
+            new_l1_handler_cooldown_seconds,
+            ..L1ProviderConfig::default()
+        },
+    };
+
+    assert!(config.validate().is_ok());
+}

--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -29,7 +29,7 @@ pub mod l1_scraper_tests;
 type L1ScraperResult<T, B> = Result<T, L1ScraperError<B>>;
 
 // Sensible lower bound.
-const L1_BLOCK_TIME: u64 = 10;
+pub const L1_BLOCK_TIME: u64 = 10;
 
 pub struct L1Scraper<B: BaseLayerContract> {
     pub config: L1ScraperConfig,


### PR DESCRIPTION
We add a validation to `L1MessageProviderConfig`.