### PR TITLE
echonet: add HTML report UI and download endpoint

### DIFF
--- a/echonet/constants.py
+++ b/echonet/constants.py
@@ -22,6 +22,7 @@ MAX_BLOCK_NUMBER: int = 1 << 200
 IGNORED_L2_GAS_MISMATCH_ATTESTATION_CALLDATA = (
     "0x10398fe631af9ab2311840432d507bf7ef4b959ae967f1507928f5afe888a99"
 )
+
 # ---------------------------------------------------------------------------
 # Echonet config file locations / names
 # ---------------------------------------------------------------------------

--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -1,7 +1,9 @@
+import base64
 import json
 import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
 
 import flask  # pyright: ignore[reportMissingImports]
@@ -13,6 +15,13 @@ from echonet.feeder_client import FeederClient
 from echonet.helpers import format_hex
 from echonet.l1_logic.l1_manager import L1Manager
 from echonet.logger import get_logger
+from echonet.reports import (
+    RevertClassifier,
+    RevertComparisonTextReport,
+    SnapshotTextReport,
+    build_report_view_model,
+)
+from echonet.sequencer_manager import _read_namespace_from_serviceaccount
 from echonet.shared_context import SharedContext, l1_manager, shared
 from echonet.transaction_sender import start_background_sender
 
@@ -20,6 +29,18 @@ BlockNumberParam = Union[int, Literal["latest"]]
 
 flask_logger = get_logger("flask")
 logger = get_logger("echo_center")
+
+
+def _build_gcp_logs_context() -> dict[str, str]:
+    """Context used by the report UI to build GCP Logs Explorer links."""
+    ns = _read_namespace_from_serviceaccount()
+    return {
+        "gcp_project_id": CONFIG.gcp_logs.project_id,
+        "gcp_location": CONFIG.gcp_logs.location,
+        "gke_cluster_name": CONFIG.gcp_logs.gke_cluster_name,
+        "k8s_namespace": ns,
+        "duration": "PT2H",
+    }
 
 
 def _total_l2_gas_consumed(receipt: JsonObject) -> int:
@@ -671,6 +692,62 @@ class EchoCenterService:
         snap = self.shared.get_report_snapshot()
         return self._json_response(snap.to_dict(), requests.codes.ok)
 
+    def handle_report_ui(self) -> flask.Response:
+        """HTML report dashboard."""
+        vm = build_report_view_model(self.shared.get_report_snapshot())
+        return flask.render_template(
+            "report.html",
+            export=False,
+            logs=_build_gcp_logs_context(),
+            **vm,
+        )
+
+    def handle_report_ui_download(self) -> flask.Response:
+        """
+        Download a static, self-contained HTML snapshot of the current report.
+        """
+        vm = build_report_view_model(self.shared.get_report_snapshot())
+
+        css_path = Path(__file__).resolve().parent / "static" / "report.css"
+        inline_css_b64 = base64.b64encode(css_path.read_bytes()).decode("ascii")
+
+        html = flask.render_template(
+            "report.html",
+            export=True,
+            inline_css_b64=inline_css_b64,
+            logs=_build_gcp_logs_context(),
+            **vm,
+        )
+        resp = flask.Response(
+            html.encode("utf-8"),
+            status=requests.codes.ok,
+            headers=[
+                ["Content-Type", "text/html; charset=utf-8"],
+                ["Content-Disposition", 'attachment; filename="echonet_report.html"'],
+            ],
+        )
+        return resp
+
+    def handle_report_text(self) -> flask.Response:
+        """
+        Plain-text snapshot report (similar to the old `reports.py` output).
+        """
+        snap = self.shared.get_report_snapshot()
+
+        snapshot_text = SnapshotTextReport(snap).render()
+        reverts_text = RevertComparisonTextReport(
+            classifier=RevertClassifier(),
+        ).render(
+            mainnet_reverts=dict(snap.revert_errors_mainnet),
+            echonet_reverts=dict(snap.revert_errors_echonet),
+        )
+        out = snapshot_text.rstrip() + "\n\n" + reverts_text
+        return flask.Response(
+            out.encode("utf-8"),
+            status=requests.codes.ok,
+            headers=[["Content-Type", "text/plain; charset=utf-8"]],
+        )
+
     def handle_block_dump(self) -> flask.Response:
         args = flask.request.args.to_dict(flat=True)
         bn = int(args["blockNumber"])
@@ -889,6 +966,21 @@ def get_compiled_class_by_class_hash() -> flask.Response:
 @app.route("/l1", methods=["GET", "POST"])
 def l1() -> flask.Response:
     return service.handle_l1()
+
+
+@app.route("/echonet/report/ui", methods=["GET"])
+def report_ui() -> flask.Response:
+    return service.handle_report_ui()
+
+
+@app.route("/echonet/report/ui/download", methods=["GET"])
+def report_ui_download() -> flask.Response:
+    return service.handle_report_ui_download()
+
+
+@app.route("/echonet/report/text", methods=["GET"])
+def report_text() -> flask.Response:
+    return service.handle_report_text()
 
 
 # Start the transaction sender automatically on startup.

--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -55,7 +55,7 @@ class ResyncTrigger(ResyncTriggerPayload):
     """
     Metadata stored when a transaction causes a resync trigger.
 
-    This is persisted into report snapshots and rendered by `reports.py`.
+    This is persisted into report snapshots and rendered by the reporting UI/text endpoints.
     """
 
     count: int
@@ -183,6 +183,15 @@ class L1Config:
 
 
 @dataclass(frozen=True, slots=True)
+class GcpLogsConfig:
+    """Config used to build Google Cloud Logs Explorer links in the report UI."""
+
+    project_id: str
+    location: str
+    gke_cluster_name: str
+
+
+@dataclass(frozen=True, slots=True)
 class EchonetConfig:
     feeder: FeederGatewayConfig
     sequencer: SequencerGatewayConfig
@@ -194,6 +203,7 @@ class EchonetConfig:
     tx_filter: TxFilterConfig
     resync: ResyncConfig
     l1: L1Config
+    gcp_logs: GcpLogsConfig
 
     @classmethod
     def from_files(cls, keys_path: Path, secrets_path: Path) -> "EchonetConfig":
@@ -216,6 +226,9 @@ class EchonetConfig:
             {"X-Throttling-Bypass": feeder_bypass} if feeder_bypass else {}
         )
         l1_provider_api_key = str(secrets["l1_provider_api_key"])
+        gcp_project_id = str(secrets.get("gcp_project_id", ""))
+        gcp_location = str(secrets.get("gcp_location", ""))
+        gke_cluster_name = str(secrets.get("gke_cluster_name", ""))
 
         return cls(
             feeder=FeederGatewayConfig(
@@ -247,6 +260,11 @@ class EchonetConfig:
             ),
             l1=L1Config(
                 l1_provider_api_key=l1_provider_api_key,
+            ),
+            gcp_logs=GcpLogsConfig(
+                project_id=gcp_project_id,
+                location=gcp_location,
+                gke_cluster_name=gke_cluster_name,
             ),
         )
 

--- a/echonet/k8s/echonet/deployment.yaml
+++ b/echonet/k8s/echonet/deployment.yaml
@@ -38,8 +38,6 @@ spec:
               base64 -d /bundle/echonet-src.tgz.b64 > /tmp/echonet-src.tgz
               tar -xzf /tmp/echonet-src.tgz -C /app
               test -f /app/echonet/__init__.py
-              # Convenience for interactive debugging: allow `python reports.py` from /app.
-              ln -sf /app/echonet/reports.py /app/reports.py
           volumeMounts:
             - name: echonet-src-bundle
               mountPath: /bundle

--- a/echonet/k8s/echonet/secret.yaml
+++ b/echonet/k8s/echonet/secret.yaml
@@ -11,6 +11,9 @@ stringData:
   echonet_secrets.json: |
     {
       "l1_provider_api_key": "<REPLACE_ME>",
-      "feeder_x_throttling_bypass": "<REPLACE_ME>"
+      "feeder_x_throttling_bypass": "<REPLACE_ME>",
+      "gcp_project_id": "<REPLACE_ME>",
+      "gcp_location": "<REPLACE_ME>",
+      "gke_cluster_name": "<REPLACE_ME>"
     }
 

