### PR TITLE
echonet: record l2 gas mismatches in report snapshot

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -591,10 +591,17 @@ class EchoCenterService:
                 self.logger.warning(
                     "l2_gas mismatch: "
                     f"tx={tx_hash} "
-                    f"echo_block={int(echo_block_number)} "
+                    f"echo_block={echo_block_number} "
                     f"source_block={source_block} "
                     f"blob_total_gas_l2={blob_l2_gas} "
                     f"fgw_total_gas_consumed_l2={fgw_l2_gas}"
+                )
+                self.shared.record_l2_gas_mismatch(
+                    tx_hash=tx_hash,
+                    echo_block=echo_block_number,
+                    source_block=source_block,
+                    blob_total_gas_l2=blob_l2_gas,
+                    fgw_total_gas_consumed_l2=fgw_l2_gas,
                 )
 
     @staticmethod

--- a/echonet/report_models.py
+++ b/echonet/report_models.py
@@ -42,6 +42,7 @@ class SnapshotModel:
     revert_errors_echonet: Mapping[str, RevertErrorInfo]
     resync_causes: ResyncTriggerMap
     certain_failures: ResyncTriggerMap
+    l2_gas_mismatches: list[JsonObject]
 
     def to_dict(self) -> JsonObject:
         """
@@ -70,6 +71,7 @@ class SnapshotModel:
             "latest_block_timestamp": self.latest_block_timestamp,
             "timestamp_diff_seconds": self.timestamp_diff_seconds,
             "uptime_seconds": self.uptime_seconds,
+            "l2_gas_mismatches": self.l2_gas_mismatches,
         }
 
     @classmethod
@@ -83,7 +85,7 @@ class SnapshotModel:
             first_block_timestamp=data["first_block_timestamp"],
             latest_block_timestamp=data["latest_block_timestamp"],
             timestamp_diff_seconds=data["timestamp_diff_seconds"],
-            uptime_seconds=data.get("uptime_seconds"),
+            uptime_seconds=data["uptime_seconds"],
             total_sent_tx_count=data["total_sent_tx_count"],
             committed_count=data["committed_count"],
             pending_total_count=data["pending_total_count"],
@@ -94,4 +96,5 @@ class SnapshotModel:
             revert_errors_echonet=data["revert_errors_echonet"],
             resync_causes=data["resync_causes"],
             certain_failures=data["certain_failures"],
+            l2_gas_mismatches=data["l2_gas_mismatches"],
         )

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -163,6 +163,38 @@ class _ResyncTracker:
 
 
 @dataclass(slots=True)
+class _ReportL2GasMismatchTracker:
+    """Tracks L2 gas mismatch rows for reporting."""
+
+    l2_gas_mismatches: List[JsonObject]
+
+    @classmethod
+    def empty(cls) -> "_ReportL2GasMismatchTracker":
+        return cls(
+            l2_gas_mismatches=[],
+        )
+
+    def record_l2_gas_mismatch(
+        self,
+        *,
+        tx_hash: str,
+        echo_block: int,
+        source_block: int,
+        blob_total_gas_l2: int,
+        fgw_total_gas_consumed_l2: int | None,
+    ) -> None:
+        self.l2_gas_mismatches.append(
+            {
+                "tx_hash": tx_hash,
+                "echo_block": echo_block,
+                "source_block": source_block,
+                "blob_total_gas_l2": blob_total_gas_l2,
+                "fgw_total_gas_consumed_l2": fgw_total_gas_consumed_l2,
+            }
+        )
+
+
+@dataclass(slots=True)
 class _BlockStore:
     """In-memory storage for echo_center outputs and raw feeder blocks."""
 
@@ -369,6 +401,7 @@ class SharedContext:
         self._tx = _TxTracker.empty()
         self._errors = _TxErrorTracker.empty()
         self._resync = _ResyncTracker.empty()
+        self._l2_gas_mismatches = _ReportL2GasMismatchTracker.empty()
         self._blocks = _BlockStore.empty()
         self._progress = _ProgressMarkers.empty()
 
@@ -448,6 +481,25 @@ class SharedContext:
             self._progress.sender_current_block = None
         _BlockStore.write_snapshot_items_to_disk(snapshot_items, base_dir=archive_dir)
         l1_manager.clear_stored_blocks()
+
+    # --- Report extras (cumulative; preserved across resync) ---
+    def record_l2_gas_mismatch(
+        self,
+        *,
+        tx_hash: str,
+        echo_block: int,
+        source_block: int,
+        blob_total_gas_l2: int,
+        fgw_total_gas_consumed_l2: int | None,
+    ) -> None:
+        with self._lock:
+            self._l2_gas_mismatches.record_l2_gas_mismatch(
+                tx_hash=tx_hash,
+                echo_block=echo_block,
+                source_block=source_block,
+                blob_total_gas_l2=blob_total_gas_l2,
+                fgw_total_gas_consumed_l2=fgw_total_gas_consumed_l2,
+            )
 
     # --- Block storage (echo_center output + raw FGW blocks) ---
     def store_block(
@@ -544,6 +596,7 @@ class SharedContext:
                 revert_errors_echonet=dict(self._errors.revert_errors_echonet),
                 resync_causes=dict(self._resync.resync_causes),
                 certain_failures=dict(self._resync.certain_failures),
+                l2_gas_mismatches=list(self._l2_gas_mismatches.l2_gas_mismatches),
             )
 
     # --- Progress markers ---


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily adds reporting/telemetry state and a new response field; main risk is backward compatibility for any consumers expecting the old `/echonet/report` schema or missing fields in `SnapshotModel.from_dict`.
> 
> **Overview**
> Adds persistent tracking of per-transaction L2 gas mismatches and exposes them via `/echonet/report` as a new `l2_gas_mismatches` field on `SnapshotModel`.
> 
> When `echo_center` detects a blob vs feeder-gateway L2 gas discrepancy, it now records a structured mismatch row in `SharedContext` (in addition to logging), and the snapshot `from_dict` path is tightened to require `uptime_seconds` and `l2_gas_mismatches`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3f48c502ed84b774c7cb7f445711cee5df43cc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->