### PR TITLE
apollo_integration_tests: fix AccountTxGenerator invoke_tx to call TestContract fn (#6838)

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -523,6 +523,14 @@ async fn collect_execution_results_and_stream_txs(
 
         match result {
             Ok((tx_execution_info, state_maps)) => {
+                if let Some(ref revert_error) = tx_execution_info.revert_error {
+                    warn!(
+                        "Transaction {} is reverted during execution while still accepted. Revert \
+                         Error: {:?}",
+                        input_tx.tx_hash(),
+                        revert_error,
+                    );
+                }
                 let (tx_index, duplicate_tx_hash) =
                     execution_data.execution_infos.insert_full(tx_hash, tx_execution_info);
                 assert_eq!(duplicate_tx_hash, None, "Duplicate transaction: {tx_hash}.");
@@ -565,7 +573,7 @@ async fn collect_execution_results_and_stream_txs(
             }
             Err(err) => {
                 info!(
-                    "Transaction {} failed with error: {}.",
+                    "Transaction {} failed to execute with error: {}.",
                     tx_hash,
                     err.log_compatible_to_string()
                 );

--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -85,7 +85,7 @@ use crate::utils::{
 };
 
 pub const DEFAULT_SENDER_ACCOUNT: AccountId = 0;
-const BLOCK_MAX_CAPACITY_GAS: GasAmount = GasAmount(30000000);
+const BLOCK_MAX_CAPACITY_N_STEPS: GasAmount = GasAmount(100000000); // Capacity allows multiple transactions per block.
 pub const BLOCK_TO_WAIT_FOR_DEPLOY_AND_INVOKE: BlockNumber = BlockNumber(4);
 pub const BLOCK_TO_WAIT_FOR_DECLARE: BlockNumber =
     BlockNumber(BLOCK_TO_WAIT_FOR_DEPLOY_AND_INVOKE.0 + 10);
@@ -971,7 +971,7 @@ async fn get_sequencer_setup_configs(
                 monitoring_endpoint_config,
                 executable_component_config.clone(),
                 base_layer_config.clone(),
-                BLOCK_MAX_CAPACITY_GAS,
+                BLOCK_MAX_CAPACITY_N_STEPS,
                 validator_id,
                 ALLOW_BOOTSTRAP_TXS,
             );

--- a/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
@@ -21,7 +21,7 @@ async fn test_end_to_end_flow() {
     end_to_end_flow(
         TestIdentifier::EndToEndFlowTest,
         create_test_scenarios(),
-        GasAmount(59000000),
+        GasAmount(100000000), // Enough gas to cover all transactions in one block.
         false,
         false,
     )

--- a/crates/apollo_integration_tests/tests/test_many.rs
+++ b/crates/apollo_integration_tests/tests/test_many.rs
@@ -9,12 +9,13 @@ use crate::common::{end_to_end_flow, TestScenario};
 
 mod common;
 
+/// This test checks that at least one block is full.
 #[tokio::test]
-async fn many_txs() {
+async fn many_txs_fill_at_least_one_block() {
     end_to_end_flow(
         TestIdentifier::EndToEndFlowTestManyTxs,
         create_many_txs_scenario(),
-        GasAmount(17500000),
+        GasAmount(30000000),
         true,
         false,
     )

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -120,12 +120,13 @@ pub fn invoke_tx(cairo_version: CairoVersion) -> RpcTransaction {
     let account_contract = FeatureContract::AccountWithoutValidations(cairo_version);
     let sender_address = account_contract.get_instance_address(0);
     let mut nonce_manager = NonceManager::default();
+    let calldata = create_trivial_calldata(test_contract.get_instance_address(0));
 
     rpc_invoke_tx(invoke_tx_args!(
         resource_bounds: test_valid_resource_bounds(),
         nonce : nonce_manager.next(sender_address),
         sender_address,
-        calldata: create_trivial_calldata(test_contract.get_instance_address(0))
+        calldata,
     ))
 }
 
@@ -419,12 +420,14 @@ impl AccountTransactionGenerator {
     }
 
     pub fn generate_trivial_rpc_invoke_tx(&mut self, tip: u64) -> RpcTransaction {
-        let calldata = create_trivial_calldata(self.sender_address());
+        let test_contract = FeatureContract::TestContract(self.account.cairo_version());
+        let calldata = create_trivial_calldata(test_contract.get_instance_address(0));
         self.generate_rpc_invoke_tx(tip, calldata)
     }
 
     pub fn generate_trivial_executable_invoke_tx(&mut self) -> AccountTransaction {
-        let calldata = create_trivial_calldata(self.sender_address());
+        let test_contract = FeatureContract::TestContract(self.account.cairo_version());
+        let calldata = create_trivial_calldata(test_contract.get_instance_address(0));
         let invoke_args = self.build_invoke_tx_args(Tip::default().0, calldata);
         starknet_api::test_utils::invoke::executable_invoke_tx(invoke_args)
     }


### PR DESCRIPTION
Bug fix of invoke txs.
The invoke transactions were reverted due to wrong address of test_contract.