### PR TITLE
apollo_storage: implement StorageTxnRW fluent API for batched writes

### DIFF
--- a/crates/apollo_state_sync_metrics/src/metrics.rs
+++ b/crates/apollo_state_sync_metrics/src/metrics.rs
@@ -13,7 +13,7 @@ use apollo_storage::compiled_class::CasmStorageReader;
 use apollo_storage::db::TransactionKind;
 use apollo_storage::header::HeaderStorageReader;
 use apollo_storage::state::StateStorageReader;
-use apollo_storage::{StorageReader, StorageTxn};
+use apollo_storage::StorageReader;
 define_infra_metrics!(state_sync);
 
 define_metrics!(
@@ -56,7 +56,14 @@ pub async fn register_metrics(storage_reader: StorageReader) {
     update_marker_metrics(&txn);
 }
 
-pub fn update_marker_metrics<Mode: TransactionKind>(txn: &StorageTxn<'_, Mode>) {
+pub fn update_marker_metrics<T, Mode: TransactionKind>(txn: &T)
+where
+    T: HeaderStorageReader
+        + BodyStorageReader
+        + StateStorageReader<Mode>
+        + ClassManagerStorageReader
+        + CasmStorageReader,
+{
     STATE_SYNC_HEADER_MARKER
         .set_lossy(txn.get_header_marker().expect("Should have a header marker").0);
     STATE_SYNC_BODY_MARKER.set_lossy(txn.get_body_marker().expect("Should have a body marker").0);

--- a/crates/apollo_storage/src/base_layer.rs
+++ b/crates/apollo_storage/src/base_layer.rs
@@ -6,7 +6,7 @@
 //! Starknet network).
 //!
 //! Import [`BaseLayerStorageReader`] and [`BaseLayerStorageWriter`] to read and write data related
-//! to the base layer using a [`StorageTxn`].
+//! to the base layer using a `StorageTxn`.
 //! # Example
 //! ```
 //! use apollo_storage::base_layer::{BaseLayerStorageReader, BaseLayerStorageWriter};
@@ -43,8 +43,8 @@ mod base_layer_test;
 use starknet_api::block::BlockNumber;
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{MarkerKind, StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{MarkerKind, StorageResult, StorageTransaction};
 
 /// Interface for reading data related to the base layer.
 pub trait BaseLayerStorageReader {
@@ -69,17 +69,17 @@ where
     ) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> BaseLayerStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> BaseLayerStorageReader for T {
     fn get_base_layer_block_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::BaseLayerBlock)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::BaseLayerBlock)?.unwrap_or_default())
     }
 }
 
-impl BaseLayerStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> BaseLayerStorageWriter for T {
     fn update_base_layer_block_marker(self, block_number: &BlockNumber) -> StorageResult<Self> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        markers_table.upsert(&self.txn, &MarkerKind::BaseLayerBlock, block_number)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        markers_table.upsert(self.txn(), &MarkerKind::BaseLayerBlock, block_number)?;
         Ok(self)
     }
 

--- a/crates/apollo_storage/src/block_hash.rs
+++ b/crates/apollo_storage/src/block_hash.rs
@@ -1,12 +1,12 @@
 //! Interface for handling block hashes.
 //! Import [`BlockHashStorageReader`] and [`BlockHashStorageWriter`] to read and write
-//! data related to block hashes using a [`StorageTxn`].
+//! data related to block hashes using a `StorageTxn`.
 
 use starknet_api::block::{BlockHash, BlockNumber};
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{StorageResult, StorageTransaction};
 
 /// Interface for reading block hashes.
 pub trait BlockHashStorageReader {
@@ -32,27 +32,27 @@ where
     fn revert_block_hash(self, block_number: &BlockNumber) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> BlockHashStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> BlockHashStorageReader for T {
     fn get_block_hash(&self, block_number: &BlockNumber) -> StorageResult<Option<BlockHash>> {
-        let table = self.open_table(&self.tables.block_hashes)?;
-        Ok(table.get(&self.txn, block_number)?)
+        let table = self.open_table(&self.tables().block_hashes)?;
+        Ok(table.get(self.txn(), block_number)?)
     }
 }
 
-impl BlockHashStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> BlockHashStorageWriter for T {
     fn set_block_hash(
         self,
         block_number: &BlockNumber,
         block_hash: BlockHash,
     ) -> StorageResult<Self> {
-        let table = self.open_table(&self.tables.block_hashes)?;
-        table.upsert(&self.txn, block_number, &block_hash)?;
+        let table = self.open_table(&self.tables().block_hashes)?;
+        table.upsert(self.txn(), block_number, &block_hash)?;
         Ok(self)
     }
 
     fn revert_block_hash(self, target_block_number: &BlockNumber) -> StorageResult<Self> {
-        let block_hash_table = self.open_table(&self.tables.block_hashes)?;
-        block_hash_table.delete(&self.txn, target_block_number)?;
+        let block_hash_table = self.open_table(&self.tables().block_hashes)?;
+        block_hash_table.delete(self.txn(), target_block_number)?;
         Ok(self)
     }
 }

--- a/crates/apollo_storage/src/body/events.rs
+++ b/crates/apollo_storage/src/body/events.rs
@@ -1,7 +1,7 @@
 //! Interface for iterating over events from the storage.
 //!
 //! Events are part of the transaction output. Each transaction output holds an array of events.
-//! Import [`EventsReader`] to iterate over events using a read-only [`StorageTxn`].
+//! Import [`EventsReader`] to iterate over events using a read-only `StorageTxn`.
 //!
 //! # Example
 //! ```
@@ -66,7 +66,7 @@ use crate::body::{EventsTableKey, TransactionIndex};
 use crate::db::serialization::{NoVersionValueWrapper, VersionZeroWrapper};
 use crate::db::table_types::{CommonPrefix, DbCursor, DbCursorTrait, NoValue, SimpleTable, Table};
 use crate::db::{DbTransaction, RO};
-use crate::{FileHandlers, StorageResult, StorageTxn, TransactionMetadata};
+use crate::{FileHandlers, StorageResult, StorageTransaction, StorageTxn, TransactionMetadata};
 
 /// An identifier of an event.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Ord)]
@@ -134,8 +134,8 @@ impl<'txn, 'env> EventsReader<'txn, 'env> for StorageTxn<'env, RO> {
         address: ContractAddress,
         tx_index: TransactionIndex,
     ) -> StorageResult<Option<()>> {
-        let events_table = self.open_table(&self.tables.events)?;
-        Ok(events_table.get(&self.txn, &(address, tx_index))?.map(|_| ()))
+        let events_table = self.open_table(&self.tables().events)?;
+        Ok(events_table.get(self.txn(), &(address, tx_index))?.map(|_| ()))
     }
 }
 
@@ -292,14 +292,14 @@ where
         &'env self,
         key: (ContractAddress, EventIndex),
     ) -> StorageResult<EventIterByContractAddress<'env, 'txn>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
-        let events_table = self.open_table(&self.tables.events)?;
-        let mut cursor = events_table.cursor(&self.txn)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
+        let events_table = self.open_table(&self.tables().events)?;
+        let mut cursor = events_table.cursor(self.txn())?;
         let events_queue = if let Some((contract_address, tx_index)) =
             cursor.lower_bound(&(key.0, key.1.0))?.map(|(key, _)| key)
         {
             let tx_metadata =
-                transaction_metadata_table.get(&self.txn, &tx_index)?.unwrap_or_else(|| {
+                transaction_metadata_table.get(self.txn(), &tx_index)?.unwrap_or_else(|| {
                     panic!("Transaction metadata not found for transaction index: {tx_index:?}")
                 });
             let tx_output = self
@@ -322,7 +322,7 @@ where
         let next_entry_in_event_table = cursor.next()?.map(|(key, _)| key);
 
         Ok(EventIterByContractAddress {
-            txn: &self.txn,
+            txn: self.txn(),
             file_handles: &self.file_handlers,
             next_entry_in_event_table,
             events_queue,
@@ -345,8 +345,8 @@ where
         event_index: EventIndex,
         to_block_number: BlockNumber,
     ) -> StorageResult<EventIterByEventIndex<'txn>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
-        let mut tx_cursor = transaction_metadata_table.cursor(&self.txn)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
+        let mut tx_cursor = transaction_metadata_table.cursor(self.txn())?;
         let first_txn_location = tx_cursor.lower_bound(&event_index.0)?;
         let first_relevant_transaction = match first_txn_location {
             None => None,

--- a/crates/apollo_storage/src/body/mod.rs
+++ b/crates/apollo_storage/src/body/mod.rs
@@ -3,7 +3,7 @@
 //! The block body is the part of the block that contains the transactions and the transaction
 //! outputs.
 //! Import [`BodyStorageReader`] and [`BodyStorageWriter`] to read and write data related
-//! to the block bodies using a [`StorageTxn`].
+//! to the block bodies using a `StorageTxn`.
 //!
 //! See [`events`] module for the interface for handling events.
 //!
@@ -69,7 +69,9 @@ use crate::{
     StorageError,
     StorageResult,
     StorageScope,
+    StorageTransaction,
     StorageTxn,
+    StorageTxnRW,
     TransactionMetadata,
 };
 
@@ -159,6 +161,33 @@ pub trait BodyStorageReader {
 
 type RevertedBlockBody = (Vec<Transaction>, Vec<TransactionOutput>, Vec<TransactionHash>);
 
+/// Private trait extension for helper methods used by BodyStorageReader.
+trait BodyStorageReaderHelpers: StorageTransaction {
+    fn get_transactions_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<Transaction>>>;
+
+    fn get_transaction_hashes_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<TransactionHash>>>;
+
+    fn get_transactions_and_hashes_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<(Transaction, TransactionHash)>>>;
+
+    fn get_transaction_outputs_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<TransactionOutput>>>;
+}
+
 /// Interface for updating data related to the block body.
 pub trait BodyStorageWriter
 where
@@ -178,15 +207,15 @@ where
     ) -> StorageResult<(Self, Option<RevertedBlockBody>)>;
 }
 
-impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction + BodyStorageReaderHelpers> BodyStorageReader for T {
     fn get_body_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::Body)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::Body)?.unwrap_or_default())
     }
 
     fn get_event_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::Event)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::Event)?.unwrap_or_default())
     }
 
     // TODO(dvir): add option to get transaction with its hash.
@@ -197,7 +226,8 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         let Some(tx_metadata) = self.get_transaction_metadata(&transaction_index)? else {
             return Ok(None);
         };
-        let transaction = self.file_handlers.get_transaction_unchecked(tx_metadata.tx_location)?;
+        let transaction =
+            self.file_handlers().get_transaction_unchecked(tx_metadata.tx_location)?;
         Ok(Some(transaction))
     }
 
@@ -208,8 +238,9 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         let Some(tx_metadata) = self.get_transaction_metadata(&transaction_index)? else {
             return Ok(None);
         };
-        let transaction_output =
-            self.file_handlers.get_transaction_output_unchecked(tx_metadata.tx_output_location)?;
+        let transaction_output = self
+            .file_handlers()
+            .get_transaction_output_unchecked(tx_metadata.tx_output_location)?;
         Ok(Some(transaction_output))
     }
 
@@ -218,8 +249,8 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         tx_hash: &TransactionHash,
     ) -> StorageResult<Option<TransactionIndex>> {
         let transaction_hash_to_idx_table =
-            self.open_table(&self.tables.transaction_hash_to_idx)?;
-        let idx = transaction_hash_to_idx_table.get(&self.txn, tx_hash)?;
+            self.open_table(&self.tables().transaction_hash_to_idx)?;
+        let idx = transaction_hash_to_idx_table.get(self.txn(), tx_hash)?;
         Ok(idx)
     }
 
@@ -237,8 +268,8 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         &self,
         tx_index: &TransactionIndex,
     ) -> StorageResult<Option<TransactionMetadata>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
-        let metadata = transaction_metadata_table.get(&self.txn, tx_index)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
+        let metadata = transaction_metadata_table.get(self.txn(), tx_index)?;
         Ok(metadata)
     }
 
@@ -246,7 +277,7 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<Vec<Transaction>>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
         self.get_transactions_in_block(block_number, transaction_metadata_table)
     }
 
@@ -254,7 +285,7 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<Vec<TransactionHash>>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
         self.get_transaction_hashes_in_block(block_number, transaction_metadata_table)
     }
 
@@ -262,7 +293,7 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<Vec<(Transaction, TransactionHash)>>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
         self.get_transactions_and_hashes_in_block(block_number, transaction_metadata_table)
     }
 
@@ -270,7 +301,7 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<Vec<TransactionOutput>>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
         self.get_transaction_outputs_in_block(block_number, transaction_metadata_table)
     }
 
@@ -284,8 +315,8 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
             return Ok(None);
         }
 
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
-        let mut cursor = transaction_metadata_table.cursor(&self.txn)?;
+        let transaction_metadata_table = self.open_table(&self.tables().transaction_metadata)?;
+        let mut cursor = transaction_metadata_table.cursor(self.txn())?;
         let Some(next_block_number) = block_number.next() else {
             return Ok(None);
         };
@@ -304,6 +335,60 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
     }
 }
 
+impl<'env, Mode: TransactionKind> BodyStorageReaderHelpers for StorageTxn<'env, Mode> {
+    fn get_transaction_outputs_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<TransactionOutput>>> {
+        self.get_vector_of_transaction_objects(
+            block_number,
+            transaction_metadata_table,
+            |tx_metadata, file_handlers| {
+                file_handlers.get_transaction_output_unchecked(tx_metadata.tx_output_location)
+            },
+        )
+    }
+
+    fn get_transactions_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<Transaction>>> {
+        Ok(self
+            .get_transactions_and_hashes_in_block(block_number, transaction_metadata_table)?
+            .map(|pairs| pairs.into_iter().map(|(tx, _hash)| tx).collect()))
+    }
+
+    fn get_transaction_hashes_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<TransactionHash>>> {
+        self.get_vector_of_transaction_objects(
+            block_number,
+            transaction_metadata_table,
+            |tx_metadata, _file_handlers| Ok(tx_metadata.tx_hash),
+        )
+    }
+
+    fn get_transactions_and_hashes_in_block(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+    ) -> StorageResult<Option<Vec<(Transaction, TransactionHash)>>> {
+        self.get_vector_of_transaction_objects(
+            block_number,
+            transaction_metadata_table,
+            |tx_metadata, file_handlers| {
+                let transaction =
+                    file_handlers.get_transaction_unchecked(tx_metadata.tx_location)?;
+                Ok((transaction, tx_metadata.tx_hash))
+            },
+        )
+    }
+}
+
 impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
     // Returns a vector with transaction objects (can be tx hash for example).
     fn get_vector_of_transaction_objects<T>(
@@ -315,7 +400,7 @@ impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
         if self.get_body_marker()? <= block_number {
             return Ok(None);
         }
-        let mut cursor = transaction_metadata_table.cursor(&self.txn)?;
+        let mut cursor = transaction_metadata_table.cursor(self.txn())?;
         let mut current_entry =
             cursor.lower_bound(&TransactionIndex(block_number, TransactionOffsetInBlock(0)))?;
 
@@ -332,11 +417,39 @@ impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
         }
         Ok(Some(res))
     }
+}
 
