### PR TITLE
apollo_dashboard: state_sync dashboard improvements

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -495,26 +495,8 @@
     "State Sync": {
       "panels": [
         {
-          "title": "apollo_state_sync_processed_transactions",
-          "description": "The number of transactions processed by the state sync component since its last restart",
-          "type": "stat",
-          "exprs": [
-            "apollo_state_sync_processed_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
-          ],
-          "extra_params": {}
-        },
-        {
-          "title": "apollo_state_sync_reverted_transactions",
-          "description": "The number of transactions reverted by the state sync component",
-          "type": "stat",
-          "exprs": [
-            "apollo_state_sync_reverted_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
-          ],
-          "extra_params": {}
-        },
-        {
-          "title": "apollo_central_sync_central_block_marker",
-          "description": "The first block number that doesn't exist yet",
+          "title": "Central Block Marker",
+          "description": "The first block that Central Starknet hasn't seen yet",
           "type": "stat",
           "exprs": [
             "apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
@@ -522,40 +504,24 @@
           "extra_params": {}
         },
         {
-          "title": "apollo_state_sync_body_marker",
-          "description": "The first block number for which the state sync component does not have a body",
-          "type": "stat",
+          "title": "Sync Diff From Central",
+          "description": "The number of blocks that were not fully synced yet",
+          "type": "timeseries",
           "exprs": [
-            "apollo_state_sync_body_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
+            "apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"} - apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
           ],
           "extra_params": {}
         },
         {
-          "title": "apollo_state_sync_class_manager_marker",
-          "description": "The first block number for which the state sync component does not guarantee all of the corresponding classes are stored in the class manager component",
-          "type": "stat",
+          "title": "Sync Block Age",
+          "description": "The time from a block’s timestamp until its header is synced through the feeder-gateway.",
+          "type": "timeseries",
           "exprs": [
-            "apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
+            "apollo_state_sync_header_latency{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
           ],
-          "extra_params": {}
-        },
-        {
-          "title": "apollo_state_sync_header_marker",
-          "description": "The first block number for which the state sync component does not have a header",
-          "type": "stat",
-          "exprs": [
-            "apollo_state_sync_header_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
-          ],
-          "extra_params": {}
-        },
-        {
-          "title": "apollo_state_sync_state_marker",
-          "description": "The first block number for which the state sync component does not have a state body",
-          "type": "stat",
-          "exprs": [
-            "apollo_state_sync_state_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}"
-          ],
-          "extra_params": {}
+          "extra_params": {
+            "unit": "s"
+          }
         }
       ],
       "collapsed": true

--- a/crates/apollo_dashboard/src/panels/state_sync.rs
+++ b/crates/apollo_dashboard/src/panels/state_sync.rs
@@ -3,15 +3,11 @@ use apollo_state_sync_metrics::metrics::{
     P2P_SYNC_NUM_ACTIVE_INBOUND_SESSIONS,
     P2P_SYNC_NUM_ACTIVE_OUTBOUND_SESSIONS,
     P2P_SYNC_NUM_CONNECTED_PEERS,
-    STATE_SYNC_BODY_MARKER,
     STATE_SYNC_CLASS_MANAGER_MARKER,
-    STATE_SYNC_HEADER_MARKER,
-    STATE_SYNC_PROCESSED_TRANSACTIONS,
-    STATE_SYNC_REVERTED_TRANSACTIONS,
-    STATE_SYNC_STATE_MARKER,
+    STATE_SYNC_HEADER_LATENCY_SEC,
 };
 
-use crate::dashboard::{Panel, PanelType, Row};
+use crate::dashboard::{Panel, PanelType, Row, Unit};
 
 // P2P panels
 
@@ -27,39 +23,43 @@ fn get_panel_p2p_sync_num_active_outbound_sessions() -> Panel {
 
 // State Sync panels
 
-fn get_panel_state_sync_processed_transactions() -> Panel {
-    Panel::from_counter(&STATE_SYNC_PROCESSED_TRANSACTIONS, PanelType::Stat)
-}
-fn get_panel_state_sync_reverted_transactions() -> Panel {
-    Panel::from_counter(&STATE_SYNC_REVERTED_TRANSACTIONS, PanelType::Stat)
-}
 fn get_panel_central_sync_central_block_marker() -> Panel {
-    Panel::from_gauge(&CENTRAL_SYNC_CENTRAL_BLOCK_MARKER, PanelType::Stat)
+    Panel::new(
+        "Central Block Marker",
+        "The first block that Central Starknet hasn't seen yet",
+        vec![CENTRAL_SYNC_CENTRAL_BLOCK_MARKER.get_name_with_filter().to_string()],
+        PanelType::Stat,
+    )
 }
-fn get_panel_state_sync_body_marker() -> Panel {
-    Panel::from_gauge(&STATE_SYNC_BODY_MARKER, PanelType::Stat)
+fn get_panel_state_sync_diff_from_central() -> Panel {
+    Panel::new(
+        "Sync Diff From Central",
+        "The number of blocks that were not fully synced yet",
+        vec![format!(
+            "{} - {}",
+            CENTRAL_SYNC_CENTRAL_BLOCK_MARKER.get_name_with_filter(),
+            STATE_SYNC_CLASS_MANAGER_MARKER.get_name_with_filter()
+        )],
+        PanelType::TimeSeries,
+    )
 }
-fn get_panel_state_sync_class_manager_marker() -> Panel {
-    Panel::from_gauge(&STATE_SYNC_CLASS_MANAGER_MARKER, PanelType::Stat)
-}
-fn get_panel_state_sync_header_marker() -> Panel {
-    Panel::from_gauge(&STATE_SYNC_HEADER_MARKER, PanelType::Stat)
-}
-fn get_panel_state_sync_state_marker() -> Panel {
-    Panel::from_gauge(&STATE_SYNC_STATE_MARKER, PanelType::Stat)
+fn get_panel_state_sync_new_header_maturity() -> Panel {
+    Panel::new(
+        "Sync Block Age",
+        "The time from a block’s timestamp until its header is synced through the feeder-gateway.",
+        vec![STATE_SYNC_HEADER_LATENCY_SEC.get_name_with_filter().to_string()],
+        PanelType::TimeSeries,
+    )
+    .with_unit(Unit::Seconds)
 }
 
 pub(crate) fn get_state_sync_row() -> Row {
     Row::new(
         "State Sync",
         vec![
-            get_panel_state_sync_processed_transactions(),
-            get_panel_state_sync_reverted_transactions(),
             get_panel_central_sync_central_block_marker(),
-            get_panel_state_sync_body_marker(),
-            get_panel_state_sync_class_manager_marker(),
-            get_panel_state_sync_header_marker(),
-            get_panel_state_sync_state_marker(),
+            get_panel_state_sync_diff_from_central(),
+            get_panel_state_sync_new_header_maturity(),
         ],
     )
 }


### PR DESCRIPTION
- Add new header latency graph
- Add a new graph to show the diff from central block number
- Combine the marker graphs into one
- Rearrange the order of graphs, and change panel types when needed.