### PR TITLE
l1: speed-up scraper test

### DIFF
--- a/crates/apollo_l1_provider/src/l1_scraper_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper_tests.rs
@@ -354,7 +354,11 @@ async fn test_stuck_sync() {
 
     let sync_client = MockStateSyncClient::default();
     let l1_provider_client = Arc::new(FakeL1ProviderClient::default());
-    let config = Default::default();
+    let config = L1ProviderConfig {
+        // Override the default retry interval which is way too long for a test.
+        startup_sync_sleep_retry_interval_seconds: Duration::from_millis(10),
+        ..Default::default()
+    };
     let mut l1_provider = L1ProviderBuilder::new(
         config,
         l1_provider_client.clone(),


### PR DESCRIPTION
When the test was written, the default retry-interval was 0, now it is 2
and the test ran for > 10 seconds (5 retries, 2 seconds each).