### PR TITLE
apollo_network: cancel stale DialPeerStreams when target peers are removed

### DIFF
--- a/crates/apollo_network/Cargo.toml
+++ b/crates/apollo_network/Cargo.toml
@@ -63,5 +63,9 @@ tokio = { workspace = true, features = ["full", "sync", "test-util"] }
 tokio-stream.workspace = true
 waker-fn.workspace = true
 
+[[test]]
+name = "e2e_discovery_test"
+required-features = ["testing"]
+
 [lints]
 workspace = true

--- a/crates/apollo_network/src/discovery/behaviours/kad_requesting.rs
+++ b/crates/apollo_network/src/discovery/behaviours/kad_requesting.rs
@@ -147,9 +147,11 @@ impl KadRequestingBehaviour {
         }
     }
 
-    // TODO(AndrewL): When target peers change, cancel DialPeerStreams in DiallingBehaviour
-    // for peers no longer in the target set. Currently those streams retry indefinitely.
-    pub fn set_target_peers(&mut self, peers: HashSet<PeerId>) {
+    /// Updates the set of target peers and returns the set of peers that were removed
+    /// (present in the old set but not in the new one).
+    pub fn set_target_peers(&mut self, peers: HashSet<PeerId>) -> HashSet<PeerId> {
+        let removed_peers: HashSet<PeerId> =
+            self.target_peers.difference(&peers).copied().collect();
         self.peers_pending_connection =
             peers.iter().filter(|p| !self.connected_peers.contains(p)).copied().collect();
         self.target_peers = peers;
@@ -160,6 +162,7 @@ impl KadRequestingBehaviour {
                 waker.wake();
             }
         }
+        removed_peers
     }
 
     pub fn handle_kad_response(&mut self, peers: &[(PeerId, Vec<Multiaddr>)]) {

--- a/crates/apollo_network/src/discovery/discovery_test.rs
+++ b/crates/apollo_network/src/discovery/discovery_test.rs
@@ -1,5 +1,6 @@
 // TODO(shahak): add flow test
 
+use std::collections::HashSet;
 use std::convert::Infallible;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -28,6 +29,8 @@ use super::{Behaviour, DiscoveryConfig, RetryConfig, ToOtherBehaviourEvent};
 const TIMEOUT: Duration = Duration::from_secs(1);
 const SMALL_SLEEP_MILLIS: u64 = 1000;
 const LARGE_SLEEP_MILLIS: u64 = 5000;
+/// Small duration added past a deadline to ensure timers have fired.
+const TIMEOUT_EPSILON: Duration = Duration::from_millis(100);
 
 const CONFIG_WITH_ZERO_HEARTBEAT_AND_SMALL_BOOTSTRAP_DIAL: DiscoveryConfig = DiscoveryConfig {
     bootstrap_dial_retry_config: RetryConfig {
@@ -294,7 +297,7 @@ async fn discovery_sleeps_between_queries(
     connect_to_bootstrap_node(&mut behaviour, bootstrap_peer_id, bootstrap_peer_address).await;
 
     // Set a peer to request so the heartbeat has something to query.
-    behaviour.set_target_peers(std::collections::HashSet::from([PeerId::random()]));
+    behaviour.set_target_peers(HashSet::from([PeerId::random()]));
 
     // The first heartbeat fires immediately since time_for_next_kad_query starts at creation time.
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
@@ -335,7 +338,7 @@ async fn discovery_performs_queries_even_if_not_connected_to_bootstrap_peer(
     }));
 
     // Set a peer to request so the heartbeat has something to query.
-    behaviour.set_target_peers(std::collections::HashSet::from([PeerId::random()]));
+    behaviour.set_target_peers(HashSet::from([PeerId::random()]));
 
     // The first heartbeat fires immediately since time_for_next_kad_query starts at creation time.
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
@@ -351,4 +354,148 @@ async fn discovery_performs_queries_even_if_not_connected_to_bootstrap_peer(
         event,
         ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
+}
+
+#[rstest::rstest]
+#[tokio::test]
+async fn set_target_peers_cancels_dials_for_removed_peers(
+    #[values(CONFIG_WITH_LARGE_HEARTBEAT_AND_SMALL_BOOTSTRAP_SLEEP)] config: DiscoveryConfig,
+    bootstrap_peer_id: PeerId,
+    bootstrap_peer_address: Multiaddr,
+) {
+    let mut behaviour = Behaviour::new(
+        dummy_local_peer_id(),
+        config.clone(),
+        vec![(bootstrap_peer_id, bootstrap_peer_address.clone())],
+    );
+    connect_to_bootstrap_node(&mut behaviour, bootstrap_peer_id, bootstrap_peer_address).await;
+
+    let peer_a = PeerId::random();
+    let peer_a_address = Multiaddr::empty();
+    behaviour.set_target_peers(HashSet::from([peer_a]));
+
+    // Consume the KadQuery for peer_a (first heartbeat fires immediately).
+    let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
+    assert_matches!(
+        event,
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(queried_peer_id))
+            if queried_peer_id == peer_a
+    );
+
+    // Simulate DHT finding addresses for peer_a.
+    behaviour.kad_requesting.handle_kad_response(&[(peer_a, vec![peer_a_address])]);
+
+    // Poll to trigger dial for peer_a.
+    let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
+    assert_matches!(
+        event,
+        ToSwarm::Dial { opts } if opts.get_peer_id() == Some(peer_a)
+    );
+
+    // Simulate dial failure — DialPeerStream schedules retry after some time.
+    behaviour.on_swarm_event(FromSwarm::DialFailure(DialFailure {
+        peer_id: Some(peer_a),
+        error: &DialError::Aborted,
+        connection_id: ConnectionId::new_unchecked(0),
+    }));
+
+    // Remove peer_a from target set — this cancels its DialPeerStream.
+    behaviour.set_target_peers(HashSet::new());
+
+    // Advance time well past the retry backoff.
+    tokio::time::pause();
+    tokio::time::advance(config.bootstrap_dial_retry_config.max_delay_seconds + TIMEOUT_EPSILON)
+        .await;
+    tokio::time::resume();
+
+    // Assert no re-dial — the cancelled stream produces no more events.
+    assert_no_event(&mut behaviour);
+}
+
+#[rstest::rstest]
+#[tokio::test]
+async fn set_target_peers_does_not_cancel_bootstrap_dials(
+    #[values(CONFIG_WITH_LARGE_HEARTBEAT_AND_SMALL_BOOTSTRAP_SLEEP)] config: DiscoveryConfig,
+    bootstrap_peer_id: PeerId,
+    bootstrap_peer_address: Multiaddr,
+) {
+    let mut behaviour = Behaviour::new(
+        dummy_local_peer_id(),
+        config.clone(),
+        vec![(bootstrap_peer_id, bootstrap_peer_address.clone())],
+    );
+
+    // Consume the initial Dial event for bootstrap peer.
+    let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
+    assert_matches!(
+        event,
+        ToSwarm::Dial { opts } if opts.get_peer_id() == Some(bootstrap_peer_id)
+    );
+
+    // Simulate dial failure — DialPeerStream schedules retry after some time.
+    behaviour.on_swarm_event(FromSwarm::DialFailure(DialFailure {
+        peer_id: Some(bootstrap_peer_id),
+        error: &DialError::Aborted,
+        connection_id: ConnectionId::new_unchecked(0),
+    }));
+
+    // Set empty target peers — bootstrap peer was never in the target set, so its dial persists.
+    behaviour.set_target_peers(HashSet::new());
+
+    // Verify the bootstrap peer is still re-dialed after backoff.
+    let event = check_event_happens_after_given_duration(
+        &mut behaviour,
+        config.bootstrap_dial_retry_config.max_delay_seconds,
+    )
+    .await;
+    assert_matches!(
+        event,
+        ToSwarm::Dial { opts } if opts.get_peer_id() == Some(bootstrap_peer_id)
+    );
+}
+
+// TODO(AndrewL): cancel_dial is origin-agnostic — it cancels ALL DialPeerStreams for a peer,
+// including bootstrap-originated ones. If a bootstrap peer overlaps with the target set and is
+// then removed from targets, its bootstrap dial is killed too. BootstrappingBehaviour only
+// re-emits RequestDial on ConnectionClosed (not on cancellation), so the peer becomes
+// permanently unreachable. This test documents the current (buggy) behavior.
+#[rstest::rstest]
+#[tokio::test]
+async fn set_target_peers_cancels_bootstrap_dial_when_bootstrap_peer_overlaps_with_targets(
+    #[values(CONFIG_WITH_LARGE_HEARTBEAT_AND_SMALL_BOOTSTRAP_SLEEP)] config: DiscoveryConfig,
+    bootstrap_peer_id: PeerId,
+    bootstrap_peer_address: Multiaddr,
+) {
+    let mut behaviour = Behaviour::new(
+        dummy_local_peer_id(),
+        config.clone(),
+        vec![(bootstrap_peer_id, bootstrap_peer_address.clone())],
+    );
+
+    // Consume the initial Dial event for bootstrap peer.
+    let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
+    assert_matches!(
+        event,
+        ToSwarm::Dial { opts } if opts.get_peer_id() == Some(bootstrap_peer_id)
+    );
+
+    // Simulate dial failure — DialPeerStream schedules retry after some time.
+    behaviour.on_swarm_event(FromSwarm::DialFailure(DialFailure {
+        peer_id: Some(bootstrap_peer_id),
+        error: &DialError::Aborted,
+        connection_id: ConnectionId::new_unchecked(0),
+    }));
+
+    // Add bootstrap peer to the target set, then remove it.
+    behaviour.set_target_peers(HashSet::from([bootstrap_peer_id]));
+    behaviour.set_target_peers(HashSet::new());
+
+    // Advance time well past the retry backoff.
+    tokio::time::pause();
+    tokio::time::advance(config.bootstrap_dial_retry_config.max_delay_seconds + TIMEOUT_EPSILON)
+        .await;
+    tokio::time::resume();
+
+    // THIS IS THE BUG: The bootstrap dial was cancelled — no re-dial occurs.
+    assert_no_event(&mut behaviour);
 }

--- a/crates/apollo_network/src/discovery/mod.rs
+++ b/crates/apollo_network/src/discovery/mod.rs
@@ -257,7 +257,10 @@ impl Behaviour {
     }
 
     pub fn set_target_peers(&mut self, peers: std::collections::HashSet<PeerId>) {
-        self.kad_requesting.set_target_peers(peers);
+        let removed_peers = self.kad_requesting.set_target_peers(peers);
+        for peer_id in &removed_peers {
+            self.dialing.cancel_dial(peer_id);
+        }
     }
 }
 

