### PR TITLE
echonet: hide mainnet reverts past first pending tx

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -20,6 +20,7 @@ from echonet.reports import (
     RevertComparisonTextReport,
     SnapshotTextReport,
     build_report_view_model,
+    filter_mainnet_reverts_for_reporting,
 )
 from echonet.sequencer_manager import _read_namespace_from_serviceaccount
 from echonet.shared_context import SharedContext, l1_manager, shared
@@ -738,7 +739,7 @@ class EchoCenterService:
         reverts_text = RevertComparisonTextReport(
             classifier=RevertClassifier(),
         ).render(
-            mainnet_reverts=dict(snap.revert_errors_mainnet),
+            mainnet_reverts=filter_mainnet_reverts_for_reporting(snap),
             echonet_reverts=dict(snap.revert_errors_echonet),
         )
         out = snapshot_text.rstrip() + "\n\n" + reverts_text

--- a/echonet/reports.py
+++ b/echonet/reports.py
@@ -212,6 +212,20 @@ class SnapshotTextReport:
         return "\n".join(lines).rstrip() + "\n"
 
 
+def filter_mainnet_reverts_for_reporting(snapshot: SnapshotModel) -> dict[str, RevertErrorInfo]:
+    """
+    Filter mainnet-only reverts for *reporting* (UI/text/pre-resync reports).
+    """
+    cutoff_bn = next(iter(snapshot.sent_tx_hashes.values()), None)
+    if cutoff_bn is None:
+        return dict(snapshot.revert_errors_mainnet)
+    return {
+        tx_hash: info
+        for tx_hash, info in snapshot.revert_errors_mainnet.items()
+        if info["block_number"] <= cutoff_bn
+    }
+
+
 @dataclass(frozen=True, slots=True)
 class RevertRule:
     name: str
@@ -388,7 +402,7 @@ class PreResyncReportWriter:
 
         snapshot_text = header + SnapshotTextReport(snapshot).render()
         reverts_text = header + RevertComparisonTextReport(classifier=self._classifier).render(
-            mainnet_reverts=snapshot.revert_errors_mainnet,
+            mainnet_reverts=filter_mainnet_reverts_for_reporting(snapshot),
             echonet_reverts=snapshot.revert_errors_echonet,
         )
 
@@ -523,7 +537,8 @@ class _SnapshotReportRollup:
         pending_commission = s.pending_commission_count
 
         gateway_errors_count = len(s.gateway_errors)
-        reverts_mainnet_count = len(s.revert_errors_mainnet)
+        mainnet_reverts_filtered = filter_mainnet_reverts_for_reporting(s)
+        reverts_mainnet_count = len(mainnet_reverts_filtered)
         reverts_echonet_count = len(s.revert_errors_echonet)
         resync_causes_count = len(s.resync_causes)
         certain_failures_count = len(s.certain_failures)
@@ -556,7 +571,7 @@ class _SnapshotReportRollup:
             for tx_hash, payload in s.gateway_errors.items()
         ]
 
-        grouped_mainnet = _group_reverts(dict(s.revert_errors_mainnet), classifier=classifier)
+        grouped_mainnet = _group_reverts(dict(mainnet_reverts_filtered), classifier=classifier)
         grouped_echonet = _group_reverts(dict(s.revert_errors_echonet), classifier=classifier)
 
         resync_causes_rows = sorted(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Reporting-only change that filters displayed mainnet-only revert entries; no impact on transaction execution or state, but could hide useful debugging info if the cutoff heuristic is wrong.
> 
> **Overview**
> Mainnet-only revert reporting is now *filtered* to hide entries past the first currently-pending transaction’s source block.
> 
> This adds `filter_mainnet_reverts_for_reporting(snapshot)` and applies it consistently across the text report endpoint (`/echonet/report/text`), pre-resync log bundles, and the HTML report KPIs/grouping so counts and lists reflect the filtered set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0f4b487d6c76f2b5b9d8720146ceb6d500a92ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->