### PR TITLE
apollo_network_benchmark: add RoundRobin mode to enum and round_duration_seconds arg

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/stress_test_node.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/stress_test_node.rs
@@ -98,7 +98,7 @@ impl BroadcastNetworkStressTestNode {
     /// Determines if this node should broadcast messages based on the mode
     pub fn should_broadcast(&self) -> bool {
         match self.args.user.mode {
-            Mode::AllBroadcast => true,
+            Mode::AllBroadcast | Mode::RoundRobin => true,
             Mode::OneBroadcast => {
                 let broadcaster_id = Self::get_broadcaster_id(&self.args);
                 self.args.runner.id == broadcaster_id

--- a/crates/apollo_network_benchmark/src/node_args.rs
+++ b/crates/apollo_network_benchmark/src/node_args.rs
@@ -11,6 +11,9 @@ pub enum Mode {
     /// Only the node specified by --broadcaster broadcasts messages
     #[value(name = "one")]
     OneBroadcast,
+    /// Nodes take turns broadcasting in round-robin fashion
+    #[value(name = "rr")]
+    RoundRobin,
 }
 
 #[derive(Debug, Clone, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +85,10 @@ pub struct UserArgs {
     /// Which node ID should do the broadcasting - for OneBroadcast mode
     #[arg(long, env, required_if_eq("mode", "one"))]
     pub broadcaster: Option<u64>,
+
+    /// Duration each node broadcasts before switching (in seconds) - for RoundRobin mode
+    #[arg(long, env, default_value = "3")]
+    pub round_duration_seconds: u64,
 
     /// Size of StressTestMessage
     #[arg(long, env, default_value = "1024")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark CLI/options and a small gating condition for whether a node sends messages; no production networking logic is modified.
> 
> **Overview**
> Adds a new stress-test `Mode::RoundRobin` (CLI value `rr`) and a corresponding `--round-duration-seconds` argument (default `3`) to configure how long each node should broadcast before switching.
> 
> Updates `BroadcastNetworkStressTestNode::should_broadcast` to treat `RoundRobin` as a broadcasting mode (same decision path as `AllBroadcast`), enabling message sender startup when `mode=rr`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cf9aa882dc4c7bce80b6599dd3153fa4880fea5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->