### PR TITLE
apollo_infra: add local client request timeout test

### DIFF
--- a/crates/apollo_infra/src/tests/concurrent_servers_test.rs
+++ b/crates/apollo_infra/src/tests/concurrent_servers_test.rs
@@ -144,7 +144,7 @@ async fn setup_concurrent_local_test() -> LocalConcurrentComponentClient {
         tx_a,
         &TEST_LOCAL_CLIENT_METRICS,
     );
-    let local_server_config = LocalServerConfig{max_concurrency: 10, ..Default::default()};
+    let local_server_config = LocalServerConfig { max_concurrency: 10, ..Default::default() };
     let mut concurrent_local_server = ConcurrentLocalComponentServer::new(
         component,
         &local_server_config,

--- a/crates/apollo_infra/src/tests/local_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/local_component_client_server_test.rs
@@ -3,7 +3,13 @@ use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::channel;
 use tokio::task;
 
-use crate::component_client::{ClientError, ClientResult, LocalClientConfig, LocalComponentClient};
+use crate::component_client::{
+    ClientError,
+    ClientResult,
+    LocalClientConfig,
+    LocalComponentClient,
+    REQUEST_TIMEOUT_ERROR_MESSAGE,
+};
 use crate::component_definitions::{ComponentClient, RequestWrapper};
 use crate::component_server::{ComponentServerStarter, LocalComponentServer, LocalServerConfig};
 use crate::tests::{
@@ -97,4 +103,28 @@ async fn local_client_server() {
     });
 
     test_a_b_functionality(a_client, b_client, expected_value).await;
+}
+
+/// "Server" receives the request but never sends a response. Verifies the client times out and
+/// returns CommunicationFailure("request timed out").
+#[tokio::test]
+async fn request_times_out_when_server_never_responds() {
+    let (tx, mut rx) = channel::<RequestWrapper<ComponentARequest, ComponentAResponse>>(1);
+    task::spawn(async move {
+        // Receive one request and never respond (hold wrapper, never send on res_tx).
+        let _wrapper = rx.recv().await;
+        std::future::pending::<()>().await
+    });
+    task::yield_now().await;
+
+    let timeout_config = LocalClientConfig { request_timeout_ms: 200, ..Default::default() };
+    let client = ComponentAClient::new(timeout_config, tx, &TEST_LOCAL_CLIENT_METRICS);
+
+    let Err(e) = client.a_get_value().await else {
+        panic!("Expected an error");
+    };
+    assert!(
+        e.to_string().contains(REQUEST_TIMEOUT_ERROR_MESSAGE),
+        "Expected error to contain '{REQUEST_TIMEOUT_ERROR_MESSAGE}', got: {e}"
+    );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that validate existing timeout behavior; no production logic is modified.
> 
> **Overview**
> Adds a new Tokio test that simulates a local component server receiving a request but never responding, and asserts the `LocalComponentClient` returns a `CommunicationFailure` containing `REQUEST_TIMEOUT_ERROR_MESSAGE` when `request_timeout_ms` elapses.
> 
> Also includes a minor formatting-only adjustment in `concurrent_servers_test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d67866f13cd0bf0be677046cee397f1a583210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->