### PR TITLE
starknet_patricia_storage: add config field to rocksDB storage

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/committer_config.json
@@ -9,6 +9,7 @@
     "committer_config.storage_config.inner_storage_config.enable_statistics": true,
     "committer_config.storage_config.inner_storage_config.max_background_jobs": 8,
     "committer_config.storage_config.inner_storage_config.use_mmap_reads": false,
+    "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": false,
     "committer_config.storage_config.inner_storage_config.max_subcompactions": 8,
     "committer_config.storage_config.inner_storage_config.max_write_buffers": 4,
     "committer_config.storage_config.inner_storage_config.num_threads": 8,

--- a/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
@@ -8,6 +8,7 @@
   "committer_config.storage_config.inner_storage_config.cache_size": 8589934592,
   "committer_config.storage_config.inner_storage_config.enable_statistics": true,
   "committer_config.storage_config.inner_storage_config.max_background_jobs": 8,
+  "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": false,
   "committer_config.storage_config.inner_storage_config.max_subcompactions": 8,
   "committer_config.storage_config.inner_storage_config.max_write_buffers": 4,
   "committer_config.storage_config.inner_storage_config.num_threads": 8,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -579,6 +579,11 @@
     "privacy": "Public",
     "value": false
   },
+  "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": {
+    "description": "Whether to spawn blocking tasks for read operations",
+    "privacy": "Public",
+    "value": false
+  },
   "committer_config.storage_config.inner_storage_config.write_buffer_size": {
     "description": "Amount of data to build up in memory before writing to disk",
     "privacy": "Public",

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -152,6 +152,8 @@ pub struct RocksDbStorageConfig {
     pub enable_statistics: bool,
     /// Whether to use mmap for reading SST files.
     pub use_mmap_reads: bool,
+    /// Whether to spawn blocking tasks for read operations.
+    pub spawn_blocking_reads: bool,
 }
 
 impl Default for RocksDbStorageConfig {
@@ -171,6 +173,7 @@ impl Default for RocksDbStorageConfig {
             bloom_filter_bits: BLOOM_FILTER_NUM_BITS,
             enable_statistics: true,
             use_mmap_reads: false,
+            spawn_blocking_reads: false,
         }
     }
 }
@@ -242,6 +245,12 @@ impl SerializeConfig for RocksDbStorageConfig {
                 "use_mmap_reads",
                 &self.use_mmap_reads,
                 "Whether to use mmap for reading SST files",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "spawn_blocking_reads",
+                &self.spawn_blocking_reads,
+                "Whether to spawn blocking tasks for read operations",
                 ParamPrivacyInput::Public,
             ),
         ])

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -123,6 +123,7 @@ impl RocksDbOptions {
 pub struct RocksDbStorage {
     db: Arc<DB>,
     options: Arc<RocksDbOptions>,
+    _config: RocksDbStorageConfig,
 }
 
 /// Configuration for RocksDB storage.
@@ -263,7 +264,7 @@ impl RocksDbStorage {
     pub fn new(path: &Path, config: RocksDbStorageConfig) -> PatriciaStorageResult<Self> {
         let options = RocksDbOptions::from_config(&config);
         let db = Arc::new(DB::open(&options.db_options, path)?);
-        Ok(Self { db, options: Arc::new(options) })
+        Ok(Self { db, options: Arc::new(options), _config: config })
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only stores the provided `RocksDbStorageConfig` inside `RocksDbStorage` without changing DB options or read/write behavior.
> 
> **Overview**
> `RocksDbStorage` now retains a copy of the `RocksDbStorageConfig` passed to `RocksDbStorage::new` via a new `_config` field, ensuring the original serializable config is kept alongside the constructed `RocksDbOptions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d394c772efc9eda3c03c6e14d68f86069ce2ba03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->