### PR TITLE
apollo_dashboard: Fix time to complete sync panel

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -785,7 +785,7 @@
           "description": "Estimated time to complete syncing to the latest block (based on a 10m window rate).\nThe value is computed from the sync rate of the `committer offset` (the next block to commit, representing the current committed state), compared against the `central block marker` (the latest block known to central).",
           "type": "timeseries",
           "exprs": [
-            "(apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} - committer_offset{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) / clamp_min(rate(committer_offset{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m]) - rate(apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m]), 1)"
+            "(apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} - on (namespace) committer_offset{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) / clamp_min(rate(committer_offset{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m]) - on (namespace) rate(apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m]), 1)"
           ],
           "extra_params": {
             "unit": "s"

--- a/crates/apollo_dashboard/src/panels/state_sync.rs
+++ b/crates/apollo_dashboard/src/panels/state_sync.rs
@@ -77,8 +77,9 @@ fn get_panel_time_to_complete_sync() -> Panel {
             DEFAULT_DURATION
         ),
         format!(
-            "({target_total} - {committer_offset}) / clamp_min(rate({committer_offset}[{d}]) - \
-             rate({target_total}[{d}]), 1)",
+            "({target_total} - on (namespace) {committer_offset}) / \
+             clamp_min(rate({committer_offset}[{d}]) - on (namespace) rate({target_total}[{d}]), \
+             1)",
             target_total = CENTRAL_SYNC_CENTRAL_BLOCK_MARKER.get_name_with_filter(),
             committer_offset = COMMITTER_OFFSET.get_name_with_filter(),
             d = DEFAULT_DURATION


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates a Grafana/PromQL expression only; main risk is the panel showing unexpected values if the label-matching change is incorrect for some deployments.
> 
> **Overview**
> Fixes the **"Time to Complete Sync"** Grafana panel calculation by explicitly matching the `committer_offset` and `apollo_central_sync_central_block_marker` series *on `namespace`* for both the remaining-work numerator and the rate-based denominator.
> 
> Updates both the generated dashboard panel (`state_sync.rs`) and the checked-in `dev_grafana.json` so the panel uses consistent PromQL label-join behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0429379b010087acfce7ad1498048e2715fcfa0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->