+impl StorageTxnRW<'_> {
+    fn get_vector_of_transaction_objects<T>(
+        &self,
+        block_number: BlockNumber,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
+        tx_metadata_to_tx_object: fn(TransactionMetadata, &FileHandlers<RW>) -> StorageResult<T>,
+    ) -> StorageResult<Option<Vec<T>>> {
+        if self.get_body_marker()? <= block_number {
+            return Ok(None);
+        }
+        let mut cursor = transaction_metadata_table.cursor(self.txn())?;
+        let mut current =
+            cursor.lower_bound(&TransactionIndex(block_number, TransactionOffsetInBlock(0)))?;
+        let mut res = Vec::new();
+        while let Some((TransactionIndex(current_block_number, _), tx_metadata)) = current {
+            if current_block_number != block_number {
+                break;
+            }
+            let tx_output = tx_metadata_to_tx_object(tx_metadata, &self.file_handlers)?;
+            res.push(tx_output);
+            current = cursor.next()?;
+        }
+        Ok(Some(res))
+    }
+}
+
+impl BodyStorageReaderHelpers for StorageTxnRW<'_> {
     fn get_transaction_outputs_in_block(
         &self,
         block_number: BlockNumber,
-        transaction_metadata_table: TransactionMetadataTable<'env>,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
     ) -> StorageResult<Option<Vec<TransactionOutput>>> {
         self.get_vector_of_transaction_objects(
             block_number,
@@ -350,7 +463,7 @@ impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
     fn get_transactions_in_block(
         &self,
         block_number: BlockNumber,
-        transaction_metadata_table: TransactionMetadataTable<'env>,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
     ) -> StorageResult<Option<Vec<Transaction>>> {
         self.get_vector_of_transaction_objects(
             block_number,
@@ -364,7 +477,7 @@ impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
     fn get_transaction_hashes_in_block(
         &self,
         block_number: BlockNumber,
-        transaction_metadata_table: TransactionMetadataTable<'env>,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
     ) -> StorageResult<Option<Vec<TransactionHash>>> {
         self.get_vector_of_transaction_objects(
             block_number,
@@ -376,7 +489,7 @@ impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
     fn get_transactions_and_hashes_in_block(
         &self,
         block_number: BlockNumber,
-        transaction_metadata_table: TransactionMetadataTable<'env>,
+        transaction_metadata_table: TransactionMetadataTable<'_>,
     ) -> StorageResult<Option<Vec<(Transaction, TransactionHash)>>> {
         self.get_vector_of_transaction_objects(
             block_number,
@@ -390,23 +503,24 @@ impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
     }
 }
 
-impl BodyStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW> + BodyStorageReader> BodyStorageWriter for T {
     #[latency_histogram("storage_append_body_latency_seconds", false)]
     fn append_body(self, block_number: BlockNumber, block_body: BlockBody) -> StorageResult<Self> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        update_marker(&self.txn, &markers_table, block_number)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        update_marker(self.txn(), &markers_table, block_number)?;
 
-        if self.scope != StorageScope::StateOnly {
-            let events_table = self.open_table(&self.tables.events)?;
+        if self.scope() != StorageScope::StateOnly {
+            let events_table = self.open_table(&self.tables().events)?;
             let transaction_hash_to_idx_table =
-                self.open_table(&self.tables.transaction_hash_to_idx)?;
-            let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
-            let file_offset_table = self.txn.open_table(&self.tables.file_offsets)?;
+                self.open_table(&self.tables().transaction_hash_to_idx)?;
+            let transaction_metadata_table =
+                self.open_table(&self.tables().transaction_metadata)?;
+            let file_offset_table = self.txn().open_table(&self.tables().file_offsets)?;
 
             write_transactions(
                 &block_body,
-                &self.txn,
-                &self.file_handlers,
+                self.txn(),
+                self.file_handlers(),
                 &file_offset_table,
                 &transaction_hash_to_idx_table,
                 &transaction_metadata_table,
@@ -422,7 +536,7 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
         self,
         block_number: BlockNumber,
     ) -> StorageResult<(Self, Option<RevertedBlockBody>)> {
-        let markers_table = self.open_table(&self.tables.markers)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
 
         // Assert that body marker equals the reverted block number + 1
         let current_header_marker = self.get_body_marker()?;
@@ -439,14 +553,15 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
         }
 
         let reverted_block_body = 'reverted_block_body: {
-            if self.scope == StorageScope::StateOnly {
+            if self.scope() == StorageScope::StateOnly {
                 break 'reverted_block_body None;
             }
 
-            let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
+            let transaction_metadata_table =
+                self.open_table(&self.tables().transaction_metadata)?;
             let transaction_hash_to_idx_table =
-                self.open_table(&self.tables.transaction_hash_to_idx)?;
-            let events_table = self.open_table(&self.tables.events)?;
+                self.open_table(&self.tables().transaction_hash_to_idx)?;
+            let events_table = self.open_table(&self.tables().events)?;
 
             let transactions = self
                 .get_block_transactions(block_number)?
@@ -465,16 +580,16 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
                 let tx_index = TransactionIndex(block_number, TransactionOffsetInBlock(offset));
 
                 for event in tx_output.events().iter() {
-                    events_table.delete(&self.txn, &(event.from_address, tx_index))?;
+                    events_table.delete(self.txn(), &(event.from_address, tx_index))?;
                 }
-                transaction_hash_to_idx_table.delete(&self.txn, tx_hash)?;
-                transaction_metadata_table.delete(&self.txn, &tx_index)?;
+                transaction_hash_to_idx_table.delete(self.txn(), tx_hash)?;
+                transaction_metadata_table.delete(self.txn(), &tx_index)?;
             }
             Some((transactions, transaction_outputs, transaction_hashes))
         };
 
-        markers_table.upsert(&self.txn, &MarkerKind::Body, &block_number)?;
-        markers_table.upsert(&self.txn, &MarkerKind::Event, &block_number)?;
+        markers_table.upsert(self.txn(), &MarkerKind::Body, &block_number)?;
+        markers_table.upsert(self.txn(), &MarkerKind::Event, &block_number)?;
         Ok((self, reverted_block_body))
     }
 }

--- a/crates/apollo_storage/src/class.rs
+++ b/crates/apollo_storage/src/class.rs
@@ -1,7 +1,7 @@
 //! Interface for handling data related to Starknet [classes (Cairo 1)](https://docs.rs/starknet_api/latest/starknet_api/state/struct.ContractClass.html) and [deprecated classes (Cairo 0)](https://docs.rs/starknet_api/latest/starknet_api/deprecated_contract_class/struct.ContractClass.html).
 //!
 //! Import [`ClassStorageReader`] and [`ClassStorageWriter`] to read and write data related to
-//! classes using a [`StorageTxn`].
+//! classes using a `StorageTxn`.
 //!
 //! Note that the written classes' hashes should be the same as those declared in the block's state
 //! diff and deploy transactions (now depreacted). This is not validated but breaking this will
@@ -75,7 +75,7 @@ use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContract
 use starknet_api::state::SierraContractClass;
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
+use crate::db::RW;
 use crate::mmap_file::LocationInFile;
 use crate::state::{DeclaredClassesTable, DeprecatedDeclaredClassesTable, FileOffsetTable};
 use crate::{
@@ -86,7 +86,7 @@ use crate::{
     OffsetKind,
     StorageError,
     StorageResult,
-    StorageTxn,
+    StorageTransaction,
 };
 
 /// Interface for reading data related to classes or deprecated classes.
@@ -150,8 +150,7 @@ where
     ) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> ClassStorageReader for StorageTxn<'_, Mode> {
-    // TODO(Nadin): Consider moving the function to the general impl StorageTxn<'_, Mode> block.
+impl<T: StorageTransaction> ClassStorageReader for T {
     fn get_class(&self, class_hash: &ClassHash) -> StorageResult<Option<SierraContractClass>> {
         let contract_class_location = self.get_class_location(class_hash)?;
         contract_class_location.map(|location| self.get_class_from_location(location)).transpose()
@@ -161,15 +160,15 @@ impl<Mode: TransactionKind> ClassStorageReader for StorageTxn<'_, Mode> {
         &self,
         class_hash: &ClassHash,
     ) -> StorageResult<Option<crate::LocationInFile>> {
-        let declared_classes_table = self.open_table(&self.tables.declared_classes)?;
-        Ok(declared_classes_table.get(&self.txn, class_hash)?)
+        let declared_classes_table = self.open_table(&self.tables().declared_classes)?;
+        Ok(declared_classes_table.get(self.txn(), class_hash)?)
     }
 
     fn get_class_from_location(
         &self,
         location: crate::LocationInFile,
     ) -> StorageResult<SierraContractClass> {
-        self.file_handlers.get_contract_class_unchecked(location)
+        self.file_handlers().get_contract_class_unchecked(location)
     }
 
     fn get_deprecated_class(
@@ -187,9 +186,9 @@ impl<Mode: TransactionKind> ClassStorageReader for StorageTxn<'_, Mode> {
         class_hash: &ClassHash,
     ) -> StorageResult<Option<LocationInFile>> {
         let deprecated_declared_classes_table =
-            self.open_table(&self.tables.deprecated_declared_classes)?;
+            self.open_table(&self.tables().deprecated_declared_classes)?;
         let deprecated_contract_class_location =
-            deprecated_declared_classes_table.get(&self.txn, class_hash)?;
+            deprecated_declared_classes_table.get(self.txn(), class_hash)?;
         Ok(deprecated_contract_class_location.map(|value| value.location_in_file))
     }
 
@@ -197,16 +196,16 @@ impl<Mode: TransactionKind> ClassStorageReader for StorageTxn<'_, Mode> {
         &self,
         location: LocationInFile,
     ) -> StorageResult<DeprecatedContractClass> {
-        self.file_handlers.get_deprecated_contract_class_unchecked(location)
+        self.file_handlers().get_deprecated_contract_class_unchecked(location)
     }
 
     fn get_class_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::Class)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::Class)?.unwrap_or_default())
     }
 }
 
-impl ClassStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> ClassStorageWriter for T {
     #[latency_histogram("storage_append_classes_latency_seconds", false)]
     fn append_classes(
         self,
@@ -214,14 +213,14 @@ impl ClassStorageWriter for StorageTxn<'_, RW> {
         classes: &[(ClassHash, &SierraContractClass)],
         deprecated_classes: &[(ClassHash, &DeprecatedContractClass)],
     ) -> StorageResult<Self> {
-        let declared_classes_table = self.open_table(&self.tables.declared_classes)?;
+        let declared_classes_table = self.open_table(&self.tables().declared_classes)?;
         let deprecated_declared_classes_table =
-            self.open_table(&self.tables.deprecated_declared_classes)?;
-        let file_offset_table = self.txn.open_table(&self.tables.file_offsets)?;
-        let markers_table = self.open_table(&self.tables.markers)?;
+            self.open_table(&self.tables().deprecated_declared_classes)?;
+        let file_offset_table = self.txn().open_table(&self.tables().file_offsets)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
 
         let marker_block_number =
-            markers_table.get(&self.txn, &MarkerKind::Class)?.unwrap_or_default();
+            markers_table.get(self.txn(), &MarkerKind::Class)?.unwrap_or_default();
         if block_number != marker_block_number {
             return Err(StorageError::MarkerMismatch {
                 expected: marker_block_number,
@@ -231,22 +230,22 @@ impl ClassStorageWriter for StorageTxn<'_, RW> {
 
         write_classes(
             classes,
-            &self.txn,
+            self.txn(),
             &declared_classes_table,
-            &self.file_handlers,
+            self.file_handlers(),
             &file_offset_table,
         )?;
 
         write_deprecated_classes(
             deprecated_classes,
-            &self.txn,
+            self.txn(),
             block_number,
             &deprecated_declared_classes_table,
-            &self.file_handlers,
+            self.file_handlers(),
             &file_offset_table,
         )?;
 
-        markers_table.upsert(&self.txn, &MarkerKind::Class, &block_number.unchecked_next())?;
+        markers_table.upsert(self.txn(), &MarkerKind::Class, &block_number.unchecked_next())?;
 
         Ok(self)
     }

--- a/crates/apollo_storage/src/class_hash.rs
+++ b/crates/apollo_storage/src/class_hash.rs
@@ -3,13 +3,13 @@
 //! Use carefully, only within class manager code, which is responsible for maintaining this table.
 //!
 //! Import [`ClassHashStorageReader`] and [`ClassHashStorageWriter`] to read and write data related
-//! to classes using a [`StorageTxn`].
+//! to classes using a `StorageTxn`.
 
 use starknet_api::core::{ClassHash, CompiledClassHash};
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{StorageResult, StorageTransaction};
 
 #[cfg(test)]
 #[path = "class_hash_test.rs"]
@@ -41,24 +41,24 @@ where
     ) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> ClassHashStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> ClassHashStorageReader for T {
     fn get_executable_class_hash_v2(
         &self,
         class_hash: &ClassHash,
     ) -> StorageResult<Option<CompiledClassHash>> {
-        let table = self.open_table(&self.tables.stateless_compiled_class_hash_v2)?;
-        Ok(table.get(&self.txn, class_hash)?)
+        let table = self.open_table(&self.tables().stateless_compiled_class_hash_v2)?;
+        Ok(table.get(self.txn(), class_hash)?)
     }
 }
 
-impl ClassHashStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> ClassHashStorageWriter for T {
     fn set_executable_class_hash_v2(
         self,
         class_hash: &ClassHash,
         executable_class_hash_v2: CompiledClassHash,
     ) -> StorageResult<Self> {
-        let table = self.open_table(&self.tables.stateless_compiled_class_hash_v2)?;
-        table.upsert(&self.txn, class_hash, &executable_class_hash_v2)?;
+        let table = self.open_table(&self.tables().stateless_compiled_class_hash_v2)?;
+        table.upsert(self.txn(), class_hash, &executable_class_hash_v2)?;
         Ok(self)
     }
 }

--- a/crates/apollo_storage/src/class_manager.rs
+++ b/crates/apollo_storage/src/class_manager.rs
@@ -6,8 +6,8 @@ mod class_manager_test;
 use starknet_api::block::BlockNumber;
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{MarkerKind, StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{MarkerKind, StorageResult, StorageTransaction};
 
 /// Interface for reading data related to the class manager.
 pub trait ClassManagerStorageReader {
@@ -45,24 +45,24 @@ where
     ) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> ClassManagerStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> ClassManagerStorageReader for T {
     fn get_class_manager_block_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::ClassManagerBlock)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::ClassManagerBlock)?.unwrap_or_default())
     }
 
     fn get_compiler_backward_compatibility_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
         Ok(markers_table
-            .get(&self.txn, &MarkerKind::CompilerBackwardCompatibility)?
+            .get(self.txn(), &MarkerKind::CompilerBackwardCompatibility)?
             .unwrap_or_default())
     }
 }
 
-impl ClassManagerStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> ClassManagerStorageWriter for T {
     fn update_class_manager_block_marker(self, block_number: &BlockNumber) -> StorageResult<Self> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        markers_table.upsert(&self.txn, &MarkerKind::ClassManagerBlock, block_number)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        markers_table.upsert(self.txn(), &MarkerKind::ClassManagerBlock, block_number)?;
         Ok(self)
     }
 
