### PR TITLE
remove open issues section

### DIFF
--- a/style.md
+++ b/style.md
@@ -411,10 +411,6 @@ Take extra care when reviewing ai-generated code for these issues:
 -   Hygiene issues: leaks and races are common, since chatbots rarely take a step back and analyze the surrounding conditions in which a code is being run; always analyze flows affected by your change as the AI will not do so.
 -   Excessive allocations/clones.
 
-## Open issues
-
--   Derive ordering: rustfmt can't enforce alphabetization, and there isn't a clear standard in the community for this anyway. Alternative orderings include ordering the builtin derives first (Debug/Clone), then third-party dep's derives (Serialize), then custom derives, all in order of commonality (the more common the derive is, the more "to the left" it appears).
-
 ## Miscellaneous
 ### Async
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes a short "Open issues" note; no code or behavior is affected.
> 
> **Overview**
> Removes the "Open issues" subsection from `style.md` (the note about derive ordering), leaving the rest of the Rust coding conventions unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47be1df7dd2a4471a8b12c154e58ceb5dbf31da9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->