### PR TITLE
starknet_patricia_storage: immutable read only self method for storage trait

### DIFF
--- a/crates/starknet_patricia_storage/src/aerospike_storage.rs
+++ b/crates/starknet_patricia_storage/src/aerospike_storage.rs
@@ -164,6 +164,10 @@ impl ReadOnlyStorage for AerospikeStorage {
     async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         ImmutableReadOnlyStorage::mget(self, keys).await
     }
+
+    fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage> {
+        Some(self)
+    }
 }
 
 impl Storage for AerospikeStorage {

--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -54,6 +54,10 @@ impl ReadOnlyStorage for MapStorage {
     async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         ImmutableReadOnlyStorage::mget(self, keys).await
     }
+
+    fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage> {
+        Some(self)
+    }
 }
 
 impl Storage for MapStorage {
@@ -280,7 +284,7 @@ impl<S: Storage + ImmutableReadOnlyStorage> ImmutableReadOnlyStorage for CachedS
 }
 
 // TODO(Nimrod): Find a way to share the implementation with `ImmutableReadOnlyStorage`.
-impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
+impl<S: Storage + ImmutableReadOnlyStorage> ReadOnlyStorage for CachedStorage<S> {
     async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         self.reads.fetch_add(1, Ordering::Relaxed);
         if let Some(cached_value) = self.cache.get(key) {
@@ -322,6 +326,10 @@ impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
         );
 
         Ok(values)
+    }
+
+    fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage> {
+        Some(self)
     }
 }
 

--- a/crates/starknet_patricia_storage/src/mdbx_storage.rs
+++ b/crates/starknet_patricia_storage/src/mdbx_storage.rs
@@ -126,6 +126,10 @@ impl ReadOnlyStorage for MdbxStorage {
     async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         ImmutableReadOnlyStorage::mget(self, keys).await
     }
+
+    fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage> {
+        Some(self)
+    }
 }
 
 impl Storage for MdbxStorage {

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -300,6 +300,10 @@ impl ReadOnlyStorage for RocksDbStorage {
     async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         ImmutableReadOnlyStorage::mget(self, keys).await
     }
+
+    fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage> {
+        Some(self)
+    }
 }
 
 impl Storage for RocksDbStorage {

--- a/crates/starknet_patricia_storage/src/short_key_storage.rs
+++ b/crates/starknet_patricia_storage/src/short_key_storage.rs
@@ -10,6 +10,7 @@ use crate::storage_trait::{
     DbValue,
     EmptyStorageConfig,
     ImmutableReadOnlyStorage,
+    NullStorage,
     PatriciaStorageResult,
     ReadOnlyStorage,
     Storage,
@@ -73,6 +74,10 @@ macro_rules! define_short_key_storage {
                     .map(|key| Self::small_key(key))
                     .collect::<Vec<_>>();
                 self.storage.mget(small_keys.iter().collect::<Vec<&DbKey>>().as_slice()).await
+            }
+
+            fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage> {
+                None::<&NullStorage>
             }
         }
 

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -131,6 +131,9 @@ pub trait ReadOnlyStorage: Send {
         &mut self,
         keys: &[&DbKey],
     ) -> impl Future<Output = PatriciaStorageResult<Vec<Option<DbValue>>>> + Send;
+
+    /// If the storage supports immutable reads, returns an immutable reference to the storage.
+    fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage>;
 }
 
 /// A trait for the storage. Extends [ReadOnlyStorage] with write operations.
@@ -219,6 +222,10 @@ impl ReadOnlyStorage for NullStorage {
 
     async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         ImmutableReadOnlyStorage::mget(self, keys).await
+    }
+
+    fn get_immutable_read_only_self(&self) -> Option<&impl ImmutableReadOnlyStorage> {
+        Some(self)
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Public trait API changes (`ReadOnlyStorage`) and tighter generic bounds on `CachedStorage` may require downstream updates and could alter which storage wrappers qualify for cached reads, though runtime behavior is largely unchanged.
> 
> **Overview**
> Adds `ReadOnlyStorage::get_immutable_read_only_self()` to optionally expose an `ImmutableReadOnlyStorage` view for implementations that support concurrent immutable reads.
> 
> Updates all concrete storages (`AerospikeStorage`, `MapStorage`, `MdbxStorage`, `RocksDbStorage`, `NullStorage`) to return `Some(self)`, while `ShortKeyStorage` returns `None`, and tightens `CachedStorage`’s `ReadOnlyStorage` impl to require the inner storage also implement `ImmutableReadOnlyStorage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 162c007bc9a2fda1f39f7974e3e1af3578eff4f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->