### PR TITLE
starknet_transaction_prover: sanitize error messages returned to clients

### DIFF
--- a/crates/starknet_transaction_prover/src/server/errors.rs
+++ b/crates/starknet_transaction_prover/src/server/errors.rs
@@ -6,11 +6,15 @@
 //! - The OpenRPC spec: `resources/proving_api_openrpc.json` (under `components/errors`)
 //! - The spec validation test: `server/rpc_spec_test.rs` (`test_error_responses_match_spec`)
 
+#[cfg(test)]
+#[path = "errors_test.rs"]
+mod errors_test;
+
 use jsonrpsee::types::error::ErrorCode::InternalError;
 use jsonrpsee::types::error::INTERNAL_ERROR_MSG;
 use jsonrpsee::types::ErrorObjectOwned;
 
-use crate::errors::VirtualSnosProverError;
+use crate::errors::{RunnerError, VirtualBlockExecutorError, VirtualSnosProverError};
 
 // Starknet RPC v0.10 error codes.
 
@@ -53,26 +57,58 @@ pub fn internal_server_error(err: impl std::fmt::Display) -> ErrorObjectOwned {
 
 impl From<VirtualSnosProverError> for ErrorObjectOwned {
     fn from(err: VirtualSnosProverError) -> Self {
-        match &err {
-            VirtualSnosProverError::InvalidTransactionType(msg) => {
-                unsupported_tx_version(msg.clone())
-            }
-            VirtualSnosProverError::InvalidTransactionInput(msg) => {
-                invalid_transaction_input(msg.clone())
-            }
+        match err {
+            VirtualSnosProverError::InvalidTransactionType(msg) => unsupported_tx_version(msg),
+            VirtualSnosProverError::InvalidTransactionInput(msg) => invalid_transaction_input(msg),
             VirtualSnosProverError::ValidationError(msg) => {
                 // Check if it's a pending block error.
-                if msg.contains("Pending") {
-                    block_not_found()
-                } else {
-                    validation_failure(msg.clone())
-                }
+                if msg.contains("Pending") { block_not_found() } else { validation_failure(msg) }
             }
-            VirtualSnosProverError::RunnerError(e) => internal_server_error(e),
+            VirtualSnosProverError::RunnerError(e) => runner_error_to_rpc(*e),
             #[cfg(feature = "stwo_proving")]
-            VirtualSnosProverError::ProvingError(e) => internal_server_error(e),
-            VirtualSnosProverError::OutputParseError(e) => internal_server_error(e),
-            VirtualSnosProverError::ProgramOutputError(e) => internal_server_error(e),
+            VirtualSnosProverError::ProvingError(_) => {
+                internal_server_error("Proof generation failed.")
+            }
+            VirtualSnosProverError::OutputParseError(_) => {
+                internal_server_error("Internal proving error.")
+            }
+            VirtualSnosProverError::ProgramOutputError(_) => {
+                internal_server_error("Internal proving error.")
+            }
+        }
+    }
+}
+
+fn runner_error_to_rpc(err: RunnerError) -> ErrorObjectOwned {
+    match err {
+        RunnerError::VirtualBlockExecutor(e) => virtual_block_executor_error_to_rpc(e),
+        RunnerError::ClassesProvider(_) => {
+            internal_server_error("Failed to fetch contract classes from RPC node.")
+        }
+        RunnerError::ProofProvider(_) => {
+            internal_server_error("Failed to fetch storage proofs from RPC node.")
+        }
+        RunnerError::TransactionHashError(_) => {
+            internal_server_error("Failed to compute transaction hash.")
+        }
+        RunnerError::OsExecution(_)
+        | RunnerError::InputGenerationError(_)
+        | RunnerError::TaskJoin(_) => internal_server_error("Internal proving error."),
+    }
+}
+
+fn virtual_block_executor_error_to_rpc(err: VirtualBlockExecutorError) -> ErrorObjectOwned {
+    match err {
+        VirtualBlockExecutorError::TransactionReverted(_, reason) => {
+            internal_server_error(format!("Transaction reverted: {reason}"))
+        }
+        VirtualBlockExecutorError::TransactionExecutionError(_) => {
+            internal_server_error("Transaction execution failed.")
+        }
+        VirtualBlockExecutorError::ReexecutionError(_)
+        | VirtualBlockExecutorError::StateUnavailable
+        | VirtualBlockExecutorError::BouncerLockError(_) => {
+            internal_server_error("Failed to read block state from RPC node.")
         }
     }
 }

--- a/crates/starknet_transaction_prover/src/server/errors_test.rs
+++ b/crates/starknet_transaction_prover/src/server/errors_test.rs
@@ -1,0 +1,124 @@
+use starknet_api::felt;
+use starknet_api::transaction::TransactionHash;
+use starknet_os::io::os_output::OsOutputError;
+
+use crate::errors::{
+    ClassesProviderError,
+    ProofProviderError,
+    RunnerError,
+    VirtualBlockExecutorError,
+    VirtualSnosProverError,
+};
+use crate::server::errors::internal_server_error;
+
+fn error_data(err: VirtualSnosProverError) -> String {
+    let rpc_err: jsonrpsee::types::ErrorObjectOwned = err.into();
+    let raw_value = rpc_err.data().expect("expected error data to be present");
+    serde_json::from_str(raw_value.get()).expect("error data should be valid JSON string")
+}
+
+#[test]
+fn test_transaction_reverted_produces_user_friendly_message() {
+    let tx_hash = TransactionHash(felt!("0x123"));
+    let inner = VirtualBlockExecutorError::TransactionReverted(tx_hash, "out of gas".to_string());
+    let err = VirtualSnosProverError::from(Box::new(RunnerError::from(inner)));
+
+    let data = error_data(err);
+    assert!(data.contains("Transaction reverted"), "Expected 'Transaction reverted' in: {data}");
+    assert!(
+        !data.contains("VirtualBlockExecutorError"),
+        "Should not expose internal type name in: {data}"
+    );
+}
+
+#[test]
+fn test_transaction_execution_error_produces_user_friendly_message() {
+    let inner =
+        VirtualBlockExecutorError::TransactionExecutionError("execution failed".to_string());
+    let err = VirtualSnosProverError::from(Box::new(RunnerError::from(inner)));
+
+    let data = error_data(err);
+    assert_eq!(data, "Transaction execution failed.", "Unexpected error data: {data}");
+}
+
+#[test]
+fn test_state_unavailable_produces_user_friendly_message() {
+    let inner = VirtualBlockExecutorError::StateUnavailable;
+    let err = VirtualSnosProverError::from(Box::new(RunnerError::from(inner)));
+
+    let data = error_data(err);
+    assert!(
+        data.contains("Failed to read block state"),
+        "Expected 'Failed to read block state' in: {data}"
+    );
+    assert!(
+        !data.contains("StateUnavailable"),
+        "Should not expose internal variant name in: {data}"
+    );
+}
+
+#[test]
+fn test_classes_provider_error_produces_user_friendly_message() {
+    let inner = ClassesProviderError::GetClassesError("network timeout".to_string());
+    let err = VirtualSnosProverError::from(Box::new(RunnerError::from(inner)));
+
+    let data = error_data(err);
+    assert!(
+        data.contains("Failed to fetch contract classes"),
+        "Expected 'Failed to fetch contract classes' in: {data}"
+    );
+}
+
+#[test]
+fn test_proof_provider_error_produces_user_friendly_message() {
+    let inner = ProofProviderError::InvalidStateDiff("state diff mismatch".to_string());
+    let err = VirtualSnosProverError::from(Box::new(RunnerError::from(inner)));
+
+    let data = error_data(err);
+    assert!(
+        data.contains("Failed to fetch storage proofs"),
+        "Expected 'Failed to fetch storage proofs' in: {data}"
+    );
+}
+
+#[test]
+fn test_transaction_hash_error_produces_user_friendly_message() {
+    let err = VirtualSnosProverError::from(Box::new(RunnerError::TransactionHashError(
+        "unsupported hash version".to_string(),
+    )));
+
+    let data = error_data(err);
+    assert_eq!(data, "Failed to compute transaction hash.", "Unexpected error data: {data}");
+}
+
+#[test]
+fn test_input_generation_error_produces_generic_internal_error() {
+    let err = VirtualSnosProverError::from(Box::new(RunnerError::InputGenerationError(
+        "missing field".to_string(),
+    )));
+
+    let data = error_data(err);
+    assert!(
+        data.contains("Internal proving error"),
+        "Expected 'Internal proving error' in: {data}"
+    );
+}
+
+#[test]
+fn test_output_parse_error_produces_generic_internal_error() {
+    let inner = OsOutputError::MissingFieldInOutput("some_field".to_string());
+    let err = VirtualSnosProverError::from(inner);
+
+    let data = error_data(err);
+    assert!(
+        data.contains("Internal proving error"),
+        "Expected 'Internal proving error' in: {data}"
+    );
+}
+
+// Sanity check that the internal_server_error helper itself produces a data field.
+#[test]
+fn test_internal_server_error_has_data_field() {
+    let rpc_err = internal_server_error("some detail");
+    assert!(rpc_err.data().is_some(), "internal_server_error should always include a data field");
+}


### PR DESCRIPTION
## Summary
- Map internal error types to user-friendly RPC error messages so internal type names, stack traces, and node URLs are never exposed to external callers
- Add 9 unit tests covering each error mapping path
- Fix format string compile error in `validate_transaction_input`

## Test plan
- [x] `SEED=0 cargo test -p starknet_transaction_prover -- errors_test` — 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the JSON-RPC surface by replacing internal error details with curated messages; incorrect mapping could hinder debugging or change client-visible behavior, but it’s limited to error handling and covered by new unit tests.
> 
> **Overview**
> **Sanitizes client-facing JSON-RPC errors** by mapping `VirtualSnosProverError` (including nested `RunnerError`/`VirtualBlockExecutorError`) into user-friendly `InternalError` data strings, avoiding leakage of internal type names/details and providing specific messages for common failure modes (RPC fetches, tx hash, execution/revert, state reads, proof generation).
> 
> Adds a dedicated `errors_test.rs` module with unit tests asserting the new mappings and that `internal_server_error` always includes a `data` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6097fc1b1ac014041c146f9ebf059337f977d45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->