### PR TITLE
deployment: use starkware-libs merge gatekeeper

### DIFF
--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -9,6 +9,11 @@ on:
       - synchronize
       - edited
 
+permissions:
+  checks: read
+  statuses: read
+  contents: read
+
 env:
   RUSTFLAGS: "-D warnings"
 
@@ -48,16 +53,16 @@ jobs:
     steps:
       - name: Run Merge Gatekeeper on pull request
         if: github.event_name == 'pull_request'
-        uses: upsidr/merge-gatekeeper@v1
+        uses: starkware-libs/merge-gatekeeper@v1.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           timeout: 3600
           interval: 30
-          ignored: code-review/reviewable,build_docker_images
+          ignored: "code-review/reviewable"
 
       - name: Run Merge Gatekeeper on Merge Queue || push
         if: github.event_name == 'merge_group' || github.event_name == 'push'
-        uses: upsidr/merge-gatekeeper@v1
+        uses: starkware-libs/merge-gatekeeper@v1.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{github.ref}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI-only change, but it affects merge gating behavior and required checks for PRs/merge queue; misconfiguration could block merges or allow unintended merges. Workflow-level token permissions are adjusted, which could impact actions that implicitly relied on broader access.
> 
> **Overview**
> Updates the PR CI workflow to use `starkware-libs/merge-gatekeeper@v1.0.4` instead of `upsidr/merge-gatekeeper@v1` for both PR and merge-queue runs, and narrows the `ignored` checks list to only `code-review/reviewable`.
> 
> Adds explicit workflow-level `GITHUB_TOKEN` permissions (`checks`, `statuses`, `contents` set to read) to further restrict default access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c10274c79e70aeff378ebf0b5fbdaa35a477ea52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->