### PR TITLE
starknet_patricia_storage: spawn blocking tasks for rocksDB reads

### DIFF
--- a/crates/starknet_patricia_storage/Cargo.toml
+++ b/crates/starknet_patricia_storage/Cargo.toml
@@ -31,6 +31,7 @@ serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 validator = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/starknet_patricia_storage/src/errors.rs
+++ b/crates/starknet_patricia_storage/src/errors.rs
@@ -50,5 +50,5 @@ pub enum DeserializationError {
     // TODO(Ariel): This is only used for EdgeNode construction failures (path length etc.), add
     // error types here and use them instead of the general ValueError.
     #[error("Invalid value for deserialization: {0}.")]
-    ValueError(Box<dyn std::error::Error>),
+    ValueError(Box<dyn std::error::Error + Send>),
 }

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -17,6 +17,7 @@ use rust_rocksdb::{
     DB,
 };
 use serde::{Deserialize, Serialize};
+use tokio::task::spawn_blocking;
 use validator::Validate;
 
 use crate::storage_trait::{
@@ -279,18 +280,23 @@ impl StorageStats for RocksDbStats {
 
 impl ImmutableReadOnlyStorage for RocksDbStorage {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
-        Ok(self.db.get(&key.0)?.map(DbValue))
+        // TODO(Nimrod): Config should indicate whether to spawn a task or not.
+        let db = self.db.clone();
+        let key = key.clone();
+        Ok(spawn_blocking(move || db.get(&key.0).map(|opt| opt.map(DbValue))).await??)
     }
 
     async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
-        let raw_keys = keys.iter().map(|k| &k.0);
-        let res = self
-            .db
-            .multi_get(raw_keys)
-            .into_iter()
-            .map(|r| r.map(|opt| opt.map(DbValue)))
-            .collect::<Result<_, _>>()?;
-        Ok(res)
+        // TODO(Nimrod): Config should indicate whether to spawn a task or not.
+        let db = self.db.clone();
+        let keys: Vec<Vec<u8>> = keys.iter().map(|k| k.0.clone()).collect();
+        spawn_blocking(move || {
+            db.multi_get(keys)
+                .into_iter()
+                .map(|r| Ok(r?.map(DbValue)))
+                .collect::<PatriciaStorageResult<_>>()
+        })
+        .await?
     }
 }
 

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -7,6 +7,7 @@ use apollo_config::dumping::SerializeConfig;
 use apollo_config::{ParamPath, SerializedParam};
 use serde::{Deserialize, Serialize, Serializer};
 use starknet_types_core::felt::Felt;
+use tokio::task::JoinError;
 use validator::Validate;
 
 use crate::errors::DeserializationError;
@@ -45,6 +46,8 @@ pub enum PatriciaStorageError {
     AerospikeStorage(#[from] crate::aerospike_storage::AerospikeStorageError),
     #[error(transparent)]
     Deserialization(#[from] DeserializationError),
+    #[error(transparent)]
+    Join(#[from] JoinError),
     #[cfg(any(test, feature = "mdbx_storage"))]
     #[error(transparent)]
     Mdbx(#[from] libmdbx::Error),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes RocksDB read paths to run in `spawn_blocking`, which can affect latency/throughput and introduces new failure modes via `JoinError` propagation. Risk is moderate and localized to RocksDB read operations and error types.
> 
> **Overview**
> RocksDB `get`/`multi_get` calls are now executed via `tokio::task::spawn_blocking` in the `ImmutableReadOnlyStorage` implementation to avoid blocking the async runtime during reads.
> 
> To support this, the crate adds a `tokio` dependency and extends `PatriciaStorageError` with a `JoinError` variant; `DeserializationError::ValueError` is tightened to `Box<dyn Error + Send>` to remain compatible with spawned tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f94cf4afc2bc04f5998a0f83106bb727449a186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->