### PR TITLE
apollo_network_benchmark: add ReversedSqmr variant to NetworkProtocol enum

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/protocol.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/protocol.rs
@@ -62,6 +62,10 @@ pub fn register_protocol_channels(
 
             (MessageSender::Sqmr(sqmr_client), MessageReceiver::Sqmr(sqmr_server))
         }
+        NetworkProtocol::ReveresedSqmr => {
+            // TODO(AndrewL): Implement ReveresedSqmr protocol registration
+            todo!("ReveresedSqmr protocol registration not yet implemented")
+        }
     }
 }
 

--- a/crates/apollo_network_benchmark/src/node_args.rs
+++ b/crates/apollo_network_benchmark/src/node_args.rs
@@ -21,6 +21,9 @@ pub enum NetworkProtocol {
     /// Use SQMR for point-to-point communication
     #[value(name = "sqmr")]
     Sqmr,
+    /// Use Reversed SQMR where receivers initiate requests to broadcasters
+    #[value(name = "reversed-sqmr")]
+    ReveresedSqmr,
 }
 
 impl Display for Mode {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Low code churn, but it introduces a new user-selectable mode that will crash at runtime (`todo!()`) if chosen.
> 
> **Overview**
> Adds a new `NetworkProtocol::ReveresedSqmr` CLI-selectable variant (`--network-protocol reversed-sqmr`) for the network benchmark.
> 
> Updates `register_protocol_channels` to handle this variant, but currently calls `todo!()` with a placeholder comment instead of registering channels, so selecting it will panic at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50dae4286576932719515468640f775f698ac814. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->