### PR TITLE
rewrite types section

### DIFF
--- a/style.md
+++ b/style.md
@@ -241,16 +241,74 @@ Use `submodule_name.rs`, as `mod.rs` [is considered legacy](https://doc.rust-lan
 
 ## Types
 
-### Newtypes
-
-If newtyping as a "pass-through" wrapper (`Foo(pub Bar)`), add `Deref` and `DerefMut`.
-
-Avoid "ip addresses" (`let bar = foo.0.0.0.0.1`): prefer `Deref` when the derivation is trivial, or switch to a struct wrapper instead of a tuple otherwise.
-
 ### Type Safety
 
-Before using raw types like `u64` to represent a value, first grep the repo for existing types that wrap around it.
-Rationale: mainly consistency, but also they might have constraints on the values.
+Define types that wrap primitive types (usize, f64, bool, etc.) for frequently used struct members, function arguments, and return values.
+
+This prevents bug where you accidentally mix up values.
+
+```rust
+// BAD
+fn foo(nonce: u64) -> u64 {...}
+fn bar(nonce: u64) -> u64 {...}
+fn generate_nonce() -> u64 {...}
+
+bar(foo(generate_nonce()));
+
+// GOOD
+struct Nonce(u64);
+struct Timestamp(u64);
+fn foo(nonce: Nonce) -> Nonce {...}
+fn bar(nonce: Nonce) -> Timestamp {...} // Now it's clearer what bar returns
+fn generate_nonce() -> Nonce {...}
+
+bar(foo(generate_nonce()));
+foo(bar(foo(generate_nonce()))); // This won't compile, which is good. It would've compiled before.
+
+// ALSO BAD - This doesn't enforce anything
+type Nonce = u64;
+type Timestamp = u64;
+
+fn foo(nonce: Nonce) -> Nonce {...}
+fn bar(nonce: Nonce) -> Timestamp {...} // Now it's clearer what bar returns
+fn generate_nonce() -> Nonce {...}
+
+bar(foo(generate_nonce()));
+foo(bar(foo(generate_nonce()))); // This will compile, even though it shouldn't.
+```
+
+### Newtypes
+
+If newtyping as a "pass-through" wrapper (`Foo(pub Bar)`), add `Deref` and `DerefMut` in order to avoid patterns of `foo.0.0.1`.
+
+```rust
+// BAD
+struct Bar(pub u64);
+struct Foo(pub Bar);
+...
+if foo.0.0 > 0 {...}
+
+// GOOD
+struct Bar(u64)
+struct Foo(Bar)
+
+// Do the same for Bar. Not written here to save space.
+impl Deref for Foo {
+    type Target = Bar;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Foo {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+...
+if **foo > 0 {...}
+```
 
 ## Performance & Allocations
 

--- a/style.md
+++ b/style.md
@@ -269,32 +269,26 @@ foo(bar(foo(generate_nonce()))); // This won't compile, which is good. It would'
 type Nonce = u64;
 type Timestamp = u64;
 
-fn foo(nonce: Nonce) -> Nonce {...}
-fn bar(nonce: Nonce) -> Timestamp {...} // Now it's clearer what bar returns
-fn generate_nonce() -> Nonce {...}
+// Define functions as before
 
-bar(foo(generate_nonce()));
 foo(bar(foo(generate_nonce()))); // This will compile, even though it shouldn't.
 ```
 
 ### Newtypes
 
-If newtyping as a "pass-through" wrapper (`Foo(pub Bar)`), add `Deref` and `DerefMut` in order to avoid patterns of `foo.0.0.1`.
+If newtyping as a "pass-through" wrapper (`Foo(pub u64)`), add `Deref` and `DerefMut` in order to avoid patterns of `foo.0.0.1`.
 
 ```rust
 // BAD
-struct Bar(pub u64);
-struct Foo(pub Bar);
+struct Foo(pub u64);
 ...
 if foo.0.0 > 0 {...}
 
 // GOOD
-struct Bar(u64)
-struct Foo(Bar)
+struct Foo(u64)
 
-// Do the same for Bar. Not written here to save space.
 impl Deref for Foo {
-    type Target = Bar;
+    type Target = u64;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -307,7 +301,7 @@ impl DerefMut for Foo {
     }
 }
 ...
-if **foo > 0 {...}
+if *foo > 0 {...}
 ```
 
 ## Performance & Allocations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that do not affect runtime behavior. Risk is limited to potential confusion if the new guidance is misapplied by readers.
> 
> **Overview**
> **Expands the `## Types` section** to explicitly recommend using *newtype wrappers* around primitives for commonly used values to prevent mixing semantically different numbers/flags, with a concrete compile-time-safety example.
> 
> **Refines `### Newtypes` guidance** to push `Deref`/`DerefMut` for pass-through wrappers and adds an illustrative snippet showing how this avoids deep `.0` field-chaining.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6c4cfdc0eb6bf34bb39bd70950098449bf63df3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->