### PR TITLE
starknet_committer_and_os_cli: build storage tries concurrently based on py config

### DIFF
--- a/crates/starknet_committer_and_os_cli/src/committer_cli/parse_input/cast.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/parse_input/cast.rs
@@ -85,8 +85,6 @@ impl TryFrom<RawInput> for CommitterFactsDbInputImpl {
                 inner_map,
             )?;
         }
-        // TODO(Nimrod): Get this by adding a field to `RawInput`.
-        let build_storage_tries_concurrently = false;
         let input = Input {
             initial_read_context: FactsDbInitialRead(StateRoots {
                 contracts_trie_root_hash: HashOutput(Felt::from_bytes_be_slice(
@@ -104,7 +102,7 @@ impl TryFrom<RawInput> for CommitterFactsDbInputImpl {
             },
             config: ReaderConfig::new(
                 raw_input.config.warn_on_trivial_modifications,
-                build_storage_tries_concurrently,
+                raw_input.config.build_storage_tries_concurrently,
             ),
         };
         Ok(Self { input, log_level: raw_input.config.log_level.into(), storage })

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/parse_input/raw_input.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/parse_input/raw_input.rs
@@ -24,6 +24,7 @@ pub(crate) struct RawStorageEntry {
 #[derive(Deserialize, Debug)]
 pub(crate) struct RawConfigImpl {
     pub warn_on_trivial_modifications: bool,
+    pub build_storage_tries_concurrently: bool,
     pub log_level: PythonLogLevel,
 }
 

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/parse_input/read_test.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/parse_input/read_test.rs
@@ -87,7 +87,7 @@ fn test_simple_input_parsing() {
     ],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-    {"warn_on_trivial_modifications": true, "log_level": 5}
+    {"warn_on_trivial_modifications": true, "build_storage_tries_concurrently": false, "log_level": 5}
 ]
 
 "#;
@@ -254,7 +254,7 @@ fn test_input_parsing_with_storage_key_duplicate() {
     ],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 222, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 3],
-    {"warn_on_trivial_modifications": true, "log_level": 20}
+    {"warn_on_trivial_modifications": true, "build_storage_tries_concurrently": false, "log_level": 20}
 ]
 
 "#;
@@ -296,7 +296,7 @@ fn test_input_parsing_with_mapping_key_duplicate() {
     ],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 144, 0, 0, 0, 0, 0, 0, 0, 0, 5],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 222, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 3],
-    {"warn_on_trivial_modifications": false, "log_level": 30}
+    {"warn_on_trivial_modifications": false, "build_storage_tries_concurrently": true, "log_level": 30}
 ]
 
 "#;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables a new concurrency toggle that can change how storage tries are built at runtime, which may affect performance and expose latent race/determinism issues. The change is mostly config plumbing and test updates.
> 
> **Overview**
> Wires the Python-provided config through input parsing so `ReaderConfig::new` now uses `raw_input.config.build_storage_tries_concurrently` instead of a hardcoded `false`.
> 
> Extends `RawConfigImpl` to deserialize the new `build_storage_tries_concurrently` boolean and updates parsing tests’ JSON fixtures accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96efdd075286d86b7f9ec07fd4a255ce5b8e99ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->