@@ -82,9 +82,9 @@ impl ClassManagerStorageWriter for StorageTxn<'_, RW> {
         self,
         block_number: &BlockNumber,
     ) -> StorageResult<Self> {
-        let markers_table = self.open_table(&self.tables.markers)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
         markers_table.upsert(
-            &self.txn,
+            self.txn(),
             &MarkerKind::CompilerBackwardCompatibility,
             block_number,
         )?;

--- a/crates/apollo_storage/src/compiled_class.rs
+++ b/crates/apollo_storage/src/compiled_class.rs
@@ -2,7 +2,7 @@
 //!
 //! The compiled class is the result of compiling a Cairo program.
 //! Import [`CasmStorageReader`] and [`CasmStorageWriter`] to read and write data related to the
-//! compiled classes using a [`StorageTxn`].
+//! compiled classes using a `StorageTxn`.
 //! # Example
 //! ```
 //! use apollo_storage::open_storage;
@@ -56,9 +56,16 @@ use starknet_api::state::SierraContractClass;
 use crate::class::ClassStorageReader;
 use crate::db::serialization::VersionZeroWrapper;
 use crate::db::table_types::{SimpleTable, Table};
-use crate::db::{DbTransaction, TableHandle, TransactionKind, RW};
+use crate::db::{DbTransaction, TableHandle, RW};
 use crate::mmap_file::LocationInFile;
-use crate::{FileHandlers, MarkerKind, MarkersTable, OffsetKind, StorageResult, StorageTxn};
+use crate::{
+    FileHandlers,
+    MarkerKind,
+    MarkersTable,
+    OffsetKind,
+    StorageResult,
+    StorageTransaction,
+};
 
 /// Interface for reading data related to the compiled classes.
 pub trait CasmStorageReader {
@@ -104,7 +111,7 @@ where
     fn append_casm(self, class_hash: &ClassHash, casm: &CasmContractClass) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> CasmStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> CasmStorageReader for T {
     fn get_casm(&self, class_hash: &ClassHash) -> StorageResult<Option<CasmContractClass>> {
         let casm_location = self.get_casm_location(class_hash)?;
         casm_location.map(|location| self.get_casm_from_location(location)).transpose()
@@ -118,13 +125,13 @@ impl<Mode: TransactionKind> CasmStorageReader for StorageTxn<'_, Mode> {
     }
 
     fn get_casm_location(&self, class_hash: &ClassHash) -> StorageResult<Option<LocationInFile>> {
-        let casm_table = self.open_table(&self.tables.casms)?;
-        let casm_location = casm_table.get(&self.txn, class_hash)?;
+        let casm_table = self.open_table(&self.tables().casms)?;
+        let casm_location = casm_table.get(self.txn(), class_hash)?;
         Ok(casm_location)
     }
 
     fn get_casm_from_location(&self, location: LocationInFile) -> StorageResult<CasmContractClass> {
-        self.file_handlers.get_casm_unchecked(location)
+        self.file_handlers().get_casm_unchecked(location)
     }
 
     fn get_compiled_class_hash(
@@ -132,32 +139,32 @@ impl<Mode: TransactionKind> CasmStorageReader for StorageTxn<'_, Mode> {
         class_hash: ClassHash,
         block_number: BlockNumber,
     ) -> StorageResult<Option<CompiledClassHash>> {
-        let compiled_class_hash_table = self.open_table(&self.tables.compiled_class_hash)?;
-        Ok(compiled_class_hash_table.get(&self.txn, &(class_hash, block_number))?)
+        let compiled_class_hash_table = self.open_table(&self.tables().compiled_class_hash)?;
+        Ok(compiled_class_hash_table.get(self.txn(), &(class_hash, block_number))?)
     }
 
     fn get_compiled_class_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::CompiledClass)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::CompiledClass)?.unwrap_or_default())
     }
 }
 
-impl CasmStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> CasmStorageWriter for T {
     #[latency_histogram("storage_append_casm_latency_seconds", false)]
     fn append_casm(self, class_hash: &ClassHash, casm: &CasmContractClass) -> StorageResult<Self> {
-        let casm_table = self.open_table(&self.tables.casms)?;
-        let markers_table = self.open_table(&self.tables.markers)?;
-        let state_diff_table = self.open_table(&self.tables.state_diffs)?;
-        let file_offset_table = self.txn.open_table(&self.tables.file_offsets)?;
+        let casm_table = self.open_table(&self.tables().casms)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        let state_diff_table = self.open_table(&self.tables().state_diffs)?;
+        let file_offset_table = self.txn().open_table(&self.tables().file_offsets)?;
 
-        let location = self.file_handlers.append_casm(casm);
-        casm_table.insert(&self.txn, class_hash, &location)?;
-        file_offset_table.upsert(&self.txn, &OffsetKind::Casm, &location.next_offset())?;
+        let location = self.file_handlers().append_casm(casm);
+        casm_table.insert(self.txn(), class_hash, &location)?;
+        file_offset_table.upsert(self.txn(), &OffsetKind::Casm, &location.next_offset())?;
         update_marker(
-            &self.txn,
+            self.txn(),
             &markers_table,
             &state_diff_table,
-            self.file_handlers.clone(),
+            self.file_handlers(),
             class_hash,
         )?;
         Ok(self)
@@ -173,7 +180,7 @@ fn update_marker<'env>(
         VersionZeroWrapper<LocationInFile>,
         SimpleTable,
     >,
-    file_handlers: FileHandlers<RW>,
+    file_handlers: &FileHandlers<RW>,
     class_hash: &ClassHash,
 ) -> StorageResult<()> {
     // The marker needs to update if we reached the last class from the state diff. We can continue

--- a/crates/apollo_storage/src/consensus.rs
+++ b/crates/apollo_storage/src/consensus.rs
@@ -39,8 +39,8 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{StorageResult, StorageTransaction};
 
 /// Information about the last vote sent out by consensus.
 #[derive(Debug, Clone, Eq, PartialEq, Copy, PartialOrd, Ord, Serialize, Deserialize)]
@@ -65,23 +65,23 @@ where
     fn clear_last_voted_marker(self) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> ConsensusStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> ConsensusStorageReader for T {
     fn get_last_voted_marker(&self) -> StorageResult<Option<LastVotedMarker>> {
-        let table = self.open_table(&self.tables.last_voted_marker)?;
-        Ok(table.get(&self.txn, &())?)
+        let table = self.open_table(&self.tables().last_voted_marker)?;
+        Ok(table.get(self.txn(), &())?)
     }
 }
 
-impl ConsensusStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> ConsensusStorageWriter for T {
     fn set_last_voted_marker(self, last_voted_marker: &LastVotedMarker) -> StorageResult<Self> {
-        let table = self.open_table(&self.tables.last_voted_marker)?;
-        table.upsert(&self.txn, &(), last_voted_marker)?;
+        let table = self.open_table(&self.tables().last_voted_marker)?;
+        table.upsert(self.txn(), &(), last_voted_marker)?;
         Ok(self)
     }
 
     fn clear_last_voted_marker(self) -> StorageResult<Self> {
-        let table = self.open_table(&self.tables.last_voted_marker)?;
-        table.delete(&self.txn, &())?;
+        let table = self.open_table(&self.tables().last_voted_marker)?;
+        table.delete(self.txn(), &())?;
         Ok(self)
     }
 }

--- a/crates/apollo_storage/src/db/db_test.rs
+++ b/crates/apollo_storage/src/db/db_test.rs
@@ -74,24 +74,24 @@ fn txns_scenarios() {
     let table = txn0.open_table(&table_id).unwrap();
 
     // Insert a value.
-    let wtxn = writer.begin_rw_txn().unwrap();
-    table.insert(&wtxn, b"key", b"data0").unwrap();
+    let wtxn = writer.begin_persistent_rw_txn().unwrap();
+    table.insert(wtxn.txn(), b"key", b"data0").unwrap();
     wtxn.commit().unwrap();
 
     // Snapshot state by creating a read txn.
     let txn1 = reader.begin_ro_txn().unwrap();
 
     // Update the value.
-    let wtxn = writer.begin_rw_txn().unwrap();
-    table.upsert(&wtxn, b"key", b"data1").unwrap();
+    let wtxn = writer.begin_persistent_rw_txn().unwrap();
+    table.upsert(wtxn.txn(), b"key", b"data1").unwrap();
     wtxn.commit().unwrap();
 
     // Snapshot state by creating a read txn.
     let txn2 = reader.begin_ro_txn().unwrap();
 
     // Delete the value.
-    let wtxn2 = writer.begin_rw_txn().unwrap();
-    table.delete(&wtxn2, b"key").unwrap();
+    let wtxn2 = writer.begin_persistent_rw_txn().unwrap();
+    table.delete(wtxn2.txn(), b"key").unwrap();
     wtxn2.commit().unwrap();
 
     // Snapshot state by creating a read txn.
@@ -121,9 +121,9 @@ fn table_stats() {
     assert_eq!(empty_stat.leaf_pages, 0);
 
     // Insert a value.
-    let wtxn = writer.begin_rw_txn().unwrap();
-    let table = wtxn.open_table(&table_id).unwrap();
-    table.insert(&wtxn, b"key", b"data0").unwrap();
+    let wtxn = writer.begin_persistent_rw_txn().unwrap();
+    let table = wtxn.txn().open_table(&table_id).unwrap();
+    table.insert(wtxn.txn(), b"key", b"data0").unwrap();
     wtxn.commit().unwrap();
 
     // Non-empty table stats.
@@ -135,9 +135,9 @@ fn table_stats() {
     assert_eq!(empty_stat.leaf_pages, 1);
 
     // Delete the value.
-    let wtxn = writer.begin_rw_txn().unwrap();
-    let table = wtxn.open_table(&table_id).unwrap();
-    table.delete(&wtxn, b"key").unwrap();
+    let wtxn = writer.begin_persistent_rw_txn().unwrap();
+    let table = wtxn.txn().open_table(&table_id).unwrap();
+    table.delete(wtxn.txn(), b"key").unwrap();
     wtxn.commit().unwrap();
 
     // Empty table stats.
@@ -181,10 +181,10 @@ fn test_iter() {
         (*b"key3", *b"val3"),
         (*b"key5", *b"val5"),
     ];
-    let wtxn = writer.begin_rw_txn().unwrap();
-    let table = wtxn.open_table(&table_id).unwrap();
+    let wtxn = writer.begin_persistent_rw_txn().unwrap();
+    let table = wtxn.txn().open_table(&table_id).unwrap();
     for (k, v) in &items {
-        table.insert(&wtxn, k, v).unwrap();
+        table.insert(wtxn.txn(), k, v).unwrap();
     }
     wtxn.commit().unwrap();
 
@@ -215,10 +215,10 @@ fn with_version_zero_serialization() {
         (*b"key3", *b"val3"),
         (*b"key5", *b"val5"),
     ];
-    let wtxn = writer.begin_rw_txn().unwrap();
-    let table = wtxn.open_table(&table_id).unwrap();
+    let wtxn = writer.begin_persistent_rw_txn().unwrap();
+    let table = wtxn.txn().open_table(&table_id).unwrap();
     for (k, v) in &items {
-        table.insert(&wtxn, k, v).unwrap();
+        table.insert(wtxn.txn(), k, v).unwrap();
     }
     wtxn.commit().unwrap();
 
@@ -327,9 +327,9 @@ fn version_migration() {
     let expected_v0 = V0::default();
     // Insert a V0 entry into a table.
     {
-        let txn = writer.begin_rw_txn().unwrap();
-        let v0_table = txn.open_table(&v0_table_id).unwrap();
-        v0_table.insert(&txn, &key0, &expected_v0).unwrap();
+        let txn = writer.begin_persistent_rw_txn().unwrap();
+        let v0_table = txn.txn().open_table(&v0_table_id).unwrap();
+        v0_table.insert(txn.txn(), &key0, &expected_v0).unwrap();
         txn.commit().unwrap();
     }
     // Verify that the entry is present in the table.
@@ -346,9 +346,9 @@ fn version_migration() {
     let key1 = Key { k: 1 };
     let expected_v1 = V1::default();
     {
-        let txn = writer.begin_rw_txn().unwrap();
-        let v1_table = txn.open_table(&v1_table_id).unwrap();
-        v1_table.insert(&txn, &key1, &expected_v1).unwrap();
+        let txn = writer.begin_persistent_rw_txn().unwrap();
+        let v1_table = txn.txn().open_table(&v1_table_id).unwrap();
+        v1_table.insert(txn.txn(), &key1, &expected_v1).unwrap();
         txn.commit().unwrap();
     }
 

--- a/crates/apollo_storage/src/db/mod.rs
+++ b/crates/apollo_storage/src/db/mod.rs
@@ -265,10 +265,6 @@ impl DbReader {
 type DbReadTransaction<'env> = DbTransaction<'env, RO>;
 
 impl DbWriter {
-    pub(crate) fn begin_rw_txn(&mut self) -> DbResult<DbWriteTransaction<'_>> {
-        Ok(DbWriteTransaction { txn: self.env.begin_rw_txn()? })
-    }
-
     /// Creates a persistent write transaction that can be stored in structs without lifetime
     /// constraints.
     ///
@@ -285,7 +281,6 @@ impl DbWriter {
     /// enforced at a higher level — `DbWriter` lives inside `SharedState` which is wrapped in a
     /// `Mutex`. Only one caller can hold the `MutexGuard` at a time, so only one persistent
     /// transaction can be created at a time.
-    #[allow(dead_code)]
     pub(crate) fn begin_persistent_rw_txn(&self) -> DbResult<OwnedDbWriteTransaction> {
         let env = self.env.clone();
         let db_txn = DbWriteTransaction { txn: env.begin_rw_txn()? };
@@ -311,7 +306,6 @@ pub(crate) type DbWriteTransaction<'env> = DbTransaction<'env, RW>;
 /// Drop order:
 /// Fields are dropped in declaration order: `txn` is dropped before `env`.
 /// This ensures the transaction is properly closed before the Arc reference count is decremented.
-#[allow(dead_code)]
 pub(crate) struct OwnedDbWriteTransaction {
     // Private to prevent partial moves that would drop `env` while `txn` (carrying a transmuted
     // 'static lifetime) is still live, violating the safety invariant that `env` outlives `txn`.
@@ -319,9 +313,11 @@ pub(crate) struct OwnedDbWriteTransaction {
     // Keep the Arc alive to ensure the environment isn't dropped while the transaction exists.
     // This must be declared after `txn` to ensure correct drop order.
     _env: Arc<Environment>,
+    // TODO(Dean): Make this type !Send + !Sync to prevent crossing thread boundaries once we
+    // finalize the batching architecture. MDBX transactions are not thread-safe and should not
+    // be sent between threads. Add: _not_send_sync: PhantomData<Rc<()>>
 }
 
-#[allow(dead_code)]
 impl OwnedDbWriteTransaction {
     /// Returns a reference to the underlying write transaction.
     pub(crate) fn txn(&self) -> &DbWriteTransaction<'_> {

--- a/crates/apollo_storage/src/db/table_types/dup_sort_tables_test.rs
+++ b/crates/apollo_storage/src/db/table_types/dup_sort_tables_test.rs
@@ -40,40 +40,40 @@ fn append_greater_sub_key_test<T>(
     let ((_reader, mut writer), _temp_dir) = get_test_env();
     let table_id = create_table(&mut writer, "table").unwrap();
 
-    let txn = writer.begin_rw_txn().unwrap();
+    let txn = writer.begin_persistent_rw_txn().unwrap();
 
-    let handle = txn.open_table(&table_id).unwrap();
-    handle.append_greater_sub_key(&txn, &(2, 2), &22).unwrap();
-    handle.append_greater_sub_key(&txn, &(2, 3), &23).unwrap();
-    handle.append_greater_sub_key(&txn, &(1, 1), &11).unwrap();
-    handle.append_greater_sub_key(&txn, &(3, 0), &30).unwrap();
+    let handle = txn.txn().open_table(&table_id).unwrap();
+    handle.append_greater_sub_key(txn.txn(), &(2, 2), &22).unwrap();
+    handle.append_greater_sub_key(txn.txn(), &(2, 3), &23).unwrap();
+    handle.append_greater_sub_key(txn.txn(), &(1, 1), &11).unwrap();
+    handle.append_greater_sub_key(txn.txn(), &(3, 0), &30).unwrap();
 
     // For DupSort tables append with key that already exists should fail. Try append with smaller
     // bigger and equal values.
-    let result = handle.append_greater_sub_key(&txn, &(2, 2), &0);
+    let result = handle.append_greater_sub_key(txn.txn(), &(2, 2), &0);
     assert_matches!(result, Err(DbError::Append));
 
-    let result = handle.append_greater_sub_key(&txn, &(2, 2), &22);
+    let result = handle.append_greater_sub_key(txn.txn(), &(2, 2), &22);
     assert_matches!(result, Err(DbError::Append));
 
-    let result = handle.append_greater_sub_key(&txn, &(2, 2), &100);
+    let result = handle.append_greater_sub_key(txn.txn(), &(2, 2), &100);
     assert_matches!(result, Err(DbError::Append));
 
     // As before, but for the last main key.
-    let result = handle.append_greater_sub_key(&txn, &(3, 0), &0);
+    let result = handle.append_greater_sub_key(txn.txn(), &(3, 0), &0);
     assert_matches!(result, Err(DbError::Append));
 
-    let result = handle.append_greater_sub_key(&txn, &(3, 0), &30);
+    let result = handle.append_greater_sub_key(txn.txn(), &(3, 0), &30);
     assert_matches!(result, Err(DbError::Append));
 
-    let result = handle.append_greater_sub_key(&txn, &(3, 0), &100);
+    let result = handle.append_greater_sub_key(txn.txn(), &(3, 0), &100);
     assert_matches!(result, Err(DbError::Append));
 
     // Check the final database.
-    assert_eq!(handle.get(&txn, &(2, 2)).unwrap(), Some(22));
-    assert_eq!(handle.get(&txn, &(2, 3)).unwrap(), Some(23));
-    assert_eq!(handle.get(&txn, &(1, 1)).unwrap(), Some(11));
-    assert_eq!(handle.get(&txn, &(3, 0)).unwrap(), Some(30));
+    assert_eq!(handle.get(txn.txn(), &(2, 2)).unwrap(), Some(22));
+    assert_eq!(handle.get(txn.txn(), &(2, 3)).unwrap(), Some(23));
+    assert_eq!(handle.get(txn.txn(), &(1, 1)).unwrap(), Some(11));
+    assert_eq!(handle.get(txn.txn(), &(3, 0)).unwrap(), Some(30));
 }
 
 #[test]

--- a/crates/apollo_storage/src/db/table_types/test_utils.rs
+++ b/crates/apollo_storage/src/db/table_types/test_utils.rs
@@ -59,15 +59,15 @@ where
     for<'env> TableHandle<'env, TableKey, TableValue, T>:
         Table<'env, Key = TableKey, Value = TableValue>,
 {
-    let txn = writer.begin_rw_txn().unwrap();
-    let table = txn.open_table(&table_id).unwrap();
+    let txn = writer.begin_persistent_rw_txn().unwrap();
+    let table = txn.txn().open_table(&table_id).unwrap();
 
     // Read does not exist value.
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), None);
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), None);
 
     // Insert and read a value.
-    table.insert(&txn, &(1, 1), &11).unwrap();
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(11));
+    table.insert(txn.txn(), &(1, 1), &11).unwrap();
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(11));
 }
 
 fn insert_test<T: TableType>(
@@ -77,21 +77,24 @@ fn insert_test<T: TableType>(
     for<'env> TableHandle<'env, TableKey, TableValue, T>:
         Table<'env, Key = TableKey, Value = TableValue>,
 {
-    let txn = writer.begin_rw_txn().unwrap();
-    let table = txn.open_table(&table_id).unwrap();
+    let txn = writer.begin_persistent_rw_txn().unwrap();
+    let table = txn.txn().open_table(&table_id).unwrap();
 
     // Insert values.
-    table.insert(&txn, &(1, 2), &12).unwrap();
-    table.insert(&txn, &(2, 1), &21).unwrap();
-    table.insert(&txn, &(1, 1), &11).unwrap();
+    table.insert(txn.txn(), &(1, 2), &12).unwrap();
+    table.insert(txn.txn(), &(2, 1), &21).unwrap();
+    table.insert(txn.txn(), &(1, 1), &11).unwrap();
 
-    assert_eq!(table.get(&txn, &(1, 2)).unwrap(), Some(12));
-    assert_eq!(table.get(&txn, &(2, 1)).unwrap(), Some(21));
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(11));
+    assert_eq!(table.get(txn.txn(), &(1, 2)).unwrap(), Some(12));
+    assert_eq!(table.get(txn.txn(), &(2, 1)).unwrap(), Some(21));
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(11));
 
     // Insert duplicate key.
     assert_eq!(
-        table.insert(&txn, &(1, 1), &0).expect_err("Expected KeyAlreadyExistsError").to_string(),
+        table
+            .insert(txn.txn(), &(1, 1), &0)
+            .expect_err("Expected KeyAlreadyExistsError")
+            .to_string(),
         format!(
             "Key '{key:?}' already exists in table '{table_name}'. Error when tried to insert \
              value '0'",
@@ -101,9 +104,9 @@ fn insert_test<T: TableType>(
     );
 
     // Check the final database.
-    assert_eq!(table.get(&txn, &(1, 2)).unwrap(), Some(12));
-    assert_eq!(table.get(&txn, &(2, 1)).unwrap(), Some(21));
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(11));
+    assert_eq!(table.get(txn.txn(), &(1, 2)).unwrap(), Some(12));
+    assert_eq!(table.get(txn.txn(), &(2, 1)).unwrap(), Some(21));
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(11));
 }
 
 fn upsert_test<T: TableType>(
@@ -113,16 +116,16 @@ fn upsert_test<T: TableType>(
     for<'env> TableHandle<'env, TableKey, TableValue, T>:
         Table<'env, Key = TableKey, Value = TableValue>,
 {
-    let txn = writer.begin_rw_txn().unwrap();
-    let table = txn.open_table(&table_id).unwrap();
+    let txn = writer.begin_persistent_rw_txn().unwrap();
+    let table = txn.txn().open_table(&table_id).unwrap();
 
     // Upsert not existing key.
-    table.upsert(&txn, &(1, 1), &11).unwrap();
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(11));
+    table.upsert(txn.txn(), &(1, 1), &11).unwrap();
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(11));
 
     // (1,1) was already inserted, so this is an update.
-    table.upsert(&txn, &(1, 1), &0).unwrap();
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(0));
+    table.upsert(txn.txn(), &(1, 1), &0).unwrap();
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(0));
 }
 
 fn append_test<T: TableType>(
@@ -132,42 +135,42 @@ fn append_test<T: TableType>(
     for<'env> TableHandle<'env, TableKey, TableValue, T>:
         Table<'env, Key = TableKey, Value = TableValue>,
 {
-    let txn = writer.begin_rw_txn().unwrap();
-    let table = txn.open_table(&table_id).unwrap();
+    let txn = writer.begin_persistent_rw_txn().unwrap();
+    let table = txn.txn().open_table(&table_id).unwrap();
 
     // Append to an empty table.
-    table.append(&txn, &(1, 1), &11).unwrap();
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(11));
+    table.append(txn.txn(), &(1, 1), &11).unwrap();
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(11));
 
     // Successful appends.
-    table.append(&txn, &(1, 1), &0).unwrap();
-    table.append(&txn, &(1, 2), &12).unwrap();
-    table.append(&txn, &(2, 0), &20).unwrap();
-    table.append(&txn, &(2, 2), &22).unwrap();
+    table.append(txn.txn(), &(1, 1), &0).unwrap();
+    table.append(txn.txn(), &(1, 2), &12).unwrap();
+    table.append(txn.txn(), &(2, 0), &20).unwrap();
+    table.append(txn.txn(), &(2, 2), &22).unwrap();
 
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(0));
-    assert_eq!(table.get(&txn, &(1, 2)).unwrap(), Some(12));
-    assert_eq!(table.get(&txn, &(2, 0)).unwrap(), Some(20));
-    assert_eq!(table.get(&txn, &(2, 2)).unwrap(), Some(22));
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(0));
+    assert_eq!(table.get(txn.txn(), &(1, 2)).unwrap(), Some(12));
+    assert_eq!(table.get(txn.txn(), &(2, 0)).unwrap(), Some(20));
+    assert_eq!(table.get(txn.txn(), &(2, 2)).unwrap(), Some(22));
 
     // Override the last key with a smaller value.
-    table.append(&txn, &(2, 2), &0).unwrap();
-    assert_eq!(table.get(&txn, &(2, 2)).unwrap(), Some(0));
+    table.append(txn.txn(), &(2, 2), &0).unwrap();
+    assert_eq!(table.get(txn.txn(), &(2, 2)).unwrap(), Some(0));
 
     // Override the last key with a bigger value.
-    table.append(&txn, &(2, 2), &100).unwrap();
-    assert_eq!(table.get(&txn, &(2, 2)).unwrap(), Some(100));
+    table.append(txn.txn(), &(2, 2), &100).unwrap();
+    assert_eq!(table.get(txn.txn(), &(2, 2)).unwrap(), Some(100));
 
     // Append key that is not the last, should fail.
-    assert_matches!(table.append(&txn, &(0, 0), &0), Err(DbError::Append));
-    assert_matches!(table.append(&txn, &(1, 3), &0), Err(DbError::Append));
-    assert_matches!(table.append(&txn, &(2, 1), &0), Err(DbError::Append));
+    assert_matches!(table.append(txn.txn(), &(0, 0), &0), Err(DbError::Append));
+    assert_matches!(table.append(txn.txn(), &(1, 3), &0), Err(DbError::Append));
+    assert_matches!(table.append(txn.txn(), &(2, 1), &0), Err(DbError::Append));
 
     // Check the final database.
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(0));
-    assert_eq!(table.get(&txn, &(1, 2)).unwrap(), Some(12));
-    assert_eq!(table.get(&txn, &(2, 0)).unwrap(), Some(20));
-    assert_eq!(table.get(&txn, &(2, 2)).unwrap(), Some(100));
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(0));
+    assert_eq!(table.get(txn.txn(), &(1, 2)).unwrap(), Some(12));
+    assert_eq!(table.get(txn.txn(), &(2, 0)).unwrap(), Some(20));
+    assert_eq!(table.get(txn.txn(), &(2, 2)).unwrap(), Some(100));
 }
 
 fn delete_test<T: TableType>(
@@ -177,18 +180,18 @@ fn delete_test<T: TableType>(
     for<'env> TableHandle<'env, TableKey, TableValue, T>:
         Table<'env, Key = TableKey, Value = TableValue>,
 {
-    let txn = writer.begin_rw_txn().unwrap();
-    let table = txn.open_table(&table_id).unwrap();
+    let txn = writer.begin_persistent_rw_txn().unwrap();
+    let table = txn.txn().open_table(&table_id).unwrap();
 
-    table.insert(&txn, &(1, 1), &11).unwrap();
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), Some(11));
+    table.insert(txn.txn(), &(1, 1), &11).unwrap();
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), Some(11));
 
