### PR TITLE
apollo_central_sync: sending non-bc casms to class manager gets them from state update stream

### DIFF
--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -29,17 +29,14 @@ use apollo_state_sync_metrics::metrics::{
 };
 use apollo_storage::base_layer::{BaseLayerStorageReader, BaseLayerStorageWriter};
 use apollo_storage::body::BodyStorageWriter;
-use apollo_storage::class::{ClassStorageReader, ClassStorageWriter};
-use apollo_storage::class_manager::{ClassManagerStorageReader, ClassManagerStorageWriter};
-use apollo_storage::compiled_class::{CasmStorageReader, CasmStorageWriter};
-use apollo_storage::db::DbError;
+use apollo_storage::class_manager::ClassManagerStorageWriter;
+use apollo_storage::compiled_class::CasmStorageReader;
 use apollo_storage::header::{HeaderStorageReader, HeaderStorageWriter};
 use apollo_storage::state::{StateStorageReader, StateStorageWriter};
 use apollo_storage::{StorageError, StorageReader, StorageWriter};
 use async_stream::try_stream;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use chrono::{TimeZone, Utc};
-use futures::future::pending;
 use futures::stream;
 use futures_util::{pin_mut, select, Stream, StreamExt};
 use indexmap::IndexMap;
@@ -55,7 +52,7 @@ use starknet_api::block::{
 };
 use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
 use starknet_api::contract_class::ContractClass;
-use starknet_api::core::{ClassHash, CompiledClassHash, SequencerPublicKey};
+use starknet_api::core::{ClassHash, SequencerPublicKey};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::state::{StateDiff, ThinStateDiff};
 use tokio::sync::{Mutex, RwLock};
@@ -160,13 +157,8 @@ pub enum SyncEvent {
         // state diff.
         // Note: Since 0.11 new classes can not be implicitly declared.
         deployed_contract_class_definitions: IndexMap<ClassHash, DeprecatedContractClass>,
-    },
-    CompiledClassAvailable {
-        block_number: BlockNumber,
-        class_hash: ClassHash,
-        compiled_class_hash: CompiledClassHash,
-        compiled_class: CasmContractClass,
-        is_compiler_backward_compatible: bool,
+        // Casms of the classes that are non backward compatible.
+        non_backward_compatible_casms: IndexMap<ClassHash, CasmContractClass>,
     },
     NewBaseLayerBlock {
         block_number: BlockNumber,
@@ -275,15 +267,6 @@ impl<
             self.config.state_updates_max_stream_size,
         )
         .fuse();
