### PR TITLE
echonet: Add echonet only reverts to resync triggers

### DIFF
--- a/echonet/echonet_keys.json
+++ b/echonet/echonet_keys.json
@@ -1,6 +1,5 @@
 {
     "start_block": 0,
     "blocked_senders": "",
-    "resync_error_threshold": 1,
-    "max_pending_txs_before_pausing": 15
+    "max_pending_txs_before_pausing": 39
 }

--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -47,7 +47,8 @@ class ResyncTriggerPayload(TypedDict):
     """
 
     tx_hash: str
-    block_number: int
+    failure_block_number: int
+    revert_target_block_number: int
     reason: str
 
 
@@ -169,13 +170,6 @@ class TxFilterConfig:
 
 
 @dataclass(frozen=True, slots=True)
-class ResyncConfig:
-    """Thresholds for resync decisions."""
-
-    error_threshold: int = 1
-
-
-@dataclass(frozen=True, slots=True)
 class L1Config:
     """External provider credentials for L1 access."""
 
@@ -201,7 +195,6 @@ class EchonetConfig:
     severity: SeverityConfig
     paths: PathsConfig
     tx_filter: TxFilterConfig
-    resync: ResyncConfig
     l1: L1Config
     gcp_logs: GcpLogsConfig
 
@@ -217,7 +210,6 @@ class EchonetConfig:
         secrets = helpers.read_json_object(secrets_path)
 
         start_block = int(keys["start_block"])
-        resync_threshold = int(keys.get("resync_error_threshold", 1))
         blocked_senders_csv = str(keys.get("blocked_senders", ""))
         max_pending_txs_before_pausing = int(keys.get("max_pending_txs_before_pausing", 15))
 
@@ -254,9 +246,6 @@ class EchonetConfig:
             paths=PathsConfig(),
             tx_filter=TxFilterConfig(
                 blocked_senders=helpers.parse_csv_to_lower_set(blocked_senders_csv),
-            ),
-            resync=ResyncConfig(
-                error_threshold=resync_threshold,
             ),
             l1=L1Config(
                 l1_provider_api_key=l1_provider_api_key,

--- a/echonet/reports.py
+++ b/echonet/reports.py
@@ -179,10 +179,12 @@ class SnapshotTextReport:
             lines.append("(none)")
         else:
             for tx_hash, meta in sorted(
-                s.resync_causes.items(), key=lambda kv: kv[1]["block_number"]
+                s.resync_causes.items(), key=lambda kv: kv[1]["failure_block_number"]
             ):
                 lines.append(
-                    f"{tx_hash}: bn={meta['block_number']} reason={meta['reason']} count={meta['count']}"
+                    f"{tx_hash}: failure_block_number={meta['failure_block_number']} "
+                    f"revert_target_block_number={meta['revert_target_block_number']} "
+                    f"reason={meta['reason']} count={meta['count']}"
                 )
 
         lines.append("")
@@ -191,10 +193,12 @@ class SnapshotTextReport:
             lines.append("(none)")
         else:
             for tx_hash, meta in sorted(
-                s.certain_failures.items(), key=lambda kv: kv[1]["block_number"]
+                s.certain_failures.items(), key=lambda kv: kv[1]["failure_block_number"]
             ):
                 lines.append(
-                    f"{tx_hash}: bn={meta['block_number']} reason={meta['reason']} count={meta['count']}"
+                    f"{tx_hash}: failure_block_number={meta['failure_block_number']} "
+                    f"revert_target_block_number={meta['revert_target_block_number']} "
+                    f"reason={meta['reason']} count={meta['count']}"
                 )
 
         lines.append("")
@@ -576,11 +580,11 @@ class _SnapshotReportRollup:
 
         resync_causes_rows = sorted(
             (dict(v) for v in s.resync_causes.values()),
-            key=lambda x: (x["block_number"], x["tx_hash"]),
+            key=lambda x: (x["failure_block_number"], x["tx_hash"]),
         )
         certain_failures_rows = sorted(
             (dict(v) for v in s.certain_failures.values()),
-            key=lambda x: (-x["count"], x["block_number"]),
+            key=lambda x: (-x["count"], x["failure_block_number"]),
         )
         l2_gas_mismatches_rows = [dict(v) for v in s.l2_gas_mismatches]
         forward_rate = _format_rate(total_sent, s.uptime_seconds, unit="TPS")

--- a/echonet/resync.py
+++ b/echonet/resync.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Callable, Dict, Optional
 
 from echonet import reports
-from echonet.echonet_types import CONFIG, JsonObject, ResyncTriggerPayload
+from echonet.echonet_types import JsonObject, ResyncTriggerPayload, RevertErrorInfo
 from echonet.logger import get_logger
 from echonet.sequencer_manager import SequencerManager
 from echonet.shared_context import shared
@@ -22,17 +22,33 @@ class ResyncPolicy:
         self,
         gateway_errors: Dict[str, JsonObject],
         sent_tx_hashes: Dict[str, int],
+        echonet_only_reverts: Dict[str, RevertErrorInfo],
         current_block: int,
     ) -> Optional[ResyncTriggerPayload]:
         threshold_block = current_block - self._blocks_to_wait_before_failing_tx
 
+        # We combine all error sources into one list so we can pick a single earliest
+        # failure trigger across gateway errors, Echonet-only reverts, and stale pending txs.
         candidates: list[tuple[str, int, str]] = []
 
+        # Gateway errors are added.
         for tx_hash, error in gateway_errors.items():
-            block_number = error["block_number"]
-            if block_number <= threshold_block:
-                candidates.append((tx_hash, block_number, f"Gateway error: {error['response']}"))
+            candidates.append(
+                (tx_hash, error["block_number"], f"Gateway error: {error['response']}")
+            )
 
+        # Echonet-only reverts are added.
+        for tx_hash, info in echonet_only_reverts.items():
+            candidates.append(
+                (
+                    tx_hash,
+                    info["block_number"],
+                    f"Echonet-only revert: {info['error']}",
+                )
+            )
+
+        # Pending transactions are added only after crossing the waiting threshold;
+        # younger pending transactions are ignored.
         for tx_hash, block_number in sent_tx_hashes.items():
             if block_number <= threshold_block:
                 candidates.append(
@@ -43,16 +59,30 @@ class ResyncPolicy:
                     )
                 )
 
-        if len(candidates) < CONFIG.resync.error_threshold:
+        # No candidates accumulated yet -> do not trigger resync.
+        if not candidates:
             return None
 
-        tx_hash_trigger, block_number_trigger, reason_trigger = min(
+        # The trigger is the earliest failing block.
+        tx_hash_trigger, failure_block_number, reason_trigger = min(
             candidates, key=lambda item: item[1]
         )
+        pending_min_block = min(sent_tx_hashes.values()) if sent_tx_hashes else None
+
+        # - If there are pending txs, rewind to the earlier of:
+        #   (a) trigger failure block, or (b) oldest pending tx block.
+        # - If none are pending, rewind to the trigger failure block.
+        revert_target_block_number = (
+            min(failure_block_number, pending_min_block)
+            if pending_min_block is not None
+            else failure_block_number
+        )
+
         return {
             "tx_hash": tx_hash_trigger,
-            "block_number": block_number_trigger,
-            "reason": f"Resync after >= {CONFIG.resync.error_threshold} errors: {reason_trigger}",
+            "failure_block_number": failure_block_number,
+            "revert_target_block_number": revert_target_block_number,
+            "reason": reason_trigger,
         }
 
 
@@ -63,17 +93,17 @@ class ResyncExecutor:
         self._get_sequencer_manager = get_sequencer_manager
 
     async def execute(self, trigger: ResyncTriggerPayload) -> int:
-        is_repeated_trigger = shared.record_resync_cause(
-            trigger["tx_hash"], trigger["block_number"], trigger["reason"]
-        )
-        next_start_block = (
-            trigger["block_number"] + 1 if is_repeated_trigger else trigger["block_number"]
+        is_repeated_trigger, next_start_block = shared.record_resync_cause(
+            trigger["tx_hash"],
+            trigger["failure_block_number"],
+            trigger["revert_target_block_number"],
+            trigger["reason"],
         )
 
         self._get_sequencer_manager().scale_to_zero()
         reports.write_pre_resync_reports(
             trigger_tx_hash=trigger["tx_hash"],
-            trigger_block=trigger["block_number"],
+            trigger_block=trigger["failure_block_number"],
             trigger_reason=trigger["reason"],
             snapshot=shared.get_report_snapshot(),
             logger=logger,

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -88,7 +88,10 @@ class _TxTracker:
 class _TxErrorTracker:
     """Gateway + revert error tracking (live vs cumulative) for reporting."""
 
+    # TODO(Ron): Have all report objects contain epoch, and as such duplicate info could be removed (this is already in progress)
     gateway_errors_live: Dict[str, JsonObject]  # reset on resync
+    gateway_errors: Dict[str, JsonObject]  # cumulative across resyncs
+    echonet_only_reverts_live: Dict[str, RevertErrorInfo]  # reset on resync
     revert_errors_mainnet: Dict[str, RevertErrorInfo]  # tx_hash -> {block_number, error}
     revert_errors_echonet: Dict[str, RevertErrorInfo]  # tx_hash -> {block_number, error}
 
@@ -96,6 +99,8 @@ class _TxErrorTracker:
     def empty(cls) -> "_TxErrorTracker":
         return cls(
             gateway_errors_live={},
+            gateway_errors={},
+            echonet_only_reverts_live={},
             revert_errors_mainnet={},
             revert_errors_echonet={},
         )
@@ -103,11 +108,13 @@ class _TxErrorTracker:
     def record_gateway_error(
         self, tx_hash: str, status: int, response: str, block_number: int
     ) -> None:
-        self.gateway_errors_live[tx_hash] = {
+        payload = {
             "status": status,
             "response": response,
             "block_number": block_number,
         }
+        self.gateway_errors_live[tx_hash] = payload
+        self.gateway_errors[tx_hash] = payload
 
     def record_mainnet_revert_error(self, tx_hash: str, error: str, block_number: int) -> None:
         self.revert_errors_mainnet[tx_hash] = create_revert_error_info(
@@ -121,12 +128,13 @@ class _TxErrorTracker:
         if tx_hash in self.revert_errors_mainnet:
             self.revert_errors_mainnet.pop(tx_hash, None)
         else:
-            self.revert_errors_echonet[tx_hash] = create_revert_error_info(
-                block_number=source_block_number, error=error
-            )
+            info = create_revert_error_info(block_number=source_block_number, error=error)
+            self.revert_errors_echonet[tx_hash] = info
+            self.echonet_only_reverts_live[tx_hash] = info
 
     def clear_live(self) -> None:
         self.gateway_errors_live.clear()
+        self.echonet_only_reverts_live.clear()
 
 
 @dataclass(slots=True)
@@ -140,29 +148,50 @@ class _ResyncTracker:
     def empty(cls) -> "_ResyncTracker":
         return cls(resync_causes={}, certain_failures={})
 
-    def record_cause(self, tx_hash: str, block_number: int, reason: str) -> bool:
+    def record_cause(
+        self,
+        tx_hash: str,
+        failure_block_number: int,
+        revert_target_block_number: int,
+        reason: str,
+    ) -> tuple[bool, int]:
+        def _selected_start_block() -> int:
+            # Repeated trigger (same tx_hash seen again) means the previous resync
+            # did not clear the issue; move start to just after the latest failing
+            # block to avoid replaying the known-bad failing block endlessly.
+            return failure_block_number + 1 if is_repeated_trigger else revert_target_block_number
+
         entry = self.certain_failures.get(tx_hash)
+        is_repeated_trigger = entry is not None
         if entry:
+            revert_target_block_number = _selected_start_block()
             entry["count"] += 1
-            entry["block_number"] = block_number
+            entry["failure_block_number"] = failure_block_number
+            entry["revert_target_block_number"] = revert_target_block_number
             entry["reason"] = reason
-            return True
+            return True, revert_target_block_number
 
         entry = dict(self.resync_causes.pop(tx_hash, {}))
+        is_repeated_trigger = bool(entry)
         if entry:
+            revert_target_block_number = _selected_start_block()
             entry["count"] += 1
-            entry["block_number"] = block_number
+            entry["failure_block_number"] = failure_block_number
+            entry["revert_target_block_number"] = revert_target_block_number
             entry["reason"] = reason
             self.certain_failures[tx_hash] = entry
-            return True
+            return True, revert_target_block_number
+
+        revert_target_block_number = _selected_start_block()
 
         self.resync_causes[tx_hash] = {
             "tx_hash": tx_hash,
-            "block_number": block_number,
+            "failure_block_number": failure_block_number,
+            "revert_target_block_number": revert_target_block_number,
             "reason": reason,
             "count": 1,
         }
-        return False
+        return False, revert_target_block_number
 
 
 @dataclass(slots=True)
@@ -452,14 +481,21 @@ class SharedContext:
         with self._lock:
             return self._tx.currently_pending[tx_hash]
 
-    def get_resync_evaluation_inputs(self) -> tuple[Dict[str, JsonObject], Dict[str, int]]:
+    def get_resync_evaluation_inputs(
+        self,
+    ) -> tuple[Dict[str, JsonObject], Dict[str, int], Dict[str, RevertErrorInfo]]:
         """
         Return the minimal live state needed by transaction_sender's resync policy:
         - gateway_errors_live (tx_hash -> {status, response, block_number})
         - currently_pending (tx_hash -> source block number)
