### PR TITLE
apollo_integration_tests: add rpc invoke tx builder

### DIFF
--- a/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
+++ b/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
@@ -10,12 +10,12 @@ use mempool_test_utils::starknet_api_test_utils::{
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::felt;
 use starknet_api::rpc_transaction::RpcTransaction;
+use starknet_api::test_utils::invoke::rpc_invoke_tx;
 
 use crate::common::{end_to_end_flow, validate_tx_count, TestScenario};
 
 mod common;
 
-const DEFAULT_TIP: u64 = 1_u64;
 const CUSTOM_CAIRO_0_INVOKE_TX_COUNT: usize = 3;
 
 #[tokio::test]
@@ -75,7 +75,7 @@ fn generate_direct_test_contract_invoke_txs_cairo_0_syscall(
     .iter()
     .map(|(fn_name, fn_args)| {
         let calldata = create_calldata(test_contract.get_instance_address(0), fn_name, fn_args);
-        account_tx_generator.generate_rpc_invoke_tx(DEFAULT_TIP, calldata)
+        rpc_invoke_tx(account_tx_generator.build_invoke_tx_args().calldata(calldata))
     })
     .collect()
 }

--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -20,7 +20,11 @@ use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::state::SierraContractClass;
 use starknet_api::test_utils::declare::rpc_declare_tx;
 use starknet_api::test_utils::deploy_account::rpc_deploy_account_tx;
-use starknet_api::test_utils::invoke::{rpc_invoke_tx, InvokeTxArgs};
+use starknet_api::test_utils::invoke::{
+    executable_invoke_tx as starknet_api_executable_invoke_tx,
+    rpc_invoke_tx,
+    InvokeTxArgs,
+};
 use starknet_api::test_utils::{NonceManager, TEST_ERC20_CONTRACT_ADDRESS2};
 use starknet_api::transaction::constants::TRANSFER_ENTRY_POINT_NAME;
 use starknet_api::transaction::fields::{
@@ -55,6 +59,8 @@ pub const VALID_L1_DATA_GAS_MAX_PRICE_PER_UNIT: u128 = 100000000000000;
 #[allow(clippy::as_conversions)]
 pub const VALID_ACCOUNT_BALANCE: Fee =
     Fee(VALID_L2_GAS_MAX_AMOUNT as u128 * VALID_L2_GAS_MAX_PRICE_PER_UNIT * 1000);
+
+pub const TIP_FOR_TESTING: Tip = Tip(1);
 
 // Utils.
 
@@ -397,37 +403,27 @@ impl AccountTransactionGenerator {
         self.nonce_manager.borrow().get(self.sender_address()) != nonce!(0)
     }
 
-    fn build_invoke_tx_args(&mut self, tip: u64, calldata: Calldata) -> InvokeTxArgs {
+    pub fn build_invoke_tx_args(&mut self) -> InvokeTxArgs {
         assert!(
             self.is_deployed(),
             "Cannot invoke on behalf of an undeployed account: the first transaction of every \
              account must be a deploy account transaction."
         );
-        let nonce = self.next_nonce();
-        let invoke_args = invoke_tx_args!(
-            nonce,
-            tip: Tip(tip),
-            sender_address: self.sender_address(),
-            resource_bounds: test_valid_resource_bounds(),
-            calldata,
-        );
-        invoke_args
-    }
-
-    pub fn generate_rpc_invoke_tx(&mut self, tip: u64, calldata: Calldata) -> RpcTransaction {
-        let invoke_args = self.build_invoke_tx_args(tip, calldata);
-        rpc_invoke_tx(invoke_args)
+        InvokeTxArgs::default()
+            .sender_address(self.sender_address())
+            .tip(TIP_FOR_TESTING)
+            .nonce(self.next_nonce())
+            .resource_bounds(test_valid_resource_bounds())
     }
 
     pub fn generate_trivial_rpc_invoke_tx(&mut self, tip: u64) -> RpcTransaction {
         let test_contract = FeatureContract::TestContract(self.account.cairo_version());
         let calldata = create_trivial_calldata(test_contract.get_instance_address(0));
-        self.generate_rpc_invoke_tx(tip, calldata)
+        rpc_invoke_tx(self.build_invoke_tx_args().tip(Tip(tip)).calldata(calldata))
     }
 
     fn generate_nested_call_invoke_tx(
         &mut self,
-        tip: u64,
         outer_test_contract: &FeatureContract,
         inner_contract_pointer: &Felt,
         outer_fn_name: &str,
@@ -444,19 +440,17 @@ impl AccountTransactionGenerator {
             outer_fn_name,
             &inner_calldata.0,
         );
-        self.generate_rpc_invoke_tx(tip, calldata)
+        rpc_invoke_tx(self.build_invoke_tx_args().calldata(calldata))
     }
 
     pub fn generate_library_call_invoke_tx(
         &mut self,
-        tip: u64,
         outer_contract: &FeatureContract,
         inner_contract: &FeatureContract,
         fn_name: &str,
         fn_args: &[Felt],
     ) -> RpcTransaction {
         self.generate_nested_call_invoke_tx(
-            tip,
             outer_contract,
             &inner_contract.get_class_hash().0,
             "test_library_call",
@@ -467,14 +461,12 @@ impl AccountTransactionGenerator {
 
     pub fn generate_call_contract_invoke_tx(
         &mut self,
-        tip: u64,
         outer_contract: &FeatureContract,
         inner_contract: &ContractAddress,
         fn_name: &str,
         fn_args: &[Felt],
     ) -> RpcTransaction {
         self.generate_nested_call_invoke_tx(
-            tip,
             outer_contract,
             inner_contract.0.key(),
             "test_call_contract",
@@ -501,8 +493,7 @@ impl AccountTransactionGenerator {
     pub fn generate_trivial_executable_invoke_tx(&mut self) -> AccountTransaction {
         let test_contract = FeatureContract::TestContract(self.account.cairo_version());
         let calldata = create_trivial_calldata(test_contract.get_instance_address(0));
-        let invoke_args = self.build_invoke_tx_args(Tip::default().0, calldata);
-        starknet_api::test_utils::invoke::executable_invoke_tx(invoke_args)
+        starknet_api_executable_invoke_tx(self.build_invoke_tx_args().calldata(calldata))
     }
 
     /// Generates an `RpcTransaction` with fully custom parameters.

--- a/crates/starknet_api/src/test_utils/invoke.rs
+++ b/crates/starknet_api/src/test_utils/invoke.rs
@@ -180,3 +180,37 @@ impl TestingTxArgs for InvokeTxArgs {
         internal_invoke_tx(self.clone())
     }
 }
+
+// TODO(Itamar): Change this to use a macro and apply the same logic to DeclareTxArgs and
+// DeployAccountTxArgs.
+impl InvokeTxArgs {
+    pub fn signature(mut self, signature: TransactionSignature) -> Self {
+        self.signature = signature;
+        self
+    }
+
+    pub fn sender_address(mut self, sender_address: ContractAddress) -> Self {
+        self.sender_address = sender_address;
+        self
+    }
+
+    pub fn calldata(mut self, calldata: Calldata) -> Self {
+        self.calldata = calldata;
+        self
+    }
+
+    pub fn resource_bounds(mut self, resource_bounds: ValidResourceBounds) -> Self {
+        self.resource_bounds = resource_bounds;
+        self
+    }
+
+    pub fn tip(mut self, tip: Tip) -> Self {
+        self.tip = tip;
+        self
+    }
+
+    pub fn nonce(mut self, nonce: Nonce) -> Self {
+        self.nonce = nonce;
+        self
+    }
+}


### PR DESCRIPTION
Refactor in order to be able to generate invoke tx with more varied arguments.