### PR TITLE
improve macros section

### DIFF
--- a/style.md
+++ b/style.md
@@ -421,7 +421,7 @@ Mostly avoid `select!` unless you are certain the tasks are cancel-safe, this ca
 When spawning a task, you _must_ maintain the handle returned from the executor and make sure it completes successfully --- otherwise the task will _detach_ from the process.
 ### Macros
 
-The general rule for metaprogramming and language "power features" applies: only use macros if non-macro alternatives are not feasible and when _really_ necessary (like when writing a domain-specific language).
+Only use macros if non-macro alternatives are not feasible and when _really_ necessary (like when writing a domain-specific language).
 
 **Rationale**: [the more expressive the macro is, the less it can be reasoned about](https://matklad.github.io/2021/02/14/for-the-love-of-macros.html); well-structured non-macro code doesn't suffer from this.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that tweaks the `Macros` guideline wording/formatting; no runtime or behavioral impact.
> 
> **Overview**
> Clarifies the `Macros` section in `style.md` by turning the main guidance line into a direct statement (removing the leading “general rule” phrasing/bullet formatting) while keeping the rationale and examples unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 450475f35dbb94f5e68fc88bed47d534791a97a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->