### PR TITLE
echonet: stop halving gas prices

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -209,17 +209,6 @@ class BlobTransformer:
         return tx_hashes
 
     @staticmethod
-    def _halve_gas_prices(v: str) -> str:
-        """By shifting the integer value right by 1, the gas prices are halved."""
-        return hex(int(v, 16) >> 1)
-
-    def _with_halved_gas_prices(self, price: JsonObject) -> JsonObject:
-        out = dict(price)
-        out["price_in_wei"] = self._halve_gas_prices(out["price_in_wei"])
-        out["price_in_fri"] = self._halve_gas_prices(out["price_in_fri"])
-        return out
-
-    @staticmethod
     @dataclass(slots=True)
     class FlattenedCallInfo:
         """
@@ -478,11 +467,7 @@ class BlobTransformer:
         )
 
         meta = self._fetch_upstream_block_meta(bn_for_meta)
-        block_document["timestamp"] = meta["timestamp"]
-
-        # The gas prices are halved in order for txs to pass the fee sequencer checks.
-        for price in ("l1_gas_price", "l1_data_gas_price", "l2_gas_price"):
-            block_document[price] = self._with_halved_gas_prices(meta[price])
+        block_document.update(meta)
 
         return block_document
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the fee market metadata written into stored blocks by no longer halving gas prices, which could affect downstream fee checks/consumers that relied on the previous adjusted values.
> 
> **Overview**
> Stops adjusting fee market metadata when building stored block documents: the gas price “halving” logic was removed and `transform_block` now copies the upstream `timestamp`/`l1_gas_price`/`l1_data_gas_price`/`l2_gas_price` into the block as-is via `block_document.update(meta)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5b25dd07364e40d061632cc47f57235ab5a38b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->