### PR TITLE
apollo_integration_tests: use multi threads tokio runtime on flow tests

### DIFF
--- a/crates/apollo_integration_tests/tests/bootstrap_declare.rs
+++ b/crates/apollo_integration_tests/tests/bootstrap_declare.rs
@@ -17,7 +17,8 @@ fn create_bootstrap_declare_scenario() -> Vec<TestScenario> {
 /// Bootstrap declare txs are unique: they are sent from a special address and do not increment its
 /// nonce. As a result, they are not removed from the mempool upon successful execution, and will
 /// only be removed after being rejected during a subsequent attempt.
-#[tokio::test]
+/// The test uses 3 threads: 1 for the test's main thread and 2 for the sequencers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn bootstrap_declare() {
     end_to_end_flow(
         TestIdentifier::EndToEndFlowTestBootstrapDeclare,

--- a/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
+++ b/crates/apollo_integration_tests/tests/end_to_end_flow_test.rs
@@ -16,7 +16,8 @@ use crate::common::{end_to_end_flow, test_single_tx, TestScenario};
 
 mod common;
 
-#[tokio::test]
+/// Number of threads is 3 = Num of sequencer + 1 for the test thread.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_end_to_end_flow() {
     end_to_end_flow(
         TestIdentifier::EndToEndFlowTest,

--- a/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
+++ b/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
@@ -20,7 +20,8 @@ mod common;
 
 const CUSTOM_CAIRO_0_INVOKE_TX_COUNT: usize = 9;
 
-#[tokio::test]
+/// The test uses 3 threads: 1 for the test's main thread and 2 for the sequencers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn custom_cairo0_txs() {
     end_to_end_flow(
         TestIdentifier::EndToEndFlowTestCustomCairo0Txs,

--- a/crates/apollo_integration_tests/tests/test_custom_cairo1_txs.rs
+++ b/crates/apollo_integration_tests/tests/test_custom_cairo1_txs.rs
@@ -26,7 +26,8 @@ mod common;
 const CUSTOM_INVOKE_TX_COUNT: usize = 16;
 
 /// Test a wide range of different kinds of invoke transactions.
-#[tokio::test]
+/// Number of threads is 3 = Num of sequencer + 1 for the test thread.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn custom_cairo1_txs() {
     end_to_end_flow(
         TestIdentifier::EndToEndFlowTestCustomSyscallInvokeTxs,

--- a/crates/apollo_integration_tests/tests/test_many.rs
+++ b/crates/apollo_integration_tests/tests/test_many.rs
@@ -10,7 +10,8 @@ use crate::common::{end_to_end_flow, TestScenario};
 mod common;
 
 /// This test checks that at least one block is full.
-#[tokio::test]
+/// The test uses 3 threads: 1 for the test's main thread and 2 for the sequencers.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn many_txs_fill_at_least_one_block() {
     end_to_end_flow(
         TestIdentifier::EndToEndFlowTestManyTxs,


### PR DESCRIPTION
Run the sequencer node with multi threads tokio runtime.
The former behavior was only with "current_thread" flavor tokio runtime, which uses only one tokio thread.