### PR TITLE
apollo_network_benchmark: added network event metrics

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -5,8 +5,10 @@ use apollo_metrics::define_metrics;
 use apollo_metrics::metrics::LossyIntoF64;
 use apollo_network::metrics::{
     BroadcastNetworkMetrics,
+    EventMetrics,
     NetworkMetrics,
     SqmrNetworkMetrics,
+    EVENT_TYPE_LABELS,
     NETWORK_BROADCAST_DROP_LABELS,
 };
 
@@ -33,6 +35,7 @@ define_metrics!(
         MetricCounter { NETWORK_STRESS_TEST_SENT_MESSAGES, "network_stress_test_sent_messages", "Number of stress test messages sent via broadcast", init = 0 },
         MetricCounter { NETWORK_STRESS_TEST_RECEIVED_MESSAGES, "network_stress_test_received_messages", "Number of stress test messages received via broadcast", init = 0 },
         LabeledMetricCounter { NETWORK_DROPPED_BROADCAST_MESSAGES, "network_dropped_broadcast_messages", "Number of dropped broadcast messages by reason", init = 0, labels = NETWORK_BROADCAST_DROP_LABELS },
+        LabeledMetricCounter { NETWORK_EVENT_COUNTER, "network_event_counter", "Network events counter by type", init = 0, labels = EVENT_TYPE_LABELS },
     },
 );
 
@@ -79,12 +82,14 @@ pub fn create_network_metrics() -> apollo_network::metrics::NetworkMetrics {
         num_active_outbound_sessions: NETWORK_ACTIVE_OUTBOUND_SESSIONS,
     };
 
+    let event_metrics = EventMetrics { event_counter: NETWORK_EVENT_COUNTER };
+
     NetworkMetrics {
         num_connected_peers: NETWORK_CONNECTED_PEERS,
         num_blacklisted_peers: NETWORK_BLACKLISTED_PEERS,
         broadcast_metrics_by_topic: Some(broadcast_metrics_by_topic),
         sqmr_metrics: Some(sqmr_metrics),
-        event_metrics: None,
+        event_metrics: Some(event_metrics),
         latency_metrics: None,
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new labeled counter and wires existing `EventMetrics` into the benchmark’s `NetworkMetrics`; no behavior changes outside metrics emission.
> 
> **Overview**
> The broadcast network stress test node now exposes **network event observability** by adding a labeled `network_event_counter` metric (using `EVENT_TYPE_LABELS`).
> 
> `create_network_metrics()` is updated to construct and pass `EventMetrics` into `NetworkMetrics` (previously `event_metrics: None`), enabling the benchmark to count network events by type during runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53e7e2f9ecb984a89b7f919af42dc3ecb662b634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->