### PR TITLE
apollo_network_benchmark: add message index detection mechanism

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/message_index_detector.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/message_index_detector.rs
@@ -1,6 +1,3 @@
-// TODO(AndrewL): remove this once the struct is used
-#![allow(dead_code)]
-
 #[derive(Default, Clone, Copy)]
 pub struct MessageIndexTracker {
     seen_messages_count: u64,

--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -28,6 +28,7 @@ define_metrics!(
         MetricCounter { RECEIVE_MESSAGE_COUNT, "receive_message_count", "Number of stress test messages received via broadcast", init = 0 },
         MetricCounter { RECEIVE_MESSAGE_BYTES_SUM, "receive_message_bytes_sum", "Sum of the stress test messages received via broadcast", init = 0 },
         MetricHistogram { RECEIVE_MESSAGE_DELAY_SECONDS, "receive_message_delay_seconds", "Message delay in seconds" },
+        MetricGauge { RECEIVE_MESSAGE_PENDING_COUNT, "receive_message_pending_count", "Number of stress test messages pending to be received" },
 
         MetricGauge { NETWORK_CONNECTED_PEERS, "network_connected_peers", "Number of connected peers in the network" },
         MetricGauge { NETWORK_BLACKLISTED_PEERS, "network_blacklisted_peers", "Number of blacklisted peers in the network" },

--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/stress_test_node.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/stress_test_node.rs
@@ -11,7 +11,11 @@ use libp2p::{Multiaddr, PeerId};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
-use crate::handlers::{receive_stress_test_message, send_stress_test_messages};
+use crate::handlers::{
+    receive_stress_test_message,
+    record_indexed_message,
+    send_stress_test_messages,
+};
 use crate::metrics::create_network_metrics;
 use crate::protocol::{register_protocol_channels, MessageReceiver, MessageSender};
 
@@ -147,24 +151,39 @@ impl BroadcastNetworkStressTestNode {
         )
     }
 
-    /// Starts the message receiving task
-    pub async fn make_message_receiver_task(&mut self) -> BoxFuture<'static, ()> {
+    /// Starts the message receiving tasks (receiver + index tracker)
+    pub async fn make_message_receiver_tasks(&mut self) -> Vec<BoxFuture<'static, ()>> {
         let message_receiver =
             self.message_receiver.take().expect("message_receiver should be available");
 
-        async move {
-            info!("Starting message receiver");
-            message_receiver.for_each(receive_stress_test_message).await;
-            info!("Message receiver task ended");
-        }
-        .boxed()
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let num_peers = self.args.runner.bootstrap.len();
+
+        vec![
+            async move {
+                record_indexed_message(rx, num_peers).await;
+            }
+            .boxed(),
+            async move {
+                info!("Starting message receiver");
+                let tx_clone = tx.clone();
+                message_receiver
+                    .for_each(|message, peer_id| {
+                        let tx_clone = tx_clone.clone();
+                        receive_stress_test_message(message, peer_id, tx_clone);
+                    })
+                    .await;
+                info!("Message receiver task ended");
+            }
+            .boxed(),
+        ]
     }
 
     /// Gets all the tasks that need to be run
     async fn get_tasks(&mut self) -> Vec<BoxFuture<'static, ()>> {
         let mut tasks = Vec::new();
         tasks.push(self.start_network_manager().await);
-        tasks.push(self.make_message_receiver_task().await);
+        tasks.extend(self.make_message_receiver_tasks().await);
 
         if let Some(sender_task) = self.start_message_sender().await {
             tasks.push(sender_task);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new concurrent task wiring and unbounded channel usage in the hot receive path; misuse of peer indexing/`unwrap()` could cause panics or inaccurate metrics under load.
> 
> **Overview**
> Adds an async message-index tracking path to the broadcast stress test receiver: received messages now forward `(sender_id, message_index)` over an unbounded channel to a new `record_indexed_message` task which maintains per-peer `MessageIndexTracker`s and updates a new `RECEIVE_MESSAGE_PENDING_COUNT` gauge.
> 
> Wires this into `BroadcastNetworkStressTestNode` by splitting the receiver into two tasks (receiver + tracker) and removes the `dead_code` allowance from `message_index_detector.rs` now that it’s used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a85e9be1b56eec059cbb0acfd7d733e768c5037c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->