### PR TITLE
add missing mempool and core ports for the deploy all private script

### DIFF
--- a/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/core.yaml
@@ -20,7 +20,7 @@ config:
     batcher_config.static_config.contract_class_manager_config.native_compiler_config.max_cpu_time: 600
     batcher_config.static_config.storage_reader_server_static_config.port: 55011
     class_manager_config.static_config.class_manager_config.max_compiled_contract_class_object_size: 4089446
-    class_manager_config.static_config.class_storage_config.storage_reader_server_static_config.port: 8091
+    class_manager_config.static_config.class_storage_config.storage_reader_server_static_config.port: 55210
     components.batcher.port: 55000
     components.batcher.url: sequencer-core-service
     components.class_manager.port: 55001

--- a/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/core.yaml
@@ -105,6 +105,10 @@ service:
     port: 55012
     targetPort: 55012
     protocol: TCP
+  - name: class-manager-storage-reader
+    port: 55210
+    targetPort: 55210
+    protocol: TCP
 
 statefulSet:
   enabled: true

--- a/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/mempool.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/mempool.yaml
@@ -29,3 +29,7 @@ service:
     port: 55006
     targetPort: 55006
     protocol: TCP
+  - name: mempool-p2p-config
+    port: 53200
+    targetPort: 53200
+    protocol: TCP


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk config-only change, but incorrect port mappings could break intra-cluster connectivity for the class storage reader or mempool P2P in the hybrid testing deployment.
> 
> **Overview**
> Updates the hybrid testing `node-0` service configs to expose missing ports needed for deployment.
> 
> In `core.yaml`, changes the class storage reader port to `55210` and adds a corresponding `class-manager-storage-reader` Service port. In `mempool.yaml`, adds a Service port for the mempool P2P listener (`53200`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a2dc7a6fc2660672a7a246bff42c1ac95ee41ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->