### PR TITLE
starknet_patricia_storage: dont cache reads in cached storage

### DIFF
--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -72,7 +72,7 @@ impl Storage for MapStorage {
 }
 
 /// A storage wrapper that adds an LRU cache to an underlying storage.
-/// Only getter methods are cached.
+/// Getter methods are not cached.
 pub struct CachedStorage<S: Storage> {
     pub storage: S,
     pub cache: LruCache<DbKey, Option<DbValue>>,
@@ -229,13 +229,12 @@ impl<S: Storage> Storage for CachedStorage<S> {
 
     async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         self.reads.fetch_add(1, Ordering::Relaxed);
-        if let Some(cached_value) = self.cache.get(key) {
+        if let Some(cached_value) = self.cache.peek(key) {
             self.cached_reads.fetch_add(1, Ordering::Relaxed);
             return Ok(cached_value.clone());
         }
 
         let storage_value = self.storage.get(key).await?;
-        self.cache.put(key.clone(), storage_value.clone());
         Ok(storage_value)
     }
 
@@ -252,7 +251,7 @@ impl<S: Storage> Storage for CachedStorage<S> {
         let mut indices_to_fetch = Vec::new();
 
         for (index, key) in keys.iter().enumerate() {
-            if let Some(cached_value) = self.cache.get(key) {
+            if let Some(cached_value) = self.cache.peek(key) {
                 values[index] = cached_value.clone();
             } else {
                 keys_to_fetch.push(*key);
@@ -267,12 +266,9 @@ impl<S: Storage> Storage for CachedStorage<S> {
         self.cached_reads.fetch_add(cached_reads, Ordering::Relaxed);
 
         let fetched_values = self.storage.mget(keys_to_fetch.as_slice()).await?;
-        indices_to_fetch.iter().zip(keys_to_fetch).zip(fetched_values).for_each(
-            |((index, key), value)| {
-                self.cache.put((*key).clone(), value.clone());
-                values[*index] = value;
-            },
-        );
+        indices_to_fetch.iter().zip(fetched_values).for_each(|(index, value)| {
+            values[*index] = value;
+        });
 
         Ok(values)
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `CachedStorage` read behavior so cache entries are no longer populated on `get`/`mget`, which can materially impact performance and memory usage patterns depending on callers’ expectations.
> 
> **Overview**
> `CachedStorage` no longer populates its LRU cache on read paths: `get` and `mget` now only return cached entries (using `peek`) and otherwise fetch directly from the inner storage without inserting fetched values into the cache.
> 
> Cache updates are effectively write-driven only (via existing `set`/`mset` and `cache_on_write` behavior), and the module docs are updated to reflect that getter methods are not cached.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53550f70703a10a6078d0bcb3ac5896b79484cc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->