### PR TITLE
starknet_patricia_storage: define reads collector storage

### DIFF
--- a/crates/starknet_patricia_storage/src/lib.rs
+++ b/crates/starknet_patricia_storage/src/lib.rs
@@ -7,6 +7,7 @@ pub mod map_storage;
 pub mod map_storage_test;
 #[cfg(any(test, feature = "mdbx_storage"))]
 pub mod mdbx_storage;
+pub mod reads_collector_storage;
 #[cfg(any(test, feature = "rocksdb_storage"))]
 pub mod rocksdb_storage;
 #[cfg(feature = "short_key_storage")]

--- a/crates/starknet_patricia_storage/src/reads_collector_storage.rs
+++ b/crates/starknet_patricia_storage/src/reads_collector_storage.rs
@@ -1,0 +1,46 @@
+use crate::storage_trait::{
+    DbHashMap,
+    DbKey,
+    DbValue,
+    ImmutableReadOnlyStorage,
+    PatriciaStorageResult,
+    ReadOnlyStorage,
+};
+
+/// Wraps an [ImmutableReadOnlyStorage] reference and collects all reads performed through it.
+/// The collected reads can be retrieved via [Self::into_reads].
+pub struct ReadsCollectorStorage<'a, S: ImmutableReadOnlyStorage> {
+    storage: &'a S,
+    reads: DbHashMap,
+}
+
+impl<'a, S: ImmutableReadOnlyStorage> ReadsCollectorStorage<'a, S> {
+    pub fn new(storage: &'a S) -> Self {
+        Self { storage, reads: DbHashMap::new() }
+    }
+
+    /// Consumes the collector and returns all reads performed through it.
+    pub fn into_reads(self) -> DbHashMap {
+        self.reads
+    }
+}
+
+impl<'a, S: ImmutableReadOnlyStorage> ReadOnlyStorage for ReadsCollectorStorage<'a, S> {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+        let value = self.storage.get(key).await?;
+        if let Some(ref v) = value {
+            self.reads.insert(key.clone(), v.clone());
+        }
+        Ok(value)
+    }
+
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+        let values = self.storage.mget(keys).await?;
+        for (key, value) in keys.iter().zip(values.iter()) {
+            if let Some(v) = value {
+                self.reads.insert((*key).clone(), v.clone());
+            }
+        }
+        Ok(values)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk additive change that introduces a wrapper to record `get`/`mget` results; no existing storage implementations or read paths are modified unless they opt into using it.
> 
> **Overview**
> Adds a new `ReadsCollectorStorage` wrapper that implements `ReadOnlyStorage` over an `ImmutableReadOnlyStorage`, recording all successfully-read key/value pairs during `get_mut` and `mget_mut` calls and exposing them via `into_reads`.
> 
> Exports the new module from `starknet_patricia_storage` so other crates can wrap a storage to capture read sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e563c4b1866c7a88be49e34e0bffb071fb7347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->