### PR TITLE
apollo_metrics: simplify infra metrics macro call

### DIFF
--- a/crates/apollo_batcher/src/metrics.rs
+++ b/crates/apollo_batcher/src/metrics.rs
@@ -1,11 +1,4 @@
 use apollo_batcher_types::communication::BATCHER_REQUEST_LABELS;
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_metrics::{define_infra_metrics, define_metrics};
 use blockifier::metrics::{
     CALLS_RUNNING_NATIVE,

--- a/crates/apollo_class_manager/src/metrics.rs
+++ b/crates/apollo_class_manager/src/metrics.rs
@@ -1,11 +1,4 @@
 use apollo_compile_to_casm_types::SerializedClass;
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_metrics::{define_infra_metrics, define_metrics, generate_permutation_labels};
 use strum::VariantNames;
 

--- a/crates/apollo_compile_to_casm/src/metrics.rs
+++ b/crates/apollo_compile_to_casm/src/metrics.rs
@@ -1,11 +1,4 @@
 use apollo_compile_to_casm_types::SIERRA_COMPILER_REQUEST_LABELS;
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_metrics::{define_infra_metrics, define_metrics};
 
 define_infra_metrics!(sierra_compiler);

--- a/crates/apollo_config_manager/src/metrics.rs
+++ b/crates/apollo_config_manager/src/metrics.rs
@@ -1,11 +1,4 @@
 use apollo_config_manager_types::communication::CONFIG_MANAGER_REQUEST_LABELS;
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_metrics::define_infra_metrics;
 
 define_infra_metrics!(config_manager);

--- a/crates/apollo_gateway/src/metrics.rs
+++ b/crates/apollo_gateway/src/metrics.rs
@@ -1,10 +1,3 @@
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 #[cfg(test)]
 use apollo_metrics::metrics::LabeledMetricCounter;
 use apollo_metrics::{define_infra_metrics, define_metrics, generate_permutation_labels};

--- a/crates/apollo_l1_endpoint_monitor_types/src/lib.rs
+++ b/crates/apollo_l1_endpoint_monitor_types/src/lib.rs
@@ -2,13 +2,6 @@ use std::sync::Arc;
 
 use apollo_infra::component_client::ClientError;
 use apollo_infra::component_definitions::{ComponentClient, PrioritizedRequest};
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_infra::requests::LABEL_NAME_REQUEST_VARIANT;
 use apollo_infra::{impl_debug_for_infra_requests_and_responses, impl_labeled_request};
 use apollo_metrics::{define_infra_metrics, generate_permutation_labels};

--- a/crates/apollo_l1_gas_price/src/metrics.rs
+++ b/crates/apollo_l1_gas_price/src/metrics.rs
@@ -1,10 +1,3 @@
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_l1_gas_price_types::L1_GAS_PRICE_REQUEST_LABELS;
 use apollo_metrics::{define_infra_metrics, define_metrics};
 

--- a/crates/apollo_l1_provider/src/metrics.rs
+++ b/crates/apollo_l1_provider/src/metrics.rs
@@ -1,10 +1,3 @@
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_l1_provider_types::L1_PROVIDER_REQUEST_LABELS;
 use apollo_metrics::{define_infra_metrics, define_metrics};
 

--- a/crates/apollo_mempool/src/metrics.rs
+++ b/crates/apollo_mempool/src/metrics.rs
@@ -1,10 +1,3 @@
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_mempool_types::mempool_types::MEMPOOL_REQUEST_LABELS;
 use apollo_metrics::{define_infra_metrics, define_metrics, generate_permutation_labels};
 use starknet_api::rpc_transaction::{

--- a/crates/apollo_mempool_p2p/src/metrics.rs
+++ b/crates/apollo_mempool_p2p/src/metrics.rs
@@ -1,10 +1,3 @@
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_mempool_p2p_types::communication::MEMPOOL_P2P_REQUEST_LABELS;
 use apollo_metrics::{define_infra_metrics, define_metrics};
 use apollo_network::network_manager::metrics::{EVENT_TYPE_LABELS, NETWORK_BROADCAST_DROP_LABELS};

--- a/crates/apollo_metrics/src/metric_definitions.rs
+++ b/crates/apollo_metrics/src/metric_definitions.rs
@@ -184,16 +184,17 @@ macro_rules! define_infra_metrics {
                 },
             );
 
-            pub const [<$component:snake:upper _INFRA_METRICS>]: InfraMetrics = InfraMetrics::new(
-                LocalClientMetrics::new(
+            pub const [<$component:snake:upper _INFRA_METRICS>]: apollo_infra::metrics::InfraMetrics
+            = apollo_infra::metrics::InfraMetrics::new(
+                apollo_infra::metrics::LocalClientMetrics::new(
                     &[<$component:snake:upper _LABELED_LOCAL_RESPONSE_TIMES_SECS>],
                 ),
-                RemoteClientMetrics::new(
+                apollo_infra::metrics::RemoteClientMetrics::new(
                     &[<$component:snake:upper _REMOTE_CLIENT_SEND_ATTEMPTS>],
                     &[<$component:snake:upper _LABELED_REMOTE_RESPONSE_TIMES_SECS>],
                     &[<$component:snake:upper _LABELED_REMOTE_CLIENT_COMMUNICATION_FAILURE_TIMES_SECS>],
                 ),
-                LocalServerMetrics::new(
+                apollo_infra::metrics::LocalServerMetrics::new(
                     &[<$component:snake:upper _LOCAL_MSGS_RECEIVED>],
                     &[<$component:snake:upper _LOCAL_MSGS_PROCESSED>],
                     &[<$component:snake:upper _LOCAL_HIGH_PRIORITY_QUEUE_DEPTH>],
@@ -201,7 +202,7 @@ macro_rules! define_infra_metrics {
                     &[<$component:snake:upper _LABELED_PROCESSING_TIMES_SECS>],
                     &[<$component:snake:upper _LABELED_QUEUEING_TIMES_SECS>],
                 ),
-                RemoteServerMetrics::new(
+                apollo_infra::metrics::RemoteServerMetrics::new(
                     &[<$component:snake:upper _REMOTE_MSGS_RECEIVED>],
                     &[<$component:snake:upper _REMOTE_VALID_MSGS_RECEIVED>],
                     &[<$component:snake:upper _REMOTE_MSGS_PROCESSED>],

--- a/crates/apollo_signature_manager/src/metrics.rs
+++ b/crates/apollo_signature_manager/src/metrics.rs
@@ -1,10 +1,3 @@
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_metrics::define_infra_metrics;
 use apollo_signature_manager_types::SIGNATURE_MANAGER_REQUEST_LABELS;
 

--- a/crates/apollo_state_sync_metrics/Cargo.toml
+++ b/crates/apollo_state_sync_metrics/Cargo.toml
@@ -19,3 +19,7 @@ apollo_storage.workspace = true
 starknet_api.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[package.metadata.cargo-machete]
+# `apollo_infra` is used in the `define_infra_metrics!` macro but may be falsely detected as unused.
+ignored = ["apollo_infra"]

--- a/crates/apollo_state_sync_metrics/src/metrics.rs
+++ b/crates/apollo_state_sync_metrics/src/metrics.rs
@@ -1,10 +1,3 @@
-use apollo_infra::metrics::{
-    InfraMetrics,
-    LocalClientMetrics,
-    LocalServerMetrics,
-    RemoteClientMetrics,
-    RemoteServerMetrics,
-};
 use apollo_metrics::{define_infra_metrics, define_metrics};
 use apollo_state_sync_types::communication::STATE_SYNC_REQUEST_LABELS;
 use apollo_storage::body::BodyStorageReader;


### PR DESCRIPTION
The usage of the macro is more intuitive if one does not need to import stuff.