### PR TITLE
add section on sleep in tests

### DIFF
--- a/style.md
+++ b/style.md
@@ -423,6 +423,23 @@ fn test_get_user_name() {
 }
 ```
 
+### Sleep
+
+Never use `sleep` in tests, even for a few milliseconds. Real sleeping slows down your test suite and introduces flakiness due to timing issues.
+
+If you need to test code that calls `sleep`, use `tokio::time::pause()` and `tokio::time::advance()` to mock time:
+
+```rust
+#[tokio::test]
+async fn test_delayed_operation() {
+    tokio::time::pause(); // Pause real time
+
+    let handle = tokio::spawn(function_with_five_second_sleep());
+    tokio::time::advance(Duration::from_secs(5)).await;
+    assert_eq!(handle.await.unwrap(), "foo");
+}
+```
+
 ## Documentation Standards
 
 Use `///` as doc-strings for all non-trivial structs, functions and methods, and place it before the definition --- these show up on docs.rs and editor tooltips.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds testing guidance; no runtime code or behavior is modified.
> 
> **Overview**
> Adds a new **Testing** guideline in `style.md` discouraging use of `sleep` in tests and recommending mocking time with `tokio::time::pause()`/`advance()` instead, including an example snippet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 591f0bcf8cc6fca151ceeb1004fd687ff88772bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->