### PR TITLE
apollo_gateway: remove unnecessary todos (#9064)

### DIFF
--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -20,7 +20,7 @@ use apollo_gateway_types::gateway_types::{
 };
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_mempool_types::communication::{AddTransactionArgsWrapper, SharedMempoolClient};
-use apollo_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
+use apollo_mempool_types::mempool_types::AddTransactionArgs;
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
 use apollo_proc_macros::sequencer_latency_histogram;
 use apollo_state_sync_types::communication::SharedStateSyncClient;
@@ -198,8 +198,6 @@ impl ProcessTxBlockingTask {
     // TODO(Arni): Make into async function and remove all block_on calls once we manage removing
     // the spawn_blocking call.
     fn process_tx(self) -> GatewayResult<AddTransactionArgs> {
-        // TODO(Arni, 1/5/2024): Perform congestion control.
-
         // Perform stateless validations.
         self.stateless_tx_validator.validate(&self.tx)?;
 
@@ -236,11 +234,7 @@ impl ProcessTxBlockingTask {
             self.runtime,
         )?;
 
-        // TODO(Arni): Add the Sierra and the Casm to the mempool input.
-        Ok(AddTransactionArgs {
-            tx: internal_tx,
-            account_state: AccountState { address: executable_tx.contract_address(), nonce },
-        })
+        Ok(AddTransactionArgs::new(internal_tx, nonce))
     }
 }
 

--- a/crates/apollo_mempool_types/src/mempool_types.rs
+++ b/crates/apollo_mempool_types/src/mempool_types.rs
@@ -32,6 +32,13 @@ pub struct AddTransactionArgs {
     pub account_state: AccountState,
 }
 
+impl AddTransactionArgs {
+    pub fn new(tx: InternalRpcTransaction, nonce: Nonce) -> Self {
+        let address = tx.contract_address();
+        Self { tx, account_state: AccountState { address, nonce } }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CommitBlockArgs {
     pub address_to_nonce: HashMap<ContractAddress, Nonce>,


### PR DESCRIPTION
cherry-pick from `main`.
Merge pull request #9064 from starkware-libs/arni/gateway/remove_unecessary_todos

apollo_gateway: remove unnecessary todos