### PR TITLE
apollo_central_sync: remove compiled classes stream

### DIFF
--- a/crates/apollo_central_sync/src/sources/central.rs
+++ b/crates/apollo_central_sync/src/sources/central.rs
@@ -14,7 +14,6 @@ use apollo_starknet_client::reader::{
     StarknetReader,
 };
 use apollo_starknet_client::ClientCreationError;
-use apollo_storage::state::StateStorageReader;
 use apollo_storage::{StorageError, StorageReader};
 use async_stream::stream;
 use async_trait::async_trait;
@@ -27,7 +26,7 @@ use lru::LruCache;
 use mockall::automock;
 use papyrus_common::pending_classes::ApiContractClass;
 use starknet_api::block::{Block, BlockHash, BlockHashAndNumber, BlockNumber, BlockSignature};
-use starknet_api::core::{ClassHash, CompiledClassHash, SequencerPublicKey};
+use starknet_api::core::{ClassHash, SequencerPublicKey};
 use starknet_api::crypto::utils::Signature;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::state::StateDiff;
@@ -53,8 +52,6 @@ pub enum CentralError {
     ClientCreation(#[from] ClientCreationError),
     #[error(transparent)]
     ClientError(#[from] Arc<ReaderClientError>),
-    #[error("Could not find a state update.")]
-    StateUpdateNotFound,
     #[error("Could not find a class definitions.")]
     ClassNotFound,
     #[error("Could not find a compiled class of {}.", class_hash)]
@@ -93,12 +90,6 @@ pub trait CentralSourceTrait {
         block_number: BlockNumber,
     ) -> Result<Option<BlockHash>, CentralError>;
 
-    fn stream_compiled_classes(
-        &self,
-        initial_block_number: BlockNumber,
-        up_to_block_number: BlockNumber,
-    ) -> CompiledClassesStream<'_>;
-
     // TODO(shahak): Remove once pending block is removed.
     async fn get_class(&self, class_hash: ClassHash) -> Result<ApiContractClass, CentralError>;
 
@@ -116,8 +107,6 @@ pub(crate) type BlocksStream<'a> =
 type CentralStateUpdate =
     (BlockNumber, BlockHash, StateDiff, IndexMap<ClassHash, DeprecatedContractClass>);
 pub(crate) type StateUpdatesStream<'a> = BoxStream<'a, CentralResult<CentralStateUpdate>>;
-type CentralCompiledClass = (BlockNumber, ClassHash, CompiledClassHash, CasmContractClass);
-pub(crate) type CompiledClassesStream<'a> = BoxStream<'a, CentralResult<CentralCompiledClass>>;
 
 #[async_trait]
 impl<TStarknetClient: StarknetReader + Send + Sync + 'static> CentralSourceTrait
@@ -186,67 +175,6 @@ impl<TStarknetClient: StarknetReader + Send + Sync + 'static> CentralSourceTrait
                     }
                     Err(err) => {
                         yield (Err(err));
-                        return;
-                    }
-                }
-            }
-        }
-        .boxed()
-    }
-
-    // Returns a stream of compiled classes downloaded from the central source.
-    fn stream_compiled_classes(
-        &self,
-        initial_block_number: BlockNumber,
-        up_to_block_number: BlockNumber,
-    ) -> CompiledClassesStream<'_> {
-        stream! {
-            let txn = self.storage_reader.begin_ro_txn().map_err(CentralError::StorageError)?;
-            // TODO(Aviv): Now the class hashes include both declared classes and migrated compiled class hashes.
-            // Consider refactoring it.
-            let class_hashes = initial_block_number
-                .iter_up_to(up_to_block_number)
-                .map(|bn| {
-                    match txn.get_state_diff(bn) {
-                        Err(err) => Err(CentralError::StorageError(err)),
-                        // TODO(yair): Consider expecting, since the state diffs should not contain
-                        // holes and we suppose to never exceed the state marker.
-                        Ok(None) => Err(CentralError::StateUpdateNotFound),
-                        Ok(Some(state_diff)) => Ok((bn, state_diff)),
-                    }
-                })
-                .flat_map(|maybe_state_diff| match maybe_state_diff {
-                    Ok((bn, state_diff)) => state_diff
-                        .class_hash_to_compiled_class_hash
-                        .into_iter()
-                        .map(move |(class_hash, compiled_class_hash)| Ok((bn, class_hash, compiled_class_hash)))
-                        .collect::<Vec<_>>(),
-                    Err(err) => vec![Err(err)],
-                }).collect::<Vec<_>>();
-
-            // Drop the txn here, so we don't unnecessarily hold it open while awaiting below.
-            drop(txn);
-
-            let mut compiled_classes = futures_util::stream::iter(class_hashes)
-                .map(|maybe_item| async move {
-                    match maybe_item {
-                        Ok((block_number, class_hash, compiled_class_hash)) => {
-                            trace!("Downloading compiled class {:?}.", class_hash);
-                            let compiled_class = self.get_compiled_class(class_hash).await?;
-                            Ok((block_number, class_hash, compiled_class_hash, compiled_class))
-                        },
-                        Err(err) => Err(err),
-                    }
-                })
-                .buffered(self.concurrent_requests);
-
-            while let Some(maybe_compiled_class) = compiled_classes.next().await {
-                match maybe_compiled_class {
-                    Ok((block_number, class_hash, compiled_class_hash, compiled_class)) => {
-                        yield Ok((block_number, class_hash, compiled_class_hash, compiled_class));
-                    }
-                    Err(err) => {
-                        yield Err(err);
                         return;
                     }
                 }

--- a/crates/apollo_central_sync/src/sources/central_test.rs
+++ b/crates/apollo_central_sync/src/sources/central_test.rs
@@ -16,13 +16,11 @@ use apollo_starknet_client::reader::{
     StorageEntry,
 };
 use apollo_starknet_client::ClientError;
-use apollo_storage::class::ClassStorageWriter;
-use apollo_storage::state::StateStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
 use assert_matches::assert_matches;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use futures_util::pin_mut;
-use indexmap::{indexmap, IndexMap};
+use indexmap::IndexMap;
 use lru::LruCache;
 use mockall::predicate;
 use papyrus_common::state::MigratedCompiledClassHashEntry;
@@ -33,7 +31,6 @@ use starknet_api::core::{ClassHash, CompiledClassHash, GlobalRoot, Nonce, Sequen
 use starknet_api::crypto::utils::PublicKey;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::StarkHash;
-use starknet_api::state::{SierraContractClass as sn_api_ContractClass, ThinStateDiff};
 use starknet_api::{class_hash, contract_address, felt, storage_key};
 use tokio_stream::StreamExt;
 
@@ -463,114 +460,6 @@ async fn stream_state_updates() {
     assert_eq!(state_diff, starknet_api::state::StateDiff::default());
 
     assert!(stream.next().await.is_none());
-}
-
-#[tokio::test]
-async fn stream_compiled_classes() {
-    let ((reader, mut writer), _temp_dir) = get_test_storage();
-    writer
-        .begin_rw_txn()
-        .unwrap()
-        .append_state_diff(
-            BlockNumber(0),
-            ThinStateDiff {
-                deployed_contracts: indexmap! {},
-                storage_diffs: indexmap! {},
-                class_hash_to_compiled_class_hash: indexmap! {
-                    class_hash!("0x0") => CompiledClassHash(felt!("0x0")),
-                    class_hash!("0x1") => CompiledClassHash(felt!("0x1")),
-                },
-                deprecated_declared_classes: vec![],
-                nonces: indexmap! {},
-            },
-        )
-        .unwrap()
-        .append_state_diff(
-            BlockNumber(1),
-            ThinStateDiff {
-                deployed_contracts: indexmap! {},
-                storage_diffs: indexmap! {},
-                class_hash_to_compiled_class_hash: indexmap! {
-                    class_hash!("0x2") => CompiledClassHash(felt!("0x2")),
-                    class_hash!("0x3") => CompiledClassHash(felt!("0x3")),
-                },
-                deprecated_declared_classes: vec![],
-                nonces: indexmap! {},
-            },
-        )
-        .unwrap()
-        .append_classes(
-            BlockNumber(0),
-            &[
-                (class_hash!("0x0"), &sn_api_ContractClass::default()),
-                (class_hash!("0x1"), &sn_api_ContractClass::default()),
-            ],
-            &[],
-        )
-        .unwrap()
-        .append_classes(
-            BlockNumber(1),
-            &[
-                (class_hash!("0x2"), &sn_api_ContractClass::default()),
-                (class_hash!("0x3"), &sn_api_ContractClass::default()),
-            ],
-            &[],
-        )
-        .unwrap()
-        .commit()
-        .unwrap();
-
-    let felts: Vec<_> = (0..4).map(|i| felt!(format!("0x{i}").as_str())).collect();
-    let mut mock = MockStarknetReader::new();
-    for felt in felts.clone() {
-        mock.expect_compiled_class_by_hash()
-            .with(predicate::eq(ClassHash(felt)))
-            .times(1)
-            .returning(move |_x| {
-                Ok(Some(CasmContractClass {
-                    prime: Default::default(),
-                    compiler_version: Default::default(),
-                    bytecode: Default::default(),
-                    bytecode_segment_lengths: Default::default(),
-                    hints: Default::default(),
-                    pythonic_hints: Default::default(),
-                    entry_points_by_type: Default::default(),
-                }))
-            });
-    }
-
-    let central_source = GenericCentralSource {
-        concurrent_requests: TEST_CONCURRENT_REQUESTS,
-        apollo_starknet_client: Arc::new(mock),
-        storage_reader: reader,
-        state_update_stream_config: state_update_stream_config_for_test(),
-        class_cache: get_test_class_cache(),
-        compiled_class_cache: get_test_compiled_class_cache(),
-    };
-
-    let stream = central_source.stream_compiled_classes(BlockNumber(0), BlockNumber(2));
-    pin_mut!(stream);
-
-    let expected_compiled_class = CasmContractClass {
-        prime: Default::default(),
-        compiler_version: Default::default(),
-        bytecode: Default::default(),
-        bytecode_segment_lengths: Default::default(),
-        hints: Default::default(),
-        pythonic_hints: Default::default(),
-        entry_points_by_type: Default::default(),
-    };
-    let expected_block_numbers = [BlockNumber(0), BlockNumber(0), BlockNumber(1), BlockNumber(1)];
-    for (i, felt) in felts.into_iter().enumerate() {
-        let (block_number, class_hash, compiled_class_hash, compiled_class) =
-            stream.next().await.unwrap().unwrap();
-        let expected_class_hash = ClassHash(felt);
-        let expected_compiled_class_hash = CompiledClassHash(felt);
-        assert_eq!(block_number, expected_block_numbers[i]);
-        assert_eq!(class_hash, expected_class_hash);
-        assert_eq!(compiled_class_hash, expected_compiled_class_hash);
-        assert_eq!(compiled_class, expected_compiled_class);
-    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because this is an API removal that can break downstream callers and changes how compiled classes are expected to be obtained, though it’s largely a deletion with limited behavioral complexity.
> 
> **Overview**
> Removes the `stream_compiled_classes` API from `CentralSourceTrait`/`GenericCentralSource`, along with its supporting types and the `StateUpdateNotFound` error variant.
> 
> Cleans up related imports and deletes the now-obsolete `stream_compiled_classes` unit test and its storage-writing setup in `central_test.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dfeb4251baa6de432a8c8722e45b767fa436685. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->