### PR TITLE
echonet: Calculate committments

### DIFF
--- a/echonet/deploy_echonet.py
+++ b/echonet/deploy_echonet.py
@@ -157,6 +157,69 @@ def _probe_http_ok(url: str, timeout_seconds: float = 1.0) -> bool:
         return False
 
 
+def _find_local_block_hash_cli(repo_root: Path) -> Path | None:
+    candidates = [
+        repo_root / "target" / "debug" / "starknet_committer_and_os_cli",
+        repo_root / "target" / "release" / "starknet_committer_and_os_cli",
+    ]
+    return next((c for c in candidates if c.exists()), None)
+
+
+def _get_echonet_pod_name(namespace_args: list[str]) -> str:
+    proc = subprocess.run(
+        [
+            "kubectl",
+            *namespace_args,
+            "get",
+            "pods",
+            "-l",
+            "app=echonet,role=flask",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Failed to query echonet pod name (exit {proc.returncode}): {proc.stderr.strip()}"
+        )
+    pod_name = proc.stdout.strip()
+    if not pod_name:
+        raise RuntimeError("No echonet pod found for label selector app=echonet,role=flask.")
+    return pod_name
+
+
+def _install_block_hash_cli_into_pod(
+    namespace_args: list[str], local_binary: Path, remote_binary: str
+) -> None:
+    deadline = time.time() + 90.0
+    while time.time() <= deadline:
+        try:
+            pod_name = _get_echonet_pod_name(namespace_args)
+            kube = ["kubectl", *namespace_args]
+            pod_exec = [*kube, "exec", pod_name, "-c", "echonet", "--"]
+            subprocess.run(
+                [*pod_exec, "mkdir", "-p", str(Path(remote_binary).parent)],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                [*kube, "cp", str(local_binary), f"{pod_name}:{remote_binary}", "-c", "echonet"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                [*pod_exec, "chmod", "+x", remote_binary], check=True, capture_output=True
+            )
+            logger.info(f"Installed block-hash CLI: {local_binary} -> {pod_name}:{remote_binary}")
+            return
+        except (RuntimeError, subprocess.CalledProcessError):
+            time.sleep(1.0)
+    raise RuntimeError("Timed out waiting for echonet pod before copying block-hash CLI.")
+
+
 def _copy_generated_keys(keys_in_repo: Path, generated_path: Path) -> None:
     """
     Copy the non-secret echonet keys JSON into the kustomize generated/ directory.
@@ -210,10 +273,19 @@ def main(argv: list[str] | None = None) -> int:
         default=18080,
         help="Local port for --port-forward (default: 18080).",
     )
+    parser.add_argument(
+        "--block-hash-cli-binary",
+        default="auto",
+        help=(
+            "Local path to starknet_committer_and_os_cli to copy into the echonet pod. "
+            "Use 'auto' (default) to detect at target/debug or target/release, or 'skip' to disable."
+        ),
+    )
     args = parser.parse_args(argv)
 
     # Paths
     script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
 
     kustomize_dir = script_dir / "k8s" / "echonet"
 
@@ -257,6 +329,28 @@ def main(argv: list[str] | None = None) -> int:
     # Apply manifests
     logger.info("Applying manifests...")
     _run(["kubectl", *namespace_args, "apply", "-k", str(kustomize_dir)])
+
+    local_block_hash_cli: Path | None = None
+    if args.block_hash_cli_binary == "skip":
+        logger.info("Skipping block-hash CLI copy into pod (--block-hash-cli-binary=skip).")
+    elif args.block_hash_cli_binary == "auto":
+        local_block_hash_cli = _find_local_block_hash_cli(repo_root)
+        if not local_block_hash_cli:
+            logger.warning(
+                "No local block-hash CLI found under target/debug or target/release; "
+                "echonet may fail commitment calculation until the binary is available in the pod."
+            )
+    else:
+        local_block_hash_cli = Path(args.block_hash_cli_binary).expanduser().resolve()
+        if not local_block_hash_cli.exists():
+            raise FileNotFoundError(
+                f"--block-hash-cli-binary points to a missing file: {local_block_hash_cli}"
+            )
+
+    if local_block_hash_cli:
+        _install_block_hash_cli_into_pod(
+            namespace_args, local_block_hash_cli, "/data/echonet/bin/starknet_committer_and_os_cli"
+        )
 
     # Wait for rollout to complete.
     logger.info("Waiting for rollout status deployment/echonet...")

--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -2,6 +2,8 @@ import base64
 import json
 import logging
 import os
+import subprocess
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
@@ -77,7 +79,6 @@ def _fetch_bootstrap_constants(
 
     custom_keys = [
         "state_root",
-        "transaction_commitment",
         "event_commitment",
         "receipt_commitment",
         "state_diff_commitment",
@@ -374,6 +375,88 @@ class BlobTransformer:
             return self._chain.base_block_hash_hex
         return self._shared.get_block_field(latest_block_number, "block")["block_hash"]
 
+    def _run_block_hash_cli(self, subcommand: str, payload: JsonObject) -> Any:
+        cli_path = CONFIG.paths.block_hash_cli_path
+        if not cli_path.exists():
+            raise RuntimeError(f"Missing block-hash calculator CLI binary at: {cli_path}")
+        repo_root = Path(__file__).resolve().parent.parent
+        with tempfile.TemporaryDirectory(prefix="echonet_block_hash_", dir=repo_root) as tmp:
+            input_path = Path(tmp) / "input.json"
+            output_path = Path(tmp) / "output.json"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+            command = [
+                str(cli_path),
+                "block-hash",
+                subcommand,
+                "--input-path",
+                str(input_path),
+                "--output-path",
+                str(output_path),
+            ]
+            subprocess.run(
+                command, cwd=repo_root, capture_output=True, text=True, check=True, timeout=30
+            )
+            return json.loads(output_path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _build_thin_state_diff(blob: JsonObject) -> JsonObject:
+        state_diff = blob["state_diff"]
+        return {
+            "deployed_contracts": state_diff["address_to_class_hash"],
+            "storage_diffs": state_diff["storage_updates"]["L1"],
+            "class_hash_to_compiled_class_hash": state_diff["class_hash_to_compiled_class_hash"],
+            "deprecated_declared_classes": [],
+            "nonces": state_diff["nonces"]["L1"],
+        }
+
+    @staticmethod
+    def _build_transactions_data_for_commitments(
+        transformed_txs: List[JsonObject],
+        receipts: List[JsonObject],
+        execution_infos: List[JsonObject],
+    ) -> List[JsonObject]:
+        return [
+            {
+                "transaction_signature": tx.get("signature", []),
+                "transaction_output": {
+                    "actual_fee": receipt["actual_fee"],
+                    "events": receipt["events"],
+                    "execution_status": (
+                        {
+                            "execution_status": "REVERTED",
+                            "revert_reason": receipt.get("revert_error", ""),
+                        }
+                        if receipt["execution_status"] == "REVERTED"
+                        else {"execution_status": "SUCCEEDED"}
+                    ),
+                    "gas_consumed": execution_info["total_gas"],
+                    "messages_sent": receipt["l2_to_l1_messages"],
+                },
+                "transaction_hash": tx["transaction_hash"],
+            }
+            for tx, receipt, execution_info in zip(transformed_txs, receipts, execution_infos)
+        ]
+
+    def _compute_block_commitments(
+        self,
+        blob: JsonObject,
+        transformed_txs: List[JsonObject],
+        receipts: List[JsonObject],
+        execution_infos: List[JsonObject],
+    ) -> JsonObject:
+        block_info = blob["state_diff"]["block_info"]
+        return self._run_block_hash_cli(
+            "block-hash-commitments",
+            {
+                "transactions_data": self._build_transactions_data_for_commitments(
+                    transformed_txs, receipts, execution_infos
+                ),
+                "state_diff": self._build_thin_state_diff(blob),
+                "l1_da_mode": "BLOB" if block_info.get("use_kzg_da") else "CALLDATA",
+                "starknet_version": block_info["starknet_version"],
+            },
+        )
+
     @staticmethod
     def _compute_state_diff_length(blob: JsonObject) -> int:
         state_diff = blob["state_diff"]
@@ -486,9 +569,16 @@ class BlobTransformer:
         )
 
         source_block = self._fetch_upstream_source_block(bn_for_meta)
+        block_commitments = self._compute_block_commitments(
+            blob,
+            transformed_txs,
+            receipts,
+            execution_infos,
+        )
         block_document["status"] = source_block["status"]
         block_document["starknet_version"] = source_block["starknet_version"]
         block_document["sequencer_address"] = source_block["sequencer_address"]
+        block_document["transaction_commitment"] = str(block_commitments["transaction_commitment"])
         block_document["l2_gas_consumed"] = blob["fee_market_info"]["l2_gas_consumed"]
         block_document["next_l2_gas_price"] = blob["fee_market_info"]["next_l2_gas_price"]
         block_document["l1_da_mode"] = (

--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -157,6 +157,7 @@ class PathsConfig:
     """Filesystem locations for auxiliary artifacts (reports, snapshots, etc.)."""
 
     log_dir: Path = Path("/data/echonet")
+    block_hash_cli_path: Path = Path("/data/echonet/bin/starknet_committer_and_os_cli")
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new external CLI dependency and runs it during block transformation/deploy, which can fail at runtime if the binary is missing/mismatched and will affect correctness of stored block metadata.
> 
> **Overview**
> Echonet now **computes block commitments (notably `transaction_commitment`) by invoking an external `starknet_committer_and_os_cli` binary** during blob-to-block transformation, instead of relying on upstream-provided values.
> 
> Deployment tooling is updated to optionally **auto-detect and `kubectl cp` the CLI binary into the running echonet pod** (configurable via `--block-hash-cli-binary`), and config gains a new `CONFIG.paths.block_hash_cli_path` pointing at `/data/echonet/bin/starknet_committer_and_os_cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2e1a7823c589374189e1258ed18f35e75a6201a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->