### PR TITLE
unite getter and setter sections, and modify setter section

### DIFF
--- a/style.md
+++ b/style.md
@@ -237,12 +237,6 @@ A getter for the field `foo` should be `fn foo`, rather than `fn get_foo`
 
 The same is also encouraged for non-field getters, except for in cases where `get*` really improves readability.
 
-### `self` Mutability in Getters
-
-Getter methods should always be `&self`, never `&mut self` --- use interior mutability if mutating self is necessary for maintenance like caching.
-
-**Rationale**: aligning to user's expectation for getters, preventing borrow-checker surprises.
-
 ### Types in API
 
 Types appearing _in the API_ should strongly prefer `std` types, primitives, or types exposed by the crate for external use.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the main risk is minor confusion if teams previously followed the removed guidance around `&mut self` getters and caching via interior mutability.
> 
> **Overview**
> Updates `style.md` API conventions by folding prior getter/setter guidance into the *Getter Names* section: it now recommends exposing mutable access via `fn foo_mut() -> &mut _` instead of defining setters, and further advises avoiding setters entirely for non-data structs in favor of explicit mutation methods. It removes the previous guidance/rationale about getter `self` mutability (`&self` vs `&mut self`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c9c88e44749f0410066b5e6500655def420cf96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->