### PR TITLE
apollo_l1_provider: REVERT add consumption timelock duration to config (#7820)

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/l1_provider_config.json
+++ b/crates/apollo_deployments/resources/app_configs/l1_provider_config.json
@@ -3,7 +3,6 @@
   "l1_provider_config.bootstrap_catch_up_height_override.#is_none": true,
   "l1_provider_config.startup_sync_sleep_retry_interval_seconds": 2,
   "l1_provider_config.l1_handler_cancellation_timelock_seconds": 300,
-  "l1_provider_config.l1_handler_consumption_timelock_seconds": 300.0,
   "l1_provider_config.new_l1_handler_cooldown_seconds": 70,
   "l1_provider_config.dummy_mode": false
 }

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -201,7 +201,6 @@ pub fn create_node_config(
         provider_startup_height_override: Some(BlockNumber(1)),
         startup_sync_sleep_retry_interval_seconds: Duration::from_secs(0),
         l1_handler_cancellation_timelock_seconds: Duration::from_secs(0),
-        l1_handler_consumption_timelock_seconds: Duration::from_secs(0),
         new_l1_handler_cooldown_seconds: Duration::from_secs(0),
         ..Default::default()
     };

--- a/crates/apollo_l1_provider/src/l1_provider.rs
+++ b/crates/apollo_l1_provider/src/l1_provider.rs
@@ -472,7 +472,6 @@ impl L1ProviderBuilder {
             tx_manager: TransactionManager::new(
                 self.config.new_l1_handler_cooldown_seconds,
                 self.config.l1_handler_cancellation_timelock_seconds,
-                self.config.l1_handler_consumption_timelock_seconds,
             ),
             state: ProviderState::Bootstrap(bootstrapper),
             config: self.config,

--- a/crates/apollo_l1_provider/src/lib.rs
+++ b/crates/apollo_l1_provider/src/lib.rs
@@ -111,8 +111,6 @@ pub struct L1ProviderConfig {
     #[serde(deserialize_with = "deserialize_float_seconds_to_duration")]
     pub l1_handler_cancellation_timelock_seconds: Duration,
     #[serde(deserialize_with = "deserialize_float_seconds_to_duration")]
-    pub l1_handler_consumption_timelock_seconds: Duration,
-    #[serde(deserialize_with = "deserialize_float_seconds_to_duration")]
     pub new_l1_handler_cooldown_seconds: Duration,
     /// When true, the L1 provider operates in dummy mode.
     pub dummy_mode: bool,
@@ -125,7 +123,6 @@ impl Default for L1ProviderConfig {
             bootstrap_catch_up_height_override: None,
             startup_sync_sleep_retry_interval_seconds: Duration::from_secs(2),
             l1_handler_cancellation_timelock_seconds: Duration::from_secs(5 * 60),
-            l1_handler_consumption_timelock_seconds: Duration::from_secs(5 * 60),
             new_l1_handler_cooldown_seconds: Duration::from_secs(70),
             dummy_mode: false,
         }
@@ -138,7 +135,6 @@ impl From<L1ProviderConfig> for TransactionManagerConfig {
             new_l1_handler_tx_cooldown_secs: config.new_l1_handler_cooldown_seconds,
             l1_handler_cancellation_timelock_seconds: config
                 .l1_handler_cancellation_timelock_seconds,
-            l1_handler_consumption_timelock_seconds: config.l1_handler_consumption_timelock_seconds,
         }
     }
 }
