### PR TITLE
add section on dependency injection

### DIFF
--- a/style.md
+++ b/style.md
@@ -377,6 +377,47 @@ Put integration tests inside `tests/` at the crate root if they don't depend on 
 
 To test binary crates, either add a `lib.rs` and call its main from `main.rs` and from the test, or use integration tests that spawn the binary as a subprocess (See `CARGO_BIN_EXE_<binary_name>`).
 
+### Dependency Injection
+
+Dependency injection allows you to test a component in isolation by mocking its dependencies. This focuses the test on a single unit of code without relying on external services or complex setup.
+
+Use trait-based dependency injection with `#[automock]` from the `mockall` crate:
+
+```rust
+#[cfg_attr(test, mockall::automock)]
+trait Database {
+    fn get_user(&self, id: u64) -> Result<User, Error>;
+}
+
+struct UserService<D: Database> {
+    db: D,
+}
+
+impl<D: Database> UserService<D> {
+    fn get_user_name(&self, id: u64) -> Result<String, Error> {
+        self.db.get_user(id).map(|user| user.name)
+    }
+}
+```
+
+In your test file:
+
+```rust
+use mockall::predicate::eq;
+
+#[test]
+fn test_get_user_name() {
+    let mut mock_db = MockDatabase::new();
+    mock_db
+        .expect_get_user()
+        .with(eq(1))
+        .returning(|_| Ok(User { id: 1, name: "Alice".to_string() }));
+
+    let service = UserService { db: mock_db };
+    assert_eq!(service.get_user_name(1).unwrap(), "Alice");
+}
+```
+
 ## Documentation Standards
 
 Use `///` as doc-strings for all non-trivial structs, functions and methods, and place it before the definition --- these show up on docs.rs and editor tooltips.

--- a/style.md
+++ b/style.md
@@ -384,11 +384,14 @@ Dependency injection allows you to test a component in isolation by mocking its 
 Use trait-based dependency injection with `#[automock]` from the `mockall` crate:
 
 ```rust
+// In test builds, `automock` generates a `MockDatabase` struct that implements
+// `Database` with configurable behavior for each method.
 #[cfg_attr(test, mockall::automock)]
 trait Database {
     fn get_user(&self, id: u64) -> Result<User, Error>;
 }
 
+// The generic parameter lets us inject either a real database or a mock.
 struct UserService<D: Database> {
     db: D,
 }
@@ -408,11 +411,13 @@ use mockall::predicate::eq;
 #[test]
 fn test_get_user_name() {
     let mut mock_db = MockDatabase::new();
+    // Configure the mock: It will allow exactly one call to `get_user` with id=1, returning a fake user.
     mock_db
         .expect_get_user()
         .with(eq(1))
-        .returning(|_| Ok(User { id: 1, name: "Alice".to_string() }));
+        .return_once(|_| Ok(User { id: 1, name: "Alice".to_string() }));
 
+    // Inject the mock instead of a real database.
     let service = UserService { db: mock_db };
     assert_eq!(service.get_user_name(1).unwrap(), "Alice");
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it adds guidance and example code but does not modify any production logic or dependencies.
> 
> **Overview**
> Adds a new **Dependency Injection** subsection to `style.md` under *Testing*, recommending trait-based DI and `mockall::automock` for mocking dependencies in unit tests, with a short end-to-end example of injecting a mock into a service.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f885dae86ae802ebf0c25ed23e081c21def70961. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->