-        let compiled_class_stream = stream_new_compiled_classes(
-            self.reader.clone(),
-            self.central_source.clone(),
-            self.config.latest_block_poll_interval_millis,
-            // TODO(yair): separate config param.
-            self.config.state_updates_max_stream_size,
-            self.config.store_sierras_and_casms_block_threshold,
-        )
-        .fuse();
         let base_layer_block_stream = match &self.base_layer_source {
             Some(base_layer_source) => stream_new_base_layer_block(
                 self.reader.clone(),
@@ -296,25 +279,14 @@ impl<
         };
         // TODO(dvir): try use interval instead of stream.
         // TODO(DvirYo): fix the bug and remove this check.
-        let check_sync_progress = check_sync_progress(
-            self.reader.clone(),
-            self.config.store_sierras_and_casms_block_threshold,
-        )
-        .fuse();
-        pin_mut!(
-            block_stream,
-            state_diff_stream,
-            compiled_class_stream,
-            base_layer_block_stream,
-            check_sync_progress
-        );
+        let check_sync_progress = check_sync_progress(self.reader.clone()).fuse();
+        pin_mut!(block_stream, state_diff_stream, base_layer_block_stream, check_sync_progress);
 
         loop {
             debug!("Selecting between block sync and state diff sync.");
             let sync_event = select! {
               res = block_stream.next() => res,
               res = state_diff_stream.next() => res,
-              res = compiled_class_stream.next() => res,
               res = base_layer_block_stream.next() => res,
               res = check_sync_progress.next() => res,
               complete => break,
@@ -337,28 +309,14 @@ impl<
                 block_hash,
                 state_diff,
                 deployed_contract_class_definitions,
+                non_backward_compatible_casms,
             } => {
                 self.store_state_diff(
                     block_number,
                     block_hash,
                     state_diff,
                     deployed_contract_class_definitions,
-                )
-                .await
-            }
-            SyncEvent::CompiledClassAvailable {
-                block_number,
-                class_hash,
-                compiled_class_hash,
-                compiled_class,
-                is_compiler_backward_compatible,
-            } => {
-                self.store_compiled_class(
-                    block_number,
-                    class_hash,
-                    compiled_class_hash,
-                    compiled_class,
-                    is_compiler_backward_compatible,
+                    non_backward_compatible_casms,
                 )
                 .await
             }
@@ -398,6 +356,7 @@ impl<
                 .append_header(block_number, &block.header)?
                 .append_block_signature(block_number, &signature)?
                 .append_body(block_number, block.body)?;
+            // TODO(noamsp): remove compiler backward compatibility marker.
             if block.header.block_header_without_hash.starknet_version
                 < STARKNET_VERSION_TO_COMPILE_FROM
             {
@@ -431,13 +390,18 @@ impl<
     }
 
     #[latency_histogram("sync_store_state_diff_latency_seconds", false)]
-    #[instrument(skip(self, state_diff, deployed_contract_class_definitions), level = "debug", err)]
+    #[instrument(
+        skip(self, state_diff, deployed_contract_class_definitions, non_backward_compatible_casms),
+        level = "debug",
+        err
+    )]
     async fn store_state_diff(
         &mut self,
         block_number: BlockNumber,
         block_hash: BlockHash,
         mut state_diff: StateDiff,
         deployed_contract_class_definitions: IndexMap<ClassHash, DeprecatedContractClass>,
+        non_backward_compatible_casms: IndexMap<ClassHash, CasmContractClass>,
     ) -> StateSyncResult {
         // TODO(dan): verifications - verify state diff against stored header.
         debug!("Storing state diff.");
@@ -479,51 +443,38 @@ impl<
         let (thin_state_diff, classes, deprecated_classes) =
             ThinStateDiff::from_state_diff(state_diff);
 
-        let mut block_contains_non_backwards_compatible_classes = false;
         // Sending to class manager before updating the storage so that if the class manager send
         // fails we retry the same block.
         if let Some(class_manager_client) = &self.class_manager_client {
-            // Blocks smaller than compiler_backward_compatibility marker are added to class
-            // manager via the compiled classes stream.
-            // We're sure that if the current block is above the compiler_backward_compatibility
-            // marker then the compiler_backward_compatibility will not advance anymore, because
-            // the compiler_backward_compatibility marker advances in the header stream and this
-            // stream is behind the header stream
-            // The compiled classes stream is always behind the compiler_backward_compatibility
-            // marker
-            // TODO(shahak): Consider storing a boolean and updating it to true once
-            // compiler_backward_compatibility_marker <= block_number and avoiding the check if the
-            // boolean is true.
-            let compiler_backward_compatibility_marker =
-                self.reader.begin_ro_txn()?.get_compiler_backward_compatibility_marker()?;
-
-            // A block contains only classes with either STARKNET_VERSION_TO_COMPILE_FROM or higher
-            // or only classes below STARKNET_VERSION_TO_COMPILE_FROM, not both.
-            if compiler_backward_compatibility_marker <= block_number {
-                if compiler_backward_compatibility_marker == block_number {
-                    info!(
-                        "Reached first block ({block_number}) without non backward compatible \
-                         classes."
+            for (expected_class_hash, class) in &classes {
+                if let Some(casm) = non_backward_compatible_casms.get(expected_class_hash) {
+                    trace!(
+                        "Sending non-BC compiled class for class hash {expected_class_hash} to \
+                         class manager."
+                    );
+                    let compiled_class_hash_v2 = casm.hash(&HashVersion::V2);
+                    let sierra_version = class
+                        .get_sierra_version()
+                        .expect("Failed reading sierra version from program.");
+                    let contract_class = ContractClass::V1((casm.clone(), sierra_version));
+                    class_manager_client
+                        .add_class_and_executable_unsafe(
+                            *expected_class_hash,
+                            class.clone(),
+                            compiled_class_hash_v2,
+                            contract_class,
+                        )
+                        .await?;
+                    continue;
+                }
+                let class_hash =
+                    class_manager_client.add_class(class.clone()).await?.class_hash;
+                if class_hash != *expected_class_hash {
+                    panic!(
+                        "Class hash mismatch. Expected: {expected_class_hash}, got: \
+                         {class_hash}."
                     );
                 }
-                trace!(
-                    "Block {block_number} does not contain non backward compatible classes. \
-                     compiler_backward_compatibility_marker: \
-                     {compiler_backward_compatibility_marker}"
-                );
-                for (expected_class_hash, class) in &classes {
-                    let class_hash =
-                        class_manager_client.add_class(class.clone()).await?.class_hash;
-                    if class_hash != *expected_class_hash {
-                        panic!(
-                            "Class hash mismatch. Expected: {expected_class_hash}, got: \
-                             {class_hash}."
-                        );
-                    }
-                }
-            } else {
-                debug!("Block {} contains non backward compatible classes.", block_number);
-                block_contains_non_backwards_compatible_classes = true;
             }
 
             for (class_hash, deprecated_class) in &deprecated_classes {
@@ -531,60 +482,21 @@ impl<
                     .add_deprecated_class(*class_hash, deprecated_class.clone())
                     .await?;
             }
-        }
-        let has_class_manager = self.class_manager_client.is_some();
 
-        let store_sierras_and_casms_block_threshold =
-            self.config.store_sierras_and_casms_block_threshold;
-        let store_sierras_and_casms = block_number.0 < store_sierras_and_casms_block_threshold;
-        self.perform_storage_writes(move |writer| {
-            if has_class_manager {
+            self.perform_storage_writes(move |writer| {
                 writer
                     .begin_rw_txn()?
                     .update_class_manager_block_marker(&block_number.unchecked_next())?
                     .commit()?;
                 STATE_SYNC_CLASS_MANAGER_MARKER.set_lossy(block_number.unchecked_next().0);
-            }
+                Ok(())
+            })
+            .await?;
+        }
+
+        self.perform_storage_writes(move |writer| {
             let mut txn = writer.begin_rw_txn()?;
             txn = txn.append_state_diff(block_number, thin_state_diff)?;
-            // Non backwards compatible classes must be stored for later use since we will only be
-            // be adding them to the class manager later, once we have their compiled
-            // classes.
-            //
-            // TODO(guy.f): Properly fix handling non backwards compatible classes.
-            if store_sierras_and_casms || block_contains_non_backwards_compatible_classes {
-                let store_reason = if store_sierras_and_casms {
-                    format!(
-                        "block {} is below store_sierras_and_casms_block_threshold: \
-                         {store_sierras_and_casms_block_threshold}",
-                        block_number.0
-                    )
-                } else {
-                    format!("block {} contains non backwards compatible classes", block_number.0)
-                };
-                debug!(
-                    "Appending classes {:?} to storage since {store_reason}",
-                    classes.keys().collect::<Vec<_>>()
-                );
-                txn = txn.append_classes(
-                    block_number,
-                    &classes
-                        .iter()
-                        .map(|(class_hash, class)| (*class_hash, class))
-                        .collect::<Vec<_>>(),
-                    &deprecated_classes
-                        .iter()
-                        .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
-                        .collect::<Vec<_>>(),
-                )?;
-            } else {
-                trace!(
-                    "Skipping appending classes {:?} to storage since block is at or above \
-                     store_sierras_and_casms_block_threshold and \
-                     block_contains_non_backwards_compatible_classes is false",
-                    classes.keys().collect::<Vec<_>>()
-                );
-            }
             txn.commit()?;
             Ok(())
         })
@@ -592,76 +504,13 @@ impl<
 
         let compiled_class_marker = self.reader.begin_ro_txn()?.get_compiled_class_marker()?;
         STATE_SYNC_STATE_MARKER.set_lossy(block_number.unchecked_next().0);
+        // TODO(noamsp): remove this marker throughout the repo.
         STATE_SYNC_COMPILED_CLASS_MARKER.set_lossy(compiled_class_marker.0);
 
         // Info the user on syncing the block once all the data is stored.
         info!("SYNC_NEW_BLOCK: Added block {} with hash {:#064x}.", block_number, block_hash.0);
 
         Ok(())
-    }
-
-    #[latency_histogram("sync_store_compiled_class_latency_seconds", false)]
-    #[instrument(skip(self, compiled_class), level = "debug", err)]
-    async fn store_compiled_class(
-        &mut self,
-        block_number: BlockNumber,
-        class_hash: ClassHash,
-        _compiled_class_hash_v1: CompiledClassHash,
-        compiled_class: CasmContractClass,
-        is_compiler_backward_compatible: bool,
-    ) -> StateSyncResult {
-        let compiled_class_hash_v2 = compiled_class.hash(&HashVersion::V2);
-
-        if !is_compiler_backward_compatible {
-            if let Some(class_manager_client) = &self.class_manager_client {
-                let class = self.reader.begin_ro_txn()?.get_class(&class_hash)?.expect(
-                    "Compiled classes stream gave class hash that doesn't appear in storage.",
-                );
-                let sierra_version = class
-                    .get_sierra_version()
-                    .expect("Failed reading sierra version from program.");
-                let contract_class = ContractClass::V1((compiled_class.clone(), sierra_version));
-                class_manager_client
-                    .add_class_and_executable_unsafe(
-                        class_hash,
-                        class,
-                        compiled_class_hash_v2,
-                        contract_class,
-                    )
-                    .await
-                    .expect("Failed adding class and compiled class to class manager.");
-            }
-        }
-        if block_number.0 >= self.config.store_sierras_and_casms_block_threshold {
-            return Ok(());
-        }
-        let result = self
-            .perform_storage_writes(move |writer| {
-                writer.begin_rw_txn()?.append_casm(&class_hash, &compiled_class)?.commit()?;
-                Ok(())
-            })
-            .await;
-        // TODO(Yair): verifications - verify casm corresponds to a class on storage.
-        match result {
-            Ok(()) => {
-                let compiled_class_marker =
-                    self.reader.begin_ro_txn()?.get_compiled_class_marker()?;
-                // Write class and casm to class manager.
-                STATE_SYNC_COMPILED_CLASS_MARKER.set_lossy(compiled_class_marker.0);
-                debug!("Added compiled class.");
-                Ok(())
-            }
-            // TODO(yair): Modify the stream so it skips already stored classes.
-            // Compiled classes rewrite is valid because the stream downloads from the beginning
-            // of the block instead of the last downloaded class.
-            Err(StateSyncError::StorageError(StorageError::InnerError(
-                DbError::KeyAlreadyExists(..),
-            ))) => {
-                debug!("Compiled class of {class_hash} already stored.");
-                Ok(())
-            }
-            Err(err) => Err(err),
-        }
     }
 
     #[instrument(skip(self), level = "debug", err)]
@@ -867,6 +716,7 @@ fn stream_new_state_diffs<TCentralSource: CentralSourceTrait + Sync + Send>(
                     block_hash,
                     state_diff,
                     deployed_contract_class_definitions,
+                    non_backward_compatible_casms,
                 };
             }
         }
@@ -918,77 +768,6 @@ impl StateSync {
     }
 }
 
-fn stream_new_compiled_classes<TCentralSource: CentralSourceTrait + Sync + Send>(
-    reader: StorageReader,
-    central_source: Arc<TCentralSource>,
-    latest_block_poll_interval_millis: Duration,
-    max_stream_size: u32,
-    store_sierras_and_casms_block_threshold: u64,
-) -> impl Stream<Item = Result<SyncEvent, StateSyncError>> {
-    try_stream! {
-        loop {
-            let txn = reader.begin_ro_txn()?;
-            let mut from = txn.get_compiled_class_marker()?;
-            let state_marker = txn.get_state_marker()?;
-            let compiler_backward_compatibility_marker = txn.get_compiler_backward_compatibility_marker()?;
-            // Avoid starting streams from blocks without declared classes.
-            while from < state_marker {
-                let state_diff = txn.get_state_diff(from)?.expect("Expecting to have state diff up to the marker.");
-                if state_diff.class_hash_to_compiled_class_hash.is_empty() {
-                    from = from.unchecked_next();
-                }
-                else {
-                    break;
-                }
-            }
-            drop(txn); // Drop txn so we don't unnecessarily hold it open while sleeping.
-
-            if from == state_marker {
-                debug!(
-                    "Compiled classes syncing reached the last downloaded state update{:?}, waiting \
-                     for more state updates.", state_marker.prev()
-                );
-                tokio::time::sleep(latest_block_poll_interval_millis).await;
-                continue;
-            }
-            let mut up_to = min(state_marker, BlockNumber(from.0 + u64::from(max_stream_size)));
-            let are_casms_backward_compatible = from >= compiler_backward_compatibility_marker;
-            // We want that the stream will either have all compiled classes as backward compatible
-            // or all as not backward compatible. If needed we'll decrease up_to
-            if from < compiler_backward_compatibility_marker && up_to > compiler_backward_compatibility_marker {
-                up_to = compiler_backward_compatibility_marker;
-            }
-
-            // No point in downloading casms if we don't store them and don't send them to the
-            // class manager
-            if are_casms_backward_compatible && from.0 >= store_sierras_and_casms_block_threshold {
-                info!("Compiled classes stream reached a block that has backward compatibility for \
-                      the compiler, and block is at or above store_sierras_and_casms_block_threshold. \
-                      Finishing the compiled class stream");
-                pending::<()>().await;
-                continue;
-            }
-
-            debug!("Downloading compiled classes of blocks [{} - {}).", from, up_to);
-            let compiled_classes_stream =
-                central_source.stream_compiled_classes(from, up_to).fuse();
-            pin_mut!(compiled_classes_stream);
-
-            while let Some(maybe_compiled_class) = compiled_classes_stream.next().await {
-                let (block_number, class_hash, compiled_class_hash, compiled_class) =
-                    maybe_compiled_class?;
-                yield SyncEvent::CompiledClassAvailable {
-                    block_number,
-                    class_hash,
-                    compiled_class_hash,
-                    compiled_class,
-                    is_compiler_backward_compatible: are_casms_backward_compatible,
-                };
-            }
-        }
-    }
-}
-
 // TODO(dvir): consider combine this function and store_base_layer_block.
 fn stream_new_base_layer_block<TBaseLayerSource: BaseLayerSourceTrait + Sync>(
     reader: StorageReader,
@@ -1027,41 +806,31 @@ fn stream_new_base_layer_block<TBaseLayerSource: BaseLayerSourceTrait + Sync>(
 // TODO(dvir): add a test for this scenario.
 fn check_sync_progress(
     reader: StorageReader,
-    store_sierras_and_casms_block_threshold: u64,
 ) -> impl Stream<Item = Result<SyncEvent, StateSyncError>> {
     try_stream! {
-        let (mut header_marker, mut state_marker, mut casm_marker) = {
+        let (mut header_marker, mut state_marker) = {
             let txn = reader.begin_ro_txn()?;
             let header_marker = txn.get_header_marker()?;
             let state_marker = txn.get_state_marker()?;
-            let casm_marker = txn.get_compiled_class_marker()?;
-            (header_marker, state_marker, casm_marker)
+            (header_marker, state_marker)
         };
 
         loop{
             tokio::time::sleep(SLEEP_TIME_SYNC_PROGRESS).await;
             debug!("Checking if sync stopped progress.");
-            let (new_header_marker, new_state_marker, new_casm_marker, compiler_backward_compatibility_marker) = {
+            let (new_header_marker, new_state_marker) = {
                 let txn = reader.begin_ro_txn()?;
                 let new_header_marker = txn.get_header_marker()?;
                 let new_state_marker = txn.get_state_marker()?;
-                let new_casm_marker = txn.get_compiled_class_marker()?;
-                let compiler_backward_compatibility_marker = txn.get_compiler_backward_compatibility_marker()?;
-                (new_header_marker, new_state_marker, new_casm_marker, compiler_backward_compatibility_marker)
+                (new_header_marker, new_state_marker)
             };
-            let store_sierras_and_casms =
-                new_casm_marker.0 < store_sierras_and_casms_block_threshold;
-            let is_casm_stuck = casm_marker == new_casm_marker
-                && (new_casm_marker < compiler_backward_compatibility_marker
-                    || store_sierras_and_casms);
-            if header_marker==new_header_marker || state_marker==new_state_marker || is_casm_stuck {
+            if header_marker==new_header_marker || state_marker==new_state_marker {
                 debug!("No progress in the sync. Return NoProgress event. Header marker: {header_marker}, \
-                       State marker: {state_marker}, Casm marker: {casm_marker}.");
+                       State marker: {state_marker}.");
                 yield SyncEvent::NoProgress;
             }
             header_marker=new_header_marker;
             state_marker=new_state_marker;
-            casm_marker=new_casm_marker;
         }
     }
 }

--- a/crates/apollo_central_sync/src/sources/central_sync_test.rs
+++ b/crates/apollo_central_sync/src/sources/central_sync_test.rs
@@ -25,6 +25,7 @@ use starknet_api::block::{
     BlockHeaderWithoutHash,
     BlockNumber,
     BlockSignature,
+    StarknetVersion,
 };
 use starknet_api::core::{ClassHash, CompiledClassHash, EntryPointSelector, SequencerPublicKey};
 use starknet_api::crypto::utils::PublicKey;
@@ -37,12 +38,7 @@ use tracing::{debug, error};
 
 use super::pending::MockPendingSourceTrait;
 use crate::sources::base_layer::{BaseLayerSourceTrait, MockBaseLayerSourceTrait};
-use crate::sources::central::{
-    BlocksStream,
-    CompiledClassesStream,
-    MockCentralSourceTrait,
-    StateUpdatesStream,
-};
+use crate::sources::central::{BlocksStream, MockCentralSourceTrait, StateUpdatesStream};
 use crate::{
     CentralError,
     CentralSourceTrait,
@@ -50,6 +46,7 @@ use crate::{
     StateSyncError,
     StateSyncResult,
     SyncConfig,
+    STARKNET_VERSION_TO_COMPILE_FROM,
 };
 
 const SYNC_SLEEP_DURATION: Duration = Duration::from_millis(100); // 100ms
@@ -195,6 +192,8 @@ async fn sync_happy_flow() {
     const MAX_TIME_TO_SYNC_MS: u64 = 800;
     let _ = simple_logger::init_with_env();
 
+    let class_hash_0 = ClassHash(felt!("0x0"));
+    let compiled_class_hash_0 = CompiledClassHash(felt!("0x100"));
     let class_hash_1 = ClassHash(felt!("0x1"));
     let compiled_class_hash_1 = CompiledClassHash(felt!("0x101"));
     let class_hash_2 = ClassHash(felt!("0x2"));
@@ -228,17 +227,25 @@ async fn sync_happy_flow() {
             hash: create_block_hash(LATEST_BLOCK_NUMBER, false),
         }))
     });
+    // Block 0 is non-BC (starknet_version < V0_12_0) so get_compiled_class +
+    // add_class_and_executable_unsafe are called. Blocks 1+ are BC so add_class is called.
     central_mock.expect_stream_new_blocks().returning(move |initial, up_to| {
         let blocks_stream: BlocksStream<'_> = stream! {
             for block_number in initial.iter_up_to(up_to) {
                 if block_number.0 >= N_BLOCKS {
                     yield Err(CentralError::BlockNotFound { block_number });
                 }
+                let starknet_version = if block_number.0 == 0 {
+                    StarknetVersion::V0_11_0
+                } else {
+                    STARKNET_VERSION_TO_COMPILE_FROM
+                };
                 let header = BlockHeader {
                     block_hash: create_block_hash(block_number, false),
                     block_header_without_hash: BlockHeaderWithoutHash {
                         block_number,
                         parent_hash: create_block_hash(block_number.prev().unwrap_or_default(), false),
+                        starknet_version,
                         ..Default::default()
                     },
                     ..Default::default()
@@ -254,8 +261,6 @@ async fn sync_happy_flow() {
         blocks_stream
     });
 
-    let expected_deprecated_class = deprecated_class.clone();
-    let expected_deployed_class = deployed_class.clone();
     central_mock.expect_stream_state_updates().returning(move |initial, up_to| {
         let deprecated_class = deprecated_class.clone();
         let deployed_class = deployed_class.clone();
@@ -267,6 +272,12 @@ async fn sync_happy_flow() {
 
                 // Add declared classes to specific blocks to test compiled class hash mapping
                 let mut state_diff = match block_number.0 {
+                    0 => StateDiff {
+                        declared_classes: IndexMap::from([
+                            (class_hash_0, (compiled_class_hash_0, SierraContractClass::default())),
+                        ]),
+                        ..Default::default()
+                    },
                     1 => StateDiff {
                         declared_classes: IndexMap::from([
                             (class_hash_1, (compiled_class_hash_1, SierraContractClass::default())),
@@ -303,43 +314,15 @@ async fn sync_happy_flow() {
         state_stream
     });
 
-    // Add compiled classes stream mock
-    central_mock.expect_stream_compiled_classes().returning(move |initial, up_to| {
-        let compiled_classes_stream: CompiledClassesStream<'_> = stream! {
-            for block_number in initial.iter_up_to(up_to) {
-                if block_number.0 >= N_BLOCKS {
-                    yield Err(CentralError::BlockNotFound { block_number });
-                }
-
-                // Return compiled classes for blocks that declared them
-                match block_number.0 {
-                    1 => {
-                        let mut rng = get_rng();
-                        yield Ok((
-                            block_number,
-                            class_hash_1,
-                            compiled_class_hash_1,
-                            CasmContractClass::get_test_instance(&mut rng),
-                        ));
-                    },
-                    3 => {
-                        let mut rng = get_rng();
-                        yield Ok((
-                            block_number,
-                            class_hash_2,
-                            compiled_class_hash_2,
-                            CasmContractClass::get_test_instance(&mut rng),
-                        ));
-                    },
-                    _ => {}
-                }
-            }
-        }
-        .boxed();
-        compiled_classes_stream
-    });
-
     central_mock.expect_get_block_hash().returning(|bn| Ok(Some(create_block_hash(bn, false))));
+
+    // Only block 0 is non-BC, so only class_hash_0 triggers get_compiled_class.
+    let mut rng_casm = get_rng();
+    central_mock
+        .expect_get_compiled_class()
+        .withf(move |class_hash| *class_hash == class_hash_0)
+        .times(1)
+        .returning(move |_| Ok(CasmContractClass::get_test_instance(&mut rng_casm)));
 
     // TODO(dvir): find a better way to do this.
     let mut base_layer_mock = MockBaseLayerSourceTrait::new();
@@ -362,10 +345,17 @@ async fn sync_happy_flow() {
     // Create mock class manager client with expectations
     let mut mock_class_manager = MockClassManagerClient::new();
 
-    // Expect add_deprecated_class to be called for both class hashes
+    // Non-BC block 0: add_class_and_executable_unsafe for class_hash_0.
+    mock_class_manager
+        .expect_add_class_and_executable_unsafe()
+        .withf(move |class_hash, _class, _exec_hash, _exec_class| *class_hash == class_hash_0)
+        .times(1)
+        .returning(|_class_hash, _class, _exec_hash, _exec_class| Ok(()));
+    // BC block 1: add_class for class_hash_1.
     mock_class_manager.expect_add_class().times(1).returning(move |_class| {
         Ok(ClassHashes { class_hash: class_hash_1, ..Default::default() })
     });
+    // BC block 3: add_class for class_hash_2.
     mock_class_manager.expect_add_class().times(1).returning(move |_class| {
         Ok(ClassHashes { class_hash: class_hash_2, ..Default::default() })
     });
@@ -426,11 +416,14 @@ async fn sync_happy_flow() {
             let state_reader = txn.get_state_reader().unwrap();
 
             // Check mappings - return InProgress if not ready, otherwise assert equality
+            let state_number_0 = StateNumber::unchecked_right_after_block(BlockNumber(0));
             let state_number_1 = StateNumber::unchecked_right_after_block(BlockNumber(1));
             let state_number_2 = StateNumber::unchecked_right_after_block(BlockNumber(3));
             // Arbitrary state number after the last block.
             let state_number_final = StateNumber::unchecked_right_after_block(BlockNumber(4));
 
+            let hash_0 =
+                state_reader.get_compiled_class_hash_at(state_number_0, &class_hash_0).unwrap();
             let hash_1 =
                 state_reader.get_compiled_class_hash_at(state_number_1, &class_hash_1).unwrap();
             let hash_2 =
@@ -438,10 +431,11 @@ async fn sync_happy_flow() {
             let hash_final =
                 state_reader.get_compiled_class_hash_at(state_number_final, &class_hash_1).unwrap();
 
-            if hash_1.is_none() || hash_2.is_none() || hash_final.is_none() {
+            if hash_0.is_none() || hash_1.is_none() || hash_2.is_none() || hash_final.is_none() {
                 return CheckStoragePredicateResult::InProgress;
             }
 
+            assert_eq!(hash_0, Some(compiled_class_hash_0));
             assert_eq!(hash_1, Some(compiled_class_hash_1));
             assert_eq!(hash_2, Some(compiled_class_hash_2));
             // Ensure class hash 1 remains unchanged after later declarations.
@@ -457,23 +451,6 @@ async fn sync_happy_flow() {
                 .get_deprecated_class_definition_block_number(&deprecated_class_hash)
                 .unwrap();
             assert_eq!(declare_deprecated_block_number, Some(LATEST_BLOCK_NUMBER));
-
-            // Verify that the deprecated contract class is the same as the one that was declared.
-            let deploy_class = state_reader
-                .get_deprecated_class_definition_at(
-                    StateNumber::unchecked_right_after_block(LATEST_BLOCK_NUMBER),
-                    &deployed_class_hash,
-                )
-                .unwrap();
-            assert_eq!(deploy_class, Some(expected_deployed_class.clone()));
-
-            let declare_deprecated_class = state_reader
-                .get_deprecated_class_definition_at(
-                    StateNumber::unchecked_right_after_block(LATEST_BLOCK_NUMBER),
-                    &deprecated_class_hash,
-                )
-                .unwrap();
-            assert_eq!(declare_deprecated_class, Some(expected_deprecated_class.clone()));
 
             CheckStoragePredicateResult::Passed
         });

--- a/crates/apollo_central_sync_config/src/config.rs
+++ b/crates/apollo_central_sync_config/src/config.rs
@@ -114,6 +114,7 @@ pub struct SyncConfig {
     pub state_updates_max_stream_size: u32,
     pub verify_blocks: bool,
     pub collect_pending_data: bool,
+    // TODO(noamsp): get rid of this config param.
     pub store_sierras_and_casms_block_threshold: u64,
 }
 

--- a/crates/apollo_rpc/src/syncing_state.rs
+++ b/crates/apollo_rpc/src/syncing_state.rs
@@ -1,5 +1,5 @@
-use apollo_storage::compiled_class::CasmStorageReader;
 use apollo_storage::header::HeaderStorageReader;
+use apollo_storage::state::StateStorageReader;
 use apollo_storage::{StorageReader, StorageResult};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
@@ -49,7 +49,7 @@ pub(crate) fn get_last_synced_block(
     storage_reader: StorageReader,
 ) -> StorageResult<BlockHashAndNumber> {
     let txn = storage_reader.begin_ro_txn()?;
-    let Some(block_number) = txn.get_compiled_class_marker()?.prev() else {
+    let Some(block_number) = txn.get_state_marker()?.prev() else {
         return Ok(BlockHashAndNumber::default());
     };
     let block_hash =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the core sync event flow and when/how compiled classes are fetched and sent to the class manager, which could affect historical sync correctness and performance for pre-`V0_12_0` blocks.
> 
> **Overview**
> State sync no longer runs a separate `stream_new_compiled_classes` loop or processes `CompiledClassAvailable` events; compiled-class storage/backfill logic tied to `store_sierras_and_casms_block_threshold` is removed from the main sync path.
> 
> For blocks with `starknet_version < STARKNET_VERSION_TO_COMPILE_FROM`, the state update stream now fetches CASMs via `CentralSourceTrait::get_compiled_class` and passes them alongside the state diff, so `store_state_diff` can send non-BC classes to the class manager using `add_class_and_executable_unsafe` while continuing to use `add_class` for backward-compatible blocks.
> 
> Progress checking and RPC syncing status are simplified to use the state marker (`get_state_marker`) rather than the compiled-class marker, and tests are updated to reflect the new non-BC CASM fetch/send behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f36cbaeacfe7f3bac78aff1933850de6eab581e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->