### PR TITLE
echonet: Send block number of txs to the mempool

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -739,11 +739,11 @@ class EchoCenterService:
             headers=[["Content-Type", "text/plain; charset=utf-8"]],
         )
 
-    def handle_get_timestamp(self) -> flask.Response:
+    def handle_get_tx_block_metadata(self) -> flask.Response:
         """
-        GET /echonet/get_timestamp?tx_hash=0x...
+        GET /echonet/get_tx_block_metadata?tx_hash=0x...
 
-        Returns a JSON integer: the source block timestamp (seconds).
+        Returns a JSON object containing source block timestamp and block number.
         """
         args = flask.request.args.to_dict(flat=True)
         tx_hash = args.get("tx_hash")
@@ -753,8 +753,8 @@ class EchoCenterService:
                 requests.codes.bad_request,
             )
 
-        ts = self.shared.get_sent_tx_timestamp(tx_hash)
-        return self._json_response(ts, requests.codes.ok)
+        payload = self.shared.get_sent_tx_timestamp_and_block_number(tx_hash)
+        return self._json_response(payload, requests.codes.ok)
 
     def handle_block_dump(self) -> flask.Response:
         args = flask.request.args.to_dict(flat=True)
@@ -948,9 +948,9 @@ def report_snapshot() -> flask.Response:
     return service.handle_report_snapshot()
 
 
-@app.route("/echonet/get_timestamp", methods=["GET"])
-def get_timestamp() -> flask.Response:
-    return service.handle_get_timestamp()
+@app.route("/echonet/get_tx_block_metadata", methods=["GET"])
+def get_tx_block_metadata() -> flask.Response:
+    return service.handle_get_tx_block_metadata()
 
 
 @app.route("/echonet/block_dump", methods=["GET"])

--- a/echonet/echonet_keys.json
+++ b/echonet/echonet_keys.json
@@ -1,5 +1,5 @@
 {
     "start_block": 0,
     "blocked_senders": "",
-    "max_pending_txs_before_pausing": 39
+    "max_pending_txs_before_pausing": 500
 }

--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -35,9 +35,6 @@ class BlockStoreTuning:
     max_blocks_to_keep_in_memory: int = 100
 
 
