### PR TITLE
add section saying that code inside macro should be formatted

### DIFF
--- a/style.md
+++ b/style.md
@@ -457,6 +457,14 @@ Only use macros if non-macro alternatives are not feasible and when _really_ nec
 
 For example: using parametrization in a test (using rstest) can make tests harder to reason about and debug in some cases, when the parametrization is very complicated and involves complex types. In those cases one should consider a free-function that performs the test, and several one-line tests that call it with different args, rather than forcing a parameterized solution.
 
+#### Formatting Macros
+
+`rustfmt` does not format code inside macro invocations.
+This applies to any macro that contains Rust code, such as `stream!`, `indexmap!`.
+Make sure the code inside the macro is formatted correctly.
+
+**Tip**: Temporarily copy the code outside of the macro, run `rustfmt`, and then copy it back.
+
 ### If-let-else Pattern
 
 Prefer `let-else` or `match` patterns, they are always more concise and incur less cognitive load


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that does not affect runtime behavior or APIs.
> 
> **Overview**
> Adds a new **“Formatting Macros”** subsection to `style.md` noting that `rustfmt` does not format Rust code inside macro invocations (e.g., `stream!`, `indexmap!`) and recommending manually formatting that code (with a tip to temporarily move it outside the macro to run `rustfmt`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe869904dd62e86b757ab9d977ea643f00c76e96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->