### PR TITLE
apollo_network_benchmark: add SQMR protocol constant

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/protocol.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/protocol.rs
@@ -23,6 +23,8 @@ lazy_static::lazy_static! {
 
 pub type TopicType = Vec<u8>;
 
+pub const SQMR_PROTOCOL_NAME: &str = "/stress-test/1.0.0";
+
 /// Registers protocol channels on an existing network manager.
 /// Returns a sender and receiver for the configured protocol.
 pub fn register_protocol_channels(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single new constant with no functional changes; low chance of regressions unless later code relies on this string value being correct.
> 
> **Overview**
> Adds `SQMR_PROTOCOL_NAME` (`"/stress-test/1.0.0"`) to `broadcast_network_stress_test_node/protocol.rs` for use as a stable identifier when wiring up the stress-test protocol.
> 
> No behavioral changes to message sending/receiving or channel registration are included in this diff.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45c4eeb00a32930625e47e0ff47e4511fbc31647. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->