### PR TITLE
starknet_transaction_prover: add deployment smoke test script

### DIFF
--- a/crates/starknet_transaction_prover/DEPLOYMENT_SMOKE_TESTING_GUIDE.md
+++ b/crates/starknet_transaction_prover/DEPLOYMENT_SMOKE_TESTING_GUIDE.md
@@ -28,7 +28,10 @@ Run those periodically (daily/weekly) or before major releases.
 ## 2. Prerequisites
 
 - A deployed proving service endpoint (for example `http://127.0.0.1:3000`).
-- Access to a Starknet RPC node on the same chain as the prover (for nonce lookup).
+- The prover config must have `"validate_zero_fee_fields": false` (or pass
+  `--skip-fee-field-validation` locally) so that real chain transactions with
+  non-zero fees are accepted.
+- Access to a Starknet RPC node on the same chain as the prover.
 - `curl`
 - `jq`
 
@@ -49,12 +52,48 @@ The script runs Section 3 checks and prints a PASS/FAIL summary.
 
 Optional environment variables:
 
-- `DUMMY_ACCOUNT_ADDRESS` -- address of a dummy-validate account on the target
-  chain (default: the Sepolia Integration dummy account).
-- `STRK_TOKEN_ADDRESS` -- STRK token contract address on the target chain
-  (default: Sepolia Integration STRK address).
+- `TX_HASH` -- pre-set an `INVOKE` `0x3` tx hash to skip the block scan
+  (useful on rate-limited RPCs).
+- `LOOKBACK_BLOCKS` -- number of recent blocks to scan (default: 300).
 - `KEEP_ARTIFACTS=true` -- preserve temp files for post-mortem inspection.
   Artifacts are also preserved automatically when any check fails.
+
+Define helpers once:
+
+```bash
+rpc_call() {
+  local payload="$1"
+  curl -sS "$CHAIN_RPC_URL" -H 'content-type: application/json' -d "$payload"
+}
+
+find_tx_hash() {
+  local tx_type="$1"
+  local tx_version="$2"
+  local lookback="${3:-300}"
+  local latest_block
+  local offset
+  local block_number
+  local tx_hash
+
+  latest_block=$(rpc_call '{"jsonrpc":"2.0","id":100,"method":"starknet_blockNumber","params":[]}' | jq -r '.result')
+
+  for ((offset = 0; offset <= lookback; offset++)); do
+    block_number=$((latest_block - offset))
+    [ "$block_number" -lt 0 ] && break
+
+    tx_hash=$(rpc_call "{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"starknet_getBlockWithTxs\",\"params\":[{\"block_number\":$block_number}]}" \
+      | jq -r --arg tx_type "$tx_type" --arg tx_version "$tx_version" \
+          '[.result.transactions[] | select(.type==$tx_type and .version==$tx_version) | .transaction_hash] | .[0] // empty')
+
+    if [ -n "$tx_hash" ] && [ "$tx_hash" != "null" ]; then
+      echo "$tx_hash"
+      return 0
+    fi
+  done
+
+  return 1
+}
+```
 
 ## 3. Per-Deployment Smoke Checks
 
@@ -74,58 +113,43 @@ Pass:
 - `result` matches the `SPEC_VERSION` constant in
   `crates/starknet_transaction_prover/src/server/rpc_impl.rs` (currently `"0.10.1"`).
 
-### 3.2 Happy path: `starknet_proveTransaction` with synthetic tx
+### 3.2 Happy path: one real `starknet_proveTransaction`
 
-The script constructs a synthetic INVOKE v3 transaction targeting a
-`dummy_validate` account (empty signature, zero fees). This avoids the
-signature-invalidation problem that occurs when zeroing fee fields on real
-chain transactions.
+The script finds a real INVOKE v3 transaction from the chain and sends it
+unmodified (no fee zeroing). This preserves the original transaction hash and
+signature, so `__validate__` passes. The prover must have
+`"validate_zero_fee_fields": false` in the config (or
+`--skip-fee-field-validation` locally) to accept the non-zero fee fields.
 
-1. Fetch the dummy account's current nonce from the chain RPC.
+1. Find a finalized `INVOKE` `0x3` tx and fetch it.
 
 ```bash
-DUMMY_ACCOUNT="0x2763d2701f413cf0ad7bc73690297c4594bbfd4632ee5f017eb287051595672"
-STRK_TOKEN="0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+TX_HASH=$(find_tx_hash "INVOKE" "0x3" 300)
+if [ -z "$TX_HASH" ]; then
+  echo "No INVOKE 0x3 tx found in lookback window."
+  echo "Try a larger lookback: find_tx_hash \"INVOKE\" \"0x3\" 500"
+  echo "Remaining smoke checks require a valid tx -- cannot continue."
+else
+  curl -sS "$CHAIN_RPC_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
+    | jq '.result | del(.transaction_hash)' > /tmp/prove_tx.json
 
-NONCE=$(curl -sS "$CHAIN_RPC_URL" \
-  -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"starknet_getNonce\",\"params\":[\"latest\",\"$DUMMY_ACCOUNT\"]}" \
-  | jq -r '.result')
+  TX_BLOCK=$(curl -sS "$CHAIN_RPC_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
+    | jq -r '.result.block_number')
+
+  BASE_BLOCK=$((TX_BLOCK - 1))
+fi
 ```
 
-2. Build and send the prove request. The calldata calls `balanceOf(sender)` on
-   the STRK token -- a read-only operation that cannot fail from insufficient
-   balance.
+2. Send prove request.
 
 ```bash
-jq -nc \
-  --arg sender "$DUMMY_ACCOUNT" \
-  --arg strk "$STRK_TOKEN" \
-  --arg nonce "$NONCE" \
-  '{
-    jsonrpc: "2.0", id: 5,
-    method: "starknet_proveTransaction",
-    params: {
-      block_id: "latest",
-      transaction: {
-        type: "INVOKE", version: "0x3",
-        sender_address: $sender,
-        calldata: [$strk, "0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33", "0x1", $sender],
-        signature: [],
-        nonce: $nonce,
-        resource_bounds: {
-          l1_gas: {max_amount: "0x0", max_price_per_unit: "0x0"},
-          l2_gas: {max_amount: "0x5f5e100", max_price_per_unit: "0x0"},
-          l1_data_gas: {max_amount: "0x0", max_price_per_unit: "0x0"}
-        },
-        tip: "0x0",
-        paymaster_data: [],
-        account_deployment_data: [],
-        nonce_data_availability_mode: "L1",
-        fee_data_availability_mode: "L1"
-      }
-    }
-  }' > /tmp/prove_request_valid.json
+jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx.json \
+  '{jsonrpc:"2.0",id:5,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
+  > /tmp/prove_request_valid.json
 
 curl -sS "$PROVER_URL" \
   -H 'content-type: application/json' \

--- a/crates/starknet_transaction_prover/DEPLOYMENT_SMOKE_TESTING_GUIDE.md
+++ b/crates/starknet_transaction_prover/DEPLOYMENT_SMOKE_TESTING_GUIDE.md
@@ -28,7 +28,7 @@ Run those periodically (daily/weekly) or before major releases.
 ## 2. Prerequisites
 
 - A deployed proving service endpoint (for example `http://127.0.0.1:3000`).
-- Access to a Starknet RPC node on the same chain as the prover.
+- Access to a Starknet RPC node on the same chain as the prover (for nonce lookup).
 - `curl`
 - `jq`
 
@@ -49,49 +49,12 @@ The script runs Section 3 checks and prints a PASS/FAIL summary.
 
 Optional environment variables:
 
-- `TX_HASH` -- pre-set an `INVOKE` `0x3` tx hash to skip the block scan
-  (useful on rate-limited RPCs).
-- `LOOKBACK_BLOCKS` -- number of recent blocks to scan (default: 300).
+- `DUMMY_ACCOUNT_ADDRESS` -- address of a dummy-validate account on the target
+  chain (default: the Sepolia Integration dummy account).
+- `STRK_TOKEN_ADDRESS` -- STRK token contract address on the target chain
+  (default: Sepolia Integration STRK address).
 - `KEEP_ARTIFACTS=true` -- preserve temp files for post-mortem inspection.
   Artifacts are also preserved automatically when any check fails.
-
-Define helpers once:
-
-```bash
-rpc_call() {
-  local payload="$1"
-  curl -sS "$CHAIN_RPC_URL" -H 'content-type: application/json' -d "$payload"
-}
-
-find_tx_hash() {
-  local tx_type="$1"
-  local tx_version="$2"
-  local lookback="${3:-300}"
-  local latest_block
-  local offset
-  local block_number
-  local tx_hash
-
-  latest_block=$(rpc_call '{"jsonrpc":"2.0","id":100,"method":"starknet_blockNumber","params":[]}' | jq -r '.result')
-
-  for ((offset = 0; offset <= lookback; offset++)); do
-    block_number=$((latest_block - offset))
-    [ "$block_number" -lt 0 ] && break
-
-    tx_hash=$(rpc_call "{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"starknet_getBlockWithTxs\",\"params\":[{\"block_number\":$block_number}]}" \
-      | jq -r --arg tx_type "$tx_type" --arg tx_version "$tx_version" \
-          '.result.transactions[] | select(.type==$tx_type and .version==$tx_version) | .transaction_hash' \
-      | head -n 1)
-
-    if [ -n "$tx_hash" ] && [ "$tx_hash" != "null" ]; then
-      echo "$tx_hash"
-      return 0
-    fi
-  done
-
-  return 1
-}
-```
 
 ## 3. Per-Deployment Smoke Checks
 
