### PR TITLE
apollo_l1_provider: REVERT add timestamp to TransactionConsumed events (#7754)

### DIFF
--- a/crates/apollo_l1_provider_types/src/lib.rs
+++ b/crates/apollo_l1_provider_types/src/lib.rs
@@ -251,10 +251,7 @@ pub enum Event {
         tx_hash: TransactionHash,
         cancellation_request_timestamp: BlockTimestamp,
     },
-    TransactionConsumed {
-        tx_hash: TransactionHash,
-        timestamp: BlockTimestamp,
-    },
+    TransactionConsumed(TransactionHash),
 }
 
 impl Event {
@@ -278,12 +275,12 @@ impl Event {
                 Self::TransactionCancellationStarted { tx_hash, cancellation_request_timestamp }
             }
             L1Event::MessageToL2Canceled(event_data) => Self::TransactionCanceled(event_data),
-            L1Event::ConsumedMessageToL2 { tx, timestamp } => {
+            L1Event::ConsumedMessageToL2(tx) => {
                 let tx_hash = tx.calculate_transaction_hash(
                     chain_id,
                     &starknet_api::transaction::L1HandlerTransaction::VERSION,
                 )?;
-                Self::TransactionConsumed { tx_hash, timestamp }
+                Self::TransactionConsumed(tx_hash)
             }
         })
     }
@@ -312,9 +309,7 @@ impl Display for Event {
                     tx_hash, cancellation_request_timestamp
                 )
             }
-            Event::TransactionConsumed { tx_hash, timestamp } => {
-                write!(f, "TransactionConsumed(tx_hash={}, block_timestamp={})", tx_hash, timestamp)
-            }
+            Event::TransactionConsumed(data) => write!(f, "TransactionConsumed({})", data),
         }
     }
 }

--- a/crates/papyrus_base_layer/src/eth_events.rs
+++ b/crates/papyrus_base_layer/src/eth_events.rs
@@ -34,7 +34,7 @@ pub fn parse_event(log: Log, block_timestamp: BlockTimestamp) -> EthereumBaseLay
         Starknet::StarknetEvents::ConsumedMessageToL2(event) => {
             let event_data = EventData::try_from(event)?;
             let tx = L1HandlerTransaction::from(event_data);
-            Ok(L1Event::ConsumedMessageToL2 { tx, timestamp: block_timestamp })
+            Ok(L1Event::ConsumedMessageToL2(tx))
         }
         Starknet::StarknetEvents::MessageToL2Canceled(event) => {
             Ok(L1Event::MessageToL2Canceled(event.try_into()?))

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -115,10 +115,7 @@ pub struct L1BlockHeader {
 /// Wraps Starknet L1 events with Starknet API types.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum L1Event {
-    ConsumedMessageToL2 {
-        tx: L1HandlerTransaction,
-        timestamp: BlockTimestamp,
-    },
+    ConsumedMessageToL2(L1HandlerTransaction),
     // TODO(Arni): Consider adding the l1_tx_hash to all variants of L1 Event.
     LogMessageToL2 {
         tx: L1HandlerTransaction,


### PR DESCRIPTION
This reverts commit 9ebd4dae4a2c63d4f92185e17c199ebdcf041dbb.