### PR TITLE
echonet: add uptime_seconds to report snapshot

### DIFF
--- a/echonet/report_models.py
+++ b/echonet/report_models.py
@@ -27,6 +27,7 @@ class SnapshotModel:
     first_block_timestamp: int | None
     latest_block_timestamp: int | None
     timestamp_diff_seconds: int | None
+    uptime_seconds: int | None
 
     # Counters
     total_sent_tx_count: int
@@ -68,6 +69,7 @@ class SnapshotModel:
             "first_block_timestamp": self.first_block_timestamp,
             "latest_block_timestamp": self.latest_block_timestamp,
             "timestamp_diff_seconds": self.timestamp_diff_seconds,
+            "uptime_seconds": self.uptime_seconds,
         }
 
     @classmethod
@@ -81,6 +83,7 @@ class SnapshotModel:
             first_block_timestamp=data["first_block_timestamp"],
             latest_block_timestamp=data["latest_block_timestamp"],
             timestamp_diff_seconds=data["timestamp_diff_seconds"],
+            uptime_seconds=data.get("uptime_seconds"),
             total_sent_tx_count=data["total_sent_tx_count"],
             committed_count=data["committed_count"],
             pending_total_count=data["pending_total_count"],

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -346,11 +346,15 @@ class SharedContext:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._started_at_monotonic = time.monotonic()
         self._tx = _TxTracker.empty()
         self._errors = _TxErrorTracker.empty()
         self._resync = _ResyncTracker.empty()
         self._blocks = _BlockStore.empty()
         self._progress = _ProgressMarkers.empty()
+
+    def get_uptime_seconds(self) -> int:
+        return int(time.monotonic() - self._started_at_monotonic)
 
     # --- Tx lifecycle ---
     def record_sent_tx(self, tx_hash: str, source_block_number: int) -> None:
@@ -482,6 +486,7 @@ class SharedContext:
             first_ts = self._progress.first_block_timestamp
             latest_ts = self._progress.latest_block_timestamp
             timestamp_diff_seconds = latest_ts - first_ts if (first_ts and latest_ts) else None
+            uptime_seconds = int(time.monotonic() - self._started_at_monotonic)
 
             return SnapshotModel(
                 start_block=configured_start_block,
@@ -492,6 +497,7 @@ class SharedContext:
                 first_block_timestamp=first_ts,
                 latest_block_timestamp=latest_ts,
                 timestamp_diff_seconds=timestamp_diff_seconds,
+                uptime_seconds=uptime_seconds,
                 total_sent_tx_count=self._tx.total_forwarded_tx_count,
                 committed_count=len(self._tx.committed),
                 pending_total_count=len(self._tx.ever_seen_pending),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new optional reporting field and a monotonic start timestamp; it doesn’t change transaction/block processing logic.
> 
> **Overview**
> The `/echonet/report` snapshot now includes **`uptime_seconds`**, computed from a monotonic start time in `SharedContext` and serialized via `SnapshotModel.to_dict()`.
> 
> `SnapshotModel.from_dict()` was updated to read the new field with `data.get(...)` for backwards compatibility when deserializing older snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a1f40fbf9bac3d31769a934f797d9dd015cf520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->