### PR TITLE
apollo_consensus_orchestrator: apply timeout to proof verification and abort tasks

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -77,11 +77,20 @@ pub(crate) struct BlockInfoValidation {
     pub l2_gas_price_fri: GasPrice,
 }
 
+/// Parameters for deadline and cancellation handling during proposal finalization.
+struct ProposalDeadlineParams {
+    clock: Arc<dyn Clock>,
+    deadline: DateTime,
+    cancel_token: CancellationToken,
+}
+
 enum HandledProposalPart {
     Continue,
     Invalid(String),
     Finished(ProposalCommitment, Box<ProposalFin>, FinishedProposalInfo),
     Failed(String),
+    Timeout(String),
+    Interrupted(String),
 }
 
 type ValidateProposalResult<T> = Result<T, ValidateProposalError>;
@@ -154,6 +163,12 @@ pub(crate) async fn validate_proposal(
     )
     .await?;
 
+    let deadline_params = ProposalDeadlineParams {
+        clock: args.deps.clock.clone(),
+        deadline,
+        cancel_token: args.cancel_token.clone(),
+    };
+
     // Validating the rest of the proposal parts.
     let (built_block, received_fin, finished_info) = loop {
         tokio::select! {
@@ -179,6 +194,7 @@ pub(crate) async fn validate_proposal(
                     &mut content,
                     &mut verify_and_store_proof_tasks,
                     args.deps.transaction_converter.clone(),
+                    &deadline_params,
                 ).await {
                     HandledProposalPart::Finished(built_block, received_fin, finished_info) => {
                         break (built_block, received_fin, finished_info);
@@ -191,6 +207,16 @@ pub(crate) async fn validate_proposal(
                     HandledProposalPart::Failed(fail_reason) => {
                         batcher_abort_proposal(args.deps.batcher.as_ref(), args.proposal_id).await?;
                         return Err(ValidateProposalError::ProposalPartFailed(fail_reason,proposal_part));
+                    }
+                    HandledProposalPart::Timeout(msg) => {
+                        // Ignoring batcher errors, to better reflect the validation timeout.
+                        batcher_abort_proposal(args.deps.batcher.as_ref(), args.proposal_id).await.ok();
+                        return Err(ValidateProposalError::ValidationTimeout(msg));
+                    }
+                    HandledProposalPart::Interrupted(msg) => {
+                        // Ignoring batcher errors, to better reflect the proposal interruption.
+                        batcher_abort_proposal(args.deps.batcher.as_ref(), args.proposal_id).await.ok();
+                        return Err(ValidateProposalError::ProposalInterrupted(msg));
                     }
                 }
             }
@@ -362,6 +388,7 @@ async fn handle_proposal_part(
     content: &mut Vec<Vec<InternalConsensusTransaction>>,
     verify_and_store_proof_tasks: &mut Vec<VerifyAndStoreProofTask>,
     transaction_converter: Arc<dyn TransactionConverterTrait>,
+    deadline_params: &ProposalDeadlineParams,
 ) -> HandledProposalPart {
     match proposal_part {
         None => {
@@ -388,10 +415,30 @@ async fn handle_proposal_part(
             // conversion, running concurrently with batcher execution. Since the fin
             // is always the last proposal part, we await all tasks here to ensure every
             // proof is verified and stored before finalizing the proposal.
+            // The tasks themselves are not cancelled, they continue running in the background,
+            // but we stop waiting for them.
             let start = Instant::now();
             for task in verify_and_store_proof_tasks.drain(..) {
-                if let Err(e) = await_verify_and_store_proof_task(task).await {
-                    return HandledProposalPart::Failed(e);
+                tokio::select! {
+                    _ = deadline_params.cancel_token.cancelled() => {
+                        let duration = start.elapsed();
+                        info!("Verification tasks interrupted after {duration:?}");
+                        return HandledProposalPart::Interrupted(
+                            "awaiting verification tasks".to_string(),
+                        );
+                    }
+                    _ = deadline_params.clock.sleep_until(deadline_params.deadline) => {
+                        let duration = start.elapsed();
+                        info!("Verification tasks timed out after {duration:?}");
+                        return HandledProposalPart::Timeout(
+                            "awaiting verification tasks".to_string(),
+                        );
+                    }
+                    result = await_verify_and_store_proof_task(task) => {
+                        if let Err(e) = result {
+                            return HandledProposalPart::Failed(e);
+                        }
+                    }
                 }
             }
             let duration = start.elapsed();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes proposal finalization to stop waiting for proof-verification tasks on deadline or cancellation, which can alter when proposals are aborted/failed under load or slow verification.
> 
> **Overview**
> Applies the proposal *deadline and cancellation token* to the finalization step that awaits `VerifyAndStoreProofTask`s after receiving `ProposalFin`, so validation can return early with `ValidationTimeout`/`ProposalInterrupted` instead of potentially blocking indefinitely.
> 
> Propagates these new outcomes through `handle_proposal_part` via `HandledProposalPart::{Timeout, Interrupted}` and ensures the batcher proposal is aborted (best-effort) when these conditions occur.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd50622fb4ca2aae7b32b8e39969ab0a808c564c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->