### PR TITLE
apollo_dashboard: Change idle threshold for http server to 30 minutes.

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts_mainnet.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts_mainnet.json
@@ -463,7 +463,7 @@
       "name": "http_server_no_successful_transactions",
       "title": "http server no successful transactions",
       "ruleGroup": "http_server",
-      "expr": "sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[600s])) or vector(0)",
+      "expr": "sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s])) or vector(0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts_testnet.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts_testnet.json
@@ -463,7 +463,7 @@
       "name": "http_server_no_successful_transactions",
       "title": "http server no successful transactions",
       "ruleGroup": "http_server",
-      "expr": "sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[600s])) or vector(0)",
+      "expr": "sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s])) or vector(0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/tps.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/tps.rs
@@ -47,7 +47,7 @@ pub(crate) fn get_http_server_no_successful_transactions() -> Alert {
         "http server no successful transactions",
         AlertGroup::HttpServer,
         &ADDED_TRANSACTIONS_SUCCESS.get_name_with_filter(),
-        Duration::from_secs(10 * SECS_IN_MIN),
+        Duration::from_secs(30 * SECS_IN_MIN),
     )
 }
 


### PR DESCRIPTION
We do this since it can trigger by uneven loadbalancing which can trigger false alerts.