### PR TITLE
apollo_transaction_converter: skip verifying (DO NOT MERGE)

### DIFF
--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -401,7 +401,7 @@ impl TransactionConverter {
     /// This is the shared verification logic used by both gateway and consensus flows.
     async fn run_proof_verification(
         proof_facts: ProofFacts,
-        proof: Proof,
+        _proof: Proof,
         proof_manager_client: SharedProofManagerClient,
     ) -> Result<bool, TransactionConverterError> {
         let contains_proof = proof_manager_client.contains_proof(proof_facts.clone()).await?;
@@ -412,7 +412,7 @@ impl TransactionConverter {
 
         let proof_facts_hash = proof_facts.hash();
         let verify_start = Instant::now();
-        tokio::task::spawn_blocking(move || Self::verify_proof(proof_facts, proof))
+        tokio::task::spawn_blocking(move || Ok::<(), TransactionConverterError>(()))
             .await
             .expect("proof verification task panicked")?;
         let verify_duration = verify_start.elapsed();
@@ -486,6 +486,7 @@ impl TransactionConverter {
 
     /// Verifies a submitted proof, validating the emitted proof facts, and comparing the bootloader
     /// program hash to the expected value.
+    #[allow(dead_code)]
     fn verify_proof(proof_facts: ProofFacts, proof: Proof) -> Result<(), VerifyProofError> {
         // Reject empty proof payloads before running the verifier.
         if proof.is_empty() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Removes a security-critical validation step by no-op’ing proof verification, which can allow invalid proofs to be accepted and stored.
> 
> **Overview**
> **Disables proof verification** in `TransactionConverter::run_proof_verification`: the proof argument is no longer used and the `spawn_blocking` step now immediately returns `Ok(())` instead of calling `Self::verify_proof`.
> 
> `verify_proof` is kept but marked `#[allow(dead_code)]`, making the real verification path effectively unreachable while preserving the proof-exists short-circuit and metrics/logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d3ab58de8ee2529163c7c16b8605ec3b7397ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->