### PR TITLE
apollo_central_sync: use starknet version table to determine if class is bc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,7 @@ dependencies = [
  "simple_logger",
  "starknet-types-core",
  "starknet_api",
+ "static_assertions",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/crates/apollo_central_sync/Cargo.toml
+++ b/crates/apollo_central_sync/Cargo.toml
@@ -45,6 +45,7 @@ simple_logger.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 starknet-types-core.workspace = true
 tokio-stream.workspace = true
+static_assertions.workspace = true
 
 [package.metadata.cargo-machete]
 # `metrics` is used in `latency_histogram` but is falsely detected as unused.

--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -467,6 +467,16 @@ impl<
                         .await?;
                     continue;
                 }
+                let starknet_version = self
+                    .reader
+                    .begin_ro_txn()?
+                    .get_starknet_version(block_number)?
+                    .expect("State sync should only process blocks with existing headers.");
+                assert!(
+                    starknet_version >= STARKNET_VERSION_TO_COMPILE_FROM,
+                    "Expected starknet version >= {STARKNET_VERSION_TO_COMPILE_FROM} for class \
+                     {expected_class_hash} but got {starknet_version}."
+                );
                 let class_hash =
                     class_manager_client.add_class(class.clone()).await?.class_hash;
                 if class_hash != *expected_class_hash {

--- a/crates/apollo_central_sync/src/sources/central_test.rs
+++ b/crates/apollo_central_sync/src/sources/central_test.rs
@@ -16,6 +16,7 @@ use apollo_starknet_client::reader::{
     StorageEntry,
 };
 use apollo_starknet_client::ClientError;
+use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
 use assert_matches::assert_matches;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
@@ -26,17 +27,26 @@ use mockall::predicate;
 use papyrus_common::state::MigratedCompiledClassHashEntry;
 use pretty_assertions::assert_eq;
 use reqwest::StatusCode;
-use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
+use starknet_api::block::{
+    BlockHash,
+    BlockHashAndNumber,
+    BlockHeader,
+    BlockHeaderWithoutHash,
+    BlockNumber,
+    StarknetVersion,
+};
 use starknet_api::core::{ClassHash, CompiledClassHash, GlobalRoot, Nonce, SequencerPublicKey};
 use starknet_api::crypto::utils::PublicKey;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::StarkHash;
 use starknet_api::{class_hash, contract_address, felt, storage_key};
+use static_assertions::const_assert;
 use tokio_stream::StreamExt;
 
 use super::state_update_stream::StateUpdateStreamConfig;
 use super::ApiContractClass;
 use crate::sources::central::{CentralError, CentralSourceTrait, GenericCentralSource};
+use crate::STARKNET_VERSION_TO_COMPILE_FROM;
 
 const TEST_CONCURRENT_REQUESTS: usize = 300;
 
@@ -271,6 +281,11 @@ async fn stream_block_headers_error() {
 async fn stream_state_updates() {
     const START_BLOCK_NUMBER: u64 = 5;
     const END_BLOCK_NUMBER: u64 = 7;
+    const FIRST_BACKWARD_COMPATIBLE_BLOCK_NUMBER: BlockNumber = BlockNumber(6);
+    const_assert!(
+        START_BLOCK_NUMBER < FIRST_BACKWARD_COMPATIBLE_BLOCK_NUMBER.0
+            && FIRST_BACKWARD_COMPATIBLE_BLOCK_NUMBER.0 < END_BLOCK_NUMBER
+    );
 
     let class_hash1 = class_hash!("0x123");
     let class_hash2 = class_hash!("0x456");
@@ -377,12 +392,38 @@ async fn stream_state_updates() {
     mock.expect_class_by_hash().with(predicate::eq(class_hash3)).times(1).returning(move |_x| {
         Ok(Some(GenericContractClass::Cairo0ContractClass(contract_class3_clone.clone())))
     });
-    let ((reader, _), _temp_dir) = get_test_storage();
+    let ((reader, mut writer), _temp_dir) = get_test_storage();
+    let mut txn = writer.begin_rw_txn().unwrap();
+    for block_number in 0..END_BLOCK_NUMBER {
+        let block_number = BlockNumber(block_number);
+        let starknet_version = if block_number < FIRST_BACKWARD_COMPATIBLE_BLOCK_NUMBER {
+            StarknetVersion::PreV0_9_1
+        } else {
+            STARKNET_VERSION_TO_COMPILE_FROM
+        };
+        let header = BlockHeader {
+            block_hash: BlockHash(StarkHash::from(block_number.0 + 1)),
+            block_header_without_hash: BlockHeaderWithoutHash {
+                block_number,
+                starknet_version,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        txn = txn.append_header(block_number, &header).unwrap();
+    }
+    txn.commit().unwrap();
+    let mut state_update_stream_config = state_update_stream_config_for_test();
+    // Ensure all state updates can be scheduled together.
+    state_update_stream_config.max_state_updates_to_download =
+        usize::try_from(END_BLOCK_NUMBER - START_BLOCK_NUMBER)
+            .expect("END_BLOCK_NUMBER should be bigger than START_BLOCK_NUMBER")
+            + 1;
     let central_source = GenericCentralSource {
         concurrent_requests: TEST_CONCURRENT_REQUESTS,
         apollo_starknet_client: Arc::new(mock),
         storage_reader: reader,
-        state_update_stream_config: state_update_stream_config_for_test(),
+        state_update_stream_config,
         // TODO(shahak): Check that downloaded classes appear in the cache.
         class_cache: get_test_class_cache(),
         compiled_class_cache: get_test_compiled_class_cache(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core state-sync/class ingestion flow and introduces a new runtime `assert!` that will panic if header version data is missing/incorrect, potentially halting sync.
> 
> **Overview**
> Updates state sync to **look up the per-block `starknet_version` from storage headers** before sending Sierra classes to the class manager for compilation; if the version is below `STARKNET_VERSION_TO_COMPILE_FROM`, the code now asserts (expecting such blocks to have been handled via the non-backward-compatible CASM path).
> 
> Test coverage is adjusted by seeding test storage with headers containing varying `starknet_version` values and tuning the state update stream config; adds `static_assertions` as a dev-dependency to enforce test constants at compile time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 073fd166a6a0b95f27e8ce9aba52906369a74c43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->