### PR TITLE
apollo_propeller: drain send queue on DialUpgradeError

### DIFF
--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -554,14 +554,17 @@ impl ConnectionHandler for Handler {
                     );
                 }
 
-                // TODO(AndrewL): Handle DialUpgradeError properly. Current issues:
-                // 1. Silent delivery failure: send_queue is not drained, so messages accumulate
-                //    with no failure signal to the behaviour.
-                // 2. Infinite renegotiation loop: resetting to Idle while send_queue is non-empty
-                //    causes poll_send to immediately request another OutboundSubstreamRequest,
-                //    looping forever against unsupported peers.
-                // Fix: drain send_queue, push a HandlerOut::SendError onto events_to_emit with
-                // the dropped count, and reset to Idle.
+                // Clear the send queue and report the failure to the behaviour. Without this,
+                // messages would silently accumulate and the handler would enter an infinite
+                // renegotiation loop (Idle → request → error → Idle → ...) against unsupported
+                // peers.
+                let dropped_count = self.send_queue.len();
+                if dropped_count > 0 {
+                    self.send_queue.clear();
+                    self.events_to_emit.push_back(HandlerOut::SendError(format!(
+                        "Dial upgrade failed, {dropped_count} queued message(s) lost"
+                    )));
+                }
                 // TODO(AndrewL): Trigger poll (e.g. via a waker) after resetting to Idle so that
                 // a new substream can be established promptly.
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes failure-path behavior in the libp2p handler by dropping queued outbound messages and surfacing a new send error event, which could affect callers relying on prior retry/queue semantics.
> 
> **Overview**
> Fixes `DialUpgradeError` handling in the Propeller connection handler by **draining `send_queue` on outbound negotiation failure** and emitting a `HandlerOut::SendError` with the number of dropped queued messages.
> 
> This prevents silent message buildup and avoids an infinite outbound renegotiation loop when connecting to peers that don’t support the Propeller protocol.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba9df14088f8035e91b072b47514fedce1f07dd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->