### PR TITLE
add section on test names

### DIFF
--- a/style.md
+++ b/style.md
@@ -76,6 +76,16 @@ the former will display the error, and the latter will simply say `expected True
     -    If you're not interested in the value, or if error type doesn't implement `PartialEq`, simply call `result.unwrap()`
 -   Avoid doing too many things in one test with a single assert at the end, unless other tests exist that cover enough parts of the test separately so that finding the source will be simple.
 
+### Test Names
+
+Tests should start with a `test_` prefix.
+
+**Rationale:** Even though the `#[test]` attribute marks test functions, a `test_` prefix makes it
+immediately clear which functions are tests and which are helper functions.
+
+Unlike regular functions, test names can be long. Feel free to describe the exact scenario or edge
+case you're testing, e.g. `test_send_tx_with_duplicate_nonce_returns_already_received`.
+
 ### Integration and Flow Tests
 Unit tests should be short (< 1 sec) and deterministic, unless there's a specific reason otherwise.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or build/test execution.
> 
> **Overview**
> Adds a new **Test Names** subsection to `style.md` under *Testing* that standardizes unit test naming: tests should use a `test_` prefix and can be long/descriptive to clearly distinguish tests from helper functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0448af829abea0b423afea1600beb17ad73f15a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->