--- a/echonet/reports.py
+++ b/echonet/reports.py
@@ -608,6 +608,7 @@ def build_report_view_model(
     r = _SnapshotReportRollup.from_snapshot(snapshot)
 
     return {
+        "feeder_base_url": str(CONFIG.feeder.base_url).rstrip("/"),
         "snapshot": r.s,
         "meta": {
             "generated_at_utc": r.now_utc,

--- a/echonet/sequencer_manager.py
+++ b/echonet/sequencer_manager.py
@@ -25,6 +25,8 @@ REVERT_INACTIVITY_SUBSTRINGS: tuple[str, ...] = (
     "Successfully reverted State Sync's storage to height marker",
 )
 
+_CACHED_NAMESPACE_BY_PATH: dict[str, str] = {}
+
 
 ConfigMutator = Callable[[JsonObject], None]
 
@@ -337,8 +339,13 @@ class SequencerManager:
         logger.info("Resync workflow complete.")
 
 
-def _read_namespace_from_serviceaccount(namespace_path: str) -> str:
-    with open(namespace_path, "r") as f:
+def _read_namespace_from_serviceaccount(namespace_path: Optional[str] = None) -> str:
+    resolved_path = namespace_path or SequencerKubeSpec().serviceaccount_namespace_path
+    cached = _CACHED_NAMESPACE_BY_PATH.get(resolved_path)
+    if cached is not None:
+        return cached
+    with open(resolved_path, "r") as f:
         namespace = f.read().strip()
     logger.info(f"Auto-detected namespace: {namespace}")
+    _CACHED_NAMESPACE_BY_PATH[resolved_path] = namespace
     return namespace

--- a/echonet/static/favicon.svg
+++ b/echonet/static/favicon.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Echonet">
+  <defs>
+    <radialGradient id="bg" cx="30%" cy="25%" r="90%">
+      <stop offset="0" stop-color="#141b33"/>
+      <stop offset="1" stop-color="#0b1020"/>
+    </radialGradient>
+    <linearGradient id="g" x1="14" y1="50" x2="50" y2="14" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#33d1a0"/>
+      <stop offset="1" stop-color="#7aa2ff"/>
+    </linearGradient>
+  </defs>
+
+  <!-- rounded app tile -->
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#bg)"/>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#g)" opacity="0.14"/>
+
+  <!-- echo rings + network nodes -->
+  <circle cx="32" cy="32" r="20" fill="none" stroke="url(#g)" stroke-width="3" opacity="0.78"/>
+  <circle cx="32" cy="32" r="14" fill="none" stroke="url(#g)" stroke-width="3" opacity="0.32"/>
+  <circle cx="46.5" cy="24" r="2" fill="#b8c7ff" opacity="0.9"/>
+  <circle cx="19.5" cy="33" r="2" fill="#b8c7ff" opacity="0.75"/>
+  <circle cx="42" cy="46.5" r="2" fill="#b8c7ff" opacity="0.6"/>
+
+  <!-- bold, rounded E (sequencer "blocks" vibe) -->
+  <path
+    d="M24 22V42 M24 22H42 M24 32H38 M24 42H42"
+    fill="none"
+    stroke="#eef2ff"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/echonet/static/report.css
+++ b/echonet/static/report.css
@@ -1,0 +1,778 @@
+:root {
+    color-scheme: light dark;
+    --bg: #0b0d12;
+    --panel: #121827;
+    --panel2: #0f1422;
+    --text: #e7eaf0;
+    --muted: #a7b0c0;
+    --border: rgba(255, 255, 255, 0.08);
+    --shadow: rgba(0, 0, 0, 0.35);
+    --ok: #2ecc71;
+    --warn: #f1c40f;
+    --bad: #ff5d5d;
+    --accent: #7aa2ff;
+    /* Secondary backdrop accent (keep neutral by default; "risk" theme will override). */
+    --accent2: var(--accent);
+    --link: var(--accent);
+    --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --sans: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+/* Light theme variables (toggled via [data-theme="light"]) */
+html[data-theme="light"] {
+    --bg: #f6f7fb;
+    --panel: #ffffff;
+    --panel2: #fbfbfe;
+    --text: #111827;
+    --muted: #5b6475;
+    --border: rgba(17, 24, 39, 0.10);
+    --shadow: rgba(0, 0, 0, 0.10);
+    --accent: #2457ff;
+    --accent2: var(--accent);
+    --link: var(--accent);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    height: 100%;
+}
+
+body {
+    margin: 0;
+    font-family: var(--sans);
+    background: var(--bg);
+    color: var(--text);
+}
+
+/* Fixed soft glow backdrop (no hard band while scrolling). */
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: -1;
+    background:
+        radial-gradient(1100px 680px at 18% -8%,
+            color-mix(in oklab, var(--accent) 34%, transparent),
+            transparent 62%),
+        radial-gradient(980px 640px at 88% 8%,
+            color-mix(in oklab, var(--accent2) 26%, transparent),
+            transparent 66%),
+        radial-gradient(1300px 880px at 52% 118%,
+            color-mix(in oklab, var(--accent) 18%, transparent),
+            transparent 70%);
+}
+
+/* Make section anchors scroll nicely under sticky header. */
+section[id] {
+    scroll-margin-top: 86px;
+}
+
+/* In "risk" theme, make the glow a bit stronger. */
+html[data-theme="risk"] body::before {
+    background:
+        radial-gradient(1100px 680px at 18% -8%,
+            color-mix(in oklab, var(--accent) 44%, transparent),
+            transparent 62%),
+        radial-gradient(980px 640px at 88% 8%,
+            color-mix(in oklab, var(--accent2) 38%, transparent),
+            transparent 66%),
+        radial-gradient(1300px 880px at 52% 118%,
+            color-mix(in oklab, var(--accent) 26%, transparent),
+            transparent 70%);
+}
+
+.pillLink {
+    cursor: pointer;
+    user-select: none;
+}
+
+.pillLink:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
+}
+
+/* Risk theme (accent is set dynamically by JS based on echonet-only revert rate). */
+html[data-theme="risk"] {
+    --link: var(--accent);
+}
+
+a {
+    color: var(--link);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.mono {
+    font-family: var(--mono);
+}
+
+.right {
+    text-align: right;
+}
+
+.smallMuted {
+    color: var(--muted);
+    font-size: 12px;
+    margin-top: 10px;
+    line-height: 1.35;
+}
+
+.empty {
+    color: var(--muted);
+    padding: 12px 0;
+}
+
+.countPill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 8px;
+    padding: 2px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 82%, transparent);
+    color: var(--muted);
+    font-size: 12px;
+    font-family: var(--mono);
+}
+
+.topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel) 88%, transparent);
+    backdrop-filter: blur(10px);
+}
+
+.brand .title {
+    font-size: 16px;
+    font-weight: 650;
+    letter-spacing: 0.2px;
+}
+
+.brand .subtitle {
+    margin-top: 2px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.controls {
+    display: flex;
+    gap: 10px;
+    align-items: end;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.inlineForm {
+    display: flex;
+    gap: 10px;
+    align-items: end;
+    flex-wrap: wrap;
+    margin-top: 10px;
+}
+
+.formActions {
+    display: flex;
+    gap: 10px;
+    align-items: end;
+}
+
+.statusLine {
+    color: var(--muted);
+    font-size: 12px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+    font-family: var(--mono);
+}
+
+.control {
+    display: grid;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.control input,
+.control select {
+    min-width: 220px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--panel2);
+    color: var(--text);
+    outline: none;
+}
+
+.noSpin[type="number"] {
+    appearance: textfield;
+    -moz-appearance: textfield;
+}
+
+/* Chrome, Safari, Edge */
+.noSpin[type="number"]::-webkit-outer-spin-button,
+.noSpin[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.control select {
+    min-width: 120px;
+}
+
+.control input:focus,
+.control select:focus {
+    border-color: color-mix(in oklab, var(--link) 55%, var(--border));
+    box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 18%, transparent);
+}
+
+.btn {
+    appearance: none;
+    border: 1px solid var(--border);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--panel) 92%, white 8%), var(--panel));
+    color: var(--text);
+    padding: 8px 10px;
+    border-radius: 10px;
+    cursor: pointer;
+    font-size: 12px;
+    box-shadow: 0 8px 20px var(--shadow);
+}
+
+.btn:hover {
+    filter: brightness(1.05);
+}
+
+.btn:active {
+    transform: translateY(1px);
+}
+
+.btnLink {
+    display: inline-flex;
+    align-items: center;
+}
+
+.btnSmall {
+    padding: 5px 7px;
+    border-radius: 9px;
+    box-shadow: none;
+}
+
+.rowActions {
+    display: flex;
+    gap: 5px;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+}
+
+.tableMeta {
+    margin: -2px 0 10px;
+}
+
+.container {
+    max-width: 1280px;
+    margin: 18px auto;
+    padding: 0 16px 30px;
+}
+
+.stack {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 14px;
+}
+
+.row2 {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.grid {
+    display: grid;
+    gap: 14px;
+}
+
+.kpis {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.span2 {
+    grid-column: span 2;
+}
+
+.twoCol {
+    margin-top: 14px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 1050px) {
+    .kpis {
+        grid-template-columns: 1fr;
+    }
+
+    .span2 {
+        grid-column: auto;
+    }
+
+    .twoCol {
+        grid-template-columns: 1fr;
+    }
+
+    .row2 {
+        grid-template-columns: 1fr;
+    }
+
+    .control input {
+        min-width: 180px;
+    }
+}
+
+.card {
+    background: linear-gradient(180deg, color-mix(in oklab, var(--panel) 92%, white 8%), var(--panel));
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 14px 14px 12px;
+    box-shadow: 0 16px 40px var(--shadow);
+    min-width: 0;
+    /* allow shrinking in CSS grid */
+}
+
+.cardTitle {
+    font-weight: 650;
+    letter-spacing: 0.2px;
+    margin-bottom: 10px;
+}
+
+/* Collapsible section cards (page-level sections). */
+.sectionDetails > summary {
+    list-style: none;
+    cursor: pointer;
+    user-select: none;
+}
+
+.sectionDetails > summary::-webkit-details-marker {
+    display: none;
+}
+
+.sectionDetails > summary.sectionSummary {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+    font-weight: 650;
+    letter-spacing: 0.2px;
+    /* Override generic `.details summary` styling; match original `.cardTitle`. */
+    color: var(--text);
+    font-size: inherit;
+    position: relative;
+    padding-right: 18px; /* room for chevron */
+    margin: 0 0 10px;
+}
+
+.sectionDetails:not([open]) > summary.sectionSummary {
+    margin-bottom: 0;
+}
+
+.sectionSummaryLeft {
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.sectionSummaryRight {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.sectionDetails > summary.sectionSummary::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 7px solid color-mix(in oklab, var(--muted) 65%, transparent);
+    opacity: 0.85;
+    transform: translateY(-50%) rotate(0deg);
+    transition: transform 120ms ease, border-top-color 120ms ease, opacity 120ms ease;
+}
+
+.sectionDetails[open] > summary.sectionSummary::after {
+    transform: translateY(-50%) rotate(180deg);
+    border-top-color: color-mix(in oklab, var(--link) 70%, transparent);
+    opacity: 0.95;
+}
+
+.sectionDetails > summary.sectionSummary:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
+    border-radius: 12px;
+}
+
+.kpiProgress .cardTitle {
+    margin-bottom: 8px;
+}
+
+.progressHero {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 12px 14px;
+    align-items: start;
+}
+
+.heroLabel {
+    color: var(--muted);
+    font-size: 12px;
+}
+
+.heroValue {
+    font-size: 36px;
+    font-weight: 800;
+    letter-spacing: -0.6px;
+    margin-top: 2px;
+}
+
+.heroRow {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 18px;
+    align-items: start;
+}
+
+.heroSub {
+    color: var(--muted);
+    font-size: 12px;
+    margin-top: 6px;
+}
+
+.kvTight {
+    gap: 6px 10px;
+}
+
+.bigNumber {
+    font-size: 32px;
+    font-weight: 750;
+    letter-spacing: -0.3px;
+    margin-top: 4px;
+}
+
+.kv {
+    display: grid;
+    grid-template-columns: 1.3fr 1fr;
+    gap: 8px 10px;
+    align-items: baseline;
+}
+
+.kv .k {
+    color: var(--muted);
+    font-size: 12px;
+}
+
+.kv .v {
+    font-size: 13px;
+}
+
+.pillRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.pill {
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+    border: 1px solid var(--border);
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+}
+
+.pill.neutral {
+    color: var(--muted);
+}
+
+.pill.ok {
+    border-color: color-mix(in oklab, var(--ok) 42%, var(--border));
+    background: color-mix(in oklab, var(--ok) 10%, var(--panel2));
+}
+
+.pill.warn {
+    border-color: color-mix(in oklab, var(--warn) 45%, var(--border));
+    background: color-mix(in oklab, var(--warn) 10%, var(--panel2));
+}
+
+.pill.bad {
+    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
+    background: color-mix(in oklab, var(--bad) 10%, var(--panel2));
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    font-size: 12px;
+    font-family: var(--mono);
+}
+
+.badge.bad {
+    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
+}
+
+.table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: color-mix(in oklab, var(--panel2) 75%, transparent);
+    table-layout: fixed;
+}
+
+.table thead th {
+    text-align: left;
+    font-size: 12px;
+    color: var(--muted);
+    font-weight: 650;
+    padding: 10px 10px;
+    border-bottom: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+}
+
+.table thead th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+body[data-report-export="1"] .table thead th.sortable {
+    cursor: default;
+}
+
+.table thead th.sortable:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 14%, transparent);
+    border-radius: 10px;
+}
+
+.table thead th.sortable:hover {
+    color: color-mix(in oklab, var(--muted) 50%, var(--text));
+}
+
+.table thead th.sortable::after {
+    content: "";
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-left: 8px;
+    vertical-align: middle;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 6px solid color-mix(in oklab, var(--muted) 55%, transparent);
+    opacity: 0.55;
+    transform: translateY(-1px);
+}
+
+.table thead th.sortable[data-sort-dir="asc"]::after {
+    border-top: 0;
+    border-bottom: 6px solid color-mix(in oklab, var(--link) 70%, transparent);
+    opacity: 0.9;
+}
+
+.table thead th.sortable[data-sort-dir="desc"]::after {
+    border-top: 6px solid color-mix(in oklab, var(--link) 70%, transparent);
+    opacity: 0.9;
+}
+
+body[data-report-export="1"] .table thead th.sortable::after {
+    display: none;
+}
+
+.table tbody td {
+    padding: 9px 10px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+    font-size: 13px;
+    overflow: hidden;
+}
+
+.table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.table tbody tr:nth-child(2n) td {
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+}
+
+.table tbody tr:hover td {
+    background: color-mix(in oklab, var(--link) 10%, transparent);
+}
+
+.status {
+    display: inline-flex;
+    min-width: 52px;
+    justify-content: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 85%, transparent);
+}
+
+.status.ok {
+    border-color: color-mix(in oklab, var(--ok) 42%, var(--border));
+}
+
+.status.warn {
+    border-color: color-mix(in oklab, var(--warn) 45%, var(--border));
+}
+
+.status.bad {
+    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
+}
+
+tr.sev.bad td {
+    box-shadow: inset 3px 0 0 color-mix(in oklab, var(--bad) 75%, transparent);
+}
+
+tr.sev.warn td {
+    box-shadow: inset 3px 0 0 color-mix(in oklab, var(--warn) 70%, transparent);
+}
+
+.hash {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+    cursor: pointer;
+    user-select: none;
+}
+
+body[data-report-export="1"] .hash {
+    cursor: text;
+    user-select: text;
+}
+
+.hash:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
+    border-radius: 8px;
+}
+
+body[data-report-export="1"] .hash:focus {
+    box-shadow: none;
+}
+
+/* Column sizing (used via <colgroup>) */
+.colBn {
+    width: 110px;
+}
+
+.colCount {
+    width: 90px;
+}
+
+.colStatus {
+    width: 92px;
+}
+
+.colHash {
+    width: 360px;
+}
+
+.colActions {
+    width: 280px;
+}
+
+@media (max-width: 1050px) {
+    .progressHero {
+        grid-template-columns: 1fr;
+    }
+
+    .heroRow {
+        grid-template-columns: 1fr;
+    }
+
+    .colHash {
+        width: 260px;
+    }
+
+    .colActions {
+        width: 260px;
+    }
+}
+
+.details:not(.sectionDetails) summary {
+    cursor: pointer;
+    user-select: none;
+    color: var(--link);
+    font-size: 12px;
+}
+
+.details.nested {
+    margin-top: 6px;
+}
+
+.pre {
+    margin: 10px 0 0;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in oklab, var(--panel2) 92%, transparent);
+    overflow: auto;
+    max-height: 320px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+.reason {
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+.footer {
+    margin-top: 18px;
+    padding: 12px 2px;
+    color: var(--muted);
+    font-size: 12px;
+}
+
+/* Hidden rows for filtering */
+tr.isHidden,
+details.isHidden {
+    display: none;
+}

--- a/echonet/static/report.js
+++ b/echonet/static/report.js
@@ -1,0 +1,717 @@
+(() => {
+    const STORAGE = {
+        refresh: "echonet.report.refreshSeconds",
+        theme: "echonet.report.theme",
+        filter: "echonet.report.filter",
+        scope: "echonet.report.filterScope",
+        blockDumpNumber: "echonet.report.blockDumpNumber",
+        blockDumpKind: "echonet.report.blockDumpKind",
+    };
+
+    function $(id) {
+        return document.getElementById(id);
+    }
+
+    function qs() {
+        return new URLSearchParams(window.location.search || "");
+    }
+
+    function applyTheme(theme) {
+        const html = document.documentElement;
+        if (theme === "light" || theme === "dark" || theme === "risk") {
+            html.setAttribute("data-theme", theme);
+        } else {
+            html.removeAttribute("data-theme");
+        }
+
+        // "risk" sets --accent/--accent2 inline; clear when leaving it so dark/light
+        // revert to CSS defaults immediately (no refresh required).
+        if (theme !== "risk") {
+            html.style.removeProperty("--accent");
+            html.style.removeProperty("--accent2");
+        }
+    }
+
+    function getDefaultTheme() {
+        // Default: risk (accent derived from echonet-only revert rate).
+        return "risk";
+    }
+
+    function nextTheme(current) {
+        // Cycle: risk -> dark -> light -> risk
+        if (current === "risk") return "dark";
+        if (current === "dark") return "light";
+        return "risk";
+    }
+
+    function normalize(s) {
+        return (s || "").toString().toLowerCase().trim();
+    }
+
+    function setHidden(el, hidden) {
+        if (!el) return;
+        if (hidden) el.classList.add("isHidden");
+        else el.classList.remove("isHidden");
+    }
+
+    function openCollapsibleSection(root) {
+        if (!root) return;
+        const tag = root.tagName ? root.tagName.toLowerCase() : "";
+        if (tag === "details") {
+            root.open = true;
+            return;
+        }
+        const d =
+            root.querySelector &&
+            root.querySelector('details[data-section-details="1"], details.sectionDetails');
+        if (d) d.open = true;
+    }
+
+    function countVisibleRows(root) {
+        const rows = root.querySelectorAll("tr[data-search]");
+        let total = 0;
+        let visible = 0;
+        rows.forEach((tr) => {
+            total += 1;
+            if (!tr.classList.contains("isHidden")) visible += 1;
+        });
+        return { total, visible };
+    }
+
+    function updateTableMeta() {
+        // Tables (by data-table)
+        document.querySelectorAll("[data-table-meta]").forEach((el) => {
+            const name = el.getAttribute("data-table-meta");
+            if (!name) return;
+            const tables = document.querySelectorAll(`table[data-table="${CSS.escape(name)}"]`);
+            let total = 0;
+            let visible = 0;
+            tables.forEach((t) => {
+                const c = countVisibleRows(t);
+                total += c.total;
+                visible += c.visible;
+            });
+            el.textContent = total === 0 ? "" : `Showing ${visible}/${total} rows`;
+        });
+
+        // Global stats (all rows)
+        const stats = $("filterStats");
+        if (stats) {
+            const all = countVisibleRows(document);
+            stats.textContent = all.total === 0 ? "" : `${all.visible}/${all.total} rows`;
+        }
+    }
+
+    function filterAll(query, scope) {
+        const q = normalize(query);
+
+        const activeScope = scope || "all";
+
+        // Filter each filterable container independently. If scope doesn't match, leave it unfiltered.
+        const containers = document.querySelectorAll(".filterable[data-filter-scope]");
+        containers.forEach((root) => {
+            const rootScope = root.getAttribute("data-filter-scope") || "";
+            const doFilter = activeScope === "all" || activeScope === rootScope;
+            const rows = root.querySelectorAll("tr[data-search]");
+            rows.forEach((tr) => {
+                if (!doFilter) {
+                    setHidden(tr, false);
+                    return;
+                }
+                const hay = normalize(tr.getAttribute("data-search"));
+                const match = !q || hay.includes(q);
+                setHidden(tr, !match);
+            });
+
+            // If root is a <details>, hide the entire group if it has no visible rows (only when filtering it).
+            if (root.tagName && root.tagName.toLowerCase() === "details") {
+                if (!doFilter) {
+                    setHidden(root, false);
+                } else {
+                    const anyVisible = root.querySelector("tr[data-search]:not(.isHidden)") != null;
+                    setHidden(root, !anyVisible);
+                }
+            }
+        });
+
+        updateTableMeta();
+    }
+
+    function initSectionCollapsePersistence() {
+        // Persist section open/closed state across refreshes (like refresh dropdown).
+        // Keyed by the <section id="..."> that wraps a `details.sectionDetails`.
+        try {
+            const prefix = "echonet.report.sectionOpen.";
+            document.querySelectorAll('details.sectionDetails[data-section-details="1"]').forEach((d) => {
+                const section = d.closest("section[id]");
+                const id = section ? (section.id || "") : "";
+                if (!id) return;
+
+                const key = prefix + id;
+                const saved = localStorage.getItem(key);
+                if (saved === "1") d.open = true;
+                else if (saved === "0") d.open = false;
+                else {
+                    // Defaults: everything open except pending txs.
+                    if (id === "pending-txs") d.open = false;
+                }
+
+                d.addEventListener("toggle", () => {
+                    try {
+                        localStorage.setItem(key, d.open ? "1" : "0");
+                    } catch (_) { }
+                });
+            });
+        } catch (_) {
+            // If localStorage is unavailable, just fall back to HTML defaults.
+        }
+    }
+
+    function toast(msg) {
+        // Tiny toast without dependencies.
+        let el = document.getElementById("toast");
+        if (!el) {
+            el = document.createElement("div");
+            el.id = "toast";
+            el.style.position = "fixed";
+            el.style.bottom = "14px";
+            el.style.right = "14px";
+            el.style.padding = "10px 12px";
+            el.style.borderRadius = "12px";
+            el.style.border = "1px solid rgba(255,255,255,0.12)";
+            el.style.background = "rgba(20, 24, 39, 0.92)";
+            el.style.backdropFilter = "blur(10px)";
+            el.style.color = "#e7eaf0";
+            el.style.fontSize = "12px";
+            el.style.fontFamily = "ui-sans-serif, system-ui";
+            el.style.boxShadow = "0 18px 40px rgba(0,0,0,0.35)";
+            el.style.zIndex = "999";
+            el.style.opacity = "0";
+            el.style.transform = "translateY(6px)";
+            el.style.transition = "opacity 120ms ease, transform 120ms ease";
+            document.body.appendChild(el);
+        }
+        el.textContent = msg;
+        requestAnimationFrame(() => {
+            el.style.opacity = "1";
+            el.style.transform = "translateY(0)";
+        });
+        window.clearTimeout(el._t);
+        el._t = window.setTimeout(() => {
+            el.style.opacity = "0";
+            el.style.transform = "translateY(6px)";
+        }, 1100);
+    }
+
+    async function copyText(text) {
+        const t = (text || "").toString();
+        if (!t) return;
+        try {
+            await navigator.clipboard.writeText(t);
+            toast("Copied");
+            return;
+        } catch (_) {
+            // fall through
+        }
+        // Fallback
+        const ta = document.createElement("textarea");
+        ta.value = t;
+        ta.style.position = "fixed";
+        ta.style.left = "-1000px";
+        ta.style.top = "-1000px";
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try {
+            document.execCommand("copy");
+            toast("Copied");
+        } catch (_) {
+            toast("Copy failed");
+        } finally {
+            document.body.removeChild(ta);
+        }
+    }
+
+    function initCopyButtons() {
+        document.querySelectorAll("button.copyBtn[data-copy]").forEach((btn) => {
+            btn.addEventListener("click", () => copyText(btn.getAttribute("data-copy")));
+        });
+    }
+
+    function initHashClickToCopy() {
+        document.querySelectorAll(".hash").forEach((el) => {
+            el.addEventListener("click", (e) => {
+                // Avoid interfering with text selection.
+                if (window.getSelection && (window.getSelection().toString() || "").trim()) return;
+                e.preventDefault();
+                e.stopPropagation();
+                const t = el.getAttribute("title") || el.textContent || "";
+                copyText(t.trim());
+            });
+            el.setAttribute("role", "button");
+            el.setAttribute("tabindex", "0");
+            el.addEventListener("keydown", (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    const t = el.getAttribute("title") || el.textContent || "";
+                    copyText(t.trim());
+                }
+            });
+        });
+    }
+
+    function buildGcpLogsUrl({ txHash } = {}) {
+        const b = document.body?.dataset || {};
+        const projectId = (b.gcpProjectId || "").trim();
+        const location = (b.gcpLocation || "").trim();
+        const cluster = (b.gkeClusterName || "").trim();
+        const namespace = (b.k8sNamespace || "").trim();
+        const duration = (b.gcpLogsDuration || "").trim();
+
+        const lines = [];
+        lines.push('resource.type="k8s_container"');
+        // These labels are harmless even if they don't match (they narrow search).
+        if (projectId) lines.push(`resource.labels.project_id="${projectId}"`);
+        if (location) lines.push(`resource.labels.location="${location}"`);
+        if (cluster) lines.push(`resource.labels.cluster_name="${cluster}"`);
+        if (namespace) lines.push(`resource.labels.namespace_name="${namespace}"`);
+
+        if (txHash) {
+            const h = txHash.trim();
+            // A simple string search is good enough here.
+            lines.push(`"${h}"`);
+        }
+
+        const q = lines.join("\n");
+        const encoded = encodeURIComponent(q);
+        const cursorTimestamp = encodeURIComponent(new Date().toISOString());
+        const url =
+            `https://console.cloud.google.com/logs/query;` +
+            `query=${encoded};storageScope=project;cursorTimestamp=${cursorTimestamp};duration=${encodeURIComponent(duration)}` +
+            `?project=${encodeURIComponent(projectId)}`;
+        return url;
+    }
+
+    function initLogsLinks() {
+        // Base namespace logs link.
+        const base = $("logsBaseLink");
+        if (base) {
+            base.href = buildGcpLogsUrl();
+        }
+
+        // Per-tx logs links.
+        document.querySelectorAll("a.logsLink[data-logs-tx]").forEach((a) => {
+            const txHash = a.getAttribute("data-logs-tx") || "";
+            a.href = buildGcpLogsUrl({ txHash });
+        });
+    }
+
+    function initFilter() {
+        const input = $("filterInput");
+        if (!input) return;
+        const scopeSelect = $("scopeSelect");
+
+        const params = qs();
+        const urlQ = params.get("q");
+        const urlScope = params.get("scope");
+
+        const savedQ = localStorage.getItem(STORAGE.filter) || "";
+        const savedScope = localStorage.getItem(STORAGE.scope) || "all";
+
+        // URL params win (shareable view), otherwise fall back to local storage.
+        input.value = (urlQ != null ? urlQ : savedQ) || "";
+        if (scopeSelect) scopeSelect.value = (urlScope != null ? urlScope : savedScope) || "all";
+
+        filterAll(input.value, scopeSelect ? scopeSelect.value : "all");
+        input.addEventListener("input", () => {
+            localStorage.setItem(STORAGE.filter, input.value);
+            filterAll(input.value, scopeSelect ? scopeSelect.value : "all");
+        });
+        if (scopeSelect) {
+            scopeSelect.addEventListener("change", () => {
+                localStorage.setItem(STORAGE.scope, scopeSelect.value);
+                filterAll(input.value, scopeSelect.value);
+            });
+        }
+        // Preserve focus across auto-refresh reloads (best-effort).
+        const focusKey = "echonet.report.filterFocused";
+        input.addEventListener("focus", () => sessionStorage.setItem(focusKey, "1"));
+        input.addEventListener("blur", () => sessionStorage.setItem(focusKey, "0"));
+        if (sessionStorage.getItem(focusKey) === "1") {
+            // Defer to allow initial layout to settle.
+            setTimeout(() => {
+                input.focus();
+                // Put caret at end.
+                const v = input.value || "";
+                input.setSelectionRange(v.length, v.length);
+            }, 0);
+        }
+
+        // Keyboard shortcuts:
+        // - "/" focuses filter (like many dashboards)
+        // - "Escape" clears filter
+        window.addEventListener("keydown", (e) => {
+            if (e.defaultPrevented) return;
+            const tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : "";
+            const inTypingContext = tag === "input" || tag === "textarea" || tag === "select";
+
+            if (!inTypingContext && e.key === "/") {
+                e.preventDefault();
+                input.focus();
+                input.select();
+                return;
+            }
+            if (e.key === "Escape") {
+                if (document.activeElement === input || input.value) {
+                    input.value = "";
+                    localStorage.setItem(STORAGE.filter, "");
+                    filterAll("", scopeSelect ? scopeSelect.value : "all");
+                    input.blur();
+                    toast("Filter cleared");
+                }
+            }
+        });
+    }
+
+    function initCopyVisibleHashes() {
+        const btn = $("copyVisibleBtn");
+        if (!btn) return;
+        const scopeSelect = $("scopeSelect");
+
+        function collectHashesWithin(root) {
+            const out = [];
+            root.querySelectorAll("tr[data-search]:not(.isHidden) .hash").forEach((el) => {
+                const t = (el.getAttribute("title") || el.textContent || "").trim();
+                if (t) out.push(t);
+            });
+            return out;
+        }
+
+        btn.addEventListener("click", () => {
+            const scope = scopeSelect ? (scopeSelect.value || "all") : "all";
+            let hashes = [];
+            if (scope === "all") {
+                hashes = collectHashesWithin(document);
+            } else {
+                document
+                    .querySelectorAll(`.filterable[data-filter-scope="${CSS.escape(scope)}"]`)
+                    .forEach((root) => {
+                        hashes.push(...collectHashesWithin(root));
+                    });
+            }
+
+            const uniq = Array.from(new Set(hashes));
+            if (!uniq.length) {
+                toast("No visible hashes");
+                return;
+            }
+            copyText(uniq.join("\n"));
+            toast(`Copied ${uniq.length} hashes`);
+        });
+    }
+
+    function initRefresh() {
+        const select = $("refreshSelect");
+        const btn = $("refreshNowBtn");
+        if (!select) return;
+
+        const params = qs();
+        const urlRefresh = params.get("refresh");
+        const saved = localStorage.getItem(STORAGE.refresh) || "off";
+        select.value = (urlRefresh != null ? urlRefresh : saved) || "off";
+
+        let timer = null;
+        function setTimer(v) {
+            if (timer) window.clearInterval(timer);
+            timer = null;
+            if (v === "off") return;
+            const secs = parseInt(v, 10);
+            if (!Number.isFinite(secs) || secs <= 0) return;
+            timer = window.setInterval(() => window.location.reload(), secs * 1000);
+        }
+
+        setTimer(select.value);
+        select.addEventListener("change", () => {
+            localStorage.setItem(STORAGE.refresh, select.value);
+            setTimer(select.value);
+        });
+
+        if (btn) btn.addEventListener("click", () => window.location.reload());
+    }
+
+    function initThemeToggle() {
+        const btn = $("themeToggleBtn");
+        if (!btn) return;
+        const params = qs();
+        const urlTheme = params.get("theme");
+        let saved = (urlTheme != null ? urlTheme : (localStorage.getItem(STORAGE.theme) || getDefaultTheme())) || getDefaultTheme();
+        // Migrate old "system" setting to the new default.
+        if (saved === "system") {
+            saved = getDefaultTheme();
+            localStorage.setItem(STORAGE.theme, saved);
+        }
+        applyTheme(saved);
+        if (saved === "risk") applyRiskAccent();
+        btn.addEventListener("click", () => {
+            let cur = localStorage.getItem(STORAGE.theme) || getDefaultTheme();
+            if (cur === "system") cur = getDefaultTheme();
+            const nxt = nextTheme(cur);
+            localStorage.setItem(STORAGE.theme, nxt);
+            applyTheme(nxt);
+            if (nxt === "risk") applyRiskAccent();
+            toast(`Theme: ${nxt}`);
+        });
+    }
+
+    function initBlockDumpPersistence() {
+        const num = $("blockDumpNumber");
+        const kind = $("blockDumpKind");
+        if (!num && !kind) return;
+
+        // Restore (localStorage wins; no URL param support needed here since the form opens in a new tab).
+        try {
+            if (num) {
+                const saved = localStorage.getItem(STORAGE.blockDumpNumber);
+                if (saved != null && saved !== "") num.value = saved;
+            }
+            if (kind) {
+                const saved = localStorage.getItem(STORAGE.blockDumpKind);
+                if (saved != null && saved !== "") kind.value = saved;
+            }
+        } catch (_) { }
+
+        // Preserve focus across auto-refresh reloads (best-effort), like filter input.
+        if (num) {
+            const focusKey = "echonet.report.blockDumpNumberFocused";
+            num.addEventListener("focus", () => sessionStorage.setItem(focusKey, "1"));
+            num.addEventListener("blur", () => sessionStorage.setItem(focusKey, "0"));
+            if (sessionStorage.getItem(focusKey) === "1") {
+                setTimeout(() => {
+                    num.focus();
+                    num.select();
+                }, 0);
+            }
+        }
+
+        // Persist changes.
+        if (num) {
+            num.addEventListener("input", () => {
+                try {
+                    localStorage.setItem(STORAGE.blockDumpNumber, num.value || "");
+                } catch (_) { }
+            });
+        }
+        if (kind) {
+            kind.addEventListener("change", () => {
+                try {
+                    localStorage.setItem(STORAGE.blockDumpKind, kind.value || "");
+                } catch (_) { }
+            });
+        }
+    }
+
+    function clamp01(x) {
+        const n = Number(x);
+        if (!Number.isFinite(n)) return 0;
+        if (n < 0) return 0;
+        if (n > 1) return 1;
+        return n;
+    }
+
+    function lerp(a, b, t) {
+        return Math.round(a + (b - a) * t);
+    }
+
+    function applyRiskAccent() {
+        // Map echonet-only revert rate -> accent color.
+        // 0% => muted green; 1%+ => muted red.
+        const risk = clamp01(document.body?.dataset?.echonetRevertRisk);
+
+        // Muted (non-neon) endpoints.
+        const green = { r: 52, g: 156, b: 98 }; // slightly stronger green
+        const red = { r: 196, g: 56, b: 56 };   // slightly stronger red
+
+        const r = lerp(green.r, red.r, risk);
+        const g = lerp(green.g, red.g, risk);
+        const b = lerp(green.b, red.b, risk);
+
+        const accent = `rgb(${r} ${g} ${b})`;
+        document.documentElement.style.setProperty("--accent", accent);
+        // Keep any secondary glow aligned with the same accent (avoid hard banding).
+        document.documentElement.style.setProperty("--accent2", accent);
+    }
+
+    function initScrollLinks() {
+        function scrollToId(id) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            // If the target section is collapsed, open it before scrolling.
+            openCollapsibleSection(el);
+            el.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+
+        document.querySelectorAll("[data-scroll-to]").forEach((el) => {
+            const id = el.getAttribute("data-scroll-to");
+            if (!id) return;
+
+            el.addEventListener("click", () => scrollToId(id));
+            el.addEventListener("keydown", (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    scrollToId(id);
+                }
+            });
+        });
+    }
+
+    function initRestoreScrollPosition() {
+        const key = "echonet.report.scrollY";
+        let ticking = false;
+        window.addEventListener("scroll", () => {
+            if (ticking) return;
+            ticking = true;
+            window.requestAnimationFrame(() => {
+                try {
+                    sessionStorage.setItem(key, String(window.scrollY || 0));
+                } catch (_) { }
+                ticking = false;
+            });
+        });
+
+        const params = qs();
+        const hasExplicitAnchor = (window.location.hash || "").length > 1 || params.get("section");
+        if (hasExplicitAnchor) return;
+        const raw = sessionStorage.getItem(key);
+        const y = raw ? parseInt(raw, 10) : 0;
+        if (Number.isFinite(y) && y > 0) {
+            window.scrollTo({ top: y, behavior: "auto" });
+        }
+    }
+
+    function initSectionParamScroll() {
+        const params = qs();
+        const section = params.get("section");
+        if (!section) return;
+        const el = document.getElementById(section);
+        if (el) {
+            // If the target section is collapsed, open it before scrolling.
+            openCollapsibleSection(el);
+            setTimeout(() => el.scrollIntoView({ behavior: "smooth", block: "start" }), 0);
+        }
+    }
+
+    function initHashOpen() {
+        const h = (window.location.hash || "").trim();
+        if (!h || h === "#") return;
+        const id = h.startsWith("#") ? h.slice(1) : h;
+        if (!id) return;
+        const el = document.getElementById(id);
+        if (el) openCollapsibleSection(el);
+    }
+
+    function getCellValue(tr, idx) {
+        const td = tr.children && tr.children[idx];
+        if (!td) return "";
+        return (td.textContent || "").trim();
+    }
+
+    function tryParseNumber(s) {
+        const t = (s || "").replace(/,/g, "").trim();
+        if (!t) return null;
+        const n = Number(t);
+        return Number.isFinite(n) ? n : null;
+    }
+
+    function initSortableTables() {
+        document.querySelectorAll("table").forEach((table) => {
+            const thead = table.querySelector("thead");
+            const tbody = table.querySelector("tbody");
+            if (!thead || !tbody) return;
+            const headers = thead.querySelectorAll("th.sortable");
+            if (!headers.length) return;
+
+            headers.forEach((th, idx) => {
+                th.setAttribute("role", "button");
+                th.setAttribute("tabindex", "0");
+                const sortType = th.getAttribute("data-sort") || "auto";
+
+                function doSort() {
+                    const cur = th.getAttribute("data-sort-dir") || "none";
+                    const next = cur === "asc" ? "desc" : "asc";
+
+                    // Reset siblings
+                    headers.forEach((h) => {
+                        if (h !== th) {
+                            h.removeAttribute("data-sort-dir");
+                            h.removeAttribute("aria-sort");
+                        }
+                    });
+
+                    th.setAttribute("data-sort-dir", next);
+                    th.setAttribute("aria-sort", next === "asc" ? "ascending" : "descending");
+
+                    const rows = Array.from(tbody.querySelectorAll("tr"));
+                    rows.sort((a, b) => {
+                        const av = getCellValue(a, idx);
+                        const bv = getCellValue(b, idx);
+
+                        if (sortType === "num") {
+                            const an = tryParseNumber(av);
+                            const bn = tryParseNumber(bv);
+                            const ax = an == null ? Number.NEGATIVE_INFINITY : an;
+                            const bx = bn == null ? Number.NEGATIVE_INFINITY : bn;
+                            return next === "asc" ? ax - bx : bx - ax;
+                        }
+
+                        // auto / str
+                        const an = tryParseNumber(av);
+                        const bn = tryParseNumber(bv);
+                        if (sortType === "auto" && an != null && bn != null) {
+                            return next === "asc" ? an - bn : bn - an;
+                        }
+
+                        const as = normalize(av);
+                        const bs = normalize(bv);
+                        if (as < bs) return next === "asc" ? -1 : 1;
+                        if (as > bs) return next === "asc" ? 1 : -1;
+                        return 0;
+                    });
+
+                    rows.forEach((tr) => tbody.appendChild(tr));
+                }
+
+                th.addEventListener("click", doSort);
+                th.addEventListener("keydown", (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        doSort();
+                    }
+                });
+            });
+        });
+    }
+
+    function boot() {
+        initCopyButtons();
+        initHashClickToCopy();
+        initLogsLinks();
+        initFilter();
+        initCopyVisibleHashes();
+        initRefresh();
+        initThemeToggle();
+        initBlockDumpPersistence();
+        initSectionCollapsePersistence();
+        initScrollLinks();
+        initSortableTables();
+        initSectionParamScroll();
+        initHashOpen();
+        initRestoreScrollPosition();
+        updateTableMeta();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", boot);
+    } else {
+        boot();
+    }
+})();

