### PR TITLE
starknet_os_flow_tests: add a test with most recent allowed block number

### DIFF
--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -88,9 +88,15 @@ pub fn get_valid_virtual_os_program_hash() -> Felt {
 
 /// Creates valid proof facts for tests that validate the proof facts.
 pub fn create_valid_proof_facts_for_testing() -> ProofFacts {
+    create_valid_proof_facts_with_block_number(None)
+}
+
+/// Creates valid proof facts for tests with a custom block number.
+pub fn create_valid_proof_facts_with_block_number(block_number: Option<u64>) -> ProofFacts {
     ProofFacts::custom_proof_facts_for_testing(
         get_valid_virtual_os_program_hash(),
         *TEST_OS_CONFIG_HASH,
+        block_number,
     )
 }
 

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -2284,7 +2284,11 @@ fn proof_facts_with_zero_block_hash() -> ProofFacts {
 
 /// Returns invalid proof_facts with an invalid program hash.
 fn proof_facts_with_invalid_program_hash() -> ProofFacts {
-    ProofFacts::custom_proof_facts_for_testing(Felt::from(0x12345678_u64), *TEST_OS_CONFIG_HASH)
+    ProofFacts::custom_proof_facts_for_testing(
+        Felt::from(0x12345678_u64),
+        *TEST_OS_CONFIG_HASH,
+        None,
+    )
 }
 
 /// Returns invalid proof_facts with a mismatched config hash.
@@ -2292,6 +2296,7 @@ fn proof_facts_with_invalid_config_hash() -> ProofFacts {
     ProofFacts::custom_proof_facts_for_testing(
         get_valid_virtual_os_program_hash(),
         Felt::from(0x12345678_u64),
+        None,
     )
 }
 

--- a/crates/starknet_api/src/test_utils.rs
+++ b/crates/starknet_api/src/test_utils.rs
@@ -394,13 +394,17 @@ impl ProofFacts {
     /// Returns a ProofFacts instance for testing with dummy program hash.
     /// For tests requiring validation, use a custom program hash.
     pub fn snos_proof_facts_for_testing() -> Self {
-        Self::custom_proof_facts_for_testing(VIRTUAL_OS_PROGRAM_HASH, *TEST_OS_CONFIG_HASH)
+        Self::custom_proof_facts_for_testing(VIRTUAL_OS_PROGRAM_HASH, *TEST_OS_CONFIG_HASH, None)
     }
 
     /// Returns a ProofFacts instance for testing with custom fields.
-    pub fn custom_proof_facts_for_testing(program_hash: Felt, config_hash: Felt) -> Self {
+    pub fn custom_proof_facts_for_testing(
+        program_hash: Felt,
+        config_hash: Felt,
+        block_number: Option<u64>,
+    ) -> Self {
         let block_hash_history_start = CURRENT_BLOCK_NUMBER - BLOCK_HASH_HISTORY_RANGE;
-        let block_number_u64 = block_hash_history_start + 2;
+        let block_number_u64 = block_number.unwrap_or(block_hash_history_start + 2);
         let block_number = felt!(block_number_u64);
         let block_hash = test_block_hash(block_number_u64).0;
         assert!(

--- a/crates/starknet_os_flow_tests/src/tests.rs
+++ b/crates/starknet_os_flow_tests/src/tests.rs
@@ -501,6 +501,7 @@ async fn test_os_logic(
     )
     .await;
     let chain_id = &test_builder.chain_id();
+    let current_block_number = test_builder.first_block_number();
     let n_expected_txs = 32;
     let mut expected_storage_updates = HashMap::new();
 
@@ -592,9 +593,12 @@ async fn test_os_logic(
         &[**contract_addresses[0]],
     );
     let config_hash = test_builder.compute_virtual_os_config_hash();
+    // We use the most recent block number that the OS is allowed to look up, to verify that both
+    // the blockifier and the OS enforce the same boundary.
     let proof_facts = ProofFacts::custom_proof_facts_for_testing(
         get_valid_virtual_os_program_hash(),
         config_hash,
+        Some(current_block_number.0 - STORED_BLOCK_HASH_BUFFER),
     );
     test_builder.add_funded_account_invoke(invoke_tx_args! {
         calldata,
@@ -1150,7 +1154,9 @@ async fn test_new_class_execution_info(#[values(true, false)] use_kzg_da: bool) 
     let proof_facts = ProofFacts::custom_proof_facts_for_testing(
         get_valid_virtual_os_program_hash(),
         config_hash,
+        None,
     );
+
     let only_query = false;
     let expected_execution_info = ExpectedExecutionInfo::new(
         only_query,

--- a/crates/starknet_os_flow_tests/src/virtual_os_test.rs
+++ b/crates/starknet_os_flow_tests/src/virtual_os_test.rs
@@ -217,6 +217,7 @@ async fn test_get_execution_info(#[case] virtual_os: bool) {
         ProofFacts::custom_proof_facts_for_testing(
             get_valid_virtual_os_program_hash(),
             test_builder.compute_virtual_os_config_hash(),
+            None,
         )
     };
     let expected_execution_info = ExpectedExecutionInfo {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to test utilities and test code, primarily a signature update and call-site adjustments, with no impact on production transaction or consensus logic.
> 
> **Overview**
> Adds support for specifying an explicit `block_number` when generating test `ProofFacts`, by extending `ProofFacts::custom_proof_facts_for_testing` (and wrappers in `blockifier` test utils) with an optional block-number parameter.
> 
> Updates call sites across `blockifier` and `starknet_os_flow_tests` to pass `None` (default behavior) or a boundary value, enabling new/updated tests that exercise validation at the *most recent allowed* stored block-hash boundary (`current_block_number - STORED_BLOCK_HASH_BUFFER`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a4119ad95916f24fe59cf53f9292c62fa79583c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->