+        - echonet_only_reverts_live (tx_hash -> {block_number, error})
         """
         with self._lock:
-            return dict(self._errors.gateway_errors_live), dict(self._tx.currently_pending)
+            return (
+                dict(self._errors.gateway_errors_live),
+                dict(self._tx.currently_pending),
+                dict(self._errors.echonet_only_reverts_live),
+            )
 
     # --- Errors ---
     def record_gateway_error(
@@ -484,9 +520,17 @@ class SharedContext:
             )
 
     # --- Resync causes ---
-    def record_resync_cause(self, tx_hash: str, block_number: int, reason: str) -> bool:
+    def record_resync_cause(
+        self,
+        tx_hash: str,
+        failure_block_number: int,
+        revert_target_block_number: int,
+        reason: str,
+    ) -> tuple[bool, int]:
         with self._lock:
-            return self._resync.record_cause(tx_hash, block_number, reason)
+            return self._resync.record_cause(
+                tx_hash, failure_block_number, revert_target_block_number, reason
+            )
 
     def clear_for_resync(self) -> None:
         """Clear live state for a new run while preserving cumulative stats."""
@@ -612,7 +656,7 @@ class SharedContext:
                 pending_total_count=len(self._tx.ever_seen_pending),
                 pending_commission_count=len(self._tx.ever_seen_pending) - len(self._tx.committed),
                 sent_tx_hashes=dict(self._tx.currently_pending),
-                gateway_errors=dict(self._errors.gateway_errors_live),
+                gateway_errors=dict(self._errors.gateway_errors),
                 revert_errors_mainnet=dict(self._errors.revert_errors_mainnet),
                 revert_errors_echonet=dict(self._errors.revert_errors_echonet),
                 resync_causes=dict(self._resync.resync_causes),

--- a/echonet/templates/report.html
+++ b/echonet/templates/report.html
@@ -454,8 +454,8 @@
             </thead>
             <tbody>
               {% for row in resync.causes %}
-              <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.count }}">
-                <td class="mono">{{ row.block_number }}</td>
+              <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
+                <td class="mono">{{ row.failure_block_number }}</td>
                 <td class="mono">{{ row.count }}</td>
                 <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
                 <td class="mono">{{ row.reason }}</td>
@@ -467,10 +467,10 @@
                     <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                       data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
                       target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
                       target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
                   </div>
                 </td>
@@ -511,9 +511,9 @@
             </thead>
             <tbody>
               {% for row in resync.certain_failures %}
-              <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.count }}">
+              <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
                 <td class="mono">{{ row.count }}</td>
-                <td class="mono">{{ row.block_number }}</td>
+                <td class="mono">{{ row.failure_block_number }}</td>
                 <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
                 <td class="mono">{{ row.reason }}</td>
                 <td class="right">
@@ -524,10 +524,10 @@
                     <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
                       data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
                       target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
                     <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
                       target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
                   </div>
                 </td>

--- a/echonet/transaction_sender.py
+++ b/echonet/transaction_sender.py
@@ -289,10 +289,15 @@ class TransactionSenderService:
                             shared.record_forwarded_block(block_number, len(valid_txs))
                         shared.set_block_timestamp(timestamp)
 
-                        gw_errors, sent_tx_hashes = shared.get_resync_evaluation_inputs()
+                        (
+                            gw_errors,
+                            sent_tx_hashes,
+                            echonet_only_reverts,
+                        ) = shared.get_resync_evaluation_inputs()
                         resync_trigger = resync_policy.evaluate(
                             gateway_errors=gw_errors,
                             sent_tx_hashes=sent_tx_hashes,
+                            echonet_only_reverts=echonet_only_reverts,
                             current_block=block_number,
                         )
                         if resync_trigger:
@@ -300,8 +305,11 @@ class TransactionSenderService:
                         block_number += 1
                     if not resync_trigger:
                         return
+                    failure_block_number = resync_trigger["failure_block_number"]
+                    revert_target_block_number = resync_trigger["revert_target_block_number"]
                     logger.warning(
-                        f"Resync triggered by tx {resync_trigger['tx_hash']} at block {resync_trigger['block_number']}: "
+                        f"Resync triggered by tx {resync_trigger['tx_hash']}: "
+                        f"failure_block_number={failure_block_number} revert_target_block_number={revert_target_block_number}: "
                         f"{resync_trigger['reason']}"
                     )
                     async with forwarding_lock:


### PR DESCRIPTION
echonet: Add echonet only reverts to resync triggers

Made-with: Cursor

echonet: log failing and rollback blocks on resync trigger

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the resync trigger selection and start-block rewind behavior, which can affect how far the node rolls back and how often it resyncs. Also changes reporting payload fields, so mismatches could break report rendering if any consumers weren’t updated.
> 
> **Overview**
> Resync decisions now consider *Echonet-only revert errors* alongside gateway errors and long-pending txs, and choose the **earliest failing block** as the trigger.
> 
> Resync trigger metadata is updated from `block_number` to `failure_block_number` plus a computed `revert_target_block_number`, and repeated triggers advance the next resync start block to avoid replaying a known-bad block.
> 
> Reporting is updated to reflect the new fields (text + HTML UI) and to keep gateway errors **cumulative across resyncs**; the obsolete `resync_error_threshold` config is removed and `max_pending_txs_before_pausing` is bumped to `39`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b2c2fa050e46e90b3650c05410f9725e9a222dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->