### PR TITLE
starknet_os_flow_tests: add daily fuzz test seed offset

### DIFF
--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo0/compiled/fuzz_revert_compiled.json
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo0/compiled/fuzz_revert_compiled.json
@@ -49,7 +49,7 @@
         ],
         "EXTERNAL": [
             {
-                "offset": 716,
+                "offset": 728,
                 "selector": "0x8e64dfac867f301a439703710296f437e9f91d1bba17cfea5ad7f137a5acd"
             },
             {
@@ -157,18 +157,36 @@
                     "__main__",
                     "__main__.test_revert_fuzz"
                 ],
-                "end_pc": 712,
+                "end_pc": 716,
                 "flow_tracking_data": {
                     "ap_tracking": {
                         "group": 27,
-                        "offset": 73
+                        "offset": 74
+                    },
+                    "reference_ids": {}
+                },
+                "name": "error_message",
+                "start_pc": 712,
+                "value": "get_block_hash_cairo0"
+            },
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__",
+                    "__main__.test_revert_fuzz"
+                ],
+                "end_pc": 724,
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 27,
+                        "offset": 74
                     },
                     "reference_ids": {
                         "__main__.test_revert_fuzz.scenario": 9
                     }
                 },
                 "name": "error_message",
-                "start_pc": 708,
+                "start_pc": 720,
                 "value": "Unknown scenario: {scenario}."
             }
         ],
@@ -886,20 +904,32 @@
             "0x1104800180018000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe42",
             "0x208b7fff7fff7ffe",
+            "0x4826800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff0",
+            "0x20680017fff7fff",
+            "0xa",
+            "0x480680017fff8000",
+            "0x1",
+            "0x400680017fff7fff",
+            "0x0",
+            "0x48127fe97fff8000",
+            "0x48127fe97fff8000",
+            "0x48127fe97fff8000",
+            "0x208b7fff7fff7ffe",
             "0x480680017fff8000",
             "0x0",
             "0x400680017fff7fff",
             "0x1",
-            "0x48127fea7fff8000",
-            "0x48127fea7fff8000",
-            "0x48127fea7fff8000",
+            "0x48127fe97fff8000",
+            "0x48127fe97fff8000",
+            "0x48127fe97fff8000",
             "0x208b7fff7fff7ffe",
             "0x402b7ffd7ffc7ffd",
             "0x480280007ffb8000",
             "0x480280017ffb8000",
             "0x480280027ffb8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe33",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe27",
             "0x40780017fff7fff",
             "0x1",
             "0x48127ffc7fff8000",
@@ -1126,7 +1156,7 @@
                     }
                 }
             ],
