### PR TITLE
apollo_storage: add BatchConfig for transaction batching

### DIFF
--- a/crates/apollo_class_manager_config/src/config.rs
+++ b/crates/apollo_class_manager_config/src/config.rs
@@ -72,6 +72,7 @@ impl Default for FsClassStorageConfig {
                     max_object_size: 1 << 10, // 1KB; a class hash is 32B.
                 },
                 scope: StorageScope::StateOnly,
+                batch_config: Default::default(),
             },
             storage_reader_server_static_config: StorageReaderServerStaticConfig::default(),
         }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -339,6 +339,16 @@
     "privacy": "Public",
     "value": 1
   },
+  "batcher_config.static_config.storage.batch_config.batch_size": {
+    "description": "Number of logical commits before actual MDBX commit.",
+    "privacy": "Public",
+    "value": 100
+  },
+  "batcher_config.static_config.storage.batch_config.enabled": {
+    "description": "Whether transaction batching is enabled.",
+    "privacy": "Public",
+    "value": false
+  },
   "batcher_config.static_config.storage.db_config.chain_id": {
     "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
     "pointer_target": "chain_id",
@@ -433,6 +443,16 @@
     "description": "Limitation of compiled contract class object size.",
     "privacy": "Public",
     "value": 4089446
+  },
+  "class_manager_config.static_config.class_storage_config.class_hash_storage_config.batch_config.batch_size": {
+    "description": "Number of logical commits before actual MDBX commit.",
+    "privacy": "Public",
+    "value": 100
+  },
+  "class_manager_config.static_config.class_storage_config.class_hash_storage_config.batch_config.enabled": {
+    "description": "Whether transaction batching is enabled.",
+    "privacy": "Public",
+    "value": false
   },
   "class_manager_config.static_config.class_storage_config.class_hash_storage_config.db_config.chain_id": {
     "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
@@ -2174,6 +2194,16 @@
     "privacy": "Public",
     "value": 5
   },
