### PR TITLE
apollo_storage: use unique_u16! macro for port allocation in storage reader server tests

### DIFF
--- a/crates/apollo_infra_utils/src/test_utils.rs
+++ b/crates/apollo_infra_utils/src/test_utils.rs
@@ -8,7 +8,7 @@ use strum::EnumCount;
 use tracing::instrument;
 
 const PORTS_PER_INSTANCE: u16 = 80;
-pub const MAX_NUMBER_OF_INSTANCES_PER_TEST: u16 = 25;
+pub const MAX_NUMBER_OF_INSTANCES_PER_TEST: u16 = 27;
 #[allow(clippy::as_conversions)]
 const MAX_NUMBER_OF_TESTS: u16 = TestIdentifier::COUNT as u16;
 const BASE_PORT: u16 = 11000;

--- a/crates/apollo_storage/src/storage_reader_server_test.rs
+++ b/crates/apollo_storage/src/storage_reader_server_test.rs
@@ -1,6 +1,7 @@
 use std::net::{IpAddr, Ipv4Addr};
 
 use apollo_infra_utils::test_utils::{AvailablePorts, TestIdentifier};
+use apollo_proc_macros::unique_u16;
 use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -69,7 +70,7 @@ async fn endpoint_successful_query() {
         .unwrap();
 
     let mut available_ports =
-        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), 0);
+        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), unique_u16!());
 
     let config =
         ServerConfig::new(IpAddr::from(Ipv4Addr::LOCALHOST), available_ports.get_next_port(), true);
@@ -90,7 +91,7 @@ async fn endpoint_query_nonexistent_block() {
     let ((reader, _writer), _temp_dir) = get_test_storage();
 
     let mut available_ports =
-        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), 1);
+        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), unique_u16!());
 
     let config =
         ServerConfig::new(IpAddr::from(Ipv4Addr::LOCALHOST), available_ports.get_next_port(), true);
@@ -111,7 +112,7 @@ async fn endpoint_handler_error() {
     let ((reader, _writer), _temp_dir) = get_test_storage();
 
     let mut available_ports =
-        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), 2);
+        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), unique_u16!());
 
     let config =
         ServerConfig::new(IpAddr::from(Ipv4Addr::LOCALHOST), available_ports.get_next_port(), true);
@@ -136,7 +137,7 @@ async fn endpoint_invalid_json() {
     let ((reader, _writer), _temp_dir) = get_test_storage();
 
     let mut available_ports =
-        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), 3);
+        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), unique_u16!());
     let config =
         ServerConfig::new(IpAddr::from(Ipv4Addr::LOCALHOST), available_ports.get_next_port(), true);
 
@@ -166,7 +167,7 @@ async fn endpoint_disabled_returns_service_unavailable() {
     let ((reader, _writer), _temp_dir) = get_test_storage();
 
     let mut available_ports =
-        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), 4);
+        AvailablePorts::new(TestIdentifier::StorageReaderServerUnitTests.into(), unique_u16!());
 
     let config = ServerConfig::new(
         IpAddr::from(Ipv4Addr::LOCALHOST),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to test-only port allocation logic and a small bump to the allowed per-test instance count, with no production code paths affected.
> 
> **Overview**
> Updates `apollo_storage`’s `storage_reader_server_test` to allocate per-test port ranges using `unique_u16!()` instead of hardcoded instance indices, reducing the chance of port collisions when tests run concurrently.
> 
> Also increases `MAX_NUMBER_OF_INSTANCES_PER_TEST` in `apollo_infra_utils::test_utils` from 25 to 27 to accommodate the expanded unique instance indexing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a35b094d05d3c084285a89f7c8836f21113db181. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->