### PR TITLE
echonet: Add forwarding lock and epoch gating

### DIFF
--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -404,9 +404,14 @@ class SharedContext:
         self._l2_gas_mismatches = _ReportL2GasMismatchTracker.empty()
         self._blocks = _BlockStore.empty()
         self._progress = _ProgressMarkers.empty()
+        self._epoch = 0
 
     def get_uptime_seconds(self) -> int:
         return int(time.monotonic() - self._started_at_monotonic)
+
+    def get_epoch(self) -> int:
+        with self._lock:
+            return self._epoch
 
     # --- Tx lifecycle ---
     def record_sent_tx(self, tx_hash: str, source_block_number: int) -> None:
@@ -472,6 +477,7 @@ class SharedContext:
     def clear_for_resync(self) -> None:
         """Clear live state for a new run while preserving cumulative stats."""
         with self._lock:
+            self._epoch += 1
             snapshot_items = self._blocks.snapshot_items()
             archive_dir = self._blocks._ensure_archive_dir()
             self._tx.currently_pending.clear()

--- a/echonet/transaction_sender.py
+++ b/echonet/transaction_sender.py
@@ -113,6 +113,7 @@ class TxData:
     tx: JsonObject
     source_block_number: int
     source_timestamp: Optional[int]
+    epoch: int
 
 
 class TxSelector:
@@ -215,6 +216,7 @@ class TransactionSenderService:
 
         async with aiohttp.ClientSession(timeout=timeout) as session:
             tx_queue: "asyncio.Queue[Optional[TxData]]" = asyncio.Queue(maxsize=config.queue_size)
+            forwarding_lock = asyncio.Lock()
 
             transformer = TxTransformer(feeder)
             forwarder = HttpForwarder(
@@ -259,6 +261,8 @@ class TransactionSenderService:
 
                     timestamp = block["timestamp"]
                     shared.store_fgw_block(block_number, block)
+
+                    epoch = shared.get_epoch()
                     revert_errors = _extract_revert_errors_by_tx_hash(block)
                     if revert_errors:
                         shared.record_mainnet_revert_errors(block_number, revert_errors)
@@ -274,6 +278,7 @@ class TransactionSenderService:
                             tx=tx,
                             source_block_number=block_number,
                             source_timestamp=timestamp,
+                            epoch=epoch,
                         )
                         await tx_queue.put(tx_data)
 
@@ -292,8 +297,9 @@ class TransactionSenderService:
                             f"Resync triggered by tx {trigger['tx_hash']} at block {trigger['block_number']}: "
                             f"{trigger['reason']}"
                         )
-                        await drain_queue()
-                        block_number = await resync_executor.execute(trigger=trigger)
+                        async with forwarding_lock:
+                            await drain_queue()
+                            block_number = await resync_executor.execute(trigger=trigger)
                         continue
 
                     block_number += 1
@@ -317,9 +323,13 @@ class TransactionSenderService:
                         ):
                             await asyncio.sleep(CONFIG.tx_sender.poll_interval_seconds)
 
-                        await forwarder.forward(
-                            prepared, source_block_number=item.source_block_number
-                        )
+                        async with forwarding_lock:
+                            if item.epoch != shared.get_epoch():
+                                continue
+                            await forwarder.forward(
+                                prepared,
+                                source_block_number=item.source_block_number,
+                            )
                     finally:
                         tx_queue.task_done()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core tx forwarding/resync concurrency path; a mistake could drop or stall transactions, though the change is localized and guarded by a lock+epoch check.
> 
> **Overview**
> Prevents stale/overlapping forwards during resync by introducing an **epoch counter** in `SharedContext` that increments on `clear_for_resync()`, and tagging queued `TxData` with the current epoch.
> 
> `transaction_sender` now serializes forwarding-related operations with an `asyncio` **forwarding lock**: resync drains/executes under the lock, and the consumer re-checks `epoch` under the same lock to skip txs from a previous run before calling `HttpForwarder.forward()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb0effd6ea6b3adfdf73e73f1e06f1117d148836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->