### PR TITLE
apollo_propeller: add inbound_channel_capacity config field

### DIFF
--- a/crates/apollo_propeller/src/config.rs
+++ b/crates/apollo_propeller/src/config.rs
@@ -15,6 +15,10 @@ pub struct Config {
     pub stream_protocol: StreamProtocol,
     /// Maximum size of a message sent over the wire.
     pub max_wire_message_size: usize,
+    /// Capacity of the bounded channel between each handler and the engine for inbound units.
+    /// Controls back-pressure: when the channel is full, the handler stops reading from the
+    /// network, causing yamux flow control to slow the remote peer.
+    pub inbound_channel_capacity: usize,
 }
 
 impl Default for Config {
@@ -23,6 +27,7 @@ impl Default for Config {
             stale_message_timeout: Duration::from_secs(120),
             stream_protocol: StreamProtocol::new("/propeller/0.1.0"),
             max_wire_message_size: 1 << 20, // 1 MB
+            inbound_channel_capacity: 16,
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change (new field + default) with no behavioral impact until consumers start using the new parameter.
> 
> **Overview**
> Adds a new `Config::inbound_channel_capacity` setting to parameterize the bounded handler→engine inbound channel size, with documentation describing its back-pressure behavior and a default of `256`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d992b45d916e6cabdbf1a505177fb7daaac792ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->