### PR TITLE
deployment: adds workflow which injects a check-box to PR description case of changes in services.rs

### DIFF
--- a/.github/workflows/sync_check.yaml
+++ b/.github/workflows/sync_check.yaml
@@ -1,0 +1,53 @@
+name: Cross-Repo Sync Check
+
+on:
+  pull_request:
+    # 'edited' allows the check to pass the moment the dev clicks the box
+    # 'synchronize' handles new commits
+    types: [opened, synchronize, edited]
+    paths:
+      - "crates/apollo_deployments/src/service.rs"
+      - ".github/workflows/sync_check.yaml"
+
+jobs:
+  manage-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Sync Checkbox Logic
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const checkbox = "- [ ] I have synced these changes to **Private Repo Y**";
+            const checked = "- [x] I have synced these changes to **Private Repo Y**";
+            
+            // 1. Fetch the latest PR body (don't rely on the 'context' which might be stale)
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const body = pr.body || "";
+            const hasCheckbox = body.includes("- [ ] I have synced") || body.includes("- [x] I have synced");
+
+            // 2. If Cursor BOT or the Dev hasn't added the checkbox, append it.
+            if (!hasCheckbox) {
+              const newBody = body + "\n\n---\n### ⚠️ Cross-Repo Sync Required\n" + checkbox + "\n*The private repo Y depends on these config changes.*";
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                body: newBody
+              });
+              core.setFailed("Added sync checklist. Please update Private Repo Y and check the box.");
+              return; 
+            }
+
+            // 3. Final enforcement: Is it checked?
+            if (body.includes(checked)) {
+              console.log("Sync confirmed!");
+            } else {
+              core.setFailed("Please check the 'Sync to Private Repo Y' box once the private repo is aligned.");
+            }


### PR DESCRIPTION
---

### ⚠️ Cross-Repo Sync Required

- [x] I have synced these changes to **Private Repo Y**
_The private repo Y depends on these config changes._

<!-- CURSOR_SUMMARY -->

---

> [!NOTE]
> **Medium Risk**
> Adds a GitHub Actions workflow that modifies PR bodies and gates merges via a required checkbox, which can affect developer workflow and relies on `pull-requests: write` permissions.
>
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/sync_check.yaml`) that triggers on PRs touching `crates/apollo_deployments/src/service.rs` (or the workflow itself) and **enforces a cross-repo sync confirmation**.
>
> The job fetches the latest PR body, appends a “synced to Private Repo Y” checkbox section if missing, and fails the check until the checkbox is marked as checked.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf077d45f09da349cb801a5480618e42b3ac72ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

<!-- /CURSOR_SUMMARY -->