### PR TITLE
starknet_patricia_storage: gather for cached storage

### DIFF
--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -6,12 +6,14 @@ use std::sync::Arc;
 
 use apollo_config::dumping::{prepend_sub_config_name, ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use async_trait::async_trait;
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use validator::{Validate, ValidationErrors};
 
 use crate::storage_trait::{
+    run_tasks_and_collect_reads,
     AsyncStorage,
     DbHashMap,
     DbKey,
@@ -27,6 +29,7 @@ use crate::storage_trait::{
     Storage,
     StorageConfigTrait,
     StorageStats,
+    StorageTask,
 };
 
 // 10M entries.
@@ -434,4 +437,14 @@ impl<S: Storage> Storage for CachedStorage<S> {
     }
 }
 
-impl<S: AsyncStorage> AsyncStorage for CachedStorage<S> {}
+#[async_trait]
+impl<S: AsyncStorage> AsyncStorage for CachedStorage<S> {
+    async fn gather<T: StorageTask<Self>>(&mut self, tasks: Vec<T>) -> Vec<T::Output> {
+        let (reads, outputs) = run_tasks_and_collect_reads::<Self, T>(self, tasks).await;
+        let mut cache = self.cache.write().await;
+        reads.into_iter().for_each(|(key, value)| {
+            cache.put(key, Some(value));
+        });
+        outputs
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces custom `AsyncStorage::gather` behavior for `CachedStorage`, which affects concurrency and cache coherency; mistakes could lead to stale/missing cache entries or increased lock contention.
> 
> **Overview**
> `CachedStorage` now provides its own async `gather` implementation that **collects keys read by concurrent `StorageTask`s and writes them into the LRU cache** after the tasks complete.
> 
> This wires in `run_tasks_and_collect_reads` and adds `async_trait` usage so cache warming happens automatically for batched async reads, instead of relying on the default `gather` behavior that ignored collected reads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23cc929968b9751a0645dcfbb38ed895f5f47589. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->