+  "consensus_manager_config.consensus_manager_config.static_config.storage_config.batch_config.batch_size": {
+    "description": "Number of logical commits before actual MDBX commit.",
+    "privacy": "Public",
+    "value": 100
+  },
+  "consensus_manager_config.consensus_manager_config.static_config.storage_config.batch_config.enabled": {
+    "description": "Whether transaction batching is enabled.",
+    "privacy": "Public",
+    "value": false
+  },
   "consensus_manager_config.consensus_manager_config.static_config.storage_config.db_config.chain_id": {
     "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
     "pointer_target": "chain_id",
@@ -3493,6 +3523,16 @@
     "description": "URL for communicating with Starknet in write_api methods.",
     "pointer_target": "starknet_url",
     "privacy": "Public"
+  },
+  "state_sync_config.static_config.storage_config.batch_config.batch_size": {
+    "description": "Number of logical commits before actual MDBX commit.",
+    "privacy": "Public",
+    "value": 100
+  },
+  "state_sync_config.static_config.storage_config.batch_config.enabled": {
+    "description": "Whether transaction batching is enabled.",
+    "privacy": "Public",
+    "value": false
   },
   "state_sync_config.static_config.storage_config.db_config.chain_id": {
     "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -121,6 +121,7 @@ pub mod storage_reader_server_test_utils;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::fs;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use apollo_config::dumping::{prepend_sub_config_name, ser_param, SerializeConfig};
@@ -502,17 +503,17 @@ pub struct StorageReader {
 /// - Operations may fail partway through (e.g., duplicate key errors, marker mismatches)
 /// - Immediate commit guarantees are required after each write
 /// - During initialization/revert operations (batching should be disabled)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Validate)]
 pub struct BatchConfig {
     /// Whether batching is enabled.
     pub enabled: bool,
-    /// Number of logical commits before actual MDBX commit.
-    pub batch_size: usize,
+    /// Number of logical commits before actual MDBX commit. Must be at least 1.
+    pub batch_size: NonZeroUsize,
 }
 
 impl Default for BatchConfig {
     fn default() -> Self {
-        Self { enabled: false, batch_size: 100 }
+        Self { enabled: false, batch_size: NonZeroUsize::new(100).expect("100 is non-zero") }
     }
 }
 
@@ -836,6 +837,8 @@ pub struct StorageConfig {
     #[validate(nested)]
     pub mmap_file_config: MmapFileConfig,
     pub scope: StorageScope,
+    #[serde(default)]
+    #[validate(nested)]
     pub batch_config: BatchConfig,
 }
 

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -486,6 +486,55 @@ pub struct StorageReader {
     open_readers_metric: Option<&'static MetricGauge>,
 }
 
+/// Configuration for transaction batching.
+///
+/// # When to Use Batching
+///
+/// Batching is designed for high-throughput sync operations where:
+/// - Blocks are validated before writing (no duplicate keys, correct markers, etc.)
+/// - Write operations are expected to succeed
+/// - Data integrity is ensured at a higher level (by the sync protocol)
+///
+/// # When not to Use Batching
+///
+/// Do not enable batching when:
+/// - Testing error handling scenarios (intentionally triggering write failures)
+/// - Operations may fail partway through (e.g., duplicate key errors, marker mismatches)
+/// - Immediate commit guarantees are required after each write
+/// - During initialization/revert operations (batching should be disabled)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct BatchConfig {
+    /// Whether batching is enabled.
+    pub enabled: bool,
+    /// Number of logical commits before actual MDBX commit.
+    pub batch_size: usize,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self { enabled: false, batch_size: 100 }
+    }
+}
+
+impl SerializeConfig for BatchConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
+            ser_param(
+                "enabled",
+                &self.enabled,
+                "Whether transaction batching is enabled.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "batch_size",
+                &self.batch_size,
+                "Number of logical commits before actual MDBX commit.",
+                ParamPrivacyInput::Public,
+            ),
+        ])
+    }
+}
+
 impl StorageReader {
     /// Takes a snapshot of the current state of the storage and returns a [`StorageTxn`] for
     /// reading data from the storage.
@@ -787,6 +836,7 @@ pub struct StorageConfig {
     #[validate(nested)]
     pub mmap_file_config: MmapFileConfig,
     pub scope: StorageScope,
+    pub batch_config: BatchConfig,
 }
 
 impl SerializeConfig for StorageConfig {
@@ -800,6 +850,7 @@ impl SerializeConfig for StorageConfig {
         dumped_config
             .extend(prepend_sub_config_name(self.mmap_file_config.dump(), "mmap_file_config"));
         dumped_config.extend(prepend_sub_config_name(self.db_config.dump(), "db_config"));
+        dumped_config.extend(prepend_sub_config_name(self.batch_config.dump(), "batch_config"));
         dumped_config
     }
 }

--- a/crates/apollo_storage/src/test_utils.rs
+++ b/crates/apollo_storage/src/test_utils.rs
@@ -25,6 +25,7 @@ fn build_storage_config(storage_scope: StorageScope, path_prefix: PathBuf) -> St
         },
         scope: storage_scope,
         mmap_file_config: get_mmap_file_test_config(),
+        batch_config: crate::BatchConfig::default(),
     }
 }
 

--- a/crates/apollo_storage/tests/open_storage_in_processes_test.rs
+++ b/crates/apollo_storage/tests/open_storage_in_processes_test.rs
@@ -39,6 +39,7 @@ fn get_test_config_with_path(storage_scope: Option<StorageScope>, path: PathBuf)
             growth_step: 1 << 20,     // 1MB
             max_object_size: 1 << 16, // 64KB
         },
+        batch_config: apollo_storage::BatchConfig::default(),
     }
 }
 

--- a/crates/native_blockifier/src/storage.rs
+++ b/crates/native_blockifier/src/storage.rs
@@ -70,6 +70,7 @@ impl PapyrusStorage {
                 growth_step: 2 << 30,     // 2GB
                 max_object_size: 1 << 30, // 1GB
             },
