### PR TITLE
make short unit test into a recommendation

### DIFF
--- a/style.md
+++ b/style.md
@@ -77,7 +77,9 @@ the former will display the error, and the latter will simply say `expected True
 -   Avoid doing too many things in one test with a single assert at the end, unless other tests exist that cover enough parts of the test separately so that finding the source will be simple.
 
 ### Integration and Flow Tests
-Use unit tests for short (< 1 sec) and threadsafe tests, otherwise put these tests in `tests/` at the crate root. Benefits of `tests/`:
+Unit tests should be short (< 1 sec) and deterministic, unless there's a specific reason otherwise.
+
+Other tests should be under `tests/` at the crate root. Benefits of `tests/`:
 
 - Runs without `cfg(test)`, simulating real usage.
 - Each test file runs sequentially, avoiding thread-safety issues.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior; risk is limited to minor shifts in team testing expectations.
> 
> **Overview**
> Updates the `Testing` guidelines in `style.md` to make “unit tests should be short (<1s)” a softer recommendation and to explicitly emphasize **determinism** for unit tests, rather than tying unit-vs-integration choice to thread safety/time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78613899c898e3df8a9b93b2193575bb4189b27f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->