### PR TITLE
apollo_infra: use LocalClientConfig in local client and add request timeout

### DIFF
--- a/crates/apollo_infra/src/component_client/definitions.rs
+++ b/crates/apollo_infra/src/component_client/definitions.rs
@@ -6,6 +6,9 @@ use thiserror::Error;
 use super::{LocalComponentClient, RemoteComponentClient};
 use crate::component_definitions::ServerError;
 
+/// A constant for the error message returned when a request times out.
+pub const REQUEST_TIMEOUT_ERROR_MESSAGE: &str = "Request timed out";
+
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ClientError {
     #[error("Communication error: {0}")]

--- a/crates/apollo_infra/src/component_client/local_component_client.rs
+++ b/crates/apollo_infra/src/component_client/local_component_client.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use apollo_config::dumping::{ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
@@ -8,10 +9,11 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::time::Instant;
 use tracing::field::{display, Empty};
-use tracing::instrument;
+use tracing::{instrument, warn};
 use validator::Validate;
 
-use crate::component_client::ClientResult;
+use crate::component_client::definitions::REQUEST_TIMEOUT_ERROR_MESSAGE;
+use crate::component_client::{ClientError, ClientResult};
 use crate::component_definitions::{ComponentClient, RequestId, RequestWrapper};
 use crate::metrics::LocalClientMetrics;
 use crate::requests::LabeledRequest;
@@ -47,6 +49,7 @@ where
     Request: Send,
     Response: Send,
 {
+    config: LocalClientConfig,
     tx: Sender<RequestWrapper<Request, Response>>,
     metrics: &'static LocalClientMetrics,
 }
@@ -57,10 +60,11 @@ where
     Response: Send,
 {
     pub fn new(
+        config: LocalClientConfig,
         tx: Sender<RequestWrapper<Request, Response>>,
         metrics: &'static LocalClientMetrics,
     ) -> Self {
-        Self { tx, metrics }
+        Self { config, tx, metrics }
     }
 }
 
@@ -79,11 +83,22 @@ where
         let (res_tx, mut res_rx) = channel::<Response>(1);
         let request_wrapper = RequestWrapper::new(request, res_tx, request_id);
         let start = Instant::now();
-        self.tx.send(request_wrapper).await.expect("Outbound connection should be open.");
-        let response = res_rx.recv().await.expect("Inbound connection should be open.");
-        let elapsed = start.elapsed();
-        self.metrics.record_response_time(elapsed.as_secs_f64(), request_label);
-        Ok(response)
+        let timeout_duration = Duration::from_millis(self.config.request_timeout_ms);
+        let request_future = async {
+            self.tx.send(request_wrapper).await.expect("Outbound connection should be open.");
+            res_rx.recv().await.expect("Inbound connection should be open.")
+        };
+        match tokio::time::timeout(timeout_duration, request_future).await {
+            Ok(response) => {
+                let elapsed = start.elapsed();
+                self.metrics.record_response_time(elapsed.as_secs_f64(), request_label);
+                Ok(response)
+            }
+            Err(_) => {
+                warn!("Local request timed out after {} ms", self.config.request_timeout_ms);
+                Err(ClientError::CommunicationFailure(REQUEST_TIMEOUT_ERROR_MESSAGE.to_string()))
+            }
+        }
     }
 }
 
@@ -95,6 +110,6 @@ where
     Response: Send,
 {
     fn clone(&self) -> Self {
-        Self { tx: self.tx.clone(), metrics: self.metrics }
+        Self { config: self.config.clone(), tx: self.tx.clone(), metrics: self.metrics }
     }
 }

--- a/crates/apollo_infra/src/component_client/remote_component_client.rs
+++ b/crates/apollo_infra/src/component_client/remote_component_client.rs
@@ -24,6 +24,7 @@ use tracing::{debug, instrument, trace, warn};
 use validator::Validate;
 
 use super::definitions::{ClientError, ClientResult};