@@ -157,13 +153,6 @@ impl SerializeConfig for L1ProviderConfig {
                 &self.l1_handler_cancellation_timelock_seconds.as_secs(),
                 "How long to allow a transaction requested for cancellation to be validated \
                  against (proposals are banned upon receiving a cancellation request).",
-                ParamPrivacyInput::Public,
-            ),
-            ser_param(
-                "l1_handler_consumption_timelock_seconds",
-                &self.l1_handler_consumption_timelock_seconds.as_secs_f64(),
-                "How long to wait after a transaction is consumed on L1 before it can be cleared \
-                 from the transaction manager.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_l1_provider/src/test_utils.rs
+++ b/crates/apollo_l1_provider/src/test_utils.rs
@@ -260,7 +260,6 @@ impl L1ProviderContentBuilder {
         self.with_config(L1ProviderConfig {
             new_l1_handler_cooldown_seconds: nonzero_timelock,
             l1_handler_cancellation_timelock_seconds: nonzero_timelock,
-            l1_handler_consumption_timelock_seconds: nonzero_timelock,
             ..config
         })
     }

--- a/crates/apollo_l1_provider/src/transaction_manager.rs
+++ b/crates/apollo_l1_provider/src/transaction_manager.rs
@@ -42,13 +42,11 @@ impl TransactionManager {
     pub fn new(
         new_l1_handler_tx_cooldown_secs: Duration,
         l1_handler_cancellation_timelock_seconds: Duration,
-        l1_handler_consumption_timelock_seconds: Duration,
     ) -> Self {
         Self {
             config: TransactionManagerConfig {
                 new_l1_handler_tx_cooldown_secs,
                 l1_handler_cancellation_timelock_seconds,
-                l1_handler_consumption_timelock_seconds,
             },
             records: Default::default(),
             proposable_index: Default::default(),
@@ -290,7 +288,7 @@ impl Default for TransactionManager {
     // Note that new will init the epoch at 1, not 0, this is because a 0 epoch in the transaction
     // manager will make new transactions automatically staged by default in the first block.
     fn default() -> Self {
-        Self::new(Duration::from_secs(0), Duration::from_secs(0), Duration::from_secs(0))
+        Self::new(Duration::from_secs(0), Duration::from_secs(0))
     }
 }
 #[derive(Debug, Default)]
@@ -373,10 +371,4 @@ pub struct TransactionManagerConfig {
     /// How long to allow a transaction requested for cancellation to be validated against
     /// (proposals are banned upon receiving a cancellation request).
     pub l1_handler_cancellation_timelock_seconds: Duration,
-    /// How long to wait before allowing a transaction that was consumed on L1 to be removed from
-    /// the transaction managers records.
-    // The motivation behind this timelock is to make debugging easier and to be more careful
-    // about permanently deleting information.
-    // This only delays a cleanup action, so the duration of the timelock wouldn't affect the UX.
-    pub l1_handler_consumption_timelock_seconds: Duration,
 }

--- a/crates/apollo_l1_provider/tests/end_to_end.rs
+++ b/crates/apollo_l1_provider/tests/end_to_end.rs
@@ -51,11 +51,9 @@ async fn timing_flows() {
 
     let cancellation_timelock = 2;
     let new_message_cooldown = 1;
-    let consumption_timelock = 1;
     let mut l1_provider = L1ProviderBuilder::new(
         L1ProviderConfig {
             l1_handler_cancellation_timelock_seconds: Duration::from_secs(cancellation_timelock),
-            l1_handler_consumption_timelock_seconds: Duration::from_secs(consumption_timelock),
             new_l1_handler_cooldown_seconds: Duration::from_secs(new_message_cooldown),
             ..Default::default()
         },

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -1829,11 +1829,6 @@
     "privacy": "Public",
     "value": 300
   },
-  "l1_provider_config.l1_handler_consumption_timelock_seconds": {
-    "description": "How long to wait after a transaction is consumed on L1 before it can be cleared from the transaction manager.",
-    "privacy": "Public",
-    "value": 300.0
-  },
   "l1_provider_config.new_l1_handler_cooldown_seconds": {
     "description": "How long to wait before allowing new L1 handler transactions to be proposed (validation is available immediately), from the moment they are scraped.",
     "privacy": "Public",


### PR DESCRIPTION
This reverts commit ac80273fa291267f66d4508372c9edcb30ab5517.