### PR TITLE
fix: correct LICENSE file path in starknet_api README

### DIFF
--- a/docs/starknet_api/README.md
+++ b/docs/starknet_api/README.md
@@ -7,4 +7,4 @@
 ## License
 
 This project is licensed under the **Apache 2.0 license**.
-See [LICENSE](LICENSE) for more information.
+See [LICENSE](../../LICENSE) for more information.


### PR DESCRIPTION
Update the relative path to LICENSE file from 'LICENSE' to '../../LICENSE' 
in docs/starknet_api/README.md to fix the broken link that was causing 
file not found errors.

The LICENSE file is located in the project root, so the path needs to 
go up two directories from the docs/starknet_api/ location.