-            "722": [
+            "734": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -1255,6 +1285,10 @@
             "__main__.SCENARIO_EMIT_EVENT": {
                 "type": "const",
                 "value": 16
+            },
+            "__main__.SCENARIO_GET_BLOCK_HASH": {
+                "type": "const",
+                "value": 17
             },
             "__main__.SCENARIO_INCREMENT_COUNTER": {
                 "type": "const",
@@ -1906,7 +1940,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 716,
+                "pc": 728,
                 "type": "function"
             },
             "__wrappers__.test_revert_fuzz.Args": {

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo0/fuzz_revert.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo0/fuzz_revert.cairo
@@ -30,6 +30,7 @@ const SCENARIO_CALL_UNDEPLOYED = 13;
 const SCENARIO_CALL_NON_EXISTING_ENTRY_POINT = 14;
 const SCENARIO_LIBRARY_CALL_NON_EXISTING_ENTRY_POINT = 15;
 const SCENARIO_EMIT_EVENT = 16;
+const SCENARIO_GET_BLOCK_HASH = 17;
 
 // selector_from_name("pop_front").
 const POP_FRONT_SELECTOR = 0x289c2d7d6351cd03d4f928bde75fa14d5f52e32bdbc750d5296e1b48c12f1c3;
@@ -253,6 +254,13 @@ func test_revert_fuzz{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
         let value = pop_front(orchestrator);
         FuzzEvent.emit(value);
         test_revert_fuzz();
+        return ();
+    }
+
+    if (scenario == SCENARIO_GET_BLOCK_HASH) {
+        with_attr error_message("get_block_hash_cairo0") {
+            assert 0 = 1;
+        }
         return ();
     }
 

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo1/fuzz_revert.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo1/fuzz_revert.cairo
@@ -7,6 +7,8 @@ trait IOrchestrator<TContractState> {
     fn should_fail_undeployed_panic_message(ref self: TContractState) -> felt252;
     fn should_fail_call_no_entrypoint_panic_message(ref self: TContractState) -> felt252;
     fn should_fail_libcall_no_entrypoint_panic_message(ref self: TContractState) -> felt252;
+    fn should_fail_get_block_hash_panic_message(ref self: TContractState) -> felt252;
+    fn should_succeed_get_block_hash_panic_message(ref self: TContractState) -> felt252;
 }
 
 #[starknet::contract]
@@ -39,6 +41,7 @@ mod FuzzRevertContract {
         CallNonExistingEntryPoint,
         LibraryCallNonExistingEntryPoint,
         EmitEvent,
+        GetBlockHash,
     }
 
     impl FeltTryIntoScenario of TryInto<felt252, Scenario> {
@@ -64,6 +67,7 @@ mod FuzzRevertContract {
                 14 => Some(Scenario::CallNonExistingEntryPoint),
                 15 => Some(Scenario::LibraryCallNonExistingEntryPoint),
                 16 => Some(Scenario::EmitEvent),
+                17 => Some(Scenario::GetBlockHash),
                 _ => None,
             }
         }
@@ -112,6 +116,19 @@ mod FuzzRevertContract {
             }
         }
 
+        /// If should_unwrap is true, prepends the orchestrator index to the error and panics.
+        fn maybe_unwrap_error(ref self: ContractState, error: Array<felt252>, should_unwrap: bool) {
+            if should_unwrap {
+                // The inner error does not contain the orchestrator index, so to propagate
+                // the error the index must be prepended.
+                let mut new_error: Array<felt252> = array![self.orchestrator().get_index()];
+                for elem in error {
+                    new_error.append(elem);
+                }
+                panic(new_error);
+            }
+        }
+
         /// Handle a syscall that immediately fails (e.g. calling a non-existing entry point).
         fn handle_syscall_immediate_failure(
             ref self: ContractState,
@@ -121,20 +138,7 @@ mod FuzzRevertContract {
         ) {
             match result {
                 Result::Ok(_) => panic_with_felt252(panic_message_if_ok),
-                Result::Err(mut error) => {
-                    // Syscall failed immediately, so no inner calls could have modified the
-                    // orchestrator index. No need to handle index propagation (the !should_unwrap
-                    // case).
-                    if should_unwrap {
-                        // The inner error does not contain the orchestrator index, so to propagate
-                        // the error the index must be prepended.
-                        let mut new_error: Array<felt252> = array![self.orchestrator().get_index()];
-                        for elem in error {
-                            new_error.append(elem);
-                        }
-                        panic(new_error);
-                    }
-                }
+                Result::Err(error) => self.maybe_unwrap_error(error, should_unwrap),
             }
         }
     }
@@ -272,6 +276,22 @@ mod FuzzRevertContract {
                     );
             },
             Scenario::EmitEvent => { self.emit(FuzzEvent { data: orchestrator.pop_front() }); },
+            Scenario::GetBlockHash => {
+                let block_number: u64 = orchestrator.pop_front().try_into().unwrap();
+                let expect_panic: bool = orchestrator.pop_front() != 0;
+                let should_unwrap = true;
+                match syscalls::get_block_hash_syscall(block_number) {
+                    Result::Ok(_) => assert(
+                        !expect_panic, orchestrator.should_fail_get_block_hash_panic_message()
+                    ),
+                    Result::Err(error) => {
+                        assert(
+                            expect_panic, orchestrator.should_succeed_get_block_hash_panic_message()
+                        );
+                        self.maybe_unwrap_error(error, should_unwrap);
+                    }
+                }
+            },
         }
 
         // Unless explicitly stated otherwise, the next operation should be in the current call

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo1/fuzz_revert_2.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo1/fuzz_revert_2.cairo
@@ -9,6 +9,8 @@ trait IOrchestrator<TContractState> {
     fn should_fail_undeployed_panic_message(ref self: TContractState) -> felt252;
     fn should_fail_call_no_entrypoint_panic_message(ref self: TContractState) -> felt252;
     fn should_fail_libcall_no_entrypoint_panic_message(ref self: TContractState) -> felt252;
+    fn should_fail_get_block_hash_panic_message(ref self: TContractState) -> felt252;
+    fn should_succeed_get_block_hash_panic_message(ref self: TContractState) -> felt252;
 }
 
 #[starknet::contract]
