### PR TITLE
echonet: mark k8s deployment as non-evictable

### DIFF
--- a/echonet/k8s/echonet/deployment.yaml
+++ b/echonet/k8s/echonet/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         role: flask
         app.kubernetes.io/name: echonet
         app.kubernetes.io/component: api
+        scaleops.sh/managed-unevictable: "true"
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: echonet
 


### PR DESCRIPTION
Adds labels/annotations to discourage disruption by autoscalers and schedulers.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only metadata change; main risk is reduced autoscaler flexibility leading to stuck scale-downs or higher cost if misapplied.
> 
> **Overview**
> Marks the `echonet` Kubernetes `Deployment` pods as **non-evictable/non-disruptable** by adding `scaleops.sh/managed-unevictable: "true"` plus autoscaler annotations `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` and `karpenter.sh/do-not-disrupt: "true"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a61882a86bb7d9bb8c02430471a274cd760bb610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->