### PR TITLE
echonet: Stop ignoring attestation reverts

### DIFF
--- a/echonet/constants.py
+++ b/echonet/constants.py
@@ -18,12 +18,6 @@ STATE_BLOCK_HASH_SELECTOR = "0x382d83e3"  # stateBlockHash()
 # Value to use as the end block number if none is given, large enough to not stop in the middle.
 MAX_BLOCK_NUMBER: int = 1 << 200
 
-# Revert error patterns to ignore when extracting revert mappings.
-IGNORED_REVERT_PATTERNS = [
-    "attestation is out of window",
-    "attestation with wrong block hash",
-]
-
 # ---------------------------------------------------------------------------
 # Echonet config file locations / names
 # ---------------------------------------------------------------------------

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import ClassVar, Dict, List, Mapping, Optional, Set
 
-from echonet.constants import IGNORED_REVERT_PATTERNS
 from echonet.echonet_types import (
     BLOCK_STORE_TUNING,
     CONFIG,
@@ -96,15 +95,6 @@ class _TxErrorTracker:
     def record_echonet_revert_error(
         self, tx_hash: str, error: str, source_block_number: int
     ) -> None:
-        def matches_ignored_revert_error(revert_error: str) -> bool:
-            return any(pattern in revert_error.lower() for pattern in IGNORED_REVERT_PATTERNS)
-
-        # Ignore expected revert errors. Exclude from both mainnet and echonet reports.
-        if matches_ignored_revert_error(error):
-            if tx_hash in self.revert_errors_mainnet:
-                self.revert_errors_mainnet.pop(tx_hash, None)
-            return
-
         # If we already have a mainnet revert for this tx, treat as matched and drop it.
         if tx_hash in self.revert_errors_mainnet:
             self.revert_errors_mainnet.pop(tx_hash, None)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to error/reporting logic that increases reported revert volume but doesn’t alter transaction execution or security-sensitive flows.
> 
> **Overview**
> Stops filtering out specific attestation-related revert errors from reporting.
> 
> This removes `IGNORED_REVERT_PATTERNS` from `echonet/constants.py` and deletes the ignore-and-drop logic in `_TxErrorTracker.record_echonet_revert_error`, so those reverts will now be tracked (and still de-duplicated against matching mainnet reverts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a92066e5b0f023a160be4b5f4c5394c712444bf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->