### PR TITLE
apollo_network: add peer access control behaviour to deny unauthorized inbound connections

### DIFF
--- a/crates/apollo_network/src/lib.rs
+++ b/crates/apollo_network/src/lib.rs
@@ -208,6 +208,9 @@ pub mod mixed_behaviour;
 #[cfg(not(any(test, feature = "testing")))]
 mod mixed_behaviour;
 pub mod network_manager;
+mod peer_access_control;
+#[cfg(test)]
+mod peer_access_control_test;
 pub mod peer_manager;
 #[cfg(any(test, feature = "testing"))]
 pub mod prune_dead_connections;

--- a/crates/apollo_network/src/mixed_behaviour.rs
+++ b/crates/apollo_network/src/mixed_behaviour.rs
@@ -18,13 +18,21 @@ use crate::discovery::DiscoveryConfig;
 use crate::event_tracker::EventMetricsTracker;
 use crate::metrics::{EventMetrics, LatencyMetrics};
 use crate::peer_manager::PeerManagerConfig;
-use crate::{discovery, gossipsub_impl, peer_manager, prune_dead_connections, sqmr};
+use crate::{
+    discovery,
+    gossipsub_impl,
+    peer_access_control,
+    peer_manager,
+    prune_dead_connections,
+    sqmr,
+};
 
 // TODO(Shahak): consider reducing the pulicity of all behaviour to pub(crate)
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "Event")]
 pub struct MixedBehaviour {
     pub limits: connection_limits::Behaviour,
+    pub peer_access_control: peer_access_control::Behaviour,
     pub peer_manager: peer_manager::PeerManager,
     pub discovery: Toggle<discovery::Behaviour>,
     pub identify: identify::Behaviour,
@@ -88,27 +96,27 @@ impl MixedBehaviour {
         let kademlia_config = kad::Config::new(protocol_name);
         let connection_limits = ConnectionLimits::default().with_max_established_per_peer(Some(1));
 
+        let bootstrap_peers_with_ids: Option<Vec<(PeerId, Multiaddr)>> = bootstrap_peers_multiaddrs
+            .map(|addrs| {
+                addrs
+                    .iter()
+                    .map(|addr| {
+                        (
+                            DialOpts::from(addr.clone())
+                                .get_peer_id()
+                                .expect("bootstrap_peer_multiaddr doesn't have a peer id"),
+                            addr.clone(),
+                        )
+                    })
+                    .collect()
+            });
+
         Self {
             limits: connection_limits::Behaviour::new(connection_limits),
+            peer_access_control: peer_access_control::Behaviour::new(),
             peer_manager: peer_manager::PeerManager::new(peer_manager_config),
-            discovery: bootstrap_peers_multiaddrs
-                .map(|bootstrap_peer_multiaddr| {
-                    discovery::Behaviour::new(
-                        local_peer_id,
-                        discovery_config,
-                        bootstrap_peer_multiaddr
-                            .iter()
-                            .map(|bootstrap_peer_multiaddr| {
-                                (
-                                    DialOpts::from(bootstrap_peer_multiaddr.clone())
-                                        .get_peer_id()
-                                        .expect("bootstrap_peer_multiaddr doesn't have a peer id"),
-                                    bootstrap_peer_multiaddr.clone(),
-                                )
-                            })
-                            .collect(),
-                    )
-                })
+            discovery: bootstrap_peers_with_ids
+                .map(|peers| discovery::Behaviour::new(local_peer_id, discovery_config, peers))
                 .into(),
             identify: match node_version {
                 Some(version) => identify::Behaviour::new(

--- a/crates/apollo_network/src/network_manager/mod.rs
+++ b/crates/apollo_network/src/network_manager/mod.rs
@@ -7,7 +7,7 @@ mod test;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -188,8 +188,10 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             .committee_store
             .add_epoch(epoch_id, members)
             .expect("Committee members contain duplicate peer IDs");
+        let allowed_peers: HashSet<PeerId> = output.allowed_peers.into_iter().collect();
+        self.swarm.behaviour_mut().peer_access_control.set_allowed_peers(allowed_peers.clone());
         if let Some(discovery) = self.swarm.behaviour_mut().discovery.as_mut() {
-            discovery.set_target_peers(output.allowed_peers.into_iter().collect());
+            discovery.set_target_peers(allowed_peers);
         }
         todo!("Wire remaining AddEpochOutput fields to behaviours");
     }

--- a/crates/apollo_network/src/peer_access_control.rs
+++ b/crates/apollo_network/src/peer_access_control.rs
@@ -1,0 +1,162 @@
+use std::collections::HashSet;
+use std::convert::Infallible;
+use std::task::{Context, Poll, Waker};
+
+use libp2p::core::transport::PortUse;
+use libp2p::core::Endpoint;
+use libp2p::swarm::{
+    dummy,
+    CloseConnection,
+    ConnectionDenied,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    ToSwarm,
+};
+use libp2p::{Multiaddr, PeerId};
+use tracing::info;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Peer {0} is not in the allowed peers set.")]
+pub struct PeerNotAllowedError(PeerId);
+
+/// Enforces a peer whitelist by denying connections from peers not in the allowed set and
+/// requesting disconnection of peers that are removed from the allowed set.
+///
+/// Inbound connections are denied at the established stage (the earliest point where the peer's
+/// identity is known after the noise handshake). Outbound connections are denied at the pending
+/// stage when the peer ID is available.
+///
+/// Until [`set_allowed_peers`](Behaviour::set_allowed_peers) is called the allowed set is empty,
+/// so all connections are denied.
+pub struct Behaviour {
+    allowed_peers: HashSet<PeerId>,
+    // TODO(AndrewL): Default to true once all call-sites (e2e tests, NetworkManager bootstrap)
+    // wire `set_allowed_peers` with the correct peer set.
+    enforcement_active: bool,
+    pending_disconnections: Vec<PeerId>,
+    waker: Option<Waker>,
+}
+
+impl Behaviour {
+    pub fn new() -> Self {
+        Self {
+            allowed_peers: HashSet::new(),
+            enforcement_active: false,
+            pending_disconnections: Vec::new(),
+            waker: None,
+        }
+    }
+
+    pub fn set_allowed_peers(&mut self, peers: HashSet<PeerId>) {
+        self.enforcement_active = true;
+        // Peers in the old set but not the new set should be disconnected. Requesting
+        // disconnection for a peer that is not currently connected is a no-op in libp2p.
+        let newly_disallowed: Vec<PeerId> =
+            self.allowed_peers.difference(&peers).copied().collect();
+
+        for peer_id in newly_disallowed {
+            if !self.pending_disconnections.contains(&peer_id) {
+                info!(%peer_id, "Queuing disconnection for peer no longer in allowed set");
+                self.pending_disconnections.push(peer_id);
+            }
+        }
+
+        self.allowed_peers = peers;
+
+        if !self.pending_disconnections.is_empty() {
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+
+    fn is_peer_allowed(&self, peer_id: &PeerId) -> bool {
+        !self.enforcement_active || self.allowed_peers.contains(peer_id)
+    }
+
+    fn deny_if_not_allowed(
+        &self,
+        peer: PeerId,
+    ) -> Result<dummy::ConnectionHandler, ConnectionDenied> {
+        if self.is_peer_allowed(&peer) {
+            Ok(dummy::ConnectionHandler)
+        } else {
+            Err(ConnectionDenied::new(PeerNotAllowedError(peer)))
+        }
+    }
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = dummy::ConnectionHandler;
+    type ToSwarm = Infallible;
+
+    // Inbound connections can only be checked at the established stage because the peer's identity
+    // is not yet known during `handle_pending_inbound_connection` (it is revealed after the noise
+    // handshake completes).
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<Self::ConnectionHandler, ConnectionDenied> {
+        self.deny_if_not_allowed(peer)
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        maybe_peer: Option<PeerId>,
+        _addresses: &[Multiaddr],
+        _effective_role: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        if let Some(peer) = maybe_peer {
+            self.deny_if_not_allowed(peer)?;
+        }
+        Ok(vec![])
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: Endpoint,
+        _port_use: PortUse,
+    ) -> Result<Self::ConnectionHandler, ConnectionDenied> {
+        self.deny_if_not_allowed(peer)
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection_id: ConnectionId,
+        _event: <Self::ConnectionHandler as libp2p::swarm::ConnectionHandler>::ToBehaviour,
+    ) {
+    }
+
+    fn on_swarm_event(&mut self, _event: FromSwarm<'_>) {}
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<
+        ToSwarm<
+            Self::ToSwarm,
+            <Self::ConnectionHandler as libp2p::swarm::ConnectionHandler>::FromBehaviour,
+        >,
+    > {
+        // CloseConnection is always accepted by the swarm — it never fails or returns an error.
+        // If the peer is not currently connected the event is silently ignored.
+        if let Some(peer_id) = self.pending_disconnections.pop() {
+            return Poll::Ready(ToSwarm::CloseConnection {
+                peer_id,
+                connection: CloseConnection::All,
+            });
+        }
+
+        self.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}

--- a/crates/apollo_network/src/peer_access_control_test.rs
+++ b/crates/apollo_network/src/peer_access_control_test.rs
@@ -1,0 +1,156 @@
+use std::collections::HashSet;
+use std::task::{Context, Poll};
+
+use libp2p::core::{ConnectedPoint, Endpoint};
+use libp2p::swarm::behaviour::ConnectionEstablished;
+use libp2p::swarm::{ConnectionId, FromSwarm, NetworkBehaviour, ToSwarm};
+use libp2p::{Multiaddr, PeerId};
+
+use super::peer_access_control::Behaviour;
+
+#[test]
+fn allows_all_before_enforcement() {
+    let mut behaviour = Behaviour::new();
+
+    let random_peer = PeerId::random();
+    let result = behaviour.handle_established_inbound_connection(
+        ConnectionId::new_unchecked(0),
+        random_peer,
+        &Multiaddr::empty(),
+        &Multiaddr::empty(),
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn denies_non_allowed_peer() {
+    let allowed_peer = PeerId::random();
+    let mut behaviour = Behaviour::new();
+
+    behaviour.set_allowed_peers(HashSet::from([allowed_peer]));
+
+    let stranger = PeerId::random();
+    let result = behaviour.handle_established_inbound_connection(
+        ConnectionId::new_unchecked(0),
+        stranger,
+        &Multiaddr::empty(),
+        &Multiaddr::empty(),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn allows_allowed_peers() {
+    let allowed_peer = PeerId::random();
+    let mut behaviour = Behaviour::new();
+
+    behaviour.set_allowed_peers(HashSet::from([allowed_peer]));
+
+    let result = behaviour.handle_established_inbound_connection(
+        ConnectionId::new_unchecked(0),
+        allowed_peer,
+        &Multiaddr::empty(),
+        &Multiaddr::empty(),
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn disconnects_removed_peers_on_allowed_change() {
+    let peer_a = PeerId::random();
+    let peer_b = PeerId::random();
+    let mut behaviour = Behaviour::new();
+
+    behaviour.set_allowed_peers(HashSet::from([peer_a, peer_b]));
+
+    // Remove peer_b from the allowed set.
+    behaviour.set_allowed_peers(HashSet::from([peer_a]));
+
+    let disconnected = expect_all_events_are_close_connections(&mut behaviour);
+    assert_eq!(disconnected, vec![peer_b]);
+}
+
+#[test]
+fn denies_outbound_to_non_allowed_peer() {
+    let mut behaviour = Behaviour::new();
+    behaviour.set_allowed_peers(HashSet::from([PeerId::random()]));
+
+    let stranger = PeerId::random();
+    let result = behaviour.handle_pending_outbound_connection(
+        ConnectionId::new_unchecked(0),
+        Some(stranger),
+        &[],
+        Endpoint::Dialer,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn allows_outbound_to_allowed_peer() {
+    let allowed_peer = PeerId::random();
+    let mut behaviour = Behaviour::new();
+    behaviour.set_allowed_peers(HashSet::from([allowed_peer]));
+
+    let result = behaviour.handle_pending_outbound_connection(
+        ConnectionId::new_unchecked(0),
+        Some(allowed_peer),
+        &[],
+        Endpoint::Dialer,
+    );
+    result.unwrap();
+}
+
+#[test]
+fn empty_allowed_set_disconnects_all_previously_allowed() {
+    let peer_a = PeerId::random();
+    let peer_b = PeerId::random();
+    let mut behaviour = Behaviour::new();
+
+    behaviour.set_allowed_peers(HashSet::from([peer_a, peer_b]));
+
+    behaviour.set_allowed_peers(HashSet::new());
+
+    let disconnected = expect_all_events_are_close_connections(&mut behaviour);
+    assert!(disconnected.contains(&peer_a));
+    assert!(disconnected.contains(&peer_b));
+}
+
+// TODO(AndrewL): unite these test helpers with sqmr tests into a shared test util file.
+
+fn expect_close_connection_event(behaviour: &mut Behaviour) -> Option<PeerId> {
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    match behaviour.poll(&mut cx) {
+        Poll::Ready(ToSwarm::CloseConnection { peer_id, .. }) => Some(peer_id),
+        Poll::Ready(other) => panic!("Unexpected event: {other:?}"),
+        Poll::Pending => None,
+    }
+}
+
+/// Drains all pending `CloseConnection` events, panicking if any other event type is emitted.
+fn expect_all_events_are_close_connections(behaviour: &mut Behaviour) -> Vec<PeerId> {
+    let mut disconnected = Vec::new();
+    while let Some(peer_id) = expect_close_connection_event(behaviour) {
+        disconnected.push(peer_id);
+    }
+    disconnected
+}
+
+#[allow(dead_code)]
+fn simulate_connection_established(
+    behaviour: &mut Behaviour,
+    peer_id: PeerId,
+    connection_id: usize,
+) {
+    let address = Multiaddr::empty();
+    behaviour.on_swarm_event(FromSwarm::ConnectionEstablished(ConnectionEstablished {
+        peer_id,
+        connection_id: ConnectionId::new_unchecked(connection_id),
+        endpoint: &ConnectedPoint::Listener {
+            local_addr: address.clone(),
+            send_back_addr: address,
+        },
+        failed_addresses: &[],
+        other_established: 0,
+    }));
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new connection gating logic into the libp2p swarm, which can deny/close peer connections when enforcement is enabled and the allowed set changes. While enforcement defaults off, incorrect wiring of `set_allowed_peers` could inadvertently disconnect or block peers once activated.
> 
> **Overview**
> Introduces a new `peer_access_control` libp2p `NetworkBehaviour` that can **enforce a peer whitelist** by denying inbound/outbound connections for non-allowed peers and emitting `CloseConnection` events for peers removed from the allowed set.
> 
> Wires this behaviour into `MixedBehaviour` and updates `NetworkManager::add_epoch` to set the allowed peer set (and reuse it for discovery targeting). Adds unit tests covering allow/deny behavior and disconnection scheduling when the whitelist changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cea430d19638e742d9e8a1b37202329300f65bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->