### PR TITLE
starknet_patricia_storage: introduce immutable read only storage

### DIFF
--- a/crates/starknet_patricia_storage/src/aerospike_storage.rs
+++ b/crates/starknet_patricia_storage/src/aerospike_storage.rs
@@ -33,6 +33,7 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    ImmutableReadOnlyStorage,
     NoStats,
     PatriciaStorageResult,
     ReadOnlyStorage,
@@ -129,8 +130,8 @@ impl AerospikeStorage {
     }
 }
 
-impl ReadOnlyStorage for AerospikeStorage {
-    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+impl ImmutableReadOnlyStorage for AerospikeStorage {
+    async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         let record = self
             .client
             .get(&self.config.read_policy, &self.get_key(key.clone())?, Bins::All)
@@ -138,7 +139,7 @@ impl ReadOnlyStorage for AerospikeStorage {
         self.extract_value(&record)
     }
 
-    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         let mut ops = Vec::new();
         for key in keys.iter() {
             ops.push(BatchOperation::read(
@@ -160,6 +161,16 @@ impl ReadOnlyStorage for AerospikeStorage {
                 },
             })
             .collect::<Result<_, _>>()
+    }
+}
+
+impl ReadOnlyStorage for AerospikeStorage {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+        ImmutableReadOnlyStorage::get(self, key).await
+    }
+
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+        ImmutableReadOnlyStorage::mget(self, keys).await
     }
 }
 

--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -16,6 +16,7 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    ImmutableReadOnlyStorage,
     NoStats,
     NullStorage,
     PatriciaStorageResult,
@@ -36,13 +37,23 @@ pub struct BorrowedStorage<'a, S: Storage> {
     pub storage: &'a mut S,
 }
 
-impl ReadOnlyStorage for MapStorage {
-    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+impl ImmutableReadOnlyStorage for MapStorage {
+    async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(self.0.get(key).cloned())
     }
 
-    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         Ok(keys.iter().map(|key| self.0.get(key).cloned()).collect())
+    }
+}
+
+impl ReadOnlyStorage for MapStorage {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+        ImmutableReadOnlyStorage::get(self, key).await
+    }
+
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+        ImmutableReadOnlyStorage::mget(self, keys).await
     }
 }
 

--- a/crates/starknet_patricia_storage/src/mdbx_storage.rs
+++ b/crates/starknet_patricia_storage/src/mdbx_storage.rs
@@ -22,6 +22,7 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    ImmutableReadOnlyStorage,
     PatriciaStorageResult,
     ReadOnlyStorage,
     Storage,
@@ -104,14 +105,14 @@ impl MdbxStorage {
     }
 }
 
-impl ReadOnlyStorage for MdbxStorage {
-    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+impl ImmutableReadOnlyStorage for MdbxStorage {
+    async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         let txn = self.db.begin_ro_txn()?;
         let table = txn.open_table(None)?;
         Ok(txn.get(&table, &key.0)?.map(DbValue))
     }
 
-    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         let txn = self.db.begin_ro_txn()?;
         let table = txn.open_table(None)?;
         let mut res = Vec::with_capacity(keys.len());
@@ -119,6 +120,16 @@ impl ReadOnlyStorage for MdbxStorage {
             res.push(txn.get(&table, &key.0)?.map(DbValue));
         }
         Ok(res)
+    }
+}
+
+impl ReadOnlyStorage for MdbxStorage {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+        ImmutableReadOnlyStorage::get(self, key).await
+    }
+
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+        ImmutableReadOnlyStorage::mget(self, keys).await
     }
 }
 

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -26,6 +26,7 @@ use crate::storage_trait::{
     DbOperation,
     DbOperationMap,
     DbValue,
+    ImmutableReadOnlyStorage,
     PatriciaStorageError,
     PatriciaStorageResult,
     ReadOnlyStorage,
@@ -276,12 +277,12 @@ impl StorageStats for RocksDbStats {
     }
 }
 
