### PR TITLE
remove laziness



### DIFF
--- a/style.md
+++ b/style.md
@@ -312,14 +312,6 @@ Avoid allocations when a stack-based type will do, in particular: prefer arrays/
 
 Use `Vec::with_capacity()` when size is known to avoid reallocations.
 
-### Laziness
-
-Prefer returning lazy types from inner functions and delay the actual evaluation when possible, in practice this mostly mean holding off on `collect`ing until the actual usage.
-
-**Motivation**: helps the compiler optimize better, usually means less allocations, and in some cases avoid allocation entirely if somewhere up the stack it short-circuits.
-
-**Exception**: Early evaluation is still OK if the allocation is small and/or performed in a non-critical location, but only if it makes the code clearer.
-
 ### Lazy Gotchas - `foo_or` vs `foo_or_else`
 
 Methods that end with `_or`, like `unwrap_or`, are typically eagerly evaluated, meaning `foo.unwrap_or(expensive_calculation_of_foo())` will always be evaluated, even if the original value is unwrapped --- use `_or_else` methods for lazy evaluations, which is typically what you want.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates coding guidance without affecting runtime behavior.
> 
> **Overview**
> Removes the `Performance & Allocations` subsection on general “Laziness” advice (delaying `collect`, etc.) from `style.md`.
> 
> The remaining guidance emphasizes specific lazy-evaluation pitfalls via the `foo_or` vs `foo_or_else` section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4270e34d49cf874bb76b4ed372a837cd9ed1478a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->