### PR TITLE
Make `get_call_result` pub

### DIFF
--- a/crates/blockifier/src/execution/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/entry_point_execution.rs
@@ -485,7 +485,7 @@ pub fn finalize_execution(
     })
 }
 
-fn get_call_result(
+pub fn get_call_result(
     runner: &CairoRunner,
     syscall_handler: &SyscallHintProcessor<'_>,
     tracked_resource: &TrackedResource,


### PR DESCRIPTION
We are using it in starknet foundry and had to copy it because the function is not public.