### PR TITLE
add section on american english vs british english

### DIFF
--- a/style.md
+++ b/style.md
@@ -478,6 +478,12 @@ let Some(num) = foo else {
 derp(num)
 ```
 
+### American English
+
+Prefer American English spelling over British English in all code components: identifiers, comments, log messages, error messages, etc. For example, use `serialize` (not `serialise`), `initialize` (not `initialise`), `canceled` (not `cancelled`).
+
+If a 3rd-party crate or API uses British English spelling, maintain that spelling when referring to its types, functions, or fields.
+
 ### Associated Functions
 
 All associated functions should depend on `Self`. Associated functions that don't should be free functions.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change to `style.md` with no impact on runtime behavior or APIs.
> 
> **Overview**
> Adds a new **American English** guideline to `style.md`, standardizing on American spellings in identifiers, comments, logs, and error messages, with an exception to preserve 3rd-party API spelling when referencing external types/fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21bf85745fd6d369668a79d8dfd6608bef86f95e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->