### PR TITLE
add comment in return value section to split checking the value and performing action to 2 lines

### DIFF
--- a/style.md
+++ b/style.md
@@ -206,13 +206,24 @@ Don't run any non-const code inside `expect`, it is evaluated eagerly which can 
 
 Always check return values from functions/methods, especially when modifying collections, which typically return an `Option` or a `bool`.
 
+In addition, when doing a mutable action on a collection that returns a result, prefer splitting
+calling the action and checking the result into 2 different lines, as the action might be missed
+inside the condition
+
 ```rust
-// BAD
+// BAD - we don't check the result
 map.insert(foo);
 
+// BAD - it's easy to miss that an insert happened here
+if map.insert(foo) {
+    handle_duplicate();
+}
+
 // GOOD
-let result = map.insert(foo);
-assert!(result, "dup-check was done previously in ...")
+let is_duplicate = map.insert(foo);
+if is_duplicate {
+    handle_duplicate();
+}
 ```
 
 ## APIs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates coding conventions without affecting runtime behavior.
> 
> **Overview**
> Updates `style.md` *Return Values* guidance to emphasize capturing and checking the result of mutating collection operations on a separate line, with revised BAD/GOOD examples showing how to avoid hiding side effects inside conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a17fefe22e840e3296ae18a41be8f4654a3e3131. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->