### PR TITLE
apollo_central_sync: use starknet version as single source of truth for non BC classes

### DIFF
--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -30,7 +30,7 @@ use apollo_state_sync_metrics::metrics::{
 use apollo_storage::base_layer::{BaseLayerStorageReader, BaseLayerStorageWriter};
 use apollo_storage::body::BodyStorageWriter;
 use apollo_storage::class::{ClassStorageReader, ClassStorageWriter};
-use apollo_storage::class_manager::{ClassManagerStorageReader, ClassManagerStorageWriter};
+use apollo_storage::class_manager::ClassManagerStorageWriter;
 use apollo_storage::compiled_class::{CasmStorageReader, CasmStorageWriter};
 use apollo_storage::db::DbError;
 use apollo_storage::header::{HeaderStorageReader, HeaderStorageWriter};
@@ -166,7 +166,6 @@ pub enum SyncEvent {
         class_hash: ClassHash,
         compiled_class_hash: CompiledClassHash,
         compiled_class: CasmContractClass,
-        is_compiler_backward_compatible: bool,
     },
     NewBaseLayerBlock {
         block_number: BlockNumber,
@@ -281,7 +280,6 @@ impl<
             self.config.latest_block_poll_interval_millis,
             // TODO(yair): separate config param.
             self.config.state_updates_max_stream_size,
-            self.config.store_sierras_and_casms_block_threshold,
         )
         .fuse();
         let base_layer_block_stream = match &self.base_layer_source {
@@ -296,11 +294,7 @@ impl<
         };
         // TODO(dvir): try use interval instead of stream.
         // TODO(DvirYo): fix the bug and remove this check.
-        let check_sync_progress = check_sync_progress(
-            self.reader.clone(),
-            self.config.store_sierras_and_casms_block_threshold,
-        )
-        .fuse();
+        let check_sync_progress = check_sync_progress(self.reader.clone()).fuse();
         pin_mut!(
             block_stream,
             state_diff_stream,
@@ -351,14 +345,12 @@ impl<
                 class_hash,
                 compiled_class_hash,
                 compiled_class,
-                is_compiler_backward_compatible,
             } => {
                 self.store_compiled_class(
                     block_number,
                     class_hash,
                     compiled_class_hash,
                     compiled_class,
-                    is_compiler_backward_compatible,
                 )
                 .await
             }
@@ -393,23 +385,12 @@ impl<
             block.body.transactions.len().try_into().expect("Failed to convert usize to u64");
         let timestamp = block.header.block_header_without_hash.timestamp;
         self.perform_storage_writes(move |writer| {
-            let mut txn = writer
+            writer
                 .begin_rw_txn()?
                 .append_header(block_number, &block.header)?
                 .append_block_signature(block_number, &signature)?
-                .append_body(block_number, block.body)?;
-            if block.header.block_header_without_hash.starknet_version
-                < STARKNET_VERSION_TO_COMPILE_FROM
-            {
-                trace!(
-                    "Updating compiler backward compatibility marker to {}",
-                    block_number.unchecked_next()
-                );
-                txn = txn.update_compiler_backward_compatibility_marker(
-                    &block_number.unchecked_next(),
-                )?;
-            }
-            txn.commit()?;
+                .append_body(block_number, block.body)?
+                .commit()?;
             Ok(())
         })
         .await?;
@@ -479,38 +460,24 @@ impl<
         let (thin_state_diff, classes, deprecated_classes) =
             ThinStateDiff::from_state_diff(state_diff);
 
-        let mut block_contains_non_backwards_compatible_classes = false;
+        let block_starknet_version = self
+            .reader
+            .begin_ro_txn()?
+            .get_starknet_version(block_number)?
+            .expect("Block header must be present before state diff is processed.");
+
+        let is_bc_compatible_block = block_starknet_version >= STARKNET_VERSION_TO_COMPILE_FROM;
         // Sending to class manager before updating the storage so that if the class manager send
         // fails we retry the same block.
         if let Some(class_manager_client) = &self.class_manager_client {
-            // Blocks smaller than compiler_backward_compatibility marker are added to class
-            // manager via the compiled classes stream.
-            // We're sure that if the current block is above the compiler_backward_compatibility
-            // marker then the compiler_backward_compatibility will not advance anymore, because
-            // the compiler_backward_compatibility marker advances in the header stream and this
-            // stream is behind the header stream
-            // The compiled classes stream is always behind the compiler_backward_compatibility
-            // marker
-            // TODO(shahak): Consider storing a boolean and updating it to true once
-            // compiler_backward_compatibility_marker <= block_number and avoiding the check if the
-            // boolean is true.
-            let compiler_backward_compatibility_marker =
-                self.reader.begin_ro_txn()?.get_compiler_backward_compatibility_marker()?;
+            // Non-BC blocks (starknet_version < STARKNET_VERSION_TO_COMPILE_FROM) must be added
+            // to the class manager via the compiled classes stream, which provides the pre-compiled
+            // CASM. BC blocks are compiled by the class manager itself.
+            // The block header is guaranteed to be in storage before the state diff stream
+            // processes this block (header stream is always ahead).
 
-            // A block contains only classes with either STARKNET_VERSION_TO_COMPILE_FROM or higher
-            // or only classes below STARKNET_VERSION_TO_COMPILE_FROM, not both.
-            if compiler_backward_compatibility_marker <= block_number {
-                if compiler_backward_compatibility_marker == block_number {
-                    info!(
-                        "Reached first block ({block_number}) without non backward compatible \
-                         classes."
-                    );
-                }
-                trace!(
-                    "Block {block_number} does not contain non backward compatible classes. \
-                     compiler_backward_compatibility_marker: \
-                     {compiler_backward_compatibility_marker}"
-                );
+            if is_bc_compatible_block {
+                trace!("Block {block_number} does not contain non backward compatible classes");
                 for (expected_class_hash, class) in &classes {
                     let class_hash =
                         class_manager_client.add_class(class.clone()).await?.class_hash;
@@ -521,9 +488,6 @@ impl<
                         );
                     }
                 }
-            } else {
-                debug!("Block {} contains non backward compatible classes.", block_number);
-                block_contains_non_backwards_compatible_classes = true;
             }
 
             for (class_hash, deprecated_class) in &deprecated_classes {
@@ -531,39 +495,26 @@ impl<
                     .add_deprecated_class(*class_hash, deprecated_class.clone())
                     .await?;
             }
-        }
-        let has_class_manager = self.class_manager_client.is_some();
 
