### PR TITLE
blockifier: move stateful validator trait to blockifier crate

### DIFF
--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -55,7 +55,7 @@ apollo_network_types = { workspace = true, features = ["testing"] }
 apollo_state_sync_types = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
 assert_matches.workspace = true
-blockifier = { workspace = true, features = ["testing"] }
+blockifier = { workspace = true, features = ["mocks", "testing"] }
 blockifier_test_utils.workspace = true
 cairo-lang-sierra-to-casm.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -16,6 +16,7 @@ cairo_native = [
   "dep:apollo_compile_to_native",
   "dep:cairo-native",
 ]
+mocks = []
 native_blockifier = []
 node_api = []
 reexecution = ["transaction_serde"]

--- a/crates/blockifier/src/blockifier/stateful_validator.rs
+++ b/crates/blockifier/src/blockifier/stateful_validator.rs
@@ -42,6 +42,24 @@ pub enum StatefulValidatorError {
 
 pub type StatefulValidatorResult<T> = Result<T, StatefulValidatorError>;
 
+#[cfg_attr(any(test, feature = "mocks"), mockall::automock)]
+pub trait StatefulValidatorTrait {
+    #[allow(clippy::result_large_err)]
+    fn validate(&mut self, account_tx: AccountTransaction) -> StatefulValidatorResult<()>;
+    fn block_info(&self) -> &BlockInfo;
+}
+
+impl<S: StateReader> StatefulValidatorTrait for StatefulValidator<S> {
+    #[allow(clippy::result_large_err)]
+    fn validate(&mut self, account_tx: AccountTransaction) -> StatefulValidatorResult<()> {
+        self.perform_validations(account_tx)
+    }
+
+    fn block_info(&self) -> &BlockInfo {
+        StatefulValidator::block_info(self)
+    }
+}
+
 /// Manages state related transaction validations for pre-execution flows.
 pub struct StatefulValidator<S: StateReader> {
     tx_executor: TransactionExecutor<S>,


### PR DESCRIPTION
Added a "mocks" feature to allow generating `MockStatefulValidatorTrait` for use in other crates during testing.