### PR TITLE
improve casting section

### DIFF
--- a/style.md
+++ b/style.md
@@ -480,9 +480,14 @@ All associated functions should depend on `Self`. Associated functions that don'
 
 ### Casting
 
-If you have to cast a value due to an implementation detail, like a pass-through newtype, prefer `into` over `ImplementationDetail::from`.
+If you have to cast a value use:
+* `into`/`try_into`: If the compiler can deduce the types alone
+* `from`/`try_from`: If it can't
+
+**Rationale**: `3.into()` is cleaner than `usize::from(3)`, but the latter is still cleaner than `Into::<usize>::into(3)`
 
 Avoid using `as` casts unless there is no other choice --- they are banned by the linter in our repo.
+
 **Rationale**: if `as` casts overflow or underflow, they saturate, and do so without printing or panicking --- most of the time this isn't the desired result, and can introduce silent bugs.
 
 ```rust


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies when to use `into`/`from` and adds rationale about `as` cast overflow behavior.
> 
> **Overview**
> Updates the Rust style guide’s *Casting* section to give clearer guidance on choosing `into`/`try_into` vs `from`/`try_from` based on whether the compiler can infer the target type.
> 
> Also adds a brief rationale explaining why `as` casts are discouraged (silent saturation on overflow/underflow), alongside the existing linter prohibition and example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1221a77e72888466c47cb00fb9969e6b0383a413. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->