+use crate::component_client::definitions::REQUEST_TIMEOUT_ERROR_MESSAGE;
 use crate::component_definitions::{
     ComponentClient,
     RequestId,
@@ -36,7 +37,6 @@ use crate::requests::LabeledRequest;
 use crate::serde_utils::SerdeWrapper;
 
 pub const DEFAULT_RETRIES: usize = 15;
-pub const REQUEST_TIMEOUT_ERROR_MESSAGE: &str = "request timed out";
 
 const DEFAULT_IDLE_CONNECTIONS: usize = 10;
 const DEFAULT_IDLE_TIMEOUT_MS: u64 = 30000;

--- a/crates/apollo_infra/src/tests/concurrent_servers_test.rs
+++ b/crates/apollo_infra/src/tests/concurrent_servers_test.rs
@@ -13,6 +13,7 @@ use tokio::time::timeout;
 
 use crate::component_client::{
     ClientResult,
+    LocalClientConfig,
     LocalComponentClient,
     RemoteClientConfig,
     RemoteComponentClient,
@@ -138,8 +139,12 @@ async fn setup_concurrent_local_test() -> LocalConcurrentComponentClient {
     let (tx_a, rx_a) =
         channel::<RequestWrapper<ConcurrentComponentRequest, ConcurrentComponentResponse>>(32);
 
-    let local_client = LocalConcurrentComponentClient::new(tx_a, &TEST_LOCAL_CLIENT_METRICS);
-    let local_server_config = LocalServerConfig { max_concurrency: 10, ..Default::default() };
+    let local_client = LocalConcurrentComponentClient::new(
+        LocalClientConfig::default(),
+        tx_a,
+        &TEST_LOCAL_CLIENT_METRICS,
+    );
+    let local_server_config = LocalServerConfig{max_concurrency: 10, ..Default::default()};
     let mut concurrent_local_server = ConcurrentLocalComponentServer::new(
         component,
         &local_server_config,

--- a/crates/apollo_infra/src/tests/local_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/local_component_client_server_test.rs
@@ -3,7 +3,7 @@ use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::channel;
 use tokio::task;
 
-use crate::component_client::{ClientError, ClientResult, LocalComponentClient};
+use crate::component_client::{ClientError, ClientResult, LocalClientConfig, LocalComponentClient};
 use crate::component_definitions::{ComponentClient, RequestWrapper};
 use crate::component_server::{ComponentServerStarter, LocalComponentServer, LocalServerConfig};
 use crate::tests::{
@@ -68,8 +68,16 @@ async fn local_client_server() {
     let (tx_a, rx_a) = channel::<RequestWrapper<ComponentARequest, ComponentAResponse>>(32);
     let (tx_b, rx_b) = channel::<RequestWrapper<ComponentBRequest, ComponentBResponse>>(32);
 
-    let a_client = ComponentAClient::new(tx_a.clone(), &TEST_LOCAL_CLIENT_METRICS);
-    let b_client = ComponentBClient::new(tx_b.clone(), &TEST_LOCAL_CLIENT_METRICS);
+    let a_client = ComponentAClient::new(
+        LocalClientConfig::default(),
+        tx_a.clone(),
+        &TEST_LOCAL_CLIENT_METRICS,
+    );
+    let b_client = ComponentBClient::new(
+        LocalClientConfig::default(),
+        tx_b.clone(),
+        &TEST_LOCAL_CLIENT_METRICS,
+    );
 
     let component_a = ComponentA::new(Box::new(b_client.clone()));
     let component_b = ComponentB::new(setup_value, Box::new(a_client.clone()));

--- a/crates/apollo_infra/src/tests/local_request_prioritization.rs
+++ b/crates/apollo_infra/src/tests/local_request_prioritization.rs
@@ -4,7 +4,7 @@ use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use tokio::sync::mpsc::channel;
 use tokio::task;
 
-use crate::component_client::LocalComponentClient;
+use crate::component_client::{LocalClientConfig, LocalComponentClient};
 use crate::component_definitions::{
     ComponentClient,
     ComponentRequestHandler,
@@ -90,7 +90,8 @@ async fn request_prioritization() {
 
     // Create the channel, a client, a component, and a server.
     let (tx, rx) = channel::<RequestWrapper<PriorityTestRequest, PriorityTestResponse>>(32);
-    let client = LocalComponentClient::new(tx, &TEST_LOCAL_CLIENT_METRICS);
+    let client =
+        LocalComponentClient::new(LocalClientConfig::default(), tx, &TEST_LOCAL_CLIENT_METRICS);
     let component = PriorityTestComponent::new();
     let local_server_config = LocalServerConfig::default();
     let mut component_server =

--- a/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
@@ -31,6 +31,7 @@ use tokio::task;
 use crate::component_client::{
     ClientError,
     ClientResult,
+    LocalClientConfig,
     LocalComponentClient,
     RemoteClientConfig,
     RemoteComponentClient,
@@ -370,10 +371,12 @@ async fn setup_for_tests(
     let (tx_b, rx_b) = channel::<RequestWrapper<ComponentBRequest, ComponentBResponse>>(32);
 
     let a_local_client = LocalComponentClient::<ComponentARequest, ComponentAResponse>::new(
+        LocalClientConfig::default(),
         tx_a,
         &TEST_LOCAL_CLIENT_METRICS,
     );
     let b_local_client = LocalComponentClient::<ComponentBRequest, ComponentBResponse>::new(
+        LocalClientConfig::default(),
         tx_b,
         &TEST_LOCAL_CLIENT_METRICS,
     );

--- a/crates/apollo_infra/src/tests/server_metrics_test.rs
+++ b/crates/apollo_infra/src/tests/server_metrics_test.rs
@@ -14,6 +14,7 @@ use tokio::task::{self, JoinSet};
 
 use crate::component_client::{
     ClientResult,
+    LocalClientConfig,
     LocalComponentClient,
     RemoteClientConfig,
     RemoteComponentClient,
@@ -131,7 +132,8 @@ fn basic_test_setup(max_concurrency: usize) -> BasicSetup {
 
     let (tx, rx) = channel::<RequestWrapper<TestComponentRequest, TestComponentResponse>>(32);
 
-    let local_client = LocalTestComponentClient::new(tx, &TEST_LOCAL_CLIENT_METRICS);
+    let local_client =
+        LocalTestComponentClient::new(LocalClientConfig::default(), tx, &TEST_LOCAL_CLIENT_METRICS);
 
     BasicSetup { component, local_client, rx, test_sem, local_server_config }
 }

--- a/crates/apollo_l1_events/tests/utils/mod.rs
+++ b/crates/apollo_l1_events/tests/utils/mod.rs
@@ -101,8 +101,11 @@ pub(crate) async fn setup_scraper_and_provider<
     let (tx, rx) = channel::<RequestWrapper<L1EventsProviderRequest, L1EventsProviderResponse>>(32);
 
     // Create the provider client.
-    let l1_events_provider_client =
-        LocalComponentClient::new(tx, L1_EVENTS_PROVIDER_INFRA_METRICS.get_local_client_metrics());
+    let l1_events_provider_client = LocalComponentClient::new(
+        apollo_infra::component_client::LocalClientConfig::default(),
+        tx,
+        L1_EVENTS_PROVIDER_INFRA_METRICS.get_local_client_metrics(),
+    );
 
     // L1 provider setup.
     let l1_events_provider_config = L1EventsProviderConfig {

--- a/crates/apollo_node/src/clients.rs
+++ b/crates/apollo_node/src/clients.rs
@@ -48,7 +48,7 @@ use apollo_gateway_types::communication::{
     RemoteGatewayClient,
     SharedGatewayClient,
 };
-use apollo_infra::component_client::{Client, LocalComponentClient};
+use apollo_infra::component_client::{Client, LocalClientConfig, LocalComponentClient};
 use apollo_l1_events::communication::{LocalL1EventsProviderClient, RemoteL1EventsProviderClient};
 use apollo_l1_events::metrics::L1_EVENTS_PROVIDER_INFRA_METRICS;
 use apollo_l1_events_types::{
@@ -347,8 +347,11 @@ macro_rules! create_client {
         match *$execution_mode {
             ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
             | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-                let local_client =
-                    Some(<$local_client_type>::new($channel_expr, $local_client_metrics));
+                let local_client = Some(<$local_client_type>::new(
+                    LocalClientConfig::default(),
+                    $channel_expr,
+                    $local_client_metrics,
+                ));
                 Client::new(local_client, None)
             }
             ReactiveComponentExecutionMode::Remote => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `LocalComponentClient::send` to enforce a configurable request/response timeout, which can introduce new failure paths (timeouts) for slow or stalled in-process components. Also changes the `LocalComponentClient::new` API, requiring call-site updates across node wiring and tests.
> 
> **Overview**
> Adds `LocalClientConfig` to `LocalComponentClient` and updates `send` to wrap the full local request/response cycle in `tokio::time::timeout`, returning `ClientError::CommunicationFailure` on timeout and emitting a warning.
> 
> Unifies the timeout error string by moving `REQUEST_TIMEOUT_ERROR_MESSAGE` into `component_client::definitions`, and updates all local client construction sites (node `create_client!` macro and multiple tests) to pass `LocalClientConfig::default()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de12b31e35a3cdc17a31f6ec74c463a9167bd426. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->