### PR TITLE
add instruction that TODOs should have an owner

### DIFF
--- a/style.md
+++ b/style.md
@@ -395,6 +395,9 @@ Don't use abbreviations: use `cannot` (rather than `can't`), `transaction` (rath
 
 In all comment types (including inline comments!) start comments with a capital letter and end with a dot.
 
+When writing a TODO comment, always add an owner for that TODO inside the comment.
+If it's not you, make sure the owner is aware of the TODO
+
 ### Textual Content Quality
 
 All textual content, including code-comments, commit messages, `expect` messages (see also [Assertions](#assertions) section), should include _additional_ information not readily observable in the surrounding code. Take extra care when using AI-generated code, which tends to include a lot of trivial comment-bloat.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Updates `style.md` to require that `TODO` comments include an explicit owner (and to ensure the owner is aware if it’s someone else).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 057c933e61f3a140046fb433c304e1060025f696. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->