-        let store_sierras_and_casms_block_threshold =
-            self.config.store_sierras_and_casms_block_threshold;
-        let store_sierras_and_casms = block_number.0 < store_sierras_and_casms_block_threshold;
-        self.perform_storage_writes(move |writer| {
-            if has_class_manager {
+            self.perform_storage_writes(move |writer| {
                 writer
                     .begin_rw_txn()?
                     .update_class_manager_block_marker(&block_number.unchecked_next())?
                     .commit()?;
                 STATE_SYNC_CLASS_MANAGER_MARKER.set_lossy(block_number.unchecked_next().0);
-            }
+                Ok(())
+            })
+            .await?;
+        }
+
+        self.perform_storage_writes(move |writer| {
             let mut txn = writer.begin_rw_txn()?;
             txn = txn.append_state_diff(block_number, thin_state_diff)?;
-            // Non backwards compatible classes must be stored for later use since we will only be
-            // be adding them to the class manager later, once we have their compiled
-            // classes.
-            //
-            // TODO(guy.f): Properly fix handling non backwards compatible classes.
-            if store_sierras_and_casms || block_contains_non_backwards_compatible_classes {
-                let store_reason = if store_sierras_and_casms {
-                    format!(
-                        "block {} is below store_sierras_and_casms_block_threshold: \
-                         {store_sierras_and_casms_block_threshold}",
-                        block_number.0
-                    )
-                } else {
-                    format!("block {} contains non backwards compatible classes", block_number.0)
-                };
+            // Non-BC Sierra classes must be stored in storage so the compiled class stream can read
+            // them later when adding the class + CASM to the class manager.
+            if !is_bc_compatible_block {
                 debug!(
-                    "Appending classes {:?} to storage since {store_reason}",
+                    "Storing Sierra classes {:?} in storage (non-BC block {block_number})",
                     classes.keys().collect::<Vec<_>>()
                 );
                 txn = txn.append_classes(
@@ -577,14 +528,8 @@ impl<
                         .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
                         .collect::<Vec<_>>(),
                 )?;
-            } else {
-                trace!(
-                    "Skipping appending classes {:?} to storage since block is at or above \
-                     store_sierras_and_casms_block_threshold and \
-                     block_contains_non_backwards_compatible_classes is false",
-                    classes.keys().collect::<Vec<_>>()
-                );
             }
+
             txn.commit()?;
             Ok(())
         })
@@ -608,33 +553,40 @@ impl<
         class_hash: ClassHash,
         _compiled_class_hash_v1: CompiledClassHash,
         compiled_class: CasmContractClass,
-        is_compiler_backward_compatible: bool,
     ) -> StateSyncResult {
+        // The compiled class stream pauses when it reaches a BC block, so this function should
+        // only be called for non-BC blocks.
+        debug_assert!(
+            self.reader
+                .begin_ro_txn()
+                .ok()
+                .and_then(|txn| txn.get_starknet_version(block_number).ok().flatten())
+                .map(|v| v < STARKNET_VERSION_TO_COMPILE_FROM)
+                .unwrap_or(true),
+            "store_compiled_class called for BC block {block_number}"
+        );
+
         let compiled_class_hash_v2 = compiled_class.hash(&HashVersion::V2);
 
-        if !is_compiler_backward_compatible {
-            if let Some(class_manager_client) = &self.class_manager_client {
-                let class = self.reader.begin_ro_txn()?.get_class(&class_hash)?.expect(
+        if let Some(class_manager_client) = &self.class_manager_client {
+            let class =
+                self.reader.begin_ro_txn()?.get_class(&class_hash)?.expect(
                     "Compiled classes stream gave class hash that doesn't appear in storage.",
                 );
-                let sierra_version = class
-                    .get_sierra_version()
-                    .expect("Failed reading sierra version from program.");
-                let contract_class = ContractClass::V1((compiled_class.clone(), sierra_version));
-                class_manager_client
-                    .add_class_and_executable_unsafe(
-                        class_hash,
-                        class,
-                        compiled_class_hash_v2,
-                        contract_class,
-                    )
-                    .await
-                    .expect("Failed adding class and compiled class to class manager.");
-            }
+            let sierra_version =
+                class.get_sierra_version().expect("Failed reading sierra version from program.");
+            let contract_class = ContractClass::V1((compiled_class.clone(), sierra_version));
+            class_manager_client
+                .add_class_and_executable_unsafe(
+                    class_hash,
+                    class,
+                    compiled_class_hash_v2,
+                    contract_class,
+                )
+                .await
+                .expect("Failed adding class and compiled class to class manager.");
         }
-        if block_number.0 >= self.config.store_sierras_and_casms_block_threshold {
-            return Ok(());
-        }
+
         let result = self
             .perform_storage_writes(move |writer| {
                 writer.begin_rw_txn()?.append_casm(&class_hash, &compiled_class)?.commit()?;
@@ -895,25 +847,37 @@ fn stream_new_compiled_classes<TCentralSource: CentralSourceTrait + Sync + Send>
     central_source: Arc<TCentralSource>,
     latest_block_poll_interval_millis: Duration,
     max_stream_size: u32,
-    store_sierras_and_casms_block_threshold: u64,
 ) -> impl Stream<Item = Result<SyncEvent, StateSyncError>> {
     try_stream! {
+        let mut reached_bc_block = false;
         loop {
             let txn = reader.begin_ro_txn()?;
             let mut from = txn.get_compiled_class_marker()?;
             let state_marker = txn.get_state_marker()?;
-            let compiler_backward_compatibility_marker = txn.get_compiler_backward_compatibility_marker()?;
-            // Avoid starting streams from blocks without declared classes.
             while from < state_marker {
+                // The block header is guaranteed to be in storage for any block below state_marker.
+                let starknet_version_at_from = txn.get_starknet_version(from)?.expect("Block header must exist for block below state_marker.");
+                // Pause when `from` has reached a BC block: no compiled classes need to be downloaded.
+                if starknet_version_at_from >= STARKNET_VERSION_TO_COMPILE_FROM {
+                    reached_bc_block = true;
+                    break;
+                }
                 let state_diff = txn.get_state_diff(from)?.expect("Expecting to have state diff up to the marker.");
                 if state_diff.class_hash_to_compiled_class_hash.is_empty() {
                     from = from.unchecked_next();
-                }
-                else {
+                } else {
                     break;
                 }
             }
-            drop(txn); // Drop txn so we don't unnecessarily hold it open while sleeping.
+            drop(txn); // Drop txn so we don't unnecessarily hold it open.
+
+            if reached_bc_block {
+                info!(
+                    "Compiled classes stream reached BC block {from}, pausing the stream."
+                );
+                pending::<()>().await;
+                continue;
+            }
 
             if from == state_marker {
                 debug!(
@@ -923,23 +887,24 @@ fn stream_new_compiled_classes<TCentralSource: CentralSourceTrait + Sync + Send>
                 tokio::time::sleep(latest_block_poll_interval_millis).await;
                 continue;
             }
-            let mut up_to = min(state_marker, BlockNumber(from.0 + u64::from(max_stream_size)));
-            let are_casms_backward_compatible = from >= compiler_backward_compatibility_marker;
-            // We want that the stream will either have all compiled classes as backward compatible
-            // or all as not backward compatible. If needed we'll decrease up_to
-            if from < compiler_backward_compatibility_marker && up_to > compiler_backward_compatibility_marker {
-                up_to = compiler_backward_compatibility_marker;
-            }
 
-            // No point in downloading casms if we don't store them and don't send them to the
-            // class manager
-            if are_casms_backward_compatible && from.0 >= store_sierras_and_casms_block_threshold {
-                info!("Compiled classes stream reached a block that has backward compatibility for \
-                      the compiler, and block is at or above store_sierras_and_casms_block_threshold. \
-                      Finishing the compiled class stream");
-                pending::<()>().await;
-                continue;
+            // Cap up_to at the first BC block so each batch is entirely non-BC.
+            // Since starknet_version is monotonically non-decreasing, the non-BC range is always
+            // a contiguous prefix.
+            let mut up_to = min(state_marker, BlockNumber(from.0 + u64::from(max_stream_size)));
+            let scan_txn = reader.begin_ro_txn()?;
+            let mut scan = from.unchecked_next();
+            while scan < up_to {
+                let scan_version = scan_txn
+                    .get_starknet_version(scan)?
+                    .expect("Block header must exist for block below state_marker.");
+                if scan_version >= STARKNET_VERSION_TO_COMPILE_FROM {
+                    up_to = scan;
+                    break;
+                }
+                scan = scan.unchecked_next();
             }
+            drop(scan_txn);
 
             debug!("Downloading compiled classes of blocks [{} - {}).", from, up_to);
             let compiled_classes_stream =
@@ -954,7 +919,6 @@ fn stream_new_compiled_classes<TCentralSource: CentralSourceTrait + Sync + Send>
                     class_hash,
                     compiled_class_hash,
                     compiled_class,
-                    is_compiler_backward_compatible: are_casms_backward_compatible,
                 };
             }
         }
@@ -999,7 +963,6 @@ fn stream_new_base_layer_block<TBaseLayerSource: BaseLayerSourceTrait + Sync>(
 // TODO(dvir): add a test for this scenario.
 fn check_sync_progress(
     reader: StorageReader,
-    store_sierras_and_casms_block_threshold: u64,
 ) -> impl Stream<Item = Result<SyncEvent, StateSyncError>> {
     try_stream! {
         let (mut header_marker, mut state_marker, mut casm_marker) = {
@@ -1010,30 +973,38 @@ fn check_sync_progress(
             (header_marker, state_marker, casm_marker)
         };
 
-        loop{
+        loop {
             tokio::time::sleep(SLEEP_TIME_SYNC_PROGRESS).await;
             debug!("Checking if sync stopped progress.");
-            let (new_header_marker, new_state_marker, new_casm_marker, compiler_backward_compatibility_marker) = {
+            let (new_header_marker, new_state_marker, new_casm_marker) = {
                 let txn = reader.begin_ro_txn()?;
                 let new_header_marker = txn.get_header_marker()?;
                 let new_state_marker = txn.get_state_marker()?;
                 let new_casm_marker = txn.get_compiled_class_marker()?;
-                let compiler_backward_compatibility_marker = txn.get_compiler_backward_compatibility_marker()?;
-                (new_header_marker, new_state_marker, new_casm_marker, compiler_backward_compatibility_marker)
+                (new_header_marker, new_state_marker, new_casm_marker)
             };
-            let store_sierras_and_casms =
-                new_casm_marker.0 < store_sierras_and_casms_block_threshold;
+            // The casm stream is stuck only if it hasn't advanced AND there are more non-BC blocks
+            // to process.
             let is_casm_stuck = casm_marker == new_casm_marker
-                && (new_casm_marker < compiler_backward_compatibility_marker
-                    || store_sierras_and_casms);
-            if header_marker==new_header_marker || state_marker==new_state_marker || is_casm_stuck {
-                debug!("No progress in the sync. Return NoProgress event. Header marker: {header_marker}, \
-                       State marker: {state_marker}, Casm marker: {casm_marker}.");
+                && new_casm_marker < new_state_marker
+                && reader
+                    .begin_ro_txn()?
+                    .get_starknet_version(new_casm_marker)?
+                    .expect("Block header must exist for block below state_marker.")
+                    < STARKNET_VERSION_TO_COMPILE_FROM;
+            if header_marker == new_header_marker
+                || state_marker == new_state_marker
+                || is_casm_stuck
+            {
+                debug!(
+                    "No progress in the sync. Return NoProgress event. Header marker: \
+                     {header_marker}, State marker: {state_marker}, Casm marker: {casm_marker}."
+                );
                 yield SyncEvent::NoProgress;
             }
-            header_marker=new_header_marker;
-            state_marker=new_state_marker;
-            casm_marker=new_casm_marker;
+            header_marker = new_header_marker;
+            state_marker = new_state_marker;
+            casm_marker = new_casm_marker;
         }
     }
 }

--- a/crates/apollo_central_sync/src/sources/central_sync_test.rs
+++ b/crates/apollo_central_sync/src/sources/central_sync_test.rs
@@ -107,9 +107,6 @@ fn get_test_sync_config(verify_blocks: bool) -> SyncConfig {
         state_updates_max_stream_size: STREAM_SIZE,
         verify_blocks,
         collect_pending_data: false,
-        // TODO(Shahak): Add test where store_sierras_and_casms_block_threshold is disabled, i.e.,
-        // setting 0.
-        store_sierras_and_casms_block_threshold: u64::MAX,
     }
 }
 

--- a/crates/apollo_central_sync_config/src/config.rs
+++ b/crates/apollo_central_sync_config/src/config.rs
@@ -114,7 +114,6 @@ pub struct SyncConfig {
     pub state_updates_max_stream_size: u32,
     pub verify_blocks: bool,
     pub collect_pending_data: bool,
-    pub store_sierras_and_casms_block_threshold: u64,
 }
 
 impl SerializeConfig for SyncConfig {
@@ -164,17 +163,6 @@ impl SerializeConfig for SyncConfig {
                 "Whether to collect data on pending blocks.",
                 ParamPrivacyInput::Public,
             ),
-            ser_param(
-                "store_sierras_and_casms_block_threshold",
-                &self.store_sierras_and_casms_block_threshold,
-                "Block-number threshold for persisting **Sierra** and **CASM** to local storage \
-                 (for backward compatibility with the native blockifier). For blocks with \
-                 block_number < this value, Sierra and CASM are stored for all classes; for \
-                 block_number >= this value they are stored only for **legacy** classes (compiled \
-                 with a version < `STARKNET_VERSION_TO_COMPILE_FROM`). Use 0 to store for no \
-                 blocks, or a large value (e.g. u64::MAX) to store for all.",
-                ParamPrivacyInput::Public,
-            ),
         ])
     }
 }
@@ -189,7 +177,6 @@ impl Default for SyncConfig {
             state_updates_max_stream_size: 1000,
             verify_blocks: true,
             collect_pending_data: false,
-            store_sierras_and_casms_block_threshold: 0,
         }
     }
 }

--- a/crates/apollo_deployments/resources/app_configs/replacer_state_sync_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_state_sync_config.json
@@ -15,7 +15,6 @@
   "state_sync_config.static_config.central_sync_client_config.sync_config.latest_block_poll_interval_millis": 500,
   "state_sync_config.static_config.central_sync_client_config.sync_config.recoverable_error_sleep_duration": 3,
   "state_sync_config.static_config.central_sync_client_config.sync_config.state_updates_max_stream_size": 1000,
-  "state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold": "$$$_STATE_SYNC_CONFIG-STATIC_CONFIG-CENTRAL_SYNC_CLIENT_CONFIG-SYNC_CONFIG-STORE_SIERRAS_AND_CASMS_BLOCK_THRESHOLD_$$$",
   "state_sync_config.static_config.central_sync_client_config.sync_config.verify_blocks": false,
   "state_sync_config.static_config.network_config.#is_none": "$$$_STATE_SYNC_CONFIG-STATIC_CONFIG-NETWORK_CONFIG-IS_NONE_$$$",
   "state_sync_config.static_config.network_config.advertised_multiaddr": "",

--- a/crates/apollo_deployments/resources/app_configs/state_sync_config.json
+++ b/crates/apollo_deployments/resources/app_configs/state_sync_config.json
@@ -14,7 +14,6 @@
   "state_sync_config.static_config.central_sync_client_config.sync_config.collect_pending_data": false,
   "state_sync_config.static_config.central_sync_client_config.sync_config.recoverable_error_sleep_duration": 3,
   "state_sync_config.static_config.central_sync_client_config.sync_config.state_updates_max_stream_size": 1000,
-  "state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold": 0,
   "state_sync_config.static_config.central_sync_client_config.sync_config.verify_blocks": false,
   "state_sync_config.static_config.network_config.#is_none": "",
   "state_sync_config.static_config.network_config.advertised_multiaddr.#is_none": true,

--- a/crates/apollo_deployments/src/service.rs
+++ b/crates/apollo_deployments/src/service.rs
@@ -96,7 +96,6 @@ pub static KEYS_TO_BE_REPLACED: phf::Set<&'static str> = phf_set! {
     "sierra_compiler_config.max_bytecode_size",
     "starknet_url",
     "state_sync_config.static_config.central_sync_client_config.#is_none",
-    "state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold",
     "state_sync_config.static_config.network_config.#is_none",
     "state_sync_config.static_config.p2p_sync_client_config.#is_none",
     "state_sync_config.static_config.rpc_config.port",

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3284,11 +3284,6 @@
     "privacy": "Public",
     "value": 1000
   },
-  "state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold": {
-    "description": "Block-number threshold for persisting **Sierra** and **CASM** to local storage (for backward compatibility with the native blockifier). For blocks with block_number < this value, Sierra and CASM are stored for all classes; for block_number >= this value they are stored only for **legacy** classes (compiled with a version < `STARKNET_VERSION_TO_COMPILE_FROM`). Use 0 to store for no blocks, or a large value (e.g. u64::MAX) to store for all.",
-    "privacy": "Public",
-    "value": 0
-  },
   "state_sync_config.static_config.central_sync_client_config.sync_config.verify_blocks": {
     "description": "Whether to verify incoming blocks.",
     "privacy": "Public",

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -841,6 +841,7 @@ pub enum MarkerKind {
     BaseLayerBlock,
     /// Marks the last written class manager block.
     ClassManagerBlock,
+    /// TODO(noamsp): delete this marker.
     /// Marks the block beyond the last block that its classes can't be compiled with the current
     /// compiler version used in the class manager. Determined by starknet version.
     CompilerBackwardCompatibility,

--- a/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/core.yaml
@@ -64,7 +64,6 @@ config:
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee.#is_none: true
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee: ""
     state_sync_config.static_config.central_sync_client_config.#is_none: true
-    state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold: 0
     state_sync_config.static_config.network_config.#is_none: false
     state_sync_config.static_config.network_config.port: 55010
     state_sync_config.static_config.p2p_sync_client_config.#is_none: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the state sync/class-manager integration and compiled-class streaming behavior based on stored `starknet_version`, which can affect how/when classes and CASMs are persisted and sent to the class manager during sync.
> 
> **Overview**
> Switches non-backward-compatible (non-BC) class handling to use the block header’s `starknet_version` as the single source of truth, removing the previous reliance on the `compiler_backward_compatibility_marker` and the `store_sierras_and_casms_block_threshold` config.
> 
> State diff processing now sends Sierra classes directly to the class manager only for BC blocks, and persists Sierra classes to storage only for non-BC blocks so the compiled-class stream can later attach CASM and call `add_class_and_executable_unsafe`. The compiled-class stream now scans headers to stop/pause at the first BC block and batches downloads to include only non-BC ranges; the sync “stuck” detector (`check_sync_progress`) is updated accordingly.
> 
> Removes `store_sierras_and_casms_block_threshold` from config/schema/deployment overlays and stops updating the compiler-compatibility marker during header writes (marker remains in storage with a TODO to delete).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c6ec2951f3cda0327cc1ab4025c74da7c5f099a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->