--- a/crates/apollo_network/src/lib.rs
+++ b/crates/apollo_network/src/lib.rs
@@ -199,15 +199,19 @@ mod config_test;
 pub mod discovery;
 #[cfg(test)]
 mod e2e_broadcast_test;
-#[cfg(test)]
-mod e2e_discovery_test;
 mod event_tracker;
 pub mod gossipsub_impl;
 pub mod metrics;
 pub mod misconduct_score;
+#[cfg(any(test, feature = "testing"))]
+pub mod mixed_behaviour;
+#[cfg(not(any(test, feature = "testing")))]
 mod mixed_behaviour;
 pub mod network_manager;
 pub mod peer_manager;
+#[cfg(any(test, feature = "testing"))]
+pub mod prune_dead_connections;
+#[cfg(not(any(test, feature = "testing")))]
 mod prune_dead_connections;
 pub mod sqmr;
 #[cfg(test)]
@@ -244,6 +248,9 @@ use validator::{Validate, ValidationError};
 
 use crate::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
 
+#[cfg(any(test, feature = "testing"))]
+pub type Bytes = Vec<u8>;
+#[cfg(not(any(test, feature = "testing")))]
 pub(crate) type Bytes = Vec<u8>;
 
 // TODO(Shahak): add peer manager config to the network config