@@ -41,6 +43,7 @@ mod FuzzRevertContract {
         CallNonExistingEntryPoint,
         LibraryCallNonExistingEntryPoint,
         EmitEvent,
+        GetBlockHash,
     }
 
     impl FeltTryIntoScenario of TryInto<felt252, Scenario> {
@@ -66,6 +69,7 @@ mod FuzzRevertContract {
                 14 => Some(Scenario::CallNonExistingEntryPoint),
                 15 => Some(Scenario::LibraryCallNonExistingEntryPoint),
                 16 => Some(Scenario::EmitEvent),
+                17 => Some(Scenario::GetBlockHash),
                 _ => None,
             }
         }
@@ -114,6 +118,19 @@ mod FuzzRevertContract {
             }
         }
 
+        /// If should_unwrap is true, prepends the orchestrator index to the error and panics.
+        fn maybe_unwrap_error(ref self: ContractState, error: Array<felt252>, should_unwrap: bool) {
+            if should_unwrap {
+                // The inner error does not contain the orchestrator index, so to propagate
+                // the error the index must be prepended.
+                let mut new_error: Array<felt252> = array![self.orchestrator().get_index()];
+                for elem in error {
+                    new_error.append(elem);
+                }
+                panic(new_error);
+            }
+        }
+
         /// Handle a syscall that immediately fails (e.g. calling a non-existing entry point).
         fn handle_syscall_immediate_failure(
             ref self: ContractState,
@@ -123,20 +140,7 @@ mod FuzzRevertContract {
         ) {
             match result {
                 Result::Ok(_) => panic_with_felt252(panic_message_if_ok),
-                Result::Err(mut error) => {
-                    // Syscall failed immediately, so no inner calls could have modified the
-                    // orchestrator index. No need to handle index propagation (the !should_unwrap
-                    // case).
-                    if should_unwrap {
-                        // The inner error does not contain the orchestrator index, so to propagate
-                        // the error the index must be prepended.
-                        let mut new_error: Array<felt252> = array![self.orchestrator().get_index()];
-                        for elem in error {
-                            new_error.append(elem);
-                        }
-                        panic(new_error);
-                    }
-                }
+                Result::Err(error) => self.maybe_unwrap_error(error, should_unwrap),
             }
         }
     }
@@ -274,6 +278,22 @@ mod FuzzRevertContract {
                     );
             },
             Scenario::EmitEvent => { self.emit(FuzzEvent { data: orchestrator.pop_front() }); },