+            batch_config: Default::default(),
         };
         let (reader, writer) = apollo_storage::open_storage(storage_config)?;
         log::debug!("Initialized Blockifier storage.");

--- a/crates/starknet_committer_cli/src/commands.rs
+++ b/crates/starknet_committer_cli/src/commands.rs
@@ -8,7 +8,7 @@ use apollo_storage::db::DbConfig;
 use apollo_storage::header::HeaderStorageReader;
 use apollo_storage::mmap_file::MmapFileConfig;
 use apollo_storage::state::StateStorageReader;
-use apollo_storage::{open_storage, StorageConfig, StorageReader, StorageScope};
+use apollo_storage::{open_storage, BatchConfig, StorageConfig, StorageReader, StorageScope};
 use blake2::digest::consts::U31;
 use blake2::{Blake2s, Digest};
 use rand::distributions::Uniform;
@@ -66,6 +66,7 @@ static BATCHER_STORAGE_CONFIG: LazyLock<StorageConfig> = LazyLock::new(|| Storag
         max_object_size: 1073741824,
     },
     scope: StorageScope::StateOnly,
+    batch_config: BatchConfig { enabled: false, batch_size: 100 },
 });
 
 // This is based on the state sync's storage configuration on mainnet.
@@ -85,6 +86,7 @@ static STATE_SYNC_STORAGE_CONFIG: LazyLock<StorageConfig> = LazyLock::new(|| Sto
         max_object_size: 1073741824,
     },
     scope: StorageScope::FullArchive,
+    batch_config: BatchConfig { enabled: false, batch_size: 100 },
 });
 
 const FLAVOR_PERIOD_MANY_WINDOW: usize = 10;

--- a/crates/starknet_committer_cli/src/commands.rs
+++ b/crates/starknet_committer_cli/src/commands.rs
@@ -66,7 +66,7 @@ static BATCHER_STORAGE_CONFIG: LazyLock<StorageConfig> = LazyLock::new(|| Storag
         max_object_size: 1073741824,
     },
     scope: StorageScope::StateOnly,
-    batch_config: BatchConfig { enabled: false, batch_size: 100 },
+    batch_config: BatchConfig::default(),
 });
 
 // This is based on the state sync's storage configuration on mainnet.
@@ -86,7 +86,7 @@ static STATE_SYNC_STORAGE_CONFIG: LazyLock<StorageConfig> = LazyLock::new(|| Sto
         max_object_size: 1073741824,
     },
     scope: StorageScope::FullArchive,
-    batch_config: BatchConfig { enabled: false, batch_size: 100 },
+    batch_config: BatchConfig::default(),
 });
 
 const FLAVOR_PERIOD_MANY_WINDOW: usize = 10;


### PR DESCRIPTION
## Summary

Adds `BatchConfig` struct for configuring transaction batching behavior. This allows enabling/disabling batching and configuring the batch size (number of logical commits before an actual MDBX commit).

**Changes:**
- Add `BatchConfig` struct with `enabled` (bool) and `batch_size` (usize) fields
- Implement `Default` and `SerializeConfig` for `BatchConfig`
- Add `batch_config` field to `StorageConfig`

## Test plan

- Existing tests pass
- Configuration is used by subsequent PRs in the stack

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a config-structure extension with safe defaults (`enabled=false`) and `serde(default)` for backward-compatible deserialization; no storage write-path behavior is changed yet.
> 
> **Overview**
> Adds a new `BatchConfig` (`enabled`, `batch_size`) to `apollo_storage` and nests it under `StorageConfig`, including validation and config-dumping support.
> 
> Wires the new field through default `StorageConfig` constructions across the codebase (e.g., class manager storage, native blockifier storage, tests, and committer benchmark configs) and publishes the new `batch_config.*` parameters in `apollo_node`’s `config_schema.json` for batcher/state-sync/consensus/class-manager storage configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73da3a557883b1daef0e90dc06c1a89035acace4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->