### PR TITLE
deployment: Add grafana JSON size assertion

### DIFF
--- a/deployments/sequencer/src/constructs/grafana.py
+++ b/deployments/sequencer/src/constructs/grafana.py
@@ -20,6 +20,8 @@ from imports.dashboards.co.starkware.grafana import (
 from src.config.loaders import GrafanaAlertRuleGroupConfigLoader, GrafanaDashboardConfigLoader
 from src.utils import generate_random_hash
 
+MAX_ALLOWED_DASHBOARD_JSON_SIZE = 3 * 1024 * 1024  # 3MB
+
 
 class GrafanaBaseConstruct(Construct):
     """Base construct for Grafana resources with shared functionality."""
@@ -68,11 +70,16 @@ class GrafanaDashboardConstruct(GrafanaBaseConstruct):
         self._get_shared_grafana_dashboard()
 
     def _get_shared_grafana_dashboard_spec(self):
+        dashboard_json = json.dumps(self.grafana_dashboard, indent=1)
+        assert (
+            len(dashboard_json.encode("utf-8")) < MAX_ALLOWED_DASHBOARD_JSON_SIZE
+        ), "Grafana dashboard JSON is too large"
+
         return SharedGrafanaDashboardSpec(
             collection_name=f"shared-grafana-dashboard",
             dashboard_name=self.custom_name,
             folder_name=self.cluster,
-            dashboard_json=json.dumps(self.grafana_dashboard, indent=1),
+            dashboard_json=dashboard_json,
         )
 
     def _get_shared_grafana_dashboard(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adds a precondition check during dashboard spec generation, with the main impact being potential deploy-time failures for unusually large dashboards.
> 
> **Overview**
> Adds a `MAX_ALLOWED_DASHBOARD_JSON_SIZE` (3MB) limit and asserts the serialized Grafana dashboard JSON stays under this threshold before creating `SharedGrafanaDashboardSpec`, reusing the precomputed `dashboard_json` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0403295a467bfbede5b3c8345e6563741c9d3f9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->