-impl ReadOnlyStorage for RocksDbStorage {
-    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+impl ImmutableReadOnlyStorage for RocksDbStorage {
+    async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(self.db.get(&key.0)?.map(DbValue))
     }
 
-    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         let raw_keys = keys.iter().map(|k| &k.0);
         let res = self
             .db
@@ -290,6 +291,16 @@ impl ReadOnlyStorage for RocksDbStorage {
             .map(|r| r.map(|opt| opt.map(DbValue)))
             .collect::<Result<_, _>>()?;
         Ok(res)
+    }
+}
+
+impl ReadOnlyStorage for RocksDbStorage {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+        ImmutableReadOnlyStorage::get(self, key).await
+    }
+
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+        ImmutableReadOnlyStorage::mget(self, keys).await
     }
 }
 

--- a/crates/starknet_patricia_storage/src/short_key_storage.rs
+++ b/crates/starknet_patricia_storage/src/short_key_storage.rs
@@ -10,6 +10,7 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    ImmutableReadOnlyStorage,
     PatriciaStorageResult,
     ReadOnlyStorage,
     Storage,
@@ -48,17 +49,36 @@ macro_rules! define_short_key_storage {
             }
         }
 
+        impl<S: Storage + ImmutableReadOnlyStorage> ImmutableReadOnlyStorage for $name<S> {
+            async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+                self.storage.get(&Self::small_key(key)).await
+            }
+
+            async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+                let small_keys = keys
+                    .iter()
+                    .map(|key| Self::small_key(key))
+                    .collect::<Vec<_>>();
+                self.storage.mget(small_keys.iter().collect::<Vec<&DbKey>>().as_slice()).await
+            }
+        }
+
         impl<S: Storage> ReadOnlyStorage for $name<S> {
             async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
                 self.storage.get_mut(&Self::small_key(key)).await
             }
 
-            async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+            async fn mget_mut(
+                &mut self,
+                keys: &[&DbKey],
+            ) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
                 let small_keys = keys
                     .iter()
                     .map(|key| Self::small_key(key))
                     .collect::<Vec<_>>();
-                self.storage.mget_mut(small_keys.iter().collect::<Vec<&DbKey>>().as_slice()).await
+                self.storage
+                    .mget_mut(small_keys.iter().collect::<Vec<&DbKey>>().as_slice())
+                    .await
             }
         }
 

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -100,6 +100,23 @@ pub trait StorageConfigTrait:
 {
 }
 
+/// A read-only view of a storage that does not require mutable access.
+/// Allows concurrent reads from multiple threads.
+pub trait ImmutableReadOnlyStorage: Send + Sync {
+    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
+    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
+    // for details.
+    fn get(
+        &self,
+        key: &DbKey,
+    ) -> impl Future<Output = PatriciaStorageResult<Option<DbValue>>> + Send;
+
+    fn mget(
+        &self,
+        keys: &[&DbKey],
+    ) -> impl Future<Output = PatriciaStorageResult<Vec<Option<DbValue>>>> + Send;
+}
+
 /// A read-only view of a storage. Does not assume concurrent access is possible.
 pub trait ReadOnlyStorage: Send + Sync {
     /// Returns value from storage, if it exists.
@@ -202,13 +219,23 @@ impl StorageConfigTrait for EmptyStorageConfig {}
 #[derive(Clone)]
 pub struct NullStorage;
 
-impl ReadOnlyStorage for NullStorage {
-    async fn get_mut(&mut self, _key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+impl ImmutableReadOnlyStorage for NullStorage {
+    async fn get(&self, _key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(None)
     }
 
-    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         Ok(vec![None; keys.len()])
+    }
+}
+
+impl ReadOnlyStorage for NullStorage {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+        ImmutableReadOnlyStorage::get(self, key).await
+    }
+
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+        ImmutableReadOnlyStorage::mget(self, keys).await
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new read-only trait and rewires multiple storage backends to use it, which could subtly affect call sites and concurrency assumptions despite keeping the existing `ReadOnlyStorage` API via delegation.
> 
> **Overview**
> Adds **`ImmutableReadOnlyStorage`** (new `get`/`mget` methods on `&self`) to enable read operations without requiring `&mut self`, supporting safer concurrent reads.
> 
> Updates Aerospike, RocksDB, MDBX, in-memory `MapStorage`, `NullStorage`, and the `ShortKeyStorage*` wrapper to implement the new trait, and refactors their existing `ReadOnlyStorage` implementations to delegate `get_mut`/`mget_mut` to `ImmutableReadOnlyStorage` where possible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1543cbb6769367b49562f1f35522dbdbbf8c84ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->