### PR TITLE
rename allocations and add &Option<T>

### DIFF
--- a/style.md
+++ b/style.md
@@ -211,6 +211,14 @@ let is_executable = false;
 create_transaction(is_dry_run, is_executable)
 ```
 
+### Wide Parameter Type
+
+Function parameters should use the most general type that satisfies the function's needs — the type that accepts the widest set of callers without requiring them to convert. In particular:
+
+- `&[T]` over `Vec<T>`
+- `&str` over `String`
+- `Option<&T>` over `&Option<T>` (callers holding `&Option<T>` can pass `.as_ref()`, but not the reverse)
+
 ### Getter Names
 
 A getter for the field `foo` should be `fn foo`, rather than `fn get_foo`
@@ -304,11 +312,9 @@ impl DerefMut for Foo {
 if *foo > 0 {...}
 ```
 
-## Performance & Allocations
+## Performance
 
 ### Allocations
-
-Avoid allocations when a stack-based type will do, in particular: prefer arrays/iterators over vecs if possible, prefer `&str` or `impl ToString` over `String`.
 
 Use `Vec::with_capacity()` when size is known to avoid reallocations.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because this only changes documentation/style guidance with no runtime or API behavior changes.
> 
> **Overview**
> Adds a new **"Wide Parameter Type"** guideline to `style.md`, recommending accepting more general argument types (e.g., `&[T]`, `&str`, and `Option<&T>` instead of `&Option<T>`).
> 
> Renames the **"Performance & Allocations"** section to **"Performance"** and trims the allocations guidance to focus on `Vec::with_capacity()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3ab39c1874046861ea3e3a7d15cb31c4f577d9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->