### PR TITLE
deployment: add profiling build mode with heaptrack support for memory leak investigation

### DIFF
--- a/.github/workflows/sequencer_docker-publish.yml
+++ b/.github/workflows/sequencer_docker-publish.yml
@@ -2,6 +2,16 @@ name: Sequencer-Docker-Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      build_mode:
+        description: "Cargo build profile: release, debug, or profiling (release with debug symbols + heaptrack)."
+        required: false
+        default: "release"
+        type: choice
+        options:
+          - release
+          - debug
+          - profiling
   push:
     tags:
       - "v*.*.*"
@@ -60,4 +70,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: BUILD_MODE=release
+          build-args: BUILD_MODE=${{ inputs.build_mode || 'release' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,6 +437,12 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(addr_of)',
 ] }
 
+# Release-optimized build with debug symbols for profiling tools (e.g. heaptrack).
+[profile.profiling]
+debug = true
+inherits = "release"
+strip = "none"
+
 [workspace.lints.clippy]
 as_conversions = "warn"
 await_holding_lock = "warn"

--- a/deployments/images/sequencer/Dockerfile
+++ b/deployments/images/sequencer/Dockerfile
@@ -19,10 +19,10 @@ WORKDIR /app
 ARG BUILD_MODE=release
 ENV BUILD_MODE=${BUILD_MODE}
 
-# Validate BUILD_MODE value
-RUN if [ "$BUILD_MODE" != "release" ] && [ "$BUILD_MODE" != "debug" ]; then \
-    echo "Error: BUILD_MODE must be either 'release' or 'debug' (got '$BUILD_MODE')" >&2; \
-    exit 1; \
+# Validate BUILD_MODE value.
+RUN if [ "$BUILD_MODE" != "release" ] && [ "$BUILD_MODE" != "debug" ] && [ "$BUILD_MODE" != "profiling" ]; then \
+        echo "Error: BUILD_MODE must be 'release', 'debug', or 'profiling' (got '$BUILD_MODE')" >&2; \
+        exit 1; \
     fi
 
 COPY --from=planner /app/recipe.json recipe.json
@@ -31,7 +31,9 @@ COPY . .
 
 RUN BUILD_FLAGS=""; \
     if [ "$BUILD_MODE" = "release" ]; then \
-    BUILD_FLAGS="--release"; \
+        BUILD_FLAGS="--release"; \
+    elif [ "$BUILD_MODE" = "profiling" ]; then \
+        BUILD_FLAGS="--profile profiling"; \
     fi; \
     cargo build $BUILD_FLAGS --bin apollo_node --features cairo_native
 
@@ -44,6 +46,11 @@ ENV BUILD_MODE=${BUILD_MODE}
 # Required for https requests: ca-certificates
 # Required for starknet-native-compile: binutils libc6-dev
 RUN apt-get update && apt-get install -y ca-certificates binutils libc6-dev
+
+# Install heaptrack for on-demand memory profiling (profiling builds only).
+RUN if [ "$BUILD_MODE" = "profiling" ]; then \
+        apt-get install -y heaptrack; \
+    fi
 
 ENV ID=1001
 WORKDIR /app
@@ -69,4 +76,10 @@ EXPOSE 8080 8081 8082
 USER ${ID}
 
 # Set the entrypoint to use tini to manage the process, while evaluating the build mode, and passing any arguments.
+#
+# Profiling usage: the node starts normally. To attach heaptrack on demand:
+#   1. Deploy with SYS_PTRACE capability (securityContext.capabilities.add: ["SYS_PTRACE"]).
+#   2. kubectl exec -it <pod> -- sh -c 'heaptrack --pid $(pidof apollo_node) -o /data/heaptrack'
+#   3. Stop with Ctrl+C, then: kubectl cp <pod>:/data/heaptrack.*.zst ./heaptrack_output.zst
+#   4. Analyze: heaptrack_print ./heaptrack_output.zst
 ENTRYPOINT ["sh", "-c", "exec tini -- /app/target/$BUILD_MODE/apollo_node \"$@\"", "--"]


### PR DESCRIPTION
Add a `profiling` Cargo profile (release + debug symbols) and update the
Dockerfile and CI workflow to support it. This enables on-demand memory
profiling with heaptrack by attaching to a running node via `--pid`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build/release tooling and the production Docker image contents (conditional `heaptrack` install), which could affect image size and build outputs but does not touch runtime application logic.
> 
> **Overview**
> Adds a new Cargo `profiling` profile (release-like build with debug symbols and no stripping) and wires it through the sequencer Docker build.
> 
> The `Sequencer-Docker-Publish` workflow can now be manually dispatched with a `build_mode` input (`release`/`debug`/`profiling`), passing it as `BUILD_MODE` to the Dockerfile. The Dockerfile accepts `profiling`, builds via `--profile profiling`, and conditionally installs `heaptrack` in the runtime image with inline usage notes for on-demand attachment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f856d3fdd5ae93aec6b8be27c2c092119c9cb984. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->