### PR TITLE
starknet_patricia_storage: immutable read for cached storage

### DIFF
--- a/crates/starknet_committer_cli/src/args.rs
+++ b/crates/starknet_committer_cli/src/args.rs
@@ -14,7 +14,11 @@ use starknet_patricia_storage::map_storage::{CachedStorage, CachedStorageConfig,
 use starknet_patricia_storage::mdbx_storage::MdbxStorage;
 use starknet_patricia_storage::rocksdb_storage::{RocksDbStorage, RocksDbStorageConfig};
 use starknet_patricia_storage::short_key_storage::ShortKeySize;
-use starknet_patricia_storage::storage_trait::{EmptyStorageConfig, Storage};
+use starknet_patricia_storage::storage_trait::{
+    EmptyStorageConfig,
+    ImmutableReadOnlyStorage,
+    Storage,
+};
 
 use crate::commands::run_storage_benchmark_wrapper;
 
@@ -225,6 +229,8 @@ pub struct CachedStorageArgs<InnerStorageArgs: StorageFromArgs> {
 #[async_trait]
 impl<InnerStorageArgs: StorageFromArgs + Sync> StorageFromArgs
     for CachedStorageArgs<InnerStorageArgs>
+where
+    InnerStorageArgs::Storage: ImmutableReadOnlyStorage,
 {
     type Storage = CachedStorage<InnerStorageArgs::Storage>;
 

--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -258,6 +258,50 @@ impl<S: Storage> CachedStorage<S> {
     }
 }
 
+/// [ImmutableReadOnlyStorage] implementation for [CachedStorage].
+/// Uses [LruCache::peek] to fetch the value from the immutable cache, this doesn't update the cache
+/// internal state.
+/// Stats are being updated using atomic counters.
+impl<S: Storage + ImmutableReadOnlyStorage> ImmutableReadOnlyStorage for CachedStorage<S> {
+    async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        if let Some(cached_value) = self.cache.peek(key) {
+            self.cached_reads.fetch_add(1, Ordering::Relaxed);
+            return Ok(cached_value.clone());
+        }
+        self.storage.get(key).await
+    }
+
+    async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+        let mut values = vec![None; keys.len()];
+        let mut keys_to_fetch = Vec::new();
+        let mut indices_to_fetch = Vec::new();
+
+        for (index, key) in keys.iter().enumerate() {
+            if let Some(cached_value) = self.cache.peek(key) {
+                values[index] = cached_value.clone();
+            } else {
+                keys_to_fetch.push(*key);
+                indices_to_fetch.push(index);
+            }
+        }
+
+        let n_keys = u64::try_from(keys.len()).expect("keys length should fit in u64");
+        let cached_reads =
+            u64::try_from(keys.len() - keys_to_fetch.len()).expect("usize should fit in u64");
+        self.reads.fetch_add(n_keys, Ordering::Relaxed);
+        self.cached_reads.fetch_add(cached_reads, Ordering::Relaxed);
+
+        let fetched_values = self.storage.mget(keys_to_fetch.as_slice()).await?;
+        indices_to_fetch.iter().zip(fetched_values).for_each(|(index, value)| {
+            values[*index] = value;
+        });
+
+        Ok(values)
+    }
+}
+
+// TODO(Nimrod): Find a way to share the implementation with `ImmutableReadOnlyStorage`.
 impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         self.reads.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new read path for `CachedStorage` that is used under immutable/concurrent access and changes trait bounds in the CLI; mistakes could cause stale/missing cache hits or incorrect stats under concurrency.
> 
> **Overview**
> `CachedStorage` now implements `ImmutableReadOnlyStorage`, enabling read-only concurrent access without mutating LRU state by using `LruCache::peek` for `get`/`mget` while still updating read/cache-hit counters atomically.
> 
> The committer CLI’s `CachedStorageArgs` wrapper now requires the inner storage to implement `ImmutableReadOnlyStorage`, ensuring cached wrappers are only constructed for backends that support immutable reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028073d717e4312780af29dc8dc1146b1590565e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->