### PR TITLE
starknet_os: set trace_enabled to false

### DIFF
--- a/crates/starknet_os/src/runner.rs
+++ b/crates/starknet_os/src/runner.rs
@@ -42,9 +42,7 @@ pub(crate) fn run_program<HP: HintProcessor + CommonHintProcessor>(
     hint_processor: &mut HP,
 ) -> Result<RunnerReturnObject, StarknetOsError> {
     // Init CairoRunConfig.
-    // TODO(Einat): Set trace_enabled to false once blake opcodes are counted in the VM.
-    let cairo_run_config =
-        CairoRunConfig { layout, relocate_mem: true, trace_enabled: true, ..Default::default() };
+    let cairo_run_config = CairoRunConfig { layout, relocate_mem: true, ..Default::default() };
     let allow_missing_builtins = cairo_run_config.allow_missing_builtins.unwrap_or(false);
 
     // Init cairo runner.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `run_program` to no longer force `trace_enabled=true`, which can alter runtime behavior for any code that relies on execution traces (e.g., debugging, profiling, or proof/trace-related tooling). Functional output should be unchanged, but trace-dependent flows may regress.
> 
> **Overview**
> Disables Cairo VM tracing in `run_program` by removing the explicit `trace_enabled: true` override and relying on `CairoRunConfig` defaults.
> 
> This reduces trace generation overhead for OS, aggregator, and virtual OS runs, but means trace data will no longer be produced unless enabled elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 392ad2c2fccd21d388b9364af852a6c6d9703aac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->