### PR TITLE
apollo_compile_to_native: use toml instead of consts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
  "mempool_test_utils",
  "rstest",
  "tempfile",
+ "toml 0.8.23",
  "toml_test_utils",
 ]
 

--- a/crates/apollo_compile_to_native/Cargo.toml
+++ b/crates/apollo_compile_to_native/Cargo.toml
@@ -27,3 +27,4 @@ toml_test_utils.workspace = true
 [build-dependencies]
 apollo_compilation_utils.workspace = true
 apollo_infra_utils.workspace = true
+toml.workspace = true

--- a/crates/apollo_compile_to_native/build.rs
+++ b/crates/apollo_compile_to_native/build.rs
@@ -1,9 +1,13 @@
+use std::path::Path;
+
 use apollo_compilation_utils::build_utils::install_compiler_binary;
 
 include!("src/constants.rs");
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    // Rerun when workspace cairo-native dependency changes.
+    println!("cargo:rerun-if-changed=../../Cargo.toml");
 
     set_run_time_out_dir_env_var();
     install_starknet_native_compile();
@@ -12,15 +16,85 @@ fn main() {
 /// Install the `starknet-native-compile` binary from the Cairo Native crate and moves the binary
 /// to the `target` directory. The `starknet-native-compile` binary is used to compile Sierra to
 /// Native. The binary is executed as a subprocess whenever Sierra to Cairo compilation is required.
+/// Installation is driven by the workspace Cargo.toml's cairo-native dependency (single source of
+/// truth).
 fn install_starknet_native_compile() {
     let binary_name = CAIRO_NATIVE_BINARY_NAME;
-    let required_version = REQUIRED_CAIRO_NATIVE_VERSION;
+    let (required_version, cargo_install_args) = cargo_install_args_from_workspace();
+    let args_refs: Vec<&str> = cargo_install_args.iter().map(String::as_str).collect();
+    install_compiler_binary(binary_name, &required_version, &args_refs, &out_dir());
+}
 
-    // TODO(Avi): Revert to `--version` install once cairo-native publishes a release with blake
-    // builtin support.
-    let cargo_install_args =
-        &[binary_name, "--git", CAIRO_NATIVE_GIT_URL, "--branch", CAIRO_NATIVE_GIT_BRANCH];
-    install_compiler_binary(binary_name, required_version, cargo_install_args, &out_dir());
+/// Reads the workspace root Cargo.toml and builds (required_version, cargo_install_args) from
+/// the workspace.dependencies["cairo-native"] entry.
+fn cargo_install_args_from_workspace() -> (String, Vec<String>) {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let workspace_cargo = Path::new(&manifest_dir).join("../../Cargo.toml");
+    let contents = std::fs::read_to_string(&workspace_cargo).unwrap_or_else(|e| {
+        panic!("Failed to read workspace Cargo.toml at {:?}: {}", workspace_cargo, e)
+    });
+    let root: toml::Table = contents.parse().expect("Failed to parse workspace Cargo.toml");
+    let workspace = root
+        .get("workspace")
+        .and_then(|v| v.as_table())
+        .expect("workspace Cargo.toml has no [workspace]");
+    let deps = workspace
+        .get("dependencies")
+        .and_then(|v| v.as_table())
+        .expect("[workspace] has no dependencies section");
+    let cairo_native =
+        deps.get("cairo-native").expect("workspace.dependencies has no cairo-native entry");
+
+    match cairo_native {
+        toml::Value::String(version) => {
+            let version = version.trim_start_matches('=');
+            let args = vec![binary_name_arg(), "--version".to_string(), version.to_string()];
+            (version.to_string(), args)
+        }
+        toml::Value::Table(t) => {
+            let version = t.get("version").and_then(|v| v.as_str());
+            let git = t.get("git").and_then(|v| v.as_str());
+            let branch = t.get("branch").and_then(|v| v.as_str());
+            let tag = t.get("tag").and_then(|v| v.as_str());
+            let rev = t.get("rev").and_then(|v| v.as_str());
+
+            let required_version = version
+                .map(|s| s.trim_start_matches('=').to_string())
+                .or_else(|| tag.map(String::from))
+                .or_else(|| rev.map(String::from))
+                .or_else(|| branch.map(String::from))
+                .expect("cairo-native must have version, or git with branch/tag/rev");
+
+            let mut args = vec![binary_name_arg()];
+            if let Some(url) = git {
+                args.push("--git".to_string());
+                args.push(url.to_string());
+                if let Some(b) = branch {
+                    args.push("--branch".to_string());
+                    args.push(b.to_string());
+                }
+                if let Some(t) = tag {
+                    args.push("--tag".to_string());
+                    args.push(t.to_string());
+                }
+                if let Some(r) = rev {
+                    args.push("--rev".to_string());
+                    args.push(r.to_string());
+                }
+            } else if let Some(v) = version {
+                args.push("--version".to_string());
+                args.push(v.trim_start_matches('=').to_string());
+            } else {
+                panic!("cairo-native must specify version or git with branch/tag/rev");
+            }
+            (required_version, args)
+        }
+        _ => panic!("workspace.dependencies.cairo-native must be a string or a table"),
+    }
+}
+
+fn binary_name_arg() -> String {
+    CAIRO_NATIVE_BINARY_NAME.to_string()
 }
 
 // Sets the `RUNTIME_ACCESSIBLE_OUT_DIR` environment variable to the `OUT_DIR` value, which will be

--- a/crates/apollo_compile_to_native/src/constants.rs
+++ b/crates/apollo_compile_to_native/src/constants.rs
@@ -1,13 +1,8 @@
 // Note: This module includes constants that are needed during build and run times. It must
 // not contain functionality that is available in only in one of these modes. Specifically, it
 // must avoid relying on env variables such as 'CARGO_*' or 'OUT_DIR'.
+//
+// The cairo-native dependency (version, git URL, branch/tag/rev) is defined only in the workspace
+// Cargo.toml; the build script reads it from there to install the starknet-native-compile binary.
 
 pub(crate) const CAIRO_NATIVE_BINARY_NAME: &str = "starknet-native-compile";
-
-// TODO(Avi): Remove git URL/branch constants once cairo-native publishes a release with blake
-// builtin support, and revert to installing from crates.io.
-pub const CAIRO_NATIVE_GIT_URL: &str = "https://github.com/lambdaclass/cairo_native";
-pub const CAIRO_NATIVE_GIT_BRANCH: &str = "tomer/blake_builtin";
-
-// Kept for the version check on the installed binary (--version output).
-pub const REQUIRED_CAIRO_NATIVE_VERSION: &str = "0.9.0-rc.1";

--- a/crates/apollo_compile_to_native/src/constants_test.rs
+++ b/crates/apollo_compile_to_native/src/constants_test.rs
@@ -1,19 +1,35 @@
 use toml_test_utils::{DependencyValue, ROOT_TOML};
 
-use crate::constants::REQUIRED_CAIRO_NATIVE_VERSION;
-
-// TODO(Avi): Re-enable once cairo-native is pinned to a stable crates.io version.
+/// Ensures the workspace defines cairo-native and that a required-version identifier can be
+/// derived (from version string, or from git branch/tag/rev in the real build script).
 #[test]
-#[ignore]
-fn required_cairo_native_version_test() {
-    let cairo_native_version = ROOT_TOML
+fn workspace_cairo_native_dependency_test() {
+    assert!(
+        ROOT_TOML.contains_dependency("cairo-native"),
+        "workspace.dependencies must define cairo-native (single source of truth for install)"
+    );
+    let (name, value) = ROOT_TOML
         .dependencies()
-        .filter_map(|(name, value)| match (name.as_str(), value) {
-            ("cairo-native", DependencyValue::Object { version, .. }) => version.as_ref(),
-            ("cairo-native", DependencyValue::String(version)) => Some(version),
-            _ => None,
-        })
-        .next()
-        .expect("cairo-native dependency not found in root toml file.");
-    assert_eq!(REQUIRED_CAIRO_NATIVE_VERSION, cairo_native_version);
+        .find(|(n, _)| n.as_str() == "cairo-native")
+        .expect("cairo-native not found in workspace.dependencies");
+    assert_eq!(name, "cairo-native");
+    match value {
+        DependencyValue::String(version) => {
+            assert!(
+                !version.trim_start_matches('=').is_empty(),
+                "cairo-native version string must be non-empty"
+            );
+        }
+        DependencyValue::Object { version, .. } => {
+            // Git deps (branch/tag/rev) have no version field; build script derives
+            // required_version from branch/tag/rev. Here we only check the dependency
+            // is present and valid.
+            if let Some(v) = version {
+                assert!(
+                    !v.trim_start_matches('=').is_empty(),
+                    "cairo-native version must be non-empty when set"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches build tooling and compiler-binary installation logic; misparsing or unexpected `cairo-native` dependency shapes could break builds or install the wrong binary.
> 
> **Overview**
> Build-time installation of `starknet-native-compile` is now driven by the workspace’s `cairo-native` dependency entry instead of hardcoded constants, by parsing the root `Cargo.toml` and generating the appropriate `cargo install` args (supports `version` and `git` + `branch`/`tag`/`rev`).
> 
> The build script now reruns when the root `Cargo.toml` changes, adds `toml` as a build dependency, removes the previously pinned cairo-native git/version constants, and updates the associated test to validate presence/shape of the workspace `cairo-native` dependency rather than matching a fixed version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5387510ffc6e8d92f883216735734b03c6d41d6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->