### PR TITLE
apollo_integration_tests: Add todo to remove txs collector logic when flow tests are stable enough.

### DIFF
--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -137,6 +137,7 @@ impl FlowTestSetup {
         )
         .await;
 
+        // TODO(Itamar): Remove txs collector logic when flow tests are stable enough.
         // Spawn a thread that listens to proposals and collects batched transactions.
         let accumulated_txs = Arc::new(Mutex::new(AccumulatedTransactions::default()));
         let tx_collector_task = TxCollector {


### PR DESCRIPTION
Continue of: https://github.com/starkware-libs/sequencer/pull/8217
We stopped using TxCollector logic for flow tests, so now we are no longer listening to streamed txs.
But the code is still very efficient for debugging, so we will keep it until the tests are more stabilized.