### PR TITLE
apollo_consensus: add consensus-level timeout for proposer block building

### DIFF
--- a/crates/apollo_consensus/src/single_height_consensus.rs
+++ b/crates/apollo_consensus/src/single_height_consensus.rs
@@ -229,6 +229,22 @@ impl SingleHeightConsensus {
         proposal_id: Option<ProposalCommitment>,
         round: Round,
     ) -> Requests {
+        if round != self.state_machine.round() {
+            // Stale: build completed after TimeoutPropose advanced us past this round. Ignore.
+            warn!(
+                "FinishedBuilding for stale round={round}; current round={}. Ignoring.",
+                self.state_machine.round()
+            );
+            return VecDeque::new();
+        }
+        if !self.state_machine.is_awaiting_finished_building() {
+            // Stale: TimeoutPropose already fired for this round; we already nil-prevoted. The SM
+            // will discard this build, so don't count it in metrics.
+            warn!(
+                "FinishedBuilding for round={round} after TimeoutPropose already fired. Ignoring."
+            );
+            return VecDeque::new();
+        }
         if proposal_id.is_none() {
             CONSENSUS_BUILD_PROPOSAL_FAILED.increment(1);
         }
@@ -237,11 +253,6 @@ impl SingleHeightConsensus {
         assert!(
             !self.state_machine.has_proposal_for_round(round),
             "There should be no entry for round {round} when proposing"
-        );
-        assert_eq!(
-            round,
-            self.state_machine.round(),
-            "State machine should not progress while awaiting proposal"
         );
         debug!(%round, proposal_commitment = ?proposal_id, "Built proposal.");
         self.state_machine.handle_event(StateMachineEvent::FinishedBuilding(proposal_id, round))

--- a/crates/apollo_consensus/src/single_height_consensus_test.rs
+++ b/crates/apollo_consensus/src/single_height_consensus_test.rs
@@ -61,6 +61,7 @@ fn new_shc(id: ValidatorId, is_observer: bool) -> SingleHeightConsensus {
 
 #[track_caller]
 fn assert_start_build_proposal(reqs: &mut VecDeque<SMRequest>) {
+    assert_matches!(reqs.pop_front(), Some(SMRequest::ScheduleTimeout(Step::Propose, ROUND_0)));
     assert_matches!(reqs.pop_front(), Some(SMRequest::StartBuildProposal(ROUND_0)));
     assert!(reqs.is_empty(), "unexpected requests: {:?}", reqs);
 }

--- a/crates/apollo_consensus/src/state_machine.rs
+++ b/crates/apollo_consensus/src/state_machine.rs
@@ -193,6 +193,10 @@ impl StateMachine {
         self.last_self_precommit.clone()
     }
 
+    pub(crate) fn is_awaiting_finished_building(&self) -> bool {
+        self.awaiting_finished_building
+    }
+
     /// Check if a vote has already been received (either in the vote maps or queued).
     /// Returns the status of the vote: NotReceived, Duplicate, or Conflict.
     pub(crate) fn received_vote(&self, vote: &Vote) -> VoteStatus {
@@ -295,6 +299,9 @@ impl StateMachine {
                 StateMachineEvent::FinishedBuilding(_, round) if round == self.round => {
                     self.events_queue.push_front(event);
                 }
+                StateMachineEvent::TimeoutPropose(round) if round == self.round => {
+                    self.events_queue.push_front(event);
+                }
                 _ => {
                     self.events_queue.push_back(event);
                     return VecDeque::new();
@@ -341,7 +348,11 @@ impl StateMachine {
     fn handle_event_internal(&mut self, event: StateMachineEvent) -> VecDeque<SMRequest> {
         trace!("Processing event: {:?}", event);
         if self.awaiting_finished_building {
-            assert!(matches!(event, StateMachineEvent::FinishedBuilding(_, _)), "{event:?}");
+            assert!(
+                matches!(event, StateMachineEvent::FinishedBuilding(_, r) if r == self.round)
+                    || matches!(event, StateMachineEvent::TimeoutPropose(r) if r == self.round),
+                "{event:?}"
+            );
         }
 
         match event {
@@ -367,8 +378,21 @@ impl StateMachine {
         proposal_id: Option<ProposalCommitment>,
         round: u32,
     ) -> VecDeque<SMRequest> {
-        assert!(self.awaiting_finished_building);
-        assert_eq!(round, self.round);
+        if round != self.round {
+            // Defensive: SHC should have filtered this.
+            warn!(
+                "FinishedBuilding for stale round={round}; current round={}. Ignoring.",
+                self.round
+            );
+            return VecDeque::new();
+        }
+        if !self.awaiting_finished_building {
+            // Defensive: SHC should have filtered this.
+            warn!(
+                "FinishedBuilding for round={round} after TimeoutPropose already fired. Ignoring."
+            );
+            return VecDeque::new();
+        }
         self.awaiting_finished_building = false;
         let old = self.proposals.insert(round, (proposal_id, None));
         assert!(old.is_none(), "Proposal built when one already exists for this round.");
@@ -391,9 +415,11 @@ impl StateMachine {
         if self.step != Step::Propose || round != self.round {
             return VecDeque::new();
         };
+        let was_build_timeout = self.awaiting_finished_building;
+        self.awaiting_finished_building = false;
         warn!(
-            "PROPOSAL_FAILED: Proposal failed as validator. Applying TimeoutPropose for \
-             round={round}."
+            "PROPOSAL_FAILED: Proposal failed as {}. Applying TimeoutPropose for round={round}.",
+            if was_build_timeout { "proposer (build timeout)" } else { "validator" }
         );
         CONSENSUS_TIMEOUTS.increment(1, &[(LABEL_NAME_TIMEOUT_TYPE, TimeoutType::Propose.into())]);
         let mut output = self.make_self_vote(VoteType::Prevote, None);
@@ -510,7 +536,10 @@ impl StateMachine {
             None => {
                 self.awaiting_finished_building = true;
                 // Upon conditions are not checked while awaiting a new proposal.
-                VecDeque::from([SMRequest::StartBuildProposal(self.round)])
+                VecDeque::from([
+                    SMRequest::ScheduleTimeout(Step::Propose, self.round),
+                    SMRequest::StartBuildProposal(self.round),
+                ])
             }
         }
     }

--- a/crates/apollo_consensus/src/state_machine_test.rs
+++ b/crates/apollo_consensus/src/state_machine_test.rs
@@ -60,6 +60,7 @@ fn assert_decision_reached(wrapper: &mut TestWrapper, expected_block: Option<Pro
 
 #[track_caller]
 fn assert_start_build_proposal(wrapper: &mut TestWrapper, round: Round) {
+    assert_schedule_timeout(wrapper, Step::Propose, round);
     match wrapper.next_request() {
         Some(SMRequest::StartBuildProposal(r)) if r == round => {}
         other => panic!("expected StartBuildProposal({}), got {:?}", round, other),
@@ -896,4 +897,62 @@ fn prevote_nil_when_new_proposal_differs_from_locked_value() {
     wrapper.send_finished_validation(OTHER_PROPOSAL, round_1);
     // Should prevote nil (None) because proposal differs from locked value.
     assert_broadcast_prevote(&mut wrapper, round_1, None, *VALIDATOR_ID);
+}
+
+#[test]
+fn timeout_propose_unblocks_proposer_while_awaiting_finished_building() {
+    // Proposer in awaiting_finished_building receives TimeoutPropose; must advance to Prevote
+    // and broadcast nil, same as validator timeout. Build never returned.
+    let mut wrapper = TestWrapper::new(
+        *PROPOSER_ID,
+        4,
+        |_: Round| *PROPOSER_ID,
+        |_: Round| Ok(*PROPOSER_ID),
+        false,
+        QuorumType::Byzantine,
+    );
+    wrapper.start();
+    assert_start_build_proposal(&mut wrapper, ROUND);
+    assert_no_more_requests(&mut wrapper);
+
+    // Simulate build timeout: TimeoutPropose fires while still awaiting FinishedBuilding.
+    wrapper.send_timeout_propose(ROUND);
+    // Proposer advances to Prevote with nil, like a validator.
+    assert_broadcast_prevote(&mut wrapper, ROUND, None, *PROPOSER_ID);
+    assert_no_more_requests(&mut wrapper);
+
+    // awaiting_finished_building should be changed to false, so we can handle the received
+    // prevotes.
+    wrapper.send_prevote(None, ROUND);
+    wrapper.send_prevote(None, ROUND);
+    // Nil prevote quorum triggers ScheduleTimeout(Prevote) and nil precommit broadcast.
+    assert_schedule_timeout(&mut wrapper, Step::Prevote, ROUND);
+    assert_broadcast_precommit(&mut wrapper, ROUND, None, *PROPOSER_ID);
+    assert_no_more_requests(&mut wrapper);
+}
+
+#[test]
+fn timeout_propose_then_build_finishes() {
+    // TimeoutPropose fires first (build appeared to hang), then FinishedBuilding arrives late.
+    // Both must be processed; the late FinishedBuilding inserts the proposal without panic.
+    let mut wrapper = TestWrapper::new(
+        *PROPOSER_ID,
+        4,
+        |_: Round| *PROPOSER_ID,
+        |_: Round| Ok(*PROPOSER_ID),
+        false,
+        QuorumType::Byzantine,
+    );
+    wrapper.start();
+    assert_start_build_proposal(&mut wrapper, ROUND);
+    assert_no_more_requests(&mut wrapper);
+
+    // TimeoutPropose fires first (build timed out at consensus level).
+    wrapper.send_timeout_propose(ROUND);
+    assert_broadcast_prevote(&mut wrapper, ROUND, None, *PROPOSER_ID);
+    assert_no_more_requests(&mut wrapper);
+
+    // Build finishes late; must be processed without panic. Proposal is ignored.
+    wrapper.send_finished_building(PROPOSAL_ID, ROUND);
+    assert_no_more_requests(&mut wrapper);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core consensus event ordering and timeout behavior; mistakes could cause liveness issues or incorrect proposal handling under race conditions between build completion and `TimeoutPropose`. Changes are localized and covered by new tests for the key edge cases.
> 
> **Overview**
> Adds a consensus-level propose timeout for the **proposer build path**, ensuring the state machine can process `TimeoutPropose` even while `awaiting_finished_building` and advance by broadcasting a nil prevote.
> 
> Makes late/stale `FinishedBuilding` events **non-fatal** by filtering them in `SingleHeightConsensus` and defensively ignoring them in the `StateMachine`, and schedules `ScheduleTimeout(Step::Propose, round)` when starting proposal building. Updates tests to assert the new timeout scheduling and adds coverage for timeout-then-build and timeout-while-awaiting scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84dfce8af175705244e9e20f59cf8c7cc98c8aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->