### PR TITLE
apollo_l1_gas_price: add assert to verify lag_interval_seconds is non-zero

### DIFF
--- a/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
@@ -102,6 +102,10 @@ impl EthToStrkOracleClient {
         &self,
         quantized_timestamp: u64,
     ) -> AbortOnDropHandle<Result<u128, EthToStrkOracleClientError>> {
+        assert!(
+            self.config.lag_interval_seconds > 0,
+            "lag_interval_seconds should be greater than 0"
+        );
         let adjusted_timestamp = quantized_timestamp * self.config.lag_interval_seconds;
         let query_timeout_sec = self.config.query_timeout_sec;
         let client = self.client.clone();

--- a/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/eth_to_strk_oracle.rs
@@ -163,8 +163,9 @@ fn resolve_query(body: String) -> Result<u128, EthToStrkOracleClientError> {
             return Err(EthToStrkOracleClientError::MissingFieldError("price".to_string(), body));
         }
     };
-    let rate = u128::from_str_radix(price.trim_start_matches("0x"), 16)
-        .expect("Failed to parse price as u128");
+    let rate = u128::from_str_radix(price.trim_start_matches("0x"), 16).map_err(|e| {
+        EthToStrkOracleClientError::ParseError(format!("Failed to parse price {price}: {e}"))
+    })?;
     // Extract decimals from API response. Also returns MissingFieldError if value is not a number.
     let decimals = match json.get("decimals").and_then(|v| v.as_u64()) {
         Some(decimals) => decimals,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive assertion to fail fast on invalid configuration; behavior only changes when `lag_interval_seconds` is misconfigured to 0.
> 
> **Overview**
> Adds a runtime `assert!` in `EthToStrkOracleClient::spawn_query` to guarantee `lag_interval_seconds > 0` before computing the adjusted timestamp for oracle requests, preventing silent bad queries/overflows when the config is invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fad8441f1e4fc782d49608cac9c7c5d83c9eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->