@@ -111,40 +74,58 @@ Pass:
 - `result` matches the `SPEC_VERSION` constant in
   `crates/starknet_transaction_prover/src/server/rpc_impl.rs` (currently `"0.10.1"`).
 
-### 3.2 Happy path: one real `starknet_proveTransaction`
+### 3.2 Happy path: `starknet_proveTransaction` with synthetic tx
 
-1. Find a finalized `INVOKE` `0x3` tx, fetch it, and zero out fee fields.
+The script constructs a synthetic INVOKE v3 transaction targeting a
+`dummy_validate` account (empty signature, zero fees). This avoids the
+signature-invalidation problem that occurs when zeroing fee fields on real
+chain transactions.
+
+1. Fetch the dummy account's current nonce from the chain RPC.
 
 ```bash
-TX_HASH=$(find_tx_hash "INVOKE" "0x3" 300)
-[ -z "$TX_HASH" ] && { echo "No INVOKE 0x3 tx found in lookback window"; exit 1; }
+DUMMY_ACCOUNT="0x2763d2701f413cf0ad7bc73690297c4594bbfd4632ee5f017eb287051595672"
+STRK_TOKEN="0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 
-curl -sS "$CHAIN_RPC_URL" \
+NONCE=$(curl -sS "$CHAIN_RPC_URL" \
   -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
-  | jq '.result | del(.transaction_hash)' > /tmp/prove_tx.json
-
-TX_BLOCK=$(curl -sS "$CHAIN_RPC_URL" \
-  -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
-  | jq -r '.result.block_number')
-
-BASE_BLOCK=$((TX_BLOCK - 1))
-
-jq '
-  .tip = "0x0" |
-  .resource_bounds.l1_gas.max_price_per_unit = "0x0" |
-  .resource_bounds.l2_gas.max_price_per_unit = "0x0" |
-  .resource_bounds.l1_data_gas.max_price_per_unit = "0x0"
-' /tmp/prove_tx.json > /tmp/prove_tx_zeroed.json
+  -d "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"starknet_getNonce\",\"params\":[\"latest\",\"$DUMMY_ACCOUNT\"]}" \
+  | jq -r '.result')
 ```
 
-2. Send prove request.
+2. Build and send the prove request. The calldata calls `balanceOf(sender)` on
+   the STRK token -- a read-only operation that cannot fail from insufficient
+   balance.
 
 ```bash
-jq -c --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx_zeroed.json \
-  '{jsonrpc:"2.0",id:5,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
-  > /tmp/prove_request_valid.json
+jq -nc \
+  --arg sender "$DUMMY_ACCOUNT" \
+  --arg strk "$STRK_TOKEN" \
+  --arg nonce "$NONCE" \
+  '{
+    jsonrpc: "2.0", id: 5,
+    method: "starknet_proveTransaction",
+    params: {
+      block_id: "latest",
+      transaction: {
+        type: "INVOKE", version: "0x3",
+        sender_address: $sender,
+        calldata: [$strk, "0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33", "0x1", $sender],
+        signature: [],
+        nonce: $nonce,
+        resource_bounds: {
+          l1_gas: {max_amount: "0x0", max_price_per_unit: "0x0"},
+          l2_gas: {max_amount: "0x5f5e100", max_price_per_unit: "0x0"},
+          l1_data_gas: {max_amount: "0x0", max_price_per_unit: "0x0"}
+        },
+        tip: "0x0",
+        paymaster_data: [],
+        account_deployment_data: [],
+        nonce_data_availability_mode: "L1",
+        fee_data_availability_mode: "L1"
+      }
+    }
+  }' > /tmp/prove_request_valid.json
 
 curl -sS "$PROVER_URL" \
   -H 'content-type: application/json' \

--- a/crates/starknet_transaction_prover/MANUAL_TESTING_GUIDE.md
+++ b/crates/starknet_transaction_prover/MANUAL_TESTING_GUIDE.md
@@ -39,6 +39,33 @@ export PROVER_URL="http://127.0.0.1:3000"
 export CHAIN_RPC_URL="https://your-starknet-rpc"
 ```
 
+### Changing service configuration
+
+Several sections require starting the service with specific flags. For a
+**deployed** service, edit the prover's JSON config file (mounted as a
+Kubernetes ConfigMap) and restart the pod. Key config fields and their CLI
+equivalents:
+
+| JSON config field | CLI flag | Type |
+|-------------------|----------|------|
+| `cors_allow_origin` | `--cors-allow-origin` | array of strings (`["*"]` or `["http://..."]`) |
+| `max_concurrent_requests` | `--max-concurrent-requests` | integer |
+| `validate_zero_fee_fields` | `--skip-fee-field-validation` (inverted) | boolean |
+
+Example: to allow wildcard CORS and lower concurrency to 1, update the config
+file:
+
+```json
+{
+  "cors_allow_origin": ["*"],
+  "max_concurrent_requests": 1
+}
+```
+
+Then restart the pod (or `kubectl rollout restart`).
+
+For **local** testing, pass CLI flags to `cargo run` (see section 3).
+
 Define helper functions once for the rest of the guide:
 
 ```bash
@@ -59,22 +86,27 @@ find_tx_hash() {
   latest_block=$(rpc_call '{"jsonrpc":"2.0","id":100,"method":"starknet_blockNumber","params":[]}' \
     | jq -r '.result')
 
+  printf 'Searching last %d blocks for %s %s...\n' "$lookback" "$tx_type" "$tx_version" >&2
+
   for ((offset = 0; offset <= lookback; offset++)); do
     block_number=$((latest_block - offset))
     [ "$block_number" -lt 0 ] && break
 
+    printf '\r  block %d (%d/%d)' "$block_number" "$((offset + 1))" "$lookback" >&2
+
     tx_hash=$(rpc_call \
       "{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"starknet_getBlockWithTxs\",\"params\":[{\"block_number\":$block_number}]}" \
       | jq -r --arg tx_type "$tx_type" --arg tx_version "$tx_version" \
-          '.result.transactions[] | select(.type==$tx_type and .version==$tx_version) | .transaction_hash' \
-      | head -n 1)
+          '[.result.transactions[] | select(.type==$tx_type and .version==$tx_version) | .transaction_hash] | .[0] // empty')
 
     if [ -n "$tx_hash" ] && [ "$tx_hash" != "null" ]; then
+      printf '\r  found in block %d (%d/%d)\n' "$block_number" "$((offset + 1))" "$lookback" >&2
       echo "$tx_hash"
       return 0
     fi
   done
 
+  printf '\r  not found after %d blocks\n' "$offset" >&2
   return 1
 }
 ```
@@ -137,98 +169,42 @@ Expected success:
 
 `starknet_proveTransaction` expects:
 
-- `params.block_id`: base block ID (must not be `"pending"`)
-- `params.transaction`: transaction object of type `INVOKE` and version `0x3`
+- `params[0]`: base block ID (must not be `"pending"`)
+- `params[1]`: transaction object of type `INVOKE` and version `0x3`
 
-#### Approach A: Synthetic transaction (recommended)
+When the prover config has `"validate_zero_fee_fields": false` (or is started
+with `--skip-fee-field-validation`), real chain transactions can be sent with
+their original fee fields intact. This preserves
+the transaction hash and signature, so `__validate__` passes without needing
+a dummy-validate account.
 
-Use a synthetic INVOKE v3 targeting a `dummy_validate` account (empty signature,
-zero fees). This avoids the signature-invalidation problem that occurs when
-zeroing fee fields on real chain transactions.
-
-The calldata calls `balanceOf(sender)` on the STRK token -- a read-only
-operation that cannot fail from insufficient balance.
-
-```bash
-DUMMY_ACCOUNT="0x2763d2701f413cf0ad7bc73690297c4594bbfd4632ee5f017eb287051595672"
-STRK_TOKEN="0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
-
-NONCE=$(curl -sS "$CHAIN_RPC_URL" \
-  -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"starknet_getNonce\",\"params\":[\"latest\",\"$DUMMY_ACCOUNT\"]}" \
-  | jq -r '.result')
-
-jq -nc \
-  --arg sender "$DUMMY_ACCOUNT" \
-  --arg strk "$STRK_TOKEN" \
-  --arg nonce "$NONCE" \
-  '{
-    jsonrpc: "2.0", id: 5,
-    method: "starknet_proveTransaction",
-    params: {
-      block_id: "latest",
-      transaction: {
-        type: "INVOKE", version: "0x3",
-        sender_address: $sender,
-        calldata: [$strk, "0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33", "0x1", $sender],
-        signature: [],
-        nonce: $nonce,
-        resource_bounds: {
-          l1_gas: {max_amount: "0x0", max_price_per_unit: "0x0"},
-          l2_gas: {max_amount: "0x5f5e100", max_price_per_unit: "0x0"},
-          l1_data_gas: {max_amount: "0x0", max_price_per_unit: "0x0"}
-        },
-        tip: "0x0",
-        paymaster_data: [],
-        account_deployment_data: [],
-        nonce_data_availability_mode: "L1",
-        fee_data_availability_mode: "L1"
-      }
-    }
-  }' > /tmp/prove_request_valid.json
-
-curl -sS "$PROVER_URL" \
-  -H 'content-type: application/json' \
-  -d "$(cat /tmp/prove_request_valid.json)" | jq .
-```
-
-#### Approach B: Chain transaction with fee zeroing
-
-Fetching a real transaction from chain and zeroing its fee fields changes the
-transaction hash, which invalidates the signature. This approach only works if
-the prover is started with `--skip-fee-field-validation`, or if the sender
-account uses a dummy validate function.
-
-1. Find one finalized `INVOKE` `0x3` tx hash.
+1. Find one finalized `INVOKE` `0x3` tx hash and fetch it.
 
 ```bash
 TX_HASH=$(find_tx_hash "INVOKE" "0x3" 300)
-[ -z "$TX_HASH" ] && { echo "No INVOKE 0x3 tx found in lookback window"; exit 1; }
+if [ -z "$TX_HASH" ]; then
+  echo "No INVOKE 0x3 tx found in lookback window."
+  echo "Try a larger lookback: find_tx_hash \"INVOKE\" \"0x3\" 500"
+  echo "Sections 4.2-9 require a valid tx -- cannot continue."
+else
+  curl -sS "$CHAIN_RPC_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
+    | jq '.result | del(.transaction_hash)' > /tmp/prove_tx.json
+
+  TX_BLOCK=$(curl -sS "$CHAIN_RPC_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
+    | jq -r '.result.block_number')
+
+  BASE_BLOCK=$((TX_BLOCK - 1))
+fi
 ```
 
