### PR TITLE
apollo_dashboard: Change panels from pod to pvc grouping and labeling

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -4006,7 +4006,7 @@
           "description": "Pod disk utilization (used / capacity)",
           "type": "timeseries",
           "exprs": [
-            "\n            (\n                sum by (namespace, pod) (\n                    kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            /\n            (\n                sum by (namespace, pod) (\n                    kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            "
+            "\n            (\n                sum by (namespace, persistentvolumeclaim) (\n                    kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            /\n            (\n                sum by (namespace, persistentvolumeclaim) (\n                    kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            "
           ],
           "extra_params": {
             "unit": "percentunit",
@@ -4028,7 +4028,7 @@
               ]
             },
             "legends": [
-              "{{pod}}"
+              "{{persistentvolumeclaim}}"
             ]
           }
         },
@@ -4037,7 +4037,7 @@
           "description": "Pod disk limit utilization (used / capacity)",
           "type": "timeseries",
           "exprs": [
-            "\n            (\n                sum by (namespace, pod) (\n                    kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            /\n            (\n                sum by (namespace, pod) (\n                    kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            "
+            "\n            (\n                sum by (namespace, persistentvolumeclaim) (\n                    kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            /\n            (\n                sum by (namespace, persistentvolumeclaim) (\n                    kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}\n                )\n            )\n            "
           ],
           "extra_params": {
             "unit": "percentunit",
@@ -4059,7 +4059,7 @@
               ]
             },
             "legends": [
-              "{{pod}}"
+              "{{persistentvolumeclaim}}"
             ]
           }
         }

--- a/crates/apollo_dashboard/src/infra_panels.rs
+++ b/crates/apollo_dashboard/src/infra_panels.rs
@@ -17,6 +17,7 @@ use crate::query_builder::increase;
 const INFRA_ROW_TITLE_SUFFIX: &str = "Infra";
 const INFRA_INCREASE_DURATION: &str = "1m";
 pub(crate) const POD_LEGEND: [&str; 1] = ["{{pod}}"];
+pub(crate) const PVC_LEGEND: [&str; 1] = ["{{persistentvolumeclaim}}"];
 
 pub(crate) fn get_component_infra_row(row_name: impl ToString, metrics: &InfraMetrics) -> Row {
     let mut panels: Vec<Panel> = Vec::new();

--- a/crates/apollo_dashboard/src/panels/pod_metrics.rs
+++ b/crates/apollo_dashboard/src/panels/pod_metrics.rs
@@ -1,7 +1,7 @@
 use apollo_metrics::metric_definitions::METRIC_LABEL_FILTER;
 
 use crate::dashboard::Row;
-use crate::infra_panels::POD_LEGEND;
+use crate::infra_panels::{POD_LEGEND, PVC_LEGEND};
 use crate::panel::{Panel, PanelType, Unit};
 
 // TODO(Tsabary): replace query building with relevant functions and templates.
@@ -160,8 +160,8 @@ fn get_pod_memory_limit_utilization_panel() -> Panel {
 //   total volume bytes used by the pod
 //   ----------------------------------
 //   total volume capacity bytes of the pod
-// Aggregated per (namespace, pod), the result is a value between 0.0 and 1.0 per pod.
-// Interpreted as: "How much of the provisioned PVC capacity is this pod using?"
+// Aggregated per (namespace, persistentvolumeclaim), the result is a value between 0.0 and 1.0 per
+// PVC. Interpreted as: "How much of the provisioned PVC capacity is this pod using?"
 fn get_pod_disk_utilization_panel() -> Panel {
     Panel::new(
         "Pod Disk Utilization",
@@ -169,13 +169,13 @@ fn get_pod_disk_utilization_panel() -> Panel {
         format!(
             "
             (
-                sum by (namespace, pod) (
+                sum by (namespace, persistentvolumeclaim) (
                     kubelet_volume_stats_used_bytes{METRIC_LABEL_FILTER}
                 )
             )
             /
             (
-                sum by (namespace, pod) (
+                sum by (namespace, persistentvolumeclaim) (
                     kubelet_volume_stats_capacity_bytes{METRIC_LABEL_FILTER}
                 )
             )
@@ -183,7 +183,7 @@ fn get_pod_disk_utilization_panel() -> Panel {
         ),
         PanelType::TimeSeries,
     )
-    .with_legends(POD_LEGEND)
+    .with_legends(PVC_LEGEND)
     .with_unit(Unit::PercentUnit)
     .with_absolute_thresholds(pod_metric_thresholds())
 }
@@ -192,8 +192,9 @@ fn get_pod_disk_utilization_panel() -> Panel {
 //   total volume bytes used by the pod
 //   ----------------------------------
 //   total volume capacity bytes of the pod (effective disk limit)
-// Aggregated per (namespace, pod), the result is a value between 0.0 and 1.0 per pod.
-// Interpreted as: "How close is this pod's PVC storage to being full (disk *limit* saturation)?"
+// Aggregated per (namespace, persistentvolumeclaim), the result is a value between 0.0 and 1.0 per
+// PVC. Interpreted as: "How close is this pod's PVC storage to being full (disk *limit*
+// saturation)?"
 fn get_pod_disk_limit_utilization_panel() -> Panel {
     Panel::new(
         "Pod Disk Limit Utilization",
@@ -201,13 +202,13 @@ fn get_pod_disk_limit_utilization_panel() -> Panel {
         format!(
             "
             (
-                sum by (namespace, pod) (
+                sum by (namespace, persistentvolumeclaim) (
                     kubelet_volume_stats_used_bytes{METRIC_LABEL_FILTER}
                 )
             )
             /
             (
-                sum by (namespace, pod) (
+                sum by (namespace, persistentvolumeclaim) (
                     kubelet_volume_stats_capacity_bytes{METRIC_LABEL_FILTER}
                 )
             )
@@ -215,7 +216,7 @@ fn get_pod_disk_limit_utilization_panel() -> Panel {
         ),
         PanelType::TimeSeries,
     )
-    .with_legends(POD_LEGEND)
+    .with_legends(PVC_LEGEND)
     .with_unit(Unit::PercentUnit)
     .with_absolute_thresholds(pod_metric_thresholds())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dashboard-only PromQL/legend changes; low risk beyond potentially altering how disk utilization is attributed and displayed (PVC vs pod).
> 
> **Overview**
> Updates the dashboard’s **pod disk utilization** panels to aggregate `kubelet_volume_stats_*` metrics by `persistentvolumeclaim` instead of `pod`, and updates legends accordingly.
> 
> Introduces a shared `PVC_LEGEND` constant and applies it in both the Rust panel definitions (`pod_metrics.rs`) and the generated `dev_grafana.json` so the UI labels match the new PVC grouping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fd25c40624a5f73f501a7fa84bdcedf5f976e22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->