### PR TITLE
add section advocating to use Self

### DIFF
--- a/style.md
+++ b/style.md
@@ -484,6 +484,26 @@ Prefer American English spelling over British English in all code components: id
 
 If a 3rd-party crate or API uses British English spelling, maintain that spelling when referring to its types, functions, or fields.
 
+### Self-referencing in methods
+
+Inside `impl` blocks, prefer using `Self` instead of repeating the concrete type name.
+
+```rust
+// BAD
+impl Foo {
+    fn new() -> Foo {
+        Foo { bar: 0 }
+    }
+}
+
+// GOOD
+impl Foo {
+    fn new() -> Self {
+        Self { bar: 0 }
+    }
+}
+```
+
 ### Associated Functions
 
 All associated functions should depend on `Self`. Associated functions that don't should be free functions.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates coding conventions without affecting runtime behavior or APIs.
> 
> **Overview**
> Adds a new Rust style guide section recommending using `Self` within `impl` blocks (e.g., return types and struct construction) instead of repeating the concrete type name, with a small BAD/GOOD example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62f52ce18f73455db012cdbd7320cf15a2861306. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->