-2. Fetch the tx, zero fee fields, and send.
+2. Send the prove request.
 
 ```bash
-curl -sS "$CHAIN_RPC_URL" \
-  -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
-  | jq '.result | del(.transaction_hash)' > /tmp/prove_tx.json
-
-TX_BLOCK=$(curl -sS "$CHAIN_RPC_URL" \
-  -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
-  | jq -r '.result.block_number')
-
-BASE_BLOCK=$((TX_BLOCK - 1))
-
-jq '
-  .tip = "0x0" |
-  .resource_bounds.l1_gas.max_price_per_unit = "0x0" |
-  .resource_bounds.l2_gas.max_price_per_unit = "0x0" |
-  .resource_bounds.l1_data_gas.max_price_per_unit = "0x0"
-' /tmp/prove_tx.json > /tmp/prove_tx_zeroed.json
-
-jq -c --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx_zeroed.json \
+jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx.json \
   '{jsonrpc:"2.0",id:5,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
   > /tmp/prove_request_valid.json
 
@@ -250,7 +226,7 @@ Use a valid `INVOKE v3` tx in `/tmp/prove_tx.json` from section 4.2 unless noted
 ### 5.1 Pending block is rejected
 
 ```bash
-jq -c --slurpfile tx /tmp/prove_tx_zeroed.json \
+jq -nc --slurpfile tx /tmp/prove_tx.json \
   '{jsonrpc:"2.0",id:11,method:"starknet_proveTransaction",params:["pending",$tx[0]]}' \
   > /tmp/prove_request_pending.json
 
@@ -268,18 +244,20 @@ Find a `DECLARE` `0x3` tx and drop `transaction_hash` before sending.
 
 ```bash
 DECLARE_HASH=$(find_tx_hash "DECLARE" "0x3" 500)
-[ -z "$DECLARE_HASH" ] && { echo "No DECLARE 0x3 tx found in lookback window"; exit 1; }
+if [ -z "$DECLARE_HASH" ]; then
+  echo "No DECLARE 0x3 tx found in lookback window -- skipping"
+else
+  curl -sS "$CHAIN_RPC_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$DECLARE_HASH\"]}" \
+    | jq '.result | del(.transaction_hash)' > /tmp/declare_tx.json
 
-curl -sS "$CHAIN_RPC_URL" \
-  -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$DECLARE_HASH\"]}" \
-  | jq '.result | del(.transaction_hash)' > /tmp/declare_tx.json
+  jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/declare_tx.json \
+    '{jsonrpc:"2.0",id:14,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
+    > /tmp/prove_request_declare.json
 
-jq -c --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/declare_tx.json \
-  '{jsonrpc:"2.0",id:14,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
-  > /tmp/prove_request_declare.json
-
-curl -sS "$PROVER_URL" -H 'content-type: application/json' -d "$(cat /tmp/prove_request_declare.json)" | jq .
+  curl -sS "$PROVER_URL" -H 'content-type: application/json' -d "$(cat /tmp/prove_request_declare.json)" | jq .
+fi
 ```
 
 Expected error:
@@ -291,20 +269,22 @@ Expected error:
 
 ```bash
 DEPLOY_HASH=$(find_tx_hash "DEPLOY_ACCOUNT" "0x3" 500)
-[ -z "$DEPLOY_HASH" ] && { echo "No DEPLOY_ACCOUNT 0x3 tx found in lookback window"; exit 1; }
+if [ -z "$DEPLOY_HASH" ]; then
+  echo "No DEPLOY_ACCOUNT 0x3 tx found in lookback window -- skipping"
+else
+  curl -sS "$CHAIN_RPC_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":17,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$DEPLOY_HASH\"]}" \
+    | jq '.result | del(.transaction_hash)' > /tmp/deploy_account_tx.json
 
-curl -sS "$CHAIN_RPC_URL" \
-  -H 'content-type: application/json' \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":17,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$DEPLOY_HASH\"]}" \
-  | jq '.result | del(.transaction_hash)' > /tmp/deploy_account_tx.json
+  jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/deploy_account_tx.json \
+    '{jsonrpc:"2.0",id:18,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
+    > /tmp/prove_request_deploy_account.json
 
-jq -c --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/deploy_account_tx.json \
-  '{jsonrpc:"2.0",id:18,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
-  > /tmp/prove_request_deploy_account.json
-
-curl -sS "$PROVER_URL" \
-  -H 'content-type: application/json' \
-  -d "$(cat /tmp/prove_request_deploy_account.json)" | jq .
+  curl -sS "$PROVER_URL" \
+    -H 'content-type: application/json' \
+    -d "$(cat /tmp/prove_request_deploy_account.json)" | jq .
+fi
 ```
 
 Expected error:
@@ -314,6 +294,10 @@ Expected error:
 
 ### 5.4 Invalid transaction input: non-zero fee fields
 
+> **Note:** This test only applies when `validate_zero_fee_fields` is `true`
+> (default). If it is `false` in the config or `--skip-fee-field-validation` is
+> passed, non-zero fee fields are accepted and this test should be skipped.
+
 The service rejects transactions with non-zero `max_price_per_unit` or `tip`
 (unless `--skip-fee-field-validation` is set). Mutate a valid invoke to trigger
 the check.
@@ -321,7 +305,7 @@ the check.
 ```bash
 jq '.tip = "0x1"' /tmp/prove_tx.json > /tmp/prove_tx_nonzero_tip.json
 
-jq -c --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx_nonzero_tip.json \
+jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx_nonzero_tip.json \
   '{jsonrpc:"2.0",id:19,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
   > /tmp/prove_request_nonzero_tip.json
 
@@ -338,9 +322,9 @@ Expected error:
 Mutate a valid invoke tx to break validation (for example set nonce to a clearly wrong value).
 
 ```bash
-jq '.nonce = "0xdeadbeef"' /tmp/prove_tx_zeroed.json > /tmp/prove_tx_invalid_nonce.json
+jq '.nonce = "0xdeadbeef"' /tmp/prove_tx.json > /tmp/prove_tx_invalid_nonce.json
 
-jq -c --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx_invalid_nonce.json \
+jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx /tmp/prove_tx_invalid_nonce.json \
   '{jsonrpc:"2.0",id:15,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
   > /tmp/prove_request_invalid_nonce.json
 
@@ -376,8 +360,8 @@ Use a lightweight request (`starknet_specVersion`) for all CORS tests.
 
 ### 6.1 Wildcard mode allows any origin
 
-Start the service with `--cors-allow-origin '*'` (or restart if already running
-with different CORS settings).
+Set `"cors_allow_origin": ["*"]` in the prover config file and restart the pod
+(or start locally with `--cors-allow-origin '*'`).
 
 Send a request with an `Origin` header and check for the CORS response header:
 
@@ -395,7 +379,8 @@ Pass criteria:
 
 ### 6.2 Allowlist mode returns the matching origin
 
-Start the service with a specific allowed origin:
+Set `"cors_allow_origin": ["http://localhost:5173"]` in the prover config file
+and restart the pod. For local testing:
 
 ```bash
 cargo run -p starknet_transaction_prover -- \
@@ -455,7 +440,8 @@ Pass criteria (with the matching origin from 6.2):
 
 ### 6.4 CORS disabled (default)
 
-Start the service without any `--cors-allow-origin` flag:
+Set `"cors_allow_origin": []` in the prover config file and restart the pod.
+For local testing, omit the `--cors-allow-origin` flag:
 
 ```bash
 cargo run -p starknet_transaction_prover -- \
@@ -478,7 +464,9 @@ Pass criteria:
 
 ### 6.5 Origin normalization
 
