### PR TITLE
apollo_central_sync: add trace message.

### DIFF
--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -1093,6 +1093,9 @@ fn check_sync_progress(
                 debug!("No progress in the sync. Return NoProgress event. Header marker: {header_marker}, \
                        State marker: {state_marker}, Casm marker: {casm_marker}.");
                 yield SyncEvent::NoProgress;
+            } else {
+                trace!("Sync is progressing. Header marker: {header_marker}, State marker: \
+                {state_marker}, Casm marker: {casm_marker}.");
             }
             header_marker=new_header_marker;
             state_marker=new_state_marker;


### PR DESCRIPTION
Trace to let us know if (and how long it took to check) if there was sync progress