### PR TITLE
l1: move send_messages_to_l2 util into `AnvilBaseLayer`

### DIFF
--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -191,7 +191,7 @@ impl FlowTestSetup {
 
     pub async fn send_messages_to_l2(&self, l1_handlers: &[L1HandlerTransaction]) {
         for l1_handler in l1_handlers {
-            self.anvil_base_layer.ethereum_base_layer.contract.send_message_to_l2(l1_handler).await;
+            self.anvil_base_layer.send_message_to_l2(l1_handler).await;
         }
     }
 }

--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -658,7 +658,7 @@ impl IntegrationTestManager {
         let send_l1_handler_tx_fn = &mut |l1_handler_tx| {
             send_message_to_l2_and_calculate_tx_hash(
                 l1_handler_tx,
-                &self.anvil_base_layer.ethereum_base_layer.contract,
+                &self.anvil_base_layer,
                 &chain_id,
             )
         };

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -53,10 +53,8 @@ use blockifier::context::ChainInfo;
 use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
 use blockifier_test_utils::contracts::FeatureContract;
 use mempool_test_utils::starknet_api_test_utils::{AccountId, MultiAccountTransactionGenerator};
-use papyrus_base_layer::ethereum_base_layer_contract::{
-    EthereumBaseLayerConfig,
-    StarknetL1Contract,
-};
+use papyrus_base_layer::anvil_base_layer::AnvilBaseLayer;
+use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerConfig;
 use serde::Deserialize;
 use serde_json::{json, to_value};
 use starknet_api::block::BlockNumber;
@@ -475,10 +473,10 @@ pub fn create_l1_to_l2_messages_args(
 
 pub async fn send_message_to_l2_and_calculate_tx_hash(
     l1_handler: L1HandlerTransaction,
-    starknet_l1_contract: &StarknetL1Contract,
+    anvil_base_layer: &AnvilBaseLayer,
     chain_id: &ChainId,
 ) -> TransactionHash {
-    starknet_l1_contract.send_message_to_l2(&l1_handler).await;
+    anvil_base_layer.send_message_to_l2(&l1_handler).await;
     l1_handler.calculate_transaction_hash(chain_id, &l1_handler.version).unwrap()
 }
 

--- a/crates/apollo_l1_provider/tests/scraper_end_to_end.rs
+++ b/crates/apollo_l1_provider/tests/scraper_end_to_end.rs
@@ -146,7 +146,7 @@ async fn scraper_end_to_end() {
     let mut scraper = L1Scraper::new(
         l1_scraper_config,
         Arc::new(l1_provider_client),
-        base_layer.clone(),
+        base_layer.ethereum_base_layer.clone(),
         event_identifiers_to_track(),
         l1_start_block,
     )

--- a/crates/papyrus_base_layer/src/anvil_base_layer.rs
+++ b/crates/papyrus_base_layer/src/anvil_base_layer.rs
@@ -1,10 +1,13 @@
 use std::ops::RangeInclusive;
 
 use alloy::node_bindings::NodeError as AnvilError;
+use alloy::primitives::U256;
 use alloy::providers::{DynProvider, Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use colored::*;
 use starknet_api::block::BlockHashAndNumber;
+use starknet_api::transaction::L1HandlerTransaction;
 use url::Url;
 
 use crate::ethereum_base_layer_contract::{
@@ -12,6 +15,7 @@ use crate::ethereum_base_layer_contract::{
     EthereumBaseLayerContract,
     EthereumBaseLayerError,
     Starknet,
+    StarknetL1Contract,
 };
 use crate::{BaseLayerContract, L1BlockHeader, L1BlockNumber, L1BlockReference, L1Event};
 
@@ -22,7 +26,7 @@ use crate::{BaseLayerContract, L1BlockHeader, L1BlockNumber, L1BlockReference, L
 /// unit tests is not supported and is discouraged, since unit tests should not need to run a whole
 /// L1 (and they are parallelized, which creates port issues). For unit tests, prefer using
 /// `ProviderBuilder::new().on_mocked_client` to mock L1.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct AnvilBaseLayer {
     pub anvil_provider: DynProvider,
     pub ethereum_base_layer: EthereumBaseLayerContract,
@@ -64,6 +68,13 @@ impl AnvilBaseLayer {
             anvil_provider: anvil_client.erased(),
             ethereum_base_layer: EthereumBaseLayerContract { config, contract },
         }
+    }
+
+    pub async fn send_message_to_l2(
+        &self,
+        l1_handler: &L1HandlerTransaction,
+    ) -> TransactionReceipt {
+        send_message_to_l2(&self.ethereum_base_layer.contract, l1_handler).await
     }
 
     pub fn config() -> EthereumBaseLayerConfig {
@@ -134,4 +145,33 @@ impl BaseLayerContract for AnvilBaseLayer {
     async fn set_provider_url(&mut self, _url: Url) -> Result<(), Self::Error> {
         unimplemented!("Anvil base layer is tied to a an Anvil server, url is fixed.")
     }
+}
+
+/// Converts a given [L1 handler transaction](starknet_api::transaction::L1HandlerTransaction)
+/// to match the interface of the given [starknet l1 contract](StarknetL1Contract), and
+/// triggers the L1 entry point, which sends the message to L2.
+pub async fn send_message_to_l2(
+    starknet_core_contract: &StarknetL1Contract,
+    l1_handler: &L1HandlerTransaction,
+) -> TransactionReceipt {
+    const PAID_FEE_ON_L1: U256 = U256::from_be_slice(b"paid"); // Arbitrary value.
+
+    let l2_contract_address = l1_handler.contract_address.0.key().to_hex_string().parse().unwrap();
+    let l2_entry_point = l1_handler.entry_point_selector.0.to_hex_string().parse().unwrap();
+
+    // The calldata of an L1 handler transaction consists of the L1 sender address followed by
+    // the transaction payload. We remove the sender address to extract the message
+    // payload.
+    let payload =
+        l1_handler.calldata.0[1..].iter().map(|x| x.to_hex_string().parse().unwrap()).collect();
+    let msg = starknet_core_contract.sendMessageToL2(l2_contract_address, l2_entry_point, payload);
+
+    msg
+        // Sets a non-zero fee to be paid on L1.
+        .value(PAID_FEE_ON_L1)
+        // Sends the transaction to the Starknet L1 contract. For debugging purposes, replace
+        // `.send()` with `.call_raw()` to retrieve detailed error messages from L1.
+        .send().await.expect("Transaction submission to Starknet L1 contract failed.")
+        // Waits until the transaction is received on L1 and then fetches its receipt.
+        .get_receipt().await.expect("Transaction was not received on L1 or receipt retrieval failed.")
 }

--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -10,7 +10,7 @@ use starknet_api::core::EntryPointSelector;
 use starknet_api::transaction::L1HandlerTransaction;
 use starknet_api::{calldata, contract_address, felt};
 
-use crate::anvil_base_layer::AnvilBaseLayer;
+use crate::anvil_base_layer::{send_message_to_l2, AnvilBaseLayer};
 use crate::constants::{EventIdentifier, LOG_MESSAGE_TO_L2_EVENT_IDENTIFIER};
 use crate::ethereum_base_layer_contract::{
     EthereumBaseLayerConfig,
@@ -142,7 +142,7 @@ async fn events_from_other_contract() {
         calldata: calldata!(DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS, felt!("0x1"), felt!("0x2")),
         ..Default::default()
     };
-    let this_receipt = this_contract.send_message_to_l2(&this_l1_handler.clone()).await;
+    let this_receipt = send_message_to_l2(this_contract, &this_l1_handler.clone()).await;
     assert!(this_receipt.status());
     let this_block_number = this_receipt.block_number.unwrap();
 
@@ -152,7 +152,7 @@ async fn events_from_other_contract() {
         calldata: calldata!(DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS, felt!("0x1"), felt!("0x2")),
         ..Default::default()
     };
-    let other_receipt = other_contract.send_message_to_l2(&other_l1_handler.clone()).await;
+    let other_receipt = send_message_to_l2(&other_contract, &other_l1_handler.clone()).await;
     assert!(other_receipt.status());
     let other_block_number = other_receipt.block_number.unwrap();
 

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -43,40 +43,6 @@ sol!(
 /// L2 from this contract, which appear on the corresponding base layer.
 pub type StarknetL1Contract = Starknet::StarknetInstance<(), RootProvider>;
 
-#[cfg(any(feature = "testing", test))]
-impl StarknetL1Contract {
-    /// Converts a given [L1 handler transaction](starknet_api::transaction::L1HandlerTransaction)
-    /// to match the interface of the given [starknet l1 contract](StarknetL1Contract), and
-    /// triggers the L1 entry point which sends the message to L2.
-    pub async fn send_message_to_l2(
-        &self,
-        l1_handler: &starknet_api::transaction::L1HandlerTransaction,
-    ) -> alloy::rpc::types::TransactionReceipt {
-        use alloy::primitives::U256;
-        const PAID_FEE_ON_L1: U256 = U256::from_be_slice(b"paid"); // Arbitrary value.
-
-        let l2_contract_address =
-            l1_handler.contract_address.0.key().to_hex_string().parse().unwrap();
-        let l2_entry_point = l1_handler.entry_point_selector.0.to_hex_string().parse().unwrap();
-
-        // The calldata of an L1 handler transaction consists of the L1 sender address followed by
-        // the transaction payload. We remove the sender address to extract the message
-        // payload.
-        let payload =
-            l1_handler.calldata.0[1..].iter().map(|x| x.to_hex_string().parse().unwrap()).collect();
-        let msg = self.sendMessageToL2(l2_contract_address, l2_entry_point, payload);
-
-        msg
-            // Sets a non-zero fee to be paid on L1.
-            .value(PAID_FEE_ON_L1)
-            // Sends the transaction to the Starknet L1 contract. For debugging purposes, replace
-            // `.send()` with `.call_raw()` to retrieve detailed error messages from L1.
-            .send().await.expect("Transaction submission to Starknet L1 contract failed.")
-            // Waits until the transaction is received on L1 and then fetches its receipt.
-            .get_receipt().await.expect("Transaction was not received on L1 or receipt retrieval failed.")
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct EthereumBaseLayerContract {
     pub config: EthereumBaseLayerConfig,


### PR DESCRIPTION
Encodes an `L1HandlerTransaction` so that it can be sent to L1.
Move into a method on `AnvilBaseLayer` for most cases, instead of adding
a method to the auto-generated `Starknet` solidity contract.
Using a free function to allow calling this function on multiple
Starknet contracts (as is the case on sepolia with legacy contracts).