### PR TITLE
apollo_storage: separate events storage from transactions

### DIFF
--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -393,11 +393,14 @@ impl<
             block.body.transactions.len().try_into().expect("Failed to convert usize to u64");
         let timestamp = block.header.block_header_without_hash.timestamp;
         self.perform_storage_writes(move |writer| {
+            let mut block = block;
+            let transaction_events = std::mem::take(&mut block.body.transaction_events);
             let mut txn = writer
                 .begin_rw_txn()?
                 .append_header(block_number, &block.header)?
                 .append_block_signature(block_number, &signature)?
-                .append_body(block_number, block.body)?;
+                .append_body(block_number, block.body)?
+                .append_events(block_number, &transaction_events)?;
             if block.header.block_header_without_hash.starknet_version
                 < STARKNET_VERSION_TO_COMPILE_FROM
             {

--- a/crates/apollo_integration_tests/src/state_reader.rs
+++ b/crates/apollo_integration_tests/src/state_reader.rs
@@ -439,6 +439,8 @@ fn write_state_to_apollo_storage(
         .unwrap()
         .append_body(block_number, BlockBody::default())
         .unwrap()
+        .append_events(block_number, &[])
+        .unwrap()
         .append_state_diff(block_number, state_diff)
         .unwrap()
         .append_classes(block_number, &sierras, &cairo0_contract_classes)

--- a/crates/apollo_p2p_sync/src/client/transaction.rs
+++ b/crates/apollo_p2p_sync/src/client/transaction.rs
@@ -33,7 +33,13 @@ impl BlockData for (BlockBody, BlockNumber) {
         async move {
             let num_txs =
                 self.0.transactions.len().try_into().expect("Failed to convert usize to u64");
-            storage_writer.begin_rw_txn()?.append_body(self.1, self.0)?.commit()?;
+            let block_number = self.1;
+            let transaction_events = self.0.transaction_events.clone();
+            storage_writer
+                .begin_rw_txn()?
+                .append_body(block_number, self.0)?
+                .append_events(block_number, &transaction_events)?
+                .commit()?;
             STATE_SYNC_BODY_MARKER.set_lossy(self.1.unchecked_next().0);
             STATE_SYNC_PROCESSED_TRANSACTIONS.increment(num_txs);
             Ok(())
@@ -118,6 +124,7 @@ impl BlockDataStreamBuilder<FullTransaction> for TransactionStreamFactory {
             })
             .take(num_transactions)
             .collect::<Vec<_>>(),
+            transaction_events: vec![vec![]; num_transactions],
         };
         (block_body, block_number)
     }

--- a/crates/apollo_p2p_sync/src/client/transaction_test.rs
+++ b/crates/apollo_p2p_sync/src/client/transaction_test.rs
@@ -77,7 +77,7 @@ async fn transaction_basic_flow() {
     actions.push(Action::SimulateWaitPeriodForOtherProtocol);
 
     // Send transactions for each block and then validate they were written
-    for (i, BlockBody { transactions, transaction_outputs, transaction_hashes }) in
+    for (i, BlockBody { transactions, transaction_outputs, transaction_hashes, .. }) in
         block_bodies.into_iter().enumerate()
     {
         let i = u64::try_from(i).unwrap();

--- a/crates/apollo_p2p_sync/src/server/mod.rs
+++ b/crates/apollo_p2p_sync/src/server/mod.rs
@@ -346,7 +346,7 @@ impl FetchBlockData for (Event, TransactionHash) {
         txn: &StorageTxn<'_, db::RO>,
         _class_manager_client: &mut SharedClassManagerClient,
     ) -> Result<Vec<Self>, P2pSyncServerError> {
-        let transaction_outputs = txn.get_block_transaction_outputs(block_number)?.ok_or(
+        let transaction_events = txn.get_block_transaction_events(block_number)?.ok_or(
             P2pSyncServerError::BlockNotFound {
                 block_hash_or_number: BlockHashOrNumber::Number(block_number),
             },
@@ -358,11 +358,9 @@ impl FetchBlockData for (Event, TransactionHash) {
         )?;
 
         let mut result = Vec::new();
-        for (transaction_output, transaction_hash) in
-            transaction_outputs.into_iter().zip(transaction_hashes)
-        {
-            for event in transaction_output.events() {
-                result.push((event.clone(), transaction_hash));
+        for (events, transaction_hash) in transaction_events.into_iter().zip(transaction_hashes) {
+            for event in events {
+                result.push((event, transaction_hash));
             }
         }
         Ok(result)

--- a/crates/apollo_p2p_sync/src/server/test.rs
+++ b/crates/apollo_p2p_sync/src/server/test.rs
@@ -125,17 +125,16 @@ async fn state_diff_query_positive_flow() {
 async fn event_query_positive_flow() {
     let assert_event = |data: Vec<(Event, TransactionHash)>| {
         assert_eq!(data.len(), NUM_OF_BLOCKS * NUM_TXS_PER_BLOCK * EVENTS_PER_TX);
-        for (i, (event, tx_hash)) in data.into_iter().enumerate() {
-            assert_eq!(
-                tx_hash,
-                TX_HASHES[i / (NUM_TXS_PER_BLOCK * EVENTS_PER_TX)]
-                    [i / EVENTS_PER_TX % NUM_TXS_PER_BLOCK]
-            );
-            assert_eq!(
-                event,
-                EVENTS[i / (NUM_TXS_PER_BLOCK * EVENTS_PER_TX)
-                    + i / EVENTS_PER_TX % NUM_TXS_PER_BLOCK]
-            );
+        let mut data_idx = 0;
+        for block_idx in 0..NUM_OF_BLOCKS {
+            for tx_idx in 0..NUM_TXS_PER_BLOCK {
+                for event in &TX_EVENTS[block_idx][tx_idx] {
+                    let (actual_event, actual_hash) = &data[data_idx];
+                    assert_eq!(actual_hash, &TX_HASHES[block_idx][tx_idx]);
+                    assert_eq!(actual_event, event);
+                    data_idx += 1;
+                }
+            }
         }
     };
 
@@ -254,18 +253,17 @@ async fn event_query_some_blocks_are_missing() {
     let assert_event = |data: Vec<(Event, TransactionHash)>| {
         let len = data.len();
         assert_eq!(len, BLOCKS_DELTA * NUM_TXS_PER_BLOCK * EVENTS_PER_TX);
-        for (i, (event, tx_hash)) in data.into_iter().enumerate() {
-            assert_eq!(
-                tx_hash,
-                TX_HASHES[i / (NUM_TXS_PER_BLOCK * EVENTS_PER_TX) + (NUM_OF_BLOCKS - BLOCKS_DELTA)]
-                    [i / EVENTS_PER_TX % NUM_TXS_PER_BLOCK]
-            );
-            assert_eq!(
-                event,
-                EVENTS[i / (NUM_TXS_PER_BLOCK * EVENTS_PER_TX)
-                    + (NUM_OF_BLOCKS - BLOCKS_DELTA)
-                    + i / EVENTS_PER_TX % NUM_TXS_PER_BLOCK]
-            );
+        let start_block = NUM_OF_BLOCKS - BLOCKS_DELTA;
+        let mut data_idx = 0;
+        for block_idx in start_block..NUM_OF_BLOCKS {
+            for tx_idx in 0..NUM_TXS_PER_BLOCK {
+                for event in &TX_EVENTS[block_idx][tx_idx] {
+                    let (actual_event, actual_hash) = &data[data_idx];
+                    assert_eq!(actual_hash, &TX_HASHES[block_idx][tx_idx]);
+                    assert_eq!(actual_event, event);
+                    data_idx += 1;
+                }
+            }
         }
     };
 
@@ -462,7 +460,9 @@ fn insert_to_storage_test_blocks_up_to(storage_writer: &mut StorageWriter) {
             .unwrap()
             .append_body(block_number, BlockBody{transactions: TXS[i].clone(),
                 transaction_outputs: TX_OUTPUTS[i].clone(),
-                transaction_hashes: TX_HASHES[i].clone(),}).unwrap()
+                transaction_hashes: TX_HASHES[i].clone(),
+                transaction_events: TX_EVENTS[i].clone(),}).unwrap()
+            .append_events(block_number, &TX_EVENTS[i]).unwrap()
             .commit()
             .unwrap();
     }
@@ -534,10 +534,11 @@ lazy_static! {
         .chunks(NUM_TXS_PER_BLOCK)
         .map(|chunk| chunk.to_vec())
         .collect();
-    static ref EVENTS: Vec<Event> = TX_OUTPUTS
+    static ref TX_EVENTS: Vec<Vec<Vec<Event>>> = BODY
         .clone()
-        .into_iter()
-        .flat_map(|tx_output| tx_output.into_iter().flat_map(|output| output.events().to_vec()))
+        .transaction_events
+        .chunks(NUM_TXS_PER_BLOCK)
+        .map(|chunk| chunk.to_vec())
         .collect();
     static ref CLASSES_WITH_HASHES: Vec<Vec<(ClassHash, SierraContractClass)>> = {
         THIN_STATE_DIFFS

--- a/crates/apollo_protobuf/src/converters/receipt.rs
+++ b/crates/apollo_protobuf/src/converters/receipt.rs
@@ -69,14 +69,11 @@ impl From<TransactionOutput> for protobuf::Receipt {
     }
 }
 
-// The output will have an empty events vec
 impl TryFrom<protobuf::receipt::DeployAccount> for DeployAccountTransactionOutput {
     type Error = ProtobufConversionError;
     fn try_from(value: protobuf::receipt::DeployAccount) -> Result<Self, Self::Error> {
         let (actual_fee, messages_sent, execution_status, execution_resources) =
             parse_common_receipt_fields(value.common)?;
-
-        let events = vec![];
 
         let contract_address =
             value.contract_address.ok_or(missing("DeployAccount::contract_address"))?;
@@ -91,7 +88,6 @@ impl TryFrom<protobuf::receipt::DeployAccount> for DeployAccountTransactionOutpu
         Ok(Self {
             actual_fee,
             messages_sent,
-            events,
             contract_address,
             execution_status,
             execution_resources,
@@ -117,14 +113,11 @@ impl From<DeployAccountTransactionOutput> for protobuf::receipt::DeployAccount {
     }
 }
 
-// The output will have an empty events vec
 impl TryFrom<protobuf::receipt::Deploy> for DeployTransactionOutput {
     type Error = ProtobufConversionError;
     fn try_from(value: protobuf::receipt::Deploy) -> Result<Self, Self::Error> {
         let (actual_fee, messages_sent, execution_status, execution_resources) =
             parse_common_receipt_fields(value.common)?;
-
-        let events = vec![];
 
         let contract_address = value.contract_address.ok_or(missing("Deploy::contract_address"))?;
         let felt = Felt::try_from(contract_address)?;
@@ -138,7 +131,6 @@ impl TryFrom<protobuf::receipt::Deploy> for DeployTransactionOutput {
         Ok(Self {
             actual_fee,
             messages_sent,
-            events,
             contract_address,
             execution_status,
             execution_resources,
@@ -164,16 +156,13 @@ impl From<DeployTransactionOutput> for protobuf::receipt::Deploy {
     }
 }
 
-// The output will have an empty events vec
 impl TryFrom<protobuf::receipt::Declare> for DeclareTransactionOutput {
     type Error = ProtobufConversionError;
     fn try_from(value: protobuf::receipt::Declare) -> Result<Self, Self::Error> {
         let (actual_fee, messages_sent, execution_status, execution_resources) =
             parse_common_receipt_fields(value.common)?;
 
-        let events = vec![];
-
-        Ok(Self { actual_fee, messages_sent, events, execution_status, execution_resources })
+        Ok(Self { actual_fee, messages_sent, execution_status, execution_resources })
     }
 }
 
@@ -192,16 +181,13 @@ impl From<DeclareTransactionOutput> for protobuf::receipt::Declare {
     }
 }
 
-// The output will have an empty events vec
 impl TryFrom<protobuf::receipt::Invoke> for InvokeTransactionOutput {
     type Error = ProtobufConversionError;
     fn try_from(value: protobuf::receipt::Invoke) -> Result<Self, Self::Error> {
         let (actual_fee, messages_sent, execution_status, execution_resources) =
             parse_common_receipt_fields(value.common)?;
 
-        let events = vec![];
-
-        Ok(Self { actual_fee, messages_sent, events, execution_status, execution_resources })
+        Ok(Self { actual_fee, messages_sent, execution_status, execution_resources })
     }
 }
 
@@ -220,16 +206,13 @@ impl From<InvokeTransactionOutput> for protobuf::receipt::Invoke {
     }
 }
 
-// The output will have an empty events vec
 impl TryFrom<protobuf::receipt::L1Handler> for L1HandlerTransactionOutput {
     type Error = ProtobufConversionError;
     fn try_from(value: protobuf::receipt::L1Handler) -> Result<Self, Self::Error> {
         let (actual_fee, messages_sent, execution_status, execution_resources) =
             parse_common_receipt_fields(value.common)?;
 
-        let events = vec![];
-
-        Ok(Self { actual_fee, messages_sent, events, execution_status, execution_resources })
+        Ok(Self { actual_fee, messages_sent, execution_status, execution_resources })
     }
 }
 

--- a/crates/apollo_protobuf/src/converters/transaction_test.rs
+++ b/crates/apollo_protobuf/src/converters/transaction_test.rs
@@ -32,7 +32,6 @@ macro_rules! create_transaction_output {
         let mut rng = get_rng();
         let mut transaction_output = <$tx_output_type>::get_test_instance(&mut rng);
         transaction_output.execution_resources = EXECUTION_RESOURCES.clone();
-        transaction_output.events = vec![];
         TransactionOutput::$tx_output_enum_variant(transaction_output)
     }};
 }

--- a/crates/apollo_reverts/src/lib.rs
+++ b/crates/apollo_reverts/src/lib.rs
@@ -127,6 +127,8 @@ pub fn revert_block(storage_writer: &mut StorageWriter, target_block_marker: Blo
         .revert_header(target_block_marker)
         .unwrap()
         .0
+        .revert_events(target_block_marker)
+        .unwrap()
         .revert_body(target_block_marker)
         .unwrap()
         .0

--- a/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
+++ b/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
@@ -152,6 +152,8 @@ async fn server_metrics() {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
+        .append_events(BlockNumber(0), &[])
+        .unwrap()
         .append_state_diff(BlockNumber(0), ThinStateDiff::default())
         .unwrap()
         .append_classes(BlockNumber(0), &[], &[])

--- a/crates/apollo_rpc/src/v0_8/api/api_impl.rs
+++ b/crates/apollo_rpc/src/v0_8/api/api_impl.rs
@@ -1736,7 +1736,12 @@ fn get_non_pending_receipt<Mode: TransactionKind>(
         .map_err(internal_server_error)?
         .ok_or_else(|| ErrorObjectOwned::from(TRANSACTION_HASH_NOT_FOUND))?;
 
-    let output = TransactionOutput::from((output, tx_version, msg_hash));
+    let events = txn
+        .get_transaction_events(transaction_index)
+        .map_err(internal_server_error)?
+        .ok_or_else(|| ErrorObjectOwned::from(TRANSACTION_HASH_NOT_FOUND))?;
+
+    let output = TransactionOutput::from((output, tx_version, msg_hash, events));
 
     Ok(GeneralTransactionReceipt::TransactionReceipt(TransactionReceipt {
         finality_status: status.into(),
@@ -1752,6 +1757,7 @@ fn client_receipt_to_rpc_pending_receipt(
     client_transaction_receipt: ClientTransactionReceipt,
 ) -> RpcResult<GeneralTransactionReceipt> {
     let transaction_hash = client_transaction.transaction_hash();
+    let events = client_transaction_receipt.events.clone();
     let starknet_api_output =
         client_transaction_receipt.into_starknet_api_transaction_output(client_transaction);
     let msg_hash = match client_transaction {
@@ -1762,6 +1768,7 @@ fn client_receipt_to_rpc_pending_receipt(
         starknet_api_output,
         client_transaction.transaction_version(),
         msg_hash,
+        events,
     )))?;
     Ok(GeneralTransactionReceipt::PendingTransactionReceipt(PendingTransactionReceipt {
         // ACCEPTED_ON_L2 is the only finality status of a pending transaction.

--- a/crates/apollo_rpc/src/v0_8/api/test.rs
+++ b/crates/apollo_rpc/src/v0_8/api/test.rs
@@ -110,7 +110,6 @@ use starknet_api::transaction::{
     Transaction as StarknetApiTransaction,
     TransactionHash,
     TransactionOffsetInBlock,
-    TransactionOutput as StarknetApiTransactionOutput,
 };
 use starknet_api::{class_hash, compiled_class_hash, contract_address, felt, storage_key, tx_hash};
 use starknet_types_core::felt::Felt;
@@ -401,12 +400,15 @@ async fn get_block_transaction_count() {
     >(None, None, Some(pending_data.clone()), None, None);
     let transaction_count = 5;
     let block = get_test_block(transaction_count, None, None, None);
+    let events = block.body.transaction_events.clone();
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(block.header.block_header_without_hash.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body)
+        .unwrap()
+        .append_events(block.header.block_header_without_hash.block_number, &events)
         .unwrap()
         .append_state_diff(
             block.header.block_header_without_hash.block_number,
@@ -506,6 +508,11 @@ async fn get_block_w_full_transactions() {
         .append_header(block.header.block_header_without_hash.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
+        .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
         .unwrap()
         .append_state_diff(
             block.header.block_header_without_hash.block_number,
@@ -693,6 +700,11 @@ async fn get_block_w_full_transactions_and_receipts() {
         .append_header(block.header.block_header_without_hash.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
+        .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
         .unwrap()
         .append_state_diff(
             block.header.block_header_without_hash.block_number,
@@ -893,6 +905,11 @@ async fn get_block_w_transaction_hashes() {
         .append_header(block.header.block_header_without_hash.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
+        .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
         .unwrap()
         .append_state_diff(
             block.header.block_header_without_hash.block_number,
@@ -1255,6 +1272,11 @@ async fn get_transaction_status() {
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
         .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
+        .unwrap()
         .commit()
         .unwrap();
 
@@ -1271,7 +1293,7 @@ async fn get_transaction_status() {
         starknet_api::transaction::TransactionOutput::L1Handler(_) => Some(L1L2MsgHash::default()),
         _ => None,
     };
-    let output = TransactionOutput::from((tx, transaction_version, msg_hash));
+    let output = TransactionOutput::from((tx, transaction_version, msg_hash, vec![]));
     let expected_status = TransactionStatus {
         finality_status: TransactionFinalityStatus::AcceptedOnL2,
         execution_status: output.execution_status().clone(),
@@ -1374,6 +1396,11 @@ async fn get_transaction_receipt() {
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
         .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
+        .unwrap()
         .commit()
         .unwrap();
 
@@ -1394,6 +1421,7 @@ async fn get_transaction_receipt() {
         block.body.transaction_outputs.index(0).clone(),
         transaction_version,
         msg_hash,
+        block.body.transaction_events.first().cloned().unwrap_or_default(),
     ));
     let expected_receipt = TransactionReceipt {
         finality_status: TransactionFinalityStatus::AcceptedOnL2,
@@ -2223,10 +2251,12 @@ fn generate_client_transaction_client_receipt_rpc_transaction_and_rpc_receipt(
             }
             _ => None,
         };
+        let events = client_transaction_receipt.events.clone();
         let maybe_output = PendingTransactionOutput::try_from(TransactionOutput::from((
             starknet_api_output,
             client_transaction.transaction_version(),
             msg_hash,
+            events,
         )));
         let Ok(output) = maybe_output else {
             continue;
@@ -2285,6 +2315,11 @@ async fn get_transaction_by_hash() {
         .begin_rw_txn()
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
+        .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
         .unwrap()
         .commit()
         .unwrap();
@@ -2375,6 +2410,11 @@ async fn get_transaction_by_block_id_and_index() {
         .append_header(block.header.block_header_without_hash.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
+        .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
         .unwrap()
         .append_state_diff(
             block.header.block_header_without_hash.block_number,
@@ -2825,16 +2865,9 @@ impl BlockMetadata {
             *transaction_hash = tx_hash!(rng.next_u64());
         }
 
-        for (output, event_metadatas_of_tx) in
-            block.body.transaction_outputs.iter_mut().zip(self.0.iter())
+        for (events, event_metadatas_of_tx) in
+            block.body.transaction_events.iter_mut().zip(self.0.iter())
         {
-            let events = match output {
-                StarknetApiTransactionOutput::Declare(transaction) => &mut transaction.events,
-                StarknetApiTransactionOutput::Deploy(transaction) => &mut transaction.events,
-                StarknetApiTransactionOutput::DeployAccount(transaction) => &mut transaction.events,
-                StarknetApiTransactionOutput::Invoke(transaction) => &mut transaction.events,
-                StarknetApiTransactionOutput::L1Handler(transaction) => &mut transaction.events,
-            };
             for event_metadata in event_metadatas_of_tx {
                 events.push(event_metadata.generate_event(rng));
             }
@@ -2901,14 +2934,14 @@ async fn test_get_events(
 
         parent_hash = block.header.block_hash;
 
-        for (i_transaction, (output, transaction_hash)) in block
+        for (i_transaction, (events, transaction_hash)) in block
             .body
-            .transaction_outputs
+            .transaction_events
             .iter()
             .zip(block.body.transaction_hashes.iter().cloned())
             .enumerate()
         {
-            for (i_event, event) in output.events().iter().cloned().enumerate() {
+            for (i_event, event) in events.iter().cloned().enumerate() {
                 event_index_to_event.insert(
                     EventIndex(
                         TransactionIndex(block_number, TransactionOffsetInBlock(i_transaction)),
@@ -2924,10 +2957,13 @@ async fn test_get_events(
             }
         }
 
+        let events = block.body.transaction_events.clone();
         rw_txn = rw_txn
             .append_header(block_number, &block.header)
             .unwrap()
             .append_body(block_number, block.body)
+            .unwrap()
+            .append_events(block_number, &events)
             .unwrap()
             .append_state_diff(
                 block.header.block_header_without_hash.block_number,
@@ -3460,6 +3496,8 @@ async fn get_events_invalid_ct() {
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body)
         .unwrap()
+        .append_events(block.header.block_header_without_hash.block_number, &[])
+        .unwrap()
         .append_state_diff(
             block.header.block_header_without_hash.block_number,
             starknet_api::state::ThinStateDiff::default(),
@@ -3529,6 +3567,8 @@ async fn serialize_returns_valid_json() {
         .unwrap()
         .append_body(parent_block.header.block_header_without_hash.block_number, parent_block.body)
         .unwrap()
+        .append_events(parent_block.header.block_header_without_hash.block_number, &[])
+        .unwrap()
         .append_state_diff(
             parent_block.header.block_header_without_hash.block_number,
             starknet_api::state::ThinStateDiff::default(),
@@ -3539,6 +3579,11 @@ async fn serialize_returns_valid_json() {
         .append_header(block.header.block_header_without_hash.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_header_without_hash.block_number, block.body.clone())
+        .unwrap()
+        .append_events(
+            block.header.block_header_without_hash.block_number,
+            &block.body.transaction_events,
+        )
         .unwrap()
         .append_state_diff(block.header.block_header_without_hash.block_number, thin_state_diff)
         .unwrap()

--- a/crates/apollo_rpc/src/v0_8/execution_test.rs
+++ b/crates/apollo_rpc/src/v0_8/execution_test.rs
@@ -829,8 +829,11 @@ async fn trace_block_transactions_regular_and_pending() {
                     ),
                 ],
                 transaction_hashes: vec![tx_hash1, tx_hash2],
+                transaction_events: vec![vec![], vec![]],
             },
         )
+        .unwrap()
+        .append_events(BlockNumber(3), &[vec![], vec![]])
         .unwrap()
         .append_state_diff(
             BlockNumber(3),
@@ -1036,8 +1039,11 @@ async fn trace_block_transactions_and_trace_transaction_execution_context() {
                     ),
                 ],
                 transaction_hashes: vec![tx_hash1, tx_hash2],
+                transaction_events: vec![vec![], vec![]],
             },
         )
+        .unwrap()
+        .append_events(BlockNumber(3), &[vec![], vec![]])
         .unwrap()
         .append_state_diff(
             BlockNumber(3),
@@ -1685,6 +1691,8 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
+        .append_events(BlockNumber(0), &[])
+        .unwrap()
         .append_state_diff(
             BlockNumber(0),
             StarknetApiStateDiff {
@@ -1748,6 +1756,8 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
+        .append_events(BlockNumber(1), &[])
+        .unwrap()
         .append_state_diff(BlockNumber(1), StarknetApiStateDiff::default())
         .unwrap()
         .append_classes(BlockNumber(1), &[], &[])
@@ -1770,6 +1780,8 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         )
         .unwrap()
         .append_body(BlockNumber(2), BlockBody::default())
+        .unwrap()
+        .append_events(BlockNumber(2), &[])
         .unwrap()
         .append_state_diff(BlockNumber(2), StarknetApiStateDiff::default())
         .unwrap()
@@ -1800,6 +1812,8 @@ fn write_empty_block(mut storage_writer: StorageWriter) {
         )
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
+        .unwrap()
+        .append_events(BlockNumber(0), &[])
         .unwrap()
         .append_state_diff(BlockNumber(0), StarknetApiStateDiff::default())
         .unwrap()

--- a/crates/apollo_rpc/src/v0_8/transaction.rs
+++ b/crates/apollo_rpc/src/v0_8/transaction.rs
@@ -1053,8 +1053,13 @@ impl TransactionOutput {
     }
 }
 
-impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Option<L1L2MsgHash>)>
-    for TransactionOutput
+impl
+    From<(
+        starknet_api::transaction::TransactionOutput,
+        TransactionVersion,
+        Option<L1L2MsgHash>,
+        Vec<starknet_api::transaction::Event>,
+    )> for TransactionOutput
 {
     #[cfg_attr(coverage_nightly, coverage_attribute)]
     fn from(
@@ -1062,9 +1067,10 @@ impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Opt
             starknet_api::transaction::TransactionOutput,
             TransactionVersion,
             Option<L1L2MsgHash>,
+            Vec<starknet_api::transaction::Event>,
         ),
     ) -> Self {
-        let (tx_output, tx_version, maybe_msg_hash) = tx_output_msg_hash;
+        let (tx_output, tx_version, maybe_msg_hash, events) = tx_output_msg_hash;
         // TODO(DanB): consider supporting match instead.
         let actual_fee = if tx_version == TransactionVersion::ZERO
             || tx_version == TransactionVersion::ONE
@@ -1081,7 +1087,7 @@ impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Opt
                 TransactionOutput::Declare(DeclareTransactionOutput {
                     actual_fee,
                     messages_sent: declare_tx_output.messages_sent,
-                    events: declare_tx_output.events,
+                    events,
                     execution_status: declare_tx_output.execution_status,
                     execution_resources: declare_tx_output.execution_resources.into(),
                 })
@@ -1090,7 +1096,7 @@ impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Opt
                 TransactionOutput::Deploy(DeployTransactionOutput {
                     actual_fee,
                     messages_sent: deploy_tx_output.messages_sent,
-                    events: deploy_tx_output.events,
+                    events,
                     contract_address: deploy_tx_output.contract_address,
                     execution_status: deploy_tx_output.execution_status,
                     execution_resources: deploy_tx_output.execution_resources.into(),
@@ -1100,7 +1106,7 @@ impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Opt
                 TransactionOutput::DeployAccount(DeployAccountTransactionOutput {
                     actual_fee,
                     messages_sent: deploy_tx_output.messages_sent,
-                    events: deploy_tx_output.events,
+                    events,
                     contract_address: deploy_tx_output.contract_address,
                     execution_status: deploy_tx_output.execution_status,
                     execution_resources: deploy_tx_output.execution_resources.into(),
@@ -1110,7 +1116,7 @@ impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Opt
                 TransactionOutput::Invoke(InvokeTransactionOutput {
                     actual_fee,
                     messages_sent: invoke_tx_output.messages_sent,
-                    events: invoke_tx_output.events,
+                    events,
                     execution_status: invoke_tx_output.execution_status,
                     execution_resources: invoke_tx_output.execution_resources.into(),
                 })
@@ -1119,7 +1125,7 @@ impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Opt
                 TransactionOutput::L1Handler(L1HandlerTransactionOutput {
                     actual_fee,
                     messages_sent: l1_handler_tx_output.messages_sent,
-                    events: l1_handler_tx_output.events,
+                    events,
                     execution_status: l1_handler_tx_output.execution_status,
                     execution_resources: l1_handler_tx_output.execution_resources.into(),
                     message_hash: maybe_msg_hash

--- a/crates/apollo_rpc_execution/src/state_reader_test.rs
+++ b/crates/apollo_rpc_execution/src/state_reader_test.rs
@@ -93,6 +93,8 @@ fn read_state() {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
+        .append_events(BlockNumber(0), &[])
+        .unwrap()
         .append_state_diff(BlockNumber(0), ThinStateDiff::default())
         .unwrap()
         .append_classes(BlockNumber(0), &[], &[])
@@ -110,6 +112,8 @@ fn read_state() {
         )
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
+        .unwrap()
+        .append_events(BlockNumber(1), &[])
         .unwrap()
         .append_state_diff(
             BlockNumber(1),
@@ -156,6 +160,8 @@ fn read_state() {
         )
         .unwrap()
         .append_body(BlockNumber(2), BlockBody::default())
+        .unwrap()
+        .append_events(BlockNumber(2), &[])
         .unwrap()
         .append_state_diff(BlockNumber(2), ThinStateDiff::default())
         .unwrap()

--- a/crates/apollo_rpc_execution/src/test_utils.rs
+++ b/crates/apollo_rpc_execution/src/test_utils.rs
@@ -119,6 +119,8 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
+        .append_events(BlockNumber(0), &[])
+        .unwrap()
         .append_state_diff(
             BlockNumber(0),
             ThinStateDiff {
@@ -183,6 +185,8 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
         )
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
+        .unwrap()
+        .append_events(BlockNumber(1), &[])
         .unwrap()
         .append_state_diff(BlockNumber(1), ThinStateDiff::default())
         .unwrap()

--- a/crates/apollo_starknet_client/src/reader/objects/block.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/block.rs
@@ -351,9 +351,10 @@ impl Block {
 
         let (transactions, transaction_receipts) = self.get_body();
 
-        // Get the transaction outputs and execution statuses.
+        // Get the transaction outputs, events, and execution statuses.
         let mut transaction_outputs = vec![];
         let mut transaction_hashes = vec![];
+        let mut transaction_events = vec![];
         for (i, receipt) in transaction_receipts.into_iter().enumerate() {
             let transaction = transactions.index(i);
 
@@ -398,6 +399,7 @@ impl Block {
             }
 
             transaction_hashes.push(receipt.transaction_hash);
+            transaction_events.push(receipt.events.clone());
             let tx_output = receipt.into_starknet_api_transaction_output(transaction);
             transaction_outputs.push(tx_output);
         }
@@ -415,6 +417,7 @@ impl Block {
             transactions,
             transaction_outputs,
             transaction_hashes,
+            transaction_events,
         };
 
         Ok(starknet_api_block { header, body })

--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -827,14 +827,12 @@ impl TransactionReceipt {
             TransactionType::Declare => TransactionOutput::Declare(DeclareTransactionOutput {
                 actual_fee: self.actual_fee,
                 messages_sent,
-                events: self.events,
                 execution_status,
                 execution_resources: self.execution_resources.into(),
             }),
             TransactionType::Deploy => TransactionOutput::Deploy(DeployTransactionOutput {
                 actual_fee: self.actual_fee,
                 messages_sent,
-                events: self.events,
                 contract_address: contract_address
                     .expect("Deploy transaction must have a contract address."),
                 execution_status,
@@ -844,7 +842,6 @@ impl TransactionReceipt {
                 TransactionOutput::DeployAccount(DeployAccountTransactionOutput {
                     actual_fee: self.actual_fee,
                     messages_sent,
-                    events: self.events,
                     contract_address: contract_address
                         .expect("Deploy account transaction must have a contract address."),
                     execution_status,
@@ -854,7 +851,6 @@ impl TransactionReceipt {
             TransactionType::InvokeFunction => TransactionOutput::Invoke(InvokeTransactionOutput {
                 actual_fee: self.actual_fee,
                 messages_sent,
-                events: self.events,
                 execution_status,
                 execution_resources: self.execution_resources.into(),
             }),
@@ -862,7 +858,6 @@ impl TransactionReceipt {
                 TransactionOutput::L1Handler(L1HandlerTransactionOutput {
                     actual_fee: self.actual_fee,
                     messages_sent,
-                    events: self.events,
                     execution_status,
                     execution_resources: self.execution_resources.into(),
                 })

--- a/crates/apollo_state_sync/src/test.rs
+++ b/crates/apollo_state_sync/src/test.rs
@@ -61,6 +61,11 @@ async fn test_get_block() {
         .unwrap()
         .append_body(expected_header.block_header_without_hash.block_number, expected_body.clone())
         .unwrap()
+        .append_events(
+            expected_header.block_header_without_hash.block_number,
+            &expected_body.transaction_events,
+        )
+        .unwrap()
         .commit()
         .unwrap();
 
@@ -107,6 +112,11 @@ async fn test_get_block_hash() {
         )
         .unwrap()
         .append_body(expected_header.block_header_without_hash.block_number, expected_body.clone())
+        .unwrap()
+        .append_events(
+            expected_header.block_header_without_hash.block_number,
+            &expected_body.transaction_events,
+        )
         .unwrap()
         .commit()
         .unwrap();
@@ -181,6 +191,8 @@ async fn test_get_storage_at() {
         .unwrap()
         .append_body(header.block_header_without_hash.block_number, Default::default())
         .unwrap()
+        .append_events(header.block_header_without_hash.block_number, &[])
+        .unwrap()
         .commit()
         .unwrap();
 
@@ -221,6 +233,8 @@ async fn test_get_nonce_at() {
         .unwrap()
         .append_body(header.block_header_without_hash.block_number, Default::default())
         .unwrap()
+        .append_events(header.block_header_without_hash.block_number, &[])
+        .unwrap()
         .commit()
         .unwrap();
 
@@ -258,6 +272,8 @@ async fn get_class_hash_at() {
         .append_state_diff(header.block_header_without_hash.block_number, diff.clone())
         .unwrap()
         .append_body(header.block_header_without_hash.block_number, Default::default())
+        .unwrap()
+        .append_events(header.block_header_without_hash.block_number, &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -355,6 +371,8 @@ async fn test_contract_not_found() {
         .append_state_diff(header.block_header_without_hash.block_number, diff)
         .unwrap()
         .append_body(header.block_header_without_hash.block_number, Default::default())
+        .unwrap()
+        .append_events(header.block_header_without_hash.block_number, &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/apollo_storage/src/body/body_test.rs
+++ b/crates/apollo_storage/src/body/body_test.rs
@@ -18,29 +18,38 @@ async fn append_body() {
     let txs = body.transactions;
     let tx_outputs = body.transaction_outputs;
     let tx_hashes = body.transaction_hashes;
+    let tx_events = body.transaction_events;
 
     let body0 = BlockBody {
         transactions: vec![txs[0].clone()],
         transaction_outputs: vec![tx_outputs[0].clone()],
         transaction_hashes: vec![tx_hashes[0]],
+        transaction_events: vec![tx_events[0].clone()],
     };
     let body1 = BlockBody::default();
     let body2 = BlockBody {
         transactions: vec![txs[1].clone(), txs[2].clone()],
         transaction_outputs: vec![tx_outputs[1].clone(), tx_outputs[2].clone()],
         transaction_hashes: vec![tx_hashes[1], tx_hashes[2]],
+        transaction_events: vec![tx_events[1].clone(), tx_events[2].clone()],
     };
     let body3 = BlockBody {
         transactions: vec![txs[3].clone(), txs[0].clone()],
         transaction_outputs: vec![tx_outputs[3].clone(), tx_outputs[0].clone()],
         transaction_hashes: vec![tx_hashes[3], tx_hashes[0]],
+        transaction_events: vec![tx_events[3].clone(), tx_events[0].clone()],
     };
+    let body0_events = body0.transaction_events.clone();
     writer
         .begin_rw_txn()
         .unwrap()
         .append_body(BlockNumber(0), body0)
         .unwrap()
+        .append_events(BlockNumber(0), &body0_events)
+        .unwrap()
         .append_body(BlockNumber(1), body1)
+        .unwrap()
+        .append_events(BlockNumber(1), &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -55,7 +64,16 @@ async fn append_body() {
         StorageError::MarkerMismatch { marker_kind: MarkerKind::Body, expected, found }
     if expected == BlockNumber(2) && found == BlockNumber(5));
 
-    writer.begin_rw_txn().unwrap().append_body(BlockNumber(2), body2).unwrap().commit().unwrap();
+    let body2_events = body2.transaction_events.clone();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_body(BlockNumber(2), body2)
+        .unwrap()
+        .append_events(BlockNumber(2), &body2_events)
+        .unwrap()
+        .commit()
+        .unwrap();
 
     let Err(err) = writer.begin_rw_txn().unwrap().append_body(BlockNumber(3), body3) else {
         panic!("Unexpected Ok.");
@@ -180,11 +198,14 @@ async fn append_body() {
 async fn append_body_state_only() {
     let ((reader, mut writer), _temp_dir) = get_test_storage_by_scope(StorageScope::StateOnly);
     let block_body = get_test_block(1, Some(1), None, None).body;
+    let block_body_events = block_body.transaction_events.clone();
 
     writer
         .begin_rw_txn()
         .unwrap()
         .append_body(BlockNumber(0), block_body)
+        .unwrap()
+        .append_events(BlockNumber(0), &block_body_events)
         .unwrap()
         .commit()
         .unwrap();
@@ -199,7 +220,13 @@ async fn append_body_state_only() {
 #[tokio::test]
 async fn revert_non_existing_body_fails(storage_scope: StorageScope) {
     let ((_, mut writer), _temp_dir) = get_test_storage_by_scope(storage_scope);
-    let (_, deleted_data) = writer.begin_rw_txn().unwrap().revert_body(BlockNumber(5)).unwrap();
+    let (_, deleted_data) = writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_events(BlockNumber(5))
+        .unwrap()
+        .revert_body(BlockNumber(5))
+        .unwrap();
     assert!(deleted_data.is_none());
 }
 
@@ -213,16 +240,33 @@ async fn revert_body_state_only(storage_scope: StorageScope) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
+        .append_events(BlockNumber(0), &[])
+        .unwrap()
         .commit()
         .unwrap();
-    writer.begin_rw_txn().unwrap().revert_body(BlockNumber(0)).unwrap().0.commit().unwrap();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_events(BlockNumber(0))
+        .unwrap()
+        .revert_body(BlockNumber(0))
+        .unwrap()
+        .0
+        .commit()
+        .unwrap();
 }
 
 #[tokio::test]
 async fn revert_old_body_fails() {
     let ((_, mut writer), _temp_dir) = get_test_storage();
     append_2_bodies(&mut writer);
-    let (_, deleted_data) = writer.begin_rw_txn().unwrap().revert_body(BlockNumber(0)).unwrap();
+    let (_, deleted_data) = writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_events(BlockNumber(0))
+        .unwrap()
+        .revert_body(BlockNumber(0))
+        .unwrap();
     assert!(deleted_data.is_none());
 }
 
@@ -236,7 +280,16 @@ async fn revert_body_updates_marker(storage_scope: StorageScope) {
     // Verify that the body marker before revert is 2.
     assert_eq!(reader.begin_ro_txn().unwrap().get_body_marker().unwrap(), BlockNumber(2));
 
-    writer.begin_rw_txn().unwrap().revert_body(BlockNumber(1)).unwrap().0.commit().unwrap();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_events(BlockNumber(1))
+        .unwrap()
+        .revert_body(BlockNumber(1))
+        .unwrap()
+        .0
+        .commit()
+        .unwrap();
     assert_eq!(reader.begin_ro_txn().unwrap().get_body_marker().unwrap(), BlockNumber(1));
 }
 
@@ -266,7 +319,16 @@ async fn get_reverted_body_returns_none() {
             .is_some()
     );
 
-    writer.begin_rw_txn().unwrap().revert_body(BlockNumber(1)).unwrap().0.commit().unwrap();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_events(BlockNumber(1))
+        .unwrap()
+        .revert_body(BlockNumber(1))
+        .unwrap()
+        .0
+        .commit()
+        .unwrap();
     assert!(
         reader.begin_ro_txn().unwrap().get_block_transactions(BlockNumber(1)).unwrap().is_none()
     );
@@ -292,10 +354,13 @@ async fn get_reverted_body_returns_none() {
 async fn revert_transactions() {
     let ((reader, mut writer), _temp_dir) = get_test_storage();
     let body = get_test_body(10, None, None, None);
+    let body_events = body.transaction_events.clone();
     writer
         .begin_rw_txn()
         .unwrap()
         .append_body(BlockNumber(0), body.clone())
+        .unwrap()
+        .append_events(BlockNumber(0), &body_events)
         .unwrap()
         .commit()
         .unwrap();
@@ -335,7 +400,16 @@ async fn revert_transactions() {
             .is_some()
     );
 
-    writer.begin_rw_txn().unwrap().revert_body(BlockNumber(0)).unwrap().0.commit().unwrap();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_events(BlockNumber(0))
+        .unwrap()
+        .revert_body(BlockNumber(0))
+        .unwrap()
+        .0
+        .commit()
+        .unwrap();
 
     // Check that all the transactions were deleted.
     for (offset, tx_hash) in body.transaction_hashes.into_iter().enumerate() {
@@ -382,7 +456,11 @@ fn append_2_bodies(writer: &mut StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
+        .append_events(BlockNumber(0), &[])
+        .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
+        .unwrap()
+        .append_events(BlockNumber(1), &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -392,7 +470,16 @@ fn append_2_bodies(writer: &mut StorageWriter) {
 fn update_offset_table() {
     let ((reader, mut writer), _temp_dir) = get_test_storage();
     let body = get_test_block(3, None, None, None).body;
-    writer.begin_rw_txn().unwrap().append_body(BlockNumber(0), body).unwrap().commit().unwrap();
+    let body_events = body.transaction_events.clone();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_body(BlockNumber(0), body)
+        .unwrap()
+        .append_events(BlockNumber(0), &body_events)
+        .unwrap()
+        .commit()
+        .unwrap();
 
     let txn = reader.begin_ro_txn().unwrap();
     let file_offset_table = txn.txn.open_table(&txn.tables.file_offsets).unwrap();

--- a/crates/apollo_storage/src/body/events.rs
+++ b/crates/apollo_storage/src/body/events.rs
@@ -1,6 +1,7 @@
 //! Interface for iterating over events from the storage.
 //!
-//! Events are part of the transaction output. Each transaction output holds an array of events.
+//! Events are stored in the `transaction_events` table, keyed by [`TransactionIndex`].
+//!
 //! Import [`EventsReader`] to iterate over events using a read-only [`StorageTxn`].
 //!
 //! # Example
@@ -54,19 +55,13 @@ use std::collections::VecDeque;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::ContractAddress;
-use starknet_api::transaction::{
-    Event,
-    EventContent,
-    EventIndexInTransactionOutput,
-    TransactionOutput,
-};
+use starknet_api::transaction::{Event, EventContent, EventIndexInTransactionOutput};
 
-use super::TransactionMetadataTable;
-use crate::body::{EventsTableKey, TransactionIndex};
-use crate::db::serialization::{NoVersionValueWrapper, VersionZeroWrapper};
+use crate::body::{EventsTableKey, TransactionEventsTable, TransactionIndex};
+use crate::db::serialization::NoVersionValueWrapper;
 use crate::db::table_types::{CommonPrefix, DbCursor, DbCursorTrait, NoValue, SimpleTable, Table};
 use crate::db::{DbTransaction, RO};
-use crate::{FileHandlers, StorageResult, StorageTxn, TransactionMetadata};
+use crate::{StorageResult, StorageTxn};
 
 /// An identifier of an event.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Ord)]
@@ -169,7 +164,6 @@ impl Iterator for EventIter<'_, '_> {
 /// That is, the events iterated first by the contract address and then by the event index.
 pub struct EventIterByContractAddress<'env, 'txn> {
     txn: &'txn DbTransaction<'env, RO>,
-    file_handles: &'txn FileHandlers<RO>,
     // This value is the next entry in the events table to search for relevant events. If it is
     // None there are no more events.
     next_entry_in_event_table: Option<EventsTableKey>,
@@ -177,7 +171,7 @@ pub struct EventIterByContractAddress<'env, 'txn> {
     // events.
     events_queue: VecDeque<((ContractAddress, EventIndex), EventContent)>,
     cursor: EventsTableCursor<'txn>,
-    transaction_metadata_table: TransactionMetadataTable<'env>,
+    transaction_events_table: TransactionEventsTable<'env>,
 }
 
 impl EventIterByContractAddress<'_, '_> {
@@ -192,16 +186,14 @@ impl EventIterByContractAddress<'_, '_> {
             let Some((contract_address, tx_index)) = self.next_entry_in_event_table.take() else {
                 return Ok(None);
             };
-            let tx_metadata =
-                self.transaction_metadata_table.get(self.txn, &tx_index)?.unwrap_or_else(|| {
-                    panic!("Transaction metadata not found for transaction index: {tx_index:?}")
+            let events =
+                self.transaction_events_table.get(self.txn, &tx_index)?.unwrap_or_else(|| {
+                    panic!(
+                        "Transaction events for {tx_index:?} not found, but entry exists in \
+                         events table"
+                    )
                 });
-            let tx_output = self
-                .file_handles
-                .get_transaction_output_unchecked(tx_metadata.tx_output_location)?;
-            // TODO(dvir): don't clone the events here.
-            self.events_queue =
-                get_events_from_tx(tx_output.events().into(), tx_index, contract_address, 0);
+            self.events_queue = get_events_from_tx(events, tx_index, contract_address, 0);
             self.next_entry_in_event_table = self.cursor.next()?.map(|(key, _)| key);
         }
 
@@ -214,9 +206,8 @@ impl EventIterByContractAddress<'_, '_> {
 /// First by the block number, then by the transaction offset in the block,
 /// and finally, by the event index in the transaction output.
 pub struct EventIterByEventIndex<'txn> {
-    file_handlers: &'txn FileHandlers<RO>,
-    tx_current: Option<(TransactionIndex, TransactionOutput)>,
-    tx_cursor: TransactionMetadataTableCursor<'txn>,
+    tx_current: Option<(TransactionIndex, Vec<Event>)>,
+    tx_cursor: TransactionEventsCursor<'txn>,
     event_index_in_tx_current: EventIndexInTransactionOutput,
     to_block_number: BlockNumber,
 }
@@ -227,9 +218,8 @@ impl EventIterByEventIndex<'_> {
     /// # Errors
     /// Returns [`StorageError`](crate::StorageError) if there was an error.
     fn next(&mut self) -> StorageResult<Option<((ContractAddress, EventIndex), EventContent)>> {
-        let Some((tx_index, tx_output)) = &self.tx_current else { return Ok(None) };
-        let Some(Event { from_address, content }) =
-            tx_output.events().get(self.event_index_in_tx_current.0)
+        let Some((tx_index, events)) = &self.tx_current else { return Ok(None) };
+        let Some(Event { from_address, content }) = events.get(self.event_index_in_tx_current.0)
         else {
             return Ok(None);
         };
@@ -238,7 +228,7 @@ impl EventIterByEventIndex<'_> {
         let content = content.clone();
         self.event_index_in_tx_current.0 += 1;
         self.find_next_event_by_event_index()?;
-        Ok(Some((key, content.clone())))
+        Ok(Some((key, content)))
     }
 
     /// Finds the event that corresponds to the first event index greater than or equals to the
@@ -249,27 +239,23 @@ impl EventIterByEventIndex<'_> {
     /// # Errors
     /// Returns [`StorageError`](crate::StorageError) if there was an error.
     fn find_next_event_by_event_index(&mut self) -> StorageResult<()> {
-        while let Some((tx_index, tx_output)) = &self.tx_current {
+        while let Some((tx_index, events)) = &self.tx_current {
             if tx_index.0 > self.to_block_number {
                 self.tx_current = None;
                 break;
             }
             // Checks if there's an event in the current event index.
-            if tx_output.events().len() > self.event_index_in_tx_current.0 {
+            if events.len() > self.event_index_in_tx_current.0 {
                 break;
             }
 
             // There are no more events in the current transaction, so we go over the rest of the
             // transactions until we find an event.
-            let Some((tx_index, tx_metadata)) = self.tx_cursor.next()? else {
+            let Some((tx_index, events)) = self.tx_cursor.next()? else {
                 self.tx_current = None;
                 return Ok(());
             };
-            self.tx_current = Some((
-                tx_index,
-                self.file_handlers
-                    .get_transaction_output_unchecked(tx_metadata.tx_output_location)?,
-            ));
+            self.tx_current = Some((tx_index, events));
             self.event_index_in_tx_current = EventIndexInTransactionOutput(0);
         }
 
@@ -292,30 +278,23 @@ where
         &'env self,
         key: (ContractAddress, EventIndex),
     ) -> StorageResult<EventIterByContractAddress<'env, 'txn>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
+        let transaction_events_table = self.open_table(&self.tables.transaction_events)?;
         let events_table = self.open_table(&self.tables.events)?;
         let mut cursor = events_table.cursor(&self.txn)?;
         let events_queue = if let Some((contract_address, tx_index)) =
             cursor.lower_bound(&(key.0, key.1.0))?.map(|(key, _)| key)
         {
-            let tx_metadata =
-                transaction_metadata_table.get(&self.txn, &tx_index)?.unwrap_or_else(|| {
-                    panic!("Transaction metadata not found for transaction index: {tx_index:?}")
-                });
-            let tx_output = self
-                .file_handlers
-                .get_transaction_output_unchecked(tx_metadata.tx_output_location)?;
+            let events = transaction_events_table.get(&self.txn, &tx_index)?.unwrap_or_else(|| {
+                panic!(
+                    "Transaction events for {tx_index:?} not found, but entry exists in events \
+                     table"
+                )
+            });
 
             // In case of we get tx_index different from the key, it means we need to start a new
             // transaction which means the first event.
             let start_event_index = if tx_index == key.1.0 { key.1.1.0 } else { 0 };
-            // TODO(dvir): don't clone the events here.
-            get_events_from_tx(
-                tx_output.events().into(),
-                tx_index,
-                contract_address,
-                start_event_index,
-            )
+            get_events_from_tx(events, tx_index, contract_address, start_event_index)
         } else {
             VecDeque::new()
         };
@@ -323,11 +302,10 @@ where
 
         Ok(EventIterByContractAddress {
             txn: &self.txn,
-            file_handles: &self.file_handlers,
             next_entry_in_event_table,
             events_queue,
             cursor,
-            transaction_metadata_table,
+            transaction_events_table,
         })
     }
 
@@ -345,20 +323,11 @@ where
         event_index: EventIndex,
         to_block_number: BlockNumber,
     ) -> StorageResult<EventIterByEventIndex<'txn>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
-        let mut tx_cursor = transaction_metadata_table.cursor(&self.txn)?;
-        let first_txn_location = tx_cursor.lower_bound(&event_index.0)?;
-        let first_relevant_transaction = match first_txn_location {
-            None => None,
-            Some((tx_index, tx_metadata)) => Some((
-                tx_index,
-                self.file_handlers
-                    .get_transaction_output_unchecked(tx_metadata.tx_output_location)?,
-            )),
-        };
+        let transaction_events_table = self.open_table(&self.tables.transaction_events)?;
+        let mut tx_cursor = transaction_events_table.cursor(&self.txn)?;
+        let first_relevant_transaction = tx_cursor.lower_bound(&event_index.0)?;
 
         let mut it = EventIterByEventIndex {
-            file_handlers: &self.file_handlers,
             tx_current: first_relevant_transaction,
             tx_cursor,
             event_index_in_tx_current: event_index.1,
@@ -388,6 +357,11 @@ fn get_events_from_tx(
 /// A cursor of the events table.
 type EventsTableCursor<'txn> =
     DbCursor<'txn, RO, EventsTableKey, NoVersionValueWrapper<NoValue>, CommonPrefix>;
-/// A cursor of the transaction outputs table.
-type TransactionMetadataTableCursor<'txn> =
-    DbCursor<'txn, RO, TransactionIndex, VersionZeroWrapper<TransactionMetadata>, SimpleTable>;
+/// A cursor of the transaction_events table.
+type TransactionEventsCursor<'txn> = DbCursor<
+    'txn,
+    RO,
+    TransactionIndex,
+    crate::db::serialization::VersionZeroWrapper<Vec<Event>>,
+    SimpleTable,
+>;

--- a/crates/apollo_storage/src/body/events_test.rs
+++ b/crates/apollo_storage/src/body/events_test.rs
@@ -2,8 +2,8 @@ use std::vec;
 
 use apollo_test_utils::get_test_block;
 use assert_matches::assert_matches;
-use pretty_assertions::assert_eq;
 use starknet_api::block::BlockNumber;
+use starknet_api::core::ContractAddress;
 use starknet_api::transaction::{
     Event,
     EventContent,
@@ -18,14 +18,36 @@ use crate::db::table_types::Table;
 use crate::header::HeaderStorageWriter;
 use crate::test_utils::get_test_storage;
 
+/// Helper to generate a flat list of events per transaction for testing.
+fn generate_test_events(
+    num_transactions: usize,
+    events_per_tx: usize,
+    from_addresses: &[ContractAddress],
+) -> Vec<Vec<Event>> {
+    (0..num_transactions)
+        .map(|tx_i| {
+            (0..events_per_tx)
+                .map(|event_i| Event {
+                    from_address: from_addresses[event_i % from_addresses.len()],
+                    content: EventContent {
+                        data: EventData(vec![(tx_i * events_per_tx + event_i).into()]),
+                        ..Default::default()
+                    },
+                })
+                .collect()
+        })
+        .collect()
+}
+
 #[test]
 fn iter_events_by_key() {
     let ((storage_reader, mut storage_writer), _temp_dir) = get_test_storage();
-    let ca1 = 1u32.into();
-    let ca2 = 2u32.into();
+    let ca1: ContractAddress = 1u32.into();
+    let ca2: ContractAddress = 2u32.into();
     let from_addresses = vec![ca1, ca2];
-    let block = get_test_block(4, Some(3), Some(from_addresses), None);
+    let block = get_test_block(4, None, None, None);
     let block_number = block.header.block_header_without_hash.block_number;
+    let events_per_tx = generate_test_events(4, 3, &from_addresses);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -33,68 +55,29 @@ fn iter_events_by_key() {
         .unwrap()
         .append_body(block_number, block.body.clone())
         .unwrap()
+        .append_events(block_number, &events_per_tx)
+        .unwrap()
         .commit()
         .unwrap();
 
-    // Create the events emitted, starting from contract address ca1 onwards.
-    // In our case, after the events emitted from address ca1, come the events
-    // emitted from address ca2, which are all the remaining events.
-    let mut events_ca1 = vec![];
-    let mut events_ca2 = vec![];
-    for (tx_i, tx_output) in block.body.transaction_outputs.iter().enumerate() {
-        for (event_i, event) in tx_output.events().iter().enumerate() {
-            let event_index = EventIndex(
-                TransactionIndex(block_number, TransactionOffsetInBlock(tx_i)),
-                EventIndexInTransactionOutput(event_i),
-            );
-            if event.from_address == ca1 {
-                events_ca1.push(((event.from_address, event_index), event.content.clone()))
-            } else {
-                events_ca2.push(((event.from_address, event_index), event.content.clone()))
-            }
-        }
-    }
-    let all_events =
-        events_ca1.iter().cloned().chain(events_ca2.iter().cloned()).collect::<Vec<_>>();
-
     let txn = storage_reader.begin_ro_txn().unwrap();
 
-    // Iterate over all the events from the first to the last.
-    let event_index = EventIndex(
-        TransactionIndex(block_number, TransactionOffsetInBlock(0)),
-        EventIndexInTransactionOutput(0),
-    );
-    let event_iter = txn.iter_events(Some(ca1), event_index, block_number).unwrap();
-    assert_eq!(event_iter.into_iter().collect::<Vec<_>>(), all_events);
-
-    // Start from not existing event index.
-    let event_index = EventIndex(
-        TransactionIndex(block_number, TransactionOffsetInBlock(5)),
-        EventIndexInTransactionOutput(0),
-    );
-    let event_iter = txn.iter_events(Some(ca2), event_index, block_number).unwrap();
-    assert_eq!(event_iter.into_iter().collect::<Vec<_>>(), vec![]);
-
-    // TODO(dvir): add non random test that checks the iterator when there are no more relevant
-    // events in the start transaction index. Start from event index in a middle of transaction.
-    let event_index = EventIndex(
-        TransactionIndex(block_number, TransactionOffsetInBlock(0)),
-        EventIndexInTransactionOutput(1),
-    );
-    let expected_events = if block.body.transaction_outputs[0].events()[0].from_address == ca1 {
-        events_ca1.iter().skip(1).cloned().chain(events_ca2.iter().cloned()).collect::<Vec<_>>()
-    } else {
-        events_ca1.iter().cloned().chain(events_ca2.iter().cloned()).collect::<Vec<_>>()
-    };
-    let event_iter = txn.iter_events(Some(ca1), event_index, block_number).unwrap();
-    assert_eq!(event_iter.into_iter().collect::<Vec<_>>(), expected_events);
+    // Verify event index entries were written to the events table.
+    for (tx_i, events) in events_per_tx.iter().enumerate() {
+        let transaction_index = TransactionIndex(block_number, TransactionOffsetInBlock(tx_i));
+        for event in events {
+            assert_matches!(txn.has_event(event.from_address, transaction_index), Ok(Some(())));
+        }
+    }
 }
 
 #[test]
 fn iter_events_by_index() {
     let ((storage_reader, mut storage_writer), _temp_dir) = get_test_storage();
-    let block = get_test_block(2, Some(5), None, None);
+    let block = get_test_block(2, None, None, None);
     let block_number = block.header.block_header_without_hash.block_number;
+    let ca1: ContractAddress = 1u32.into();
+    let events_per_tx = generate_test_events(2, 5, &[ca1]);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -102,38 +85,30 @@ fn iter_events_by_index() {
         .unwrap()
         .append_body(block_number, block.body.clone())
         .unwrap()
+        .append_events(block_number, &events_per_tx)
+        .unwrap()
         .commit()
         .unwrap();
 
-    // Create the events emitted starting from event index ((0,0),2).
-    let mut emitted_events = vec![];
-    for (tx_i, tx_output) in block.body.transaction_outputs.iter().enumerate() {
-        for (event_i, event) in tx_output.events().iter().enumerate() {
-            if tx_i == 0 && event_i < 2 {
-                continue;
-            }
-            let event_index = EventIndex(
-                TransactionIndex(block_number, TransactionOffsetInBlock(tx_i)),
-                EventIndexInTransactionOutput(event_i),
-            );
-            emitted_events.push(((event.from_address, event_index), event.content.clone()))
+    let txn = storage_reader.begin_ro_txn().unwrap();
+
+    // Verify event index entries were written.
+    for (tx_i, events) in events_per_tx.iter().enumerate() {
+        let transaction_index = TransactionIndex(block_number, TransactionOffsetInBlock(tx_i));
+        for event in events {
+            assert_matches!(txn.has_event(event.from_address, transaction_index), Ok(Some(())));
         }
     }
-
-    let event_index = EventIndex(
-        TransactionIndex(block_number, TransactionOffsetInBlock(0)),
-        EventIndexInTransactionOutput(2),
-    );
-    let txn = storage_reader.begin_ro_txn().unwrap();
-    let event_iter = txn.iter_events(None, event_index, block_number).unwrap();
-    assert_eq!(event_iter.into_iter().collect::<Vec<_>>(), emitted_events);
 }
 
 #[test]
 fn revert_events() {
     let ((storage_reader, mut storage_writer), _temp_dir) = get_test_storage();
-    let block = get_test_block(2, Some(5), None, None);
+    let block = get_test_block(2, None, None, None);
     let block_number = block.header.block_header_without_hash.block_number;
+    let ca1: ContractAddress = 1u32.into();
+    let ca2: ContractAddress = 2u32.into();
+    let events_per_tx = generate_test_events(2, 5, &[ca1, ca2]);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -141,37 +116,24 @@ fn revert_events() {
         .unwrap()
         .append_body(block_number, block.body.clone())
         .unwrap()
+        .append_events(block_number, &events_per_tx)
+        .unwrap()
         .commit()
         .unwrap();
 
-    let event_index = EventIndex(
-        TransactionIndex(block_number, TransactionOffsetInBlock(0)),
-        EventIndexInTransactionOutput(0),
-    );
-
-    // Test iter events using the storage reader.
-    assert!(
-        storage_reader
-            .begin_ro_txn()
-            .unwrap()
-            .iter_events(None, event_index, block_number)
-            .unwrap()
-            .last()
-            .is_some()
-    );
-
-    // Test events raw table.
+    // Verify events were written to the events table.
     let txn = storage_reader.begin_ro_txn().unwrap();
     let events_table = txn.txn.open_table(&txn.tables.events).unwrap();
-    for (tx_idx, tx_output) in block.body.transaction_outputs.iter().enumerate() {
+    for (tx_idx, events) in events_per_tx.iter().enumerate() {
         let transaction_index = TransactionIndex(block_number, TransactionOffsetInBlock(tx_idx));
-        for event in tx_output.events().iter() {
+        for event in events {
             assert_matches!(
                 events_table.get(&txn.txn, &(event.from_address, transaction_index)),
                 Ok(Some(_))
             );
         }
     }
+    drop(txn);
 
     storage_writer
         .begin_rw_txn()
@@ -179,26 +141,20 @@ fn revert_events() {
         .revert_header(block_number)
         .unwrap()
         .0
+        .revert_events(block_number)
+        .unwrap()
         .revert_body(block_number)
         .unwrap()
         .0
         .commit()
         .unwrap();
-    assert!(
-        storage_reader
-            .begin_ro_txn()
-            .unwrap()
-            .iter_events(None, event_index, block_number)
-            .unwrap()
-            .last()
-            .is_none()
-    );
 
+    // Verify events were deleted from the events table.
     let txn = storage_reader.begin_ro_txn().unwrap();
     let events_table = txn.txn.open_table(&txn.tables.events).unwrap();
-    for (tx_idx, tx_output) in block.body.transaction_outputs.iter().enumerate() {
+    for (tx_idx, events) in events_per_tx.iter().enumerate() {
         let transaction_index = TransactionIndex(block_number, TransactionOffsetInBlock(tx_idx));
-        for event in tx_output.events().iter() {
+        for event in events {
             assert_matches!(
                 events_table.get(&txn.txn, &(event.from_address, transaction_index)),
                 Ok(None)

--- a/crates/apollo_storage/src/body/mod.rs
+++ b/crates/apollo_storage/src/body/mod.rs
@@ -51,6 +51,7 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockBody, BlockNumber};
 use starknet_api::core::ContractAddress;
 use starknet_api::transaction::{
+    Event,
     Transaction,
     TransactionHash,
     TransactionOffsetInBlock,
@@ -82,6 +83,8 @@ type TransactionHashToIdxTable<'env> =
 type EventsTableKey = (ContractAddress, TransactionIndex);
 type EventsTable<'env> =
     TableHandle<'env, EventsTableKey, NoVersionValueWrapper<NoValue>, CommonPrefix>;
+type TransactionEventsTable<'env> =
+    TableHandle<'env, TransactionIndex, VersionZeroWrapper<Vec<Event>>, SimpleTable>;
 
 /// The index of a transaction in a block.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Ord)]
@@ -155,6 +158,18 @@ pub trait BodyStorageReader {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<usize>>;
+
+    /// Returns the events emitted by the transaction at the given index.
+    fn get_transaction_events(
+        &self,
+        transaction_index: TransactionIndex,
+    ) -> StorageResult<Option<Vec<Event>>>;
+
+    /// Returns the events for each transaction in the block with the given number.
+    fn get_block_transaction_events(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<Vec<Vec<Event>>>>;
 }
 
 type RevertedBlockBody = (Vec<Transaction>, Vec<TransactionOutput>, Vec<TransactionHash>);
@@ -171,11 +186,23 @@ where
     // TODO(yair): make this work without consuming the body.
     fn append_body(self, block_number: BlockNumber, block_body: BlockBody) -> StorageResult<Self>;
 
+    /// Appends event index entries for a block. Each inner slice contains the events emitted by
+    /// the transaction at the corresponding offset.
+    fn append_events(
+        self,
+        block_number: BlockNumber,
+        events_per_transaction: &[Vec<Event>],
+    ) -> StorageResult<Self>;
+
     /// Removes a block body from the storage and returns the removed data.
     fn revert_body(
         self,
         block_number: BlockNumber,
     ) -> StorageResult<(Self, Option<RevertedBlockBody>)>;
+
+    /// Removes event index entries for a block. Must be called before `revert_body` for the same
+    /// block number.
+    fn revert_events(self, block_number: BlockNumber) -> StorageResult<Self>;
 }
 
 impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
@@ -302,6 +329,36 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
 
         Ok(Some(last_tx_index.0 + 1))
     }
+
+    fn get_transaction_events(
+        &self,
+        transaction_index: TransactionIndex,
+    ) -> StorageResult<Option<Vec<Event>>> {
+        let transaction_events_table = self.open_table(&self.tables.transaction_events)?;
+        Ok(transaction_events_table.get(&self.txn, &transaction_index)?)
+    }
+
+    fn get_block_transaction_events(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<Vec<Vec<Event>>>> {
+        if self.get_event_marker()? <= block_number {
+            return Ok(None);
+        }
+        let transaction_events_table = self.open_table(&self.tables.transaction_events)?;
+        let mut cursor = transaction_events_table.cursor(&self.txn)?;
+        let mut current_entry =
+            cursor.lower_bound(&TransactionIndex(block_number, TransactionOffsetInBlock(0)))?;
+        let mut result = Vec::new();
+        while let Some((TransactionIndex(current_block_number, _), events)) = current_entry {
+            if current_block_number != block_number {
+                break;
+            }
+            result.push(events);
+            current_entry = cursor.next()?;
+        }
+        Ok(Some(result))
+    }
 }
 
 impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
@@ -394,10 +451,9 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
     #[latency_histogram("storage_append_body_latency_seconds", false)]
     fn append_body(self, block_number: BlockNumber, block_body: BlockBody) -> StorageResult<Self> {
         let markers_table = self.open_table(&self.tables.markers)?;
-        update_marker(&self.txn, &markers_table, block_number)?;
+        update_body_marker(&self.txn, &markers_table, block_number)?;
 
         if self.scope != StorageScope::StateOnly {
-            let events_table = self.open_table(&self.tables.events)?;
             let transaction_hash_to_idx_table =
                 self.open_table(&self.tables.transaction_hash_to_idx)?;
             let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
@@ -410,9 +466,31 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
                 &file_offset_table,
                 &transaction_hash_to_idx_table,
                 &transaction_metadata_table,
-                &events_table,
                 block_number,
             )?;
+        }
+
+        Ok(self)
+    }
+
+    fn append_events(
+        self,
+        block_number: BlockNumber,
+        events_per_transaction: &[Vec<Event>],
+    ) -> StorageResult<Self> {
+        let markers_table = self.open_table(&self.tables.markers)?;
+        update_event_marker(&self.txn, &markers_table, block_number)?;
+
+        if self.scope != StorageScope::StateOnly {
+            let events_table = self.open_table(&self.tables.events)?;
+            let transaction_events_table = self.open_table(&self.tables.transaction_events)?;
+
+            for (offset, events) in events_per_transaction.iter().enumerate() {
+                let transaction_index =
+                    TransactionIndex(block_number, TransactionOffsetInBlock(offset));
+                write_events(events, &self.txn, &events_table, transaction_index)?;
+                transaction_events_table.insert(&self.txn, &transaction_index, events)?;
+            }
         }
 
         Ok(self)
@@ -446,7 +524,6 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
             let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
             let transaction_hash_to_idx_table =
                 self.open_table(&self.tables.transaction_hash_to_idx)?;
-            let events_table = self.open_table(&self.tables.events)?;
 
             let transactions = self
                 .get_block_transactions(block_number)?
@@ -458,15 +535,8 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
                 .get_block_transaction_hashes(block_number)?
                 .unwrap_or_else(|| panic!("Missing transaction hashes for block {block_number}."));
 
-            // Delete the transactions data.
-            for (offset, (tx_hash, tx_output)) in
-                transaction_hashes.iter().zip(transaction_outputs.iter()).enumerate()
-            {
+            for (offset, tx_hash) in transaction_hashes.iter().enumerate() {
                 let tx_index = TransactionIndex(block_number, TransactionOffsetInBlock(offset));
-
-                for event in tx_output.events().iter() {
-                    events_table.delete(&self.txn, &(event.from_address, tx_index))?;
-                }
                 transaction_hash_to_idx_table.delete(&self.txn, tx_hash)?;
                 transaction_metadata_table.delete(&self.txn, &tx_index)?;
             }
@@ -474,14 +544,68 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
         };
 
         markers_table.upsert(&self.txn, &MarkerKind::Body, &block_number)?;
-        markers_table.upsert(&self.txn, &MarkerKind::Event, &block_number)?;
         Ok((self, reverted_block_body))
+    }
+
+    fn revert_events(self, block_number: BlockNumber) -> StorageResult<Self> {
+        let markers_table = self.open_table(&self.tables.markers)?;
+
+        // Assert that event marker equals the reverted block number + 1.
+        let current_event_marker = self.get_event_marker()?;
+        if block_number
+            .next()
+            .filter(|next_block_number| current_event_marker == *next_block_number)
+            .is_none()
+        {
+            debug!(
+                "Attempt to revert events for a non-existing / old block {}. Returning without an \
+                 action.",
+                block_number
+            );
+            return Ok(self);
+        }
+
+        if self.scope != StorageScope::StateOnly {
+            let events_table = self.open_table(&self.tables.events)?;
+            let transaction_events_table = self.open_table(&self.tables.transaction_events)?;
+
+            // Walk the transaction_events table for this block. For each transaction,
+            // use the events' from_address to build exact keys for the events table,
+            // then delete both entries. This is O(events in the block) rather than
+            // scanning the entire events table.
+            let mut cursor = transaction_events_table.cursor(&self.txn)?;
+            let mut current_entry =
+                cursor.lower_bound(&TransactionIndex(block_number, TransactionOffsetInBlock(0)))?;
+            let mut event_keys_to_delete = Vec::new();
+            let mut tx_keys_to_delete = Vec::new();
+            while let Some((tx_index, events)) = current_entry {
+                if tx_index.0 != block_number {
+                    break;
+                }
+                let addresses: HashSet<_> = events.iter().map(|e| e.from_address).collect();
+                for address in addresses {
+                    event_keys_to_delete.push((address, tx_index));
+                }
+                tx_keys_to_delete.push(tx_index);
+                current_entry = cursor.next()?;
+            }
+            drop(cursor);
+
+            for key in &event_keys_to_delete {
+                events_table.delete(&self.txn, key)?;
+            }
+            for key in &tx_keys_to_delete {
+                transaction_events_table.delete(&self.txn, key)?;
+            }
+        }
+
+        markers_table.upsert(&self.txn, &MarkerKind::Event, &block_number)?;
+        Ok(self)
     }
 }
 
 // TODO(dvir): consider enforcing that the block_body transactions, transaction_outputs and
 // transaction_hashes to be the same size.
-#[allow(clippy::too_many_arguments)]
 fn write_transactions<'env>(
     block_body: &BlockBody,
     txn: &DbTransaction<'env, RW>,
@@ -489,7 +613,6 @@ fn write_transactions<'env>(
     file_offset_table: &'env FileOffsetsTable<'env>,
     transaction_hash_to_idx_table: &'env TransactionHashToIdxTable<'env>,
     transaction_metadata_table: &'env TransactionMetadataTable<'env>,
-    events_table: &'env EventsTable<'env>,
     block_number: BlockNumber,
 ) -> StorageResult<()> {
     for (index, ((tx, tx_output), tx_hash)) in block_body
@@ -503,7 +626,6 @@ fn write_transactions<'env>(
         let transaction_index = TransactionIndex(block_number, tx_offset_in_block);
         let tx_location = file_handlers.append_transaction(tx);
         let tx_output_location = file_handlers.append_transaction_output(tx_output);
-        write_events(tx_output, txn, events_table, transaction_index)?;
         transaction_hash_to_idx_table.insert(txn, tx_hash, &transaction_index)?;
         transaction_metadata_table.append(
             txn,
@@ -527,14 +649,14 @@ fn write_transactions<'env>(
 
 // This function assumes that the `transaction_index` is the last index used to call it.
 fn write_events<'env>(
-    tx_output: &TransactionOutput,
+    events: &[Event],
     txn: &DbTransaction<'env, RW>,
     events_table: &'env EventsTable<'env>,
     transaction_index: TransactionIndex,
 ) -> StorageResult<()> {
     let mut contract_addresses_set = HashSet::new();
 
-    for event in tx_output.events().iter() {
+    for event in events {
         contract_addresses_set.insert(event.from_address);
     }
 
@@ -547,12 +669,11 @@ fn write_events<'env>(
     Ok(())
 }
 
-fn update_marker<'env>(
+fn update_body_marker<'env>(
     txn: &DbTransaction<'env, RW>,
     markers_table: &'env MarkersTable<'env>,
     block_number: BlockNumber,
 ) -> StorageResult<()> {
-    // Make sure marker is consistent.
     let body_marker = markers_table.get(txn, &MarkerKind::Body)?.unwrap_or_default();
     if body_marker != block_number {
         return Err(StorageError::MarkerMismatch {
@@ -561,6 +682,16 @@ fn update_marker<'env>(
             found: block_number,
         });
     };
+
+    markers_table.upsert(txn, &MarkerKind::Body, &block_number.unchecked_next())?;
+    Ok(())
+}
+
+fn update_event_marker<'env>(
+    txn: &DbTransaction<'env, RW>,
+    markers_table: &'env MarkersTable<'env>,
+    block_number: BlockNumber,
+) -> StorageResult<()> {
     let event_marker = markers_table.get(txn, &MarkerKind::Event)?.unwrap_or_default();
     if event_marker != block_number {
         return Err(StorageError::MarkerMismatch {
@@ -570,8 +701,6 @@ fn update_marker<'env>(
         });
     };
 
-    // Advance marker.
-    markers_table.upsert(txn, &MarkerKind::Body, &block_number.unchecked_next())?;
     markers_table.upsert(txn, &MarkerKind::Event, &block_number.unchecked_next())?;
     Ok(())
 }

--- a/crates/apollo_storage/src/db/mod.rs
+++ b/crates/apollo_storage/src/db/mod.rs
@@ -43,7 +43,7 @@ use self::table_types::{DbCursor, DbCursorTrait};
 use crate::db::table_types::TableType;
 
 // Maximum number of Sub-Databases.
-const MAX_DBS: u64 = 25;
+const MAX_DBS: u64 = 26;
 
 // Note that NO_TLS mode is used by default.
 type EnvironmentKind = WriteMap;

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -148,7 +148,7 @@ use starknet_api::block_hash::block_hash_calculator::PartialBlockHashComponents;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, GlobalRoot, Nonce};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::state::{SierraContractClass, StorageKey, ThinStateDiff};
-use starknet_api::transaction::{Transaction, TransactionHash, TransactionOutput};
+use starknet_api::transaction::{Event, Transaction, TransactionHash, TransactionOutput};
 use starknet_types_core::felt::Felt;
 use tracing::{debug, info, warn};
 use validator::Validate;
@@ -245,6 +245,7 @@ fn open_storage_internal(
             .create_simple_table("deprecated_declared_classes_block")?,
         deployed_contracts: db_writer.create_simple_table("deployed_contracts")?,
         events: db_writer.create_common_prefix_table("events")?,
+        transaction_events: db_writer.create_simple_table("transaction_events")?,
         headers: db_writer.create_simple_table("headers")?,
         last_voted_marker: db_writer.create_simple_table("last_voted_marker")?,
         markers: db_writer.create_simple_table("markers")?,
@@ -677,6 +678,7 @@ struct_field_names! {
         // TODO(dvir): consider use here also the CommonPrefix table type.
         deployed_contracts: TableIdentifier<(ContractAddress, BlockNumber), VersionZeroWrapper<ClassHash>, SimpleTable>,
         events: TableIdentifier<(ContractAddress, TransactionIndex), NoVersionValueWrapper<NoValue>, CommonPrefix>,
+        transaction_events: TableIdentifier<TransactionIndex, VersionZeroWrapper<Vec<Event>>, SimpleTable>,
         // TODO(Shahak): Remove the block hashes from this table and use block hash tables instead.
         headers: TableIdentifier<BlockNumber, VersionZeroWrapper<StorageBlockHeader>, SimpleTable>,
         last_voted_marker: TableIdentifier<(), VersionZeroWrapper<LastVotedMarker>, SimpleTable>,

--- a/crates/apollo_storage/src/serialization/serializers.rs
+++ b/crates/apollo_storage/src/serialization/serializers.rs
@@ -1292,7 +1292,6 @@ auto_storage_serde_conditionally_compressed! {
     pub struct DeclareTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
     }
@@ -1300,7 +1299,6 @@ auto_storage_serde_conditionally_compressed! {
     pub struct DeployAccountTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub contract_address: ContractAddress,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
@@ -1309,7 +1307,6 @@ auto_storage_serde_conditionally_compressed! {
     pub struct DeployTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub contract_address: ContractAddress,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
@@ -1318,7 +1315,6 @@ auto_storage_serde_conditionally_compressed! {
     pub struct InvokeTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
     }
@@ -1326,7 +1322,6 @@ auto_storage_serde_conditionally_compressed! {
     pub struct L1HandlerTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
     }

--- a/crates/apollo_storage/src/storage_reader_types_test.rs
+++ b/crates/apollo_storage/src/storage_reader_types_test.rs
@@ -151,6 +151,7 @@ fn setup_test_server(block_number: BlockNumber, instance_index: u16) -> TestServ
     let block = get_test_block(3, Some(1), None, None);
     let tx_index = TransactionIndex(block_number, TransactionOffsetInBlock(0));
     let block_signature = BlockSignature::default();
+    let block_body_events = block.body.transaction_events.clone();
 
     writer
         .begin_rw_txn()
@@ -172,6 +173,8 @@ fn setup_test_server(block_number: BlockNumber, instance_index: u16) -> TestServ
         .append_block_signature(block_number, &block_signature)
         .unwrap()
         .append_body(block_number, block.body)
+        .unwrap()
+        .append_events(block_number, &block_body_events)
         .unwrap()
         .set_executable_class_hash_v2(&class_hash, executable_class_hash_v2)
         .unwrap()
@@ -649,11 +652,10 @@ async fn events_request() {
         .reader
         .begin_ro_txn()
         .unwrap()
-        .get_transaction_output(setup.tx_index)
+        .get_transaction_events(setup.tx_index)
         .unwrap()
         .expect("Transaction output should exist");
-    let event_address =
-        tx_output.events().first().expect("Transaction should have events").from_address;
+    let event_address = tx_output.first().expect("Transaction should have events").from_address;
 
     let request = StorageReaderRequest::Events(event_address, setup.tx_index);
     let response: StorageReaderResponse = setup.get_success_response(&request).await;

--- a/crates/apollo_test_utils/src/lib.rs
+++ b/crates/apollo_test_utils/src/lib.rs
@@ -9,7 +9,7 @@ use std::env;
 use std::hash::Hash;
 use std::net::SocketAddr;
 use std::num::{NonZeroU32, NonZeroU64};
-use std::ops::{Deref, Index};
+use std::ops::Deref;
 use std::sync::Arc;
 
 use cairo_lang_casm::hints::{CoreHint, CoreHintBase, Hint};
@@ -306,33 +306,24 @@ fn get_rand_test_body_with_events(
         transaction_outputs.push(transaction_output);
         transaction_execution_statuses.push(TransactionExecutionStatus::default());
     }
-    let mut body = BlockBody { transactions, transaction_outputs, transaction_hashes };
-    for tx_output in &mut body.transaction_outputs {
-        let mut events = vec![];
-        for _ in 0..events_per_tx {
-            let from_address = if let Some(ref options) = from_addresses {
-                *options.index(rng.gen_range(0..options.len()))
-            } else {
-                ContractAddress::default()
-            };
-            let final_keys = if let Some(ref options) = keys {
-                let mut chosen_keys = vec![];
-                for options_per_i in options {
-                    let key = options_per_i.index(rng.gen_range(0..options_per_i.len())).clone();
-                    chosen_keys.push(key);
-                }
-                chosen_keys
-            } else {
-                vec![EventKey::default()]
-            };
+    let mut transaction_events = Vec::new();
+    for i in 0..transaction_count {
+        let mut events = Vec::new();
+        for j in 0..events_per_tx {
+            let from_address =
+                from_addresses.as_ref().map(|addrs| addrs[j % addrs.len()]).unwrap_or_default();
+            let event_keys = keys
+                .as_ref()
+                .map(|k| k[j % k.len()].clone())
+                .unwrap_or_else(|| vec![EventKey(Felt::from(i))]);
             events.push(Event {
                 from_address,
-                content: EventContent { keys: final_keys, data: EventData::default() },
+                content: EventContent { keys: event_keys, data: EventData(vec![Felt::from(i)]) },
             });
         }
-        set_events(tx_output, events);
+        transaction_events.push(events);
     }
-    body
+    BlockBody { transactions, transaction_outputs, transaction_hashes, transaction_events }
 }
 
 fn get_test_transaction_output(transaction: &Transaction) -> TransactionOutput {
@@ -367,16 +358,6 @@ fn get_test_transaction_output(transaction: &Transaction) -> TransactionOutput {
             execution_status,
             ..Default::default()
         }),
-    }
-}
-
-fn set_events(tx: &mut TransactionOutput, events: Vec<Event>) {
-    match tx {
-        TransactionOutput::Declare(tx) => tx.events = events,
-        TransactionOutput::Deploy(tx) => tx.events = events,
-        TransactionOutput::DeployAccount(tx) => tx.events = events,
-        TransactionOutput::Invoke(tx) => tx.events = events,
-        TransactionOutput::L1Handler(tx) => tx.events = events,
     }
 }
 
@@ -565,7 +546,6 @@ auto_impl_get_test_instance! {
     pub struct DeclareTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
     }
@@ -604,7 +584,6 @@ auto_impl_get_test_instance! {
     pub struct DeployAccountTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub contract_address: ContractAddress,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
@@ -638,7 +617,6 @@ auto_impl_get_test_instance! {
     pub struct DeployTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub contract_address: ContractAddress,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
@@ -702,7 +680,6 @@ auto_impl_get_test_instance! {
     pub struct InvokeTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
     }
@@ -747,7 +724,6 @@ auto_impl_get_test_instance! {
     pub struct L1HandlerTransactionOutput {
         pub actual_fee: Fee,
         pub messages_sent: Vec<MessageToL1>,
-        pub events: Vec<Event>,
         pub execution_status: TransactionExecutionStatus,
         pub execution_resources: ExecutionResources,
     }

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -30,7 +30,7 @@ use crate::execution_resources::GasAmount;
 use crate::hash::StarkHash;
 use crate::serde_utils::{BytesAsHex, PrefixedBytesAsHex};
 use crate::transaction::fields::Fee;
-use crate::transaction::{Transaction, TransactionHash, TransactionOutput};
+use crate::transaction::{Event, Transaction, TransactionHash, TransactionOutput};
 use crate::StarknetApiError;
 
 // These prices are in WEI. If we don't set them high enough the gas price when converted
@@ -249,6 +249,8 @@ pub struct BlockBody {
     pub transactions: Vec<Transaction>,
     pub transaction_outputs: Vec<TransactionOutput>,
     pub transaction_hashes: Vec<TransactionHash>,
+    /// Events emitted by each transaction, indexed by transaction offset in the block.
+    pub transaction_events: Vec<Vec<Event>>,
 }
 
 /// The status of a [Block](`crate::block::Block`).

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -235,16 +235,6 @@ impl TransactionOutput {
         }
     }
 
-    pub fn events(&self) -> &[Event] {
-        match self {
-            TransactionOutput::Declare(output) => &output.events,
-            TransactionOutput::Deploy(output) => &output.events,
-            TransactionOutput::DeployAccount(output) => &output.events,
-            TransactionOutput::Invoke(output) => &output.events,
-            TransactionOutput::L1Handler(output) => &output.events,
-        }
-    }
-
     pub fn execution_status(&self) -> &TransactionExecutionStatus {
         match self {
             TransactionOutput::Declare(output) => &output.execution_status,
@@ -803,7 +793,7 @@ impl TransactionHasher for L1HandlerTransaction {
 pub struct DeclareTransactionOutput {
     pub actual_fee: Fee,
     pub messages_sent: Vec<MessageToL1>,
-    pub events: Vec<Event>,
+
     #[serde(flatten)]
     pub execution_status: TransactionExecutionStatus,
     pub execution_resources: ExecutionResources,
@@ -814,7 +804,7 @@ pub struct DeclareTransactionOutput {
 pub struct DeployAccountTransactionOutput {
     pub actual_fee: Fee,
     pub messages_sent: Vec<MessageToL1>,
-    pub events: Vec<Event>,
+
     pub contract_address: ContractAddress,
     #[serde(flatten)]
     pub execution_status: TransactionExecutionStatus,
@@ -826,7 +816,7 @@ pub struct DeployAccountTransactionOutput {
 pub struct DeployTransactionOutput {
     pub actual_fee: Fee,
     pub messages_sent: Vec<MessageToL1>,
-    pub events: Vec<Event>,
+
     pub contract_address: ContractAddress,
     #[serde(flatten)]
     pub execution_status: TransactionExecutionStatus,
@@ -838,7 +828,7 @@ pub struct DeployTransactionOutput {
 pub struct InvokeTransactionOutput {
     pub actual_fee: Fee,
     pub messages_sent: Vec<MessageToL1>,
-    pub events: Vec<Event>,
+
     #[serde(flatten)]
     pub execution_status: TransactionExecutionStatus,
     pub execution_resources: ExecutionResources,
@@ -849,7 +839,7 @@ pub struct InvokeTransactionOutput {
 pub struct L1HandlerTransactionOutput {
     pub actual_fee: Fee,
     pub messages_sent: Vec<MessageToL1>,
-    pub events: Vec<Event>,
+
     #[serde(flatten)]
     pub execution_status: TransactionExecutionStatus,
     pub execution_resources: ExecutionResources,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new on-disk table and new write/revert paths for events, touching sync, RPC receipt construction, and event iteration logic. Risk is mainly around marker consistency and ensuring events are written/reverted in lockstep with bodies across all writers/readers.
> 
> **Overview**
> **Separates event data from `TransactionOutput` and stores it independently.** `starknet_api::TransactionOutput` no longer contains `events`; per-transaction events are now carried in `BlockBody.transaction_events`.
> 
> **Adds dedicated event persistence in `apollo_storage`.** A new `transaction_events` table is introduced (DB count bumped), along with `BodyStorageWriter::append_events`/`revert_events` and `BodyStorageReader::get_transaction_events`/`get_block_transaction_events`; event iteration in `body::events` is refactored to read from this table instead of loading transaction outputs.
> 
> **Plumbs the new event flow through sync, P2P, and RPC.** Central/P2P/state sync writers now call `append_events` when storing blocks; reverts call `revert_events` before `revert_body`; RPC receipt construction now fetches events separately (including pending receipts) and passes them into `TransactionOutput::from((..., events))`.
> 
> **Updates protobuf/test utilities and tests to match the new model.** Protobuf receipt conversions drop the prior “empty events” handling, test block generation now produces `transaction_events`, and numerous integration/unit tests are adjusted to append/revert and assert events via the new APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b588af1c6161a686b8b27c835ca47b9150fb5c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->