### PR TITLE
apollo_batcher: rename get_height to get_next_height

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -242,7 +242,7 @@ impl Batcher {
             return Err(BatcherError::HeightInProgress);
         }
 
-        let storage_height = self.get_height_from_storage()?;
+        let storage_height = self.get_next_height_from_storage()?;
         if storage_height != input.height {
             return Err(BatcherError::StorageHeightMarkerMismatch {
                 marker_height: storage_height,
@@ -580,7 +580,7 @@ impl Batcher {
         Ok(SendProposalContentResponse { response: ProposalStatus::Aborted })
     }
 
-    fn get_height_from_storage(&self) -> BatcherResult<BlockNumber> {
+    fn get_next_height_from_storage(&self) -> BatcherResult<BlockNumber> {
         self.storage_reader.state_diff_height().map_err(|err| {
             error!("Failed to get height from storage: {}", err);
             BatcherError::InternalError
@@ -588,8 +588,8 @@ impl Batcher {
     }
 
     #[instrument(skip(self), err)]
-    pub async fn get_height(&self) -> BatcherResult<GetHeightResponse> {
-        let height = self.get_height_from_storage()?;
+    pub async fn get_next_height(&self) -> BatcherResult<GetHeightResponse> {
+        let height = self.get_next_height_from_storage()?;
         Ok(GetHeightResponse { height })
     }
 
@@ -656,7 +656,7 @@ impl Batcher {
         } = sync_block;
         let block_number = block_header_without_hash.block_number;
 
-        let height = self.get_height_from_storage()?;
+        let height = self.get_next_height_from_storage()?;
         if height != block_number {
             return Err(BatcherError::StorageHeightMarkerMismatch {
                 marker_height: height,
@@ -1129,7 +1129,7 @@ impl Batcher {
     // This function will panic if there is a storage failure to revert the block.
     pub async fn revert_block(&mut self, input: RevertBlockInput) -> BatcherResult<()> {
         info!("Reverting block at height {}.", input.height);
-        let height = self.get_height_from_storage()?.prev().ok_or(
+        let height = self.get_next_height_from_storage()?.prev().ok_or(
             BatcherError::StorageHeightMarkerMismatch {
                 marker_height: BlockNumber(0),
                 requested_height: input.height,

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -845,14 +845,14 @@ async fn multiple_proposals_with_l1_every_n_proposals() {
 
 #[rstest]
 #[tokio::test]
-async fn get_height() {
+async fn get_next_height() {
     let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
 
     let batcher = create_batcher(MockDependencies { storage_reader, ..Default::default() }).await;
 
-    let result = batcher.get_height().await.unwrap();
+    let result = batcher.get_next_height().await.unwrap();
     assert_eq!(result, GetHeightResponse { height: INITIAL_HEIGHT });
 }
 
@@ -1618,12 +1618,12 @@ async fn decision_reached_return_success_when_l1_commit_block_fails(
 }
 
 #[tokio::test]
-async fn get_height_with_real_storage() {
+async fn get_next_height_with_real_storage() {
     // Real storage starts at height 0.
     let batcher =
         create_batcher_with_real_storage(MockDependenciesWithRealStorage::default()).await;
 
-    let result = batcher.get_height().await;
+    let result = batcher.get_next_height().await;
     assert_eq!(result, Ok(GetHeightResponse { height: BlockNumber(0) }));
 }
 

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -26,7 +26,7 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
                 BatcherResponse::GetBlockHash(self.get_block_hash(block_number))
             }
             BatcherRequest::GetCurrentHeight => {
-                BatcherResponse::GetCurrentHeight(self.get_height().await)
+                BatcherResponse::GetCurrentHeight(self.get_next_height().await)
             }
             BatcherRequest::GetProposalContent(input) => {
                 BatcherResponse::GetProposalContent(self.get_proposal_content(input).await)

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -50,7 +50,7 @@ pub trait BatcherClient: Send + Sync {
     /// Gets the block hash for a given block number.
     async fn get_block_hash(&self, block_number: BlockNumber) -> BatcherClientResult<BlockHash>;
     /// Gets the first height that is not written in the storage yet.
-    async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
+    async fn get_next_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
     /// proposal).
     async fn get_proposal_content(
@@ -229,7 +229,7 @@ where
         )
     }
 
-    async fn get_height(&self) -> BatcherClientResult<GetHeightResponse> {
+    async fn get_next_height(&self) -> BatcherClientResult<GetHeightResponse> {
         let request = BatcherRequest::GetCurrentHeight;
         handle_all_response_variants!(
             self,

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -166,7 +166,7 @@ impl ConsensusManager {
         );
 
         let current_height =
-            self.batcher_client.get_height().await.expect("Failed to get height from batcher");
+            self.batcher_client.get_next_height().await.expect("Failed to get height from batcher");
         let run_consensus_args = self.create_run_consensus_args(current_height.height);
 
         let network_task =
@@ -334,7 +334,7 @@ impl ConsensusManager {
         // If we revert all blocks up to height X (including), the new height marker will be X.
         let batcher_height_marker = self
             .batcher_client
-            .get_height()
+            .get_next_height()
             .await
             .expect("Failed to get batcher_height_marker from batcher")
             .height;

--- a/crates/apollo_consensus_manager/src/consensus_manager_test.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager_test.rs
@@ -31,7 +31,7 @@ async fn revert_batcher_blocks() {
 
     let mut mock_batcher_client = MockBatcherClient::new();
     mock_batcher_client
-        .expect_get_height()
+        .expect_get_next_height()
         .returning(|| Ok(GetHeightResponse { height: BATCHER_HEIGHT }));
 
     let mut mock_voted_height_storage = MockHeightVotedStorageTrait::new();
@@ -87,7 +87,7 @@ async fn revert_voted_height_when_batcher_already_at_target() {
     let mut mock_batcher_client = MockBatcherClient::new();
     // Batcher is already at the target height — no blocks to revert.
     mock_batcher_client
-        .expect_get_height()
+        .expect_get_next_height()
         .returning(|| Ok(GetHeightResponse { height: TARGET_HEIGHT }));
     mock_batcher_client.expect_revert_block().times(0).returning(|_| Ok(()));
 
@@ -130,7 +130,9 @@ async fn revert_voted_height_when_batcher_already_at_target() {
 async fn no_reverts_without_config() {
     let mut mock_batcher = MockBatcherClient::new();
     mock_batcher.expect_revert_block().times(0).returning(|_| Ok(()));
-    mock_batcher.expect_get_height().returning(|| Ok(GetHeightResponse { height: BlockNumber(0) }));
+    mock_batcher
+        .expect_get_next_height()
+        .returning(|| Ok(GetHeightResponse { height: BlockNumber(0) }));
 
     let config = ConsensusManagerConfig {
         consensus_manager_config: ConsensusConfig {

--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -321,7 +321,7 @@ impl FlowSequencerSetup {
     }
 
     pub async fn batcher_height(&self) -> BlockNumber {
-        self.clients.get_batcher_shared_client().unwrap().get_height().await.unwrap().height
+        self.clients.get_batcher_shared_client().unwrap().get_next_height().await.unwrap().height
     }
 
     pub async fn get_block_hash(&self, block_number: BlockNumber) -> BlockHash {

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -336,7 +336,7 @@ pub async fn create_node_components(
                         "L1 provider's dummy mode initialization requires the batcher to be set \
                          up in order to align to its height",
                     )
-                    .get_height()
+                    .get_next_height()
                     .await
                     .unwrap()
                     .height


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pure rename/propagation of an API method with no behavioral change; main risk is missed call sites causing compile/runtime integration issues.
> 
> **Overview**
> Renames the batcher height API to clarify semantics: `get_height`/`get_height_from_storage` become `get_next_height`/`get_next_height_from_storage`, and all callers are updated accordingly.
> 
> Updates request handling (`GetCurrentHeight`), consensus manager startup/revert logic, node initialization, and integration/unit tests to use the new method name while keeping the underlying behavior (returning the next unwritten storage height) the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d30776678688d858946ed3d19a8d0c3927474fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->