### PR TITLE
remove bad example in foo_or_else section

### DIFF
--- a/style.md
+++ b/style.md
@@ -484,19 +484,6 @@ let x = u128::MAX as u64; // This doesn't panic, it saturates and simply sets `x
 Methods that end with `_or`, like `unwrap_or`, are typically eagerly evaluated, meaning `foo.unwrap_or(expensive_calculation_of_foo())` will always be evaluated, even if the original value is unwrapped --- use `_or_else` methods for lazy evaluations, which is typically what you want.
 The same also holds for `expect`, and in general for all methods that take a non-closure parameter.
 
-```rust
-// BAD
-// always panics!
-map.get(key).expect(panic!("{key} should exist because of <reason>"));
-
-// BAD
-// Inefficient: this always allocates a String on the heap.
-map.get(key).expect(format!("{key} should exist because of <reason>"));
-
-// GOOD
-map.get(key).unwrap_or_else(|| panic!("{key} should exist because of <reason>"))
-```
-
 ### Maps/Sets
 
 Avoid iterating `HashSet` and `HashMap`, this is not deterministic in rust. Either use `BTree{Map,Set}` or `Index{Map,Set}`, and prefer `BTree` when you can, as the `Index` version has O(n) removals (it uses a `Vec` for storage).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that removes an example snippet; no runtime or behavioral impact.
> 
> **Overview**
> Removes the Rust code example block in `style.md` under **`foo_or` vs `foo_or_else`**, leaving only the explanatory text about eager vs lazy evaluation (including `expect`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5efb2d7bae18bc8319306cfb9b3c328552dfeb82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->