### PR TITLE
apollo_network_benchmark: added broadcast topic metrics

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -1,8 +1,15 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use apollo_metrics::define_metrics;
 use apollo_metrics::metrics::LossyIntoF64;
-use apollo_network::metrics::NetworkMetrics;
+use apollo_network::metrics::{
+    BroadcastNetworkMetrics,
+    NetworkMetrics,
+    NETWORK_BROADCAST_DROP_LABELS,
+};
+
+use crate::protocol::TOPIC;
 
 define_metrics!(
     Infra => {
@@ -20,6 +27,9 @@ define_metrics!(
 
         MetricGauge { NETWORK_CONNECTED_PEERS, "network_connected_peers", "Number of connected peers in the network" },
         MetricGauge { NETWORK_BLACKLISTED_PEERS, "network_blacklisted_peers", "Number of blacklisted peers in the network" },
+        MetricCounter { NETWORK_STRESS_TEST_SENT_MESSAGES, "network_stress_test_sent_messages", "Number of stress test messages sent via broadcast", init = 0 },
+        MetricCounter { NETWORK_STRESS_TEST_RECEIVED_MESSAGES, "network_stress_test_received_messages", "Number of stress test messages received via broadcast", init = 0 },
+        LabeledMetricCounter { NETWORK_DROPPED_BROADCAST_MESSAGES, "network_dropped_broadcast_messages", "Number of dropped broadcast messages by reason", init = 0, labels = NETWORK_BROADCAST_DROP_LABELS },
     },
 );
 
@@ -42,12 +52,29 @@ pub fn get_throughput(message_size_bytes: usize, heartbeat_duration: Duration) -
     tps * message_size_bytes.into_f64()
 }
 
-/// Creates barebones network metrics
 pub fn create_network_metrics() -> apollo_network::metrics::NetworkMetrics {
+    let stress_test_broadcast_metrics = BroadcastNetworkMetrics {
+        sent_broadcast_message_metrics: apollo_network::metrics::MessageMetrics {
+            num_messages: NETWORK_STRESS_TEST_SENT_MESSAGES,
+            message_size_mb: None,
+        },
+        dropped_broadcast_message_metrics: apollo_network::metrics::LabeledMessageMetrics {
+            num_messages: NETWORK_DROPPED_BROADCAST_MESSAGES,
+            message_size_mb: None,
+        },
+        received_broadcast_message_metrics: apollo_network::metrics::MessageMetrics {
+            num_messages: NETWORK_STRESS_TEST_RECEIVED_MESSAGES,
+            message_size_mb: None,
+        },
+    };
+
+    let mut broadcast_metrics_by_topic = HashMap::new();
+    broadcast_metrics_by_topic.insert(TOPIC.hash(), stress_test_broadcast_metrics);
+
     NetworkMetrics {
         num_connected_peers: NETWORK_CONNECTED_PEERS,
         num_blacklisted_peers: NETWORK_BLACKLISTED_PEERS,
-        broadcast_metrics_by_topic: None,
+        broadcast_metrics_by_topic: Some(broadcast_metrics_by_topic),
         sqmr_metrics: None,
         event_metrics: None,
         latency_metrics: None,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily adds metrics wiring for a benchmark tool; low risk aside from potential mismatches in metric labels/topic hashing affecting observability.
> 
> **Overview**
> Adds per-topic broadcast instrumentation to the broadcast network stress test node by defining new counters for sent/received messages and labeled counters for dropped messages (using `NETWORK_BROADCAST_DROP_LABELS`).
> 
> Updates `create_network_metrics()` to populate `NetworkMetrics.broadcast_metrics_by_topic` with `BroadcastNetworkMetrics` for the stress test `TOPIC`, enabling the network layer to report topic-specific broadcast metrics instead of leaving them unset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e200357c4b0aec2c9be31f4dc16013194f7d41d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->