### PR TITLE
apollo_transaction_converter: skip proof storage in consensus (DO NOT MERGE)

### DIFF
--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -462,7 +462,7 @@ impl TransactionConverter {
             }
 
             let start = Instant::now();
-            pmc.set_proof(proof_facts, proof).await?;
+            // pmc.set_proof(proof_facts, proof).await?;
             let duration = start.elapsed();
             CONSENSUS_PROOF_MANAGER_STORE_LATENCY.record(duration.as_secs_f64());
             info!(

--- a/crates/apollo_transaction_converter/src/transaction_converter_test.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter_test.rs
@@ -161,6 +161,7 @@ async fn test_proof_verification_skipped_for_invoke_v3_without_proof_facts() {
 
 #[rstest]
 #[tokio::test]
+#[ignore]
 async fn test_consensus_tx_to_internal_with_proof_facts_verifies_and_sets_proof(
     proof_facts: ProofFacts,
     proof: Proof,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Consensus no longer persists verified proofs, which can break downstream flows that assume the proof is available in the proof manager and may mask correctness issues since the test is ignored.
> 
> **Overview**
> Consensus proof handling is temporarily changed to **skip storing proofs**: `spawn_verify_and_store_proof` no longer calls `pmc.set_proof(...)` after successful verification (only records store-latency metrics/logs).
> 
> The consensus integration test that asserts proof verification *and* storage is now marked `#[ignore]` to avoid failing while proof storage is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 701a735dc1032069169382836252de7926be9a5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->