### PR TITLE
apollo_network_benchmark: added broadcasting mode selection

### DIFF
--- a/crates/apollo_network_benchmark/src/node_args.rs
+++ b/crates/apollo_network_benchmark/src/node_args.rs
@@ -4,10 +4,26 @@ use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Mode {
+    /// All nodes broadcast messages
+    #[value(name = "all")]
+    AllBroadcast,
+    /// Only the node specified by --broadcaster broadcasts messages
+    #[value(name = "one")]
+    OneBroadcast,
+}
+
+#[derive(Debug, Clone, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NetworkProtocol {
     /// Use gossipsub for broadcasting (default)
     #[value(name = "gossipsub")]
     Gossipsub,
+}
+
+impl Display for Mode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_possible_value().unwrap().get_name())
+    }
 }
 
 impl Display for NetworkProtocol {
@@ -49,9 +65,17 @@ pub struct UserArgs {
     #[arg(long, env, default_value = "100000")]
     pub buffer_size: usize,
 
+    /// The mode to use for the stress test.
+    #[arg(long, env, default_value = "all")]
+    pub mode: Mode,
+
     /// The network protocol to use for communication (default: gossipsub)
     #[arg(long, env, default_value = "gossipsub")]
     pub network_protocol: NetworkProtocol,
+
+    /// Which node ID should do the broadcasting - for OneBroadcast mode
+    #[arg(long, env, required_if_eq("mode", "one"))]
+    pub broadcaster: Option<u64>,
 
     /// Size of StressTestMessage
     #[arg(long, env, default_value = "1024")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized CLI-argument and validation changes; primary risk is breaking existing scripts if they rely on implicit broadcasting behavior or pass invalid flag combinations.
> 
> **Overview**
> Adds a new `Mode` CLI enum to `apollo_network_benchmark` to control stress-test broadcasting behavior (`all` vs `one`).
> 
> Extends `UserArgs` with `--mode` (default `all`) and `--broadcaster`, with clap validation to require `--broadcaster` when `mode=one`, plus a `Display` impl to format `Mode` values consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79551ab6cee41d3aa6b25693a363372743af9636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->