### PR TITLE
apollo_l1_provider: REVERT add mark_consumed to TransactionRecord (#7819)

### DIFF
--- a/crates/apollo_l1_provider/src/l1_provider_tests.rs
+++ b/crates/apollo_l1_provider/src/l1_provider_tests.rs
@@ -125,7 +125,6 @@ fn validate_happy_flow() {
     let mut l1_provider = L1ProviderContentBuilder::new()
         .with_txs([l1_handler(1)])
         .with_committed([l1_handler(2)])
-        .with_consumed([l1_handler(3)])
         .with_state(ProviderState::Validate)
         .build_into_l1_provider();
 
@@ -137,11 +136,6 @@ fn validate_happy_flow() {
     assert_eq!(
         l1_provider.validate(tx_hash!(2), BlockNumber(0)).unwrap(),
         ValidationStatus::Invalid(InvalidValidationStatus::AlreadyIncludedOnL2)
-    );
-    // Transaction was consumed on L1.
-    assert_eq!(
-        l1_provider.validate(tx_hash!(3), BlockNumber(0)).unwrap(),
-        ValidationStatus::Invalid(InvalidValidationStatus::ConsumedOnL1)
     );
     // Transaction wasn't deleted after the validation.
     assert_eq!(


### PR DESCRIPTION
This reverts commit eedef0f7020a78f93c7833498bfe6894296eda6a.