-Verify that invalid origin values are rejected at startup:
+Verify that invalid origin values are rejected at startup. Set
+`"cors_allow_origin": ["ftp://example.com"]` in the config file and restart (or
+pass the flag locally):
 
 ```bash
 cargo run -p starknet_transaction_prover -- \
@@ -562,6 +550,10 @@ Pass criteria:
 
 ### 7.5 Compressed prove response
 
+> **Note:** If the block from section 4.2 has aged out of the proof window
+> (you get error code 42 or -32603 mentioning storage proofs), re-run
+> section 4.2 to refresh the request with a recent block.
+
 Proof responses are large and benefit most from compression. Use the valid
 request from section 4.2:
 
@@ -586,10 +578,13 @@ Use the same valid request body from section 4.2:
 cp /tmp/prove_request_valid.json /tmp/prove_request.json
 ```
 
+> **Note:** Same freshness caveat as section 7.5 — re-run section 4.2 if
+> needed.
+
 ### 8.1 Verify concurrency limit rejects excess requests
 
-Start the service with `--max-concurrent-requests 1` so only one proving request
-runs at a time:
+Set `"max_concurrent_requests": 1` in the prover config file and restart the
+pod so only one proving request runs at a time. For local testing:
 
 ```bash
 cargo run -p starknet_transaction_prover -- \
@@ -634,7 +629,8 @@ Pass criteria:
 
 ### 8.3 Burst test
 
-Restart the service with default concurrency (`--max-concurrent-requests 2`).
+Reset `"max_concurrent_requests"` to `2` in the config file and restart the pod
+(or restart locally with `--max-concurrent-requests 2`).
 Fire 8 requests with shell concurrency 4:
 
 ```bash
@@ -658,7 +654,15 @@ bounded and the service stays healthy under sustained pressure.
 
 ### 9.1 Monitor memory during load
 
-In a separate terminal, sample the service's resident memory every 2 seconds:
+In a separate terminal, sample the service's memory every 2 seconds.
+
+**Kubernetes deployment:**
+
+```bash
+watch -n 2 kubectl top pod <pod-name> -n <namespace>
+```
+
+**Local process:**
 
 ```bash
 PROVER_PID=$(pgrep -f starknet_transaction_prover)
@@ -670,6 +674,15 @@ done
 ```
 
 ### 9.2 Using `vegeta` (recommended)
