### PR TITLE
apollo_network_benchmark: add seconds_since_epoch helper function

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/broadcast_network_stress_test_node/metrics.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use apollo_metrics::define_metrics;
 use apollo_metrics::metrics::LossyIntoF64;
@@ -60,6 +60,11 @@ pub(crate) fn register_metrics() {
 pub fn get_throughput(message_size_bytes: usize, heartbeat_duration: Duration) -> f64 {
     let tps = Duration::from_secs(1).as_secs_f64() / heartbeat_duration.as_secs_f64();
     tps * message_size_bytes.into_f64()
+}
+
+pub fn seconds_since_epoch() -> u64 {
+    let now = SystemTime::now();
+    now.duration_since(UNIX_EPOCH).unwrap().as_secs()
 }
 
 pub fn create_network_metrics() -> apollo_network::metrics::NetworkMetrics {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, isolated utility addition in benchmark code; only risk is the `unwrap()` on system clock time, which could panic in unusual environments.
> 
> **Overview**
> Adds a `seconds_since_epoch()` helper in `broadcast_network_stress_test_node/metrics.rs` (and the required `SystemTime`/`UNIX_EPOCH` imports) to expose the current Unix timestamp in seconds for use by the benchmark/stress-test code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7e9596fd3c7bd4c45b5bb7f09b474420a0c8e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->