### PR TITLE
apollo_network_benchmark: add MessageIndexTracker struct

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/main.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/main.rs
@@ -13,6 +13,7 @@ mod message_test;
 
 mod handlers;
 mod message;
+mod message_index_detector;
 pub mod metrics;
 mod protocol;
 mod stress_test_node;

--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/message_index_detector.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/message_index_detector.rs
@@ -1,0 +1,31 @@
+// TODO(AndrewL): remove this once the struct is used
+#![allow(dead_code)]
+
+#[derive(Default, Clone, Copy)]
+pub struct MessageIndexTracker {
+    seen_messages_count: u64,
+    max_message_index: Option<u64>,
+    min_message_index: Option<u64>,
+}
+
+impl MessageIndexTracker {
+    pub fn seen_message(&mut self, message_index: u64) {
+        self.seen_messages_count += 1;
+        if self.max_message_index.is_none() || self.max_message_index.unwrap() < message_index {
+            self.max_message_index = Some(message_index);
+        }
+        if self.min_message_index.is_none() || self.min_message_index.unwrap() > message_index {
+            self.min_message_index = Some(message_index);
+        }
+    }
+
+    pub fn pending_messages_count(&self) -> u64 {
+        if self.seen_messages_count == 0 {
+            return 0;
+        }
+
+        let min_message_index = self.min_message_index.unwrap();
+        let max_message_index = self.max_message_index.unwrap();
+        max_message_index - min_message_index + 1 - self.seen_messages_count
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds an unused helper module with no behavior changes to the running stress test node.
> 
> **Overview**
> Introduces a new `message_index_detector` module in the broadcast network stress test node containing `MessageIndexTracker`, which tracks min/max seen message indices and computes an estimated count of missing (pending) messages.
> 
> `main.rs` is updated to include the new module, but the tracker is not yet wired into message handling (dead-code allowed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b32f9874936c5c622c7b01adce9d56cf42df0149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->