### PR TITLE
apollo_propeller: finalized messages without any good shards are dropped

### DIFF
--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -17,7 +17,12 @@ use tracing::{debug, error, trace, warn};
 
 use crate::config::Config;
 use crate::handler::{HandlerIn, HandlerOut};
-use crate::message_processor::{EventStateManagerToEngine, MessageProcessor, UnitToValidate};
+use crate::message_processor::{
+    EventStateManagerToEngine,
+    GoodUnitsStatus,
+    MessageProcessor,
+    UnitToValidate,
+};
 use crate::metrics::PropellerMetrics;
 use crate::sharding::create_units_to_publish;
 use crate::signature;
@@ -313,6 +318,7 @@ impl Engine {
                 unit_rx,
                 engine_tx: self.state_manager_tx.clone(),
                 timeout: self.config.stale_message_timeout,
+                unit_status: GoodUnitsStatus::NoGoodUnitsReceived,
             };
 
             // TODO(AndrewL): track task handle to see if it panics or is killed.
@@ -379,11 +385,13 @@ impl Engine {
             EventStateManagerToEngine::BehaviourEvent(event) => {
                 self.emit_event(event);
             }
+            // TODO(guyn): consider the name finalized.
             EventStateManagerToEngine::Finalized {
                 committee_id,
                 publisher,
                 nonce,
                 message_root,
+                unit_status,
             } => {
                 trace!(
                     ?committee_id,
@@ -393,11 +401,30 @@ impl Engine {
                     "[ENGINE] Message finalized"
                 );
 
-                // Mark as finalized
                 let message_key = MessageKey { committee_id, publisher, nonce, root: message_root };
+
+                // Clean up task handles
+                if self.message_to_unit_tx.remove(&message_key).is_some() {
+                    trace!(?message_key, "[ENGINE] Removed task handles");
+                }
+
+                // If the message process didn't have any valid shards, we don't cache it.
+                if let GoodUnitsStatus::NoGoodUnitsReceived = unit_status {
+                    debug!(
+                        ?committee_id,
+                        ?publisher,
+                        ?message_root,
+                        "[ENGINE] Message finalized with no good shards, dropping without caching"
+                    );
+                    return;
+                }
+
+                // Cache this message and do not accept any more shards for it.
                 let expired_keys =
                     self.messages_to_ignore_shards_from.insert_and_get_expired(message_key);
 
+                // Track the messages that have been removed from the TTL cache, ignoring further
+                // shards for this message and any earlier message using the timestamp nonce.
                 if !expired_keys.is_empty() {
                     trace!(?expired_keys, "[ENGINE] Removed expired messages from TTL cache");
                     for key in expired_keys {
@@ -410,11 +437,6 @@ impl Engine {
                             .max(key.nonce);
                         self.peer_nonce.put(key.publisher, new_nonce);
                     }
-                }
-
-                // Clean up task handles
-                if self.message_to_unit_tx.remove(&message_key).is_some() {
-                    trace!(?message_key, "[ENGINE] Removed task handles");
                 }
             }
             EventStateManagerToEngine::SendUnitToPeers { unit, peers } => {

--- a/crates/apollo_propeller/src/engine_test.rs
+++ b/crates/apollo_propeller/src/engine_test.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc;
 
 use crate::config::Config;
 use crate::engine::{Engine, EngineCommand, EngineOutput, MessageKey};
-use crate::message_processor::EventStateManagerToEngine;
+use crate::message_processor::{EventStateManagerToEngine, GoodUnitsStatus};
 use crate::types::{CommitteeId, MessageRoot};
 use crate::{MerkleProof, PropellerUnit, Shard, ShardIndex, ShardsOfPeer};
 
@@ -71,6 +71,7 @@ fn finalize_message(engine: &mut Engine, publisher: PeerId, nonce: u64, root: Me
         publisher,
         nonce,
         message_root: root,
+        unit_status: GoodUnitsStatus::SomeGoodUnitsReceived,
     });
 }
 

--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -33,6 +33,7 @@ pub enum EventStateManagerToEngine {
         publisher: PeerId,
         nonce: u64,
         message_root: MessageRoot,
+        unit_status: GoodUnitsStatus,
     },
     SendUnitToPeers {
         unit: PropellerUnit,
@@ -141,6 +142,15 @@ impl ReconstructionState {
     }
 }
 
+// TODO(guyn): consider adding AllGoodShardsReceived to the enum.
+// TODO(guyn): consider adding the number of received shards to the enum.
+#[derive(Debug, Default, PartialEq, Clone, Copy, Ord, PartialOrd, Eq, Hash)]
+pub enum GoodUnitsStatus {
+    #[default]
+    NoGoodUnitsReceived,
+    SomeGoodUnitsReceived,
+}
+
 /// Message processor that handles validation and state management for a single message.
 pub struct MessageProcessor {
     pub committee_id: CommitteeId,
@@ -159,6 +169,7 @@ pub struct MessageProcessor {
     pub engine_tx: mpsc::UnboundedSender<EventStateManagerToEngine>,
 
     pub timeout: Duration,
+    pub unit_status: GoodUnitsStatus,
 }
 
 impl MessageProcessor {
@@ -205,6 +216,9 @@ impl MessageProcessor {
                 trace!("[MSG_PROC] Validation failed for index={:?}: {:?}", unit.index(), err);
                 continue;
             }
+
+            // We got at least one good shard.
+            self.unit_status = GoodUnitsStatus::SomeGoodUnitsReceived;
 
             self.maybe_broadcast_my_unit(&unit, &state);
 
@@ -397,6 +411,7 @@ impl MessageProcessor {
                 publisher: self.publisher,
                 nonce: self.nonce,
                 message_root: self.message_root,
+                unit_status: self.unit_status,
             })
             .expect("Engine task has exited");
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes finalization/dedup behavior in the engine by conditionally skipping TTL caching based on validation results, which can affect replay-protection/nonce tracking and message processing flow. Impact is bounded but touches core protocol state handling.
> 
> **Overview**
> **Finalized messages are no longer cached if no valid shards were ever received.** `MessageProcessor` now tracks a `GoodUnitsStatus` flag (set after the first successfully validated unit) and includes it in the `Finalized` event.
> 
> On `Finalized`, the engine now always cleans up per-message processor handles, but **only inserts the message into the TTL dedup cache (and triggers nonce advancement on expiry)** when `SomeGoodUnitsReceived`; messages finalized with `NoGoodUnitsReceived` are dropped without caching. Tests were updated to supply the new `unit_status`, and a small comment typo in `types.rs` was fixed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45aeee8523fe9b5c91b578dd02457c47db73cf01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->