### PR TITLE
starknet_transaction_prover: add prover input validation unit tests

### DIFF
--- a/crates/starknet_transaction_prover/src/proving/virtual_snos_prover_test.rs
+++ b/crates/starknet_transaction_prover/src/proving/virtual_snos_prover_test.rs
@@ -1,7 +1,8 @@
-//! Integration tests for the VirtualSnosProver (full prove_transaction flow).
+//! Tests for VirtualSnosProver: unit tests for input validation and integration tests for the
+//! full prove_transaction flow.
 //!
-//! These tests exercise the complete prover pipeline: transaction extraction, OS execution,
-//! and proof generation.  They run against Sepolia and support three modes
+//! The integration tests exercise the complete prover pipeline: transaction extraction, OS
+//! execution, and proof generation. They run against Sepolia and support three modes
 //! (see [`crate::running::rpc_records`] and [`crate::test_utils::resolve_test_mode`]):
 //!
 //! - **Live mode** (default): runs against a real node (requires `NODE_URL`).
@@ -15,7 +16,7 @@
 //! - `CHAIN_ID`: Override the chain ID (defaults to `Sepolia`).
 //! - `STRK_FEE_TOKEN_ADDRESS`: Override the STRK fee token contract address.
 //!
-//! # Running
+//! # Running integration tests
 //!
 //! ```bash
 //! # Live mode:
@@ -28,21 +29,175 @@
 //! cargo test -p starknet_transaction_prover virtual_snos_prover_test -- --ignored
 //! ```
 
+use std::sync::Arc;
+
+use assert_matches::assert_matches;
+use async_trait::async_trait;
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use blockifier_test_utils::calldata::create_calldata;
 use rstest::rstest;
+use starknet_api::block::GasPrice;
 use starknet_api::core::ContractAddress;
+use starknet_api::data_availability::DataAvailabilityMode;
+use starknet_api::execution_resources::GasAmount;
+use starknet_api::rpc_transaction::{
+    RpcDeployAccountTransaction, RpcDeployAccountTransactionV3, RpcInvokeTransaction,
+    RpcInvokeTransactionV3, RpcTransaction,
+};
+use starknet_api::transaction::InvokeTransaction;
+use starknet_api::transaction::fields::{
+    AllResourceBounds, Proof, ProofFacts, ResourceBounds, Tip,
+};
 use starknet_api::{contract_address, felt};
 use starknet_proof_verifier::verify_proof;
+use starknet_types_core::felt::Felt;
 
+use crate::errors::{RunnerError, VirtualSnosProverError};
 use crate::proving::virtual_snos_prover::VirtualSnosProver;
+use crate::running::runner::{RunnerOutput, VirtualSnosRunner};
 use crate::test_utils::{
-    build_client_side_rpc_invoke,
-    resolve_test_mode,
-    runner_factory,
-    DUMMY_ACCOUNT_ADDRESS,
-    STRK_TOKEN_ADDRESS_SEPOLIA,
+    DUMMY_ACCOUNT_ADDRESS, STRK_TOKEN_ADDRESS_SEPOLIA, build_client_side_rpc_invoke,
+    resolve_test_mode, runner_factory,
 };