-BLOCK_STORE_TUNING = BlockStoreTuning()
-
-
 class ResyncTriggerPayload(TypedDict):
     """
     Metadata stored when a transaction causes a resync trigger.
@@ -192,6 +189,7 @@ class EchonetConfig:
     blocks: BlockRangeDefaults
     sleep: SleepConfig
     tx_sender: TxSenderTuning
+    block_store: BlockStoreTuning
     severity: SeverityConfig
     paths: PathsConfig
     tx_filter: TxFilterConfig
@@ -241,6 +239,9 @@ class EchonetConfig:
             sleep=SleepConfig(),
             tx_sender=TxSenderTuning(
                 max_pending_txs_before_pausing=max_pending_txs_before_pausing,
+            ),
+            block_store=BlockStoreTuning(
+                max_blocks_to_keep_in_memory=max_pending_txs_before_pausing,
             ),
             severity=SeverityConfig(),
             paths=PathsConfig(),

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import ClassVar, Dict, List, Mapping, Optional, Sequence, Set
 
 from echonet.echonet_types import (
-    BLOCK_STORE_TUNING,
     CONFIG,
     JsonObject,
     ResyncTriggerMap,
@@ -49,7 +48,9 @@ class _TxTracker:
     """Transaction lifecycle and counters used by reporting."""
 
     currently_pending: Dict[str, int]  # tx_hash -> source block number
-    tx_timestamps: Dict[str, int]  # tx_hash -> source timestamp (seconds); live only
+    tx_block_metadata: Dict[
+        str, Dict[str, int]
+    ]  # tx_hash -> {"timestamp", "block_number"}; live only
     ever_seen_pending: Set[str]  # cumulative set of tx hashes ever observed pending
     committed: Dict[str, int]  # cumulative map: tx_hash -> commit block number
     total_forwarded_tx_count: int  # count of forwarded txs (counted once per block)
@@ -59,7 +60,7 @@ class _TxTracker:
     def empty(cls) -> "_TxTracker":
         return cls(
             currently_pending={},
-            tx_timestamps={},
+            tx_block_metadata={},
             ever_seen_pending=set(),
             committed={},
             total_forwarded_tx_count=0,
@@ -76,7 +77,7 @@ class _TxTracker:
         """Record a transaction as committed - add to the committed set (transactions that have been committed) and remove from the pending set"""
         self.committed[tx_hash] = block_number
         self.currently_pending.pop(tx_hash, None)
-        self.tx_timestamps.pop(tx_hash, None)
+        self.tx_block_metadata.pop(tx_hash, None)
 
     def record_forwarded_block(self, block_number: int, tx_count: int) -> None:
         if block_number > self.max_forwarded_block:
@@ -291,7 +292,7 @@ class _BlockStore:
     def _evict_old_items(
         store: Dict[int, JsonObject], current_block_number: int
     ) -> List[tuple[int, JsonObject]]:
-        cutoff = current_block_number - BLOCK_STORE_TUNING.max_blocks_to_keep_in_memory
+        cutoff = current_block_number - CONFIG.block_store.max_blocks_to_keep_in_memory
         evict_bns = [bn for bn in store.keys() if bn < cutoff]
         return [(bn, store.pop(bn)) for bn in sorted(evict_bns)]
 
@@ -450,16 +451,19 @@ class SharedContext:
         with self._lock:
             self._tx.record_sent(tx_hash, source_block_number)
 
-    def record_sent_tx_timestamps_for_block(
-        self, txs: Sequence[JsonObject], timestamp: int
+    def record_sent_tx_block_metadata_for_block(
+        self, txs: Sequence[JsonObject], timestamp: int, block_number: int
     ) -> None:
         with self._lock:
             for tx in txs:
-                self._tx.tx_timestamps[tx["transaction_hash"]] = timestamp
+                self._tx.tx_block_metadata[tx["transaction_hash"]] = {
+                    "timestamp": timestamp,
+                    "block_number": block_number,
+                }
 
-    def get_sent_tx_timestamp(self, tx_hash: str) -> int:
+    def get_sent_tx_timestamp_and_block_number(self, tx_hash: str) -> Dict[str, int]:
         with self._lock:
-            return self._tx.tx_timestamps[tx_hash]
+            return self._tx.tx_block_metadata[tx_hash]
 
     def record_forwarded_block(self, block_number: int, tx_count: int) -> None:
         with self._lock:
@@ -539,7 +543,7 @@ class SharedContext:
             snapshot_items = self._blocks.snapshot_items()
             archive_dir = self._blocks._ensure_archive_dir()
             self._tx.currently_pending.clear()
-            self._tx.tx_timestamps.clear()
+            self._tx.tx_block_metadata.clear()
             self._errors.clear_live()
             self._blocks.clear_live()
             self._progress.last_echo_center_block = None

--- a/echonet/transaction_sender.py
+++ b/echonet/transaction_sender.py
@@ -103,10 +103,10 @@ class SenderConfig:
     access_fgw_attempts: int = 3
     retry_backoff_seconds: float = 0.5
     max_retry_sleep_seconds: float = 30.0
-    sequencer_not_ready_retry_attempts: int = 70
+    sequencer_not_ready_retry_attempts: int = CONFIG.tx_sender.max_pending_txs_before_pausing * 2
 
     queue_size: int = 30
-    blocks_to_wait_before_failing_tx: int = CONFIG.tx_sender.max_pending_txs_before_pausing * 2
+    blocks_to_wait_before_failing_tx: int = CONFIG.tx_sender.max_pending_txs_before_pausing
 
 
 @dataclass(frozen=True, slots=True)
@@ -312,7 +312,9 @@ class TransactionSenderService:
                             f"Block {block_number}: total={len(all_txs)} valid={len(valid_txs)}"
                         )
 
-                        shared.record_sent_tx_timestamps_for_block(valid_txs, timestamp)
+                        shared.record_sent_tx_block_metadata_for_block(
+                            valid_txs, timestamp, block_number
+                        )
                         for tx in valid_txs:
                             tx_data = TxData(
                                 tx=tx,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes a public HTTP endpoint shape/name and adjusts multiple queue/retention tuning parameters, which can affect downstream clients and runtime memory/throughput. Logic changes are localized but impact transaction tracking and retry/pause behavior under load.
> 
> **Overview**
> Replaces the `/echonet/get_timestamp` endpoint with `/echonet/get_tx_block_metadata`, returning `{timestamp, block_number}` for a tx hash instead of a bare timestamp.
> 
> Updates tx tracking to store per-tx *block metadata* (timestamp + source block number) and wires the producer to record it; committed/resync clears this new metadata.
> 
> Retunes operational limits: raises `max_pending_txs_before_pausing` in `echonet_keys.json` (39→500), derives `block_store` in-memory retention from config, and adjusts sender retry/failure thresholds to scale with the new pending-tx limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b4edb88a74e17d0cc32457a8194561f73707ee4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->