### PR TITLE
apollo_integration_tests: add cairo 0 flow test

### DIFF
--- a/crates/apollo_infra_utils/src/test_utils.rs
+++ b/crates/apollo_infra_utils/src/test_utils.rs
@@ -8,7 +8,7 @@ use tracing::{info, instrument};
 
 const PORTS_PER_INSTANCE: u16 = 60;
 pub const MAX_NUMBER_OF_INSTANCES_PER_TEST: u16 = 28;
-const MAX_NUMBER_OF_TESTS: u16 = 10;
+const MAX_NUMBER_OF_TESTS: u16 = 11;
 const BASE_PORT: u16 = 11000;
 
 // Ensure available ports don't exceed u16::MAX.
@@ -28,6 +28,7 @@ pub enum TestIdentifier {
     EndToEndFlowTestBootstrapDeclare,
     EndToEndFlowTestManyTxs,
     EndToEndFlowTestCustomSyscallInvokeTxs,
+    EndToEndFlowTestCustomCairo0Txs,
     InfraUnitTests,
     PositiveFlowIntegrationTest,
     RestartFlowIntegrationTest,

--- a/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
+++ b/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
@@ -1,0 +1,81 @@
+use apollo_infra_utils::test_utils::TestIdentifier;
+use apollo_integration_tests::utils::ACCOUNT_ID_1 as CAIRO0_ACCOUNT_ID;
+use blockifier_test_utils::cairo_versions::CairoVersion;
+use blockifier_test_utils::calldata::create_calldata;
+use blockifier_test_utils::contracts::FeatureContract;
+use mempool_test_utils::starknet_api_test_utils::{
+    AccountTransactionGenerator,
+    MultiAccountTransactionGenerator,
+};
+use starknet_api::execution_resources::GasAmount;
+use starknet_api::felt;
+use starknet_api::rpc_transaction::RpcTransaction;
+
+use crate::common::{end_to_end_flow, validate_tx_count, TestScenario};
+
+mod common;
+
+const DEFAULT_TIP: u64 = 1_u64;
+const CUSTOM_CAIRO_0_INVOKE_TX_COUNT: usize = 3;
+
+#[tokio::test]
+async fn custom_cairo0_txs() {
+    end_to_end_flow(
+        TestIdentifier::EndToEndFlowTestCustomCairo0Txs,
+        create_custom_cairo0_txs_scenario(),
+        GasAmount(110000000),
+        false,
+        false,
+    )
+    .await
+}
+
+fn create_custom_cairo0_txs_scenario() -> Vec<TestScenario> {
+    vec![TestScenario {
+        create_rpc_txs_fn: create_cairo_0_syscall_test_txs,
+        create_l1_to_l2_messages_args_fn: |_| vec![],
+        test_tx_hashes_fn: |tx_hashes| validate_tx_count(tx_hashes, CUSTOM_CAIRO_0_INVOKE_TX_COUNT),
+    }]
+}
+
+fn create_cairo_0_syscall_test_txs(
+    tx_generator: &mut MultiAccountTransactionGenerator,
+) -> Vec<RpcTransaction> {
+    let account_tx_generator = tx_generator.account_with_id_mut(CAIRO0_ACCOUNT_ID);
+    let mut txs = vec![];
+    txs.extend(generate_direct_test_contract_invoke_txs_cairo_0_syscall(account_tx_generator));
+
+    txs
+}
+
+fn generate_direct_test_contract_invoke_txs_cairo_0_syscall(
+    account_tx_generator: &mut AccountTransactionGenerator,
+) -> Vec<RpcTransaction> {
+    let test_contract = FeatureContract::TestContract(CairoVersion::Cairo0);
+
+    [
+        (
+            "advance_counter",
+            vec![
+                felt!(2021_u64), // index
+                felt!(7_u64),    // diff_0
+                felt!(7_u64),    // diff_1
+            ],
+        ),
+        (
+            "xor_counters",
+            vec![
+                felt!(2021_u64), // index
+                felt!(31_u64),   // values.x
+                felt!(21_u64),   // values.y
+            ],
+        ),
+        ("test_ec_op", vec![]),
+    ]
+    .iter()
+    .map(|(fn_name, fn_args)| {
+        let calldata = create_calldata(test_contract.get_instance_address(0), fn_name, fn_args);
+        account_tx_generator.generate_rpc_invoke_tx(DEFAULT_TIP, calldata)
+    })
+    .collect()
+}


### PR DESCRIPTION
Create new flow test for cairo 0.
Account contract and test contract are both cairo 0.
Add three transactions direct call transaction to begin with.