### PR TITLE
apollo_gateway: update gateway dynamic config with updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,6 +1528,7 @@ version = "0.0.0"
 dependencies = [
  "apollo_class_manager_types",
  "apollo_config",
+ "apollo_config_manager_types",
  "apollo_gateway_config",
  "apollo_gateway_types",
  "apollo_infra",

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -2805,6 +2805,32 @@
           "extra_params": {}
         },
         {
+          "title": "get_gateway_dynamic_config (client-side)",
+          "description": "client-side infra metrics for request type get_gateway_dynamic_config",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(config_manager_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.50 config_manager_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(config_manager_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.95 config_manager_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(config_manager_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.50 config_manager_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(config_manager_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.95 config_manager_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(config_manager_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.50 config_manager_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(config_manager_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.95 config_manager_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_gateway_dynamic_config (server-side)",
+          "description": "server-side infra metrics for request type get_gateway_dynamic_config",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(config_manager_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.50 config_manager_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(config_manager_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.95 config_manager_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(config_manager_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.50 config_manager_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(config_manager_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_gateway_dynamic_config\"}[5m])), \"label_name\", \"0.95 config_manager_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "get_http_server_dynamic_config (client-side)",
           "description": "client-side infra metrics for request type get_http_server_dynamic_config",
           "type": "timeseries",

--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -24,6 +24,7 @@ testing = [
 [dependencies]
 apollo_class_manager_types.workspace = true
 apollo_config.workspace = true
+apollo_config_manager_types.workspace = true
 apollo_gateway_config.workspace = true
 apollo_gateway_types.workspace = true
 apollo_infra.workspace = true
@@ -53,6 +54,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 apollo_class_manager_types = { workspace = true, features = ["testing"] }
+apollo_config_manager_types = { workspace = true, features = ["testing"] }
 apollo_gateway_config = { workspace = true, features = ["testing"] }
 apollo_mempool.workspace = true
 apollo_mempool_types = { workspace = true, features = ["testing"] }

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::SharedClassManagerClient;
-use apollo_gateway_config::config::GatewayConfig;
+use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_gateway_config::config::{GatewayConfig, GatewayDynamicConfig};
 use apollo_gateway_types::deprecated_gateway_error::{
     KnownStarknetErrorCode,
     StarknetError,
@@ -39,6 +40,7 @@ use starknet_api::rpc_transaction::{
 use starknet_api::transaction::fields::{Proof, ProofFacts, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
 use starknet_types_core::felt::Felt;
+use tokio::sync::watch::{channel, Receiver, Sender};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
@@ -91,6 +93,22 @@ pub struct Gateway(
     >,
 );
 
+#[derive(Clone)]
+struct GatewayDynamicConfigUpdater {
+    config_manager_client: SharedConfigManagerClient,
+    dynamic_config_tx: Sender<GatewayDynamicConfig>,
+}
+
+impl GatewayDynamicConfigUpdater {
+    fn spawn_poll_task(&self, poll_interval: Duration) {
+        tokio::spawn(dynamic_config_poll(
+            self.dynamic_config_tx.clone(),
+            self.config_manager_client.clone(),
+            poll_interval,
+        ));
+    }
+}
+
 impl Gateway {
     fn new(
         config: GatewayConfig,
@@ -99,6 +117,7 @@ impl Gateway {
         transaction_converter: Arc<TransactionConverter>,
         stateless_tx_validator: Arc<StatelessTransactionValidator>,
         proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
+        config_manager_client: SharedConfigManagerClient,
     ) -> Self {
         Self(GenericGateway::new(
             config,
@@ -107,6 +126,7 @@ impl Gateway {
             transaction_converter,
             stateless_tx_validator,
             proof_archive_writer,
+            config_manager_client,
         ))
     }
 
@@ -125,11 +145,10 @@ pub struct GenericGateway<
     TTransactionConverter: TransactionConverterTrait,
     TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
 > {
-    // TODO(Arni): remove this once we properly update the gateway dynamic config.
-    #[allow(dead_code)]
     config: Arc<GatewayConfig>,
     gateway_app_state:
         GatewayAppState<TStatelessValidator, TTransactionConverter, TStatefulValidatorFactory>,
+    gateway_dynamic_config_updater: GatewayDynamicConfigUpdater,
 }
 
 #[derive(Clone)]
@@ -144,6 +163,23 @@ struct GatewayAppState<
     mempool_client: SharedMempoolClient,
     transaction_converter: Arc<TTransactionConverter>,
     proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
+    dynamic_config_rx: Receiver<GatewayDynamicConfig>,
+}
+
+impl<
+    TStatelessValidator: StatelessTransactionValidatorTrait,
+    TTransactionConverter: TransactionConverterTrait,
+    TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
+> GatewayAppState<TStatelessValidator, TTransactionConverter, TStatefulValidatorFactory>
+{
+    fn get_dynamic_config(&self) -> GatewayDynamicConfig {
+        // `borrow()` returns a reference to a value owned by the channel, so clone it.
+        let config = {
+            let config = self.dynamic_config_rx.borrow();
+            config.clone()
+        };
+        config
+    }
 }
 
 impl<
@@ -164,12 +200,16 @@ impl<
         transaction_converter: Arc<TTransactionConverter>,
         stateless_tx_validator: Arc<TStatelessValidator>,
         proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
+        config_manager_client: SharedConfigManagerClient,
     ) -> Self {
         let stateful_tx_validator_config =
             config.static_config.stateful_tx_validator_config.clone();
         let chain_info = config.static_config.chain_info.clone();
         let contract_class_manager_config =
             config.static_config.contract_class_manager_config.clone();
+        let (dynamic_config_tx, dynamic_config_rx) = channel(config.dynamic_config.clone());
+        let gateway_dynamic_config_updater =
+            GatewayDynamicConfigUpdater { config_manager_client, dynamic_config_tx };
         let config = Arc::new(config);
 
         Self {
@@ -188,7 +228,9 @@ impl<
                 mempool_client,
                 transaction_converter,
                 proof_archive_writer,
+                dynamic_config_rx,
             },
+            gateway_dynamic_config_updater,
         }
     }
 }
@@ -202,6 +244,8 @@ impl<
     pub async fn start(&self) {
         register_metrics();
         self.gateway_app_state.proof_archive_writer.connect().await;
+        self.gateway_dynamic_config_updater
+            .spawn_poll_task(self.config.static_config.dynamic_config_poll_interval);
     }
 
     pub async fn add_tx(
@@ -266,7 +310,7 @@ impl<
 
         let mut stateful_transaction_validator = self
             .stateful_tx_validator_factory
-            .instantiate_validator(self.config.dynamic_config.native_classes_whitelist.clone())
+            .instantiate_validator(self.get_dynamic_config().native_classes_whitelist)
             .await
             .inspect_err(|e| metric_counters.record_add_tx_failure(e))?;
 
@@ -472,6 +516,7 @@ pub fn create_gateway(
     mempool_client: SharedMempoolClient,
     class_manager_client: SharedClassManagerClient,
     proof_manager_client: SharedProofManagerClient,
+    config_manager_client: SharedConfigManagerClient,
     runtime: tokio::runtime::Handle,
 ) -> Gateway {
     let state_reader_factory = Arc::new(SyncStateReaderFactory {
@@ -505,6 +550,7 @@ pub fn create_gateway(
         transaction_converter,
         stateless_tx_validator,
         proof_archive_writer,
+        config_manager_client,
     )
 }
 
@@ -512,6 +558,21 @@ pub fn create_gateway(
 impl ComponentStarter for Gateway {
     async fn start(&mut self) {
         self.0.start().await;
+    }
+}
+
+async fn dynamic_config_poll(
+    tx: Sender<GatewayDynamicConfig>,
+    config_manager_client: SharedConfigManagerClient,
+    poll_interval: Duration,
+) {
+    let mut interval = tokio::time::interval(poll_interval);
+    loop {
+        interval.tick().await;
+        let dynamic_config_result = config_manager_client.get_gateway_dynamic_config().await;
+        if let Ok(dynamic_config) = dynamic_config_result {
+            let _ = tx.send(dynamic_config);
+        }
     }
 }
 

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, LazyLock};
 
 use apollo_config::dumping::SerializeConfig;
 use apollo_config::loading::load_and_process_config;
+use apollo_config_manager_types::communication::MockConfigManagerClient;
 use apollo_gateway_config::config::{
     GatewayConfig,
     GatewayStaticConfig,
@@ -88,8 +89,9 @@ use starknet_proof_verifier::VerifyProofError;
 use starknet_types_core::felt::Felt;
 use strum::VariantNames;
 use tempfile::TempDir;
+use tokio::sync::watch::channel;
 
-use super::GatewayAppState;
+use super::{GatewayAppState, GatewayDynamicConfigUpdater};
 use crate::errors::{GatewayResult, StatelessTransactionValidatorError};
 use crate::gateway::GenericGateway;
 use crate::metrics::{
@@ -138,6 +140,7 @@ fn mock_dependencies() -> MockDependencies {
             contract_class_manager_config: ContractClassManagerConfig::default(),
             chain_info: ChainInfo::create_for_testing(),
             block_declare: false,
+            dynamic_config_poll_interval: std::time::Duration::from_secs(1),
             authorized_declarer_accounts: None,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
         },
@@ -149,6 +152,7 @@ fn mock_dependencies() -> MockDependencies {
     let mock_transaction_converter = MockTransactionConverterTrait::new();
     let mock_stateless_transaction_validator = mock_stateless_transaction_validator();
     let mock_proof_archive_writer = MockProofArchiveWriterTrait::new();
+    let mock_config_manager_client = MockConfigManagerClient::new();
     MockDependencies {
         config,
         state_reader_factory,
@@ -156,6 +160,7 @@ fn mock_dependencies() -> MockDependencies {
         mock_transaction_converter,
         mock_stateless_transaction_validator,
         mock_proof_archive_writer,
+        mock_config_manager_client,
     }
 }
 
@@ -166,6 +171,7 @@ struct MockDependencies {
     mock_transaction_converter: MockTransactionConverterTrait,
     mock_stateless_transaction_validator: MockStatelessTransactionValidatorTrait,
     mock_proof_archive_writer: MockProofArchiveWriterTrait,
+    mock_config_manager_client: MockConfigManagerClient,
 }
 
 impl MockDependencies {
@@ -177,6 +183,7 @@ impl MockDependencies {
         StatefulTransactionValidatorFactory<TestStateReaderFactory>,
     > {
         register_metrics();
+
         GenericGateway::new(
             self.config,
             Arc::new(self.state_reader_factory),
@@ -184,6 +191,7 @@ impl MockDependencies {
             Arc::new(self.mock_transaction_converter),
             Arc::new(self.mock_stateless_transaction_validator),
             Arc::new(self.mock_proof_archive_writer),
+            Arc::new(self.mock_config_manager_client),
         )
     }
 
@@ -735,6 +743,8 @@ async fn add_tx_returns_error_when_extract_state_nonce_and_run_validations_fails
 
     let tx_args = invoke_args();
     setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
+    let (dynamic_config_tx, dynamic_config_rx) =
+        channel(mock_dependencies.config.dynamic_config.clone());
     let config = Arc::new(mock_dependencies.config);
     let gateway = GenericGateway::<
         MockStatelessTransactionValidatorTrait,
@@ -751,6 +761,11 @@ async fn add_tx_returns_error_when_extract_state_nonce_and_run_validations_fails
             mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
             transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
             proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
+            dynamic_config_rx,
+        },
+        gateway_dynamic_config_updater: GatewayDynamicConfigUpdater {
+            config_manager_client: Arc::new(MockConfigManagerClient::new()),
+            dynamic_config_tx,
         },
     };
 
@@ -798,6 +813,8 @@ async fn add_tx_returns_error_when_instantiating_validator_fails(
 
     let tx_args = invoke_args();
     setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
+    let (dynamic_config_tx, dynamic_config_rx) =
+        channel(mock_dependencies.config.dynamic_config.clone());
     let config = Arc::new(mock_dependencies.config);
     let gateway = GenericGateway::<
         MockStatelessTransactionValidatorTrait,
@@ -814,6 +831,11 @@ async fn add_tx_returns_error_when_instantiating_validator_fails(
             mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
             transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
             proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
+            dynamic_config_rx,
+        },
+        gateway_dynamic_config_updater: GatewayDynamicConfigUpdater {
+            config_manager_client: Arc::new(MockConfigManagerClient::new()),
+            dynamic_config_tx,
         },
     };
 

--- a/crates/apollo_gateway/src/test_utils.rs
+++ b/crates/apollo_gateway/src/test_utils.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use apollo_class_manager_types::MockClassManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerClient;
 use apollo_gateway_config::compiler_version::VersionId;
 use apollo_gateway_config::config::GatewayConfig;
 use apollo_mempool_types::communication::MockMempoolClient;
@@ -172,6 +173,7 @@ pub fn gateway_for_benchmark(gateway_config: GatewayConfig) -> GatewayForBenchma
     let state_reader_factory = local_test_state_reader_factory(cairo_version, false);
     let mut mempool_client = MockMempoolClient::new();
     let class_manager_client = Arc::new(MockClassManagerClient::new());
+    let config_manager_client = Arc::new(MockConfigManagerClient::new());
     let proof_manager_client = Arc::new(MockProofManagerClient::new());
     let proof_archive_writer = Arc::new(MockProofArchiveWriterTrait::new());
     let transaction_converter = TransactionConverter::new(
@@ -193,5 +195,6 @@ pub fn gateway_for_benchmark(gateway_config: GatewayConfig) -> GatewayForBenchma
         Arc::new(transaction_converter),
         stateless_tx_validator,
         proof_archive_writer,
+        config_manager_client,
     )
 }

--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use apollo_config::converters::{
     deserialize_comma_separated_str,
+    deserialize_milliseconds_to_duration,
     serialize_optional_comma_separated,
 };
 use apollo_config::dumping::{
@@ -23,6 +25,7 @@ use validator::Validate;
 use crate::compiler_version::VersionId;
 
 const DEFAULT_BUCKET_NAME: &str = "proof-archive";
+const DEFAULT_DYNAMIC_CONFIG_POLL_INTERVAL_MS: u64 = 1_000; // 1 second.
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Validate)]
 pub struct GatewayStaticConfig {
@@ -34,6 +37,8 @@ pub struct GatewayStaticConfig {
     pub contract_class_manager_config: ContractClassManagerConfig,
     pub chain_info: ChainInfo,
     pub block_declare: bool,
+    #[serde(deserialize_with = "deserialize_milliseconds_to_duration")]
+    pub dynamic_config_poll_interval: Duration,
     #[serde(default, deserialize_with = "deserialize_comma_separated_str")]
     pub authorized_declarer_accounts: Option<Vec<ContractAddress>>,
     pub proof_archive_writer_config: ProofArchiveWriterConfig,
@@ -50,6 +55,9 @@ impl Default for GatewayStaticConfig {
             },
             chain_info: ChainInfo::default(),
             block_declare: false,
+            dynamic_config_poll_interval: Duration::from_millis(
+                DEFAULT_DYNAMIC_CONFIG_POLL_INTERVAL_MS,
+            ),
             authorized_declarer_accounts: None,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
         }
@@ -64,6 +72,12 @@ impl SerializeConfig for GatewayStaticConfig {
             "If true, the gateway will block declare transactions.",
             ParamPrivacyInput::Public,
         )]);
+        dump.extend(BTreeMap::from_iter([ser_param(
+            "dynamic_config_poll_interval",
+            &self.dynamic_config_poll_interval.as_millis(),
+            "Polling interval (in milliseconds) for dynamic config.",
+            ParamPrivacyInput::Public,
+        )]));
         dump.extend(prepend_sub_config_name(
             self.stateless_tx_validator_config.dump(),
             "stateless_tx_validator_config",

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -734,6 +734,7 @@ pub fn create_gateway_config(
             contract_class_manager_config,
             chain_info,
             block_declare: false,
+            dynamic_config_poll_interval: std::time::Duration::from_secs(1),
             authorized_declarer_accounts: None,
             proof_archive_writer_config,
         },

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3014,6 +3014,11 @@
     "privacy": "Public",
     "value": 2
   },
+  "gateway_config.static_config.dynamic_config_poll_interval": {
+    "description": "Polling interval (in milliseconds) for dynamic config.",
+    "privacy": "Public",
+    "value": 1000
+  },
   "gateway_config.static_config.proof_archive_writer_config.bucket_name": {
     "description": "The name of the bucket to write proofs to. An empty string indicates a test environment that does not connect to GCS.",
     "privacy": "Public",

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -246,12 +246,16 @@ pub async fn create_node_components(
             let proof_manager_client = clients
                 .get_proof_manager_shared_client()
                 .expect("Proof Manager client should be available");
+            let config_manager_client = clients
+                .get_config_manager_shared_client()
+                .expect("Config Manager client should be available");
             Some(create_gateway(
                 gateway_config.clone(),
                 state_sync_client,
                 mempool_client,
                 class_manager_client,
                 proof_manager_client,
+                config_manager_client,
                 tokio::runtime::Handle::current(),
             ))
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a background polling task and new dependency wiring to update gateway behavior from config-manager; issues here could lead to stale/incorrect validation config or extra load due to polling. Changes are localized but affect transaction validation inputs at runtime.
> 
> **Overview**
> The gateway now **updates its dynamic config at runtime** by polling the config-manager and distributing updates via a `tokio::sync::watch` channel, replacing direct reads of `config.dynamic_config` during validation.
> 
> This threads a `SharedConfigManagerClient` into `create_gateway`/`GenericGateway::new`, adds a configurable `dynamic_config_poll_interval` to `GatewayStaticConfig` (and schema/tests), and extends the dev Grafana dashboard with client/server metrics for `get_gateway_dynamic_config` requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eed750ab220dbce3c67e8d16efbce7aa9f71379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->