### PR TITLE
starknet_committer: use read only storage if possible

### DIFF
--- a/crates/starknet_committer/src/db/facts_db/create_facts_tree.rs
+++ b/crates/starknet_committer/src/db/facts_db/create_facts_tree.rs
@@ -5,7 +5,7 @@ use starknet_patricia::patricia_merkle_tree::node_data::leaf::{Leaf, LeafModific
 use starknet_patricia::patricia_merkle_tree::original_skeleton_tree::tree::OriginalSkeletonTreeResult;
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
 use starknet_patricia_storage::db_object::HasStaticPrefix;
-use starknet_patricia_storage::storage_trait::Storage;
+use starknet_patricia_storage::storage_trait::ReadOnlyStorage;
 
 use crate::db::facts_db::FactsNodeLayout;
 use crate::db::trie_traversal::create_original_skeleton_tree;
@@ -19,7 +19,7 @@ pub mod create_facts_tree_test;
 /// Note that ATM, the Rust committer does not manage history and is not used for storage proofs;
 /// Thus, this function assumes facts layout.
 pub async fn get_leaves<'a, L: Leaf>(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     root_hash: HashOutput,
     sorted_leaf_indices: SortedLeafIndices<'a>,
     key_context: &<L as HasStaticPrefix>::KeyContext,

--- a/crates/starknet_committer/src/db/facts_db/traversal.rs
+++ b/crates/starknet_committer/src/db/facts_db/traversal.rs
@@ -10,7 +10,7 @@ use starknet_patricia::patricia_merkle_tree::node_data::leaf::Leaf;
 use starknet_patricia::patricia_merkle_tree::traversal::{SubTreeTrait, TraversalResult};
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
 use starknet_patricia_storage::db_object::HasStaticPrefix;
-use starknet_patricia_storage::storage_trait::Storage;
+use starknet_patricia_storage::storage_trait::ReadOnlyStorage;
 
 use crate::db::facts_db::types::FactsSubTree;
 use crate::db::facts_db::FactsNodeLayout;
@@ -25,7 +25,7 @@ pub mod traversal_test;
 /// If `leaves` is not `None`, it also fetches the modified leaves and inserts them into the
 /// provided map.
 pub async fn fetch_patricia_paths<L: Leaf>(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     root_hash: HashOutput,
     sorted_leaf_indices: SortedLeafIndices<'_>,
     leaves: Option<&mut HashMap<NodeIndex, L>>,
@@ -60,7 +60,7 @@ pub async fn fetch_patricia_paths<L: Leaf>(
 /// If `leaves` is not `None`, it also fetches the modified leaves and inserts them into the
 /// provided map.
 pub(crate) async fn fetch_patricia_paths_inner<'a, L: Leaf>(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     subtrees: Vec<FactsSubTree<'a>>,
     witnesses: &mut PreimageMap,
     mut leaves: Option<&mut HashMap<NodeIndex, L>>,

--- a/crates/starknet_committer/src/db/forest_trait.rs
+++ b/crates/starknet_committer/src/db/forest_trait.rs
@@ -16,6 +16,7 @@ use starknet_patricia_storage::storage_trait::{
     DbOperationMap,
     DbValue,
     PatriciaStorageResult,
+    ReadOnlyStorage,
     Storage,
 };
 
@@ -97,7 +98,7 @@ pub(crate) async fn read_forest<'a, S, Layout>(
     config: ReaderConfig,
 ) -> ForestResult<(OriginalSkeletonForest<'a>, HashMap<NodeIndex, ContractState>)>
 where
-    S: Storage,
+    S: ReadOnlyStorage,
     Layout: DbLayout,
 {
     let (contracts_trie, original_contracts_trie_leaves) =

--- a/crates/starknet_committer/src/db/trie_traversal.rs
+++ b/crates/starknet_committer/src/db/trie_traversal.rs
@@ -26,7 +26,7 @@ use starknet_patricia::patricia_merkle_tree::traversal::{
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
 use starknet_patricia_storage::db_object::{DBObject, EmptyKeyContext, HasStaticPrefix};
 use starknet_patricia_storage::errors::StorageError;
-use starknet_patricia_storage::storage_trait::{DbKey, Storage};
+use starknet_patricia_storage::storage_trait::{DbKey, ReadOnlyStorage};
 use tracing::warn;
 
 use crate::block_committer::input::{
@@ -57,7 +57,7 @@ macro_rules! log_trivial_modification {
 pub(crate) async fn fetch_nodes<'a, L, Layout>(
     skeleton_tree: &mut OriginalSkeletonTreeImpl<'a>,
     subtrees: Vec<Layout::SubTree>,
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     leaf_modifications: &LeafModifications<L>,
     config: &impl OriginalSkeletonTreeConfig,
     mut previous_leaves: Option<&mut HashMap<NodeIndex, L>>,
@@ -241,7 +241,7 @@ fn handle_child_subtree<'a, SubTree: SubTreeTrait<'a>>(
 // TODO(Aviv, 17/07/2024): Split between storage prefix implementation and function logic.
 pub async fn get_roots_from_storage<'a, L: Leaf, Layout: NodeLayout<'a, L>>(
     subtrees: &[Layout::SubTree],
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     key_context: &<L as HasStaticPrefix>::KeyContext,
 ) -> TraversalResult<Vec<FilledNode<L, Layout::NodeData>>> {
     let mut subtrees_roots = vec![];
@@ -293,7 +293,7 @@ pub(crate) fn log_warning_for_empty_leaves<L: Leaf, T: Borrow<NodeIndex> + Debug
 ///   fetching nodes from storage.
 /// - `leaf_modifications` and `previous_leaves`: Their leaf type `L` is constrained by `Layout`.
 pub async fn create_original_skeleton_tree<'a, L: Leaf, Layout: NodeLayout<'a, L>>(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     root_hash: HashOutput,
     sorted_leaf_indices: SortedLeafIndices<'a>,
     config: &impl OriginalSkeletonTreeConfig,
@@ -338,7 +338,7 @@ pub async fn create_original_skeleton_tree<'a, L: Leaf, Layout: NodeLayout<'a, L
 }
 
 pub async fn create_storage_tries<'a, Layout: NodeLayoutFor<StarknetStorageValue>>(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     actual_storage_updates: &HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
     original_contracts_trie_leaves: &HashMap<NodeIndex, ContractState>,
     config: &ReaderConfig,
@@ -380,7 +380,7 @@ where
 /// Creates the contracts trie original skeleton.
 /// Also returns the previous contracts state of the modified contracts.
 pub async fn create_contracts_trie<'a, Layout: NodeLayoutFor<ContractState>>(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     contracts_trie_root_hash: HashOutput,
     contracts_trie_sorted_indices: SortedLeafIndices<'a>,
 ) -> ForestResult<(OriginalSkeletonTreeImpl<'a>, HashMap<NodeIndex, ContractState>)>
@@ -408,7 +408,7 @@ where
 }
 
 pub async fn create_classes_trie<'a, Layout: NodeLayoutFor<CompiledClassHash>>(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     actual_classes_updates: &LeafModifications<CompiledClassHash>,
     classes_trie_root_hash: HashOutput,
     config: &ReaderConfig,

--- a/crates/starknet_committer/src/patricia_merkle_tree/tree.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/tree.rs
@@ -6,7 +6,7 @@ use starknet_patricia::patricia_merkle_tree::original_skeleton_tree::config::Ori
 use starknet_patricia::patricia_merkle_tree::traversal::TraversalResult;
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
 use starknet_patricia_storage::db_object::EmptyKeyContext;
-use starknet_patricia_storage::storage_trait::Storage;
+use starknet_patricia_storage::storage_trait::ReadOnlyStorage;
 
 use crate::block_committer::input::{
     contract_address_into_node_index,
@@ -55,7 +55,7 @@ impl OriginalSkeletonTreeConfig for OriginalSkeletonTrieConfig {
 /// Assumption: `contract_sorted_leaf_indices` contains all `contract_storage_sorted_leaf_indices`
 /// keys.
 async fn fetch_all_patricia_paths(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     classes_trie_root_hash: HashOutput,
     contracts_trie_root_hash: HashOutput,
     class_sorted_leaf_indices: SortedLeafIndices<'_>,
@@ -163,7 +163,7 @@ async fn fetch_all_patricia_paths(
 /// and contracts storage tries for both the previous and new root hashes.
 /// Fetch the leaves in the contracts trie only, to be able to get the storage root hashes.
 pub async fn fetch_previous_and_new_patricia_paths(
-    storage: &mut impl Storage,
+    storage: &mut impl ReadOnlyStorage,
     classes_trie_root_hashes: RootHashes,
     contracts_trie_root_hashes: RootHashes,
     class_hashes: &[ClassHash],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly a trait-bound refactor, but it touches multiple core trie/forest read APIs; any mismatch in storage trait implementations or call sites could cause compile/runtime integration issues.
> 
> **Overview**
> Updates the committer’s **read-only trie/forest traversal APIs** to require `ReadOnlyStorage` instead of full `Storage`, including skeleton-tree creation (`create_original_skeleton_tree`, `fetch_nodes`, `get_roots_from_storage`), facts DB leaf/path fetching, and Patricia proof generation.
> 
> `read_forest` is similarly tightened to accept read-only storage, reducing required capabilities for callers and clarifying that these code paths do not perform writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db46d8d95dba289ec392f88622a63f9140ccdde0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->