### PR TITLE
starknet_patricia_storage: always cache writes in cached storage

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/committer_config.json
@@ -1,7 +1,6 @@
 {
     "committer_config.db_path": "/data/committer",
     "committer_config.reader_config.warn_on_trivial_modifications": false,
-    "committer_config.storage_config.cache_on_write": true,
     "committer_config.storage_config.cache_size": 10000000,
     "committer_config.storage_config.include_inner_stats": true,
     "committer_config.storage_config.inner_storage_config.bloom_filter_bits": 10,

--- a/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
@@ -1,7 +1,6 @@
 {
   "committer_config.db_path": "/data/committer",
   "committer_config.reader_config.warn_on_trivial_modifications": false,
-  "committer_config.storage_config.cache_on_write": true,
   "committer_config.storage_config.cache_size": "$$$_COMMITTER_CONFIG-STORAGE_CONFIG-CACHE_SIZE_$$$",
   "committer_config.storage_config.include_inner_stats": true,
   "committer_config.storage_config.inner_storage_config.bloom_filter_bits": 10,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -524,11 +524,6 @@
     "privacy": "Public",
     "value": false
   },
-  "committer_config.storage_config.cache_on_write": {
-    "description": "If true, the cache is updated on write operations",
-    "privacy": "Public",
-    "value": true
-  },
   "committer_config.storage_config.cache_size": {
     "description": "Max number of entries in the cache",
     "privacy": "Public",

--- a/crates/starknet_committer_cli/src/args.rs
+++ b/crates/starknet_committer_cli/src/args.rs
@@ -237,7 +237,6 @@ where
     fn storage_config(&self) -> <Self::Storage as Storage>::Config {
         CachedStorageConfig {
             cache_size: NonZeroUsize::new(self.cache_size).unwrap(),
-            cache_on_write: true,
             include_inner_stats: self.include_inner_stats,
             inner_storage_config: self.storage_args.storage_config(),
         }

--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -105,7 +105,6 @@ impl Storage for MapStorage {
 pub struct CachedStorage<S: Storage> {
     pub storage: S,
     pub cache: LruCache<DbKey, Option<DbValue>>,
-    pub cache_on_write: bool,
     reads: AtomicU64,
     cached_reads: AtomicU64,
     writes: u128,
@@ -116,9 +115,6 @@ pub struct CachedStorage<S: Storage> {
 pub struct CachedStorageConfig<InnerStorageConfig: StorageConfigTrait> {
     // Max number of entries in the cache.
     pub cache_size: NonZeroUsize,
-
-    // If true, the cache is updated on write operations even if the value is not in the cache.
-    pub cache_on_write: bool,
 
     // If true, the inner stats are included when collecting statistics.
     pub include_inner_stats: bool,
@@ -131,7 +127,6 @@ impl<InnerStorageConfig: StorageConfigTrait> Default for CachedStorageConfig<Inn
     fn default() -> Self {
         Self {
             cache_size: NonZeroUsize::new(DEFAULT_CACHE_SIZE).unwrap(),
-            cache_on_write: true,
             include_inner_stats: true,
             inner_storage_config: InnerStorageConfig::default(),
         }
@@ -153,12 +148,6 @@ impl<InnerStorageConfig: StorageConfigTrait> SerializeConfig
                 "cache_size",
                 &self.cache_size,
                 "Max number of entries in the cache",
-                ParamPrivacyInput::Public,
-            ),
-            ser_param(
-                "cache_on_write",
-                &self.cache_on_write,
-                "If true, the cache is updated on write operations",
                 ParamPrivacyInput::Public,
             ),
             ser_param(
@@ -233,24 +222,11 @@ impl<S: Storage> CachedStorage<S> {
         Self {
             storage,
             cache: LruCache::new(config.cache_size),
-            cache_on_write: config.cache_on_write,
             reads: AtomicU64::new(0),
             cached_reads: AtomicU64::new(0),
             writes: 0,
             include_inner_stats: config.include_inner_stats,
         }
-    }
-
-    fn update_cached_value(&mut self, key: &DbKey, value: &DbValue) {
-        if self.cache_on_write || self.cache.contains(key) {
-            self.cache.put(key.clone(), Some(value.clone()));
-        }
-    }
-
-    fn update_cached_values(&mut self, key_to_value: &DbHashMap) {
-        key_to_value.iter().for_each(|(key, value)| {
-            self.update_cached_value(key, value);
-        });
     }
 
     pub fn total_writes(&self) -> u128 {
@@ -354,14 +330,16 @@ impl<S: Storage> Storage for CachedStorage<S> {
     async fn set(&mut self, key: DbKey, value: DbValue) -> PatriciaStorageResult<()> {
         self.writes += 1;
         self.storage.set(key.clone(), value.clone()).await?;
-        self.update_cached_value(&key, &value);
+        self.cache.put(key.clone(), Some(value.clone()));
         Ok(())
     }
 
     async fn mset(&mut self, key_to_value: DbHashMap) -> PatriciaStorageResult<()> {
         self.writes += u128::try_from(key_to_value.len()).expect("usize should fit in u128");
         self.storage.mset(key_to_value.clone()).await?;
-        self.update_cached_values(&key_to_value);
+        for (key, value) in key_to_value.into_iter() {
+            self.cache.put(key, Some(value));
+        }
         Ok(())
     }
 
@@ -379,7 +357,7 @@ impl<S: Storage> Storage for CachedStorage<S> {
             match operation {
                 DbOperation::Set(value) => {
                     self.writes += 1;
-                    self.update_cached_value(&key, &value);
+                    self.cache.put(key, Some(value));
                 }
                 DbOperation::Delete => {
                     self.cache.pop(&key);

--- a/crates/starknet_patricia_storage/src/map_storage_test.rs
+++ b/crates/starknet_patricia_storage/src/map_storage_test.rs
@@ -11,7 +11,6 @@ use crate::storage_trait::{DbKey, DbValue, EmptyStorageConfig, Storage};
 #[case::cached_storage(
     CachedStorage::new(MapStorage::default(), CachedStorageConfig {
         cache_size: NonZeroUsize::new(2).unwrap(),
-        cache_on_write: true,
         include_inner_stats: false,
         inner_storage_config: EmptyStorageConfig::default(),
     })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `CachedStorage` behavior to always insert written keys into the LRU cache and removes the `cache_on_write` toggle, which can affect memory usage and performance characteristics in production deployments.
> 
> **Overview**
> **`CachedStorage` now always caches writes.** Write paths (`set`, `mset`, `multi_set_and_delete`) unconditionally update the LRU cache, and the conditional write-caching logic and `cache_on_write` field/config are removed.
> 
> **Config surface is updated accordingly.** The `committer_config.storage_config.cache_on_write` option is removed from deployment configs, the node `config_schema.json`, and the committer CLI’s `CachedStorageConfig` construction; tests are updated to match the new config shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8222062e6a410f6c0d9279cc06a1cb3ba3436426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->