### PR TITLE
apollo_batcher: batcher does not panic on l1 provider failures

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -63,6 +63,7 @@ use crate::metrics::{
     register_metrics,
     ProposalMetricsHandle,
     BATCHED_TRANSACTIONS,
+    BATCHER_L1_PROVIDER_ERRORS,
     LAST_BATCHED_BLOCK_HEIGHT,
     LAST_PROPOSED_BLOCK_HEIGHT,
     LAST_SYNCED_BLOCK_HEIGHT,
@@ -220,16 +221,19 @@ impl Batcher {
                 error!("Failed to update gas price in mempool: {}", err);
                 BatcherError::InternalError
             })?;
-        self.l1_provider_client
+        // Ignore errors. If start_block fails, then subsequent calls to l1 provider will fail on
+        // out of session and l1 provider will restart and bootstrap again.
+        let _ = self
+            .l1_provider_client
             .start_block(SessionState::Propose, propose_block_input.block_info.block_number)
             .await
-            .map_err(|err| {
+            .inspect_err(|err| {
                 error!(
                     "L1 provider is not ready to start proposing block {}: {}. ",
                     propose_block_input.block_info.block_number, err
                 );
-                BatcherError::NotReady
-            })?;
+                BATCHER_L1_PROVIDER_ERRORS.increment(1);
+            });
 
         let tx_provider = ProposeTransactionProvider::new(
             self.mempool_client.clone(),
@@ -305,16 +309,19 @@ impl Batcher {
             validate_block_input.retrospective_block_hash,
         )?;
 
-        self.l1_provider_client
+        // Ignore errors. If start_block fails, then subsequent calls to l1 provider will fail on
+        // out of session and l1 provider will restart and bootstrap again.
+        let _ = self
+            .l1_provider_client
             .start_block(SessionState::Validate, validate_block_input.block_info.block_number)
             .await
-            .map_err(|err| {
+            .inspect_err(|err| {
                 error!(
                     "L1 provider is not ready to start validating block {}: {}. ",
                     validate_block_input.block_info.block_number, err
                 );
-                BatcherError::NotReady
-            })?;
+                BATCHER_L1_PROVIDER_ERRORS.increment(1);
+            });
 
         // A channel to send the transactions to include in the block being validated.
         let (input_tx_sender, input_tx_receiver) =
@@ -678,9 +685,7 @@ impl Batcher {
                     );
                 }
             }
-            // Rollback the state diff in the storage.
-            self.storage_writer.revert_block(height);
-            return Err(BatcherError::InternalError);
+            BATCHER_L1_PROVIDER_ERRORS.increment(1);
         }
 
         // Notify the mempool of the new block.

--- a/crates/apollo_batcher/src/metrics.rs
+++ b/crates/apollo_batcher/src/metrics.rs
@@ -43,6 +43,7 @@ define_metrics!(
         MetricCounter { REVERTED_TRANSACTIONS, "batcher_reverted_transactions", "Counter of reverted transactions across all forks", init = 0 },
         MetricCounter { SYNCED_TRANSACTIONS, "batcher_synced_transactions", "Counter of synced transactions", init = 0 },
 
+        MetricCounter { BATCHER_L1_PROVIDER_ERRORS, "batcher_l1_provider_errors", "Counter of L1 provider errors", init = 0 },
         MetricCounter { PRECONFIRMED_BLOCK_WRITTEN, "batcher_preconfirmed_block_written", "Counter of preconfirmed blocks written to storage", init = 0 },
         // Block close reason
         LabeledMetricCounter { BLOCK_CLOSE_REASON, "batcher_block_close_reason", "Number of blocks closed by reason", init = 0 , labels = BLOCK_CLOSE_REASON_LABELS},
@@ -83,6 +84,7 @@ pub fn register_metrics(storage_height: BlockNumber) {
     REVERTED_TRANSACTIONS.register();
     SYNCED_TRANSACTIONS.register();
 
+    BATCHER_L1_PROVIDER_ERRORS.register();
     PRECONFIRMED_BLOCK_WRITTEN.register();
     BLOCK_CLOSE_REASON.register();
 

--- a/crates/apollo_l1_provider_types/src/lib.rs
+++ b/crates/apollo_l1_provider_types/src/lib.rs
@@ -54,6 +54,7 @@ pub enum InvalidValidationStatus {
     ConsumedOnL1,
     // This tx is either never been seen or was seen, consumed, and deleted.
     NotFound,
+    L1ProviderError,
 }
 
 #[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]


### PR DESCRIPTION
- **apollo_l1_provider: validate_height panics instead of returning error to caller**
- **fix CI**
- **apollo_batcher: batcher does not panic on l1 provider failures**
