### PR TITLE
more comments



### DIFF
--- a/style.md
+++ b/style.md
@@ -122,12 +122,6 @@ let result = map.insert(foo);
 assert!(result, "dup-check was done previously in ...")
 ```
 
-### Maps/Sets
-
-Avoid iterating `HashSet` and `HashMap`, this is not deterministic in rust. Either use `BTree{Map,Set}` or `Index{Map,Set}`, and prefer `BTree` when you can, as the `Index` version has O(n) removals (it uses a `Vec` for storage).
-
-**Note**: there is a [clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#iter_over_hash_type) for this, we should use it after fixing the existing issues.
-
 ## APIs
 
 Types appearing _in the API_ should strongly prefer `std` types, primitives, or types exposed by the crate for external use.
@@ -275,6 +269,10 @@ map.get(key).expect(format!("{key} should exist because of <reason>"));
 // GOOD
 map.get(key).unwrap_or_else(|| panic!("{key} should exist because of <reason>"))
 ```
+
+### Maps/Sets
+
+Avoid iterating `HashSet` and `HashMap`, this is not deterministic in rust. Either use `BTree{Map,Set}` or `Index{Map,Set}`, and prefer `BTree` when you can, as the `Index` version has O(n) removals (it uses a `Vec` for storage).
 
 ## Testing
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that reorders guidance and removes an informational note; no runtime or API impact.
> 
> **Overview**
> Moves the `Maps/Sets` guidance about avoiding non-deterministic iteration of `HashMap`/`HashSet` to the Performance/Allocations section and removes the prior note about adopting the related clippy lint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dcbe90340e61ffa2efac4b9bc1b9d8e638ea218. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->