### PR TITLE
apollo_central_sync: get non bc casms in stream new state diffs

### DIFF
--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -834,6 +834,34 @@ fn stream_new_state_diffs<TCentralSource: CentralSourceTrait + Sync + Send>(
                     deployed_contract_class_definitions,
                 ) = maybe_state_diff?;
                 sort_state_diff(&mut state_diff);
+
+                // For blocks with starknet version < STARKNET_VERSION_TO_COMPILE_FROM, fetch the
+                // compiled classes from central so they can be passed to the class manager
+                // directly, bypassing compilation.
+                let mut non_backward_compatible_casms = IndexMap::<ClassHash, CasmContractClass>::new();
+                let starknet_version = reader.begin_ro_txn()?.get_starknet_version(block_number)?
+                .expect("State sync should only process blocks with existing headers.");
+                if starknet_version < STARKNET_VERSION_TO_COMPILE_FROM {
+                        let class_hashes: Vec<ClassHash> =
+                            state_diff.declared_classes.keys().copied().collect();
+                        let results = futures::future::join_all(
+                            class_hashes.iter().map(|class_hash| {
+                                let central_source = central_source.clone();
+                                async move {
+                                    central_source
+                                        .get_compiled_class(*class_hash)
+                                        .await
+                                        .map(|casm| (*class_hash, casm))
+                                }
+                            }),
+                        )
+                        .await;
+                        for result in results {
+                            let (class_hash, casm) = result?;
+                            non_backward_compatible_casms.insert(class_hash, casm);
+                        }
+                }
+
                 yield SyncEvent::StateDiffAvailable {
                     block_number,
                     block_hash,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces additional per-block network fan-out in the state diff stream, which can impact sync performance/availability and adds new failure paths when fetching compiled classes from Central.
> 
> **Overview**
> Updates `stream_new_state_diffs` to detect blocks with `starknet_version < STARKNET_VERSION_TO_COMPILE_FROM` and, for those blocks, concurrently fetch each newly declared class’s compiled CASM from Central (`get_compiled_class`) and collect them into an `IndexMap`.
> 
> This adds extra Central calls on older blocks to support bypassing compilation (though the collected CASMs are not yet emitted/consumed by the sync event).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cbd6a2aa78267a298cae160739b1190a57b945d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->