### PR TITLE
apollo_propeller: wake poll from on_behaviour_event

### DIFF
--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 use std::ops::ControlFlow;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 
 use apollo_infra_utils::warn_every_n_ms;
 use apollo_protobuf::protobuf::{PropellerUnit as ProtoUnit, PropellerUnitBatch as ProtoBatch};
@@ -73,6 +73,9 @@ pub struct Handler {
     events_to_emit: VecDeque<HandlerOut>,
     /// Maximum wire message size for batching.
     max_wire_message_size: usize,
+    /// The most recent waker from [`ConnectionHandler::poll`], used for waking the task when
+    /// new messages are enqueued via `on_behaviour_event`.
+    waker: Option<Waker>,
 }
 
 /// State of the inbound substream, opened by the remote peer.
@@ -116,6 +119,7 @@ impl Handler {
             send_queue: VecDeque::new(),
             events_to_emit: VecDeque::new(),
             max_wire_message_size: config.max_wire_message_size,
+            waker: None,
         }
     }
 
@@ -484,7 +488,9 @@ impl ConnectionHandler for Handler {
         match event {
             HandlerIn::SendUnit(msg) => {
                 self.send_queue.push_back(msg.into());
-                // TODO(AndrewL): Wake up poll to send the message
+                if let Some(waker) = self.waker.as_ref() {
+                    waker.wake_by_ref();
+                }
             }
         }
     }
@@ -495,8 +501,10 @@ impl ConnectionHandler for Handler {
     ) -> Poll<
         ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
     > {
-        // TODO(AndrewL): inline this function into poll
-        self.poll_inner(cx)
+        let result = self.poll_inner(cx);
+        // Store the waker so on_behaviour_event / on_connection_event can wake us.
+        self.waker = Some(cx.waker().clone());
+        result
     }
 
     fn on_connection_event(
@@ -565,8 +573,9 @@ impl ConnectionHandler for Handler {
                         "Dial upgrade failed, {dropped_count} queued message(s) lost"
                     )));
                 }
-                // TODO(AndrewL): Trigger poll (e.g. via a waker) after resetting to Idle so that
-                // a new substream can be established promptly.
+                if let Some(waker) = self.waker.as_ref() {
+                    waker.wake_by_ref();
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to async wakeup behavior in the connection handler; primary risk is unintended extra wakeups or missed wakeups if waker handling is incorrect.
> 
> **Overview**
> The Propeller `ConnectionHandler` now caches the latest task `Waker` from `poll` and explicitly wakes it when new messages are enqueued via `on_behaviour_event`.
> 
> It also wakes the handler after `DialUpgradeError` handling (after resetting outbound state / clearing the send queue) so the connection can promptly progress without waiting for an external poll.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f340c336edfc00ba3147d17e3e2f213d35ef89bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->