### PR TITLE
apollo_state_sync: if get_block_hash fails on block not found, try asking feeder directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,6 +2078,7 @@ version = "0.15.0-rc.2"
 dependencies = [
  "apollo_infra",
  "apollo_proc_macros",
+ "apollo_starknet_client",
  "apollo_storage",
  "async-trait",
  "futures",

--- a/crates/apollo_state_sync/src/lib.rs
+++ b/crates/apollo_state_sync/src/lib.rs
@@ -44,7 +44,7 @@ pub fn create_state_sync_and_runner(
 pub struct StateSync {
     storage_reader: StorageReader,
     new_block_sender: Sender<SyncBlock>,
-    _starknet_client: Option<Box<dyn StarknetReader + Send>>,
+    starknet_client: Option<Box<dyn StarknetReader + Send + Sync>>,
 }
 
 impl StateSync {
@@ -55,7 +55,7 @@ impl StateSync {
     ) -> Self {
         let starknet_client = config.central_sync_client_config.map(|config| {
             let config = config.central_source_config;
-            let starknet_client: Box<dyn StarknetReader + Send> = Box::new(
+            let starknet_client: Box<dyn StarknetReader + Send + Sync> = Box::new(
                 StarknetFeederGatewayClient::new(
                     config.starknet_url.as_ref(),
                     config.http_headers,
@@ -68,7 +68,7 @@ impl StateSync {
             );
             starknet_client
         });
-        Self { storage_reader, new_block_sender, _starknet_client: starknet_client }
+        Self { storage_reader, new_block_sender, starknet_client }
     }
 }
 
@@ -82,7 +82,7 @@ impl ComponentRequestHandler<StateSyncRequest, StateSyncResponse> for StateSync 
                 StateSyncResponse::GetBlock(self.get_block(block_number).map(Box::new))
             }
             StateSyncRequest::GetBlockHash(block_number) => {
-                StateSyncResponse::GetBlockHash(self.get_block_hash(block_number))
+                StateSyncResponse::GetBlockHash(self.get_block_hash(block_number).await)
             }
             StateSyncRequest::AddNewBlock(sync_block) => StateSyncResponse::AddNewBlock(
                 self.new_block_sender.send(*sync_block).await.map_err(StateSyncError::from),
@@ -149,10 +149,21 @@ impl StateSync {
         })
     }
 
-    fn get_block_hash(&self, block_number: BlockNumber) -> StateSyncResult<BlockHash> {
+    async fn get_block_hash(&self, block_number: BlockNumber) -> StateSyncResult<BlockHash> {
         // Getting the next block because the Sync block only contains parent hash.
-        let block = self.get_block(block_number.unchecked_next())?;
-        Ok(block.block_header_without_hash.parent_hash)
+        match (self.get_block(block_number.unchecked_next()), self.starknet_client.as_ref()) {
+            (Ok(block), _) => Ok(block.block_header_without_hash.parent_hash),
+            (Err(StateSyncError::BlockNotFound(_)), Some(starknet_client)) => {
+                // As a fallback, try to get the block hash through the feeder directly. This
+                // method is faster than get_block which the sync runner uses.
+                // TODO(shahak): Test this flow.
+                starknet_client
+                    .block_hash(block_number)
+                    .await?
+                    .ok_or(StateSyncError::BlockNotFound(block_number))
+            }
+            (Err(err), _) => Err(err),
+        }
     }
 
     fn get_storage_at(

--- a/crates/apollo_state_sync/src/test.rs
+++ b/crates/apollo_state_sync/src/test.rs
@@ -21,7 +21,7 @@ use crate::StateSync;
 fn setup() -> (StateSync, StorageWriter) {
     let ((storage_reader, storage_writer), _) = get_test_storage();
     let state_sync =
-        StateSync { storage_reader, new_block_sender: channel(0).0, _starknet_client: None };
+        StateSync { storage_reader, new_block_sender: channel(0).0, starknet_client: None };
     (state_sync, storage_writer)
 }
 

--- a/crates/apollo_state_sync_types/Cargo.toml
+++ b/crates/apollo_state_sync_types/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 apollo_infra.workspace = true
 apollo_proc_macros.workspace = true
+apollo_starknet_client.workspace = true
 apollo_storage.workspace = true
 async-trait.workspace = true
 futures.workspace = true

--- a/crates/apollo_state_sync_types/src/errors.rs
+++ b/crates/apollo_state_sync_types/src/errors.rs
@@ -1,3 +1,4 @@
+use apollo_starknet_client::reader::ReaderClientError;
 use apollo_storage::StorageError;
 use futures::channel::mpsc::SendError;
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,8 @@ pub enum StateSyncError {
     StarknetApiError(String),
     #[error("State is empty, latest block returned None")]
     EmptyState,
+    #[error("Error while trying to communicate with feeder gateway: {0}")]
+    ReaderClientError(String),
 }
 
 impl From<StorageError> for StateSyncError {
@@ -45,5 +48,11 @@ impl From<StarknetApiError> for StateSyncError {
 impl From<SendError> for StateSyncError {
     fn from(error: SendError) -> Self {
         StateSyncError::SendError(error.to_string())
+    }
+}
+
+impl From<ReaderClientError> for StateSyncError {
+    fn from(error: ReaderClientError) -> Self {
+        StateSyncError::ReaderClientError(error.to_string())
     }
 }


### PR DESCRIPTION
- **apollo_starknet_client: add methods based on onlyHeader=true**
- **apollo_state_sync: add starknet client to server**
- **apollo_state_sync: cherrypick #8089 from main (with conflicts)**
- **apollo_state_sync: cherrypick #8089 from main**
- **apollo_state_sync: if get_block_hash fails on block not found, try asking feeder directly**
