### PR TITLE
make the example in combinators compile

### DIFF
--- a/style.md
+++ b/style.md
@@ -538,10 +538,10 @@ Using the non-pure `for_each` combinator is also fine but only for one-liners.
 ```rust
 // BAD
 // Even if rust allows the closure to mutate self, it's surprising to do this inside a transformer like `map`.
-let new_vec = old_vec.map(|num| self.mutate_self(num))
+let new_vec = old_vec.map(|num| self.mutate_self(num)).collect();
 
 // GOOD
-let new_vec = Vec::with_capacity(old_vec.len());
+let mut new_vec = Vec::with_capacity(old_vec.len());
 for num in old_vec {
     let new_num = self.mutate_self(num);
     new_vec.push(new_num);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts Rust examples; no production code paths are affected.
> 
> **Overview**
> Updates the `Combinators` section in `style.md` so the Rust snippets compile: the `map` example now finishes with `.collect()`, and the imperative `Vec::with_capacity` example correctly declares `new_vec` as `mut` before pushing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b90e84a0009ed2ed29ea70f533c5f20190c65169. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->