+
+// --- Test helpers ---
+
+fn build_valid_invoke() -> RpcTransaction {
+    let account = ContractAddress::try_from(DUMMY_ACCOUNT_ADDRESS).unwrap();
+    build_client_side_rpc_invoke(account, Default::default())
+}
+
+fn extract_invoke_v3_mut(tx: &mut RpcTransaction) -> &mut RpcInvokeTransactionV3 {
+    match tx {
+        RpcTransaction::Invoke(RpcInvokeTransaction::V3(inner)) => inner,
+        _ => panic!("Expected InvokeV3"),
+    }
+}
+
+/// A runner that panics if called. Use this for tests where validation should reject
+/// the transaction before the runner is invoked.
+#[derive(Clone)]
+struct UnreachableRunner;
+
+#[async_trait]
+impl VirtualSnosRunner for UnreachableRunner {
+    async fn run_virtual_os(
+        &self,
+        _block_id: BlockId,
+        _txs: Vec<InvokeTransaction>,
+    ) -> Result<RunnerOutput, RunnerError> {
+        panic!("UnreachableRunner was called — validation should have rejected the transaction");
+    }
+}
+
+/// A runner that always returns an error. Use this for tests that need to verify
+/// the runner is reached (i.e., validation passed) without requiring a real node.
+#[derive(Clone)]
+struct FailingRunner;
+
+#[async_trait]
+impl VirtualSnosRunner for FailingRunner {
+    async fn run_virtual_os(
+        &self,
+        _block_id: BlockId,
+        _txs: Vec<InvokeTransaction>,
+    ) -> Result<RunnerOutput, RunnerError> {
+        Err(RunnerError::InputGenerationError("mock error".to_string()))
+    }
+}
+
+// --- Unit tests: input validation ---
+
+#[tokio::test]
+async fn test_pending_block_rejected() {
+    let prover = VirtualSnosProver::from_runner(UnreachableRunner).disable_fee_validation();
+    let result = prover.prove_transaction(BlockId::Pending, build_valid_invoke()).await;
+    assert_matches!(result, Err(VirtualSnosProverError::ValidationError(msg)) if msg.contains("Pending"));
+}
+
+#[tokio::test]
+async fn test_deploy_account_transaction_rejected() {
+    let deploy_account_tx = RpcTransaction::DeployAccount(RpcDeployAccountTransaction::V3(
+        RpcDeployAccountTransactionV3 {
+            signature: Default::default(),
+            nonce: Default::default(),
+            class_hash: Default::default(),
+            contract_address_salt: Default::default(),
+            constructor_calldata: Default::default(),
+            resource_bounds: Default::default(),
+            tip: Default::default(),
+            paymaster_data: Default::default(),
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+        },
+    ));
+
+    let prover = VirtualSnosProver::from_runner(UnreachableRunner).disable_fee_validation();
+    let result = prover.prove_transaction(BlockId::Latest, deploy_account_tx).await;
+    assert_matches!(
+        result,
+        Err(VirtualSnosProverError::InvalidTransactionType(msg)) if msg.contains("DeployAccount")
+    );
+}
+
+#[rstest]
+#[case("non-empty proof field", {
+    let mut tx = build_valid_invoke();
+    extract_invoke_v3_mut(&mut tx).proof = Proof(Arc::new(vec![0u32]));
+    tx
+})]
+#[case("non-empty proof_facts field", {
+    let mut tx = build_valid_invoke();
+    extract_invoke_v3_mut(&mut tx).proof_facts = ProofFacts(Arc::new(vec![Felt::ZERO]));
+    tx
+})]
+#[tokio::test]
+async fn test_non_empty_proof_fields_rejected(
+    #[case] _description: &str,
+    #[case] tx: RpcTransaction,
+) {
+    let prover = VirtualSnosProver::from_runner(UnreachableRunner).disable_fee_validation();
+    let result = prover.prove_transaction(BlockId::Latest, tx).await;
+    assert_matches!(result, Err(VirtualSnosProverError::InvalidTransactionInput(_)));
+}
+
+#[rstest]
+#[case("non-zero l1_gas resource bounds", {
+    let mut tx = build_valid_invoke();
+    extract_invoke_v3_mut(&mut tx).resource_bounds = AllResourceBounds {
+        l1_gas: ResourceBounds { max_amount: GasAmount(1), max_price_per_unit: GasPrice(1) },
+        ..Default::default()
+    };
+    tx
+})]
+#[case("non-zero tip", {
+    let mut tx = build_valid_invoke();
+    extract_invoke_v3_mut(&mut tx).tip = Tip(1);
+    tx
+})]
+#[tokio::test]
+async fn test_fee_fields_rejected_when_validation_enabled(
+    #[case] _description: &str,
+    #[case] tx: RpcTransaction,
+) {
+    let prover = VirtualSnosProver::from_runner(UnreachableRunner);
+    let result = prover.prove_transaction(BlockId::Latest, tx).await;
+    assert_matches!(result, Err(VirtualSnosProverError::InvalidTransactionInput(_)));
+}
+
+#[tokio::test]
+async fn test_non_zero_resource_bounds_accepted_when_validation_disabled() {
+    let mut tx = build_valid_invoke();
+    extract_invoke_v3_mut(&mut tx).resource_bounds = AllResourceBounds {
+        l1_gas: ResourceBounds { max_amount: GasAmount(1), max_price_per_unit: GasPrice(1) },
+        ..Default::default()
+    };
+
+    // Validation is explicitly disabled, so the runner should be reached.
+    let prover = VirtualSnosProver::from_runner(FailingRunner).disable_fee_validation();
+    let result = prover.prove_transaction(BlockId::Latest, tx).await;
+    assert_matches!(result, Err(VirtualSnosProverError::RunnerError(_)));
+}
 
 /// Integration test for the full prover pipeline with a `balanceOf` transaction.
 /// Runs on a Sepolia environment; in live/recording mode requires a Sepolia RPC node via
@@ -62,7 +217,7 @@ async fn test_prove_balance_of_transaction() {
     let rpc_tx = build_client_side_rpc_invoke(account, calldata);
 
     let factory = runner_factory(&test_mode.rpc_url());
-    let prover = VirtualSnosProver::from_runner(factory);
+    let prover = VirtualSnosProver::from_runner(factory).disable_fee_validation();
 
     // Run the full prover pipeline: OS execution → proof generation.
     let result = prover.prove_transaction(BlockId::Latest, rpc_tx).await;
@@ -106,7 +261,7 @@ async fn test_prove_transfer_transaction() {
     let rpc_tx = build_client_side_rpc_invoke(account, calldata);
 
     let factory = runner_factory(&test_mode.rpc_url());
-    let prover = VirtualSnosProver::from_runner(factory);
+    let prover = VirtualSnosProver::from_runner(factory).disable_fee_validation();
 
     // Run the full prover pipeline: OS execution → proof generation.
     let result = prover.prove_transaction(BlockId::Latest, rpc_tx).await;


### PR DESCRIPTION
## Summary
- Add 7 unit tests for `validate_transaction_input`: pending block rejection, non-invoke transaction types, proof/proof_facts field checks, fee field enforcement, and fee validation toggle
- Add test-only `with_fee_validation` builder method on `VirtualSnosProver`

## Test plan
- [x] `SEED=0 cargo test -p starknet_transaction_prover -- virtual_snos_prover_test` — 7 pass, 2 ignored (integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to tests and tweak integration tests to disable fee validation; no production logic changes.
> 
> **Overview**
> Adds unit tests for `VirtualSnosProver::prove_transaction` input validation, covering pending-block rejection, unsupported transaction types, non-empty `proof`/`proof_facts`, and enforcement/toggling of fee-field zero checks.
> 
> Updates the existing Sepolia integration tests to call `disable_fee_validation()` so they can run with non-zero fee-related fields without failing validation, and introduces small test-only runner stubs to assert validation short-circuits or reaches the runner as expected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8129808cf87137f1938b75cb20676c042e9ce454. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->