### PR TITLE
apollo_propeller: added metrics to engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,6 +2398,7 @@ dependencies = [
  "rstest",
  "sha2 0.10.9",
  "starknet_api",
+ "strum",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/crates/apollo_propeller/Cargo.toml
+++ b/crates/apollo_propeller/Cargo.toml
@@ -22,6 +22,7 @@ rand.workspace = true
 reed-solomon-simd.workspace = true
 sha2.workspace = true
 starknet_api.workspace = true
+strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -23,7 +23,7 @@ use crate::message_processor::{
     ReconstructionState,
     UnitToValidate,
 };
-use crate::metrics::PropellerMetrics;
+use crate::metrics::{CollectionLabel, PropellerMetrics};
 use crate::sharding::create_units_to_publish;
 use crate::signature;
 use crate::time_cache::TimeCache;
@@ -123,6 +123,12 @@ pub struct Engine {
 }
 
 impl Engine {
+    fn record_metric(&self, f: impl FnOnce(&PropellerMetrics)) {
+        if let Some(metrics) = &self.metrics {
+            f(metrics);
+        }
+    }
+
     /// Create a new engine instance.
     pub fn new(
         keypair: Keypair,
@@ -185,6 +191,12 @@ impl Engine {
             CommitteeData { schedule_manager: Arc::new(schedule_manager), peer_public_keys };
         self.committees.insert(committee_id, committee_data);
 
+        let num_committees = self.committees.len();
+        self.record_metric(|m| {
+            m.committees_registered.increment(1);
+            m.update_collection_length(CollectionLabel::RegisteredCommittees, num_committees);
+        });
+
         Ok(())
     }
 
@@ -195,6 +207,12 @@ impl Engine {
         let result = self.committees.remove(&committee_id).is_some();
         // TODO(AndrewL): Consider adding a command to MP to terminate the task.
         self.message_to_unit_tx.retain(|key, _| key.committee_id != committee_id);
+        let num_committees = self.committees.len();
+        let num_tasks = self.message_to_unit_tx.len();
+        self.record_metric(|m| {
+            m.update_collection_length(CollectionLabel::RegisteredCommittees, num_committees);
+            m.update_collection_length(CollectionLabel::ActiveProcessors, num_tasks);
+        });
         result
     }
 
@@ -232,11 +250,19 @@ impl Engine {
     /// Handle a peer connection.
     fn handle_connected(&mut self, peer_id: PeerId) {
         self.connected_peers.insert(peer_id);
+        let num_peers = self.connected_peers.len();
+        self.record_metric(|m| {
+            m.update_collection_length(CollectionLabel::ConnectedPeers, num_peers)
+        });
     }
 
     /// Handle a peer disconnection.
     fn handle_disconnected(&mut self, peer_id: PeerId) {
         self.connected_peers.remove(&peer_id);
+        let num_peers = self.connected_peers.len();
+        self.record_metric(|m| {
+            m.update_collection_length(CollectionLabel::ConnectedPeers, num_peers)
+        });
     }
 
     /// Handle an incoming unit from a peer.
@@ -246,10 +272,11 @@ impl Engine {
         let claimed_nonce = unit.nonce();
         let claimed_root = unit.root();
 
-        // Track received unit.
-        if let Some(metrics) = &self.metrics {
-            metrics.units_received.increment(1);
-        }
+        let shard_len: usize = unit.shards().0.iter().map(|s| s.0.len()).sum();
+        self.record_metric(|m| {
+            m.units_received.increment(1);
+            m.shard_bytes_received.increment(u64::try_from(shard_len).unwrap_or(u64::MAX));
+        });
 
         // Check if committee is registered.
         let Some(committee_data) = self.committees.get(&claimed_committee_id) else {
@@ -326,6 +353,10 @@ impl Engine {
             tokio::spawn(processor.run());
 
             self.message_to_unit_tx.insert(message_key, unit_tx);
+            let num_tasks = self.message_to_unit_tx.len();
+            self.record_metric(|m| {
+                m.update_collection_length(CollectionLabel::ActiveProcessors, num_tasks)
+            });
         }
 
         // Send unit to message processor
@@ -347,6 +378,7 @@ impl Engine {
     }
 
     fn emit_event(&mut self, event: Event) {
+        self.record_metric(|m| m.track_event(&event));
         self.to_behaviour_tx
             .send(EngineOutput::GenerateEvent(event))
             .expect("Behaviour has exited");
@@ -407,6 +439,10 @@ impl Engine {
                 if self.message_to_unit_tx.remove(&message_key).is_some() {
                     trace!(?message_key, "[ENGINE] Removed task handles");
                 }
+                let num_tasks = self.message_to_unit_tx.len();
+                self.record_metric(|m| {
+                    m.update_collection_length(CollectionLabel::ActiveProcessors, num_tasks)
+                });
 
                 // If the message process didn't have any valid shards, we don't cache it.
                 if !had_good_units {
@@ -438,10 +474,20 @@ impl Engine {
                         self.peer_nonce.put(key.publisher, new_nonce);
                     }
                 }
+
+                let finalized_len = self.messages_to_ignore_units_from.len();
+                self.record_metric(|m| {
+                    m.update_collection_length(CollectionLabel::FinalizedMessages, finalized_len)
+                });
             }
             EventStateManagerToEngine::SendUnitToPeers { unit, peers } => {
                 trace!(index = ?unit.index(), num_peers = peers.len(), "[ENGINE] Forwarding unit to peers");
 
+                let num_peers = u64::try_from(peers.len()).unwrap_or(u64::MAX);
+                self.record_metric(|m| {
+                    m.shard_forward_operations.increment(1);
+                    m.shards_forwarded.increment(num_peers);
+                });
                 for peer in peers {
                     self.send_unit_to_peer(unit.clone(), peer);
                 }
@@ -485,6 +531,9 @@ impl Engine {
             .schedule_manager
             .clone();
 
+        let num_units = u64::try_from(units.len()).unwrap_or(u64::MAX);
+        self.record_metric(|m| m.shards_published.increment(num_units));
+
         let peers_in_order = schedule_manager.make_broadcast_list();
         assert_eq!(
             peers_in_order.len(),
@@ -501,6 +550,11 @@ impl Engine {
     }
 
     fn send_unit_to_peer(&mut self, unit: PropellerUnit, peer: PeerId) {
+        let shard_len: usize = unit.shards().0.iter().map(|s| s.0.len()).sum();
+        self.record_metric(|m| {
+            m.shards_sent.increment(1);
+            m.shard_bytes_sent.increment(u64::try_from(shard_len).unwrap_or(u64::MAX));
+        });
         self.emit_handler_event(peer, HandlerIn::SendUnit(unit));
     }
 

--- a/crates/apollo_propeller/src/metrics.rs
+++ b/crates/apollo_propeller/src/metrics.rs
@@ -1,18 +1,236 @@
 //! Metrics for the Propeller protocol.
 //!
-//! This module provides metrics for monitoring the Propeller protocol's performance.
+//! This module provides metrics for monitoring the Propeller protocol's performance,
+//! particularly focused on shard throughput and message propagation.
 
-use apollo_metrics::metrics::MetricCounter;
+use apollo_metrics::metrics::{
+    LabeledMetricCounter,
+    LabeledMetricGauge,
+    LossyIntoF64,
+    MetricCounter,
+};
+use strum::{IntoStaticStr, VariantNames};
 
-/// Propeller protocol metrics
+use crate::types::{Event, UnitPublishError};
+use crate::UnitValidationError;
+
+/// Label name for shard validation failure reasons
+pub const LABEL_NAME_VALIDATION_FAILURE_REASON: &str = "failure_reason";
+
+/// Reasons why shard validation can fail
+#[derive(IntoStaticStr, VariantNames)]
+#[strum(serialize_all = "snake_case")]
+pub enum ShardValidationFailureReason {
+    /// Received a shard from ourselves via libp2p loopback
+    SelfSending,
+    /// Publisher received their own published shard back
+    ReceivedSelfPublishedShard,
+    /// Duplicate shard already in cache
+    DuplicateShard,
+    /// Tree topology error
+    TreeError,
+    /// Parent verification failed (wrong sender)
+    ParentVerificationFailed,
+    /// Signature verification failed
+    SignatureVerificationFailed,
+    /// Proof verification failed
+    ProofVerificationFailed,
+    /// Shards have inconsistent lengths
+    UnequalShardLengths,
+    /// Unexpected shard count per unit
+    UnexpectedShardCount,
+}
+
+impl From<&UnitValidationError> for ShardValidationFailureReason {
+    fn from(error: &UnitValidationError) -> Self {
+        match error {
+            UnitValidationError::SelfSending => Self::SelfSending,
+            UnitValidationError::ReceivedSelfPublishedUnit => Self::ReceivedSelfPublishedShard,
+            UnitValidationError::DuplicateUnit => Self::DuplicateShard,
+            UnitValidationError::ScheduleManagerError(_) => Self::TreeError,
+            UnitValidationError::UnexpectedSender { .. } => Self::ParentVerificationFailed,
+            UnitValidationError::SignatureVerificationFailed(_) => {
+                Self::SignatureVerificationFailed
+            }
+            UnitValidationError::MerkleProofVerificationFailed => Self::ProofVerificationFailed,
+            UnitValidationError::UnequalShardLengths => Self::UnequalShardLengths,
+            UnitValidationError::UnexpectedShardCount { .. } => Self::UnexpectedShardCount,
+        }
+    }
+}
+
+/// Label name for shard send failure reasons
+pub const LABEL_NAME_SEND_FAILURE_REASON: &str = "failure_reason";
+
+/// Reasons why shard sending can fail
+#[derive(IntoStaticStr, VariantNames)]
+#[strum(serialize_all = "snake_case")]
+pub enum ShardSendFailureReason {
+    /// Local peer not in peer weights
+    LocalPeerNotInPeerWeights,
+    /// Invalid data size for encoding
+    InvalidDataSize,
+    /// Signing operation failed
+    SigningFailed,
+    /// Erasure encoding failed
+    ErasureEncodingFailed,
+    /// Not connected to target peer
+    NotConnectedToPeer,
+    /// Handler error
+    HandlerError,
+    /// Tree generation error
+    ScheduleError,
+    /// Committee not registered for the broadcast
+    CommitteeNotRegistered,
+    /// Broadcast failed to complete
+    BroadcastFailed,
+}
+
+/// Label name for collection length tracking
+pub const LABEL_NAME_COLLECTION: &str = "collection";
+
+/// Collections that are tracked for size/length
+#[derive(IntoStaticStr, VariantNames)]
+#[strum(serialize_all = "snake_case")]
+pub enum CollectionLabel {
+    /// Connected peers set
+    ConnectedPeers,
+    /// Active message processors
+    ActiveProcessors,
+    /// Number of entries in the finalized messages cache (includes expired entries not yet
+    /// evicted)
+    FinalizedMessages,
+    /// Registered committees
+    RegisteredCommittees,
+}
+
+/// Metrics for the Propeller protocol.
+///
+/// Tracks shard throughput, validation rates, message reconstruction, and network health.
 pub struct PropellerMetrics {
+    /// Total number of shards published (created) by this node
+    pub shards_published: MetricCounter,
+    /// Total number of shards dispatched to peers (best-effort; actual delivery depends on the
+    /// handler)
+    pub shards_sent: MetricCounter,
+    /// Total number of shard send failures, labeled by reason
+    pub shards_send_failed: LabeledMetricCounter,
+    /// Total bytes sent in shard data (payload only, excluding protocol overhead)
+    /// (best-effort; actual delivery depends on the handler)
+    pub shard_bytes_sent: MetricCounter,
+
     /// Total number of units received from peers
     pub units_received: MetricCounter,
+    /// Total number of shards that failed validation, labeled by reason
+    pub shards_validation_failed: LabeledMetricCounter,
+    /// Total number of shard forward operations (one per `SendUnitToPeers` message)
+    pub shard_forward_operations: MetricCounter,
+    /// Total number of shards forwarded to individual peers (fan-out of forward operations)
+    pub shards_forwarded: MetricCounter,
+    /// Total bytes received in shard data (payload only, excluding protocol overhead)
+    pub shard_bytes_received: MetricCounter,
+
+    /// Total number of messages successfully reconstructed from shards
+    pub messages_reconstructed: MetricCounter,
+    /// Total number of message reconstruction failures
+    pub messages_reconstruction_failed: MetricCounter,
+    /// Total number of messages that timed out before completion
+    pub messages_timed_out: MetricCounter,
+
+    /// Total number of committee registrations (each registration generates a new tree)
+    pub committees_registered: MetricCounter,
+
+    /// Length of various collections (queues, sets, caches) tracked by label
+    pub collection_lengths: LabeledMetricGauge,
 }
 
 impl PropellerMetrics {
     /// Register all metrics with the metrics system
     pub fn register(&self) {
+        self.shards_published.register();
+        self.shards_sent.register();
+        self.shards_send_failed.register();
+        self.shard_bytes_sent.register();
+
         self.units_received.register();
+        self.shards_validation_failed.register();
+        self.shard_forward_operations.register();
+        self.shards_forwarded.register();
+        self.shard_bytes_received.register();
+
+        self.messages_reconstructed.register();
+        self.messages_reconstruction_failed.register();
+        self.messages_timed_out.register();
+
+        self.committees_registered.register();
+
+        self.collection_lengths.register();
+        // Initialize all labeled metrics to 0 so all label permutations appear in the exporter.
+        for variant in ShardValidationFailureReason::VARIANTS {
+            self.shards_validation_failed
+                .increment(0, &[(LABEL_NAME_VALIDATION_FAILURE_REASON, *variant)]);
+        }
+        for variant in ShardSendFailureReason::VARIANTS {
+            self.shards_send_failed.increment(0, &[(LABEL_NAME_SEND_FAILURE_REASON, *variant)]);
+        }
+        for variant in CollectionLabel::VARIANTS {
+            self.collection_lengths.set(0f64, &[(LABEL_NAME_COLLECTION, *variant)]);
+        }
+    }
+
+    /// Increment the validation failure counter for a specific reason
+    pub fn increment_validation_failure(&self, reason: ShardValidationFailureReason) {
+        self.shards_validation_failed
+            .increment(1, &[(LABEL_NAME_VALIDATION_FAILURE_REASON, reason.into())]);
+    }
+
+    /// Increment the send failure counter for a specific reason
+    pub fn increment_send_failure(&self, reason: ShardSendFailureReason) {
+        self.shards_send_failed.increment(1, &[(LABEL_NAME_SEND_FAILURE_REASON, reason.into())]);
+    }
+
+    /// Update the length/size of a specific collection
+    pub fn update_collection_length(&self, label: CollectionLabel, size: usize) {
+        self.collection_lengths.set(size.into_f64(), &[(LABEL_NAME_COLLECTION, label.into())]);
+    }
+
+    /// Track metrics based on emitted events
+    pub fn track_event(&self, event: &Event) {
+        match event {
+            Event::MessageReceived { .. } => {
+                self.messages_reconstructed.increment(1);
+            }
+            Event::MessageReconstructionFailed { .. } => {
+                self.messages_reconstruction_failed.increment(1);
+            }
+            Event::UnitValidationFailed { error, .. } => {
+                self.increment_validation_failure(error.into());
+            }
+            Event::UnitSendFailed { error, .. } => {
+                let reason = match error {
+                    UnitPublishError::LocalPeerNotInPeerWeights => {
+                        ShardSendFailureReason::LocalPeerNotInPeerWeights
+                    }
+                    UnitPublishError::InvalidDataSize => ShardSendFailureReason::InvalidDataSize,
+                    UnitPublishError::SigningFailed(_) => ShardSendFailureReason::SigningFailed,
+                    UnitPublishError::ErasureEncodingFailed(_) => {
+                        ShardSendFailureReason::ErasureEncodingFailed
+                    }
+                    UnitPublishError::NotConnectedToPeer(_) => {
+                        ShardSendFailureReason::NotConnectedToPeer
+                    }
+                    UnitPublishError::HandlerError(_) => ShardSendFailureReason::HandlerError,
+                    UnitPublishError::ScheduleError(_) => ShardSendFailureReason::ScheduleError,
+                    UnitPublishError::CommitteeNotRegistered(_) => {
+                        ShardSendFailureReason::CommitteeNotRegistered
+                    }
+                    UnitPublishError::BroadcastFailed => ShardSendFailureReason::BroadcastFailed,
+                };
+                self.increment_send_failure(reason);
+            }
+            Event::MessageTimeout { .. } => {
+                self.messages_timed_out.increment(1);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily observability changes (counters/gauges and labeling) with minimal impact on protocol behavior; main risk is metric cardinality/overhead if emitted at very high shard rates.
> 
> **Overview**
> Adds a substantially expanded `PropellerMetrics` surface (new counters/gauges plus labeled failure reasons) to track shard publish/send/receive bytes, forwarding fan-out, message reconstruction outcomes/timeouts, and committee registrations.
> 
> Updates the engine to consistently record these metrics (including collection-length gauges for connected peers, active processors, finalized messages, and registered committees) via a helper, and introduces `strum` for stable label/value generation and initialization of all label permutations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12383cefe12ba385be6081123268dbf13f77e188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->