### PR TITLE
apollo_gateway: remove redundant instrument from validate

### DIFF
--- a/crates/apollo_gateway/src/stateless_transaction_validator.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator.rs
@@ -29,7 +29,7 @@ pub struct StatelessTransactionValidator {
 }
 
 impl StatelessTransactionValidator {
-    #[instrument(skip(self), level = Level::INFO, err)]
+    #[instrument(skip(self), level = Level::INFO)]
     pub fn validate(&self, tx: &RpcTransaction) -> StatelessTransactionValidatorResult<()> {
         // TODO(Arni, 1/5/2024): Add a mechanism that validate the sender address is not blocked.
         // TODO(Arni, 1/5/2024): Validate transaction version.


### PR DESCRIPTION
This PR removes the `#[instrument]` attribute with `level = Level::INFO` from the `validate` method in the `StatelessTransactionValidator` implementation, as it was redundant. There is already error logging in `add_tx_inner`, which is `validate`'s only caller.