--- a/crates/apollo_network/src/network_manager/mod.rs
+++ b/crates/apollo_network/src/network_manager/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(test)]
-pub(crate) mod swarm_trait;
-#[cfg(not(test))]
+#[cfg(any(test, feature = "testing"))]
+pub mod swarm_trait;
+#[cfg(not(any(test, feature = "testing")))]
 mod swarm_trait;
 #[cfg(test)]
 mod test;
@@ -196,7 +196,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
 
     // TODO(shahak): remove the advertised_multiaddr arg once we manage external addresses
     // in a behaviour.
-    pub(crate) fn generic_new(
+    pub fn generic_new(
         mut swarm: SwarmT,
         advertised_multiaddr: Option<Multiaddr>,
         metrics: Option<NetworkMetrics>,

--- a/crates/apollo_network/tests/e2e_discovery_test.rs
+++ b/crates/apollo_network/tests/e2e_discovery_test.rs
@@ -3,6 +3,17 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+use apollo_network::discovery::DiscoveryConfig;
+use apollo_network::gossipsub_impl::Topic;
+use apollo_network::misconduct_score::MisconductScore;
+use apollo_network::mixed_behaviour::{self, MixedBehaviour};
+use apollo_network::network_manager::swarm_trait::{Event, SwarmTrait};
+use apollo_network::network_manager::GenericNetworkManager;
+use apollo_network::peer_manager::PeerManagerConfig;
+use apollo_network::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
+use apollo_network::sqmr::behaviour::SessionIdNotFoundError;
+use apollo_network::sqmr::{self, InboundSessionId, OutboundSessionId, SessionId};
+use apollo_network::Bytes;
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
 use libp2p::core::multiaddr::Protocol;
 use libp2p::gossipsub::{MessageId, PublishError, SubscriptionError, TopicHash};
@@ -12,18 +23,6 @@ use libp2p_swarm_test::SwarmExt;
 use starknet_api::core::ChainId;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::time::{self, Instant, MissedTickBehavior};
-
-use crate::discovery::DiscoveryConfig;
-use crate::gossipsub_impl::Topic;
-use crate::misconduct_score::MisconductScore;
-use crate::mixed_behaviour::{self, MixedBehaviour};
-use crate::network_manager::swarm_trait::{Event, SwarmTrait};
-use crate::network_manager::GenericNetworkManager;
-use crate::peer_manager::PeerManagerConfig;
-use crate::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
-use crate::sqmr::behaviour::SessionIdNotFoundError;
-use crate::sqmr::{self, InboundSessionId, OutboundSessionId, SessionId};
-use crate::Bytes;
 
 const MESSAGE_METADATA_BUFFER_SIZE: usize = 100;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes discovery’s dialing lifecycle by actively cancelling in-flight/retrying dials when the target peer set shrinks, which can affect connectivity and retry behavior (including an explicitly documented edge-case with bootstrap peers).
> 
> **Overview**
> Discovery now cancels *stale* dial retry streams when `set_target_peers` removes peers, preventing indefinite re-dial attempts for peers that are no longer desired.
> 
> `KadRequestingBehaviour::set_target_peers` now returns the removed peers, and `Behaviour::set_target_peers` uses that to call `DialingBehaviour::cancel_dial` for each removed peer.
> 
> Tests were updated/added to verify removed-target peers stop re-dialing, bootstrap dials are unaffected when not in the target set, and to document a known bug where removing a bootstrap peer that temporarily overlaps with targets can cancel its bootstrap dial permanently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbb08da9868ba38e7df7d88727027a8f4367a5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->