### PR TITLE
remove track_caller sentence

### DIFF
--- a/style.md
+++ b/style.md
@@ -71,7 +71,6 @@ Take extra care when reviewing ai-generated code for these issues:
 
 A failure in a unit test should immediately point to the source of the issue, and the clearly display the error encountered. Moreover, it should be possible to debug a test even if the test writer is not available, for example:
 
--   add `#[track_caller]` on test-utils which include a critical assert, so that the trace will be the callsite in the test
 -   use `assert_eq(result, Ok(<Value>))` over `assert!(result.is_ok())` ---
 the former will display the error, and the latter will simply say `expected True, got False`.
     -    If you're not interested in the value, or if error type doesn't implement `PartialEq`, simply call `result.unwrap()`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes a single testing recommendation; no code or behavior changes.
> 
> **Overview**
> Removes the `#[track_caller]` recommendation from the **Testing** section in `style.md`, leaving the remaining guidance on writing debuggable assertions and structuring tests unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcc3953bb0cd8fb5aa3d1312c0873e017fc5fa62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->