### PR TITLE
starknet_committer: util for single storage trie creation

### DIFF
--- a/crates/starknet_committer/src/db/trie_traversal.rs
+++ b/crates/starknet_committer/src/db/trie_traversal.rs
@@ -436,26 +436,56 @@ where
         let sorted_leaf_indices = storage_tries_sorted_indices
             .get(address)
             .ok_or(ForestError::MissingSortedLeafIndices(*address))?;
-        let contract_state = original_contracts_trie_leaves
+        let storage_root_hash = original_contracts_trie_leaves
             .get(&contract_address_into_node_index(address))
-            .ok_or(ForestError::MissingContractCurrentState(*address))?;
-        let config = OriginalSkeletonTrieConfig::new_for_classes_or_storage_trie(
-            config.warn_on_trivial_modifications(),
-        );
-
-        let original_skeleton = create_original_skeleton_tree::<Layout::DbLeaf, Layout>(
+            .ok_or(ForestError::MissingContractCurrentState(*address))?
+            .storage_root_hash;
+        let original_skeleton = create_storage_trie::<Layout>(
             storage,
-            contract_state.storage_root_hash,
+            *address,
+            updates,
+            storage_root_hash,
             *sorted_leaf_indices,
-            &config,
-            // TODO(Ariel): Change `LeafModifications` in `actual_storage_updates` to be an
-            // iterator over borrowed data so that the conversion below is costless.
-            &updates.iter().map(|(idx, value)| (*idx, Layout::DbLeaf::from(*value))).collect(),
-            None,
-            address,
+            config.warn_on_trivial_modifications(),
         )
         .await?;
         storage_tries.insert(*address, original_skeleton);
     }
     Ok(storage_tries)
+}
+
+/// Helper function to create a storage trie for a single contract.
+async fn create_storage_trie<'a, Layout: NodeLayoutFor<StarknetStorageValue>>(
+    storage: &mut impl ReadOnlyStorage,
+    address: ContractAddress,
+    updates: &LeafModifications<StarknetStorageValue>,
+    storage_root_hash: HashOutput,
+    sorted_leaf_indices: SortedLeafIndices<'a>,
+    warn_on_trivial_modifications: bool,
+) -> ForestResult<OriginalSkeletonTreeImpl<'a>>
+where
+    <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf:
+        HasStaticPrefix<KeyContext = ContractAddress>,
+{
+    let trie_config =
+        OriginalSkeletonTrieConfig::new_for_classes_or_storage_trie(warn_on_trivial_modifications);
+
+    // TODO(Ariel): Change `LeafModifications` in `actual_storage_updates` to be an
+    // iterator over borrowed data so that the conversion below is costless.
+    let leaf_modifications: HashMap<
+        NodeIndex,
+        <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf,
+    > = updates.iter().map(|(idx, value)| (*idx, Layout::DbLeaf::from(*value))).collect();
+
+    let previous_leaves = None;
+    Ok(create_original_skeleton_tree::<Layout::DbLeaf, Layout>(
+        storage,
+        storage_root_hash,
+        sorted_leaf_indices,
+        &trie_config,
+        &leaf_modifications,
+        previous_leaves,
+        &address,
+    )
+    .await?)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor that extracts existing storage-trie construction logic into a dedicated helper without changing data flow or external APIs. Main risk is accidental parameter/typing mismatches affecting storage trie witness generation for modified contracts.
> 
> **Overview**
> Refactors `create_storage_tries_sequentially` by extracting the per-contract storage trie skeleton construction into a new helper, `create_storage_trie`.
> 
> The new helper encapsulates building the trie config, converting `LeafModifications` into layout-specific DB leaves, and invoking `create_original_skeleton_tree`, reducing duplication and making single-contract storage trie creation reusable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36730f1674e71117028654e1bce7cb297fc8396e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->