### PR TITLE
apollo_propeller: rename finalized_messages to messages_to_ignore_shards_from

### DIFF
--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -85,8 +85,8 @@ pub struct Engine {
     // exhaustion.
     /// Registry of per-message unit senders to their message processors.
     message_to_unit_tx: HashMap<MessageKey, mpsc::UnboundedSender<UnitToValidate>>,
-    /// Recently finalized message IDs (for deduplication).
-    finalized_messages: TimeCache<MessageKey>,
+    /// Messages that have already been encountered and processed (for deduplication).
+    messages_to_ignore_shards_from: TimeCache<MessageKey>,
     /// Receiver for messages from state manager tasks.
     state_manager_rx: mpsc::UnboundedReceiver<EventStateManagerToEngine>,
     state_manager_tx: mpsc::UnboundedSender<EventStateManagerToEngine>,
@@ -110,7 +110,7 @@ impl Engine {
         let (state_manager_tx, state_manager_rx) = mpsc::unbounded_channel();
         let (broadcaster_results_tx, broadcaster_results_rx) = mpsc::unbounded_channel();
 
-        let finalized_messages = TimeCache::new(config.stale_message_timeout);
+        let messages_to_ignore_shards_from = TimeCache::new(config.stale_message_timeout);
 
         Self {
             committees: HashMap::new(),
@@ -119,7 +119,7 @@ impl Engine {
             keypair,
             local_peer_id,
             message_to_unit_tx: HashMap::new(),
-            finalized_messages,
+            messages_to_ignore_shards_from,
             state_manager_rx,
             state_manager_tx,
             prepared_units_rx: broadcaster_results_rx,
@@ -237,7 +237,7 @@ impl Engine {
 
         // TODO(guyn): Add timestamps to message key to avoid replay attacks or issues with very
         // late shards.
-        if self.finalized_messages.contains(&message_key) {
+        if self.messages_to_ignore_shards_from.contains(&message_key) {
             trace!("Message already finalized, dropping unit");
             return;
         }
@@ -356,7 +356,8 @@ impl Engine {
 
                 // Mark as finalized
                 let message_key = MessageKey { committee_id, publisher, root: message_root };
-                let expired_keys = self.finalized_messages.insert_and_get_expired(message_key);
+                let expired_keys =
+                    self.messages_to_ignore_shards_from.insert_and_get_expired(message_key);
 
                 if !expired_keys.is_empty() {
                     trace!(?expired_keys, "[ENGINE] Removed expired messages from TTL cache");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pure rename of an internal deduplication cache field and its uses; no behavioral changes expected aside from clearer intent.
> 
> **Overview**
> Renames the engine’s TTL deduplication cache from `finalized_messages` to `messages_to_ignore_shards_from`, updating initialization and all call sites where finalized messages are recorded and checked before processing incoming shards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 996cdd6ff063bcb573c6e3627358eeffdf64f6a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->