### PR TITLE
apollo_propeller: remove HandlerOut::Unit from behaviour event path

### DIFF
--- a/crates/apollo_propeller/src/behaviour.rs
+++ b/crates/apollo_propeller/src/behaviour.rs
@@ -31,6 +31,8 @@ use crate::engine::{Engine, EngineCommand, EngineOutput};
 use crate::handler::Handler;
 use crate::metrics::PropellerMetrics;
 use crate::types::{CommitteeId, CommitteeSetupError, Event, UnitPublishError};
+#[cfg(test)]
+use crate::PropellerUnit;
 
 /// The Propeller network behaviour.
 ///
@@ -132,6 +134,20 @@ impl Behaviour {
         let command = EngineCommand::RegisterHandler { peer_id, receiver };
         self.engine_commands_tx.send(command).expect("Engine task has exited");
         Handler::new(&self.config, sender)
+    }
+
+    /// Test-only mirror of `create_handler`'s channel wiring that returns the sender, so tests can
+    /// inject inbound units into the engine as if received from `peer_id`'s connection.
+    #[cfg(test)]
+    pub(crate) fn register_inbound_channel(
+        &self,
+        peer_id: PeerId,
+    ) -> futures::channel::mpsc::Sender<PropellerUnit> {
+        let (sender, receiver) =
+            futures::channel::mpsc::channel(self.config.inbound_channel_capacity);
+        let command = EngineCommand::RegisterHandler { peer_id, receiver };
+        self.engine_commands_tx.send(command).expect("Engine task has exited");
+        sender
     }
 }
 

--- a/crates/apollo_propeller/src/behaviour_test_utils.rs
+++ b/crates/apollo_propeller/src/behaviour_test_utils.rs
@@ -12,7 +12,7 @@ use starknet_api::staking::StakingWeight;
 use tokio::time::error::Elapsed;
 
 use crate::config::Config;
-use crate::handler::{HandlerIn, HandlerOut};
+use crate::handler::HandlerIn;
 use crate::types::{CommitteeId, Event};
 use crate::{Behaviour, PropellerUnit};
 
@@ -30,6 +30,9 @@ fn loopback_dialer_endpoint() -> ConnectedPoint {
 pub(crate) struct TestNode {
     pub(crate) behaviour: Behaviour,
     peer_id: PeerId,
+    /// Sender end of each connected peer's inbound unit channel, keyed by that peer's id. Lets
+    /// `simulate_receive_unit` inject a unit as if it arrived over that peer's connection.
+    inbound_senders: BTreeMap<PeerId, futures::channel::mpsc::Sender<PropellerUnit>>,
 }
 
 impl TestNode {
@@ -38,7 +41,7 @@ impl TestNode {
         let peer_id = PeerId::from(keypair.public());
         let behaviour = Behaviour::new(keypair, config);
 
-        Self { behaviour, peer_id }
+        Self { behaviour, peer_id, inbound_senders: BTreeMap::new() }
     }
 
     fn simulate_connect_to(&mut self, peer_id: PeerId) {
@@ -54,15 +57,18 @@ impl TestNode {
         });
 
         self.behaviour.on_swarm_event(event);
+        // Mirror the inbound channel a real handler would register for this connection, retaining
+        // the sender so units can be injected from this peer via `simulate_receive_unit`.
+        let sender = self.behaviour.register_inbound_channel(peer_id);
+        self.inbound_senders.insert(peer_id, sender);
     }
 
     pub(crate) fn simulate_receive_unit(&mut self, from_peer: PeerId, unit: PropellerUnit) {
-        let connection_id = ConnectionId::new_unchecked(0);
-        self.behaviour.on_connection_handler_event(
-            from_peer,
-            connection_id,
-            HandlerOut::Unit(unit),
-        );
+        self.inbound_senders
+            .get_mut(&from_peer)
+            .expect("No inbound channel for peer; simulate_connect_to must be called first")
+            .try_send(unit)
+            .expect("Inbound unit channel is full or closed");
     }
 
     async fn next_with_timeout(

--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -589,7 +589,6 @@ impl Engine {
                         self.prepare_units(committee_id, message, response_tx);
                     }
                     EngineCommand::HandleHandlerOutput { peer_id, output } => match output {
-                        HandlerOut::Unit(unit) => self.handle_unit(peer_id, unit),
                         HandlerOut::SendError(error) => self.handle_send_error(peer_id, error),
                     },
                     EngineCommand::HandleConnected { peer_id } => self.handle_connected(peer_id),

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -26,10 +26,10 @@ use crate::protocol::{PropellerCodec, PropellerProtocol};
 use crate::PropellerUnit;
 
 /// Events that the handler can send to the behaviour.
+///
+/// Units are delivered directly to the engine via the bounded channel (not through the behaviour).
 #[derive(Debug)]
 pub enum HandlerOut {
-    /// A unit was received from the remote peer.
-    Unit(PropellerUnit),
     /// An error occurred while sending a message.
     SendError(String),
 }

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -502,9 +502,12 @@ impl Handler {
         }
 
         // Read from the wire only when the unsent buffer is empty (the previous batch has been
-        // fully delivered).
-        for inbound_substream in self.inbound_substream.iter_mut() {
-            Self::poll_single_inbound_substream(inbound_substream, &mut self.unsent_units, cx);
+        // fully delivered). This prevents unbounded accumulation: a malicious peer cannot force
+        // memory growth by sending batches faster than the engine drains the channel.
+        if self.unsent_units.is_empty() {
+            for inbound_substream in self.inbound_substream.iter_mut() {
+                Self::poll_single_inbound_substream(inbound_substream, &mut self.unsent_units, cx);
+            }
         }
 
         // Send newly-decoded units to the engine channel.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor to the handler→behaviour→engine event wiring; main risk is missing inbound-unit handling if any code still relied on the removed `HandlerOut::Unit` variant.
> 
> **Overview**
> Received `PropellerUnit`s are no longer emitted as `HandlerOut` events to the behaviour; `HandlerOut::Unit` is removed and `EngineCommand::HandleHandlerOutput` now only handles send-error notifications.
> 
> This tightens the separation between inbound unit delivery (via the per-connection bounded channel registered with the engine) and the behaviour event path, reducing event traffic and potential duplication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94dbbc93215c0fbf9356a9aaa759f286054d7c88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->