+            Scenario::GetBlockHash => {
+                let block_number: u64 = orchestrator.pop_front().try_into().unwrap();
+                let expect_panic: bool = orchestrator.pop_front() != 0;
+                let should_unwrap = true;
+                match syscalls::get_block_hash_syscall(block_number) {
+                    Result::Ok(_) => assert(
+                        !expect_panic, orchestrator.should_fail_get_block_hash_panic_message()
+                    ),
+                    Result::Err(error) => {
+                        assert(
+                            expect_panic, orchestrator.should_succeed_get_block_hash_panic_message()
+                        );
+                        self.maybe_unwrap_error(error, should_unwrap);
+                    }
+                }
+            },
         }
 
         // Unless explicitly stated otherwise, the next operation should be in the current call

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo1/fuzz_revert_orchestrator.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo1/fuzz_revert_orchestrator.cairo
@@ -10,6 +10,8 @@ mod FuzzRevertOrchestratorContract {
     const UNEXPECTED_FAIL_UNDEPLOYED: felt252 = 'should_fail_undeployed';
     const UNEXPECTED_FAIL_CALL_NO_ENTRYPOINT: felt252 = 'call_no_entrypoint';
     const UNEXPECTED_FAIL_LIBCALL_NO_ENTRYPOINT: felt252 = 'libcall_no_entrypoint';
+    const UNEXPECTED_SUCCESS_GET_BLOCK_HASH: felt252 = 'get_block_hash_success';
+    const UNEXPECTED_FAIL_GET_BLOCK_HASH: felt252 = 'get_block_hash_fail';
 
     #[storage]
     struct Storage {
@@ -52,11 +54,14 @@ mod FuzzRevertOrchestratorContract {
     /// will panic (this can happen if an unexpected error occurs and is propagated).
     #[external(v0)]
     fn set_index(ref self: ContractState, index: felt252) {
+        let error = array![OOB_ERROR, index];
         let index_u64: u64 = match index.try_into() {
             Option::Some(val) => val,
-            Option::None => panic_with_felt252(OOB_ERROR),
+            Option::None => panic(error),
         };
-        assert(index_u64 <= self.scenarios.len(), OOB_ERROR);
+        if index_u64 > self.scenarios.len() {
+            panic(error);
+        }
         self.front_index.write(index_u64);
     }
 
@@ -83,6 +88,16 @@ mod FuzzRevertOrchestratorContract {
         UNEXPECTED_FAIL_LIBCALL_NO_ENTRYPOINT
     }
 
+    #[external(v0)]
+    fn should_fail_get_block_hash_panic_message(ref self: ContractState) -> felt252 {
+        UNEXPECTED_SUCCESS_GET_BLOCK_HASH
+    }
+
+    #[external(v0)]
+    fn should_succeed_get_block_hash_panic_message(ref self: ContractState) -> felt252 {
+        UNEXPECTED_FAIL_GET_BLOCK_HASH
+    }
+
     /// Start the test. The first address must be an initialized fuzz test contract.
     #[external(v0)]
     fn start_test(ref self: ContractState, first_address: ContractAddress) {
@@ -90,19 +105,32 @@ mod FuzzRevertOrchestratorContract {
             first_address, selector!("test_revert_fuzz"), array![].span(),
         ) {
             Result::Ok(_) => (),
-            Result::Err(mut error) => {
-                // Assert the error is not any unexpected error.
-                let error_value = error.pop_front().unwrap();
-                for unexpected_error in array![
+            Result::Err(error) => {
+                // Assert the error does not contain any unexpected error.
+                let unexpected_errors = array![
                     UNEXPECTED_FAIL_INVALID_SCENARIO,
                     OOB_ERROR,
                     UNEXPECTED_FAIL_UNDEPLOYED,
                     UNEXPECTED_FAIL_CALL_NO_ENTRYPOINT,
-                    UNEXPECTED_FAIL_LIBCALL_NO_ENTRYPOINT
+                    UNEXPECTED_FAIL_LIBCALL_NO_ENTRYPOINT,
+                    UNEXPECTED_SUCCESS_GET_BLOCK_HASH,
+                    UNEXPECTED_FAIL_GET_BLOCK_HASH
                 ]
+                    .span();
+                let mut contains_unexpected_error = false;
+                for error_value in error
                     .span() {
-                        assert(error_value != *unexpected_error, *unexpected_error);
+                        for unexpected_error in unexpected_errors {
+                            if error_value == unexpected_error {
+                                contains_unexpected_error = true;
+                                break;
+                            }
+                        }
                     }
+
+                if contains_unexpected_error {
+                    panic(error);
+                }
             }
         }
     }

--- a/crates/starknet_os_flow_tests/src/fuzz_tests.rs
+++ b/crates/starknet_os_flow_tests/src/fuzz_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::LazyLock;
 
+use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 use blockifier::execution::syscalls::hint_processor::ENTRYPOINT_NOT_FOUND_ERROR_FELT;
 use blockifier::test_utils::dict_state_reader::DictStateReader;
 use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
@@ -15,6 +16,7 @@ use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rstest::rstest;
 use starknet_api::abi::abi_utils::selector_from_name;
+use starknet_api::block::BlockNumber;
 use starknet_api::core::{
     calculate_contract_address,
     ClassHash,
@@ -86,15 +88,15 @@ static IS_CAIRO1: LazyLock<BTreeMap<ClassHash, bool>> = LazyLock::new(|| {
 
 /// Initial fuzz contract addresses.
 static FUZZ_ADDRESS_ORCHESTRATOR_EXPECT: Expect =
-    expect!["0x5edc3e0cce028ca57b0a6c851a5802a228e01f0d243125bdda5a774d324391c"];
+    expect!["0x4c885880af2af2afc2b57ed77bd4dfacd8da1768c0de60a14d854d6aa681678"];
 static FUZZ_ADDRESS_CAIRO1_A_EXPECT: Expect =
-    expect!["0x474118fa5c884a95b6f11544ac1d3867de528abc5785552fcc4217d3a0d9e87"];
+    expect!["0x3b22209e355bb17880121aad4621a7658a2daea2c0c7dd5159595c93ddfac67"];
 static FUZZ_ADDRESS_CAIRO1_B_EXPECT: Expect =
-    expect!["0x464ff7d18c4c3ca636f876fc73cbb8d266b19fd365709db520d7a5080603b2d"];
+    expect!["0x2c1ef35cf09a851d642b1b21141e19a49aacce41a65eeeb46decd24fc55da54"];
 static FUZZ_ADDRESS_CAIRO0_A_EXPECT: Expect =
-    expect!["0x3313b88afaab8a412227ced130eb3e32f60d24bc199b381f92701e396fe1902"];
+    expect!["0x209b4338889acf7e7c4a0654b51e51bc874df786a12d77e95a2362711cfac6c"];
 static FUZZ_ADDRESS_CAIRO0_B_EXPECT: Expect =
-    expect!["0x5e1d874a5848b5ff182b3cc54c6c5e54ccd96d933c9d90c45d11f8ed0a88f9a"];
+    expect!["0x437a3c2706d0fe102ddccafa7169b616c8f4b4124f0761edc08e9283592caf0"];
 static FUZZ_ADDRESS_ORCHESTRATOR: LazyLock<ContractAddress> = LazyLock::new(|| {
     ContractAddress::try_from(felt!(FUZZ_ADDRESS_ORCHESTRATOR_EXPECT.data())).unwrap()
 });
@@ -128,6 +130,7 @@ const UNDECLARED_SCENARIO_MESSAGE: &str = "is not declared";
 const UNDEPLOYED_SCENARIO_MESSAGE: &str = "is not deployed";
 static NON_EXISTING_ENTRY_POINT_MESSAGE: LazyLock<String> =
     LazyLock::new(|| as_cairo_short_string(&ENTRYPOINT_NOT_FOUND_ERROR_FELT).unwrap());
+const BLOCK_NUMBER_OUT_OF_RANGE_MESSAGE: &str = "Block number out of range";
 
 /// Storage key that can be written to.
 static VALID_STORAGE_KEYS: LazyLock<Vec<Felt>> =
@@ -173,6 +176,7 @@ enum FuzzOperation {
     CallNonexistingEntryPoint,
     LibraryCallNonexistingEntryPoint,
     EmitEvent,
+    GetBlockHash,
 }
 
 impl FuzzOperation {
@@ -195,6 +199,7 @@ impl FuzzOperation {
             Self::CallNonexistingEntryPoint => 14u8,
             Self::LibraryCallNonexistingEntryPoint => 15u8,
             Self::EmitEvent => 16u8,
+            Self::GetBlockHash => 17u8,
         })
     }
 }
@@ -263,6 +268,7 @@ enum FuzzOperationData {
     CallNonexistingEntryPoint(CallOperationData),
     LibraryCallNonexistingEntryPoint(LibraryCallOperationData),
     EmitEvent(Felt),
+    GetBlockHash { block_number: BlockNumber, expect_panic: bool },
 }
 
 impl FuzzOperationData {
@@ -287,6 +293,7 @@ impl FuzzOperationData {
                 FuzzOperation::LibraryCallNonexistingEntryPoint
             }
             Self::EmitEvent(_) => FuzzOperation::EmitEvent,
+            Self::GetBlockHash { .. } => FuzzOperation::GetBlockHash,
         }
     }
 
@@ -311,6 +318,9 @@ impl FuzzOperationData {
             | Self::Sha256(value)
             | Self::Keccak(value)
             | Self::EmitEvent(value) => vec![*value],
+            Self::GetBlockHash { block_number, expect_panic } => {
+                vec![block_number.0.into(), (*expect_panic).into()]
+            }
         });
         felt_vector
     }
@@ -444,6 +454,9 @@ impl RevertInfo {
 /// Represents the call tree of a fuzz test.
 #[derive(Clone)]
 struct FuzzTestContext {
+    /// The block number of the fuzz test.
+    pub block_number: BlockNumber,
+
     /// The call tree of the fuzz test.
     /// The first frame is the frame called by the orchestrator (it's parent frame is the
     /// orchestrator).
@@ -484,8 +497,9 @@ struct FuzzTestContext {
 }
 
 impl FuzzTestContext {
-    pub fn init(seed: u64, first_call: FuzzCallInfo) -> Self {
+    pub fn init(seed: u64, first_call: FuzzCallInfo, next_block_number: BlockNumber) -> Self {
         Self {
+            block_number: next_block_number,
             calls: vec![first_call],
             current_call: vec![0],
             final_state: FinalizedState::Ongoing,
@@ -723,6 +737,23 @@ impl FuzzTestContext {
                     .collect()
             }
             FuzzOperation::EmitEvent => vec![FuzzOperationData::EmitEvent(self.next_event)],
+            FuzzOperation::GetBlockHash => {
+                // If current context is Cairo0, no valid operations are possible.
+                if !self.is_current_context_cairo1() {
+                    return vec![];
+                }
+                // Two options: either one block back (error) or the retrospective block (valid).
+                vec![
+                    FuzzOperationData::GetBlockHash {
+                        block_number: BlockNumber(self.block_number.0 - 1),
+                        expect_panic: true,
+                    },
+                    FuzzOperationData::GetBlockHash {
+                        block_number: BlockNumber(self.block_number.0 - STORED_BLOCK_HASH_BUFFER),
+                        expect_panic: false,
+                    },
+                ]
+            }
         }
     }
 
@@ -996,6 +1027,11 @@ impl FuzzTestContext {
             FuzzOperationData::EmitEvent(event) => {
                 self.current_fuzz_call_info_mut().events.push(event);
                 self.next_event += Felt::ONE;
+            }
+            FuzzOperationData::GetBlockHash { expect_panic, .. } => {
+                if expect_panic {
+                    self.apply_panic(BLOCK_NUMBER_OUT_OF_RANGE_MESSAGE.to_string());
+                }
             }
         }
     }
@@ -1316,6 +1352,13 @@ impl FuzzTestContext {
                         format!("{} (event data)", operation_felt_hexes[1]),
                     ]
                 }
+                FuzzOperationData::GetBlockHash { .. } => {
+                    vec![
+                        format!("{} (Get block hash)", operation_felt_hexes[0]),
+                        format!("{} (block number)", operation_felt_hexes[1]),
+                        format!("{} (expect panic)", operation_felt_hexes[2]),
+                    ]
+                }
             });
         }
         format!(
@@ -1346,6 +1389,11 @@ impl FuzzTestManager {
             test_manager.add_funded_account_invoke(invoke_tx_args! { calldata });
         }
 
+        // Add new blocks to pass the stored block hash buffer.
+        for _ in 0..(2 * STORED_BLOCK_HASH_BUFFER) {
+            test_manager.move_to_next_block();
+        }
+
         // First call is the orchestrator calling the first fuzz test contract.
         let first_called_address = *FUZZ_ADDRESS_CAIRO1_A;
         let first_call = FuzzCallInfo::new_call(
@@ -1355,7 +1403,11 @@ impl FuzzTestManager {
             ParentFailureBehavior::Catching,
         );
         Self {
-            context: FuzzTestContext::init(seed, first_call),
+            context: FuzzTestContext::init(
+                seed,
+                first_call,
+                test_manager.get_current_block_number(),
+            ),
             test_manager,
             first_called_address,
         }

--- a/crates/starknet_os_flow_tests/src/fuzz_tests.rs
+++ b/crates/starknet_os_flow_tests/src/fuzz_tests.rs
@@ -1567,7 +1567,10 @@ async fn test_daily_fuzz_seed(
     let day: u64 = now.day().into();
     let month: u64 = now.month().into();
     let year: u64 = now.year().try_into().unwrap();
-    let seed = day * 100000000 + month * 1000000 + year * 100 + inner_seed;
+    // The offset can be used to shift the daily seed. Increment if a known (rare) issue is found
+    // and is being taken care of separately, to unblock the CI.
+    let offset = 0;
+    let seed = offset * 10000000000 + day * 100000000 + month * 1000000 + year * 100 + inner_seed;
     fuzz_test_body(seed, 10, filter).await;
 }
 

--- a/crates/starknet_os_flow_tests/src/test_manager.rs
+++ b/crates/starknet_os_flow_tests/src/test_manager.rs
@@ -517,6 +517,14 @@ impl<S: FlowTestState> TestBuilder<S> {
         self.per_block_txs.push(vec![]);
     }
 
+    /// The next tx added will be executed in this block number.
+    pub(crate) fn get_current_block_number(&self) -> BlockNumber {
+        BlockNumber(
+            self.initial_state.block_context.block_info().block_number.0
+                + u64::try_from(self.per_block_txs.len()).unwrap(),
+        )
+    }
+
     pub(crate) fn total_txs(&self) -> usize {
         self.per_block_txs.iter().map(|block| block.len()).sum()
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes how the daily fuzz test seed is computed, enabling manual shifting to bypass known flaky seeds without affecting production code.
> 
> **Overview**
> Adds an explicit `offset` component to `test_daily_fuzz_seed`’s seed generation so CI can be unblocked by shifting the daily fuzz seed when a known rare failing case is being handled separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b900af88013cf6dc0f3a4cf9d8a21b8bc90e44d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->