### PR TITLE
papyrus_base_layer: don't panic when ensure_operational fails

### DIFF
--- a/crates/papyrus_base_layer/src/monitored_base_layer.rs
+++ b/crates/papyrus_base_layer/src/monitored_base_layer.rs
@@ -39,7 +39,7 @@ impl<B: BaseLayerContract + Send + Sync> MonitoredBaseLayer<B> {
 
     /// Returns a guard to the inner base layer, wrapped in order to hide the inner Mutex type.
     async fn get(&self) -> Result<BaseLayerGuard<'_, B>, MonitoredBaseLayerError<B>> {
-        self.ensure_operational().await.unwrap();
+        self.ensure_operational().await?;
         Ok(BaseLayerGuard { inner: self.base_layer.lock().await })
     }
 


### PR DESCRIPTION
For example: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22starknet-testnet-apollo-3%22%0Aresource.labels.namespace_name%3D~%22apollo-sepolia-alpha-3%22%0Aresource.labels.container_name%3D~%22sequencer-%22%0ANOT%20resource.labels.container_name%3D%22sequencer-mempool%22%0ANOT%20resource.labels.container_name%3D%22sequencer-gateway%22%0ANOT%20resource.labels.container_name%3D%22sequencer-httpserver%22%0A;pinnedLogId=2025-08-18T14:15:14.050193740Z%2Fozq7c0jb8nvrp1ur;summaryFields=resource%252Flabels%252Fpod_name:false:32:beginning;cursorTimestamp=2025-08-18T14:14:07.996117911Z;startTime=2025-08-18T14:13:38.171Z;endTime=2025-08-18T14:18:46.797Z?inv=1&invt=Ab546A&authuser=1&rapt=AEjHL4NVnqPTB9Kjn2lAPU4LbUotooQiKbmJiNik0wVGo2-6mAhXLtij9fIuvL5b5qQ8M_Hqct2N8msCbMpGoDzwTTNjR6pT0QQp_cqA8Ry62PR-j_4tfak&project=starkware-starknet-testnet