### PR TITLE
apollo_network_benchmark: added network metrics to network manager

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use apollo_metrics::define_metrics;
 use apollo_metrics::metrics::LossyIntoF64;
+use apollo_network::metrics::NetworkMetrics;
 
 define_metrics!(
     Infra => {
@@ -16,6 +17,9 @@ define_metrics!(
         MetricCounter { RECEIVE_MESSAGE_COUNT, "receive_message_count", "Number of stress test messages received via broadcast", init = 0 },
         MetricCounter { RECEIVE_MESSAGE_BYTES_SUM, "receive_message_bytes_sum", "Sum of the stress test messages received via broadcast", init = 0 },
         MetricHistogram { RECEIVE_MESSAGE_DELAY_SECONDS, "receive_message_delay_seconds", "Message delay in seconds" },
+
+        MetricGauge { NETWORK_CONNECTED_PEERS, "network_connected_peers", "Number of connected peers in the network" },
+        MetricGauge { NETWORK_BLACKLISTED_PEERS, "network_blacklisted_peers", "Number of blacklisted peers in the network" },
     },
 );
 
@@ -36,4 +40,16 @@ pub(crate) fn register_metrics() {
 pub fn get_throughput(message_size_bytes: usize, heartbeat_duration: Duration) -> f64 {
     let tps = Duration::from_secs(1).as_secs_f64() / heartbeat_duration.as_secs_f64();
     tps * message_size_bytes.into_f64()
+}
+
+/// Creates barebones network metrics
+pub fn create_network_metrics() -> apollo_network::metrics::NetworkMetrics {
+    NetworkMetrics {
+        num_connected_peers: NETWORK_CONNECTED_PEERS,
+        num_blacklisted_peers: NETWORK_BLACKLISTED_PEERS,
+        broadcast_metrics_by_topic: None,
+        sqmr_metrics: None,
+        event_metrics: None,
+        latency_metrics: None,
+    }
 }

--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/stress_test_node.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/stress_test_node.rs
@@ -12,6 +12,7 @@ use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 use crate::handlers::{receive_stress_test_message, send_stress_test_messages};
+use crate::metrics::create_network_metrics;
 use crate::protocol::{register_protocol_channels, MessageReceiver, MessageSender};
 
 /// The main stress test node that manages network communication and monitoring
@@ -56,7 +57,9 @@ impl BroadcastNetworkStressTestNode {
         let network_config = Self::create_network_config(&args);
 
         // Create network manager
-        let mut network_manager = NetworkManager::new(network_config.clone(), None, None);
+        let network_metrics = create_network_metrics();
+        let mut network_manager =
+            NetworkManager::new(network_config.clone(), None, Some(network_metrics));
 
         // Register protocol channels
         let (message_sender, message_receiver) = register_protocol_channels(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds metrics wiring and two new gauges without changing networking behavior or message flow; risk is limited to metric registration/collection correctness.
> 
> **Overview**
> The broadcast network stress test node now initializes `NetworkManager` with a minimal `NetworkMetrics` instance, enabling collection of network-level metrics during runs.
> 
> This adds two new gauges (`network_connected_peers`, `network_blacklisted_peers`) and a helper (`create_network_metrics`) that wires them into the manager while leaving other network metric groups unset (`None`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f546ac1bd44fffe7f8dce111e86f17ee1417e0cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->