--- a/echonet/templates/report.html
+++ b/echonet/templates/report.html
@@ -1,0 +1,668 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Echonet Report</title>
+  <link rel="icon" href="{{ url_for('static', filename='favicon.svg') }}" type="image/svg+xml" />
+  {% if export %}
+  <link rel="stylesheet" href="data:text/css;base64,{{ inline_css_b64 }}" />
+  {% else %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='report.css') }}" />
+  <script defer src="{{ url_for('static', filename='report.js') }}"></script>
+  {% endif %}
+</head>
+
+<body data-echonet-revert-rate-pct="{{ meta.echonet_revert_rate_pct }}"
+  data-echonet-revert-risk="{{ meta.echonet_revert_risk_0_1 }}" data-report-export="{{ 1 if export else 0 }}"
+  data-gcp-project-id="{{ logs.gcp_project_id }}" data-gcp-location="{{ logs.gcp_location }}"
+  data-gke-cluster-name="{{ logs.gke_cluster_name }}" data-k8s-namespace="{{ logs.k8s_namespace }}"
+  data-gcp-logs-duration="{{ logs.duration }}">
+  <header class="topbar">
+    <div class="brand">
+      <div class="title">Echonet Report</div>
+      <div class="subtitle">
+        Generated <span class="mono">{{ meta.generated_at_utc }}</span>
+      </div>
+    </div>
+
+    {% if not export %}
+    <div class="controls">
+      <label class="control">
+        <span>Filter</span>
+        <input id="filterInput" type="search" placeholder="tx hash / reason / status…" autocomplete="off" />
+      </label>
+
+      <label class="control">
+        <span>Scope</span>
+        <select id="scopeSelect" title="Limit filtering to one section">
+          <option value="all">All</option>
+          <option value="pending">Pending</option>
+          <option value="gateway">Gateway errors</option>
+          <option value="reverts">Reverts</option>
+          <option value="resync">Resync</option>
+          <option value="diag">Diagnostics</option>
+        </select>
+      </label>
+
+      <label class="control">
+        <span>Auto refresh</span>
+        <select id="refreshSelect">
+          <option value="off">Off</option>
+          <option value="5">5s</option>
+          <option value="15">15s</option>
+          <option value="60">60s</option>
+        </select>
+      </label>
+
+      <button class="btn" id="refreshNowBtn" type="button">Refresh</button>
+      <button class="btn" id="copyVisibleBtn" type="button" title="Copy visible tx hashes (respects scope)">Copy
+        visible</button>
+      <a class="btn btnLink" id="logsBaseLink" href="#" target="_blank" rel="noopener"
+        title="Open GCP Logs Explorer for this namespace">Logs</a>
+      <button class="btn" id="themeToggleBtn" type="button" title="Toggle theme">Theme</button>
+      <a class="btn btnLink" href="/echonet/report/ui/download" title="Download static HTML snapshot">Download</a>
+      <a class="btn btnLink" href="/echonet/report" title="Raw JSON snapshot">JSON</a>
+      <a class="btn btnLink" href="/echonet/report/text" title="Text snapshot (plain text)">Text</a>
+      <div class="statusLine" id="filterStats" aria-live="polite"></div>
+    </div>
+    {% endif %}
+  </header>
+
+  <main class="container">
+    <div class="stack">
+      <section>
+        <div class="card kpiProgress">
+          <div class="cardTitle">Progress</div>
+          <div class="progressHero">
+            <div>
+              <div class="heroRow">
+                <div>
+                  <div class="heroLabel">Blocks processed</div>
+                  <div class="heroValue mono">{{ progress.blocks_processed }}</div>
+                </div>
+                <div>
+                  <div class="heroLabel">Current block</div>
+                  <div class="heroValue mono">{{ progress.current_block }}</div>
+                </div>
+              </div>
+            </div>
+            <div class="kv kvTight">
+              <div class="k">Initial start</div>
+              <div class="v mono">{{ progress.initial_start_block }}</div>
+              <div class="k">Current start</div>
+              <div class="v mono">{{ progress.current_start_block }}</div>
+              <div class="k">First timestamp</div>
+              <div class="v mono">{{ meta.first_block_timestamp_iso }}</div>
+              <div class="k">Latest timestamp</div>
+              <div class="v mono">{{ meta.latest_block_timestamp_iso }}</div>
+              <div class="k">Span</div>
+              <div class="v mono">{{ meta.span_human }}</div>
+              <div class="k">Forward rate</div>
+              <div class="v mono">{{ meta.forward_rate }}</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="row2">
+        <div class="card">
+          <div class="cardTitle">Transactions</div>
+          <div class="bigNumber mono">{{ kpis.total_sent_tx_count }}</div>
+          <div class="smallMuted">Total forwarded</div>
+          <div class="pillRow">
+            <span class="pill {{ severity.committed }}">Committed: <span class="mono">{{ kpis.committed_count }}</span>
+              ({{ kpis.committed_pct_of_pending_total }})</span>
+            <span class="pill {{ severity.pending }}">Pending: <span class="mono">{{ kpis.pending_commission_count
+                }}</span> ({{ kpis.pending_pct_of_pending_total }})</span>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="cardTitle">Alerts</div>
+          <div class="pillRow">
+            <span class="pill pillLink {{ severity.gateway_errors }}" role="button" tabindex="0"
+              data-scroll-to="gateway-errors">Gateway errors:
+              <span class="mono">{{ kpis.gateway_errors_count }}</span></span>
+            <span class="pill pillLink {{ severity.reverts_mainnet }}" role="button" tabindex="0"
+              data-scroll-to="reverts-mainnet">Reverts
+              (mainnet-only): <span class="mono">{{ kpis.reverts_mainnet_count }}</span>
+              <span class="mono">({{ reverts.mainnet_only.pct_of_total_sent }})</span></span>
+            <span class="pill pillLink {{ severity.reverts_echonet }}" role="button" tabindex="0"
+              data-scroll-to="reverts-echonet">Reverts
+              (echonet-only): <span class="mono">{{ kpis.reverts_echonet_count }}</span>
+              <span class="mono">({{ reverts.echonet_only.pct_of_total_sent }})</span></span>
+          </div>
+          <div class="pillRow">
+            <span class="pill pillLink {{ severity.resync_causes }}" role="button" tabindex="0"
+              data-scroll-to="resync-triggers">Resync triggers:
+              <span class="mono">{{ kpis.resync_causes_count }}</span></span>
+            <span class="pill pillLink {{ severity.certain_failures }}" role="button" tabindex="0"
+              data-scroll-to="certain-failures">Certain failures:
+              <span class="mono">{{ kpis.certain_failures_count }}</span></span>
+            <span class="pill pillLink {{ severity.l2_gas_mismatches }}" role="button" tabindex="0"
+              data-scroll-to="l2-gas-mismatches">L2 gas
+              mismatches: <span class="mono">{{ kpis.l2_gas_mismatches_count }}</span></span>
+          </div>
+          <div class="smallMuted">
+            Tip: press <span class="mono">/</span> to focus filter; <span class="mono">Esc</span> clears it.
+          </div>
+        </div>
+      </section>
+
+      <section id="pending-txs">
+        <details class="card details sectionDetails" data-section-details="1">
+          <summary class="sectionSummary">
+            <span class="sectionSummaryLeft">Non-committed tx hashes (pending)</span>
+          </summary>
+          {% if not export %}
+          <div class="tableMeta smallMuted" data-table-meta="pending"></div>
+          {% endif %}
+          {% if not pending_txs %}
+          <div class="empty">(none)</div>
+          {% else %}
+          <table class="table filterable" data-filter-scope="pending" data-table="pending">
+            <colgroup>
+              <col class="colBn" />
+              <col class="colHash" />
+              <col class="colActions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th class="sortable" data-sort="num">Source block</th>
+                <th class="sortable" data-sort="str">Tx hash</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for tx_hash, src_bn in pending_txs %}
+              <tr data-search="{{ tx_hash }} {{ src_bn }}">
+                <td class="mono">{{ src_bn }}</td>
+                <td class="mono">
+                  <span class="hash" title="{{ tx_hash }}">{{ tx_hash }}</span>
+                </td>
+                <td class="right">
+                  <div class="rowActions">
+                    {% if not export %}
+                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ tx_hash }}">Copy</button>
+                    {% endif %}
+                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ tx_hash }}" target="_blank"
+                      rel="noopener" title="Open in Voyager">Voyager</a>
+                    {% if not export %}
+                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                      data-logs-tx="{{ tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ src_bn }}&withFeeMarketInfo=true" target="_blank"
+                      rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                    <a class="btn btnSmall btnLink" href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ src_bn }}"
+                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+        </details>
+      </section>
+
+      <section id="gateway-errors">
+        <details class="card details sectionDetails" data-section-details="1" open>
+          <summary class="sectionSummary">
+            <span class="sectionSummaryLeft">Gateway errors <span class="countPill">{{ kpis.gateway_errors_count }}</span></span>
+          </summary>
+          {% if not export %}
+          <div class="tableMeta smallMuted" data-table-meta="gateway"></div>
+          {% endif %}
+          {% if not gateway_errors %}
+          <div class="empty">(none)</div>
+          {% else %}
+          <table class="table filterable" data-filter-scope="gateway" data-table="gateway">
+            <colgroup>
+              <col class="colBn" />
+              <col class="colStatus" />
+              <col class="colHash" />
+              <col />
+              <col class="colActions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th class="sortable" data-sort="num">Block</th>
+                <th class="sortable" data-sort="str">Status</th>
+                <th class="sortable" data-sort="str">Tx hash</th>
+                <th>Response</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in gateway_errors %}
+              <tr class="sev {{ severity.gateway_errors }}"
+                data-search="{{ row.tx_hash }} {{ row.status }} {{ row.block_number }} {{ row.response }}">
+                <td class="mono">{{ row.block_number }}</td>
+                <td class="mono"><span class="status {{ severity.gateway_errors }}">{{ row.status }}</span></td>
+                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                <td class="mono">
+                  <details class="details">
+                    <summary>Show</summary>
+                    <pre class="pre">{{ row.response }}</pre>
+                  </details>
+                </td>
+                <td class="right">
+                  <div class="rowActions">
+                    {% if not export %}
+                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                    {% endif %}
+                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                      rel="noopener" title="Open in Voyager">Voyager</a>
+                    {% if not export %}
+                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                      target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
+                      rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+        </details>
+      </section>
+
+      <section id="reverts-mainnet">
+        <details class="card details sectionDetails" data-section-details="1" open>
+          <summary class="sectionSummary">
+            <span class="sectionSummaryLeft">Reverted only on Mainnet <span class="countPill">{{ reverts.mainnet_only.total }} ({{ reverts.mainnet_only.pct_of_total_sent
+                }})</span></span>
+          </summary>
+          {% if reverts.mainnet_only.total == 0 %}
+          <div class="empty">(none)</div>
+          {% else %}
+          <div class="smallMuted">Use the filter box to narrow down.</div>
+          {% for group in reverts.mainnet_only.groups %}
+          <details class="details filterable" data-filter-scope="reverts" open>
+            <summary>
+              <span class="badge bad">{{ group.count }}</span>
+              <span class="mono">{{ group.name }}</span>
+              <span class="countPill">{{ group.pct_of_section }}</span>
+            </summary>
+            <table class="table" data-table="reverts">
+              <colgroup>
+                <col class="colBn" />
+                <col class="colHash" />
+                <col />
+                <col class="colActions" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th class="sortable" data-sort="num">Source block</th>
+                  <th class="sortable" data-sort="str">Tx hash</th>
+                  <th>Reason (shortened)</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in group.rows %}
+                <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
+                  <td class="mono">{{ row.block_number }}</td>
+                  <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                  <td>
+                    <div class="reason">{{ row.reason }}</div>
+                    {% if row.raw_error and row.raw_error != row.reason %}
+                    <details class="details nested">
+                      <summary>Raw</summary>
+                      <pre class="pre">{{ row.raw_error }}</pre>
+                    </details>
+                    {% endif %}
+                  </td>
+                  <td class="right">
+                    <div class="rowActions">
+                      {% if not export %}
+                      <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                      {% endif %}
+                      <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                        rel="noopener" title="Open in Voyager">Voyager</a>
+                      {% if not export %}
+                      <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                        data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                      <a class="btn btnSmall btnLink"
+                        href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                        target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                      <a class="btn btnSmall btnLink"
+                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
+                        rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      {% endif %}
+                    </div>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </details>
+          {% endfor %}
+          {% endif %}
+        </details>
+      </section>
+
+      <section id="reverts-echonet">
+        <details class="card details sectionDetails" data-section-details="1" open>
+          <summary class="sectionSummary">
+            <span class="sectionSummaryLeft">Reverted only on Echonet <span class="countPill">{{ reverts.echonet_only.total }} ({{ reverts.echonet_only.pct_of_total_sent
+                }})</span></span>
+          </summary>
+          {% if reverts.echonet_only.total == 0 %}
+          <div class="empty">(none)</div>
+          {% else %}
+          <div class="smallMuted">Use the filter box to narrow down.</div>
+          {% for group in reverts.echonet_only.groups %}
+          <details class="details filterable" data-filter-scope="reverts" open>
+            <summary>
+              <span class="badge bad">{{ group.count }}</span>
+              <span class="mono">{{ group.name }}</span>
+              <span class="countPill">{{ group.pct_of_section }}</span>
+            </summary>
+            <table class="table" data-table="reverts">
+              <colgroup>
+                <col class="colBn" />
+                <col class="colHash" />
+                <col />
+                <col class="colActions" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th class="sortable" data-sort="num">Source block</th>
+                  <th class="sortable" data-sort="str">Tx hash</th>
+                  <th>Reason (shortened)</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in group.rows %}
+                <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
+                  <td class="mono">{{ row.block_number }}</td>
+                  <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                  <td>
+                    <div class="reason">{{ row.reason }}</div>
+                    {% if row.raw_error and row.raw_error != row.reason %}
+                    <details class="details nested">
+                      <summary>Raw</summary>
+                      <pre class="pre">{{ row.raw_error }}</pre>
+                    </details>
+                    {% endif %}
+                  </td>
+                  <td class="right">
+                    <div class="rowActions">
+                      {% if not export %}
+                      <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                      {% endif %}
+                      <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                        rel="noopener" title="Open in Voyager">Voyager</a>
+                      {% if not export %}
+                      <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                        data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                      <a class="btn btnSmall btnLink"
+                        href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                        target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                      <a class="btn btnSmall btnLink"
+                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
+                        rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      {% endif %}
+                    </div>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </details>
+          {% endfor %}
+          {% endif %}
+        </details>
+      </section>
+
+      <section id="resync-triggers">
+        <details class="card details sectionDetails" data-section-details="1" open>
+          <summary class="sectionSummary">
+            <span class="sectionSummaryLeft">Resync triggers (first failures) <span class="countPill">{{ kpis.resync_causes_count }}</span></span>
+          </summary>
+          {% if not export %}
+          <div class="tableMeta smallMuted" data-table-meta="resync"></div>
+          {% endif %}
+          {% if not resync.causes %}
+          <div class="empty">(none)</div>
+          {% else %}
+          <table class="table filterable" data-filter-scope="resync" data-table="resync">
+            <colgroup>
+              <col class="colBn" />
+              <col class="colCount" />
+              <col class="colHash" />
+              <col />
+              <col class="colActions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th class="sortable" data-sort="num">Block</th>
+                <th class="sortable" data-sort="num">Count</th>
+                <th class="sortable" data-sort="str">Tx hash</th>
+                <th class="sortable" data-sort="str">Reason</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in resync.causes %}
+              <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.count }}">
+                <td class="mono">{{ row.block_number }}</td>
+                <td class="mono">{{ row.count }}</td>
+                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                <td class="mono">{{ row.reason }}</td>
+                <td class="right">
+                  <div class="rowActions">
+                    {% if not export %}
+                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                    {% endif %}
+                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                      rel="noopener" title="Open in Voyager">Voyager</a>
+                    {% if not export %}
+                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
+                      rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+        </details>
+      </section>
+
+      <section id="certain-failures">
+        <details class="card details sectionDetails" data-section-details="1" open>
+          <summary class="sectionSummary">
+            <span class="sectionSummaryLeft">Certain failures (repeated triggers) <span class="countPill">{{ kpis.certain_failures_count }}</span></span>
+          </summary>
+          {% if not export %}
+          <div class="tableMeta smallMuted" data-table-meta="certain"></div>
+          {% endif %}
+          {% if not resync.certain_failures %}
+          <div class="empty">(none)</div>
+          {% else %}
+          <table class="table filterable" data-filter-scope="resync" data-table="certain">
+            <colgroup>
+              <col class="colCount" />
+              <col class="colBn" />
+              <col class="colHash" />
+              <col />
+              <col class="colActions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th class="sortable" data-sort="num">Count</th>
+                <th class="sortable" data-sort="num">Block</th>
+                <th class="sortable" data-sort="str">Tx hash</th>
+                <th class="sortable" data-sort="str">Reason</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in resync.certain_failures %}
+              <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.count }}">
+                <td class="mono">{{ row.count }}</td>
+                <td class="mono">{{ row.block_number }}</td>
+                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                <td class="mono">{{ row.reason }}</td>
+                <td class="right">
+                  <div class="rowActions">
+                    {% if not export %}
+                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                    {% endif %}
+                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                      rel="noopener" title="Open in Voyager">Voyager</a>
+                    {% if not export %}
+                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
+                      rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+        </details>
+      </section>
+
+      <section id="l2-gas-mismatches">
+        <details class="card details sectionDetails" data-section-details="1" open>
+          <summary class="sectionSummary">
+            <span class="sectionSummaryLeft">L2 gas used mismatches <span class="countPill">{{ l2_gas_mismatches | length }}</span></span>
+          </summary>
+          {% if not export %}
+          <div class="tableMeta smallMuted" data-table-meta="diag"></div>
+          {% endif %}
+          {% if not l2_gas_mismatches %}
+          <div class="empty">(none)</div>
+          {% else %}
+          <div class="smallMuted">
+            Showing all L2 gas used mismatches.
+          </div>
+          <table class="table filterable" data-filter-scope="diag" data-table="diag">
+            <colgroup>
+              <col class="colBn" />
+              <col class="colBn" />
+              <col class="colHash" />
+              <col class="colCount" />
+              <col class="colCount" />
+              <col class="colActions" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th class="sortable" data-sort="num">Echo block</th>
+                <th class="sortable" data-sort="num">Source block</th>
+                <th class="sortable" data-sort="str">Tx hash</th>
+                <th class="sortable" data-sort="num">Blob L2 gas</th>
+                <th class="sortable" data-sort="num">FGW L2 gas</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in l2_gas_mismatches %}
+              <tr
+                data-search="{{ row.tx_hash }} {{ row.echo_block }} {{ row.source_block }} {{ row.blob_total_gas_l2 }} {{ row.fgw_total_gas_consumed_l2 }}">
+                <td class="mono">{{ row.echo_block }}</td>
+                <td class="mono">{{ row.source_block }}</td>
+                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                <td class="mono">{{ row.blob_total_gas_l2 }}</td>
+                <td class="mono">{{ row.fgw_total_gas_consumed_l2 }}</td>
+                <td class="right">
+                  <div class="rowActions">
+                    {% if not export %}
+                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                    {% endif %}
+                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                      rel="noopener" title="Open in Voyager">Voyager</a>
+                    {% if not export %}
+                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                    <a class="btn btnSmall btnLink"
+                      href="/echonet/block_dump?blockNumber={{ row.echo_block }}&kind=blob" target="_blank"
+                      rel="noopener" title="Open echonet blob dump JSON (echo block)">Echo&nbsp;blob</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.source_block }}&withFeeMarketInfo=true"
+                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Source&nbsp;block</a>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+        </details>
+      </section>
+
+      {% if not export %}
+      <section id="block-dump">
+        <div class="card">
+          <div class="cardTitle">Echonet Blocks</div>
+          <div class="smallMuted">
+            Fetch a stored payload from Echonet via <span class="mono">/echonet/block_dump</span>.
+          </div>
+          <form class="inlineForm" action="/echonet/block_dump" method="get" target="_blank" rel="noopener">
+            <label class="control">
+              <span>Block number</span>
+              <input id="blockDumpNumber" name="blockNumber" type="number" inputmode="numeric" min="0"
+                placeholder="e.g. 123456" required class="noSpin" />
+            </label>
+            <label class="control">
+              <span>Kind</span>
+              <select id="blockDumpKind" name="kind" required>
+                <option value="blob">blob</option>
+                <option value="block">block</option>
+                <option value="state_update">state_update</option>
+              </select>
+            </label>
+            <div class="formActions">
+              <button class="btn" id="blockDumpOpenBtn" type="submit">Open</button>
+            </div>
+          </form>
+        </div>
+      </section>
+      {% endif %}
+    </div>
+
+    <footer class="footer">
+      <div>
+        {% if export %}
+        Static snapshot: interactive controls + local endpoints are disabled.
+        {% else %}
+        Endpoints:
+        <a href="/echonet/report/ui">UI</a>,
+        <a href="/echonet/report">JSON</a>,
+        <a href="/echonet/report/text">Text</a>,
+        <a href="/echonet/block_dump?blockNumber=0&kind=blob">Block dump</a>
+        {% endif %}
+      </div>
+    </footer>
+  </main>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new Flask endpoints and template/static assets, plus reads additional secret config and in-cluster namespace for log-link generation. Main risk is operational/misconfiguration (missing secrets, file read paths) and serving new UI content, not core transaction processing.
> 
> **Overview**
> Adds a new HTML reporting dashboard for Echonet snapshots, exposed via `GET /echonet/report/ui`, plus `GET /echonet/report/ui/download` to export a self-contained HTML file and `GET /echonet/report/text` for a plain-text snapshot.
> 
> Extends config to include `gcp_logs` fields (project/location/cluster) and auto-detects/caches the pod namespace to generate GCP Logs Explorer links in the UI; Kubernetes secret template is updated accordingly. Also updates `build_report_view_model` to include `feeder_base_url` for UI links and removes the old `reports.py` symlink from the init container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 488da0b37406b876466b63c49eab403e3f075982. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->