### PR TITLE
echonet: improve report UI and export snapshot

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -32,6 +32,11 @@ flask_logger = get_logger("flask")
 logger = get_logger("echo_center")
 
 
+def _static_file_b64(filename: str) -> str:
+    p = Path(__file__).resolve().parent / "static" / filename
+    return base64.b64encode(p.read_bytes()).decode("ascii")
+
+
 def _build_gcp_logs_context() -> dict[str, str]:
     """Context used by the report UI to build GCP Logs Explorer links."""
     ns = _read_namespace_from_serviceaccount()
@@ -699,6 +704,7 @@ class EchoCenterService:
         return flask.render_template(
             "report.html",
             export=False,
+            inline_favicon_b64=_static_file_b64("favicon.svg"),
             logs=_build_gcp_logs_context(),
             **vm,
         )
@@ -709,13 +715,12 @@ class EchoCenterService:
         """
         vm = build_report_view_model(self.shared.get_report_snapshot())
 
-        css_path = Path(__file__).resolve().parent / "static" / "report.css"
-        inline_css_b64 = base64.b64encode(css_path.read_bytes()).decode("ascii")
-
         html = flask.render_template(
             "report.html",
             export=True,
-            inline_css_b64=inline_css_b64,
+            inline_favicon_b64=_static_file_b64("favicon.svg"),
+            inline_css_b64=_static_file_b64("report.css"),
+            inline_js_b64=_static_file_b64("report.js"),
             logs=_build_gcp_logs_context(),
             **vm,
         )

--- a/echonet/static/report.css
+++ b/echonet/static/report.css
@@ -282,6 +282,8 @@ a:hover {
     overflow-x: auto;
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
+    padding: 2px 2px 2px 4px;
+    scroll-padding-left: 4px;
 }
 
 .tableMeta {
@@ -363,17 +365,17 @@ a:hover {
 }
 
 /* Collapsible section cards (page-level sections). */
-.sectionDetails > summary {
+.sectionDetails>summary {
     list-style: none;
     cursor: pointer;
     user-select: none;
 }
 
-.sectionDetails > summary::-webkit-details-marker {
+.sectionDetails>summary::-webkit-details-marker {
     display: none;
 }
 
-.sectionDetails > summary.sectionSummary {
+.sectionDetails>summary.sectionSummary {
     display: flex;
     align-items: center;
     justify-content: flex-start;
@@ -384,11 +386,12 @@ a:hover {
     color: var(--text);
     font-size: inherit;
     position: relative;
-    padding-right: 18px; /* room for chevron */
+    padding-right: 18px;
+    /* room for chevron */
     margin: 0 0 10px;
 }
 
-.sectionDetails:not([open]) > summary.sectionSummary {
+.sectionDetails:not([open])>summary.sectionSummary {
     margin-bottom: 0;
 }
 
@@ -405,7 +408,7 @@ a:hover {
     gap: 8px;
 }
 
-.sectionDetails > summary.sectionSummary::after {
+.sectionDetails>summary.sectionSummary::after {
     content: "";
     position: absolute;
     right: 0;
@@ -420,13 +423,13 @@ a:hover {
     transition: transform 120ms ease, border-top-color 120ms ease, opacity 120ms ease;
 }
 
-.sectionDetails[open] > summary.sectionSummary::after {
+.sectionDetails[open]>summary.sectionSummary::after {
     transform: translateY(-50%) rotate(180deg);
     border-top-color: color-mix(in oklab, var(--link) 70%, transparent);
     opacity: 0.95;
 }
 
-.sectionDetails > summary.sectionSummary:focus {
+.sectionDetails>summary.sectionSummary:focus {
     outline: none;
     box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
     border-radius: 12px;

--- a/echonet/templates/report.html
+++ b/echonet/templates/report.html
@@ -5,9 +5,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Echonet Report</title>
-  <link rel="icon" href="{{ url_for('static', filename='favicon.svg') }}" type="image/svg+xml" />
+  <link rel="icon" href="data:image/svg+xml;base64,{{ inline_favicon_b64 }}" type="image/svg+xml" />
   {% if export %}
   <link rel="stylesheet" href="data:text/css;base64,{{ inline_css_b64 }}" />
+  <script defer src="data:text/javascript;base64,{{ inline_js_b64 }}"></script>
   {% else %}
   <link rel="stylesheet" href="{{ url_for('static', filename='report.css') }}" />
   <script defer src="{{ url_for('static', filename='report.js') }}"></script>
@@ -27,7 +28,6 @@
       </div>
     </div>
 
-    {% if not export %}
     <div class="controls">
       <label class="control">
         <span>Filter</span>
@@ -46,6 +46,7 @@
         </select>
       </label>
 
+      {% if not export %}
       <label class="control">
         <span>Auto refresh</span>
         <select id="refreshSelect">
@@ -57,17 +58,19 @@
       </label>
 
       <button class="btn" id="refreshNowBtn" type="button">Refresh</button>
+      {% endif %}
       <button class="btn" id="copyVisibleBtn" type="button" title="Copy visible tx hashes (respects scope)">Copy
         visible</button>
       <a class="btn btnLink" id="logsBaseLink" href="#" target="_blank" rel="noopener"
         title="Open GCP Logs Explorer for this namespace">Logs</a>
       <button class="btn" id="themeToggleBtn" type="button" title="Toggle theme">Theme</button>
+      {% if not export %}
       <a class="btn btnLink" href="/echonet/report/ui/download" title="Download static HTML snapshot">Download</a>
       <a class="btn btnLink" href="/echonet/report" title="Raw JSON snapshot">JSON</a>
       <a class="btn btnLink" href="/echonet/report/text" title="Text snapshot (plain text)">Text</a>
+      {% endif %}
       <div class="statusLine" id="filterStats" aria-live="polite"></div>
     </div>
-    {% endif %}
   </header>
 
   <main class="container">
@@ -77,6 +80,15 @@
           <div class="cardTitle">Progress</div>
           <div class="progressHero">
             <div>
+              {% set blocks_unknown = progress.blocks_processed == "(unknown)" %}
+              {% set current_unknown = progress.current_block == "(unknown)" %}
+              {% if blocks_unknown and current_unknown %}
+              <div class="heroRow">
+                <div>
+                  <div class="heroValue mono">Starting...</div>
+                </div>
+              </div>
+              {% else %}
               <div class="heroRow">
                 <div>
                   <div class="heroLabel">Blocks processed</div>
@@ -84,9 +96,12 @@
                 </div>
                 <div>
                   <div class="heroLabel">Current block</div>
-                  <div class="heroValue mono">{{ progress.current_block }}</div>
+                  <div class="heroValue mono">
+                    {% if current_unknown %}Resyncing...{% else %}{{ progress.current_block }}{% endif %}
+                  </div>
                 </div>
               </div>
+              {% endif %}
             </div>
             <div class="kv kvTight">
               <div class="k">Initial start</div>
@@ -156,9 +171,7 @@
           <summary class="sectionSummary">
             <span class="sectionSummaryLeft">Non-committed tx hashes (pending)</span>
           </summary>
-          {% if not export %}
           <div class="tableMeta smallMuted" data-table-meta="pending"></div>
-          {% endif %}
           {% if not pending_txs %}
           <div class="empty">(none)</div>
           {% else %}
@@ -184,20 +197,17 @@
                 </td>
                 <td class="right">
                   <div class="rowActions">
-                    {% if not export %}
                     <button class="btn btnSmall copyBtn" type="button" data-copy="{{ tx_hash }}">Copy</button>
-                    {% endif %}
                     <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ tx_hash }}" target="_blank"
                       rel="noopener" title="Open in Voyager">Voyager</a>
-                    {% if not export %}
                     <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                       data-logs-tx="{{ tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ src_bn }}&withFeeMarketInfo=true" target="_blank"
-                      rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                    <a class="btn btnSmall btnLink" href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ src_bn }}"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ src_bn }}&withFeeMarketInfo=true"
+                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                    <a class="btn btnSmall btnLink"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ src_bn }}"
                       target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                    {% endif %}
                   </div>
                 </td>
               </tr>
@@ -211,11 +221,10 @@
       <section id="gateway-errors">
         <details class="card details sectionDetails" data-section-details="1" open>
           <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Gateway errors <span class="countPill">{{ kpis.gateway_errors_count }}</span></span>
+            <span class="sectionSummaryLeft">Gateway errors <span class="countPill">{{ kpis.gateway_errors_count
+                }}</span></span>
           </summary>
-          {% if not export %}
           <div class="tableMeta smallMuted" data-table-meta="gateway"></div>
-          {% endif %}
           {% if not gateway_errors %}
           <div class="empty">(none)</div>
           {% else %}
@@ -251,21 +260,17 @@
                 </td>
                 <td class="right">
                   <div class="rowActions">
-                    {% if not export %}
                     <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    {% endif %}
                     <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
                       rel="noopener" title="Open in Voyager">Voyager</a>
-                    {% if not export %}
                     <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                       data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                     <a class="btn btnSmall btnLink"
                       href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
                       target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
-                      rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
-                    {% endif %}
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                      target="_blank" rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
                   </div>
                 </td>
               </tr>
@@ -279,7 +284,8 @@
       <section id="reverts-mainnet">
         <details class="card details sectionDetails" data-section-details="1" open>
           <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Reverted only on Mainnet <span class="countPill">{{ reverts.mainnet_only.total }} ({{ reverts.mainnet_only.pct_of_total_sent
+            <span class="sectionSummaryLeft">Reverted only on Mainnet <span class="countPill">{{
+                reverts.mainnet_only.total }} ({{ reverts.mainnet_only.pct_of_total_sent
                 }})</span></span>
           </summary>
           {% if reverts.mainnet_only.total == 0 %}
@@ -324,21 +330,17 @@
                   </td>
                   <td class="right">
                     <div class="rowActions">
-                      {% if not export %}
                       <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                      {% endif %}
                       <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
                         rel="noopener" title="Open in Voyager">Voyager</a>
-                      {% if not export %}
                       <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                         data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                       <a class="btn btnSmall btnLink"
                         href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
                         target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
                       <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
-                        rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                      {% endif %}
+                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                        target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
                     </div>
                   </td>
                 </tr>
@@ -354,7 +356,8 @@
       <section id="reverts-echonet">
         <details class="card details sectionDetails" data-section-details="1" open>
           <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Reverted only on Echonet <span class="countPill">{{ reverts.echonet_only.total }} ({{ reverts.echonet_only.pct_of_total_sent
+            <span class="sectionSummaryLeft">Reverted only on Echonet <span class="countPill">{{
+                reverts.echonet_only.total }} ({{ reverts.echonet_only.pct_of_total_sent
                 }})</span></span>
           </summary>
           {% if reverts.echonet_only.total == 0 %}
@@ -399,21 +402,17 @@
                   </td>
                   <td class="right">
                     <div class="rowActions">
-                      {% if not export %}
                       <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                      {% endif %}
                       <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
                         rel="noopener" title="Open in Voyager">Voyager</a>
-                      {% if not export %}
                       <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                         data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                       <a class="btn btnSmall btnLink"
                         href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
                         target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
                       <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
-                        rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                      {% endif %}
+                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                        target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
                     </div>
                   </td>
                 </tr>
@@ -429,11 +428,10 @@
       <section id="resync-triggers">
         <details class="card details sectionDetails" data-section-details="1" open>
           <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Resync triggers (first failures) <span class="countPill">{{ kpis.resync_causes_count }}</span></span>
+            <span class="sectionSummaryLeft">Resync triggers (first failures) <span class="countPill">{{
+                kpis.resync_causes_count }}</span></span>
           </summary>
-          {% if not export %}
           <div class="tableMeta smallMuted" data-table-meta="resync"></div>
-          {% endif %}
           {% if not resync.causes %}
           <div class="empty">(none)</div>
           {% else %}
@@ -463,21 +461,17 @@
                 <td class="mono">{{ row.reason }}</td>
                 <td class="right">
                   <div class="rowActions">
-                    {% if not export %}
                     <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    {% endif %}
                     <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
                       rel="noopener" title="Open in Voyager">Voyager</a>
-                    {% if not export %}
                     <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                       data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                     <a class="btn btnSmall btnLink"
                       href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
                       target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
-                      rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                    {% endif %}
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
                   </div>
                 </td>
               </tr>
@@ -491,11 +485,10 @@
       <section id="certain-failures">
         <details class="card details sectionDetails" data-section-details="1" open>
           <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Certain failures (repeated triggers) <span class="countPill">{{ kpis.certain_failures_count }}</span></span>
+            <span class="sectionSummaryLeft">Certain failures (repeated triggers) <span class="countPill">{{
+                kpis.certain_failures_count }}</span></span>
           </summary>
-          {% if not export %}
           <div class="tableMeta smallMuted" data-table-meta="certain"></div>
-          {% endif %}
           {% if not resync.certain_failures %}
           <div class="empty">(none)</div>
           {% else %}
@@ -525,21 +518,17 @@
                 <td class="mono">{{ row.reason }}</td>
                 <td class="right">
                   <div class="rowActions">
-                    {% if not export %}
                     <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    {% endif %}
                     <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
                       rel="noopener" title="Open in Voyager">Voyager</a>
-                    {% if not export %}
                     <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                       data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                     <a class="btn btnSmall btnLink"
                       href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
                       target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}" target="_blank"
-                      rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                    {% endif %}
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
                   </div>
                 </td>
               </tr>
@@ -553,11 +542,10 @@
       <section id="l2-gas-mismatches">
         <details class="card details sectionDetails" data-section-details="1" open>
           <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">L2 gas used mismatches <span class="countPill">{{ l2_gas_mismatches | length }}</span></span>
+            <span class="sectionSummaryLeft">L2 gas used mismatches <span class="countPill">{{ l2_gas_mismatches |
+                length }}</span></span>
           </summary>
-          {% if not export %}
           <div class="tableMeta smallMuted" data-table-meta="diag"></div>
-          {% endif %}
           {% if not l2_gas_mismatches %}
           <div class="empty">(none)</div>
           {% else %}
@@ -594,21 +582,20 @@
                 <td class="mono">{{ row.fgw_total_gas_consumed_l2 }}</td>
                 <td class="right">
                   <div class="rowActions">
-                    {% if not export %}
                     <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    {% endif %}
                     <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
                       rel="noopener" title="Open in Voyager">Voyager</a>
-                    {% if not export %}
                     <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                       data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                    {% if not export %}
                     <a class="btn btnSmall btnLink"
                       href="/echonet/block_dump?blockNumber={{ row.echo_block }}&kind=blob" target="_blank"
                       rel="noopener" title="Open echonet blob dump JSON (echo block)">Echo&nbsp;blob</a>
+                    {% endif %}
                     <a class="btn btnSmall btnLink"
                       href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.source_block }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Source&nbsp;block</a>
-                    {% endif %}
+                      target="_blank" rel="noopener"
+                      title="Open source block JSON (upstream feeder)">Source&nbsp;block</a>
                   </div>
                 </td>
               </tr>
@@ -652,7 +639,7 @@
     <footer class="footer">
       <div>
         {% if export %}
-        Static snapshot: interactive controls + local endpoints are disabled.
+        Static snapshot: filter/scope, copy, logs links, theme, and feeder links are enabled.
         {% else %}
         Endpoints:
         <a href="/echonet/report/ui">UI</a>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that mainly affect the HTML report rendering and the downloaded snapshot; no transaction processing or data-path logic is modified.
> 
> **Overview**
> Improves the Echonet report UI and the downloadable snapshot by **inlining static assets**: the favicon is now embedded as base64 in all renders, and the export HTML additionally embeds `report.css` and `report.js` so the download is self-contained.
> 
> Updates the report template to keep key interactivity working in exported snapshots (filter/scope, copy actions, logs/theme, and feeder links) while disabling auto-refresh and local UI endpoints, and tweaks progress messaging for startup/resync states plus minor layout polish in `report.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cc1a4d71a8f92a09b0d0f4c095e654749cd2c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->