### PR TITLE
echonet: Tune config

### DIFF
--- a/echonet/sequencer_manager.py
+++ b/echonet/sequencer_manager.py
@@ -43,7 +43,7 @@ class SequencerTiming:
     """Polling defaults used by the manager."""
 
     poll_interval_seconds: float = 2.0
-    scale_timeout_seconds: float = 1000.0
+    scale_timeout_seconds: float = 3000.0
 
 
 class SequencerManager:
@@ -224,7 +224,7 @@ class SequencerManager:
     def wait_for_synced_block_at_least(
         self,
         target_block: int,
-        timeout_seconds: float = 1000.0,
+        timeout_seconds: float = 3000.0,
         poll_interval_seconds: float = 1.0,
         tail_lines: int = 500,
         pod_name: Optional[str] = None,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk tuning change that only increases timeout defaults; main impact is workflows may wait longer before failing if the sequencer stalls.
> 
> **Overview**
> Increases default timeout values in `echonet/sequencer_manager.py` to reduce premature failures during sequencer workflows.
> 
> Specifically, raises `SequencerTiming.scale_timeout_seconds` and the default `timeout_seconds` for `wait_for_synced_block_at_least` from `1000s` to `3000s`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdc9a1a1e48ab82b1ee662e7f6d09bffcdcd8f4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->