### PR TITLE
blockifier_reexecution: add block 1,600,000 to CI reexecution set

### DIFF
--- a/crates/blockifier_reexecution/block_numbers_for_reexecution.json
+++ b/crates/blockifier_reexecution/block_numbers_for_reexecution.json
@@ -9,6 +9,7 @@
     "0.13.5": 1300000,
     "first_0.13.5_rpc_v0_8": 1400000,
     "second_0.13.5_rpc_v0_8": 1450000,
+    "0.13.6_rpc_v0_8": 1600000,
     "example_invoke_with_replace_class_syscall": 780008,
     "example_invoke_with_deploy_syscall": 870136,
     "example_deploy_account_v1": 837408,

--- a/crates/blockifier_reexecution/src/state_reader/reexecution_test.rs
+++ b/crates/blockifier_reexecution/src/state_reader/reexecution_test.rs
@@ -14,6 +14,7 @@ use crate::state_reader::utils::{get_block_numbers_for_reexecution, reexecute_bl
 #[case::v_0_13_5(1300000)]
 #[case::first_v_0_13_5_rpc_v8(1400000)]
 #[case::second_v_0_13_5_rpc_v8(1450000)]
+#[case::v_0_13_6_rpc_v8(1600000)]
 #[case::invoke_with_replace_class_syscall(780008)]
 #[case::invoke_with_deploy_syscall(870136)]
 #[case::example_deploy_account_v1(837408)]


### PR DESCRIPTION
Include block 1600000 in `block_numbers_for_reexecution.json` and extend `test_block_reexecution` cases accordingly, so CI downloads and reexecutes this block offline.
