### PR TITLE
apollo_dashboard: Fix Seconds since last function for Grafana panels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
 name = "apollo_metrics"
 version = "0.17.0-rc.0"
 dependencies = [
+ "apollo_time",
  "indexmap 2.12.0",
  "metrics",
  "metrics-exporter-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ apollo_state_sync_types.path = "crates/apollo_state_sync_types"
 apollo_storage.path = "crates/apollo_storage"
 apollo_task_executor.path = "crates/apollo_task_executor"
 apollo_test_utils.path = "crates/apollo_test_utils"
-apollo_time.path = "crates/apollo_time"
+apollo_time = { path = "crates/apollo_time", version = "0.17.0-rc.0" }
 ark-bls12-381 = "0.5.0"
 ark-ec = "0.5.0"
 ark-ff = "0.5.0"

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -779,7 +779,7 @@
           "description": "The number of seconds since the last transaction was received by the HTTP server (assuming there was a transaction in the last 12 hours)",
           "type": "timeseries",
           "exprs": [
-            "time() - max_over_time((timestamp(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h])) != 0)[12h:])"
+            "time() - max(last_over_time(http_server_last_received_transaction_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h]))"
           ],
           "extra_params": {
             "unit": "s"
@@ -1044,7 +1044,7 @@
           "description": "The number of seconds since the last transaction was received by the HTTP server (assuming there was a transaction in the last 12 hours)",
           "type": "timeseries",
           "exprs": [
-            "time() - max_over_time((timestamp(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h])) != 0)[12h:])"
+            "time() - max(last_over_time(http_server_last_received_transaction_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h]))"
           ],
           "extra_params": {
             "unit": "s"
@@ -1060,7 +1060,7 @@
           "description": "The number of seconds since the last successful scrape of the L1 message scraper (assuming there was a scrape in the last 12 hours)",
           "type": "timeseries",
           "exprs": [
-            "time() - max_over_time((timestamp(increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h])) != 0)[12h:])"
+            "time() - max(last_over_time(l1_message_scraper_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h]))"
           ],
           "extra_params": {
             "unit": "s",
@@ -1122,7 +1122,7 @@
           "description": "The number of seconds since the last successful scrape of the L1 gas price scraper (assuming there was a scrape in the last 12 hours)",
           "type": "timeseries",
           "exprs": [
-            "time() - max_over_time((timestamp(increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h])) != 0)[12h:])"
+            "time() - max(last_over_time(l1_gas_price_scraper_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h]))"
           ],
           "extra_params": {
             "unit": "s"
@@ -1133,7 +1133,7 @@
           "description": "The number of seconds since the last successful ETH→STRK rate update (assuming there was an update in the last 12 hours)",
           "type": "timeseries",
           "exprs": [
-            "time() - max_over_time((timestamp(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h])) != 0)[12h:])"
+            "time() - max(last_over_time(eth_to_strk_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h]))"
           ],
           "extra_params": {
             "unit": "s"

--- a/crates/apollo_dashboard/src/dashboard.rs
+++ b/crates/apollo_dashboard/src/dashboard.rs
@@ -74,14 +74,3 @@ impl Serialize for Row {
         map.end()
     }
 }
-
-/// Returns a PromQL expression that calculates the time since the last increase of the given
-/// metric. Assumes there was an increase in the last 12 hours.
-pub(crate) fn get_time_since_last_increase_expr(metric_name: &str) -> String {
-    const TIME_RANGE: &str = "12h";
-    format!(
-        // The max over time is the timestamp of the last increase in the last 12 hours.
-        "time() - max_over_time((timestamp(increase({metric_name}[{TIME_RANGE}])) != \
-         0)[{TIME_RANGE}:])"
-    )
-}

--- a/crates/apollo_dashboard/src/panels/http_server.rs
+++ b/crates/apollo_dashboard/src/panels/http_server.rs
@@ -5,12 +5,13 @@ use apollo_http_server::metrics::{
     ADDED_TRANSACTIONS_SUCCESS,
     ADDED_TRANSACTIONS_TOTAL,
     HTTP_SERVER_ADD_TX_LATENCY,
+    LAST_RECEIVED_TRANSACTION_TIMESTAMP_SECONDS,
 };
 use apollo_metrics::metrics::MetricQueryName;
 
-use crate::dashboard::{get_time_since_last_increase_expr, Row};
+use crate::dashboard::Row;
 use crate::panel::{Panel, PanelType, Unit};
-use crate::query_builder::{increase, DEFAULT_DURATION};
+use crate::query_builder::{increase, seconds_since_last_timestamp, DEFAULT_DURATION};
 
 fn get_panel_total_transactions_received() -> Panel {
     Panel::new(
@@ -88,7 +89,7 @@ pub(crate) fn get_panel_http_server_seconds_since_last_transaction() -> Panel {
         "Seconds since last received transaction",
         "The number of seconds since the last transaction was received by the HTTP server \
          (assuming there was a transaction in the last 12 hours)",
-        get_time_since_last_increase_expr(&ADDED_TRANSACTIONS_TOTAL.get_name_with_filter()),
+        seconds_since_last_timestamp(&LAST_RECEIVED_TRANSACTION_TIMESTAMP_SECONDS),
         PanelType::TimeSeries,
     )
     .with_unit(Unit::Seconds)

--- a/crates/apollo_dashboard/src/panels/l1_gas_price.rs
+++ b/crates/apollo_dashboard/src/panels/l1_gas_price.rs
@@ -1,11 +1,13 @@
 use apollo_l1_gas_price::metrics::{
     ETH_TO_STRK_ERROR_COUNT,
+    ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS,
     ETH_TO_STRK_RATE,
     ETH_TO_STRK_SUCCESS_COUNT,
     L1_DATA_GAS_PRICE_LATEST_MEAN_VALUE,
     L1_GAS_PRICE_LATEST_MEAN_VALUE,
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
     L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT,
+    L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS,
     L1_GAS_PRICE_SCRAPER_LATEST_SCRAPED_BLOCK,
     L1_GAS_PRICE_SCRAPER_REORG_DETECTED,
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT,
@@ -13,9 +15,9 @@ use apollo_l1_gas_price::metrics::{
 use apollo_l1_gas_price_types::DEFAULT_ETH_TO_FRI_RATE;
 use apollo_metrics::metrics::MetricQueryName;
 
-use crate::dashboard::{get_time_since_last_increase_expr, Row};
+use crate::dashboard::Row;
 use crate::panel::{Panel, PanelType, Unit};
-use crate::query_builder::{increase, DEFAULT_DURATION};
+use crate::query_builder::{increase, seconds_since_last_timestamp, DEFAULT_DURATION};
 
 fn get_panel_eth_to_strk_error_count() -> Panel {
     Panel::new(
@@ -35,7 +37,7 @@ fn get_panel_eth_to_strk_seconds_since_last_successful_update() -> Panel {
         "Seconds since last successful ETH→STRK rate update",
         "The number of seconds since the last successful ETH→STRK rate update (assuming there was \
          an update in the last 12 hours)",
-        get_time_since_last_increase_expr(&ETH_TO_STRK_SUCCESS_COUNT.get_name_with_filter()),
+        seconds_since_last_timestamp(&ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS),
         PanelType::TimeSeries,
     )
     .with_unit(Unit::Seconds)
@@ -116,9 +118,7 @@ fn get_panel_l1_gas_price_scraper_seconds_since_last_successful_scrape() -> Pane
         "Seconds since last successful L1 gas price scrape",
         "The number of seconds since the last successful scrape of the L1 gas price scraper \
          (assuming there was a scrape in the last 12 hours)",
-        get_time_since_last_increase_expr(
-            &L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.get_name_with_filter(),
-        ),
+        seconds_since_last_timestamp(&L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS),
         PanelType::TimeSeries,
     )
     .with_unit(Unit::Seconds)

--- a/crates/apollo_dashboard/src/panels/l1_provider.rs
+++ b/crates/apollo_dashboard/src/panels/l1_provider.rs
@@ -1,15 +1,15 @@
 use apollo_l1_provider::metrics::{
     L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT,
+    L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS,
     L1_MESSAGE_SCRAPER_LATEST_SCRAPED_BLOCK,
     L1_MESSAGE_SCRAPER_REORG_DETECTED,
     L1_MESSAGE_SCRAPER_SUCCESS_COUNT,
     L1_PROVIDER_NUM_PENDING_TXS,
 };
-use apollo_metrics::metrics::MetricQueryName;
 
-use crate::dashboard::{get_time_since_last_increase_expr, Row};
+use crate::dashboard::Row;
 use crate::panel::{Panel, PanelType, Unit};
-use crate::query_builder::{increase, DEFAULT_DURATION};
+use crate::query_builder::{increase, seconds_since_last_timestamp, DEFAULT_DURATION};
 
 fn get_panel_l1_message_scraper_success_count() -> Panel {
     Panel::new(
@@ -47,12 +47,13 @@ fn get_panel_l1_message_scraper_latest_scraped_block() -> Panel {
 fn get_panel_l1_provider_num_pending_txs() -> Panel {
     Panel::from_gauge(&L1_PROVIDER_NUM_PENDING_TXS, PanelType::TimeSeries)
 }
+
 fn get_panel_l1_message_scraper_seconds_since_last_successful_scrape() -> Panel {
     Panel::new(
         "Seconds since last successful l1 event scrape",
         "The number of seconds since the last successful scrape of the L1 message scraper \
          (assuming there was a scrape in the last 12 hours)",
-        get_time_since_last_increase_expr(&L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
+        seconds_since_last_timestamp(&L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS),
         PanelType::TimeSeries,
     )
     .with_unit(Unit::Seconds)

--- a/crates/apollo_dashboard/src/query_builder.rs
+++ b/crates/apollo_dashboard/src/query_builder.rs
@@ -23,6 +23,15 @@ pub(crate) fn increase(metric: &dyn MetricQueryName, duration: &str) -> String {
     format!("increase({}[{}])", metric.get_name_with_filter(), duration)
 }
 
+/// Returns a query that calculates the number of seconds since the last event timestamp recorded
+/// in a gauge (unix timestamp seconds).
+///
+/// Example output:
+/// `time() - max(last_over_time(my_last_success_timestamp_seconds{...}[12h]))`
+pub(crate) fn seconds_since_last_timestamp(metric: &dyn MetricQueryName) -> String {
+    format!("time() - max(last_over_time({}[12h]))", metric.get_name_with_filter())
+}
+
 /// Returns a query string that sums a metric **by a label**, optionally using
 /// `increase()` and filtering zeros.
 ///

--- a/crates/apollo_http_server/src/http_server.rs
+++ b/crates/apollo_http_server/src/http_server.rs
@@ -19,6 +19,7 @@ use apollo_gateway_types::gateway_types::{
 use apollo_http_server_config::config::{HttpServerConfig, HttpServerDynamicConfig};
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_infra_utils::type_name::short_type_name;
+use apollo_metrics::metrics::set_unix_now_seconds;
 use apollo_proc_macros::sequencer_latency_histogram;
 use async_trait::async_trait;
 use axum::http::HeaderMap;
@@ -44,6 +45,7 @@ use crate::metrics::{
     ADDED_TRANSACTIONS_SUCCESS,
     ADDED_TRANSACTIONS_TOTAL,
     HTTP_SERVER_ADD_TX_LATENCY,
+    LAST_RECEIVED_TRANSACTION_TIMESTAMP_SECONDS,
 };
 
 #[cfg(test)]
@@ -149,6 +151,7 @@ async fn add_rpc_tx(
     check_new_transactions_are_allowed(accept_new_txs)?;
 
     ADDED_TRANSACTIONS_TOTAL.increment(1);
+    set_unix_now_seconds(&LAST_RECEIVED_TRANSACTION_TIMESTAMP_SECONDS);
     add_tx_inner(app_state, headers, tx).await
 }
 
@@ -166,6 +169,7 @@ async fn add_tx(
     check_new_transactions_are_allowed(accept_new_txs)?;
 
     ADDED_TRANSACTIONS_TOTAL.increment(1);
+    set_unix_now_seconds(&LAST_RECEIVED_TRANSACTION_TIMESTAMP_SECONDS);
     let tx: DeprecatedGatewayTransactionV3 = match serde_json::from_str(&tx) {
         Ok(value) => value,
         Err(e) => {

--- a/crates/apollo_http_server/src/metrics.rs
+++ b/crates/apollo_http_server/src/metrics.rs
@@ -13,6 +13,7 @@ define_metrics!(
         MetricCounter { ADDED_TRANSACTIONS_FAILURE, "http_server_added_transactions_failure", "Number of transactions that failed to be added", init = 0 },
         MetricCounter { ADDED_TRANSACTIONS_INTERNAL_ERROR, "http_server_added_transactions_internal_error", "Number of transactions that failed to be added due to an internal error", init = 0 },
         MetricCounter { ADDED_TRANSACTIONS_DEPRECATED_ERROR, "http_server_added_transactions_deprecated_error", "Number of transactions that failed to be added due to a deprecated error", init = 0 },
+        MetricGauge { LAST_RECEIVED_TRANSACTION_TIMESTAMP_SECONDS, "http_server_last_received_transaction_timestamp_seconds", "Unix timestamp (seconds) of the last transaction received by the HTTP server" },
         MetricHistogram { HTTP_SERVER_ADD_TX_LATENCY, "http_server_add_tx_latency", "Latency of HTTP add_tx endpoint in secs" },
     },
 );
@@ -24,5 +25,6 @@ pub(crate) fn init_metrics() {
     ADDED_TRANSACTIONS_FAILURE.register();
     ADDED_TRANSACTIONS_INTERNAL_ERROR.register();
     ADDED_TRANSACTIONS_DEPRECATED_ERROR.register();
+    LAST_RECEIVED_TRANSACTION_TIMESTAMP_SECONDS.register();
     HTTP_SERVER_ADD_TX_LATENCY.register();
 }

--- a/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
@@ -8,6 +8,7 @@ use apollo_config::secrets::Sensitive;
 use apollo_l1_gas_price_provider_config::config::EthToStrkOracleConfig;
 use apollo_l1_gas_price_types::errors::EthToStrkOracleClientError;
 use apollo_l1_gas_price_types::EthToStrkOracleClientTrait;
+use apollo_metrics::metrics::set_unix_now_seconds;
 use async_trait::async_trait;
 use futures::FutureExt;
 use lru::LruCache;
@@ -20,6 +21,7 @@ use url::Url;
 use crate::metrics::{
     register_eth_to_strk_metrics,
     ETH_TO_STRK_ERROR_COUNT,
+    ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS,
     ETH_TO_STRK_RATE,
     ETH_TO_STRK_SUCCESS_COUNT,
 };
@@ -180,6 +182,7 @@ fn resolve_query(body: String) -> Result<u128, EthToStrkOracleClientError> {
         ));
     }
     ETH_TO_STRK_SUCCESS_COUNT.increment(1);
+    set_unix_now_seconds(&ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS);
     ETH_TO_STRK_RATE.set_lossy(rate);
     Ok(rate)
 }

--- a/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
@@ -8,6 +8,7 @@ use apollo_infra_utils::info_every_n_ms;
 use apollo_l1_gas_price_provider_config::config::L1GasPriceScraperConfig;
 use apollo_l1_gas_price_types::errors::L1GasPriceClientError;
 use apollo_l1_gas_price_types::{GasPriceData, L1GasPriceProviderClient, PriceInfo};
+use apollo_metrics::metrics::set_unix_now_seconds;
 use async_trait::async_trait;
 use papyrus_base_layer::{BaseLayerContract, L1BlockHeader, L1BlockNumber};
 use starknet_api::block::GasPrice;
@@ -17,6 +18,7 @@ use tracing::{error, info, trace, warn};
 use crate::metrics::{
     register_scraper_metrics,
     L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT,
+    L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS,
     L1_GAS_PRICE_SCRAPER_LATEST_SCRAPED_BLOCK,
     L1_GAS_PRICE_SCRAPER_REORG_DETECTED,
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT,
@@ -148,6 +150,7 @@ impl<B: BaseLayerContract + Send + Sync + Debug> L1GasPriceScraper<B> {
                 .await
                 .map_err(L1GasPriceScraperError::GasPriceClientError)?;
             L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.increment(1);
+            set_unix_now_seconds(&L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS);
             *block_number += 1;
         }
         Ok(())

--- a/crates/apollo_l1_gas_price/src/metrics.rs
+++ b/crates/apollo_l1_gas_price/src/metrics.rs
@@ -18,6 +18,8 @@ define_metrics!(
         MetricCounter { L1_GAS_PRICE_SCRAPER_REORG_DETECTED, "l1_gas_price_scraper_reorg_detected", "Number of times the L1 gas price scraper detected a reorganization in the base layer", init=0 },
         MetricCounter { ETH_TO_STRK_ERROR_COUNT, "eth_to_strk_error_count", "Number of times the query to the Eth to Strk oracle failed due to an error or timeout", init=0 },
         MetricCounter { ETH_TO_STRK_SUCCESS_COUNT, "eth_to_strk_success_count", "Number of times the query to the Eth to Strk oracle succeeded", init=0 },
+        MetricGauge { L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS, "l1_gas_price_scraper_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful L1 gas price scrape" },
+        MetricGauge { ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS, "eth_to_strk_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful ETH→STRK oracle query" },
         MetricGauge { L1_GAS_PRICE_SCRAPER_LATEST_SCRAPED_BLOCK, "l1_gas_price_scraper_latest_scraped_block", "The latest block number that the L1 gas price scraper has scraped" },
         MetricGauge { ETH_TO_STRK_RATE, "eth_to_strk_rate", "The current rate of ETH to STRK conversion" },
         MetricGauge { L1_GAS_PRICE_LATEST_MEAN_VALUE, "l1_gas_price_latest_mean_value", "The latest L1 gas price, calculated as an average by the provider client" },
@@ -35,11 +37,13 @@ pub(crate) fn register_scraper_metrics() {
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.register();
     L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT.register();
     L1_GAS_PRICE_SCRAPER_REORG_DETECTED.register();
+    L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS.register();
     L1_GAS_PRICE_SCRAPER_LATEST_SCRAPED_BLOCK.register();
 }
 
 pub(crate) fn register_eth_to_strk_metrics() {
     ETH_TO_STRK_ERROR_COUNT.register();
     ETH_TO_STRK_SUCCESS_COUNT.register();
+    ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS.register();
     ETH_TO_STRK_RATE.register();
 }

--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -8,6 +8,7 @@ use apollo_infra_utils::{debug_every_n, info_every_n_ms};
 use apollo_l1_provider_types::errors::{L1ProviderClientError, L1ProviderError};
 use apollo_l1_provider_types::{Event, SharedL1ProviderClient};
 use apollo_l1_scraper_config::config::L1ScraperConfig;
+use apollo_metrics::metrics::set_unix_now_seconds;
 use apollo_time::time::{Clock, DefaultClock};
 use async_trait::async_trait;
 use futures::future::{BoxFuture, FutureExt};
@@ -24,6 +25,7 @@ use tracing::{debug, info, instrument, trace, warn};
 use crate::metrics::{
     register_scraper_metrics,
     L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT,
+    L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS,
     L1_MESSAGE_SCRAPER_LATEST_SCRAPED_BLOCK,
     L1_MESSAGE_SCRAPER_REORG_DETECTED,
     L1_MESSAGE_SCRAPER_SUCCESS_COUNT,
@@ -107,6 +109,7 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1Scraper<BaseLayer
                 }
                 Ok(_) => {
                     L1_MESSAGE_SCRAPER_SUCCESS_COUNT.increment(1);
+                    set_unix_now_seconds(&L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS);
                 }
                 Err(e) => return Err(e),
             }

--- a/crates/apollo_l1_provider/src/metrics.rs
+++ b/crates/apollo_l1_provider/src/metrics.rs
@@ -16,6 +16,7 @@ define_metrics!(
         MetricCounter { L1_MESSAGE_SCRAPER_SUCCESS_COUNT, "l1_message_scraper_success_count", "Number of times the L1 message scraper successfully scraped messages and updated the provider", init=0 },
         MetricCounter { L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT, "l1_message_scraper_baselayer_error_count", "Number of times the L1 message scraper encountered an error while scraping the base layer", init=0},
         MetricCounter { L1_MESSAGE_SCRAPER_REORG_DETECTED, "l1_message_scraper_reorg_detected", "Number of times the L1 message scraper detected a reorganization in the base layer", init=0},
+        MetricGauge { L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS, "l1_message_scraper_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful L1 message scrape" },
         MetricGauge { L1_PROVIDER_NUM_PENDING_TXS, "l1_provider_num_pending_txs", "The number of pending L1 handler transactions in the transaction manager" },
     },
 );
@@ -25,6 +26,7 @@ pub(crate) fn register_scraper_metrics() {
     L1_MESSAGE_SCRAPER_SUCCESS_COUNT.register();
     L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT.register();
     L1_MESSAGE_SCRAPER_REORG_DETECTED.register();
+    L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS.register();
 }
 
 pub(crate) fn register_provider_metrics() {

--- a/crates/apollo_metrics/Cargo.toml
+++ b/crates/apollo_metrics/Cargo.toml
@@ -13,6 +13,7 @@ testing = ["tracing"]
 workspace = true
 
 [dependencies]
+apollo_time.workspace = true
 indexmap.workspace = true
 metrics.workspace = true
 num-traits.workspace = true

--- a/crates/apollo_metrics/src/metrics.rs
+++ b/crates/apollo_metrics/src/metrics.rs
@@ -13,7 +13,7 @@ mod histograms;
 
 // re exports
 pub use crate::metrics::counters::{LabeledMetricCounter, MetricCounter};
-pub use crate::metrics::gauges::{LabeledMetricGauge, MetricGauge};
+pub use crate::metrics::gauges::{set_unix_now_seconds, LabeledMetricGauge, MetricGauge};
 pub use crate::metrics::histograms::{HistogramValue, LabeledMetricHistogram, MetricHistogram};
 
 /// Global variable set by the main config to enable collecting profiling metrics.

--- a/crates/apollo_metrics/src/metrics/gauges.rs
+++ b/crates/apollo_metrics/src/metrics/gauges.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 #[cfg(any(feature = "testing", test))]
 use std::str::FromStr;
 
+use apollo_time::time::{Clock, DefaultClock};
 use metrics::{describe_gauge, gauge, IntoF64};
 #[cfg(any(feature = "testing", test))]
 use num_traits::Num;
@@ -29,6 +30,10 @@ impl HasMetricFilterKind for LabeledMetricGauge {
 
 pub struct MetricGauge {
     metric: Metric,
+}
+
+pub fn set_unix_now_seconds(gauge: &MetricGauge) {
+    gauge.set_lossy(Clock::unix_now(&DefaultClock));
 }
 
 impl MetricGauge {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new gauge metrics and updates multiple services/dashboards to rely on them; risk is mainly mismatched metric names/registration causing broken Grafana panels rather than runtime correctness issues.
> 
> **Overview**
> Fixes Grafana “seconds since last …” panels by switching from deriving timestamps via `increase()` on counters to using explicit *last-success unix timestamp* gauges queried with `last_over_time`.
> 
> Adds new timestamp gauge metrics and updates writers to set them on success (`http_server` on transaction receive, `l1_provider` scraper loop, `l1_gas_price` scraper and ETH→STRK oracle), introduces `apollo_metrics::set_unix_now_seconds` plus a dashboard `seconds_since_last_timestamp` query helper, and updates the bundled `dev_grafana.json` expressions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f9f14506f7dc235712c8765f44607c18a304143. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->