### PR TITLE
apollo_protobuf: compress proof in p2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,6 +2365,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unsigned-varint 0.8.0",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/apollo_protobuf/Cargo.toml
+++ b/crates/apollo_protobuf/Cargo.toml
@@ -36,6 +36,7 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true, features = ["env-filter"] }
 unsigned-varint.workspace = true
+zstd.workspace = true
 
 # Binaries dependencies
 prost-build = { workspace = true, optional = true }

--- a/crates/apollo_protobuf/src/converters/rpc_transaction.rs
+++ b/crates/apollo_protobuf/src/converters/rpc_transaction.rs
@@ -26,6 +26,46 @@ use crate::protobuf::{self};
 use crate::transaction::DeclareTransactionV3Common;
 auto_impl_into_and_try_from_vec_u8!(RpcTransactionBatch, protobuf::MempoolTransactionBatch);
 
+/// The default zstd compression level.
+const ZSTD_COMPRESSION_LEVEL: i32 = zstd::DEFAULT_COMPRESSION_LEVEL;
+
+/// Maximum decompressed proof size (256 MB) to prevent decompression bombs.
+const MAX_PROOF_DECOMPRESSED_SIZE: usize = 1 << 28;
+
+/// Compresses a proof (sequence of u32 values) into zstd-compressed bytes.
+/// Each u32 is serialized as 4 big-endian bytes before compression.
+fn compress_proof(proof_data: &[u32]) -> Vec<u8> {
+    if proof_data.is_empty() {
+        return Vec::new();
+    }
+    let raw_bytes: Vec<u8> = proof_data.iter().flat_map(|n| n.to_be_bytes()).collect();
+    zstd::bulk::compress(&raw_bytes, ZSTD_COMPRESSION_LEVEL)
+        .expect("zstd compression of proof data should not fail")
+}
+
+/// Decompresses zstd-compressed proof bytes back into a `Proof`.
+fn decompress_proof(compressed: &[u8]) -> Result<Proof, ProtobufConversionError> {
+    if compressed.is_empty() {
+        return Ok(Proof::default());
+    }
+    let decompressed =
+        zstd::bulk::decompress(compressed, MAX_PROOF_DECOMPRESSED_SIZE).map_err(|e| {
+            ProtobufConversionError::CompressionError(format!("Failed to decompress proof: {e}"))
+        })?;
+    if decompressed.len() % 4 != 0 {
+        return Err(ProtobufConversionError::BytesDataLengthMismatch {
+            type_description: "Proof",
+            num_expected: 4,
+            value: decompressed,
+        });
+    }
+    let proof_u32s: Vec<u32> = decompressed
+        .chunks_exact(4)
+        .map(|c| u32::from_be_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+    Ok(Proof::from(proof_u32s))
+}
+
 const DEPRECATED_RESOURCE_BOUNDS_ERROR: ProtobufConversionError =
     ProtobufConversionError::MissingField { field_description: "ResourceBounds::l1_data_gas" };
 
@@ -114,10 +154,10 @@ impl From<RpcDeployAccountTransactionV3> for protobuf::DeployAccountV3 {
 
 impl TryFrom<protobuf::InvokeV3WithProof> for RpcInvokeTransactionV3 {
     type Error = ProtobufConversionError;
-    fn try_from(mut value: protobuf::InvokeV3WithProof) -> Result<Self, Self::Error> {
+    fn try_from(value: protobuf::InvokeV3WithProof) -> Result<Self, Self::Error> {
         // Extract proof first, since `starknet_api::transaction::InvokeTransactionV3` does not
         // carry a `proof` field.
-        let proof = Proof::from(std::mem::take(&mut value.proof));
+        let proof = decompress_proof(&value.compressed_proof)?;
 
         let snapi_invoke: InvokeTransactionV3 = value
             .invoke
@@ -135,11 +175,13 @@ impl From<RpcInvokeTransactionV3> for protobuf::InvokeV3WithProof {
     fn from(mut value: RpcInvokeTransactionV3) -> Self {
         // Extract proof first, since `starknet_api::transaction::InvokeTransactionV3` does not
         // carry a `proof` field.
-        let proof = Arc::unwrap_or_clone(std::mem::take(&mut value.proof).0);
+        let proof_data = Arc::unwrap_or_clone(std::mem::take(&mut value.proof).0);
 
         let snapi_invoke: InvokeTransactionV3 = value.into();
 
-        Self { invoke: Some(snapi_invoke.into()), proof }
+        let compressed_proof = compress_proof(&proof_data);
+
+        Self { invoke: Some(snapi_invoke.into()), compressed_proof }
     }
 }
 

--- a/crates/apollo_protobuf/src/proto/p2p/proto/transaction.proto
+++ b/crates/apollo_protobuf/src/proto/p2p/proto/transaction.proto
@@ -68,7 +68,9 @@ message InvokeV3 {
 // Used in consensus and mempool contexts where proof is included.
 message InvokeV3WithProof {
     InvokeV3 invoke = 1;
-    repeated uint32 proof = 2;
+    // zstd-compressed proof bytes. The raw (decompressed) payload is a sequence of
+    // big-endian u32 values (4 bytes each).
+    bytes compressed_proof = 2;
 }
 
 // see https://external.integration.starknet.io/feeder_gateway/get_transaction?transactionHash=0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0

--- a/crates/apollo_protobuf/src/protobuf/protoc_output.rs
+++ b/crates/apollo_protobuf/src/protobuf/protoc_output.rs
@@ -314,8 +314,10 @@ pub struct InvokeV3 {
 pub struct InvokeV3WithProof {
     #[prost(message, optional, tag = "1")]
     pub invoke: ::core::option::Option<InvokeV3>,
-    #[prost(uint32, repeated, tag = "2")]
-    pub proof: ::prost::alloc::vec::Vec<u32>,
+    /// zstd-compressed proof bytes. The raw (decompressed) payload is a sequence of
+    /// big-endian u32 values (4 bytes each).
+    #[prost(bytes = "vec", tag = "2")]
+    pub compressed_proof: ::prost::alloc::vec::Vec<u8>,
 }
 /// see <https://external.integration.starknet.io/feeder_gateway/get_transaction?transactionHash=0x29fd7881f14380842414cdfdd8d6c0b1f2174f8916edcfeb1ede1eb26ac3ef0>
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `InvokeV3WithProof` wire format (replacing `repeated uint32 proof` with `bytes compressed_proof`), which can break interoperability with older peers and requires coordinated rollout. Adds zstd compression/decompression and size limits, so bugs here could cause transaction decoding failures or resource spikes if misconfigured.
> 
> **Overview**
> **Compresses `InvokeV3WithProof` client proof data over the wire.** The protobuf schema replaces `repeated uint32 proof` (tag 2) with `bytes compressed_proof` (tag 3) and reserves the old field number.
> 
> `rpc_transaction` converters now zstd-compress/decompress the proof as big-endian `u32` bytes, add a 256MB decompression cap, and surface decompression/length errors as `ProtobufConversionError`. The crate also adds a `zstd` dependency (and lockfile update) to support this.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 998149ccc9827b575a1b540f6888c93c1a432d22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->