### PR TITLE
apollo_propeller: track items dropped from engine TTL cache

### DIFF
--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -356,7 +356,11 @@ impl Engine {
 
                 // Mark as finalized
                 let message_key = MessageKey { committee_id, publisher, root: message_root };
-                self.finalized_messages.insert(message_key);
+                let expired_keys = self.finalized_messages.insert_and_get_expired(message_key);
+
+                if !expired_keys.is_empty() {
+                    trace!(?expired_keys, "[ENGINE] Removed expired messages from TTL cache");
+                }
 
                 // Clean up task handles
                 if self.message_to_unit_tx.remove(&message_key).is_some() {

--- a/crates/apollo_propeller/src/time_cache.rs
+++ b/crates/apollo_propeller/src/time_cache.rs
@@ -45,11 +45,13 @@ where
     /// Insert a key into the cache with the current timestamp.
     ///
     /// This also performs cleanup of expired entries from the front of the queue.
-    pub fn insert(&mut self, key: K) {
+    /// Returns the keys that were expired.
+    pub fn insert_and_get_expired(&mut self, key: K) -> Vec<K> {
         let now = Instant::now();
-        self.evict_expired(now);
+        let expired_keys = self.evict_expired(now);
         self.key_to_last_insert_time.insert(key.clone(), now);
         self.insertion_ordered_queue.push_back((now, key));
+        expired_keys
     }
 
     /// Return the number of entries in the cache, including expired entries that haven't been
@@ -58,8 +60,10 @@ where
         self.key_to_last_insert_time.len()
     }
 
-    /// Evict expired entries from the front of the insertion-order queue.
-    fn evict_expired(&mut self, now: Instant) {
+    /// Evict expired entries from the front of the insertion-order queue. Return the keys that were
+    /// expired.
+    fn evict_expired(&mut self, now: Instant) -> Vec<K> {
+        let mut expired_keys = Vec::new();
         while let Some(&(inserted_at, _)) = self.insertion_ordered_queue.front() {
             if now.duration_since(inserted_at) < self.ttl {
                 break;
@@ -70,7 +74,9 @@ where
             // (expired) timestamp; otherwise the key is still alive under its later insertion.
             if self.key_to_last_insert_time.get(&key) == Some(&expired_at) {
                 self.key_to_last_insert_time.remove(&key);
+                expired_keys.push(key);
             }
         }
+        expired_keys
     }
 }

--- a/crates/apollo_propeller/src/time_cache_test.rs
+++ b/crates/apollo_propeller/src/time_cache_test.rs
@@ -9,6 +9,7 @@ const PAST_EXPIRATION: Duration = Duration::from_millis(TTL_MS + 50);
 const KEY1: &str = "key1";
 const KEY2: &str = "key2";
 const KEY3: &str = "key3";
+const KEY4: &str = "key4";
 
 #[tokio::test]
 async fn test_time_cache_basic() {
@@ -16,7 +17,8 @@ async fn test_time_cache_basic() {
 
     let mut cache = TimeCache::new(TTL);
 
-    cache.insert(KEY1);
+    let expired = cache.insert_and_get_expired(KEY1);
+    assert!(expired.is_empty());
     assert!(cache.contains(&KEY1));
     assert!(!cache.contains(&KEY2));
 
@@ -30,8 +32,8 @@ async fn test_time_cache_cleanup() {
 
     let mut cache = TimeCache::new(TTL);
 
-    cache.insert(KEY1);
-    cache.insert(KEY2);
+    assert!(cache.insert_and_get_expired(KEY1).is_empty());
+    assert!(cache.insert_and_get_expired(KEY2).is_empty());
     assert!(cache.contains(&KEY1));
     assert!(cache.contains(&KEY2));
 
@@ -43,7 +45,9 @@ async fn test_time_cache_cleanup() {
     assert_eq!(cache.capacity(), 2);
 
     // Insert triggers cleanup of expired entries.
-    cache.insert(KEY3);
+    let mut expired = cache.insert_and_get_expired(KEY3);
+    expired.sort();
+    assert_eq!(expired, vec![KEY1, KEY2]);
     assert!(cache.contains(&KEY3));
     assert!(!cache.contains(&KEY1));
     assert!(!cache.contains(&KEY2));
@@ -56,17 +60,52 @@ async fn test_time_cache_reinsert_refreshes_expiration() {
 
     let mut cache = TimeCache::new(TTL);
 
-    cache.insert(KEY1);
+    assert!(cache.insert_and_get_expired(KEY1).is_empty());
 
     tokio::time::advance(THREE_QUARTER_TTL).await;
-    cache.insert(KEY1);
+    assert!(cache.insert_and_get_expired(KEY1).is_empty());
 
     tokio::time::advance(THREE_QUARTER_TTL).await;
     assert!(cache.contains(&KEY1));
 
     // Inserting KEY2 triggers eviction of the stale KEY1 queue entry; verify KEY1 survives
-    // because its refreshed timestamp is still within the TTL.
-    cache.insert(KEY2);
+    // because its refreshed timestamp is still within the TTL, and is NOT among the expired keys.
+    let expired = cache.insert_and_get_expired(KEY2);
+    assert!(expired.is_empty());
     assert!(cache.contains(&KEY1));
     assert!(cache.contains(&KEY2));
+}
+
+#[tokio::test]
+async fn test_reinserted_key_expires_after_refreshed_ttl() {
+    tokio::time::pause();
+
+    let mut cache = TimeCache::new(TTL);
+
+    assert!(cache.insert_and_get_expired(KEY1).is_empty());
+    assert!(cache.insert_and_get_expired(KEY2).is_empty());
+
+    tokio::time::advance(THREE_QUARTER_TTL).await;
+    // Re-insert KEY1, refreshing its TTL.
+    // KEY2 is not re-inserted so it will expire after next advance.
+    assert!(cache.insert_and_get_expired(KEY1).is_empty());
+
+    // Advance past the original TTL — KEY2 expires, KEY1's refreshed entry is still alive.
+    tokio::time::advance(THREE_QUARTER_TTL).await;
+
+    // Insert KEY3 to trigger eviction. Only KEY2 should be expired.
+    let expired = cache.insert_and_get_expired(KEY3);
+    assert_eq!(expired, vec![KEY2]);
+    assert!(cache.contains(&KEY1));
+    assert!(!cache.contains(&KEY2));
+    assert!(cache.contains(&KEY3));
+
+    // Advance past KEY1's refreshed TTL.
+    tokio::time::advance(THREE_QUARTER_TTL).await;
+
+    // Insert again to trigger eviction of KEY1.
+    let expired = cache.insert_and_get_expired(KEY4);
+    assert_eq!(expired, vec![KEY1]);
+    assert!(!cache.contains(&KEY1));
+    assert!(cache.contains(&KEY3));
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small API change confined to the in-crate `TimeCache` and a logging-only integration in the engine; behavior is otherwise unchanged aside from exposing which entries were lazily evicted.
> 
> **Overview**
> The TTL `TimeCache` now returns the list of keys evicted during lazy expiration via `insert_and_get_expired`, enabling callers to observe which entries were dropped.
> 
> `Engine` uses this new API when marking messages finalized, and emits a `trace!` log when old finalized-message IDs are purged from the TTL cache. Tests were updated to the new API and a new test was added to validate eviction behavior when a key is re-inserted (TTL refresh) and later expires.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eb9d85ed55811906c5d3fe341d1fb6778fb80eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->