### PR TITLE
l1: remove eth l1 nonce from `send_messages_to_l2`

### DIFF
--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -31,10 +31,7 @@ use mempool_test_utils::starknet_api_test_utils::{
     MultiAccountTransactionGenerator,
 };
 use papyrus_base_layer::anvil_base_layer::AnvilBaseLayer;
-use papyrus_base_layer::ethereum_base_layer_contract::{
-    EthereumBaseLayerConfig,
-    L1ToL2MessageArgs,
-};
+use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerConfig;
 use papyrus_base_layer::test_utils::{
     make_block_history_on_anvil,
     ARBITRARY_ANVIL_L1_ACCOUNT_ADDRESS,
@@ -45,7 +42,12 @@ use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::core::{ChainId, ContractAddress};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::RpcTransaction;
-use starknet_api::transaction::{TransactionHash, TransactionHasher, TransactionVersion};
+use starknet_api::transaction::{
+    L1HandlerTransaction,
+    TransactionHash,
+    TransactionHasher,
+    TransactionVersion,
+};
 use starknet_types_core::felt::Felt;
 use tokio::sync::Mutex;
 use tracing::{debug, instrument, Instrument};
@@ -187,13 +189,9 @@ impl FlowTestSetup {
             .chain_id
     }
 
-    pub async fn send_messages_to_l2(&self, l1_to_l2_messages_args: &[L1ToL2MessageArgs]) {
-        for l1_to_l2_message_args in l1_to_l2_messages_args {
-            self.anvil_base_layer
-                .ethereum_base_layer
-                .contract
-                .send_message_to_l2(l1_to_l2_message_args)
-                .await;
+    pub async fn send_messages_to_l2(&self, l1_handlers: &[L1HandlerTransaction]) {
+        for l1_handler in l1_handlers {
+            self.anvil_base_layer.ethereum_base_layer.contract.send_message_to_l2(l1_handler).await;
         }
     }
 }

--- a/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
@@ -7,10 +7,9 @@ use apollo_integration_tests::utils::{
     UNDEPLOYED_ACCOUNT_ID,
 };
 use mempool_test_utils::starknet_api_test_utils::MultiAccountTransactionGenerator;
-use papyrus_base_layer::ethereum_base_layer_contract::L1ToL2MessageArgs;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::RpcTransaction;
-use starknet_api::transaction::TransactionHash;
+use starknet_api::transaction::{L1HandlerTransaction, TransactionHash};
 
 use crate::common::{end_to_end_flow, test_single_tx, TestScenario};
 
@@ -63,7 +62,7 @@ pub fn create_test_scenarios() -> Vec<TestScenario> {
 
 fn create_l1_to_l2_message_args(
     tx_generator: &mut MultiAccountTransactionGenerator,
-) -> Vec<L1ToL2MessageArgs> {
+) -> Vec<L1HandlerTransaction> {
     const N_TXS: usize = 1;
     create_l1_to_l2_messages_args(tx_generator, N_TXS)
 }

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -8,7 +8,6 @@ use assert_matches::assert_matches;
 use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
 use blockifier_test_utils::calldata::create_trivial_calldata;
 use blockifier_test_utils::contracts::FeatureContract;
-use papyrus_base_layer::ethereum_base_layer_contract::L1ToL2MessageArgs;
 use papyrus_base_layer::test_utils::DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS;
 use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::block::GasPrice;
@@ -179,14 +178,13 @@ impl L1HandlerTransactionGenerator {
 
     /// Creates an L1 handler transaction calling the "l1_handler_set_value" entry point in
     /// [TestContract](FeatureContract::TestContract).
-    fn create_l1_to_l2_message_args(&mut self) -> L1ToL2MessageArgs {
-        let l1_tx_nonce = self.l1_tx_nonce;
+    fn create_l1_to_l2_message_args(&mut self) -> L1HandlerTransaction {
         self.l1_tx_nonce += 1;
         // TODO(Arni): Get test contract from test setup.
         let test_contract =
             FeatureContract::TestContract(CairoVersion::Cairo1(RunnableCairo1::Casm));
 
-        let l1_handler_tx = L1HandlerTransaction {
+        L1HandlerTransaction {
             contract_address: test_contract.get_instance_address(0),
             // TODO(Arni): Consider saving this value as a lazy constant.
             entry_point_selector: selector_from_name("l1_handler_set_value"),
@@ -197,9 +195,7 @@ impl L1HandlerTransactionGenerator {
                 felt!("0x44")   // value
             ],
             ..Default::default()
-        };
-
-        L1ToL2MessageArgs { tx: l1_handler_tx, l1_tx_nonce }
+        }
     }
 
     fn n_generated_txs(&self) -> u64 {
@@ -361,7 +357,7 @@ impl MultiAccountTransactionGenerator {
             .collect()
     }
 
-    pub fn create_l1_to_l2_message_args(&mut self) -> L1ToL2MessageArgs {
+    pub fn create_l1_to_l2_message_args(&mut self) -> L1HandlerTransaction {
         self.l1_handler_tx_generator.create_l1_to_l2_message_args()
     }
 

--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -10,6 +10,7 @@ use starknet_api::core::EntryPointSelector;
 use starknet_api::transaction::L1HandlerTransaction;
 use starknet_api::{calldata, contract_address, felt};
 
+use crate::anvil_base_layer::AnvilBaseLayer;
 use crate::constants::{EventIdentifier, LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER};
 use crate::ethereum_base_layer_contract::{
     EthereumBaseLayerConfig,
@@ -17,11 +18,7 @@ use crate::ethereum_base_layer_contract::{
     L1ToL2MessageArgs,
     Starknet,
 };
-use crate::test_utils::{
-    anvil_instance_from_config,
-    ethereum_base_layer_config_for_anvil,
-    DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS,
-};
+use crate::test_utils::DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS;
 use crate::{BaseLayerContract, L1Event};
 
 // TODO(Gilad): Use everywhere instead of relying on the confusing `#[ignore]` api to mark slow
@@ -117,6 +114,8 @@ async fn get_gas_price_and_timestamps() {
     assert_eq!(header.blob_fee, expected_original_blob_calc);
 }
 
+// Ensure that the base layer instance filters out events from other deployments of the core
+// contract.
 #[tokio::test]
 async fn events_from_other_contract() {
     if !in_ci() {
@@ -124,17 +123,16 @@ async fn events_from_other_contract() {
     }
     const EVENT_IDENTIFIERS: &[EventIdentifier] = &[LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER];
 
-    let this_config = ethereum_base_layer_config_for_anvil(None);
-    let _anvil = anvil_instance_from_config(&this_config);
-    let this_contract = EthereumBaseLayerContract::new(this_config.clone());
+    let anvil_base_layer = AnvilBaseLayer::new().await;
+    // Anvil base layer already auto-deployed a starknet contract.
+    let this_contract = anvil_base_layer.ethereum_base_layer;
 
-    // Test: Get events from L1 contract and other instances of this L1 contract.
     // Setup.
 
-    // Deploy the contract to the anvil instance.
-    Starknet::deploy(this_contract.contract.provider().clone()).await.unwrap();
     // Deploy another instance of the contract to the same anvil instance.
-    let other_contract = Starknet::deploy(this_contract.contract.provider().clone()).await.unwrap();
+    let provider = this_contract.contract.provider().clone();
+    let other_contract = Starknet::deploy(provider).await.unwrap();
+
     assert_ne!(
         this_contract.contract.address(),
         other_contract.address(),

--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -15,7 +15,6 @@ use crate::constants::{EventIdentifier, LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER};
 use crate::ethereum_base_layer_contract::{
     EthereumBaseLayerConfig,
     EthereumBaseLayerContract,
-    L1ToL2MessageArgs,
     Starknet,
 };
 use crate::test_utils::DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS;
@@ -145,10 +144,7 @@ async fn events_from_other_contract() {
         calldata: calldata!(DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS, felt!("0x1"), felt!("0x2")),
         ..Default::default()
     };
-    let this_receipt = this_contract
-        .contract
-        .send_message_to_l2(&L1ToL2MessageArgs { tx: this_l1_handler.clone(), l1_tx_nonce: 2 })
-        .await;
+    let this_receipt = this_contract.contract.send_message_to_l2(&this_l1_handler.clone()).await;
     assert!(this_receipt.status());
     let this_block_number = this_receipt.block_number.unwrap();
 
@@ -158,9 +154,7 @@ async fn events_from_other_contract() {
         calldata: calldata!(DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS, felt!("0x1"), felt!("0x2")),
         ..Default::default()
     };
-    let other_receipt = other_contract
-        .send_message_to_l2(&L1ToL2MessageArgs { tx: other_l1_handler.clone(), l1_tx_nonce: 3 })
-        .await;
+    let other_receipt = other_contract.send_message_to_l2(&other_l1_handler.clone()).await;
     assert!(other_receipt.status());
     let other_block_number = other_receipt.block_number.unwrap();
 


### PR DESCRIPTION
Alloy can now auto-bump nonce automatically when using Anvil, via
`AnvilBaseLayer`.
Next commit will remove nonce tracking from starknet_api_test_utils.rs