### PR TITLE
test checkbox

### DIFF
--- a/.github/workflows/apollo_deployments_service_ack.yml
+++ b/.github/workflows/apollo_deployments_service_ack.yml
@@ -1,0 +1,49 @@
+name: Apollo deployments service.rs acknowledgment
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - "crates/apollo_deployments/src/service.rs"
+      - ".github/workflows/apollo_deployments_service_ack.yml"
+
+# On PR events, cancel existing CI runs on this same PR for this workflow.
+concurrency:
+  group: >
+    ${{ github.workflow }}-
+    ${{ github.ref }}-
+    ${{ github.event_name == 'pull_request' && 'PR' || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  assert-file-exists:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Assert service.rs exists
+        run: |
+          if [ ! -f crates/apollo_deployments/src/service.rs ]; then
+            echo "::error::crates/apollo_deployments/src/service.rs was removed or is missing."
+            exit 1
+          fi
+          echo "File crates/apollo_deployments/src/service.rs exists."
+
+  manual-confirmation:
+    runs-on: ubuntu-24.04
+    needs: [assert-file-exists]
+    environment: apollo-deployments-service-ack
+    steps:
+      - name: Display acknowledgment message
+        run: |
+          echo "--- Acknowledgment message ---"
+          if [ -n "${{ vars.APOLLO_SERVICE_RS_MESSAGE }}" ]; then
+            echo "${{ vars.APOLLO_SERVICE_RS_MESSAGE }}"
+          else
+            echo "Replace this placeholder: set APOLLO_SERVICE_RS_MESSAGE in the environment or edit this workflow with your custom message."
+          fi
+          echo "---"
+          echo "This job passed after manual approval of the environment."

--- a/crates/apollo_deployments/src/service.rs
+++ b/crates/apollo_deployments/src/service.rs
@@ -41,6 +41,8 @@ use crate::test_utils::FIX_BINARY_NAME;
 const SERVICES_DIR_NAME: &str = "services/";
 const REMOTE_SERVICE_URL_PLACEHOLDER: &str = "remote_service";
 
+
+
 // TODO(Tsabary): remove ports and mempool ttl from this list.
 pub static KEYS_TO_BE_REPLACED: phf::Set<&'static str> = phf_set! {
     "base_layer_config.bpo1_start_block_number",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change: it adds a new workflow with a manual environment gate and a simple file existence check; no runtime logic changes beyond minor whitespace.
> 
> **Overview**
> Introduces a new GitHub Actions workflow, `apollo_deployments_service_ack.yml`, that triggers on PRs touching `crates/apollo_deployments/src/service.rs` and requires **manual environment approval** (`apollo-deployments-service-ack`) before the workflow completes.
> 
> The workflow first asserts the file still exists, then prints an acknowledgment message sourced from `APOLLO_SERVICE_RS_MESSAGE` (or a placeholder). Separately, `service.rs` only changes whitespace (extra blank lines).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca474c21aebb0790193c972fc27eecd9af97a4d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->