### PR TITLE
apollo_network_benchmark: added SQMR session metrics

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -6,6 +6,7 @@ use apollo_metrics::metrics::LossyIntoF64;
 use apollo_network::metrics::{
     BroadcastNetworkMetrics,
     NetworkMetrics,
+    SqmrNetworkMetrics,
     NETWORK_BROADCAST_DROP_LABELS,
 };
 
@@ -27,6 +28,8 @@ define_metrics!(
 
         MetricGauge { NETWORK_CONNECTED_PEERS, "network_connected_peers", "Number of connected peers in the network" },
         MetricGauge { NETWORK_BLACKLISTED_PEERS, "network_blacklisted_peers", "Number of blacklisted peers in the network" },
+        MetricGauge { NETWORK_ACTIVE_INBOUND_SESSIONS, "network_active_inbound_sessions", "Number of active inbound SQMR sessions" },
+        MetricGauge { NETWORK_ACTIVE_OUTBOUND_SESSIONS, "network_active_outbound_sessions", "Number of active outbound SQMR sessions" },
         MetricCounter { NETWORK_STRESS_TEST_SENT_MESSAGES, "network_stress_test_sent_messages", "Number of stress test messages sent via broadcast", init = 0 },
         MetricCounter { NETWORK_STRESS_TEST_RECEIVED_MESSAGES, "network_stress_test_received_messages", "Number of stress test messages received via broadcast", init = 0 },
         LabeledMetricCounter { NETWORK_DROPPED_BROADCAST_MESSAGES, "network_dropped_broadcast_messages", "Number of dropped broadcast messages by reason", init = 0, labels = NETWORK_BROADCAST_DROP_LABELS },
@@ -71,11 +74,16 @@ pub fn create_network_metrics() -> apollo_network::metrics::NetworkMetrics {
     let mut broadcast_metrics_by_topic = HashMap::new();
     broadcast_metrics_by_topic.insert(TOPIC.hash(), stress_test_broadcast_metrics);
 
+    let sqmr_metrics = SqmrNetworkMetrics {
+        num_active_inbound_sessions: NETWORK_ACTIVE_INBOUND_SESSIONS,
+        num_active_outbound_sessions: NETWORK_ACTIVE_OUTBOUND_SESSIONS,
+    };
+
     NetworkMetrics {
         num_connected_peers: NETWORK_CONNECTED_PEERS,
         num_blacklisted_peers: NETWORK_BLACKLISTED_PEERS,
         broadcast_metrics_by_topic: Some(broadcast_metrics_by_topic),
-        sqmr_metrics: None,
+        sqmr_metrics: Some(sqmr_metrics),
         event_metrics: None,
         latency_metrics: None,
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metrics-only change that wires two new gauges into existing `NetworkMetrics`, with minimal impact beyond observability.
> 
> **Overview**
> The broadcast network stress-test node now publishes SQMR session visibility by adding `network_active_inbound_sessions` and `network_active_outbound_sessions` gauges.
> 
> `create_network_metrics()` now populates `NetworkMetrics.sqmr_metrics` (previously `None`) with these gauges so the benchmark can report active SQMR session counts alongside existing peer/broadcast metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 204a8fa0632d78b2659ec275a6222d20120bc60b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->