### PR TITLE
apollo_infra: add LocalClientConfig

### DIFF
--- a/crates/apollo_infra/src/component_client/local_component_client.rs
+++ b/crates/apollo_infra/src/component_client/local_component_client.rs
@@ -1,15 +1,44 @@
+use std::collections::BTreeMap;
+
+use apollo_config::dumping::{ser_param, SerializeConfig};
+use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::time::Instant;
 use tracing::field::{display, Empty};
 use tracing::instrument;
+use validator::Validate;
 
 use crate::component_client::ClientResult;
 use crate::component_definitions::{ComponentClient, RequestId, RequestWrapper};
 use crate::metrics::LocalClientMetrics;
 use crate::requests::LabeledRequest;
+
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
+pub struct LocalClientConfig {
+    pub request_timeout_ms: u64,
+}
+
+impl Default for LocalClientConfig {
+    fn default() -> Self {
+        Self { request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS }
+    }
+}
+
+impl SerializeConfig for LocalClientConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([ser_param(
+            "request_timeout_ms",
+            &self.request_timeout_ms,
+            "The maximal duration in milliseconds for the full request-response cycle.",
+            ParamPrivacyInput::Public,
+        )])
+    }
+}
 
 /// The `LocalComponentClient` struct is a generic client for sending component requests and
 /// receiving responses asynchronously using Tokio mspc channels.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only introduces a new `LocalClientConfig` struct and config-dumping metadata without changing request/response behavior yet.
> 
> **Overview**
> Adds a new `LocalClientConfig` (defaulting `request_timeout_ms` to 30s) alongside `LocalComponentClient`, including `serde` (de)serialization, `validator::Validate`, and `SerializeConfig` dumping metadata to expose the timeout as a public config parameter.
> 
> No functional changes are made to `LocalComponentClient::send` yet; this is preparatory wiring for a future configurable request timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 743b6db095bb2bcd512ad8d96f1c5712b2d9c85c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->