### PR TITLE
apollo_network_benchmark: add Sqmr variant to NetworkProtocol enum

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/protocol.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/protocol.rs
@@ -45,6 +45,10 @@ pub fn register_protocol_channels(
                 MessageReceiver::Gossipsub(broadcasted_messages_receiver),
             )
         }
+        NetworkProtocol::Sqmr => {
+            // TODO(AndrewL): Implement SQMR protocol registration
+            todo!("SQMR protocol registration not yet implemented")
+        }
     }
 }
 

--- a/crates/apollo_network_benchmark/src/node_args.rs
+++ b/crates/apollo_network_benchmark/src/node_args.rs
@@ -18,6 +18,9 @@ pub enum NetworkProtocol {
     /// Use gossipsub for broadcasting (default)
     #[value(name = "gossipsub")]
     Gossipsub,
+    /// Use SQMR for point-to-point communication
+    #[value(name = "sqmr")]
+    Sqmr,
 }
 
 impl Display for Mode {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new user-selectable protocol flag that currently triggers a runtime `todo!()` panic if used; otherwise the existing gossipsub path is unchanged.
> 
> **Overview**
> Adds a new `sqmr` variant to the CLI-configurable `NetworkProtocol` enum.
> 
> Updates `register_protocol_channels` to handle `NetworkProtocol::Sqmr`, but the SQMR path is currently a `todo!()` placeholder that will panic if selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d03a2ad599bec5b226ac1c3ac3351246038ea61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->