### PR TITLE
remove github smell testing section

### DIFF
--- a/style.md
+++ b/style.md
@@ -384,10 +384,6 @@ All textual content, including code-comments, commit messages, `expect` messages
 my_vec.push(foo)
 ```
 
-## Github Smell-Testing
-
-If you have a oneliner you suspect is a bad practice, when applicable, try searching for it in the global search bar in `github.com`, if you don't see any production-grade crates doing it consider changing it.
-
 ## External Dependencies
 
 Be conservative with helper crates, and especially avoid single-use crates --- external deps increase our compilation time, and increase potential of version clashes and sudden breaking changes (not all crates adhere to Semver properly).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that removes a brief guidance section, with no impact on runtime code or behavior.
> 
> **Overview**
> Removes the `Github Smell-Testing` section from `style.md`, eliminating the recommendation to validate questionable one-liners by searching for similar usage in production crates on GitHub.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5168a30a982e3cde011f11655a8dade05e0fdf81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->