### PR TITLE
apollo_dashboard: change high_transaction_failure_ratio alert to p4 on mainnet

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts_mainnet.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts_mainnet.json
@@ -1145,7 +1145,7 @@
       ],
       "for": "30s",
       "intervalSec": 30,
-      "severity": "p2",
+      "severity": "p4",
       "observer_applicable": "false"
     },
     {

--- a/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
@@ -75,7 +75,7 @@ pub(crate) fn get_http_server_high_transaction_failure_ratio_vec() -> Vec<Alert>
     vec![
         get_http_server_high_transaction_failure_ratio(
             AlertEnvFiltering::MainnetStyleAlerts,
-            AlertSeverity::Regular,
+            AlertSeverity::WorkingHours,
         ),
         get_http_server_high_transaction_failure_ratio(
             AlertEnvFiltering::TestnetStyleAlerts,


### PR DESCRIPTION
Discussed with Ohad Barta.
Will have to add a procedure with a script to extract the failure details (reason and accounts).