### PR TITLE
apollo_storage: remove compiler backward compatibility marker

### DIFF
--- a/crates/apollo_storage/src/class_manager.rs
+++ b/crates/apollo_storage/src/class_manager.rs
@@ -14,10 +14,6 @@ pub trait ClassManagerStorageReader {
     /// The block number marker is the first block number that doesn't exist yet in the class
     /// manager.
     fn get_class_manager_block_marker(&self) -> StorageResult<BlockNumber>;
-
-    /// The block number marker is the first block number that the class manager supports
-    /// compilation from.
-    fn get_compiler_backward_compatibility_marker(&self) -> StorageResult<BlockNumber>;
 }
 
 /// Interface for writing data related to the class manager.
@@ -35,27 +31,12 @@ where
         self,
         target_block_number: BlockNumber,
     ) -> StorageResult<Self>;
-
-    /// Updates the block marker of compiler backward compatibility, marking the blocks behind the
-    /// given number as non-backward-compatible.
-    // To enforce that no commit happen after a failure, we consume and return Self on success.
-    fn update_compiler_backward_compatibility_marker(
-        self,
-        block_number: &BlockNumber,
-    ) -> StorageResult<Self>;
 }
 
 impl<Mode: TransactionKind> ClassManagerStorageReader for StorageTxn<'_, Mode> {
     fn get_class_manager_block_marker(&self) -> StorageResult<BlockNumber> {
         let markers_table = self.open_table(&self.tables.markers)?;
         Ok(markers_table.get(&self.txn, &MarkerKind::ClassManagerBlock)?.unwrap_or_default())
-    }
-
-    fn get_compiler_backward_compatibility_marker(&self) -> StorageResult<BlockNumber> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        Ok(markers_table
-            .get(&self.txn, &MarkerKind::CompilerBackwardCompatibility)?
-            .unwrap_or_default())
     }
 }
 
@@ -76,18 +57,5 @@ impl ClassManagerStorageWriter for StorageTxn<'_, RW> {
         } else {
             Ok(self)
         }
-    }
-
-    fn update_compiler_backward_compatibility_marker(
-        self,
-        block_number: &BlockNumber,
-    ) -> StorageResult<Self> {
-        let markers_table = self.open_table(&self.tables.markers)?;
-        markers_table.upsert(
-            &self.txn,
-            &MarkerKind::CompilerBackwardCompatibility,
-            block_number,
-        )?;
-        Ok(self)
     }
 }

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -841,10 +841,6 @@ pub enum MarkerKind {
     BaseLayerBlock,
     /// Marks the last written class manager block.
     ClassManagerBlock,
-    /// TODO(noamsp): delete this marker.
-    /// Marks the block beyond the last block that its classes can't be compiled with the current
-    /// compiler version used in the class manager. Determined by starknet version.
-    CompilerBackwardCompatibility,
     // TODO(Dori): fill in the missing doc.
     #[allow(missing_docs)]
     GlobalRoot,

--- a/crates/apollo_storage/src/serialization/serializers.rs
+++ b/crates/apollo_storage/src/serialization/serializers.rs
@@ -345,8 +345,7 @@ auto_storage_serde! {
         CompiledClass = 5,
         BaseLayerBlock = 6,
         ClassManagerBlock = 7,
-        CompilerBackwardCompatibility = 8,
-        GlobalRoot = 9,
+        GlobalRoot = 8,
     }
     pub struct MessageToL1 {
         pub to_address: EthAddress,

--- a/crates/apollo_storage/src/storage_reader_types.rs
+++ b/crates/apollo_storage/src/storage_reader_types.rs
@@ -244,9 +244,6 @@ impl StorageReaderServerHandler<StorageReaderRequest, StorageReaderResponse>
                     MarkerKind::CompiledClass => txn.get_compiled_class_marker()?,
                     MarkerKind::BaseLayerBlock => txn.get_base_layer_block_marker()?,
                     MarkerKind::ClassManagerBlock => txn.get_class_manager_block_marker()?,
-                    MarkerKind::CompilerBackwardCompatibility => {
-                        txn.get_compiler_backward_compatibility_marker()?
-                    }
                     MarkerKind::Event => txn.get_event_marker()?,
                     MarkerKind::GlobalRoot => txn.get_global_root_marker()?,
                 };

--- a/crates/apollo_storage/src/storage_reader_types_test.rs
+++ b/crates/apollo_storage/src/storage_reader_types_test.rs
@@ -402,10 +402,6 @@ async fn markers_request() {
         (MarkerKind::CompiledClass, txn.get_compiled_class_marker().unwrap()),
         (MarkerKind::BaseLayerBlock, txn.get_base_layer_block_marker().unwrap()),
         (MarkerKind::ClassManagerBlock, txn.get_class_manager_block_marker().unwrap()),
-        (
-            MarkerKind::CompilerBackwardCompatibility,
-            txn.get_compiler_backward_compatibility_marker().unwrap(),
-        ),
         (MarkerKind::GlobalRoot, txn.get_global_root_marker().unwrap()),
     ];
 

--- a/crates/apollo_storage/src/test_instances.rs
+++ b/crates/apollo_storage/src/test_instances.rs
@@ -69,8 +69,7 @@ auto_impl_get_test_instance! {
         CompiledClass = 5,
         BaseLayerBlock = 6,
         ClassManagerBlock = 7,
-        CompilerBackwardCompatibility = 8,
-        GlobalRoot = 9,
+        GlobalRoot = 8,
     }
     pub enum OffsetKind {
         ThinStateDiff = 0,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removes a persisted marker and shifts `MarkerKind` serialization discriminants, which can break compatibility when reading existing DB/test fixtures or communicating with older nodes expecting the old enum layout.
> 
> **Overview**
> Removes the `CompilerBackwardCompatibility` marker from storage APIs: drops its `MarkerKind` variant and deletes the corresponding read/write methods from `class_manager` and the marker request handling/tests.
> 
> Updates `MarkerKind` serialization/test enums to close the gap, renumbering `GlobalRoot` to `8` to match the removed variant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d84ecf1196b89beae3a497e28ccceed6186054b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->