### PR TITLE
echonet: Create get_timestamps endpoint

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -749,6 +749,23 @@ class EchoCenterService:
             headers=[["Content-Type", "text/plain; charset=utf-8"]],
         )
 
+    def handle_get_timestamp(self) -> flask.Response:
+        """
+        GET /echonet/get_timestamp?tx_hash=0x...
+
+        Returns a JSON integer: the source block timestamp (seconds).
+        """
+        args = flask.request.args.to_dict(flat=True)
+        tx_hash = args.get("tx_hash")
+        if not tx_hash:
+            return self._json_response(
+                {"error": "Missing required query param: tx_hash"},
+                requests.codes.bad_request,
+            )
+
+        ts = self.shared.get_sent_tx_timestamp(tx_hash)
+        return self._json_response(ts, requests.codes.ok)
+
     def handle_block_dump(self) -> flask.Response:
         args = flask.request.args.to_dict(flat=True)
         bn = int(args["blockNumber"])
@@ -932,6 +949,11 @@ def write_pre_confirmed_block() -> flask.Response:
 @app.route("/echonet/report", methods=["GET"])
 def report_snapshot() -> flask.Response:
     return service.handle_report_snapshot()
+
+
+@app.route("/echonet/get_timestamp", methods=["GET"])
+def get_timestamp() -> flask.Response:
+    return service.handle_get_timestamp()
 
 
 @app.route("/echonet/block_dump", methods=["GET"])

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar, Dict, List, Mapping, Optional, Set
+from typing import ClassVar, Dict, List, Mapping, Optional, Sequence, Set
 
 from echonet.echonet_types import (
     BLOCK_STORE_TUNING,
@@ -49,6 +49,7 @@ class _TxTracker:
     """Transaction lifecycle and counters used by reporting."""
 
     currently_pending: Dict[str, int]  # tx_hash -> source block number
+    tx_timestamps: Dict[str, int]  # tx_hash -> source timestamp (seconds); live only
     ever_seen_pending: Set[str]  # cumulative set of tx hashes ever observed pending
     committed: Dict[str, int]  # cumulative map: tx_hash -> commit block number
     total_forwarded_tx_count: int  # count of forwarded txs (counted once per block)
@@ -58,6 +59,7 @@ class _TxTracker:
     def empty(cls) -> "_TxTracker":
         return cls(
             currently_pending={},
+            tx_timestamps={},
             ever_seen_pending=set(),
             committed={},
             total_forwarded_tx_count=0,
@@ -74,6 +76,7 @@ class _TxTracker:
         """Record a transaction as committed - add to the committed set (transactions that have been committed) and remove from the pending set"""
         self.committed[tx_hash] = block_number
         self.currently_pending.pop(tx_hash, None)
+        self.tx_timestamps.pop(tx_hash, None)
 
     def record_forwarded_block(self, block_number: int, tx_count: int) -> None:
         if block_number > self.max_forwarded_block:
@@ -418,6 +421,17 @@ class SharedContext:
         with self._lock:
             self._tx.record_sent(tx_hash, source_block_number)
 
+    def record_sent_tx_timestamps_for_block(
+        self, txs: Sequence[JsonObject], timestamp: int
+    ) -> None:
+        with self._lock:
+            for tx in txs:
+                self._tx.tx_timestamps[tx["transaction_hash"]] = timestamp
+
+    def get_sent_tx_timestamp(self, tx_hash: str) -> int:
+        with self._lock:
+            return self._tx.tx_timestamps[tx_hash]
+
     def record_forwarded_block(self, block_number: int, tx_count: int) -> None:
         with self._lock:
             self._tx.record_forwarded_block(block_number, tx_count)
@@ -481,6 +495,7 @@ class SharedContext:
             snapshot_items = self._blocks.snapshot_items()
             archive_dir = self._blocks._ensure_archive_dir()
             self._tx.currently_pending.clear()
+            self._tx.tx_timestamps.clear()
             self._errors.clear_live()
             self._blocks.clear_live()
             self._progress.last_echo_center_block = None

--- a/echonet/transaction_sender.py
+++ b/echonet/transaction_sender.py
@@ -275,6 +275,7 @@ class TransactionSenderService:
                             f"Block {block_number}: total={len(all_txs)} valid={len(valid_txs)}"
                         )
 
+                        shared.record_sent_tx_timestamps_for_block(valid_txs, timestamp)
                         for tx in valid_txs:
                             tx_data = TxData(
                                 tx=tx,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new public endpoint and new in-memory state keyed by tx hash; incorrect/missing entries can cause 500s (KeyError) or stale data if lifecycle handling is wrong, though changes are localized and non-security-critical.
> 
> **Overview**
> Adds a new Echo Center API endpoint, `GET /echonet/get_timestamp?tx_hash=...`, which returns the source block timestamp for a given transaction hash.
> 
> To support this, `SharedContext` now tracks per-transaction timestamps for currently-pending forwarded txs (populated by `transaction_sender` when reading each feeder block, cleared on commit/resync), and the sender records these timestamps for each eligible tx in the block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed1f72485e20124533272a0a0ed4661bda39860f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->