### PR TITLE
deployment: Decrease indentation of grafana k8s manifest

### DIFF
--- a/deployments/sequencer/src/constructs/grafana.py
+++ b/deployments/sequencer/src/constructs/grafana.py
@@ -72,7 +72,7 @@ class GrafanaDashboardConstruct(GrafanaBaseConstruct):
             collection_name=f"shared-grafana-dashboard",
             dashboard_name=self.custom_name,
             folder_name=self.cluster,
-            dashboard_json=json.dumps(self.grafana_dashboard, indent=4),
+            dashboard_json=json.dumps(self.grafana_dashboard, indent=1),
         )
 
     def _get_shared_grafana_dashboard(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk formatting-only change that alters the generated dashboard JSON string/manifest layout but not its content or behavior.
> 
> **Overview**
> Reduces the JSON indentation used when serializing the Grafana dashboard (`dashboard_json` in `SharedGrafanaDashboardSpec`) from 4 spaces to 1, producing more compact generated Kubernetes manifests and smaller diffs without changing dashboard semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 654b1ebf62a1b1215405e841b88846cb42059c27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->