### PR TITLE
starknet_committer: create storage tries concurrently

### DIFF
--- a/crates/starknet_committer/src/db/trie_traversal.rs
+++ b/crates/starknet_committer/src/db/trie_traversal.rs
@@ -1,6 +1,7 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use starknet_api::core::ContractAddress;
 use starknet_api::hash::HashOutput;
@@ -26,7 +27,8 @@ use starknet_patricia::patricia_merkle_tree::traversal::{
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
 use starknet_patricia_storage::db_object::{DBObject, EmptyKeyContext, HasStaticPrefix};
 use starknet_patricia_storage::errors::StorageError;
-use starknet_patricia_storage::storage_trait::{DbKey, ReadOnlyStorage};
+use starknet_patricia_storage::reads_collector_storage::ReadsCollectorStorage;
+use starknet_patricia_storage::storage_trait::{AsyncStorage, DbKey, ReadOnlyStorage, StorageTask};
 use tracing::warn;
 
 use crate::block_committer::input::{
@@ -488,4 +490,85 @@ where
         &address,
     )
     .await?)
+}
+
+/// Holds all data needed to build one storage trie concurrently.
+/// Implements [StorageTask] so that [AsyncStorage::gather] can drive it.
+#[allow(dead_code)]
+struct TrieReadTask<'a, Layout: NodeLayoutFor<StarknetStorageValue>> {
+    address: ContractAddress,
+    updates: &'a LeafModifications<StarknetStorageValue>,
+    storage_root_hash: HashOutput,
+    sorted_leaf_indices: SortedLeafIndices<'a>,
+    warn_on_trivial_modifications: bool,
+    _layout: PhantomData<Layout>,
+}
+
+#[async_trait::async_trait]
+impl<'a, S, Layout> StorageTask<S> for TrieReadTask<'a, Layout>
+where
+    S: AsyncStorage,
+    Layout: NodeLayoutFor<StarknetStorageValue> + Send + 'static,
+    <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf:
+        HasStaticPrefix<KeyContext = ContractAddress>,
+    for<'b> <Layout as NodeLayout<'b, <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf>>::SubTree:
+        Send + Sync,
+    for<'b> <Layout as NodeLayout<'b, <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf>>::NodeData:
+        Send,
+{
+    type Output = ForestResult<(ContractAddress, OriginalSkeletonTreeImpl<'a>)>;
+
+    async fn run_with_storage(self, storage: &mut ReadsCollectorStorage<S>) -> Self::Output {
+        let skeleton = create_storage_trie::<Layout>(
+            storage,
+            self.address,
+            self.updates,
+            self.storage_root_hash,
+            self.sorted_leaf_indices,
+            self.warn_on_trivial_modifications,
+        )
+        .await?;
+        Ok((self.address, skeleton))
+    }
+}
+
+/// Creates the storage tries concurrently using [AsyncStorage::gather].
+#[allow(dead_code)]
+async fn create_storage_tries_concurrently<
+    'a,
+    S: AsyncStorage,
+    Layout: NodeLayoutFor<StarknetStorageValue> + Send + 'static,
+>(
+    storage: &mut S,
+    actual_storage_updates: &'a HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
+    original_contracts_trie_leaves: &HashMap<NodeIndex, ContractState>,
+    warn_on_trivial_modifications: bool,
+    storage_tries_sorted_indices: &'a HashMap<ContractAddress, SortedLeafIndices<'a>>,
+) -> ForestResult<HashMap<ContractAddress, OriginalSkeletonTreeImpl<'a>>>
+where
+    <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf:
+        HasStaticPrefix<KeyContext = ContractAddress>,
+    for<'b> <Layout as NodeLayout<'b, <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf>>::SubTree:
+        Send + Sync,
+    for<'b> <Layout as NodeLayout<'b, <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf>>::NodeData:
+        Send,
+{
+    let mut tasks = Vec::new();
+    for (address, updates) in actual_storage_updates {
+        tasks.push(TrieReadTask::<Layout> {
+            address: *address,
+            updates,
+            storage_root_hash: original_contracts_trie_leaves
+                .get(&contract_address_into_node_index(address))
+                .ok_or(ForestError::MissingContractCurrentState(*address))?
+                .storage_root_hash,
+            sorted_leaf_indices: *storage_tries_sorted_indices
+                .get(address)
+                .ok_or(ForestError::MissingSortedLeafIndices(*address))?,
+            warn_on_trivial_modifications,
+            _layout: std::marker::PhantomData,
+        });
+    }
+
+    storage.gather(tasks).await.into_iter().collect()
 }

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -367,8 +367,8 @@ pub trait AsyncStorage: AsyncImmutableStorage + Storage {
     /// Important: The outputs are *not* guaranteed to be in the same order as the tasks.
     /// Returns the collected outputs from each task.
     async fn gather<T: StorageTask<Self>>(&mut self, tasks: Vec<T>) -> Vec<T::Output> {
-        // By default, ignore the reads.
         let (_reads, outputs) = run_tasks_and_collect_reads(self, tasks).await;
+        // By default, ignore the reads.
         outputs
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds new (currently unused) concurrent code paths for building per-contract storage trie skeletons; no existing execution path is changed, so behavioral risk is low aside from potential compilation/trait-bound issues.
> 
> **Overview**
> Introduces a concurrent implementation for building per-contract storage trie original skeletons by adding a `TrieReadTask` that implements `StorageTask` and a `create_storage_tries_concurrently` helper that batches tasks and runs them via `AsyncStorage::gather`.
> 
> Minor cleanup in `AsyncStorage::gather` moves the “ignore reads” comment to match the actual returned value; functional behavior is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 417396c599c4e6a2e1aff01e447b31c2d3a884a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->