### PR TITLE
echonet: Print error message if running echonet with start block 0

### DIFF
--- a/echonet/deploy_echonet.py
+++ b/echonet/deploy_echonet.py
@@ -151,6 +151,13 @@ def _copy_generated_keys(keys_in_repo: Path, generated_path: Path) -> None:
     if "start_block" not in data:
         raise ValueError("Missing required key: start_block")
 
+    if int(data["start_block"]) == 0:
+        logger.error(
+            f"Refusing to deploy: start_block is 0 in {keys_in_repo}. "
+            "Set a non-zero start_block and re-run."
+        )
+        raise SystemExit(1)
+
     shutil.copyfile(keys_in_repo, generated_path)
     logger.info(f"Copied keys file: {keys_in_repo} -> {generated_path}")
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small deploy-script validation that only affects misconfigured runs; no runtime service logic or data paths change.
> 
> **Overview**
> Prevents accidental deployments of echonet with an invalid `start_block` configuration by adding a hard guard in `deploy_echonet.py`.
> 
> When `echonet_keys.json` has `start_block` set to `0`, the deploy script now logs a clear error and exits non-zero instead of proceeding to generate/apply kustomize resources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2e7483affbd129495777865452e990e8bfc4031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->