### PR TITLE
echonet: Check for l2 gas mismatch

### DIFF
--- a/echonet/constants.py
+++ b/echonet/constants.py
@@ -18,6 +18,10 @@ STATE_BLOCK_HASH_SELECTOR = "0x382d83e3"  # stateBlockHash()
 # Value to use as the end block number if none is given, large enough to not stop in the middle.
 MAX_BLOCK_NUMBER: int = 1 << 200
 
+# Calldata marker to ignore for l2_gas mismatch diagnostics.
+IGNORED_L2_GAS_MISMATCH_ATTESTATION_CALLDATA = (
+    "0x10398fe631af9ab2311840432d507bf7ef4b959ae967f1507928f5afe888a99"
+)
 # ---------------------------------------------------------------------------
 # Echonet config file locations / names
 # ---------------------------------------------------------------------------

--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -7,6 +7,7 @@ from typing import Any, List, Literal, Optional, Tuple, Union
 import flask  # pyright: ignore[reportMissingImports]
 import requests
 
+from echonet.constants import IGNORED_L2_GAS_MISMATCH_ATTESTATION_CALLDATA
 from echonet.echonet_types import CONFIG, BlockDumpKind, JsonObject, TxType
 from echonet.feeder_client import FeederClient
 from echonet.helpers import format_hex
@@ -19,6 +20,10 @@ BlockNumberParam = Union[int, Literal["latest"]]
 
 flask_logger = get_logger("flask")
 logger = get_logger("echo_center")
+
+
+def _total_l2_gas_consumed(receipt: JsonObject) -> int:
+    return receipt["execution_resources"]["total_gas_consumed"]["l2_gas"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -555,6 +560,43 @@ class EchoCenterService:
             logger_obj=self.logger,
         )
 
+    def _check_l2_gas_mismatches(self, stored_block: JsonObject, echo_block_number: int) -> None:
+        txs = stored_block.get("transactions", [])
+        receipts = stored_block.get("transaction_receipts", [])
+        if not txs:
+            return
+
+        fgw_l2_cache: dict[int, dict[str, int]] = {}
+        for tx, receipt in zip(txs, receipts):
+            tx_hash: str = tx["transaction_hash"]
+            if any(
+                str(x) == IGNORED_L2_GAS_MISMATCH_ATTESTATION_CALLDATA
+                for x in (tx.get("calldata", []))
+            ):
+                continue
+
+            source_block = self.shared.get_sent_block_number(tx_hash)
+            fgw_l2_by_hash = fgw_l2_cache.get(source_block)
+            if fgw_l2_by_hash is None:
+                fgw_block = self.shared.get_fgw_block(source_block)
+                fgw_l2_by_hash = {
+                    t["transaction_hash"]: _total_l2_gas_consumed(r)
+                    for t, r in zip(fgw_block["transactions"], fgw_block["transaction_receipts"])
+                }
+                fgw_l2_cache[source_block] = fgw_l2_by_hash
+
+            blob_l2_gas: int = _total_l2_gas_consumed(receipt)
+            fgw_l2_gas = fgw_l2_by_hash.get(tx_hash)
+            if blob_l2_gas != fgw_l2_gas:
+                self.logger.warning(
+                    "l2_gas mismatch: "
+                    f"tx={tx_hash} "
+                    f"echo_block={int(echo_block_number)} "
+                    f"source_block={source_block} "
+                    f"blob_total_gas_l2={blob_l2_gas} "
+                    f"fgw_total_gas_consumed_l2={fgw_l2_gas}"
+                )
+
     @staticmethod
     def _json_response(payload: Any, status: int = requests.codes.ok) -> flask.Response:
         raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
@@ -599,6 +641,8 @@ class EchoCenterService:
 
         to_store = self._transformer.transform_block(blob)
         state_update = self._transformer.transform_state_update(blob, block_number)
+
+        self._check_l2_gas_mismatches(to_store, echo_block_number=block_number)
 
         self.shared.store_block(
             block_number, blob=blob, fgw_block=to_store, state_update=state_update


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds warning-only diagnostics and a skip constant without changing storage formats or transaction execution behavior.
> 
> **Overview**
> Adds an `EchoCenterService` diagnostic pass that compares each stored transaction receipt’s `total_gas_consumed.l2_gas` against the corresponding feeder-gateway snapshot for the transaction’s source block and logs a warning on mismatches (with per-block caching to limit lookups).
> 
> Introduces `IGNORED_L2_GAS_MISMATCH_ATTESTATION_CALLDATA` to skip known attestation transactions during this check, and runs the validation during `WRITE_BLOB` handling before persisting the block/state update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db3477276a7ef585ad312be41bbe361bc175b6d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->