### PR TITLE
starknet_patricia_storage: spawn a task or not based on config

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/committer_config.json
@@ -9,7 +9,7 @@
     "committer_config.storage_config.inner_storage_config.enable_statistics": true,
     "committer_config.storage_config.inner_storage_config.max_background_jobs": 8,
     "committer_config.storage_config.inner_storage_config.use_mmap_reads": false,
-    "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": false,
+    "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": true,
     "committer_config.storage_config.inner_storage_config.max_subcompactions": 8,
     "committer_config.storage_config.inner_storage_config.max_write_buffers": 4,
     "committer_config.storage_config.inner_storage_config.num_threads": 8,

--- a/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
@@ -8,7 +8,7 @@
   "committer_config.storage_config.inner_storage_config.cache_size": 8589934592,
   "committer_config.storage_config.inner_storage_config.enable_statistics": true,
   "committer_config.storage_config.inner_storage_config.max_background_jobs": 8,
-  "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": false,
+  "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": true,
   "committer_config.storage_config.inner_storage_config.max_subcompactions": 8,
   "committer_config.storage_config.inner_storage_config.max_write_buffers": 4,
   "committer_config.storage_config.inner_storage_config.num_threads": 8,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -582,7 +582,7 @@
   "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": {
     "description": "Whether to spawn blocking tasks for read operations",
     "privacy": "Public",
-    "value": false
+    "value": true
   },
   "committer_config.storage_config.inner_storage_config.write_buffer_size": {
     "description": "Amount of data to build up in memory before writing to disk",

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -123,7 +123,7 @@ impl RocksDbOptions {
 pub struct RocksDbStorage {
     db: Arc<DB>,
     options: Arc<RocksDbOptions>,
-    _config: RocksDbStorageConfig,
+    config: RocksDbStorageConfig,
 }
 
 /// Configuration for RocksDB storage.
@@ -174,7 +174,7 @@ impl Default for RocksDbStorageConfig {
             bloom_filter_bits: BLOOM_FILTER_NUM_BITS,
             enable_statistics: true,
             use_mmap_reads: false,
-            spawn_blocking_reads: false,
+            spawn_blocking_reads: true,
         }
     }
 }
@@ -264,7 +264,7 @@ impl RocksDbStorage {
     pub fn new(path: &Path, config: RocksDbStorageConfig) -> PatriciaStorageResult<Self> {
         let options = RocksDbOptions::from_config(&config);
         let db = Arc::new(DB::open(&options.db_options, path)?);
-        Ok(Self { db, options: Arc::new(options), _config: config })
+        Ok(Self { db, options: Arc::new(options), config })
     }
 }
 
@@ -290,23 +290,35 @@ impl StorageStats for RocksDbStats {
 
 impl ImmutableReadOnlyStorage for RocksDbStorage {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
-        // TODO(Nimrod): Config should indicate whether to spawn a task or not.
-        let db = self.db.clone();
-        let key = key.clone();
-        Ok(spawn_blocking(move || db.get(&key.0).map(|opt| opt.map(DbValue))).await??)
+        if self.config.spawn_blocking_reads {
+            let db = self.db.clone();
+            let key = key.clone();
+            Ok(spawn_blocking(move || db.get(&key.0).map(|opt| opt.map(DbValue))).await??)
+        } else {
+            Ok(self.db.get(&key.0)?.map(DbValue))
+        }
     }
 
     async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
-        // TODO(Nimrod): Config should indicate whether to spawn a task or not.
-        let db = self.db.clone();
-        let keys: Vec<Vec<u8>> = keys.iter().map(|k| k.0.clone()).collect();
-        spawn_blocking(move || {
-            db.multi_get(keys)
+        if self.config.spawn_blocking_reads {
+            let db = self.db.clone();
+            let keys: Vec<Vec<u8>> = keys.iter().map(|k| k.0.clone()).collect();
+            Ok(spawn_blocking(move || {
+                db.multi_get(keys)
+                    .into_iter()
+                    .map(|r| Ok(r?.map(DbValue)))
+                    .collect::<PatriciaStorageResult<_>>()
+            })
+            .await??)
+        } else {
+            let raw_keys = keys.iter().map(|k| k.0.as_slice());
+            Ok(self
+                .db
+                .multi_get(raw_keys)
                 .into_iter()
-                .map(|r| Ok(r?.map(DbValue)))
-                .collect::<PatriciaStorageResult<_>>()
-        })
-        .await?
+                .map(|r| r.map(|opt| opt.map(DbValue)).map_err(|e| e.into()))
+                .collect::<Result<Vec<_>, PatriciaStorageError>>()?)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how RocksDB read paths are executed (blocking threadpool vs direct), which can affect runtime performance and async executor behavior under load. Also flips the default/configured value to `true`, so behavior changes in production by default.
> 
> **Overview**
> **RocksDB read behavior is now configurable.** `RocksDbStorage` retains its `RocksDbStorageConfig` and uses `spawn_blocking_reads` to decide whether `get`/`mget` execute via `tokio::spawn_blocking` or synchronously on the calling thread.
> 
> **Defaults and deployment configs change.** The default for `spawn_blocking_reads` is switched to `true`, and the node config schema plus committer app configs are updated accordingly (setting `committer_config.storage_config.inner_storage_config.spawn_blocking_reads` to `true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41e8f4ee32e94613659b51f4d30a8c4a373e25c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->