### PR TITLE
apollo_integration_tests: generate empty contract declare tx (#7718 part 2)

### DIFF
--- a/crates/mempool_test_utils/src/lib.rs
+++ b/crates/mempool_test_utils/src/lib.rs
@@ -4,5 +4,7 @@ pub const TEST_FILES_FOLDER: &str = "crates/mempool_test_utils/resources";
 pub const CONTRACT_CLASS_FILE: &str = "contract_class.json";
 pub const COMPILED_CLASS_HASH_OF_CONTRACT_CLASS: &str =
     "0x24d8d75cba029fa1896dd4d9424df66f8b279b058b4c6f3245b369c78c5d156";
+pub const EMPTY_CONTRACT_CAIRO1_COMPILED_CLASS_HASH: &str =
+    "0x6EE46561691E785D643A8296B9BF08008E432DF405A1A4BEB6ED784541B571C";
 // TODO(Arni): Move this file to 'apollo_sierra_multicompile' crate.
 pub const FAULTY_ACCOUNT_CLASS_FILE: &str = "faulty_account.sierra.json";


### PR DESCRIPTION
We will use the empty contract in the following PR's so we declare it now.