+
+Install ([releases](https://github.com/tsenart/vegeta/releases)):
+
+```bash
+curl -sL https://github.com/tsenart/vegeta/releases/download/v12.12.0/vegeta_12.12.0_linux_amd64.tar.gz \
+  | tar xz -C /usr/local/bin vegeta
+```
+
+Usage:
 
 ```bash
 echo "POST $PROVER_URL" \
@@ -683,6 +696,15 @@ vegeta report -type='hist[0,2s,5s,10s,20s,30s]' /tmp/vegeta.bin
 Start with low rate (`1 req/s`) because proving is CPU heavy.
 
 ### 9.3 Using `hey`
+
+Install ([releases](https://github.com/rakyll/hey/releases)):
+
+```bash
+curl -sL https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64 -o /usr/local/bin/hey \
+  && chmod +x /usr/local/bin/hey
+```
+
+Usage:
 
 ```bash
 hey -n 20 -c 2 -m POST -H 'Content-Type: application/json' -D /tmp/prove_request.json "$PROVER_URL"
@@ -742,3 +764,74 @@ Pass criteria:
 - Burst test: all responses are valid JSON-RPC (success or `-32005`), no `-32603`
 - Memory stays bounded under sustained load (no unbounded RSS growth)
 - Load test completed at chosen rate without process instability
+
+## 11. Documenting Test Results
+
+Record results after each test run so regressions are traceable and audit
+history is preserved.
+
+### What to record
+
+- **Date and tester** — who ran the tests and when.
+- **Build version** — the exact image tag, commit SHA, or release version under
+  test.
+- **Environment** — deployment target (e.g., `testnet-prover-01`, `staging`),
+  chain (mainnet / sepolia), and RPC node used.
+- **Configuration** — relevant config values: `validate_zero_fee_fields`,
+  `max_concurrent_requests`, `cors_allow_origin`.
+- **Per-section results** — for each item in the checklist (section 10), record
+  PASS / FAIL / SKIP with the actual response when it deviates from expected.
+- **Bugs found** — link to any issues filed as a result of the test run.
+
+### Template
+
+Copy the block below and fill in the details:
+
+```text
+# Manual Test Run — <date>
+
+Tester:       <name>
+Build:        <image tag or commit SHA>
+Environment:  <deployment target>
+Chain RPC:    <RPC endpoint used>
+Config:       validate_zero_fee_fields=<true/false>
+              max_concurrent_requests=<value>
+              cors_allow_origin=<value or []>
+
+## Results
+
+| # | Check | Result | Notes |
+|---|-------|--------|-------|
+| 4.1 | specVersion | PASS / FAIL | |
+| 4.2 | proveTransaction happy path | PASS / FAIL | proving time: ___s |
+| 5.1 | Pending block rejected (24) | PASS / FAIL | |
+| 5.2 | DECLARE rejected (61) | PASS / FAIL / SKIP | |
+| 5.3 | DEPLOY_ACCOUNT rejected (61) | PASS / FAIL / SKIP | |
+| 5.4 | Non-zero fee rejected (1000) | PASS / FAIL / SKIP | |
+| 5.5 | Invalid nonce rejected (55) | PASS / FAIL | |
+| 5.6 | Malformed params rejected | PASS / FAIL | |
+| 6.1 | CORS wildcard | PASS / FAIL | |
+| 6.2 | CORS allowlist match | PASS / FAIL | |
+| 6.2 | CORS allowlist non-match | PASS / FAIL | |
+| 6.3 | CORS preflight | PASS / FAIL | |
+| 6.4 | CORS disabled | PASS / FAIL | |
+| 6.5 | CORS invalid origin startup | PASS / FAIL | |
+| 7.1 | Gzip compression | PASS / FAIL | |
+| 7.2 | Brotli compression | PASS / FAIL | |
+| 7.3 | Zstd compression | PASS / FAIL | |
+| 7.4 | No compression | PASS / FAIL | |
+| 7.5 | Compressed prove response | PASS / FAIL | |
+| 8.1 | Concurrency limit (-32005) | PASS / FAIL | |
+| 8.2 | Recovery after rejection | PASS / FAIL | |
+| 8.3 | Burst test | PASS / FAIL | |
+| 9   | Load test | PASS / FAIL | tool: ___, rate: ___, duration: ___ |
+
+## Issues Filed
+
+- (link to any issues opened during this run)
+```
+
+### Where to store
+
+Post the completed template as a comment on the deployment PR or ticket. For
+periodic (non-deployment) test runs, file under the team's test log.

--- a/crates/starknet_transaction_prover/MANUAL_TESTING_GUIDE.md
+++ b/crates/starknet_transaction_prover/MANUAL_TESTING_GUIDE.md
@@ -137,21 +137,76 @@ Expected success:
 
 `starknet_proveTransaction` expects:
 
-- `params[0]`: base block ID (must not be `"pending"`)
-- `params[1]`: transaction object of type `INVOKE` and version `0x3`
+- `params.block_id`: base block ID (must not be `"pending"`)
+- `params.transaction`: transaction object of type `INVOKE` and version `0x3`
 
-Use this flow to build a realistic request from chain data.
+#### Approach A: Synthetic transaction (recommended)
+
+Use a synthetic INVOKE v3 targeting a `dummy_validate` account (empty signature,
+zero fees). This avoids the signature-invalidation problem that occurs when
+zeroing fee fields on real chain transactions.
+
+The calldata calls `balanceOf(sender)` on the STRK token -- a read-only
+operation that cannot fail from insufficient balance.
+
+```bash
+DUMMY_ACCOUNT="0x2763d2701f413cf0ad7bc73690297c4594bbfd4632ee5f017eb287051595672"
+STRK_TOKEN="0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+
+NONCE=$(curl -sS "$CHAIN_RPC_URL" \
+  -H 'content-type: application/json' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"starknet_getNonce\",\"params\":[\"latest\",\"$DUMMY_ACCOUNT\"]}" \
+  | jq -r '.result')
+
+jq -nc \
+  --arg sender "$DUMMY_ACCOUNT" \
+  --arg strk "$STRK_TOKEN" \
+  --arg nonce "$NONCE" \
+  '{
+    jsonrpc: "2.0", id: 5,
+    method: "starknet_proveTransaction",
+    params: {
+      block_id: "latest",
+      transaction: {
+        type: "INVOKE", version: "0x3",
+        sender_address: $sender,
+        calldata: [$strk, "0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33", "0x1", $sender],
+        signature: [],
+        nonce: $nonce,
+        resource_bounds: {
+          l1_gas: {max_amount: "0x0", max_price_per_unit: "0x0"},
+          l2_gas: {max_amount: "0x5f5e100", max_price_per_unit: "0x0"},
+          l1_data_gas: {max_amount: "0x0", max_price_per_unit: "0x0"}
+        },
+        tip: "0x0",
+        paymaster_data: [],
+        account_deployment_data: [],
+        nonce_data_availability_mode: "L1",
+        fee_data_availability_mode: "L1"
+      }
+    }
+  }' > /tmp/prove_request_valid.json
+
+curl -sS "$PROVER_URL" \
+  -H 'content-type: application/json' \
+  -d "$(cat /tmp/prove_request_valid.json)" | jq .
+```
+
+#### Approach B: Chain transaction with fee zeroing
+
+Fetching a real transaction from chain and zeroing its fee fields changes the
+transaction hash, which invalidates the signature. This approach only works if
+the prover is started with `--skip-fee-field-validation`, or if the sender
+account uses a dummy validate function.
 
 1. Find one finalized `INVOKE` `0x3` tx hash.
 
 ```bash
 TX_HASH=$(find_tx_hash "INVOKE" "0x3" 300)
 [ -z "$TX_HASH" ] && { echo "No INVOKE 0x3 tx found in lookback window"; exit 1; }
-
-echo "Using tx_hash=$TX_HASH"
 ```
 
-2. Fetch the tx object and receipt, then compute base block (`tx_block - 1`).
+2. Fetch the tx, zero fee fields, and send.
 
 ```bash
 curl -sS "$CHAIN_RPC_URL" \
@@ -165,13 +220,7 @@ TX_BLOCK=$(curl -sS "$CHAIN_RPC_URL" \
   | jq -r '.result.block_number')
 
 BASE_BLOCK=$((TX_BLOCK - 1))
-echo "tx_block=$TX_BLOCK base_block=$BASE_BLOCK"
-```
 
-3. Zero out fee fields so the request passes fee validation, then call
-   `starknet_proveTransaction`.
-
-```bash
 jq '
   .tip = "0x0" |
   .resource_bounds.l1_gas.max_price_per_unit = "0x0" |

--- a/crates/starknet_transaction_prover/MANUAL_TEST_BUG_REPORT.md
+++ b/crates/starknet_transaction_prover/MANUAL_TEST_BUG_REPORT.md
@@ -1,0 +1,57 @@
+# Manual Test Bug Report
+
+Bugs found during manual testing of the `starknet_transaction_prover` proving
+service. These are code-level issues to fix in a follow-up patch.
+
+---
+
+## Bug 1: Upstream code 41 (TransactionExecutionError) hidden as -32603
+
+**Symptom**: Section 5.5 of the manual testing guide — sending an invoke tx with
+a mutated nonce returns `-32603` ("Internal error") instead of a user-facing
+error. The upstream RPC node returns code 41 with execution error details, but
+the prover wraps it as an internal error.
+
+**Expected**: Error code 41 or 55 with the execution error detail surfaced to
+the caller.
+
+**Root cause**: `virtual_block_executor.rs:524` wraps
+`RPCStateReaderError::TransactionExecutionError` as
+`VirtualBlockExecutorError::ReexecutionError`, which `server/errors.rs:160` maps
+to `internal_server_error()`.
+
+**Fix**: Match `RPCStateReaderError::TransactionExecutionError` at line 524,
+extract `execution_error` from `RpcErrorResponse.error.data`, and surface it as
+a new `TRANSACTION_EXECUTION_ERROR` (code 41) in the prover API.
+
+**Note**: Upstream code 41 covers both validation AND execution failures (no
+structured distinction). Using code 41 (not 55) avoids mislabeling execution
+reverts as validation failures.
+
+---
+
+## Bug 2: Upstream code 42 (StorageProofNotSupported) hidden as -32603
+
+**Symptom**: Steps 7.5 & 8 of the manual testing guide — requesting a proof for
+a stale block returns `-32603` with data containing
+`"RPC provider error: JSON-RPC error: code=42, message=\"The node doesn't support storage proofs for blocks that are too far in the past\""`.
+
+**Expected**: User-facing error code 42 with a clear "block too old" message.
+
+**Root cause**: `server/errors.rs:140` maps all `RunnerError::ProofProvider(_)`
+to `internal_server_error()`.
+
+**Fix**: Match
+`ProofProviderError::Rpc(ProviderError::StarknetError(StarknetError::StorageProofNotSupported))`
+in `runner_error_to_rpc` and return a new `STORAGE_PROOF_NOT_SUPPORTED` (code
+42) error.
+
+**Key types**: `ProviderError::StarknetError(StarknetError::StorageProofNotSupported)`
+from `starknet-rust-providers-0.16.0` is a structured, matchable variant.
+
+---
+
+## Detailed fix plan
+
+A step-by-step implementation plan for both bugs is saved at:
+`.claude/plans/snuggly-soaring-cherny-code-fixes.md`

--- a/crates/starknet_transaction_prover/deployment_smoke.sh
+++ b/crates/starknet_transaction_prover/deployment_smoke.sh
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 KEEP_ARTIFACTS="${KEEP_ARTIFACTS:-false}"
-DUMMY_ACCOUNT_ADDRESS="${DUMMY_ACCOUNT_ADDRESS:-0x2763d2701f413cf0ad7bc73690297c4594bbfd4632ee5f017eb287051595672}"
-STRK_TOKEN_ADDRESS="${STRK_TOKEN_ADDRESS:-0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d}"
+LOOKBACK_BLOCKS="${LOOKBACK_BLOCKS:-300}"
 TMP_DIR="$(mktemp -d)"
 
 # Auto-detect spec version from the Rust source (single source of truth).
@@ -66,6 +65,40 @@ rpc_call_prover() {
     curl -sS "$PROVER_URL" -H 'content-type: application/json' -d "$payload"
 }
 
+find_tx_hash() {
+    local tx_type="$1"
+    local tx_version="$2"
+    local lookback="$3"
+    local latest_block
+    local offset
+    local block_number
+    local tx_hash
+
+    latest_block=$(rpc_call_chain '{"jsonrpc":"2.0","id":100,"method":"starknet_blockNumber","params":[]}' | jq -r '.result')
+    echo "  Latest block: $latest_block (scanning up to $lookback blocks for $tx_type $tx_version)" >&2
+
+    for ((offset = 0; offset <= lookback; offset++)); do
+        block_number=$((latest_block - offset))
+        [[ "$block_number" -lt 0 ]] && break
+
+        if (( offset % 50 == 0 && offset > 0 )); then
+            echo "  Scanned $offset blocks so far (at block $block_number)..." >&2
+        fi
+
+        tx_hash=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"starknet_getBlockWithTxs\",\"params\":[{\"block_number\":$block_number}]}" \
+            | jq -r --arg tx_type "$tx_type" --arg tx_version "$tx_version" \
+                '[.result.transactions[] | select(.type==$tx_type and .version==$tx_version) | .transaction_hash] | .[0] // empty')
+
+        if [[ -n "$tx_hash" && "$tx_hash" != "null" ]]; then
+            echo "  Found $tx_type $tx_version tx at block $block_number (offset $offset)" >&2
+            echo "$block_number $tx_hash"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 check_spec_version() {
     log_step "Check starknet_specVersion"
     local resp
@@ -101,56 +134,50 @@ check_compression() {
     fi
 }
 
-build_prove_request() {
-    log_step "Build starknet_proveTransaction request"
+build_valid_prove_request() {
+    log_step "Build valid starknet_proveTransaction request"
 
-    echo "  Fetching nonce for dummy account..."
-    local nonce
-    nonce=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"starknet_getNonce\",\"params\":[\"latest\",\"$DUMMY_ACCOUNT_ADDRESS\"]}" \
-        | jq -r '.result')
+    if [[ -n "${TX_HASH:-}" ]]; then
+        echo "Using pre-set TX_HASH=$TX_HASH (skipping block scan)"
+        echo "  Fetching tx receipt for block number..."
+        TX_BLOCK=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
+            | jq -r '.result.block_number')
+        if [[ "$TX_BLOCK" == "null" || -z "$TX_BLOCK" ]]; then
+            fail_step "Could not resolve transaction block number for tx $TX_HASH"
+            return 1
+        fi
+    else
+        local find_result
+        find_result=$(find_tx_hash "INVOKE" "0x3" "$LOOKBACK_BLOCKS" || true)
+        if [[ -z "$find_result" ]]; then
+            fail_step "No INVOKE 0x3 tx found in last $LOOKBACK_BLOCKS blocks"
+            return 1
+        fi
+        TX_BLOCK="${find_result%% *}"
+        TX_HASH="${find_result#* }"
+    fi
 
-    if [[ -z "$nonce" || "$nonce" == "null" ]]; then
-        fail_step "Could not fetch nonce for dummy account $DUMMY_ACCOUNT_ADDRESS"
+    echo "  Fetching tx object for $TX_HASH..."
+    rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
+        > "$TMP_DIR/prove_tx_raw.json"
+    echo "  Got response ($(wc -c < "$TMP_DIR/prove_tx_raw.json") bytes), extracting tx..."
+    jq '.result | del(.transaction_hash)' "$TMP_DIR/prove_tx_raw.json" > "$TMP_DIR/prove_tx.json"
+
+    BASE_BLOCK=$((TX_BLOCK - 1))
+    if [[ "$BASE_BLOCK" -lt 0 ]]; then
+        fail_step "Computed base block is negative for tx $TX_HASH"
         return 1
     fi
-    echo "  Nonce: $nonce"
 
-    jq -nc \
-      --arg sender "$DUMMY_ACCOUNT_ADDRESS" \
-      --arg strk "$STRK_TOKEN_ADDRESS" \
-      --arg nonce "$nonce" \
-      '{
-        jsonrpc: "2.0",
-        id: 5,
-        method: "starknet_proveTransaction",
-        params: {
-          block_id: "latest",
-          transaction: {
-            type: "INVOKE",
-            version: "0x3",
-            sender_address: $sender,
-            calldata: [$strk, "0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33", "0x1", $sender],
-            signature: [],
-            nonce: $nonce,
-            resource_bounds: {
-              l1_gas: {max_amount: "0x0", max_price_per_unit: "0x0"},
-              l2_gas: {max_amount: "0x5f5e100", max_price_per_unit: "0x0"},
-              l1_data_gas: {max_amount: "0x0", max_price_per_unit: "0x0"}
-            },
-            tip: "0x0",
-            paymaster_data: [],
-            account_deployment_data: [],
-            nonce_data_availability_mode: "L1",
-            fee_data_availability_mode: "L1"
-          }
-        }
-      }' > "$TMP_DIR/prove_request_valid.json"
+    jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx "$TMP_DIR/prove_tx.json" \
+        '{jsonrpc:"2.0",id:5,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
+        > "$TMP_DIR/prove_request_valid.json"
 
-    pass_step "Built prove request for dummy account $DUMMY_ACCOUNT_ADDRESS"
+    pass_step "Built valid prove request using tx_hash=$TX_HASH and base_block=$BASE_BLOCK"
 }
 
 check_prove_happy_path() {
-    log_step "Check starknet_proveTransaction happy path (may take 30-60s)"
+    log_step "Check starknet_proveTransaction happy path"
 
     local resp
     resp=$(rpc_call_prover "$(cat "$TMP_DIR/prove_request_valid.json")")
@@ -242,13 +269,13 @@ main() {
     echo "PROVER_URL=$PROVER_URL"
     echo "CHAIN_RPC_URL=$CHAIN_RPC_URL"
     echo "SPEC_VERSION_EXPECTED=$SPEC_VERSION_EXPECTED"
-    echo "DUMMY_ACCOUNT_ADDRESS=$DUMMY_ACCOUNT_ADDRESS"
-    echo "STRK_TOKEN_ADDRESS=$STRK_TOKEN_ADDRESS"
+    echo "LOOKBACK_BLOCKS=$LOOKBACK_BLOCKS"
     echo "KEEP_ARTIFACTS=$KEEP_ARTIFACTS"
+    [[ -n "${TX_HASH:-}" ]] && echo "TX_HASH=$TX_HASH (pre-set, will skip block scan)"
 
     check_spec_version
     check_compression
-    if build_prove_request; then
+    if build_valid_prove_request; then
         check_prove_happy_path
         check_malformed_params
         check_concurrency_and_recovery

--- a/crates/starknet_transaction_prover/deployment_smoke.sh
+++ b/crates/starknet_transaction_prover/deployment_smoke.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 KEEP_ARTIFACTS="${KEEP_ARTIFACTS:-false}"
-LOOKBACK_BLOCKS="${LOOKBACK_BLOCKS:-300}"
+DUMMY_ACCOUNT_ADDRESS="${DUMMY_ACCOUNT_ADDRESS:-0x2763d2701f413cf0ad7bc73690297c4594bbfd4632ee5f017eb287051595672}"
+STRK_TOKEN_ADDRESS="${STRK_TOKEN_ADDRESS:-0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d}"
 TMP_DIR="$(mktemp -d)"
 
 # Auto-detect spec version from the Rust source (single source of truth).
@@ -65,52 +66,6 @@ rpc_call_prover() {
     curl -sS "$PROVER_URL" -H 'content-type: application/json' -d "$payload"
 }
 
-find_tx_hash() {
-    local tx_type="$1"
-    local tx_version="$2"
-    local lookback="$3"
-    local latest_block
-    local offset
-    local block_number
-    local tx_hash
-
-    latest_block=$(rpc_call_chain '{"jsonrpc":"2.0","id":100,"method":"starknet_blockNumber","params":[]}' | jq -r '.result')
-    echo "  Latest block: $latest_block (scanning up to $lookback blocks for $tx_type $tx_version)" >&2
-
-    for ((offset = 0; offset <= lookback; offset++)); do
-        block_number=$((latest_block - offset))
-        [[ "$block_number" -lt 0 ]] && break
-
-        if (( offset % 50 == 0 && offset > 0 )); then
-            echo "  Scanned $offset blocks so far (at block $block_number)..." >&2
-        fi
-
-        tx_hash=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"starknet_getBlockWithTxs\",\"params\":[{\"block_number\":$block_number}]}" \
-            | jq -r --arg tx_type "$tx_type" --arg tx_version "$tx_version" \
-                '.result.transactions[] | select(.type==$tx_type and .version==$tx_version) | .transaction_hash' \
-            | head -n 1)
-
-        if [[ -n "$tx_hash" && "$tx_hash" != "null" ]]; then
-            echo "  Found $tx_type $tx_version tx at block $block_number (offset $offset)" >&2
-            echo "$block_number $tx_hash"
-            return 0
-        fi
-    done
-
-    return 1
-}
-
-zero_fee_fields() {
-    local input_file="$1"
-    local output_file="$2"
-    jq '
-      .tip = "0x0" |
-      .resource_bounds.l1_gas.max_price_per_unit = "0x0" |
-      .resource_bounds.l2_gas.max_price_per_unit = "0x0" |
-      .resource_bounds.l1_data_gas.max_price_per_unit = "0x0"
-    ' "$input_file" > "$output_file"
-}
-
 check_spec_version() {
     log_step "Check starknet_specVersion"
     local resp
@@ -146,52 +101,56 @@ check_compression() {
     fi
 }
 
-build_valid_prove_request() {
-    log_step "Build valid starknet_proveTransaction request"
+build_prove_request() {
+    log_step "Build starknet_proveTransaction request"
 
-    if [[ -n "${TX_HASH:-}" ]]; then
-        echo "Using pre-set TX_HASH=$TX_HASH (skipping block scan)"
-        echo "  Fetching tx receipt for block number..."
-        TX_BLOCK=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
-            | jq -r '.result.block_number')
-        if [[ "$TX_BLOCK" == "null" || -z "$TX_BLOCK" ]]; then
-            fail_step "Could not resolve transaction block number for tx $TX_HASH"
-            return 1
-        fi
-    else
-        local find_result
-        find_result=$(find_tx_hash "INVOKE" "0x3" "$LOOKBACK_BLOCKS" || true)
-        if [[ -z "$find_result" ]]; then
-            fail_step "No INVOKE 0x3 tx found in last $LOOKBACK_BLOCKS blocks"
-            return 1
-        fi
-        TX_BLOCK="${find_result%% *}"
-        TX_HASH="${find_result#* }"
-    fi
+    echo "  Fetching nonce for dummy account..."
+    local nonce
+    nonce=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"starknet_getNonce\",\"params\":[\"latest\",\"$DUMMY_ACCOUNT_ADDRESS\"]}" \
+        | jq -r '.result')
 
-    echo "  Fetching tx object for $TX_HASH..."
-    rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
-        > "$TMP_DIR/prove_tx_raw.json"
-    echo "  Got response ($(wc -c < "$TMP_DIR/prove_tx_raw.json") bytes), extracting tx..."
-    jq '.result | del(.transaction_hash)' "$TMP_DIR/prove_tx_raw.json" > "$TMP_DIR/prove_tx.json"
-
-    BASE_BLOCK=$((TX_BLOCK - 1))
-    if [[ "$BASE_BLOCK" -lt 0 ]]; then
-        fail_step "Computed base block is negative for tx $TX_HASH"
+    if [[ -z "$nonce" || "$nonce" == "null" ]]; then
+        fail_step "Could not fetch nonce for dummy account $DUMMY_ACCOUNT_ADDRESS"
         return 1
     fi
+    echo "  Nonce: $nonce"
 
-    zero_fee_fields "$TMP_DIR/prove_tx.json" "$TMP_DIR/prove_tx_zeroed.json"
+    jq -nc \
+      --arg sender "$DUMMY_ACCOUNT_ADDRESS" \
+      --arg strk "$STRK_TOKEN_ADDRESS" \
+      --arg nonce "$nonce" \
+      '{
+        jsonrpc: "2.0",
+        id: 5,
+        method: "starknet_proveTransaction",
+        params: {
+          block_id: "latest",
+          transaction: {
+            type: "INVOKE",
+            version: "0x3",
+            sender_address: $sender,
+            calldata: [$strk, "0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33", "0x1", $sender],
+            signature: [],
+            nonce: $nonce,
+            resource_bounds: {
+              l1_gas: {max_amount: "0x0", max_price_per_unit: "0x0"},
+              l2_gas: {max_amount: "0x5f5e100", max_price_per_unit: "0x0"},
+              l1_data_gas: {max_amount: "0x0", max_price_per_unit: "0x0"}
+            },
+            tip: "0x0",
+            paymaster_data: [],
+            account_deployment_data: [],
+            nonce_data_availability_mode: "L1",
+            fee_data_availability_mode: "L1"
+          }
+        }
+      }' > "$TMP_DIR/prove_request_valid.json"
 
-    jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx "$TMP_DIR/prove_tx_zeroed.json" \
-        '{jsonrpc:"2.0",id:5,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
-        > "$TMP_DIR/prove_request_valid.json"
-
-    pass_step "Built valid prove request using tx_hash=$TX_HASH and base_block=$BASE_BLOCK"
+    pass_step "Built prove request for dummy account $DUMMY_ACCOUNT_ADDRESS"
 }
 
 check_prove_happy_path() {
-    log_step "Check starknet_proveTransaction happy path"
+    log_step "Check starknet_proveTransaction happy path (may take 30-60s)"
 
     local resp
     resp=$(rpc_call_prover "$(cat "$TMP_DIR/prove_request_valid.json")")
@@ -283,13 +242,13 @@ main() {
     echo "PROVER_URL=$PROVER_URL"
     echo "CHAIN_RPC_URL=$CHAIN_RPC_URL"
     echo "SPEC_VERSION_EXPECTED=$SPEC_VERSION_EXPECTED"
-    echo "LOOKBACK_BLOCKS=$LOOKBACK_BLOCKS"
+    echo "DUMMY_ACCOUNT_ADDRESS=$DUMMY_ACCOUNT_ADDRESS"
+    echo "STRK_TOKEN_ADDRESS=$STRK_TOKEN_ADDRESS"
     echo "KEEP_ARTIFACTS=$KEEP_ARTIFACTS"
-    [[ -n "${TX_HASH:-}" ]] && echo "TX_HASH=$TX_HASH (pre-set, will skip block scan)"
 
     check_spec_version
     check_compression
-    if build_valid_prove_request; then
+    if build_prove_request; then
         check_prove_happy_path
         check_malformed_params
         check_concurrency_and_recovery

--- a/crates/starknet_transaction_prover/deployment_smoke.sh
+++ b/crates/starknet_transaction_prover/deployment_smoke.sh
@@ -57,7 +57,7 @@ fail_step() {
 
 rpc_call_chain() {
     local payload="$1"
-    curl -sS "$CHAIN_RPC_URL" -H 'content-type: application/json' -d "$payload"
+    curl -sS --max-time 30 "$CHAIN_RPC_URL" -H 'content-type: application/json' -d "$payload"
 }
 
 rpc_call_prover() {
@@ -75,10 +75,15 @@ find_tx_hash() {
     local tx_hash
 
     latest_block=$(rpc_call_chain '{"jsonrpc":"2.0","id":100,"method":"starknet_blockNumber","params":[]}' | jq -r '.result')
+    echo "  Latest block: $latest_block (scanning up to $lookback blocks for $tx_type $tx_version)" >&2
 
     for ((offset = 0; offset <= lookback; offset++)); do
         block_number=$((latest_block - offset))
         [[ "$block_number" -lt 0 ]] && break
+
+        if (( offset % 50 == 0 && offset > 0 )); then
+            echo "  Scanned $offset blocks so far (at block $block_number)..." >&2
+        fi
 
         tx_hash=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"starknet_getBlockWithTxs\",\"params\":[{\"block_number\":$block_number}]}" \
             | jq -r --arg tx_type "$tx_type" --arg tx_version "$tx_version" \
@@ -86,7 +91,8 @@ find_tx_hash() {
             | head -n 1)
 
         if [[ -n "$tx_hash" && "$tx_hash" != "null" ]]; then
-            echo "$tx_hash"
+            echo "  Found $tx_type $tx_version tx at block $block_number (offset $offset)" >&2
+            echo "$block_number $tx_hash"
             return 0
         fi
     done
@@ -121,9 +127,9 @@ check_spec_version() {
 check_compression() {
     log_step "Check HTTP response compression"
     local headers
-    headers=$(curl -sS -D- "$PROVER_URL" \
+    headers=$(curl -sS -D- --compressed "$PROVER_URL" \
         -H 'content-type: application/json' \
-        -H 'accept-encoding: gzip' \
+        -H 'accept-encoding: zstd' \
         -d '{"jsonrpc":"2.0","id":2,"method":"starknet_specVersion","params":[]}' \
         -o "$TMP_DIR/compressed_resp.json" 2>&1)
 
@@ -145,24 +151,29 @@ build_valid_prove_request() {
 
     if [[ -n "${TX_HASH:-}" ]]; then
         echo "Using pre-set TX_HASH=$TX_HASH (skipping block scan)"
+        echo "  Fetching tx receipt for block number..."
+        TX_BLOCK=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
+            | jq -r '.result.block_number')
+        if [[ "$TX_BLOCK" == "null" || -z "$TX_BLOCK" ]]; then
+            fail_step "Could not resolve transaction block number for tx $TX_HASH"
+            return 1
+        fi
     else
-        TX_HASH=$(find_tx_hash "INVOKE" "0x3" "$LOOKBACK_BLOCKS" || true)
-        if [[ -z "${TX_HASH:-}" ]]; then
+        local find_result
+        find_result=$(find_tx_hash "INVOKE" "0x3" "$LOOKBACK_BLOCKS" || true)
+        if [[ -z "$find_result" ]]; then
             fail_step "No INVOKE 0x3 tx found in last $LOOKBACK_BLOCKS blocks"
             return 1
         fi
+        TX_BLOCK="${find_result%% *}"
+        TX_HASH="${find_result#* }"
     fi
 
+    echo "  Fetching tx object for $TX_HASH..."
     rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
-        | jq '.result | del(.transaction_hash)' > "$TMP_DIR/prove_tx.json"
-
-    TX_BLOCK=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
-        | jq -r '.result.block_number')
-
-    if [[ "$TX_BLOCK" == "null" || -z "$TX_BLOCK" ]]; then
-        fail_step "Could not resolve transaction block number for tx $TX_HASH"
-        return 1
-    fi
+        > "$TMP_DIR/prove_tx_raw.json"
+    echo "  Got response ($(wc -c < "$TMP_DIR/prove_tx_raw.json") bytes), extracting tx..."
+    jq '.result | del(.transaction_hash)' "$TMP_DIR/prove_tx_raw.json" > "$TMP_DIR/prove_tx.json"
 
     BASE_BLOCK=$((TX_BLOCK - 1))
     if [[ "$BASE_BLOCK" -lt 0 ]]; then
@@ -172,7 +183,7 @@ build_valid_prove_request() {
 
     zero_fee_fields "$TMP_DIR/prove_tx.json" "$TMP_DIR/prove_tx_zeroed.json"
 
-    jq -c --argjson base "$BASE_BLOCK" --slurpfile tx "$TMP_DIR/prove_tx_zeroed.json" \
+    jq -nc --argjson base "$BASE_BLOCK" --slurpfile tx "$TMP_DIR/prove_tx_zeroed.json" \
         '{jsonrpc:"2.0",id:5,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
         > "$TMP_DIR/prove_request_valid.json"
 

--- a/crates/starknet_transaction_prover/deployment_smoke.sh
+++ b/crates/starknet_transaction_prover/deployment_smoke.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+KEEP_ARTIFACTS="${KEEP_ARTIFACTS:-false}"
+LOOKBACK_BLOCKS="${LOOKBACK_BLOCKS:-300}"
+TMP_DIR="$(mktemp -d)"
+
+# Auto-detect spec version from the Rust source (single source of truth).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPEC_VERSION_EXPECTED=$(grep -oP 'const SPEC_VERSION: &str = "\K[^"]+' \
+    "$SCRIPT_DIR/src/server/rpc_impl.rs" 2>/dev/null \
+    || echo "0.10.1")
+
+cleanup() {
+    if [[ "$KEEP_ARTIFACTS" == "true" || "$FAIL_COUNT" -gt 0 ]]; then
+        echo "Artifacts preserved in $TMP_DIR"
+    else
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "ERROR: required command '$cmd' is not installed."
+        exit 2
+    fi
+}
+
+require_env() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        echo "ERROR: environment variable $name must be set."
+        exit 2
+    fi
+}
+
+log_step() {
+    echo ""
+    echo "==> $1"
+}
+
+pass_step() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "PASS: $1"
+}
+
+fail_step() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "FAIL: $1"
+}
+
+rpc_call_chain() {
+    local payload="$1"
+    curl -sS "$CHAIN_RPC_URL" -H 'content-type: application/json' -d "$payload"
+}
+
+rpc_call_prover() {
+    local payload="$1"
+    curl -sS "$PROVER_URL" -H 'content-type: application/json' -d "$payload"
+}
+
+find_tx_hash() {
+    local tx_type="$1"
+    local tx_version="$2"
+    local lookback="$3"
+    local latest_block
+    local offset
+    local block_number
+    local tx_hash
+
+    latest_block=$(rpc_call_chain '{"jsonrpc":"2.0","id":100,"method":"starknet_blockNumber","params":[]}' | jq -r '.result')
+
+    for ((offset = 0; offset <= lookback; offset++)); do
+        block_number=$((latest_block - offset))
+        [[ "$block_number" -lt 0 ]] && break
+
+        tx_hash=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":101,\"method\":\"starknet_getBlockWithTxs\",\"params\":[{\"block_number\":$block_number}]}" \
+            | jq -r --arg tx_type "$tx_type" --arg tx_version "$tx_version" \
+                '.result.transactions[] | select(.type==$tx_type and .version==$tx_version) | .transaction_hash' \
+            | head -n 1)
+
+        if [[ -n "$tx_hash" && "$tx_hash" != "null" ]]; then
+            echo "$tx_hash"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+zero_fee_fields() {
+    local input_file="$1"
+    local output_file="$2"
+    jq '
+      .tip = "0x0" |
+      .resource_bounds.l1_gas.max_price_per_unit = "0x0" |
+      .resource_bounds.l2_gas.max_price_per_unit = "0x0" |
+      .resource_bounds.l1_data_gas.max_price_per_unit = "0x0"
+    ' "$input_file" > "$output_file"
+}
+
+check_spec_version() {
+    log_step "Check starknet_specVersion"
+    local resp
+    resp=$(rpc_call_prover '{"jsonrpc":"2.0","id":1,"method":"starknet_specVersion","params":[]}')
+    echo "$resp" > "$TMP_DIR/spec_version.json"
+
+    if jq -e --arg expected "$SPEC_VERSION_EXPECTED" '.result == $expected' "$TMP_DIR/spec_version.json" >/dev/null; then
+        pass_step "starknet_specVersion returned $SPEC_VERSION_EXPECTED"
+    else
+        fail_step "starknet_specVersion did not return $SPEC_VERSION_EXPECTED"
+    fi
+}
+
+check_compression() {
+    log_step "Check HTTP response compression"
+    local headers
+    headers=$(curl -sS -D- "$PROVER_URL" \
+        -H 'content-type: application/json' \
+        -H 'accept-encoding: gzip' \
+        -d '{"jsonrpc":"2.0","id":2,"method":"starknet_specVersion","params":[]}' \
+        -o "$TMP_DIR/compressed_resp.json" 2>&1)
+
+    if echo "$headers" | grep -qi 'content-encoding'; then
+        local result
+        result=$(jq -r '.result' "$TMP_DIR/compressed_resp.json" 2>/dev/null || true)
+        if [[ "$result" == "$SPEC_VERSION_EXPECTED" ]]; then
+            pass_step "Compressed response returned valid JSON with correct spec version"
+        else
+            fail_step "Compressed response did not contain expected spec version (got: $result)"
+        fi
+    else
+        fail_step "No content-encoding header in response (compression layer may not be active)"
+    fi
+}
+
+build_valid_prove_request() {
+    log_step "Build valid starknet_proveTransaction request"
+
+    if [[ -n "${TX_HASH:-}" ]]; then
+        echo "Using pre-set TX_HASH=$TX_HASH (skipping block scan)"
+    else
+        TX_HASH=$(find_tx_hash "INVOKE" "0x3" "$LOOKBACK_BLOCKS" || true)
+        if [[ -z "${TX_HASH:-}" ]]; then
+            fail_step "No INVOKE 0x3 tx found in last $LOOKBACK_BLOCKS blocks"
+            return 1
+        fi
+    fi
+
+    rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"starknet_getTransactionByHash\",\"params\":[\"$TX_HASH\"]}" \
+        | jq '.result | del(.transaction_hash)' > "$TMP_DIR/prove_tx.json"
+
+    TX_BLOCK=$(rpc_call_chain "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"starknet_getTransactionReceipt\",\"params\":[\"$TX_HASH\"]}" \
+        | jq -r '.result.block_number')
+
+    if [[ "$TX_BLOCK" == "null" || -z "$TX_BLOCK" ]]; then
+        fail_step "Could not resolve transaction block number for tx $TX_HASH"
+        return 1
+    fi
+
+    BASE_BLOCK=$((TX_BLOCK - 1))
+    if [[ "$BASE_BLOCK" -lt 0 ]]; then
+        fail_step "Computed base block is negative for tx $TX_HASH"
+        return 1
+    fi
+
+    zero_fee_fields "$TMP_DIR/prove_tx.json" "$TMP_DIR/prove_tx_zeroed.json"
+
+    jq -c --argjson base "$BASE_BLOCK" --slurpfile tx "$TMP_DIR/prove_tx_zeroed.json" \
+        '{jsonrpc:"2.0",id:5,method:"starknet_proveTransaction",params:[{block_number:$base},$tx[0]]}' \
+        > "$TMP_DIR/prove_request_valid.json"
+
+    pass_step "Built valid prove request using tx_hash=$TX_HASH and base_block=$BASE_BLOCK"
+}
+
+check_prove_happy_path() {
+    log_step "Check starknet_proveTransaction happy path"
+
+    local resp
+    resp=$(rpc_call_prover "$(cat "$TMP_DIR/prove_request_valid.json")")
+    echo "$resp" > "$TMP_DIR/prove_happy.json"
+
+    if jq -e '.result.proof and .result.proof_facts' "$TMP_DIR/prove_happy.json" >/dev/null; then
+        pass_step "starknet_proveTransaction returned proof and proof_facts"
+    else
+        fail_step "starknet_proveTransaction happy path failed"
+    fi
+}
+
+check_malformed_params() {
+    log_step "Check malformed params rejection"
+    local resp
+    resp=$(rpc_call_prover '{"jsonrpc":"2.0","id":16,"method":"starknet_proveTransaction","params":["latest"]}')
+    echo "$resp" > "$TMP_DIR/malformed.json"
+
+    if jq -e '.error != null' "$TMP_DIR/malformed.json" >/dev/null; then
+        pass_step "Malformed params returned JSON-RPC error"
+    else
+        fail_step "Malformed params did not return an error"
+    fi
+}
+
+check_concurrency_and_recovery() {
+    log_step "Check concurrency behavior and recovery"
+
+    local i
+    local pids=()
+    local transport_failures=0
+
+    for i in 1 2 3; do
+        (
+            curl -sS "$PROVER_URL" -H 'content-type: application/json' \
+                -d "$(cat "$TMP_DIR/prove_request_valid.json")" > "$TMP_DIR/concurrency_$i.json"
+        ) &
+        pids+=("$!")
+    done
+
+    for pid in "${pids[@]}"; do
+        if ! wait "$pid"; then
+            transport_failures=$((transport_failures + 1))
+        fi
+    done
+
+    local success_count=0
+    local busy_count=0
+    local internal_error_count=0
+    for i in 1 2 3; do
+        if [[ ! -s "$TMP_DIR/concurrency_$i.json" ]]; then
+            continue
+        fi
+        if jq -e '.result != null' "$TMP_DIR/concurrency_$i.json" >/dev/null; then
+            success_count=$((success_count + 1))
+        fi
+        if jq -e '.error.code == -32005' "$TMP_DIR/concurrency_$i.json" >/dev/null; then
+            busy_count=$((busy_count + 1))
+        fi
+        if jq -e '.error.code == -32603' "$TMP_DIR/concurrency_$i.json" >/dev/null; then
+            internal_error_count=$((internal_error_count + 1))
+        fi
+    done
+
+    if [[ "$success_count" -ge 1 && "$transport_failures" -eq 0 && "$internal_error_count" -eq 0 ]]; then
+        pass_step "Concurrency check ok (success=$success_count busy=$busy_count)"
+    else
+        fail_step "Concurrency check failed (success=$success_count busy=$busy_count transport_failures=$transport_failures internal_errors=$internal_error_count)"
+    fi
+
+    local recovery_resp
+    recovery_resp=$(rpc_call_prover '{"jsonrpc":"2.0","id":17,"method":"starknet_specVersion","params":[]}')
+    echo "$recovery_resp" > "$TMP_DIR/recovery.json"
+
+    if jq -e --arg expected "$SPEC_VERSION_EXPECTED" '.result == $expected' "$TMP_DIR/recovery.json" >/dev/null; then
+        pass_step "Service recovery check passed"
+    else
+        fail_step "Service recovery check failed"
+    fi
+}
+
+main() {
+    require_cmd curl
+    require_cmd jq
+    require_env PROVER_URL
+    require_env CHAIN_RPC_URL
+
+    echo "Running starknet_transaction_prover deployment smoke tests"
+    echo "PROVER_URL=$PROVER_URL"
+    echo "CHAIN_RPC_URL=$CHAIN_RPC_URL"
+    echo "SPEC_VERSION_EXPECTED=$SPEC_VERSION_EXPECTED"
+    echo "LOOKBACK_BLOCKS=$LOOKBACK_BLOCKS"
+    echo "KEEP_ARTIFACTS=$KEEP_ARTIFACTS"
+    [[ -n "${TX_HASH:-}" ]] && echo "TX_HASH=$TX_HASH (pre-set, will skip block scan)"
+
+    check_spec_version
+    check_compression
+    if build_valid_prove_request; then
+        check_prove_happy_path
+        check_malformed_params
+        check_concurrency_and_recovery
+    fi
+
+    echo ""
+    echo "Smoke test summary: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+
+    if [[ "$FAIL_COUNT" -eq 0 ]]; then
+        echo "Overall result: PASS"
+        exit 0
+    fi
+
+    echo "Overall result: FAIL"
+    exit 1
+}
+
+main "$@"


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new bash smoke-test runner and updates documentation; no Rust service logic changes, so runtime risk is low and mostly limited to operational/testing workflow accuracy.
> 
> **Overview**
> Adds an executable `deployment_smoke.sh` that automates post-deploy smoke checks against a prover + chain RPC: verifies `starknet_specVersion` (auto-detected from `rpc_impl.rs`), HTTP compression, builds a real `starknet_proveTransaction` request from on-chain `INVOKE v3` data, runs a happy-path proof, malformed-params rejection, and a quick concurrency/recovery probe, then prints a PASS/FAIL summary while preserving artifacts on failure.
> 
> Updates `DEPLOYMENT_SMOKE_TESTING_GUIDE.md` and `MANUAL_TESTING_GUIDE.md` to align with sending real transactions *unmodified* (requiring `validate_zero_fee_fields=false` / `--skip-fee-field-validation`), improves `find_tx_hash` robustness/UX, documents how to change config in Kubernetes vs local flags, and adds guidance for skipping/refreshing tests when transactions/blocks aren’t available or become stale.
> 
> Adds `MANUAL_TEST_BUG_REPORT.md` capturing two discovered error-mapping issues (upstream Starknet RPC codes 41/42 being surfaced as `-32603`) for follow-up work (no code changes here).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8e5d4efca3775829c243a59081efb32ba42eb57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->