### PR TITLE
apollo_network_benchmark: added ping latency metrics

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -6,6 +6,7 @@ use apollo_metrics::metrics::LossyIntoF64;
 use apollo_network::metrics::{
     BroadcastNetworkMetrics,
     EventMetrics,
+    LatencyMetrics,
     NetworkMetrics,
     SqmrNetworkMetrics,
     EVENT_TYPE_LABELS,
@@ -36,6 +37,8 @@ define_metrics!(
         MetricCounter { NETWORK_STRESS_TEST_RECEIVED_MESSAGES, "network_stress_test_received_messages", "Number of stress test messages received via broadcast", init = 0 },
         LabeledMetricCounter { NETWORK_DROPPED_BROADCAST_MESSAGES, "network_dropped_broadcast_messages", "Number of dropped broadcast messages by reason", init = 0, labels = NETWORK_BROADCAST_DROP_LABELS },
         LabeledMetricCounter { NETWORK_EVENT_COUNTER, "network_event_counter", "Network events counter by type", init = 0, labels = EVENT_TYPE_LABELS },
+
+        MetricHistogram { PING_LATENCY_SECONDS, "ping_latency_seconds", "Ping latency in seconds" },
     },
 );
 
@@ -84,12 +87,14 @@ pub fn create_network_metrics() -> apollo_network::metrics::NetworkMetrics {
 
     let event_metrics = EventMetrics { event_counter: NETWORK_EVENT_COUNTER };
 
+    let latency_metrics = LatencyMetrics { ping_latency_seconds: PING_LATENCY_SECONDS };
+
     NetworkMetrics {
         num_connected_peers: NETWORK_CONNECTED_PEERS,
         num_blacklisted_peers: NETWORK_BLACKLISTED_PEERS,
         broadcast_metrics_by_topic: Some(broadcast_metrics_by_topic),
         sqmr_metrics: Some(sqmr_metrics),
         event_metrics: Some(event_metrics),
-        latency_metrics: None,
+        latency_metrics: Some(latency_metrics),
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only adds a new metrics histogram and plumbs it into existing `NetworkMetrics`; no protocol or data-path behavior changes.
> 
> **Overview**
> Adds ping latency instrumentation to the broadcast network stress test node by defining a new `PING_LATENCY_SECONDS` histogram and wiring it into `NetworkMetrics` via `LatencyMetrics` (previously `latency_metrics` was `None`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c4ab72bf53b1bad7603f1a2005d6b8ff23b644b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->