-    table.delete(&txn, &(1, 1)).unwrap();
+    table.delete(txn.txn(), &(1, 1)).unwrap();
     // Delete non-existent value.
-    table.delete(&txn, &(2, 2)).unwrap();
+    table.delete(txn.txn(), &(2, 2)).unwrap();
 
-    assert_eq!(table.get(&txn, &(1, 1)).unwrap(), None);
-    assert_eq!(table.get(&txn, &(2, 2)).unwrap(), None);
+    assert_eq!(table.get(txn.txn(), &(1, 1)).unwrap(), None);
+    assert_eq!(table.get(txn.txn(), &(2, 2)).unwrap(), None);
 }
 
 fn table_cursor_test<T: TableType>(
@@ -224,16 +227,16 @@ fn table_cursor_test<T: TableType>(
         ((3, 3), 4),
     ];
 
-    let txn = writer.begin_rw_txn().unwrap();
-    let table = txn.open_table(&table_id).unwrap();
+    let txn = writer.begin_persistent_rw_txn().unwrap();
+    let table = txn.txn().open_table(&table_id).unwrap();
 
     // Insert the values to the table.
     for (k, v) in &VALUES {
-        table.insert(&txn, k, v).unwrap();
+        table.insert(txn.txn(), k, v).unwrap();
     }
 
     // Test lower_bound().
-    let mut cursor = table.cursor(&txn).unwrap();
+    let mut cursor = table.cursor(txn.txn()).unwrap();
     let current_entry = cursor.lower_bound(&(0, 0)).unwrap();
     assert_eq!(current_entry, Some(((1, 1), 7)));
     let current_entry = cursor.lower_bound(&(2, 2)).unwrap();
@@ -244,7 +247,7 @@ fn table_cursor_test<T: TableType>(
     assert_eq!(current_entry, None);
 
     // Iterate using next().
-    let mut cursor = table.cursor(&txn).unwrap();
+    let mut cursor = table.cursor(txn.txn()).unwrap();
     let mut current_entry = cursor.lower_bound(&(0, 0)).unwrap();
     for kv_pair in SORTED_VALUES {
         assert_eq!(current_entry, Some(kv_pair));
@@ -257,7 +260,7 @@ fn table_cursor_test<T: TableType>(
     assert_eq!(current_entry, None);
 
     // Iterate using prev().
-    let mut cursor = table.cursor(&txn).unwrap();
+    let mut cursor = table.cursor(txn.txn()).unwrap();
     let mut current_entry = cursor.lower_bound(&(4, 4)).unwrap();
     assert_eq!(current_entry, None);
     for kv_pair in SORTED_VALUES.iter().rev().cloned() {
@@ -309,7 +312,7 @@ pub(crate) fn random_table_test<T0: TableType, T1: TableType>(
 
     for iter in 0..ITERS {
         debug!("iteration: {iter:?}");
-        let wtxn = writer.begin_rw_txn().unwrap();
+        let wtxn = writer.begin_persistent_rw_txn().unwrap();
         let random_op = rng.gen_range(0..4);
         let key = get_random_key(&mut rng);
         let value = rng.gen_range(0..MAX_VALUE);
@@ -318,8 +321,8 @@ pub(crate) fn random_table_test<T0: TableType, T1: TableType>(
         if random_op == 0 {
             // Insert
             debug!("insert: {key:?}, {value:?}");
-            let first_res = first_table.insert(&wtxn, &key, &value);
-            let second_res = second_table.insert(&wtxn, &key, &value);
+            let first_res = first_table.insert(wtxn.txn(), &key, &value);
+            let second_res = second_table.insert(wtxn.txn(), &key, &value);
             assert!(
                 (first_res.is_ok() && second_res.is_ok())
                     || (matches!(first_res.unwrap_err(), DbError::KeyAlreadyExists(..))
@@ -328,15 +331,15 @@ pub(crate) fn random_table_test<T0: TableType, T1: TableType>(
         } else if random_op == 1 {
             // Upsert
             debug!("upsert: {key:?}, {value:?}");
-            first_table.upsert(&wtxn, &key, &value).unwrap();
-            second_table.upsert(&wtxn, &key, &value).unwrap();
+            first_table.upsert(wtxn.txn(), &key, &value).unwrap();
+            second_table.upsert(wtxn.txn(), &key, &value).unwrap();
         } else if random_op == 2 {
             // Append
             // TODO(dvir): consider increasing the number of successful appends (append of not the
             // last entry will fail).
             debug!("append: {key:?}, {value:?}");
-            let first_res = first_table.append(&wtxn, &key, &value);
-            let second_res = second_table.append(&wtxn, &key, &value);
+            let first_res = first_table.append(wtxn.txn(), &key, &value);
+            let second_res = second_table.append(wtxn.txn(), &key, &value);
             assert!(
                 (first_res.is_ok() && second_res.is_ok())
                     || (matches!(first_res.unwrap_err(), DbError::Append)
@@ -345,8 +348,8 @@ pub(crate) fn random_table_test<T0: TableType, T1: TableType>(
         } else if random_op == 3 {
             // Delete
             debug!("delete: {key:?}");
-            first_table.delete(&wtxn, &key).unwrap();
-            second_table.delete(&wtxn, &key).unwrap();
+            first_table.delete(wtxn.txn(), &key).unwrap();
+            second_table.delete(wtxn.txn(), &key).unwrap();
         }
 
         wtxn.commit().unwrap();

--- a/crates/apollo_storage/src/global_root.rs
+++ b/crates/apollo_storage/src/global_root.rs
@@ -1,13 +1,13 @@
 //! Interface for handling global root.
 //! Import [`GlobalRootStorageReader`] and [`GlobalRootStorageWriter`] to read and write
-//! data related to global root using a [`StorageTxn`].
+//! data related to global root using a `StorageTxn`.
 
 use starknet_api::block::BlockNumber;
 use starknet_api::core::GlobalRoot;
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{MarkerKind, StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{MarkerKind, StorageResult, StorageTransaction};
 
 /// Interface for reading global root.
 pub trait GlobalRootStorageReader {
@@ -33,29 +33,29 @@ where
     fn revert_global_root(self, block_number: &BlockNumber) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> GlobalRootStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> GlobalRootStorageReader for T {
     fn get_global_root(&self, block_number: &BlockNumber) -> StorageResult<Option<GlobalRoot>> {
-        let table = self.open_table(&self.tables.global_root)?;
-        Ok(table.get(&self.txn, block_number)?)
+        let table = self.open_table(&self.tables().global_root)?;
+        Ok(table.get(self.txn(), block_number)?)
     }
 }
 
-impl GlobalRootStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> GlobalRootStorageWriter for T {
     fn set_global_root(
         self,
         block_number: &BlockNumber,
         global_root: GlobalRoot,
     ) -> StorageResult<Self> {
-        let table = self.open_table(&self.tables.global_root)?;
-        table.upsert(&self.txn, block_number, &global_root)?;
+        let table = self.open_table(&self.tables().global_root)?;
+        table.upsert(self.txn(), block_number, &global_root)?;
         Ok(self)
     }
 
     fn revert_global_root(self, target_block_number: &BlockNumber) -> StorageResult<Self> {
-        let global_roots_table = self.open_table(&self.tables.global_root)?;
-        global_roots_table.delete(&self.txn, target_block_number)?;
-        let markers_table = self.open_table(&self.tables.markers)?;
-        markers_table.upsert(&self.txn, &MarkerKind::GlobalRoot, target_block_number)?;
+        let global_roots_table = self.open_table(&self.tables().global_root)?;
+        global_roots_table.delete(self.txn(), target_block_number)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        markers_table.upsert(self.txn(), &MarkerKind::GlobalRoot, target_block_number)?;
         Ok(self)
     }
 }

--- a/crates/apollo_storage/src/global_root_marker.rs
+++ b/crates/apollo_storage/src/global_root_marker.rs
@@ -1,13 +1,13 @@
 //! Interface for handling global root markers.
 //! The global root marker is the highest block number for which the global root is stored.
 //! Import [`GlobalRootMarkerStorageReader`] and [`GlobalRootMarkerStorageWriter`] to
-//! read and write data related to global root markers using a [`StorageTxn`].
+//! read and write data related to global root markers using a `StorageTxn`.
 
 use starknet_api::block::BlockNumber;
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{MarkerKind, StorageError, StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{MarkerKind, StorageError, StorageResult, StorageTransaction};
 
 /// Interface for reading global root markers.
 pub trait GlobalRootMarkerStorageReader {
@@ -28,14 +28,14 @@ where
     ) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> GlobalRootMarkerStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> GlobalRootMarkerStorageReader for T {
     fn get_global_root_marker(&self) -> StorageResult<BlockNumber> {
-        let table = self.open_table(&self.tables.markers)?;
-        Ok(table.get(&self.txn, &MarkerKind::GlobalRoot)?.unwrap_or_default())
+        let table = self.open_table(&self.tables().markers)?;
+        Ok(table.get(self.txn(), &MarkerKind::GlobalRoot)?.unwrap_or_default())
     }
 }
 
-impl GlobalRootMarkerStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> GlobalRootMarkerStorageWriter for T {
     fn checked_increment_global_root_marker(
         self,
         expected_marker: BlockNumber,
@@ -47,9 +47,9 @@ impl GlobalRootMarkerStorageWriter for StorageTxn<'_, RW> {
                 expected: expected_marker,
             });
         }
-        let markers_table = self.open_table(&self.tables.markers)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
         markers_table.upsert(
-            &self.txn,
+            self.txn(),
             &MarkerKind::GlobalRoot,
             &current_marker.unchecked_next(),
         )?;

--- a/crates/apollo_storage/src/header.rs
+++ b/crates/apollo_storage/src/header.rs
@@ -2,7 +2,7 @@
 //!
 //! The block header is the part of the block that contains metadata about the block.
 //! Import [`HeaderStorageReader`] and [`HeaderStorageWriter`] to read and write data related
-//! to the block headers using a [`StorageTxn`].
+//! to the block headers using a `StorageTxn`.
 //! # Example
 //! ```
 //! use apollo_storage::open_storage;
@@ -65,8 +65,8 @@ use tracing::debug;
 
 use crate::db::serialization::NoVersionValueWrapper;
 use crate::db::table_types::{DbCursorTrait, SimpleTable, Table};
-use crate::db::{DbTransaction, TableHandle, TransactionKind, RW};
-use crate::{MarkerKind, MarkersTable, StorageError, StorageResult, StorageTxn};
+use crate::db::{DbTransaction, TableHandle, RW};
+use crate::{MarkerKind, MarkersTable, StorageError, StorageResult, StorageTransaction};
 
 /// Storage representation of a Starknet block header.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
@@ -189,18 +189,18 @@ where
     ) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> HeaderStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> HeaderStorageReader for T {
     fn get_header_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::Header)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::Header)?.unwrap_or_default())
     }
 
     fn get_storage_block_header(
         &self,
         block_number: &BlockNumber,
     ) -> StorageResult<Option<StorageBlockHeader>> {
-        let headers_table = self.open_table(&self.tables.headers)?;
-        Ok(headers_table.get(&self.txn, block_number)?)
+        let headers_table = self.open_table(&self.tables().headers)?;
+        Ok(headers_table.get(self.txn(), block_number)?)
     }
 
     fn get_block_header(&self, block_number: BlockNumber) -> StorageResult<Option<BlockHeader>> {
@@ -240,8 +240,8 @@ impl<Mode: TransactionKind> HeaderStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_hash: &BlockHash,
     ) -> StorageResult<Option<BlockNumber>> {
-        let block_hash_to_number_table = self.open_table(&self.tables.block_hash_to_number)?;
-        let block_number = block_hash_to_number_table.get(&self.txn, block_hash)?;
+        let block_hash_to_number_table = self.open_table(&self.tables().block_hash_to_number)?;
+        let block_number = block_hash_to_number_table.get(self.txn(), block_hash)?;
         Ok(block_number)
     }
 
@@ -254,8 +254,8 @@ impl<Mode: TransactionKind> HeaderStorageReader for StorageTxn<'_, Mode> {
             return Ok(None);
         }
 
-        let starknet_version_table = self.open_table(&self.tables.starknet_version)?;
-        let mut cursor = starknet_version_table.cursor(&self.txn)?;
+        let starknet_version_table = self.open_table(&self.tables().starknet_version)?;
+        let mut cursor = starknet_version_table.cursor(self.txn())?;
         let Some(next_block_number) = block_number.next() else {
             return Ok(None);
         };
@@ -275,8 +275,8 @@ impl<Mode: TransactionKind> HeaderStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<StarknetVersion>> {
-        let starknet_version_table = self.open_table(&self.tables.starknet_version)?;
-        let starknet_version = starknet_version_table.get(&self.txn, &block_number)?;
+        let starknet_version_table = self.open_table(&self.tables().starknet_version)?;
+        let starknet_version = starknet_version_table.get(self.txn(), &block_number)?;
         Ok(starknet_version)
     }
 
@@ -284,23 +284,23 @@ impl<Mode: TransactionKind> HeaderStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<BlockSignature>> {
-        let block_signatures_table = self.open_table(&self.tables.block_signatures)?;
-        let block_signature = block_signatures_table.get(&self.txn, &block_number)?;
+        let block_signatures_table = self.open_table(&self.tables().block_signatures)?;
+        let block_signature = block_signatures_table.get(self.txn(), &block_number)?;
         Ok(block_signature)
     }
 }
 
-impl HeaderStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> HeaderStorageWriter for T {
     fn append_header(
         self,
         block_number: BlockNumber,
         block_header: &BlockHeader,
     ) -> StorageResult<Self> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        let headers_table = self.open_table(&self.tables.headers)?;
-        let block_hash_to_number_table = self.open_table(&self.tables.block_hash_to_number)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        let headers_table = self.open_table(&self.tables().headers)?;
+        let block_hash_to_number_table = self.open_table(&self.tables().block_hash_to_number)?;
 
-        update_marker(&self.txn, &markers_table, block_number)?;
+        update_marker(self.txn(), &markers_table, block_number)?;
 
         let storage_block_header = StorageBlockHeader {
             block_hash: block_header.block_hash,
@@ -324,10 +324,10 @@ impl HeaderStorageWriter for StorageTxn<'_, RW> {
             n_events: block_header.n_events,
         };
 
-        headers_table.append(&self.txn, &block_number, &storage_block_header)?;
+        headers_table.append(self.txn(), &block_number, &storage_block_header)?;
 
         update_hash_mapping(
-            &self.txn,
+            self.txn(),
             &block_hash_to_number_table,
             &storage_block_header,
             block_number,
@@ -345,15 +345,15 @@ impl HeaderStorageWriter for StorageTxn<'_, RW> {
         block_number: &BlockNumber,
         starknet_version: &StarknetVersion,
     ) -> StorageResult<Self> {
-        let starknet_version_table = self.open_table(&self.tables.starknet_version)?;
-        let mut cursor = starknet_version_table.cursor(&self.txn)?;
+        let starknet_version_table = self.open_table(&self.tables().starknet_version)?;
+        let mut cursor = starknet_version_table.cursor(self.txn())?;
         cursor.lower_bound(block_number)?;
         let res = cursor.prev()?;
 
         match res {
             Some((_block_number, last_starknet_version))
                 if last_starknet_version == *starknet_version => {}
-            _ => starknet_version_table.insert(&self.txn, block_number, starknet_version)?,
+            _ => starknet_version_table.insert(self.txn(), block_number, starknet_version)?,
         }
         Ok(self)
     }
@@ -362,11 +362,11 @@ impl HeaderStorageWriter for StorageTxn<'_, RW> {
         self,
         block_number: BlockNumber,
     ) -> StorageResult<(Self, Option<BlockHeader>, Option<BlockSignature>)> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        let headers_table = self.open_table(&self.tables.headers)?;
-        let block_hash_to_number_table = self.open_table(&self.tables.block_hash_to_number)?;
-        let starknet_version_table = self.open_table(&self.tables.starknet_version)?;
-        let block_signatures_table = self.open_table(&self.tables.block_signatures)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        let headers_table = self.open_table(&self.tables().headers)?;
+        let block_hash_to_number_table = self.open_table(&self.tables().block_hash_to_number)?;
+        let starknet_version_table = self.open_table(&self.tables().starknet_version)?;
+        let block_signatures_table = self.open_table(&self.tables().block_signatures)?;
 
         // Assert that header marker equals the reverted block number + 1
         let current_header_marker = self.get_header_marker()?;
@@ -385,15 +385,15 @@ impl HeaderStorageWriter for StorageTxn<'_, RW> {
         };
 
         let reverted_header = headers_table
-            .get(&self.txn, &block_number)?
+            .get(self.txn(), &block_number)?
             .expect("Missing header for block {block_number}.");
-        markers_table.upsert(&self.txn, &MarkerKind::Header, &block_number)?;
-        headers_table.delete(&self.txn, &block_number)?;
-        block_hash_to_number_table.delete(&self.txn, &reverted_header.block_hash)?;
+        markers_table.upsert(self.txn(), &MarkerKind::Header, &block_number)?;
+        headers_table.delete(self.txn(), &block_number)?;
+        block_hash_to_number_table.delete(self.txn(), &reverted_header.block_hash)?;
 
         // Revert starknet version and get the version.
         // TODO(shahak): Fix code duplication with get_starknet_version.
-        let mut cursor = starknet_version_table.cursor(&self.txn)?;
+        let mut cursor = starknet_version_table.cursor(self.txn())?;
         cursor.lower_bound(&next_block_number)?;
         let res = cursor.prev()?;
 
@@ -404,12 +404,12 @@ impl HeaderStorageWriter for StorageTxn<'_, RW> {
                  have at least a single mapping."
             ),
         };
-        starknet_version_table.delete(&self.txn, &block_number)?;
+        starknet_version_table.delete(self.txn(), &block_number)?;
 
         // Revert block signature.
-        let reverted_block_signature = block_signatures_table.get(&self.txn, &block_number)?;
+        let reverted_block_signature = block_signatures_table.get(self.txn(), &block_number)?;
         if reverted_block_signature.is_some() {
-            block_signatures_table.delete(&self.txn, &block_number)?;
+            block_signatures_table.delete(self.txn(), &block_number)?;
         }
 
         Ok((
@@ -455,8 +455,8 @@ impl HeaderStorageWriter for StorageTxn<'_, RW> {
             });
         }
 
-        let block_signatures_table = self.open_table(&self.tables.block_signatures)?;
-        block_signatures_table.insert(&self.txn, &block_number, block_signature)?;
+        let block_signatures_table = self.open_table(&self.tables().block_signatures)?;
+        block_signatures_table.insert(self.txn(), &block_number, block_signature)?;
         Ok(self)
     }
 }

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -122,7 +122,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::fs;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use apollo_config::dumping::{prepend_sub_config_name, ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
@@ -165,6 +165,7 @@ use crate::db::{
     DbReader,
     DbTransaction,
     DbWriter,
+    OwnedDbWriteTransaction,
     TableHandle,
     TableIdentifier,
     TransactionKind,
@@ -271,28 +272,34 @@ fn open_storage_internal(
         &tables.file_offsets,
     )?;
 
+    // When batching is disabled, use batch_size=1 to get immediate commit behavior.
+    // This allows us to use the same code path for both batching and non-batching modes.
+    let batch_size = if storage_config.batch_config.enabled {
+        storage_config.batch_config.batch_size.get()
+    } else {
+        1
+    };
+
+    let shared_state = SharedState::new(db_writer, tables.clone(), batch_size);
+
     let reader = StorageReader {
         db_reader,
-        tables: tables.clone(),
         scope: storage_config.scope,
         file_readers,
+        tables,
         open_readers_metric,
     };
-    let writer = StorageWriter { db_writer, tables, scope: storage_config.scope, file_writers };
-
-    let writer = set_version_if_needed(reader.clone(), writer)?;
-    verify_storage_version(reader.clone())?;
+    let mut writer = StorageWriter::new(file_writers, storage_config.scope, shared_state);
+    set_version_if_needed(&mut writer)?;
+    verify_storage_version(&mut writer)?;
     Ok((reader, writer))
 }
 
 // In case storage version does not exist, set it to the crate version.
 // Expected to happen once - when the node is launched for the first time.
 // If the storage scope has changed, update accordingly.
-fn set_version_if_needed(
-    reader: StorageReader,
-    mut writer: StorageWriter,
-) -> StorageResult<StorageWriter> {
-    let Some(existing_storage_version) = get_storage_version(reader)? else {
+fn set_version_if_needed(writer: &mut StorageWriter) -> StorageResult<()> {
+    let Some(existing_storage_version) = get_storage_version(writer)? else {
         // Initialize the storage version.
         writer.begin_rw_txn()?.set_state_version(&STORAGE_VERSION_STATE)?.commit()?;
         // If in full-archive mode, also set the block version.
@@ -303,7 +310,7 @@ fn set_version_if_needed(
             "Storage was initialized with state_version: {:?}, scope: {:?}, blocks_version: {:?}",
             STORAGE_VERSION_STATE, writer.scope, STORAGE_VERSION_BLOCKS
         );
-        return Ok(writer);
+        return Ok(());
     };
     debug!("Existing storage state: {:?}", existing_storage_version);
     // Handle the case where the storage scope has changed.
@@ -370,7 +377,7 @@ fn set_version_if_needed(
         }
     }
     wtxn.commit()?;
-    Ok(writer)
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -390,18 +397,19 @@ enum StorageVersion {
     StateOnly(StateOnlyVersion),
 }
 
-fn get_storage_version(reader: StorageReader) -> StorageResult<Option<StorageVersion>> {
-    let current_storage_version_state =
-        reader.begin_ro_txn()?.get_state_version().map_err(|err| {
-            if matches!(err, StorageError::InnerError(DbError::InnerDeserialization)) {
-                tracing::error!(
-                    "Cannot deserialize storage version. Storage major version has been changed, \
-                     re-sync is needed."
-                );
-            }
-            err
-        })?;
-    let current_storage_version_blocks = reader.begin_ro_txn()?.get_blocks_version()?;
+/// Reads storage version using RW transaction to see uncommitted batched writes.
+fn get_storage_version(writer: &mut StorageWriter) -> StorageResult<Option<StorageVersion>> {
+    let txn = writer.begin_rw_txn()?;
+    let current_storage_version_state = txn.get_state_version().map_err(|err| {
+        if matches!(err, StorageError::InnerError(DbError::InnerDeserialization)) {
+            tracing::error!(
+                "Cannot deserialize storage version. Storage major version has been changed, \
+                 re-sync is needed."
+            );
+        }
+        err
+    })?;
+    let current_storage_version_blocks = txn.get_blocks_version()?;
     let Some(current_storage_version_state) = current_storage_version_state else {
         return Ok(None);
     };
@@ -419,8 +427,8 @@ fn get_storage_version(reader: StorageReader) -> StorageResult<Option<StorageVer
 }
 
 // Assumes the storage has a version.
-fn verify_storage_version(reader: StorageReader) -> StorageResult<()> {
-    let existing_storage_version = get_storage_version(reader)?;
+fn verify_storage_version(writer: &mut StorageWriter) -> StorageResult<()> {
+    let existing_storage_version = get_storage_version(writer)?;
     debug!(
         "Crate storage version: State = {STORAGE_VERSION_STATE:} Blocks = \
          {STORAGE_VERSION_BLOCKS:}. Existing storage state: {existing_storage_version:?} "
@@ -539,14 +547,18 @@ impl SerializeConfig for BatchConfig {
 impl StorageReader {
     /// Takes a snapshot of the current state of the storage and returns a [`StorageTxn`] for
     /// reading data from the storage.
+    ///
+    /// RO transactions get a fresh read-only transaction from the database, providing a
+    /// consistent snapshot of committed data.
     pub fn begin_ro_txn(&self) -> StorageResult<StorageTxn<'_, RO>> {
-        Ok(StorageTxn::new(
-            self.db_reader.begin_ro_txn()?,
-            self.file_readers.clone(),
-            self.tables.clone(),
-            self.scope,
-            MetricsHandler::new(self.open_readers_metric),
-        ))
+        Ok(StorageTxn {
+            txn: self.db_reader.begin_ro_txn()?,
+            // TODO(Dean): Wrap FileHandlers with an Arc to avoid cloning.
+            file_handlers: self.file_readers.clone(),
+            tables: self.tables.clone(),
+            scope: self.scope,
+            _metric_updater: MetricsHandler::new(self.open_readers_metric),
+        })
     }
 
     /// Returns metadata about the tables in the storage.
@@ -569,27 +581,95 @@ impl StorageReader {
     }
 }
 
+/// Shared state for storage operations, including transaction batching.
+/// Contains common resources needed by both StorageReader and StorageWriter.
+struct SharedState {
+    db_writer: DbWriter,
+    tables: Arc<Tables>,
+    active_txn: Option<OwnedDbWriteTransaction>,
+    commit_counter: usize,
+    batch_size: usize,
+}
+
+impl SharedState {
+    /// Creates a new SharedState wrapped in `Arc<Mutex>`.
+    fn new(db_writer: DbWriter, tables: Arc<Tables>, batch_size: usize) -> Arc<Mutex<Self>> {
+        Arc::new(Mutex::new(Self {
+            db_writer,
+            tables,
+            active_txn: None,
+            commit_counter: 0,
+            batch_size,
+        }))
+    }
+
+    /// Ensures an active persistent transaction exists, creating one if needed.
+    fn ensure_active_txn(&mut self) -> StorageResult<()> {
+        if self.active_txn.is_none() {
+            self.active_txn = Some(self.db_writer.begin_persistent_rw_txn()?);
+            self.commit_counter = 0;
+        }
+        Ok(())
+    }
+}
+
+/// Type alias for shared state.
+type SharedStorageState = Arc<Mutex<SharedState>>;
+
 /// A struct for starting RW transactions ([`StorageTxn`]) to the storage.
 /// There is a single non clonable writer instance, to make sure there is only one write transaction
 /// at any given moment.
 pub struct StorageWriter {
-    db_writer: DbWriter,
     file_writers: FileHandlers<RW>,
-    tables: Arc<Tables>,
     scope: StorageScope,
+    /// Shared state containing db_writer, tables, and batching information.
+    shared_state: SharedStorageState,
 }
 
 impl StorageWriter {
-    /// Takes a snapshot of the current state of the storage and returns a [`StorageTxn`] for
-    /// reading and modifying data in the storage.
-    pub fn begin_rw_txn(&mut self) -> StorageResult<StorageTxn<'_, RW>> {
-        Ok(StorageTxn::new(
-            self.db_writer.begin_rw_txn()?,
-            self.file_writers.clone(),
-            self.tables.clone(),
-            self.scope,
-            MetricsHandler::new(None),
-        ))
+    /// Creates a new StorageWriter with the given configuration.
+    fn new(
+        file_writers: FileHandlers<RW>,
+        scope: StorageScope,
+        shared_state: SharedStorageState,
+    ) -> Self {
+        Self { file_writers, scope, shared_state }
+    }
+
+    /// Returns a [`StorageTxnRW`] for reading and modifying data in the storage.
+    ///
+    /// This may return a reference to an ongoing persistent transaction rather than
+    /// a fresh snapshot. Multiple calls to `begin_rw_txn()` will share the same
+    /// underlying transaction until the batch commits (when counter reaches batch_size).
+    /// When batch_size=1, this behaves like non-batching mode (commits on every transaction).
+    pub fn begin_rw_txn(&mut self) -> StorageResult<StorageTxnRW<'_>> {
+        let mut guard = self.shared_state.lock().unwrap();
+        guard.ensure_active_txn()?;
+        Ok(StorageTxnRW {
+            guard,
+            file_handlers: self.file_writers.clone(),
+            scope: self.scope,
+            _metric_updater: MetricsHandler::new(None),
+        })
+    }
+
+    /// Forces an immediate commit of any pending batched writes and resets the batch counter.
+    ///
+    /// This should be called before error recovery/retry paths to ensure that
+    /// uncommitted writes are persisted. Without this, a StorageReader's RO transaction
+    /// would not see the uncommitted writes from the current batch.
+    ///
+    /// This is a no-op if there are no pending writes (commit_counter == 0).
+    pub fn flush_pending_writes(&mut self) -> StorageResult<()> {
+        let mut guard = self.shared_state.lock().unwrap();
+        if guard.commit_counter > 0 {
+            self.file_writers.flush();
+            guard.commit_counter = 0;
+            if let Some(txn) = guard.active_txn.take() {
+                txn.commit()?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -617,9 +697,74 @@ impl Drop for MetricsHandler {
     }
 }
 
+/// Common interface for all storage transactions (RO and RW).
+/// This allows reader and writer traits to be implemented once generically, eliminating
+/// duplication.
+pub(crate) trait StorageTransaction: Sized {
+    /// The transaction mode (RO or RW).
+    type Mode: TransactionKind;
+
+    /// Returns a reference to the underlying database transaction.
+    fn txn(&self) -> &DbTransaction<'_, Self::Mode>;
+
+    /// Returns a reference to the table definitions.
+    fn tables(&self) -> &Arc<Tables>;
+
+    /// Returns a reference to the file handlers.
+    fn file_handlers(&self) -> &FileHandlers<Self::Mode>;
+
+    /// Returns the storage scope.
+    fn scope(&self) -> StorageScope;
+
+    /// Opens a table for reading or writing.
+    /// Default implementation handles scope validation for StateOnly mode.
+    fn open_table<K: Key + Debug, V: ValueSerde + Debug, T: TableType>(
+        &self,
+        table_id: &TableIdentifier<K, V, T>,
+    ) -> StorageResult<TableHandle<'_, K, V, T>> {
+        if self.scope() == StorageScope::StateOnly {
+            let tables = self.tables();
+            let unused_tables = [
+                tables.events.name,
+                tables.transaction_hash_to_idx.name,
+                tables.transaction_metadata.name,
+            ];
+            if unused_tables.contains(&table_id.name) {
+                return Err(StorageError::ScopeError {
+                    table_name: table_id.name.to_owned(),
+                    storage_scope: self.scope(),
+                });
+            }
+        }
+        Ok(self.txn().open_table(table_id)?)
+    }
+
+    fn get_state_diff_location(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<LocationInFile>> {
+        let tables = self.tables();
+        let state_diffs_table = self.open_table(&tables.state_diffs)?;
+        Ok(state_diffs_table.get(self.txn(), &block_number)?)
+    }
+
+    fn get_state_diff_from_location(
+        &self,
+        state_diff_location: LocationInFile,
+    ) -> StorageResult<ThinStateDiff> {
+        self.file_handlers().get_thin_state_diff_unchecked(state_diff_location)
+    }
+
+    fn get_file_offset(&self, offset_kind: OffsetKind) -> StorageResult<Option<usize>> {
+        let tables = self.tables();
+        let table = self.open_table(&tables.file_offsets)?;
+        Ok(table.get(self.txn(), &offset_kind)?)
+    }
+}
+
 /// A struct for interacting with the storage.
 /// The actually functionality is implemented on the transaction in multiple traits.
-pub struct StorageTxn<'env, Mode: TransactionKind> {
+pub struct StorageTxn<'env, Mode: TransactionKind + 'static> {
     txn: DbTransaction<'env, Mode>,
     file_handlers: FileHandlers<Mode>,
     tables: Arc<Tables>,
@@ -628,77 +773,112 @@ pub struct StorageTxn<'env, Mode: TransactionKind> {
     _metric_updater: MetricsHandler,
 }
 
-impl StorageTxn<'_, RW> {
+/// RW-specific transaction that holds a MutexGuard for safe access to the persistent transaction.
+/// The MutexGuard is held for the entire lifetime of StorageTxnRW, ensuring safe access
+/// to the transaction.
+pub struct StorageTxnRW<'a> {
+    guard: MutexGuard<'a, SharedState>,
+    file_handlers: FileHandlers<RW>,
+    scope: StorageScope,
+    _metric_updater: MetricsHandler,
+}
+
+impl StorageTransaction for StorageTxnRW<'_> {
+    type Mode = RW;
+
+    fn txn(&self) -> &DbTransaction<'_, RW> {
+        self.guard.active_txn.as_ref().unwrap().txn()
+    }
+
+    fn tables(&self) -> &Arc<Tables> {
+        &self.guard.tables
+    }
+
+    fn file_handlers(&self) -> &FileHandlers<RW> {
+        &self.file_handlers
+    }
+
+    fn scope(&self) -> StorageScope {
+        self.scope
+    }
+}
+
+impl<'a> StorageTxnRW<'a> {
+    pub(crate) fn txn(&self) -> &DbTransaction<'_, RW> {
+        <Self as StorageTransaction>::txn(self)
+    }
+
     /// Commits the changes made in the transaction to the storage.
+    ///
+    /// This method consumes `self` to ensure that the transaction cannot be used after commit.
+    /// This design prevents accidental writes to a transaction that has already been committed
+    /// (or is in a committed batch), which would otherwise cause data inconsistencies.
+    ///
+    /// The commit counter is incremented. When it reaches batch_size, the MDBX transaction
+    /// is actually committed.
+    ///
+    /// NOTE: Empty Commits Are Allowed
+    /// ===============================
+    /// We increment the counter for ALL commits, including empty transactions that
+    /// didn't perform any writes. We are aware that this can happen and accept it
+    /// as a trade-off for simpler implementation.
+    ///
+    /// This means the actual batch size (number of transactions with real writes)
+    /// may be less than the configured batch_size due to empty commits incrementing
+    /// the counter. Empty commits can occur in scenarios such as:
+    /// - Version checks that find no update needed
+    /// - Read-only operations that still call commit() for consistency
+    /// - Conditional writes where the condition evaluates to false
+    ///
+    /// The simpler logic (always increment) avoids the complexity of maintaining
+    /// a "dirty flag" and calling mark_dirty() throughout the codebase.
     #[sequencer_latency_histogram(STORAGE_COMMIT_LATENCY, false)]
-    pub fn commit(self) -> StorageResult<()> {
-        self.file_handlers.flush();
-        Ok(self.txn.commit()?)
+    pub fn commit(mut self) -> StorageResult<()> {
+        self.guard.commit_counter += 1;
+        if self.guard.commit_counter >= self.guard.batch_size {
+            // Batch size reached - flush files and commit the MDBX transaction.
+            self.file_handlers.flush();
+            let txn_to_commit = self.guard.active_txn.take();
+            self.guard.commit_counter = 0;
+
+            if let Some(txn) = txn_to_commit {
+                txn.commit()?;
+            } else {
+                return Err(StorageError::DBInconsistency {
+                    msg: "Batch commit triggered but no active transaction exists".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'env, Mode: TransactionKind> StorageTransaction for StorageTxn<'env, Mode> {
+    type Mode = Mode;
+
+    fn txn(&self) -> &DbTransaction<'_, Mode> {
+        &self.txn
+    }
+
+    fn tables(&self) -> &Arc<Tables> {
+        &self.tables
+    }
+
+    fn file_handlers(&self) -> &FileHandlers<Mode> {
+        &self.file_handlers
+    }
+
+    fn scope(&self) -> StorageScope {
+        self.scope
     }
 }
 
 impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
-    fn new(
-        txn: DbTransaction<'env, Mode>,
-        file_handlers: FileHandlers<Mode>,
-        tables: Arc<Tables>,
-        scope: StorageScope,
-        metric_updater: MetricsHandler,
-    ) -> Self {
-        Self { txn, file_handlers, tables, scope, _metric_updater: metric_updater }
-    }
-
     pub(crate) fn open_table<K: Key + Debug, V: ValueSerde + Debug, T: TableType>(
         &self,
         table_id: &TableIdentifier<K, V, T>,
     ) -> StorageResult<TableHandle<'_, K, V, T>> {
-        if self.scope == StorageScope::StateOnly {
-            let unused_tables = [
-                self.tables.events.name,
-                self.tables.transaction_hash_to_idx.name,
-                self.tables.transaction_metadata.name,
-            ];
-            if unused_tables.contains(&table_id.name) {
-                return Err(StorageError::ScopeError {
-                    table_name: table_id.name.to_owned(),
-                    storage_scope: self.scope,
-                });
-            }
-        }
-        Ok(self.txn.open_table(table_id)?)
-    }
-
-    /// Returns the location of the state diff in the mmap file for the given block number.
-    pub fn get_state_diff_location(
-        &self,
-        block_number: BlockNumber,
-    ) -> StorageResult<Option<LocationInFile>> {
-        let state_diffs_table = self.open_table(&self.tables.state_diffs)?;
-        Ok(state_diffs_table.get(&self.txn, &block_number)?)
-    }
-
-    /// Returns the thin state diff stored in the mmap file at the given location.
-    pub fn get_state_diff_from_location(
-        &self,
-        state_diff_location: LocationInFile,
-    ) -> StorageResult<ThinStateDiff> {
-        self.file_handlers.get_thin_state_diff_unchecked(state_diff_location)
-    }
-
-    /// Returns the nonce for a contract at a given address and block number.
-    pub fn get_nonce(
-        &self,
-        contract_address: ContractAddress,
-        block_number: BlockNumber,
-    ) -> StorageResult<Option<Nonce>> {
-        let nonces_table = self.open_table(&self.tables.nonces)?;
-        Ok(nonces_table.get(&self.txn, &(contract_address, block_number))?)
-    }
-
-    /// Returns the file offset for a given offset kind.
-    pub fn get_file_offset(&self, offset_kind: OffsetKind) -> StorageResult<Option<usize>> {
-        let table = self.open_table(&self.tables.file_offsets)?;
-        Ok(table.get(&self.txn, &offset_kind)?)
+        <Self as StorageTransaction>::open_table(self, table_id)
     }
 }
 

--- a/crates/apollo_storage/src/partial_block_hash.rs
+++ b/crates/apollo_storage/src/partial_block_hash.rs
@@ -1,14 +1,14 @@
 //! Interface for handling partial block hashes.
 //! Import [`PartialBlockHashComponentsStorageReader`] and
 //! [`PartialBlockHashComponentsStorageWriter`] to read and write data related to partial block
-//! hashes using a [`StorageTxn`].
+//! hashes using a `StorageTxn`.
 
 use starknet_api::block::BlockNumber;
 use starknet_api::block_hash::block_hash_calculator::PartialBlockHashComponents;
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{StorageResult, StorageTransaction};
 
 /// Interface for reading partial block hashes.
 pub trait PartialBlockHashComponentsStorageReader {
@@ -40,24 +40,24 @@ where
     ) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> PartialBlockHashComponentsStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> PartialBlockHashComponentsStorageReader for T {
     fn get_partial_block_hash_components(
         &self,
         block_number: &BlockNumber,
     ) -> StorageResult<Option<PartialBlockHashComponents>> {
-        let table = self.open_table(&self.tables.partial_block_hashes_components)?;
-        Ok(table.get(&self.txn, block_number)?)
+        let table = self.open_table(&self.tables().partial_block_hashes_components)?;
+        Ok(table.get(self.txn(), block_number)?)
     }
 }
 
-impl PartialBlockHashComponentsStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> PartialBlockHashComponentsStorageWriter for T {
     fn set_partial_block_hash_components(
         self,
         block_number: &BlockNumber,
         partial_block_hash: &PartialBlockHashComponents,
     ) -> StorageResult<Self> {
-        let table = self.open_table(&self.tables.partial_block_hashes_components)?;
-        table.insert(&self.txn, block_number, partial_block_hash)?;
+        let table = self.open_table(&self.tables().partial_block_hashes_components)?;
+        table.insert(self.txn(), block_number, partial_block_hash)?;
         Ok(self)
     }
 
@@ -65,8 +65,8 @@ impl PartialBlockHashComponentsStorageWriter for StorageTxn<'_, RW> {
         self,
         block_number: &BlockNumber,
     ) -> StorageResult<Self> {
-        let table = self.open_table(&self.tables.partial_block_hashes_components)?;
-        table.delete(&self.txn, block_number)?;
+        let table = self.open_table(&self.tables().partial_block_hashes_components)?;
+        table.delete(self.txn(), block_number)?;
         Ok(self)
     }
 }

--- a/crates/apollo_storage/src/state/mod.rs
+++ b/crates/apollo_storage/src/state/mod.rs
@@ -1,7 +1,7 @@
 //! Interface for handling data related to Starknet [state](https://docs.rs/starknet_api/latest/starknet_api/state/index.html).
 //!
 //! Import [`StateStorageReader`] and [`StateStorageWriter`] to read and write data related to state
-//! diffs using a [`StorageTxn`].
+//! diffs using a `StorageTxn`.
 //!
 //! See [`StateReader`] struct for querying specific data from the state.
 //!
@@ -80,7 +80,7 @@ use crate::{
     OffsetKind,
     StorageError,
     StorageResult,
-    StorageTxn,
+    StorageTransaction,
 };
 
 // TODO(shahak): Move the table aliases to the crate level.
@@ -135,6 +135,7 @@ pub(crate) type CompiledClassHashTable<'env> = TableHandle<
 //   nonce of `contract_address` was changed to `nonce`.
 // * compiled_class_hash_table: (class_hash, block_num) -> (compiled_class_hash). Specifies that at
 //   `block_num`, the compiled class hash of `class_hash` was changed to `compiled_class_hash`.
+#[allow(private_interfaces)]
 pub trait StateStorageReader<Mode: TransactionKind> {
     /// The state marker is the first block number that doesn't exist yet.
     fn get_state_marker(&self) -> StorageResult<BlockNumber>;
@@ -172,22 +173,51 @@ where
     ) -> StorageResult<(Self, Option<RevertedStateDiff>)>;
 }
 
-impl<Mode: TransactionKind> StateStorageReader<Mode> for StorageTxn<'_, Mode> {
+#[allow(private_interfaces)]
+impl<T: StorageTransaction> StateStorageReader<T::Mode> for T {
     // The block number marker is the first block number that doesn't exist yet.
     fn get_state_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table.get(&self.txn, &MarkerKind::State)?.unwrap_or_default())
+        let markers_table = self.open_table(&self.tables().markers)?;
+        Ok(markers_table.get(self.txn(), &MarkerKind::State)?.unwrap_or_default())
     }
     fn get_state_diff(&self, block_number: BlockNumber) -> StorageResult<Option<ThinStateDiff>> {
-        let state_diff_location = self.get_state_diff_location(block_number)?;
+        let state_diffs_table = self.open_table(&self.tables().state_diffs)?;
+        let state_diff_location = state_diffs_table.get(self.txn(), &block_number)?;
         match state_diff_location {
             None => Ok(None),
-            Some(location) => Ok(Some(self.get_state_diff_from_location(location)?)),
+            Some(location) => {
+                Ok(Some(self.file_handlers().get_thin_state_diff_unchecked(location)?))
+            }
         }
     }
 
-    fn get_state_reader(&self) -> StorageResult<StateReader<'_, Mode>> {
-        StateReader::new(self)
+    fn get_state_reader(&self) -> StorageResult<StateReader<'_, T::Mode>> {
+        let inner_txn = self.txn();
+        let compiled_class_hash_table = inner_txn.open_table(&self.tables().compiled_class_hash)?;
+        let declared_classes_table = inner_txn.open_table(&self.tables().declared_classes)?;
+        let declared_classes_block_table =
+            inner_txn.open_table(&self.tables().declared_classes_block)?;
+        let deprecated_declared_classes_table =
+            inner_txn.open_table(&self.tables().deprecated_declared_classes)?;
+        let deprecated_declared_classes_block_table =
+            inner_txn.open_table(&self.tables().deprecated_declared_classes_block)?;
+        let deployed_contracts_table = inner_txn.open_table(&self.tables().deployed_contracts)?;
+        let nonces_table = inner_txn.open_table(&self.tables().nonces)?;
+        let storage_table = inner_txn.open_table(&self.tables().contract_storage)?;
+        let markers_table = inner_txn.open_table(&self.tables().markers)?;
+        Ok(StateReader {
+            txn: inner_txn,
+            compiled_class_hash_table,
+            declared_classes_table,
+            declared_classes_block_table,
+            deprecated_declared_classes_table,
+            deprecated_declared_classes_block_table,
+            deployed_contracts_table,
+            nonces_table,
+            storage_table,
+            markers_table,
+            file_handlers: self.file_handlers(),
+        })
     }
 }
 
@@ -207,43 +237,6 @@ pub struct StateReader<'env, Mode: TransactionKind> {
 }
 
 impl<'env, Mode: TransactionKind> StateReader<'env, Mode> {
-    /// Creates a new state reader from a storage transaction.
-    ///
-    /// Opens a handle to each table to be used when reading.
-    ///
-    /// # Arguments
-    /// * txn - A storage transaction object.
-    ///
-    /// # Errors
-    /// Returns [`StorageError`] if there was an error opening the tables.
-    fn new(txn: &'env StorageTxn<'env, Mode>) -> StorageResult<Self> {
-        let compiled_class_hash_table = txn.txn.open_table(&txn.tables.compiled_class_hash)?;
-        let declared_classes_table = txn.txn.open_table(&txn.tables.declared_classes)?;
-        let declared_classes_block_table =
-            txn.txn.open_table(&txn.tables.declared_classes_block)?;
-        let deprecated_declared_classes_table =
-            txn.txn.open_table(&txn.tables.deprecated_declared_classes)?;
-        let deprecated_declared_classes_block_table =
-            txn.txn.open_table(&txn.tables.deprecated_declared_classes_block)?;
-        let deployed_contracts_table = txn.txn.open_table(&txn.tables.deployed_contracts)?;
-        let nonces_table = txn.txn.open_table(&txn.tables.nonces)?;
-        let storage_table = txn.txn.open_table(&txn.tables.contract_storage)?;
-        let markers_table = txn.txn.open_table(&txn.tables.markers)?;
-        Ok(StateReader {
-            txn: &txn.txn,
-            compiled_class_hash_table,
-            declared_classes_table,
-            declared_classes_block_table,
-            deprecated_declared_classes_table,
-            deprecated_declared_classes_block_table,
-            deployed_contracts_table,
-            nonces_table,
-            storage_table,
-            markers_table,
-            file_handlers: &txn.file_handlers,
-        })
-    }
-
     /// Returns the class hash at a given state number.
     /// If class hash is not found, returns `None`.
     ///
@@ -511,51 +504,53 @@ impl<'env, Mode: TransactionKind> StateReader<'env, Mode> {
     }
 }
 
-impl StateStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> StateStorageWriter for T {
     #[sequencer_latency_histogram(STORAGE_APPEND_THIN_STATE_DIFF_LATENCY, false)]
     fn append_state_diff(
         self,
         block_number: BlockNumber,
         thin_state_diff: ThinStateDiff,
     ) -> StorageResult<Self> {
-        let file_offset_table = self.txn.open_table(&self.tables.file_offsets)?;
-        let markers_table = self.open_table(&self.tables.markers)?;
-        let state_diffs_table = self.open_table(&self.tables.state_diffs)?;
-        let nonces_table = self.open_table(&self.tables.nonces)?;
-        let deployed_contracts_table = self.open_table(&self.tables.deployed_contracts)?;
-        let storage_table = self.open_table(&self.tables.contract_storage)?;
-        let declared_classes_block_table = self.open_table(&self.tables.declared_classes_block)?;
+        let inner_txn = self.txn();
+        let file_offset_table = inner_txn.open_table(&self.tables().file_offsets)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        let state_diffs_table = self.open_table(&self.tables().state_diffs)?;
+        let nonces_table = self.open_table(&self.tables().nonces)?;
+        let deployed_contracts_table = self.open_table(&self.tables().deployed_contracts)?;
+        let storage_table = self.open_table(&self.tables().contract_storage)?;
+        let declared_classes_block_table =
+            self.open_table(&self.tables().declared_classes_block)?;
         let deprecated_declared_classes_block_table =
-            self.open_table(&self.tables.deprecated_declared_classes_block)?;
-        let compiled_class_hash_table = self.open_table(&self.tables.compiled_class_hash)?;
+            self.open_table(&self.tables().deprecated_declared_classes_block)?;
+        let compiled_class_hash_table = self.open_table(&self.tables().compiled_class_hash)?;
 
         // Write state.
         write_deployed_contracts(
             &thin_state_diff.deployed_contracts,
-            &self.txn,
+            inner_txn,
             block_number,
             &deployed_contracts_table,
             &nonces_table,
         )?;
         write_storage_diffs(
             &thin_state_diff.storage_diffs,
-            &self.txn,
+            inner_txn,
             block_number,
             &storage_table,
         )?;
         // Must be called after write_deployed_contracts since the nonces are updated there.
-        write_nonces(&thin_state_diff.nonces, &self.txn, block_number, &nonces_table)?;
+        write_nonces(&thin_state_diff.nonces, inner_txn, block_number, &nonces_table)?;
 
         for (class_hash, _) in &thin_state_diff.class_hash_to_compiled_class_hash {
-            let not_declared = declared_classes_block_table.get(&self.txn, class_hash)?.is_none();
+            let not_declared = declared_classes_block_table.get(inner_txn, class_hash)?.is_none();
             if not_declared {
-                declared_classes_block_table.insert(&self.txn, class_hash, &block_number)?;
+                declared_classes_block_table.insert(inner_txn, class_hash, &block_number)?;
             }
         }
 
         write_compiled_class_hashes(
             &thin_state_diff.class_hash_to_compiled_class_hash,
-            &self.txn,
+            inner_txn,
             block_number,
             &compiled_class_hash_table,
         )?;
@@ -563,9 +558,9 @@ impl StateStorageWriter for StorageTxn<'_, RW> {
         for class_hash in thin_state_diff.deprecated_declared_classes.iter() {
             // Cairo0 classes can be declared in different blocks. The first block to declare the
             // class is recorded here.
-            if deprecated_declared_classes_block_table.get(&self.txn, class_hash)?.is_none() {
+            if deprecated_declared_classes_block_table.get(inner_txn, class_hash)?.is_none() {
                 deprecated_declared_classes_block_table.insert(
-                    &self.txn,
+                    inner_txn,
                     class_hash,
                     &block_number,
                 )?;
@@ -573,17 +568,17 @@ impl StateStorageWriter for StorageTxn<'_, RW> {
         }
 
         // Write state diff.
-        let location = self.file_handlers.append_state_diff(&thin_state_diff);
-        state_diffs_table.append(&self.txn, &block_number, &location)?;
-        file_offset_table.upsert(&self.txn, &OffsetKind::ThinStateDiff, &location.next_offset())?;
+        let location = self.file_handlers().append_state_diff(&thin_state_diff);
+        state_diffs_table.append(inner_txn, &block_number, &location)?;
+        file_offset_table.upsert(inner_txn, &OffsetKind::ThinStateDiff, &location.next_offset())?;
 
-        update_marker_to_next_block(&self.txn, &markers_table, MarkerKind::State, block_number)?;
+        update_marker_to_next_block(inner_txn, &markers_table, MarkerKind::State, block_number)?;
 
         advance_compiled_class_marker_over_blocks_without_classes(
-            &self.txn,
+            inner_txn,
             &markers_table,
             &state_diffs_table,
-            &self.file_handlers,
+            self.file_handlers(),
         )?;
 
         Ok(self)
@@ -594,22 +589,23 @@ impl StateStorageWriter for StorageTxn<'_, RW> {
         self,
         block_number: BlockNumber,
     ) -> StorageResult<(Self, Option<RevertedStateDiff>)> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        let declared_classes_table = self.open_table(&self.tables.declared_classes)?;
-        let declared_classes_block_table = self.open_table(&self.tables.declared_classes_block)?;
+        let markers_table = self.open_table(&self.tables().markers)?;
+        let declared_classes_table = self.open_table(&self.tables().declared_classes)?;
+        let declared_classes_block_table =
+            self.open_table(&self.tables().declared_classes_block)?;
         let deprecated_declared_classes_table =
-            self.open_table(&self.tables.deprecated_declared_classes)?;
+            self.open_table(&self.tables().deprecated_declared_classes)?;
         let deprecated_declared_classes_block_table =
-            self.open_table(&self.tables.deprecated_declared_classes_block)?;
+            self.open_table(&self.tables().deprecated_declared_classes_block)?;
         // TODO(yair): Consider reverting the compiled classes in their own module.
-        let compiled_classes_table = self.open_table(&self.tables.casms)?;
+        let compiled_classes_table = self.open_table(&self.tables().casms)?;
         let compiled_class_hash_v2_table =
-            self.open_table(&self.tables.stateless_compiled_class_hash_v2)?;
-        let deployed_contracts_table = self.open_table(&self.tables.deployed_contracts)?;
-        let nonces_table = self.open_table(&self.tables.nonces)?;
-        let storage_table = self.open_table(&self.tables.contract_storage)?;
-        let state_diffs_table = self.open_table(&self.tables.state_diffs)?;
-        let compiled_class_hash_table = self.open_table(&self.tables.compiled_class_hash)?;
+            self.open_table(&self.tables().stateless_compiled_class_hash_v2)?;
+        let deployed_contracts_table = self.open_table(&self.tables().deployed_contracts)?;
+        let nonces_table = self.open_table(&self.tables().nonces)?;
+        let storage_table = self.open_table(&self.tables().contract_storage)?;
+        let state_diffs_table = self.open_table(&self.tables().state_diffs)?;
+        let compiled_class_hash_table = self.open_table(&self.tables().compiled_class_hash)?;
 
         let current_state_marker = self.get_state_marker()?;
 
@@ -629,68 +625,69 @@ impl StateStorageWriter for StorageTxn<'_, RW> {
         let thin_state_diff = self
             .get_state_diff(block_number)?
             .unwrap_or_else(|| panic!("Missing state diff for block {block_number}."));
-        markers_table.upsert(&self.txn, &MarkerKind::State, &block_number)?;
-        let classes_marker = markers_table.get(&self.txn, &MarkerKind::Class)?.unwrap_or_default();
+        let inner_txn = self.txn();
+        markers_table.upsert(inner_txn, &MarkerKind::State, &block_number)?;
+        let classes_marker = markers_table.get(inner_txn, &MarkerKind::Class)?.unwrap_or_default();
         if classes_marker == next_block_number {
-            markers_table.upsert(&self.txn, &MarkerKind::Class, &block_number)?;
+            markers_table.upsert(inner_txn, &MarkerKind::Class, &block_number)?;
         }
         let compiled_classes_marker =
-            markers_table.get(&self.txn, &MarkerKind::CompiledClass)?.unwrap_or_default();
+            markers_table.get(inner_txn, &MarkerKind::CompiledClass)?.unwrap_or_default();
         if compiled_classes_marker == next_block_number {
-            markers_table.upsert(&self.txn, &MarkerKind::CompiledClass, &block_number)?;
+            markers_table.upsert(inner_txn, &MarkerKind::CompiledClass, &block_number)?;
         }
         let deleted_class_hashes = delete_declared_classes_block(
-            &self.txn,
+            inner_txn,
             &thin_state_diff,
             &declared_classes_block_table,
             block_number,
         )?;
         let deleted_classes = delete_declared_classes(
-            &self.txn,
+            inner_txn,
             &thin_state_diff,
             &declared_classes_table,
-            &self.file_handlers,
+            self.file_handlers(),
         )?;
         let deleted_deprecated_class_hashes = delete_deprecated_declared_classes_block(
-            &self.txn,
+            inner_txn,
             block_number,
             &thin_state_diff,
             &deprecated_declared_classes_block_table,
         )?;
         let deleted_deprecated_classes = delete_deprecated_declared_classes(
-            &self.txn,
+            inner_txn,
             block_number,
             &thin_state_diff,
             &deprecated_declared_classes_table,
-            &self.file_handlers,
+            self.file_handlers(),
         )?;
         let deleted_compiled_classes = delete_compiled_classes(
-            &self.txn,
+            inner_txn,
             thin_state_diff.class_hash_to_compiled_class_hash.keys(),
             &compiled_classes_table,
-            &self.file_handlers,
+            self.file_handlers(),
         )?;
         delete_compiled_class_hashes_v2(
-            &self.txn,
+            inner_txn,
             thin_state_diff.class_hash_to_compiled_class_hash.keys(),
             &compiled_class_hash_v2_table,
         )?;
         delete_deployed_contracts(
-            &self.txn,
+            inner_txn,
             block_number,
             &thin_state_diff,
             &deployed_contracts_table,
             &nonces_table,
         )?;
-        delete_storage_diffs(&self.txn, block_number, &thin_state_diff, &storage_table)?;
-        delete_nonces(&self.txn, block_number, &thin_state_diff, &nonces_table)?;
+        delete_storage_diffs(inner_txn, block_number, &thin_state_diff, &storage_table)?;
+        delete_nonces(inner_txn, block_number, &thin_state_diff, &nonces_table)?;
         delete_compiled_class_hashes(
-            &self.txn,
+            inner_txn,
             block_number,
             &thin_state_diff,
             &compiled_class_hash_table,
         )?;
-        state_diffs_table.delete(&self.txn, &block_number)?;
+        state_diffs_table.delete(inner_txn, &block_number)?;
 
         Ok((
             self,

--- a/crates/apollo_storage/src/storage_reader_types.rs
+++ b/crates/apollo_storage/src/storage_reader_types.rs
@@ -25,7 +25,14 @@ use crate::mmap_file::LocationInFile;
 use crate::state::StateStorageReader;
 use crate::storage_reader_server::{StorageReaderServer, StorageReaderServerHandler};
 use crate::version::{Version, VersionStorageReader};
-use crate::{MarkerKind, OffsetKind, StorageError, StorageReader, TransactionMetadata};
+use crate::{
+    MarkerKind,
+    OffsetKind,
+    StorageError,
+    StorageReader,
+    StorageTransaction,
+    TransactionMetadata,
+};
 
 /// Type alias for the generic storage reader server.
 pub type GenericStorageReaderServer = StorageReaderServer<

--- a/crates/apollo_storage/src/storage_reader_types_test.rs
+++ b/crates/apollo_storage/src/storage_reader_types_test.rs
@@ -36,7 +36,7 @@ use crate::storage_reader_types::{
 };
 use crate::test_utils::get_test_storage;
 use crate::version::VersionStorageReader;
-use crate::{MarkerKind, OffsetKind, StorageReader};
+use crate::{MarkerKind, OffsetKind, StorageReader, StorageTransaction};
 
 const TEST_BLOCK_NUMBER: BlockNumber = BlockNumber(0);
 

--- a/crates/apollo_storage/src/test_utils.rs
+++ b/crates/apollo_storage/src/test_utils.rs
@@ -25,7 +25,7 @@ fn build_storage_config(storage_scope: StorageScope, path_prefix: PathBuf) -> St
         },
         scope: storage_scope,
         mmap_file_config: get_mmap_file_test_config(),
-        batch_config: crate::BatchConfig::default(),
+        batch_config: Default::default(),
     }
 }
 

--- a/crates/apollo_storage/src/version.rs
+++ b/crates/apollo_storage/src/version.rs
@@ -5,8 +5,8 @@ mod version_test;
 use serde::{Deserialize, Serialize};
 
 use crate::db::table_types::Table;
-use crate::db::{TransactionKind, RW};
-use crate::{StorageError, StorageResult, StorageTxn};
+use crate::db::RW;
+use crate::{StorageError, StorageResult, StorageTransaction};
 
 const VERSION_STATE_KEY: &str = "storage_version_state";
 const VERSION_BLOCKS_KEY: &str = "storage_version_blocks";
@@ -58,21 +58,21 @@ where
     fn delete_blocks_version(self) -> StorageResult<Self>;
 }
 
-impl<Mode: TransactionKind> VersionStorageReader for StorageTxn<'_, Mode> {
+impl<T: StorageTransaction> VersionStorageReader for T {
     fn get_state_version(&self) -> StorageResult<Option<Version>> {
-        let version_table = self.open_table(&self.tables.storage_version)?;
-        Ok(version_table.get(&self.txn, &VERSION_STATE_KEY.to_string())?)
+        let version_table = self.open_table(&self.tables().storage_version)?;
+        Ok(version_table.get(self.txn(), &VERSION_STATE_KEY.to_string())?)
     }
 
     fn get_blocks_version(&self) -> StorageResult<Option<Version>> {
-        let version_table = self.open_table(&self.tables.storage_version)?;
-        Ok(version_table.get(&self.txn, &VERSION_BLOCKS_KEY.to_string())?)
+        let version_table = self.open_table(&self.tables().storage_version)?;
+        Ok(version_table.get(self.txn(), &VERSION_BLOCKS_KEY.to_string())?)
     }
 }
 
-impl VersionStorageWriter for StorageTxn<'_, RW> {
+impl<T: StorageTransaction<Mode = RW>> VersionStorageWriter for T {
     fn set_state_version(self, version: &Version) -> StorageResult<Self> {
-        let version_table = self.open_table(&self.tables.storage_version)?;
+        let version_table = self.open_table(&self.tables().storage_version)?;
         if let Some(current_storage_version) = self.get_state_version()? {
             if current_storage_version.major != version.major {
                 return Err(StorageError::StorageVersionInconsistency(
@@ -91,12 +91,12 @@ impl VersionStorageWriter for StorageTxn<'_, RW> {
                 ));
             };
         }
-        version_table.upsert(&self.txn, &VERSION_STATE_KEY.to_string(), version)?;
+        version_table.upsert(self.txn(), &VERSION_STATE_KEY.to_string(), version)?;
         Ok(self)
     }
 
     fn set_blocks_version(self, version: &Version) -> StorageResult<Self> {
-        let version_table = self.open_table(&self.tables.storage_version)?;
+        let version_table = self.open_table(&self.tables().storage_version)?;
         if let Some(current_storage_version) = self.get_blocks_version()? {
             if current_storage_version.major != version.major {
                 return Err(StorageError::StorageVersionInconsistency(
@@ -116,12 +116,12 @@ impl VersionStorageWriter for StorageTxn<'_, RW> {
                 ));
             };
         }
-        version_table.upsert(&self.txn, &VERSION_BLOCKS_KEY.to_string(), version)?;
+        version_table.upsert(self.txn(), &VERSION_BLOCKS_KEY.to_string(), version)?;
         Ok(self)
     }
     fn delete_blocks_version(self) -> StorageResult<Self> {
-        let version_table = self.open_table(&self.tables.storage_version)?;
-        version_table.delete(&self.txn, &VERSION_BLOCKS_KEY.to_string())?;
+        let version_table = self.open_table(&self.tables().storage_version)?;
+        version_table.delete(self.txn(), &VERSION_BLOCKS_KEY.to_string())?;
         Ok(self)
     }
 }

--- a/crates/apollo_storage/src/version_test.rs
+++ b/crates/apollo_storage/src/version_test.rs
@@ -22,6 +22,7 @@ use crate::{
     verify_storage_version,
     StorageError,
     StorageScope,
+    StorageTransaction,
     StorageWriter,
     STORAGE_VERSION_BLOCKS,
     STORAGE_VERSION_STATE,
@@ -204,8 +205,8 @@ fn open_storage_state_only_different_blocks_major_versions() {
 // Changes the storage version with version_key to the given version.
 fn change_storage_version(writer: &mut StorageWriter, version_key: &str, version: &Version) {
     let wtxn = writer.begin_rw_txn().unwrap();
-    let version_table = wtxn.open_table(&wtxn.tables.storage_version).unwrap();
-    version_table.upsert(&wtxn.txn, &version_key.to_string(), version).unwrap();
+    let version_table = wtxn.open_table(&wtxn.tables().storage_version).unwrap();
+    version_table.upsert(wtxn.txn(), &version_key.to_string(), version).unwrap();
     wtxn.commit().unwrap();
 }
 
@@ -224,16 +225,17 @@ fn get_different_major_version(version: Version) -> Version {
 
 #[test]
 fn test_verify_storage_version_good_flow() {
-    let ((reader_full_archive, _), _temp_dir) =
+    let ((_reader_full_archive, mut writer_full_archive), _temp_dir) =
         get_test_storage_by_scope(StorageScope::FullArchive);
-    let ((reader_state_only, _), _temp_dir) = get_test_storage_by_scope(StorageScope::StateOnly);
-    verify_storage_version(reader_full_archive).unwrap();
-    verify_storage_version(reader_state_only).unwrap();
+    let ((_reader_state_only, mut writer_state_only), _temp_dir2) =
+        get_test_storage_by_scope(StorageScope::StateOnly);
+    verify_storage_version(&mut writer_full_archive).unwrap();
+    verify_storage_version(&mut writer_state_only).unwrap();
 }
 
 #[test]
 fn test_verify_storage_version_different_minor_blocks_version() {
-    let ((reader, mut writer), _temp_dir) = get_test_storage_by_scope(StorageScope::FullArchive);
+    let ((_reader, mut writer), _temp_dir) = get_test_storage_by_scope(StorageScope::FullArchive);
     let blocks_higher_version =
         Version { major: STORAGE_VERSION_BLOCKS.major, minor: STORAGE_VERSION_BLOCKS.minor + 1 };
     writer
@@ -244,7 +246,7 @@ fn test_verify_storage_version_different_minor_blocks_version() {
         .commit()
         .unwrap();
     assert_matches!(
-        verify_storage_version(reader),
+        verify_storage_version(&mut writer),
         Err(StorageError::StorageVersionInconsistency(
             StorageVersionError::InconsistentStorageVersion {
                 crate_version: STORAGE_VERSION_BLOCKS,
@@ -256,7 +258,7 @@ fn test_verify_storage_version_different_minor_blocks_version() {
 
 #[test]
 fn test_verify_storage_version_different_minor_state_version() {
-    let ((reader, mut writer), _temp_dir) = get_test_storage_by_scope(StorageScope::FullArchive);
+    let ((_reader, mut writer), _temp_dir) = get_test_storage_by_scope(StorageScope::FullArchive);
     let state_higher_version =
         Version { major: STORAGE_VERSION_STATE.major, minor: STORAGE_VERSION_STATE.minor + 1 };
     writer
@@ -267,7 +269,7 @@ fn test_verify_storage_version_different_minor_state_version() {
         .commit()
         .unwrap();
     assert_matches!(
-        verify_storage_version(reader),
+        verify_storage_version(&mut writer),
         Err(StorageError::StorageVersionInconsistency(
             StorageVersionError::InconsistentStorageVersion {
                 crate_version: STORAGE_VERSION_STATE,
@@ -279,11 +281,10 @@ fn test_verify_storage_version_different_minor_state_version() {
 
 #[test]
 fn test_set_version_if_needed() {
-    let ((mut reader, mut writer), _temp_dir) = get_test_storage_by_scope(StorageScope::StateOnly);
-    reader.scope = StorageScope::FullArchive;
+    let ((_reader, mut writer), _temp_dir) = get_test_storage_by_scope(StorageScope::StateOnly);
     writer.scope = StorageScope::FullArchive;
     assert!(
-        set_version_if_needed(reader, writer).is_err(),
+        set_version_if_needed(&mut writer).is_err(),
         "Should fail, because storage scope cannot shift from state-only to full-archive."
     );
 }


### PR DESCRIPTION
## Summary

Implements the core batching infrastructure with `StorageTxnRW` - a fluent API for batched write transactions. This is the main PR that enables transaction batching for sync writes.

**Key changes:**

### New types
- `SharedState` - Holds the active transaction, commit counter, and batch configuration
- `StorageTxnRW` - Write transaction wrapper with fluent API methods that return `Self`

### Batching behavior
- When batching is enabled, multiple logical commits are batched into a single MDBX commit
- `StorageTxnRW::commit()` increments a counter and only commits to MDBX when `batch_size` is reached
- When batching is disabled (`batch_size=1`), every logical commit triggers an immediate MDBX commit

### Storage initialization fix
- `set_version_if_needed()` and `verify_storage_version()` now use RW transactions
- This ensures version checks see uncommitted batched writes

### Fluent API across storage modules
All storage modules updated to use the new fluent API:
- `base_layer.rs`, `block_hash.rs`, `body/mod.rs`, `body/events.rs`
- `class.rs`, `class_hash.rs`, `class_manager.rs`, `compiled_class.rs`
- `consensus.rs`, `global_root.rs`, `global_root_marker.rs`, `header.rs`
- `partial_block_hash.rs`, `state/mod.rs`, `version.rs`

## Test plan

- All 276 `apollo_storage` tests pass
- Batching tests added in subsequent PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new batched-write transaction path that changes commit semantics and relies on an `unsafe` lifetime extension for persistent MDBX write transactions; bugs here could cause data loss, stalled commits, or subtle consistency issues.
> 
> **Overview**
> Adds **batched write transactions** to `apollo_storage` by introducing `SharedState` (tracks an active persistent RW txn + commit counter) and a new `StorageTxnRW` that performs *logical* commits and only commits to MDBX once `batch_size` is reached (with `batch_size=1` preserving immediate-commit behavior). A new `StorageWriter::flush_pending_writes()` forces pending batched commits to persist.
> 
> Refactors storage APIs to a common `StorageTransaction` trait so most reader/writer traits are implemented generically over both `StorageTxn` and `StorageTxnRW`; modules across headers/body/state/classes/etc. are updated accordingly, along with marker/metrics helpers. Storage version initialization/verification is updated to use RW transactions so version reads can see uncommitted batched writes, and DB tests are updated to use `begin_persistent_rw_txn()` (removing `DbWriter::begin_rw_txn()` usage).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9d196732258464b9b42d322ea3801a0270e2360. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->