### PR TITLE
apollo_l1_gas_price: dont panic when parsing eth/strk rate

### DIFF
--- a/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
@@ -163,8 +163,9 @@ fn resolve_query(body: String) -> Result<u128, EthToStrkOracleClientError> {
             return Err(EthToStrkOracleClientError::MissingFieldError("price".to_string(), body));
         }
     };
-    let rate = u128::from_str_radix(price.trim_start_matches("0x"), 16)
-        .expect("Failed to parse price as u128");
+    let rate = u128::from_str_radix(price.trim_start_matches("0x"), 16).map_err(|e| {
+        EthToStrkOracleClientError::ParseError(format!("Failed to parse price {price}: {e}"))
+    })?;
     // Extract decimals from API response. Also returns MissingFieldError if value is not a number.
     let decimals = match json.get("decimals").and_then(|v| v.as_u64()) {
         Some(decimals) => decimals,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only error handling for parsing the `price` field, converting a potential panic into a typed `ParseError` without affecting successful-path behavior.
> 
> **Overview**
> Prevents panics in `resolve_query` when decoding the oracle `price` field by replacing `expect`-based hex parsing with fallible parsing that returns `EthToStrkOracleClientError::ParseError` (including the offending value and parse error). This makes malformed/invalid API responses fail gracefully instead of crashing the client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 308d408400d3d7df42e73821326d4e861cef0b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->