### PR TITLE
starknet_os_flow_tests,starknet_os_runner: add virtual SNOS prover e2e flow test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12244,7 +12244,9 @@ dependencies = [
 name = "starknet_os_flow_tests"
 version = "0.18.0-dev.0"
 dependencies = [
+ "apollo_transaction_converter",
  "assert_matches",
+ "async-trait",
  "blockifier",
  "blockifier_test_utils",
  "cairo-lang-starknet-classes",

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -462,7 +462,7 @@ impl TransactionConverter {
 
             let verify_start = Instant::now();
             let proof_facts_hash = task_proof_facts.hash();
-            Self::verify_proof(task_proof_facts, task_proof)?;
+            verify_proof(task_proof_facts, task_proof)?;
             let verify_duration = verify_start.elapsed();
             PROOF_VERIFICATION_LATENCY.record(verify_duration.as_secs_f64());
             info!(
@@ -479,39 +479,39 @@ impl TransactionConverter {
             verification_task,
         }))
     }
+}
 
-    /// Verifies a submitted proof, validating the emitted proof facts, and comparing the bootloader
-    /// program hash to the expected value.
-    fn verify_proof(proof_facts: ProofFacts, proof: Proof) -> Result<(), VerifyProofError> {
-        // Reject empty proof payloads before running the verifier.
-        if proof.is_empty() {
-            return Err(VerifyProofError::EmptyProof);
-        }
-
-        // Validate that the first element of proof facts is PROOF_VERSION.
-        let expected_proof_version = PROOF_VERSION;
-        let actual_first = proof_facts.0.first().copied().unwrap_or_default();
-        if actual_first != expected_proof_version {
-            return Err(VerifyProofError::InvalidProofVersion {
-                expected: expected_proof_version,
-                actual: actual_first,
-            });
-        }
-
-        // Verify proof and extract program output and program hash.
-        let output = stwo_verify(proof)?;
-
-        let program_variant = proof_facts.0.get(1).copied().unwrap_or_default();
-        let expected_proof_facts = output.program_output.try_into_proof_facts(program_variant)?;
-        if expected_proof_facts != proof_facts {
-            return Err(VerifyProofError::ProofFactsMismatch);
-        }
-
-        // Validate the bootloader program hash output against the expected bootloader hash.
-        if output.program_hash != BOOTLOADER_PROGRAM_HASH {
-            return Err(VerifyProofError::BootloaderHashMismatch);
-        }
-
-        Ok(())
+/// Verifies a submitted proof, validating the emitted proof facts, and comparing the bootloader
+/// program hash to the expected value.
+pub fn verify_proof(proof_facts: ProofFacts, proof: Proof) -> Result<(), VerifyProofError> {
+    // Reject empty proof payloads before running the verifier.
+    if proof.is_empty() {
+        return Err(VerifyProofError::EmptyProof);
     }
+
+    // Validate that the first element of proof facts is PROOF_VERSION.
+    let expected_proof_version = PROOF_VERSION;
+    let actual_first = proof_facts.0.first().copied().unwrap_or_default();
+    if actual_first != expected_proof_version {
+        return Err(VerifyProofError::InvalidProofVersion {
+            expected: expected_proof_version,
+            actual: actual_first,
+        });
+    }
+
+    // Verify proof and extract program output and program hash.
+    let output = stwo_verify(proof)?;
+
+    let program_variant = proof_facts.0.get(1).copied().unwrap_or_default();
+    let expected_proof_facts = output.program_output.try_into_proof_facts(program_variant)?;
+    if expected_proof_facts != proof_facts {
+        return Err(VerifyProofError::ProofFactsMismatch);
+    }
+
+    // Validate the bootloader program hash output against the expected bootloader hash.
+    if output.program_hash != BOOTLOADER_PROGRAM_HASH {
+        return Err(VerifyProofError::BootloaderHashMismatch);
+    }
+
+    Ok(())
 }

--- a/crates/starknet_os_flow_tests/Cargo.toml
+++ b/crates/starknet_os_flow_tests/Cargo.toml
@@ -7,7 +7,9 @@ license-file.workspace = true
 description = "Integration tests for Starknet OS execution and state commitment flow."
 
 [dev-dependencies]
+apollo_transaction_converter.workspace = true
 assert_matches.workspace = true
+async-trait.workspace = true
 blockifier = { workspace = true, features = ["reexecution", "testing"] }
 blockifier_test_utils.workspace = true
 cairo-lang-starknet-classes.workspace = true

--- a/crates/starknet_os_flow_tests/src/virtual_os_test.rs
+++ b/crates/starknet_os_flow_tests/src/virtual_os_test.rs
@@ -1,3 +1,4 @@
+use apollo_transaction_converter::transaction_converter::verify_proof;
 use blockifier::execution::contract_class::TrackedResource;
 use blockifier::test_utils::dict_state_reader::DictStateReader;
 use blockifier::test_utils::get_valid_virtual_os_program_hash;
@@ -18,14 +19,19 @@ use starknet_api::transaction::{
     TransactionVersion,
 };
 use starknet_api::{calldata, contract_address, invoke_tx_args};
+use starknet_os_runner::proving::virtual_snos_prover::ProveTransactionResult;
 use starknet_types_core::felt::Felt;
 
 use crate::test_manager::{TestBuilder, TestBuilderConfig, FUNDED_ACCOUNT_ADDRESS};
 use crate::tests::NON_TRIVIAL_RESOURCE_BOUNDS;
 
+/// End-to-end test: executes a message-to-L1 transaction through the virtual OS, generates a
+/// proof, and verifies both the L2-to-L1 messages and the proof.
+///
+/// Note: running the prover is heavy; this should be the only test that does so.
 #[rstest]
 #[tokio::test]
-async fn test_basic_happy_flow() {
+async fn test_end_to_end_happy_flow() {
     let test_contract = FeatureContract::TestContract(CairoVersion::Cairo1(RunnableCairo1::Casm));
 
     let (mut test_builder, [contract_address]) =
@@ -34,19 +40,29 @@ async fn test_basic_happy_flow() {
 
     let to_address = Felt::from(85);
     let payload = vec![Felt::from(12), Felt::from(34)];
+    let message = MessageToL1 {
+        from_address: contract_address,
+        to_address: EthAddress::try_from(to_address).unwrap(),
+        payload: L2ToL1Payload(payload.clone()),
+    };
     let calldata = create_calldata(
         contract_address,
         "test_send_message_to_l1",
         &[to_address, Felt::from(payload.len()), payload[0], payload[1]],
     );
     test_builder.add_funded_account_invoke(invoke_tx_args! { calldata });
-    test_builder.messages_to_l1.push(MessageToL1 {
-        from_address: contract_address,
-        to_address: EthAddress::try_from(to_address).unwrap(),
-        payload: L2ToL1Payload(payload),
-    });
+    test_builder.messages_to_l1.push(message.clone());
 
-    test_builder.build().await.run_virtual_and_validate();
+    // Run the virtual OS, validate, and prove.
+    let ProveTransactionResult { proof, proof_facts, l2_to_l1_messages } =
+        test_builder.build().await.run_virtual().prove().await;
+
+    // Validate messages.
+    assert_eq!(l2_to_l1_messages, [message]);
+
+    // Validate proof.
+    verify_proof(proof_facts, proof).expect("Proof verification should succeed");
+    // TODO(Yoni): run a tx with the proof.
 }
 
 /// Security tests.

--- a/crates/starknet_os_flow_tests/src/virtual_os_test_manager.rs
+++ b/crates/starknet_os_flow_tests/src/virtual_os_test_manager.rs
@@ -1,10 +1,16 @@
 use starknet_api::transaction::fields::VIRTUAL_OS_OUTPUT_VERSION;
+use starknet_api::transaction::MessageToL1;
 use starknet_os::io::virtual_os_output::{
     compute_messages_to_l1_hashes,
     VirtualOsOutput,
     VirtualOsRunnerOutput,
 };
 use starknet_os::runner::run_virtual_os;
+use starknet_os_runner::proving::virtual_snos_prover::{
+    prove_virtual_snos_run,
+    ProveTransactionResult,
+};
+use starknet_os_runner::running::runner::RunnerOutput;
 
 use crate::initial_state::FlowTestState;
 use crate::test_manager::TestRunner;
@@ -15,6 +21,8 @@ pub(crate) struct VirtualOsTestOutput {
     pub(crate) runner_output: VirtualOsRunnerOutput,
     /// The expected values computed from the OS hints.
     pub(crate) expected_virtual_os_output: VirtualOsOutput,
+    /// The L2-to-L1 messages produced by the executed transactions.
+    pub(crate) messages_to_l1: Vec<MessageToL1>,
     // TODO(Yoni): consider adding more data for sanity checks, such as the expected state diff.
 }
 
@@ -25,6 +33,17 @@ impl VirtualOsTestOutput {
             .expect("Parsing virtual OS output should not fail.");
 
         assert_eq!(virtual_os_output, self.expected_virtual_os_output);
+    }
+
+    /// Validates the output and proves the result.
+    pub(crate) async fn prove(self) -> ProveTransactionResult {
+        self.validate();
+
+        let runner_output = RunnerOutput {
+            cairo_pie: self.runner_output.cairo_pie,
+            l2_to_l1_messages: self.messages_to_l1,
+        };
+        prove_virtual_snos_run(runner_output).await.expect("prove_virtual_snos_run should succeed")
     }
 }
 
@@ -38,6 +57,7 @@ impl<S: FlowTestState> TestRunner<S> {
             self.os_hints.os_hints_config.chain_info.compute_virtual_os_config_hash().unwrap();
 
         let messages_to_l1_hashes = compute_messages_to_l1_hashes(&self.messages_to_l1);
+        let messages_to_l1 = self.messages_to_l1;
         let expected_virtual_os_output = VirtualOsOutput {
             version: VIRTUAL_OS_OUTPUT_VERSION,
             base_block_number: first_block.block_info.block_number,
@@ -50,7 +70,7 @@ impl<S: FlowTestState> TestRunner<S> {
         let runner_output =
             run_virtual_os(self.os_hints).expect("Running virtual OS should not fail.");
 
-        VirtualOsTestOutput { runner_output, expected_virtual_os_output }
+        VirtualOsTestOutput { runner_output, expected_virtual_os_output, messages_to_l1 }
     }
 
     /// Runs the virtual OS and validates the output against expected values.

--- a/crates/starknet_os_runner/src/proving/virtual_snos_prover.rs
+++ b/crates/starknet_os_runner/src/proving/virtual_snos_prover.rs
@@ -76,7 +76,7 @@ pub struct VirtualSnosProverOutput {
 /// The prover is generic over the runner, allowing different implementations
 /// (RPC-based, mock, etc.) to be used interchangeably.
 #[derive(Clone)]
-pub(crate) struct VirtualSnosProver<R: VirtualSnosRunner> {
+pub struct VirtualSnosProver<R: VirtualSnosRunner> {
     /// Runner for executing the virtual OS.
     runner: R,
 }

--- a/crates/starknet_os_runner/src/running/runner.rs
+++ b/crates/starknet_os_runner/src/running/runner.rs
@@ -347,7 +347,7 @@ where
 /// allowing different runner implementations (RPC-based, mock, etc.) to be used
 /// interchangeably.
 #[async_trait]
-pub(crate) trait VirtualSnosRunner: Clone + Send + Sync {
+pub trait VirtualSnosRunner: Clone + Send + Sync {
     /// Runs the Starknet virtual OS with the given transactions on top of the specified block.
     async fn run_virtual_os(
         &self,


### PR DESCRIPTION
Add an end-to-end flow test for `VirtualSnosProver` with message-to-L1 functionality.

### Changes:
- **`starknet_os_flow_tests`**: Add `virtual_snos_prover_test` with a `PrecomputedRunner` that feeds pre-computed virtual OS output into the prover, and a test (`test_virtual_snos_prover_message_to_l1`) that validates L2-to-L1 messages and proof verification.
- **`starknet_os_runner`**: Make `RunnerOutput`, `VirtualSnosRunner`, `VirtualSnosProver`, and `from_runner` public to enable external test usage.
- **`apollo_transaction_converter`**: Extract `verify_proof` from `TransactionConverter` into a standalone public function so it can be used in tests.
- **`starknet_os_flow_tests`**: Add `messages_to_l1` field to `VirtualOsTestOutput` for passing L2-to-L1 messages to the prover.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a heavy end-to-end proving test and widens public API surface (`VirtualSnosRunner`/`VirtualSnosProver` and `verify_proof`), which could affect downstream crates and increase CI/runtime costs.
> 
> **Overview**
> Adds an end-to-end `starknet_os_flow_tests` integration test that executes a virtual OS invoke producing an L2-to-L1 message, runs the virtual SNOS prover to generate a proof, and then asserts both the emitted `MessageToL1` list and proof validity.
> 
> To support this, `apollo_transaction_converter` exposes `verify_proof` as a standalone public helper (instead of a `TransactionConverter` method), and `starknet_os_runner` makes `VirtualSnosRunner` and `VirtualSnosProver` public so external crates can drive proving. The test harness now carries `messages_to_l1` through `VirtualOsTestOutput` and uses `prove_virtual_snos_run` to prove validated virtual OS output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a12ef8e16aebfc5b68684b83d6b0a8675be1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->