### PR TITLE
apollo_network_benchmark: added Serialize to args

### DIFF
--- a/crates/apollo_network_benchmark/src/node_args.rs
+++ b/crates/apollo_network_benchmark/src/node_args.rs
@@ -62,7 +62,7 @@ pub struct RunnerArgs {
     pub bootstrap: Vec<String>,
 }
 
-#[derive(Parser, Debug, Clone)]
+#[derive(Parser, Debug, Clone, Serialize)]
 #[command(version, about, long_about = None)]
 /// Arguments from the user.
 pub struct UserArgs {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a derive macro only; no behavioral changes to parsing or runtime logic aside from enabling serialization where used.
> 
> **Overview**
> Adds `serde::Serialize` to the `UserArgs` clap struct in `node_args.rs`, enabling benchmark user CLI arguments to be serialized (e.g., for logging/exporting config snapshots).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de48202fe5a354a6d77ff500246d0965b0372b56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->