### PR TITLE
apollo_propeller: wire bounded unit channels between handler and engine

### DIFF
--- a/crates/apollo_propeller/src/behaviour.rs
+++ b/crates/apollo_propeller/src/behaviour.rs
@@ -123,6 +123,16 @@ impl Behaviour {
         self.engine_commands_tx.send(command).expect("Engine task has exited");
         response_rx
     }
+
+    /// Creates a handler for a new connection, wiring a bounded channel between the handler
+    /// and the engine for inbound unit delivery.
+    fn create_handler(&self, peer_id: PeerId) -> Handler {
+        let (sender, receiver) =
+            futures::channel::mpsc::channel(self.config.inbound_channel_capacity);
+        let command = EngineCommand::RegisterHandler { peer_id, receiver };
+        self.engine_commands_tx.send(command).expect("Engine task has exited");
+        Handler::new(&self.config, sender)
+    }
 }
 
 impl NetworkBehaviour for Behaviour {
@@ -132,22 +142,22 @@ impl NetworkBehaviour for Behaviour {
     fn handle_established_inbound_connection(
         &mut self,
         _connection_id: ConnectionId,
-        _peer: PeerId,
+        peer: PeerId,
         _local_addr: &libp2p::core::Multiaddr,
         _remote_addr: &libp2p::core::Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(Handler::new(&self.config))
+        Ok(self.create_handler(peer))
     }
 
     fn handle_established_outbound_connection(
         &mut self,
         _connection_id: ConnectionId,
-        _peer: PeerId,
+        peer: PeerId,
         _addr: &libp2p::core::Multiaddr,
         _role_override: Endpoint,
         _port_use: libp2p::core::transport::PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(Handler::new(&self.config))
+        Ok(self.create_handler(peer))
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm<'_>) {

--- a/crates/apollo_propeller/src/config.rs
+++ b/crates/apollo_propeller/src/config.rs
@@ -15,6 +15,10 @@ pub struct Config {
     pub stream_protocol: StreamProtocol,
     /// Maximum size of a message sent over the wire.
     pub max_wire_message_size: usize,
+    /// Capacity of the bounded channel between each handler and the engine for inbound units.
+    /// Controls back-pressure: when the channel is full, the handler stops reading from the
+    /// network, causing yamux flow control to slow the remote peer.
+    pub inbound_channel_capacity: usize,
 }
 
 impl Default for Config {
@@ -23,6 +27,7 @@ impl Default for Config {
             stale_message_timeout: Duration::from_secs(120),
             stream_protocol: StreamProtocol::new("/propeller/0.1.0"),
             max_wire_message_size: 1 << 20, // 1 MB
+            inbound_channel_capacity: 16,
         }
     }
 }

--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -6,9 +6,12 @@
 
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use apollo_infra_utils::warn_every_n_ms;
+use futures::stream::SelectAll;
+use futures::StreamExt;
 use libp2p::identity::{Keypair, PeerId, PublicKey};
 use lru::LruCache;
 use starknet_api::staking::StakingWeight;
@@ -47,6 +50,10 @@ type BroadcastResult = (Result<Vec<PropellerUnit>, UnitPublishError>, BroadcastR
 // or blocks legitimate messages. To prevent this we must make sure that message processors that
 // never get a correct signature (with the right nonce) are not counted in the
 // messages_to_ignore_units_from cache, and don't update the nonce tracked for each peer.
+
+/// A stream of `(PeerId, PropellerUnit)` from a single connection handler's bounded channel.
+type InboundUnitStream = Pin<Box<dyn futures::Stream<Item = (PeerId, PropellerUnit)> + Send>>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct MessageKey {
     committee_id: CommitteeId,
@@ -81,6 +88,10 @@ pub enum EngineCommand {
     },
     HandleDisconnected {
         peer_id: PeerId,
+    },
+    RegisterHandler {
+        peer_id: PeerId,
+        receiver: futures::channel::mpsc::Receiver<PropellerUnit>,
     },
 }
 
@@ -119,6 +130,9 @@ pub struct Engine {
     prepared_units_tx: mpsc::UnboundedSender<BroadcastResult>,
     from_behaviour_rx: mpsc::UnboundedReceiver<EngineCommand>,
     to_behaviour_tx: mpsc::UnboundedSender<EngineOutput>,
+    /// Receivers for inbound units from connection handlers, polled via `SelectAll`.
+    /// Each receiver corresponds to one connection's bounded channel.
+    inbound_unit_receivers: SelectAll<InboundUnitStream>,
     metrics: Option<PropellerMetrics>,
 }
 
@@ -160,6 +174,7 @@ impl Engine {
             prepared_units_tx: broadcaster_results_tx,
             from_behaviour_rx,
             to_behaviour_tx: output_tx,
+            inbound_unit_receivers: SelectAll::new(),
             metrics,
         }
     }
@@ -579,7 +594,16 @@ impl Engine {
                     },
                     EngineCommand::HandleConnected { peer_id } => self.handle_connected(peer_id),
                     EngineCommand::HandleDisconnected { peer_id } => self.handle_disconnected(peer_id),
+                    EngineCommand::RegisterHandler { peer_id, receiver } => {
+                        let tagged_stream: InboundUnitStream =
+                            Box::pin(receiver.map(move |unit| (peer_id, unit)));
+                        self.inbound_unit_receivers.push(tagged_stream);
+                    }
                 },
+
+                Some((peer_id, unit)) = self.inbound_unit_receivers.next() => {
+                    self.handle_unit(peer_id, unit);
+                }
 
                 Some((result, response)) = self.prepared_units_rx.recv() => {
                     self.handle_broadcaster_result(result, response);

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -73,6 +73,12 @@ pub struct Handler {
     events_to_emit: VecDeque<HandlerOut>,
     /// Maximum wire message size for batching.
     max_wire_message_size: usize,
+    /// Bounded channel for sending received units directly to the engine, bypassing the Swarm's
+    /// event path. Provides back-pressure: when the channel is full, the handler stops reading
+    /// from the network.
+    // TODO(AndrewL): remove #[allow(dead_code)] once used
+    #[allow(dead_code)]
+    unit_sender: futures::channel::mpsc::Sender<PropellerUnit>,
     /// The most recent waker from [`ConnectionHandler::poll`], used for waking the task when
     /// new messages are enqueued via `on_behaviour_event`.
     waker: Option<Waker>,
@@ -109,7 +115,10 @@ enum OutboundSubstreamState {
 
 impl Handler {
     /// Builds a new [`Handler`].
-    pub fn new(config: &Config) -> Self {
+    pub fn new(
+        config: &Config,
+        unit_sender: futures::channel::mpsc::Sender<PropellerUnit>,
+    ) -> Self {
         let protocol =
             PropellerProtocol::new(config.stream_protocol.clone(), config.max_wire_message_size);
         Handler {
@@ -119,6 +128,7 @@ impl Handler {
             send_queue: VecDeque::new(),
             events_to_emit: VecDeque::new(),
             max_wire_message_size: config.max_wire_message_size,
+            unit_sender,
             waker: None,
         }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches connection setup and message delivery plumbing; miswiring or incorrect back-pressure behavior could drop or stall inbound traffic.
> 
> **Overview**
> Adds per-connection bounded `mpsc` channels to deliver inbound `PropellerUnit`s directly from each `Handler` to the `Engine`, and registers each channel via a new `Behaviour::create_handler` helper invoked on both inbound/outbound connection establishment.
> 
> Updates `Handler::new` to accept and store the channel sender (preparing for bypassing the Swarm event path and enabling back-pressure via `Config::inbound_channel_capacity`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f800849d94429f0520dbf3bb652d0f86e1d428c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->