### PR TITLE
starknet_committer: parallel reads using unordered futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12290,6 +12290,7 @@ dependencies = [
  "derive_more 2.1.1",
  "ethnum",
  "expect-test",
+ "futures",
  "hex",
  "pretty_assertions",
  "rand 0.8.5",

--- a/crates/starknet_committer/Cargo.toml
+++ b/crates/starknet_committer/Cargo.toml
@@ -14,6 +14,7 @@ apollo_config.workspace = true
 async-trait.workspace = true
 derive_more = { workspace = true, features = ["as_ref", "from", "into"] }
 ethnum.workspace = true
+futures.workspace = true
 hex.workspace = true
 pretty_assertions.workspace = true
 rand.workspace = true

--- a/crates/starknet_committer/src/db/trie_traversal.rs
+++ b/crates/starknet_committer/src/db/trie_traversal.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
+use futures::stream::{FuturesUnordered, StreamExt};
 use starknet_api::core::ContractAddress;
 use starknet_api::hash::HashOutput;
 use starknet_patricia::db_layout::{NodeLayout, NodeLayoutFor};
@@ -26,7 +27,8 @@ use starknet_patricia::patricia_merkle_tree::traversal::{
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
 use starknet_patricia_storage::db_object::{DBObject, EmptyKeyContext, HasStaticPrefix};
 use starknet_patricia_storage::errors::StorageError;
-use starknet_patricia_storage::storage_trait::{DbKey, ReadOnlyStorage};
+use starknet_patricia_storage::map_storage::ReadsCollectorStorage;
+use starknet_patricia_storage::storage_trait::{DbKey, ImmutableReadOnlyStorage, ReadOnlyStorage};
 use tracing::warn;
 
 use crate::block_committer::input::{
@@ -457,5 +459,67 @@ where
         .await?;
         storage_tries.insert(*address, original_skeleton);
     }
+    Ok(storage_tries)
+}
+
+// TODO(Nimrod): Remove the `allow(dead_code)` once we use this function.
+#[allow(dead_code)]
+async fn create_storage_tries_concurrently<'a, Layout: NodeLayoutFor<StarknetStorageValue>>(
+    storage: &impl ImmutableReadOnlyStorage,
+    actual_storage_updates: &HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
+    original_contracts_trie_leaves: &HashMap<NodeIndex, ContractState>,
+    config: &ReaderConfig,
+    storage_tries_sorted_indices: &HashMap<ContractAddress, SortedLeafIndices<'a>>,
+) -> ForestResult<HashMap<ContractAddress, OriginalSkeletonTreeImpl<'a>>>
+where
+    <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf:
+        HasStaticPrefix<KeyContext = ContractAddress>,
+{
+    let mut futures = FuturesUnordered::new();
+    let mut storage_tries = HashMap::new();
+
+    let trie_config = OriginalSkeletonTrieConfig::new_for_classes_or_storage_trie(
+        config.warn_on_trivial_modifications(),
+    );
+    for (address, updates) in actual_storage_updates {
+        // Extract data needed for this contract.
+        let sorted_leaf_indices = *storage_tries_sorted_indices
+            .get(address)
+            .ok_or(ForestError::MissingSortedLeafIndices(*address))?;
+        let contract_state = original_contracts_trie_leaves
+            .get(&contract_address_into_node_index(address))
+            .ok_or(ForestError::MissingContractCurrentState(*address))?;
+        let cloned_trie_config = trie_config.clone();
+
+        // TODO(Ariel): Change `LeafModifications` in `actual_storage_updates` to be an
+        // iterator over borrowed data so that the conversion below is costless.
+        let leaf_modifications: HashMap<
+            NodeIndex,
+            <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf,
+        > = updates.iter().map(|(idx, value)| (*idx, Layout::DbLeaf::from(*value))).collect();
+        let mut reads_collector_storage = ReadsCollectorStorage::new(storage);
+        // Create the future - tokio will poll all futures concurrently.
+        futures.push(async move {
+            let previous_leaves = None;
+            let original_skeleton = create_original_skeleton_tree::<Layout::DbLeaf, Layout>(
+                &mut reads_collector_storage,
+                contract_state.storage_root_hash,
+                sorted_leaf_indices,
+                &cloned_trie_config,
+                &leaf_modifications,
+                previous_leaves,
+                address,
+            )
+            .await?;
+            Ok::<_, ForestError>((address, original_skeleton))
+        });
+    }
+
+    // Collect all results as they complete.
+    while let Some(result) = futures.next().await {
+        let (address, original_skeleton) = result?;
+        storage_tries.insert(*address, original_skeleton);
+    }
+
     Ok(storage_tries)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new, currently unused concurrent code path for building storage tries; no existing runtime behavior changes, but it introduces new async/concurrency utilities that could be error-prone when enabled later.
> 
> **Overview**
> Introduces an (currently unused) concurrent implementation for building per-contract storage trie original skeletons using `FuturesUnordered`, switching the new helper to accept an `ImmutableReadOnlyStorage` and wrapping it with `ReadsCollectorStorage` per task.
> 
> Updates `starknet_committer` dependencies to include `futures` (and updates `Cargo.lock`) to support the new unordered-futures-based traversal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3d01bae452287a5e6335713c0f3aa04e98f24d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->