### PR TITLE
apollo_l1_provider: REVERT add remove record functionality (#7888)

### DIFF
--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -189,10 +189,6 @@ impl TransactionManager {
         self.records.contains_key(&tx_hash)
     }
 
-    // The snapshot is not sorted. This is to optimize for performance. This is because the
-    // Records::remove method uses swap_remove instead of shift_remove for better performance,
-    // which can change the order of remaining elements. If sorting is needed, change
-    // Records::remove to use shift_remove instead of swap_remove.
     pub(crate) fn snapshot(&self) -> TransactionManagerSnapshot {
         let mut snapshot = TransactionManagerSnapshot::default();
 

--- a/crates/apollo_l1_provider/src/transaction_record.rs
+++ b/crates/apollo_l1_provider/src/transaction_record.rs
@@ -274,13 +274,6 @@ impl Records {
             }
         }
     }
-
-    pub fn remove(&mut self, hash: &TransactionHash) {
-        // Insertion order is not required for Records functionality, so we use `swap_remove_entry`
-        // for O(1) performance instead of `shift_remove_entry` which is O(n).
-        // The only case where the order of records might matter is for snapshot.
-        self.0.swap_remove_entry(hash);
-    }
 }
 
 impl Deref for Records {


### PR DESCRIPTION
This reverts commit 3f5c095d622d7054ff2ef5ff440b99562394d64e.