### PR TITLE
deployment: Sort grafana alert rule group file by title

### DIFF
--- a/deployments/sequencer/src/constructs/grafana.py
+++ b/deployments/sequencer/src/constructs/grafana.py
@@ -162,10 +162,16 @@ class GrafanaAlertRuleGroupConstruct(GrafanaBaseConstruct):
 
     def _get_shared_grafana_alert_rule_group_spec(self):
         """Build the spec for the alert rule group."""
-        rules = []
-        for alert_file in self.grafana_alert_files:
-            alert_rule = self.grafana_alert_group.load(str(alert_file))
-            rules.append(self._get_shared_grafana_alert_rule_group_rules(alert_rule))
+        loaded_alert_rules = [
+            self.grafana_alert_group.load(str(alert_file))
+            for alert_file in self.grafana_alert_files
+        ]
+        # Keep rule order deterministic so generated YAML has stable PR diffs.
+        loaded_alert_rules.sort(key=lambda rule: rule["title"].lower())
+        rules = [
+            self._get_shared_grafana_alert_rule_group_rules(alert_rule)
+            for alert_rule in loaded_alert_rules
+        ]
 
         return SharedGrafanaAlertRuleGroupSpec(
             name=self.custom_name,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the ordering of generated Grafana alert rules by sorting on `title`, which could affect diff noise and evaluation order but not rule content.
> 
> **Overview**
> Grafana alert rule group generation now loads all alert rule files first and **sorts them case-insensitively by `title`** before converting them into `SharedGrafanaAlertRuleGroupSpec.rules`.
> 
> This makes the rendered rule group order deterministic across runs, instead of depending on filesystem/loader ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c95d508e8b427970d45e9796acee27965f5dfef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->