### PR TITLE
deployment: improve grafana legends regex

### DIFF
--- a/deployments/monitoring/src/builders/dashboard_builder.py
+++ b/deployments/monitoring/src/builders/dashboard_builder.py
@@ -123,12 +123,22 @@ def create_grafana_panel(panel: dict, panel_id: int, y_position: int, x_position
 
 
 def remove_cluster_and_namespace_from_display_name():
+    # One label-set segment that can include quoted values (with escaped chars),
+    # so braces inside matcher regex strings do not terminate the segment early.
+    label_set_chunk = r'(?:[^{}"]|"(?:\\.|[^"\\])*")*'
+
     return {
         "id": "renameByRegex",
         "options": {
             # Remove 'cluster' and 'namespace' label from display name if it is a panel with
             # combined namespaces (meaning it contains 'cluster' but not 'location').
-            "regex": "^(.*)\{(?=[^}]*cluster)(?![^}]*location)[^}]*\}(.*)$",
+            "regex": (
+                rf"^(.*)\{{"
+                rf"(?={label_set_chunk}cluster)"
+                rf"(?!{label_set_chunk}location)"
+                rf"{label_set_chunk}"
+                rf"\}}(.*)$"
+            ),
             "renamePattern": "$1$2",
         },
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk string/regex adjustment limited to dashboard JSON generation, though it could slightly change legend renaming behavior if the new pattern matches differently.
> 
> **Overview**
> Improves the `renameByRegex` transformation used by `remove_cluster_and_namespace_from_display_name()` when generating Grafana panels by switching to a safer, chunked label-set matcher that tolerates quoted/escaped values.
> 
> This prevents braces inside quoted matcher/regex strings from prematurely ending the `{...}` match, making legend/display-name cleanup for combined-namespace panels more reliable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8d2f22011691d798d6ba47a6497b00baebb1cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->