### PR TITLE
apollo_network_benchmark: moved peerID creation files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,7 @@ dependencies = [
 name = "apollo_network_benchmark"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "apollo_metrics",
  "apollo_network",
  "clap",

--- a/crates/apollo_network_benchmark/Cargo.toml
+++ b/crates/apollo_network_benchmark/Cargo.toml
@@ -10,6 +10,7 @@ description = "Benchmarking tool for the Apollo Network"
 testing = []
 
 [dependencies]
+anyhow.workspace = true
 apollo_metrics.workspace = true
 apollo_network.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/stress_test_node.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/stress_test_node.rs
@@ -31,7 +31,8 @@ pub struct BroadcastNetworkStressTestNode {
 impl BroadcastNetworkStressTestNode {
     /// Creates network configuration from arguments
     fn create_network_config(args: &NodeArgs) -> NetworkConfig {
-        let peer_private_key = create_peer_private_key(args.runner.id);
+        let peer_private_key =
+            apollo_network_benchmark::peer_key::private_key_from_node_id(args.runner.id);
 
         let mut network_config = NetworkConfig {
             port: args.runner.p2p_port,
@@ -235,18 +236,4 @@ pub async fn race_and_kill_tasks(spawned_tasks: Vec<JoinHandle<()>>) {
     for task in remaining_tasks {
         task.abort();
     }
-}
-
-fn create_peer_private_key(peer_index: u64) -> [u8; 32] {
-    let array = peer_index.to_le_bytes();
-    assert_eq!(array.len(), 8);
-    let mut private_key = [0u8; 32];
-    private_key[0..8].copy_from_slice(&array);
-
-    // Log the secret key
-    let peer_private_key_hex =
-        private_key.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
-    info!("Secret Key: {peer_private_key_hex:#?}");
-
-    private_key
 }

--- a/crates/apollo_network_benchmark/src/lib.rs
+++ b/crates/apollo_network_benchmark/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod metrics;
 pub mod node_args;
+pub mod peer_key;

--- a/crates/apollo_network_benchmark/src/peer_key.rs
+++ b/crates/apollo_network_benchmark/src/peer_key.rs
@@ -1,0 +1,18 @@
+use anyhow::Context;
+use libp2p::identity::Keypair;
+
+/// Derives a deterministic ed25519 private key from a node index.
+/// The index is written as little-endian bytes into the first 8 bytes of a 32-byte seed.
+pub fn private_key_from_node_id(node_id: u64) -> [u8; 32] {
+    let mut key = [0u8; 32];
+    key[..8].copy_from_slice(&node_id.to_le_bytes());
+    key
+}
+
+/// Returns the PeerId string for a given node index.
+pub fn peer_id_from_node_id(node_id: u64) -> anyhow::Result<String> {
+    let secret_key_bytes = private_key_from_node_id(node_id);
+    let keypair = Keypair::ed25519_from_bytes(secret_key_bytes)
+        .context("Failed to derive keypair from node id")?;
+    Ok(keypair.public().to_peer_id().to_string())
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor isolated to benchmark tooling; behavior should remain equivalent aside from removing secret-key logging and adding a new helper.
> 
> **Overview**
> Centralizes deterministic peer key generation for the benchmark tooling by introducing `peer_key` (with `private_key_from_node_id` and `peer_id_from_node_id`) and exporting it from the crate.
> 
> Updates `stress_test_node.rs` to use the shared helper and removes the old inline key derivation (including the previous secret-key logging); adds `anyhow` to support error context when deriving a `PeerId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291ab1d553b90088bcb52c35864d809d37b6c989. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->