### PR TITLE
echonet: Modify transaction sender configuration

### DIFF
--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -135,9 +135,7 @@ class BlockRangeDefaults:
 class SleepConfig:
     """Sleep/delay settings for block streaming and special transaction pacing."""
 
-    sleep_between_blocks_seconds: float = 2.0
-    initial_slow_blocks_count: int = 10
-    extra_sleep_time_seconds: float = 3.0
+    producer_startup_sleep_seconds: float = 10.0
     deploy_account_sleep_time_seconds: float = 2.0
 
 

--- a/echonet/transaction_sender.py
+++ b/echonet/transaction_sender.py
@@ -8,7 +8,7 @@ import threading
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Optional, Sequence, Set
 
-import aiohttp
+import aiohttp  # pyright: ignore[reportMissingImports]
 import requests
 
 from echonet.echonet_types import CONFIG, JsonObject, TxType
@@ -105,10 +105,9 @@ class SenderConfig:
     retries: int = 3
     retry_backoff_seconds: float = 0.5
     max_retry_sleep_seconds: float = 30.0
-    sleep_between_blocks_seconds: float = CONFIG.sleep.sleep_between_blocks_seconds
 
-    queue_size: int = 100
-    blocks_to_wait_before_failing_tx: int = 30
+    queue_size: int = 30
+    blocks_to_wait_before_failing_tx: int = 50
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,12 +236,15 @@ class TransactionSenderService:
             # TODO(Ron): shorten this function
             async def producer() -> None:
                 block_number = config.start_block
-                current_start_block = config.start_block
                 while not self._stop_event.is_set():
                     if config.end_block and block_number > config.end_block:
                         return
 
                     shared.set_sender_current_block(block_number)
+                    if block_number == shared.get_current_start_block(
+                        default_start_block=config.start_block
+                    ):
+                        await asyncio.sleep(CONFIG.sleep.producer_startup_sleep_seconds)
 
                     block = await fetch_block_transactions(
                         feeder,
@@ -291,15 +293,9 @@ class TransactionSenderService:
                         )
                         await drain_queue()
                         block_number = await resync_executor.execute(trigger=trigger)
-                        current_start_block = block_number
                         continue
 
                     block_number += 1
-                    await self._sleep_between_blocks(
-                        current_block=block_number,
-                        start_block=current_start_block,
-                        base_sleep_seconds=config.sleep_between_blocks_seconds,
-                    )
 
             async def consumer() -> None:
                 while True:
@@ -333,18 +329,6 @@ class TransactionSenderService:
             await tx_queue.put(None)
             await tx_queue.join()
             await consumer_task
-
-    async def _sleep_between_blocks(
-        self,
-        current_block: int,
-        start_block: int,
-        base_sleep_seconds: float,
-    ) -> None:
-        effective_sleep = base_sleep_seconds
-        if (current_block - start_block) < CONFIG.sleep.initial_slow_blocks_count:
-            effective_sleep = float(base_sleep_seconds) + CONFIG.sleep.extra_sleep_time_seconds
-        if effective_sleep > 0:
-            await asyncio.sleep(effective_sleep)
 
 
 class TransactionSenderRunner:
@@ -399,8 +383,7 @@ class TransactionSenderRunner:
                     f"TransactionSenderRunner starting: feeder_url={config.feeder_url} "
                     f"sequencer_url={config.sequencer_url} start_block={config.start_block} "
                     f"end_block={config.end_block} timeout={config.request_timeout_seconds} "
-                    f"retries={config.retries} backoff={config.retry_backoff_seconds} "
-                    f"sleep={config.sleep_between_blocks_seconds}"
+                    f"retries={config.retries} backoff={config.retry_backoff_seconds}"
                 )
                 asyncio.run(self._service.run(config))
             finally:
@@ -442,7 +425,6 @@ def start_background_sender(
     request_timeout_seconds: float = 15.0,
     retries: int = 3,
     retry_backoff_seconds: float = 0.5,
-    sleep_between_blocks_seconds: float = CONFIG.sleep.sleep_between_blocks_seconds,
 ) -> bool:
     """
     Start the background transaction sender.
@@ -455,7 +437,6 @@ def start_background_sender(
         request_timeout_seconds=request_timeout_seconds,
         retries=retries,
         retry_backoff_seconds=retry_backoff_seconds,
-        sleep_between_blocks_seconds=sleep_between_blocks_seconds,
     )
     return TransactionSenderRunner.background().start(config=cfg)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the transaction streaming rate and queue/backpressure defaults, which can affect throughput and resync behavior in production even though it’s mostly configuration/logic tuning.
> 
> **Overview**
> Adjusts the transaction sender’s pacing and buffering behavior.
> 
> Replaces per-block delay logic with a one-time producer startup sleep (`SleepConfig.producer_startup_sleep_seconds`), reduces `SenderConfig.queue_size` (100 -> 30), and increases the resync wait threshold (`blocks_to_wait_before_failing_tx` 30 -> 50). Also removes the `sleep_between_blocks_seconds` parameter/plumbing and adds a `pyright` import ignore for `aiohttp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 167e7d1cc93bb1fe33f6dea577c03bf996523ad4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->