### PR TITLE
add logging section

### DIFF
--- a/style.md
+++ b/style.md
@@ -324,11 +324,11 @@ Every piece of information that can help debug a specific flow or be useful to k
 
 ### Logging Levels
 
-- **ERROR**: An unexpected condition that prevents the system from functioning correctly. Requires immediate attention.
+- **ERROR**: An unexpected condition that requires immediate attention.
 - **WARN**: A potentially harmful situation that the system can recover from, but that may indicate a problem.
-- **INFO**: High-level events that confirm the system is working as expected, or help convey the current state of the system.
+- **INFO**: High-level events that help convey the current state of the system or confirm it is working as expected.
 - **DEBUG**: Detailed information useful for diagnosing issues in the environment. Should not be so frequent that it drowns out other debug logs when all logs are displayed.
-- **TRACE**: Very fine-grained information, such as entering/exiting functions or loop iterations. Typically only enabled for targeted debugging.
+- **TRACE**: Any log that would be too frequent or verbose at a higher level, drowning out other logs when displayed. Typically only enabled for targeted debugging.
 
 ### Log Titles
 

--- a/style.md
+++ b/style.md
@@ -318,6 +318,24 @@ pub use <some_3rd_party_crate>::some::type::Bar;
 
 The above internalizes `Bar` as an inner type of the re-exporting crate. This by-itself can be nice-to-have sometimes due to [APIs](#APIs), however this will also internalize all `impl trait for Bar` into the current crate, which almost always isn't what we want.
 
+## Logging
+
+Every piece of information that can help debug a specific flow or be useful to know the state of the system should be logged.
+
+### Logging Levels
+
+- **ERROR**: An unexpected condition that prevents the system from functioning correctly. Requires immediate attention.
+- **WARN**: A potentially harmful situation that the system can recover from, but that may indicate a problem.
+- **INFO**: High-level events that confirm the system is working as expected, or help convey the current state of the system.
+- **DEBUG**: Detailed information useful for diagnosing issues in the environment. Should not be so frequent that it drowns out other debug logs when all logs are displayed.
+- **TRACE**: Very fine-grained information, such as entering/exiting functions or loop iterations. Typically only enabled for targeted debugging.
+
+### Log Titles
+
+For logs that are frequently searched, add a title in `ALL_CAPS` at the beginning of the message. Once introduced, the title should not be changed.
+
+This gives log viewers a stable search term that doesn't break when the rest of the message is reworded.
+
 ## Types
 
 ### Type Safety

--- a/style.md
+++ b/style.md
@@ -78,9 +78,7 @@ the former will display the error, and the latter will simply say `expected True
 -   Avoid doing too many things in one test with a single assert at the end, unless other tests exist that cover enough parts of the test separately so that finding the source will be simple.
 
 ### Integration and Flow Tests
-Use unit tests for short (< 1 sec) and threadsafe tests, otherwise use cargo integration tests:
-
-Put these tests in `tests/` at the crate root. Benefits of `tests/`:
+Use unit tests for short (< 1 sec) and threadsafe tests, otherwise put these tests in `tests/` at the crate root. Benefits of `tests/`:
 
 - Runs without `cfg(test)`, simulating real usage.
 - Each test file runs sequentially, avoiding thread-safety issues.
@@ -90,8 +88,8 @@ If the integration test needs features of this crate, use a dedicated integratio
 
 ### Binary Tests
 
-To test binary crates, add a `lib.rs` and call its main from `main.rs` and from the test.
-
+Prefer not to test binaries by running them as executables.
+Instead, refactor the main logic into a function and unit-test it.
 ### Dependency Injection
 
 Dependency injection allows you to test a component in isolation by mocking its dependencies. This focuses the test on a single unit of code without relying on external services or complex setup.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or runtime behavior is modified.
> 
> **Overview**
> Adds a new **Logging** section to `style.md`, defining when to log, standard meanings for log levels (`ERROR`→`TRACE`), and a convention for stable, searchable log message titles using `ALL_CAPS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a763710b64e4e79009eb76f3e6d0061a7e3ee4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->