### PR TITLE
apollo_network_benchmark: added broadcast metrics tracking

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/handlers.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/handlers.rs
@@ -6,12 +6,24 @@ use libp2p::PeerId;
 
 use crate::message::{StressTestMessage, METADATA_SIZE};
 use crate::metrics::{
+    get_throughput,
+    BROADCAST_MESSAGE_BYTES,
+    BROADCAST_MESSAGE_BYTES_SUM,
+    BROADCAST_MESSAGE_COUNT,
+    BROADCAST_MESSAGE_HEARTBEAT_MILLIS,
+    BROADCAST_MESSAGE_SEND_DELAY_SECONDS,
+    BROADCAST_MESSAGE_THROUGHPUT,
     RECEIVE_MESSAGE_BYTES,
     RECEIVE_MESSAGE_BYTES_SUM,
     RECEIVE_MESSAGE_COUNT,
     RECEIVE_MESSAGE_DELAY_SECONDS,
 };
 use crate::protocol::MessageSender;
+
+fn update_broadcast_metrics(message_size_bytes: usize, broadcast_heartbeat: Duration) {
+    BROADCAST_MESSAGE_HEARTBEAT_MILLIS.set(broadcast_heartbeat.as_millis().into_f64());
+    BROADCAST_MESSAGE_THROUGHPUT.set(get_throughput(message_size_bytes, broadcast_heartbeat));
+}
 
 fn create_message(id: u64, size_bytes: usize) -> StressTestMessage {
     let message = StressTestMessage::new(id, 0, vec![0; size_bytes.saturating_sub(*METADATA_SIZE)]);
@@ -30,6 +42,7 @@ pub async fn send_stress_test_messages(
 
     let mut message_index = 0;
     let mut message = create_message(args.runner.id, size_bytes);
+    update_broadcast_metrics(message.len(), heartbeat);
 
     let mut interval = tokio::time::interval(heartbeat);
     loop {
@@ -38,7 +51,13 @@ pub async fn send_stress_test_messages(
         message.metadata.time = SystemTime::now();
         message.metadata.message_index = message_index;
         let message_clone = message.clone().into();
+        let start_time = std::time::Instant::now();
         message_sender.send_message(&peers, message_clone).await;
+        BROADCAST_MESSAGE_SEND_DELAY_SECONDS.record(start_time.elapsed().as_secs_f64());
+        BROADCAST_MESSAGE_BYTES.set(message.len().into_f64());
+        BROADCAST_MESSAGE_COUNT.increment(1);
+        BROADCAST_MESSAGE_BYTES_SUM
+            .increment(u64::try_from(message.len()).expect("Message length too large for u64"));
         message_index += 1;
     }
 }

--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -1,7 +1,17 @@
+use std::time::Duration;
+
 use apollo_metrics::define_metrics;
+use apollo_metrics::metrics::LossyIntoF64;
 
 define_metrics!(
     Infra => {
+        MetricGauge { BROADCAST_MESSAGE_HEARTBEAT_MILLIS, "broadcast_message_theoretical_heartbeat_millis", "The number of ms we sleep between each two consecutive broadcasts" },
+        MetricGauge { BROADCAST_MESSAGE_THROUGHPUT, "broadcast_message_theoretical_throughput", "Throughput in bytes/second of the broadcasted messages" },
+        MetricGauge { BROADCAST_MESSAGE_BYTES, "broadcast_message_bytes", "Size of the stress test sent message in bytes" },
+        MetricCounter { BROADCAST_MESSAGE_COUNT, "broadcast_message_count", "Number of stress test messages sent via broadcast", init = 0 },
+        MetricCounter { BROADCAST_MESSAGE_BYTES_SUM, "broadcast_message_bytes_sum", "Sum of the stress test messages sent via broadcast", init = 0 },
+        MetricHistogram { BROADCAST_MESSAGE_SEND_DELAY_SECONDS, "broadcast_message_send_delay_seconds", "Message sending delay in seconds" },
+
         MetricGauge { RECEIVE_MESSAGE_BYTES, "receive_message_bytes", "Size of the stress test received message in bytes" },
         MetricCounter { RECEIVE_MESSAGE_COUNT, "receive_message_count", "Number of stress test messages received via broadcast", init = 0 },
         MetricCounter { RECEIVE_MESSAGE_BYTES_SUM, "receive_message_bytes_sum", "Sum of the stress test messages received via broadcast", init = 0 },
@@ -10,8 +20,20 @@ define_metrics!(
 );
 
 pub(crate) fn register_metrics() {
+    BROADCAST_MESSAGE_HEARTBEAT_MILLIS.register();
+    BROADCAST_MESSAGE_THROUGHPUT.register();
+    BROADCAST_MESSAGE_BYTES.register();
+    BROADCAST_MESSAGE_COUNT.register();
+    BROADCAST_MESSAGE_BYTES_SUM.register();
+    BROADCAST_MESSAGE_SEND_DELAY_SECONDS.register();
     RECEIVE_MESSAGE_BYTES.register();
     RECEIVE_MESSAGE_COUNT.register();
     RECEIVE_MESSAGE_BYTES_SUM.register();
     RECEIVE_MESSAGE_DELAY_SECONDS.register();
+}
+
+/// Calculates the throughput given the message size and heartbeat duration
+pub fn get_throughput(message_size_bytes: usize, heartbeat_duration: Duration) -> f64 {
+    let tps = Duration::from_secs(1).as_secs_f64() / heartbeat_duration.as_secs_f64();
+    tps * message_size_bytes.into_f64()
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds instrumentation and lightweight calculations around the existing send loop without changing protocol or message contents; main risk is minor performance impact from extra metrics updates.
> 
> **Overview**
> Adds **sender-side broadcast metrics** to the `broadcast_network_stress_test_node`.
> 
> `send_stress_test_messages` now records theoretical heartbeat/throughput, per-message bytes, message count and byte-sum counters, and a histogram of `send_message` duration; `metrics.rs` defines/registers these new metrics and adds a small `get_throughput` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3774b62ddfdeddff00646aa87ff80cb3f57498f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->