### PR TITLE
starknet_transaction_prover: add CORS and config validation tests

### DIFF
--- a/crates/starknet_transaction_prover/src/server/config_test.rs
+++ b/crates/starknet_transaction_prover/src/server/config_test.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
+use assert_matches::assert_matches;
 use clap::Parser;
 use rstest::rstest;
 use tempfile::NamedTempFile;
@@ -290,4 +291,131 @@ fn env_var_sets_tls_key_file() {
     let args = CliArgs::parse_from(["starknet-transaction-prover"]);
 
     assert_eq!(args.tls_key_file, Some(PathBuf::from("/etc/ssl/key.pem")));
+}
+
+#[test]
+fn test_missing_rpc_url_rejected() {
+    let mut args = base_args();
+    args.rpc_url = None; // No CLI arg, and no config file, so default empty rpc_node_url is used.
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    assert_matches!(error, ConfigError::MissingRequiredField(_));
+}
+
+#[test]
+fn test_max_concurrent_requests_zero_rejected() {
+    let mut args = base_args();
+    args.max_concurrent_requests = Some(0);
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    assert_matches!(error, ConfigError::InvalidArgument(_));
+}
+
+#[test]
+fn test_max_connections_zero_rejected() {
+    let mut args = base_args();
+    args.max_connections = Some(0);
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    assert_matches!(error, ConfigError::InvalidArgument(_));
+}
+
+#[test]
+fn test_no_cors_with_cors_allow_origin_rejected() {
+    let mut args = base_args();
+    args.no_cors = true;
+    args.cors_allow_origin = vec!["http://localhost:5173".to_string()];
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    let ConfigError::InvalidArgument(message) = error else {
+        panic!("Expected ConfigError::InvalidArgument, got {error:?}");
+    };
+    assert!(message.contains("mutually exclusive"), "expected 'mutually exclusive' in: {message}");
+}
+
+#[test]
+fn test_skip_fee_field_validation_disables_validation() {
+    let mut args = base_args();
+    args.skip_fee_field_validation = true;
+
+    let config = ServiceConfig::from_args(args).unwrap();
+
+    assert!(!config.prover_config.validate_zero_fee_fields);
+}
+
+#[test]
+fn test_no_cors_clears_config_file_origins() {
+    let mut config_file = NamedTempFile::new().unwrap();
+    write!(
+        config_file,
+        r#"{{"rpc_node_url":"http://localhost:9545","cors_allow_origin":["http://localhost:5173"]}}"#,
+    )
+    .unwrap();
+
+    let mut args = base_args();
+    args.config_file = Some(config_file.path().to_path_buf());
+    args.rpc_url = None;
+    args.no_cors = true;
+
+    let config = ServiceConfig::from_args(args).unwrap();
+
+    assert!(config.cors_allow_origin.is_empty());
+}
+
+#[test]
+fn test_config_file_values_used_when_no_cli_overrides() {
+    let mut config_file = NamedTempFile::new().unwrap();
+    write!(
+        config_file,
+        r#"{{"rpc_node_url":"http://localhost:9545","port":8080,"ip":"127.0.0.1"}}"#,
+    )
+    .unwrap();
+
+    let mut args = base_args();
+    args.config_file = Some(config_file.path().to_path_buf());
+    args.rpc_url = None;
+
+    let config = ServiceConfig::from_args(args).unwrap();
+
+    assert_eq!(config.port, 8080);
+    assert_eq!(config.ip, "127.0.0.1".parse::<std::net::IpAddr>().unwrap());
+}
+
+#[test]
+fn test_cli_overrides_config_file_values() {
+    let mut config_file = NamedTempFile::new().unwrap();
+    write!(config_file, r#"{{"rpc_node_url":"http://localhost:9545","port":8080}}"#,).unwrap();
+
+    let mut args = base_args();
+    args.config_file = Some(config_file.path().to_path_buf());
+    args.rpc_url = None;
+    args.port = Some(9090);
+
+    let config = ServiceConfig::from_args(args).unwrap();
+
+    assert_eq!(config.port, 9090);
+}
+
+#[test]
+fn test_cors_rejects_non_http_scheme() {
+    let mut args = base_args();
+    args.cors_allow_origin = vec!["ftp://example.com".to_string()];
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    assert_matches!(error, ConfigError::InvalidArgument(_));
+}
+
+#[test]
+fn test_cors_rejects_origin_with_userinfo() {
+    let mut args = base_args();
+    args.cors_allow_origin = vec!["http://user@example.com".to_string()];
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    assert_matches!(error, ConfigError::InvalidArgument(_));
 }

--- a/crates/starknet_transaction_prover/src/server/cors.rs
+++ b/crates/starknet_transaction_prover/src/server/cors.rs
@@ -1,5 +1,9 @@
 //! CORS configuration utilities for the JSON-RPC server.
 
+#[cfg(test)]
+#[path = "cors_test.rs"]
+mod cors_test;
+
 use anyhow::Context;
 use http::{header, HeaderValue, Method};
 use tower_http::cors::{AllowOrigin, CorsLayer};

--- a/crates/starknet_transaction_prover/src/server/cors_test.rs
+++ b/crates/starknet_transaction_prover/src/server/cors_test.rs
@@ -1,0 +1,73 @@
+use assert_matches::assert_matches;
+use rstest::rstest;
+
+use crate::errors::ConfigError;
+use crate::server::cors::{build_cors_layer, cors_mode, normalize_cors_allow_origins};
+
+#[test]
+fn test_build_cors_layer_returns_none_for_empty_origins() {
+    let result = build_cors_layer(&[]).expect("build_cors_layer should not fail");
+    assert!(result.is_none(), "Expected None for empty origins list");
+}
+
+#[test]
+fn test_build_cors_layer_returns_some_for_wildcard() {
+    let origins = vec!["*".to_string()];
+    let result = build_cors_layer(&origins).expect("build_cors_layer should not fail");
+    assert!(result.is_some(), "Expected Some for wildcard origin");
+}
+
+#[test]
+fn test_build_cors_layer_returns_some_for_allowlist() {
+    let origins = vec!["http://example.com".to_string()];
+    let result = build_cors_layer(&origins).expect("build_cors_layer should not fail");
+    assert!(result.is_some(), "Expected Some for non-empty allowlist");
+}
+
+#[rstest]
+#[case::disabled(vec![], "disabled")]
+#[case::wildcard(vec!["*".to_string()], "wildcard")]
+#[case::allowlist(vec!["http://example.com".to_string()], "allowlist")]
+#[case::multiple_origins(vec!["http://a.com".to_string(), "http://b.com".to_string()], "allowlist")]
+fn test_cors_mode_labels(#[case] origins: Vec<String>, #[case] expected_label: &str) {
+    assert_eq!(cors_mode(&origins), expected_label);
+}
+
+#[test]
+fn test_normalize_rejects_ftp_scheme() {
+    let result = normalize_cors_allow_origins(vec!["ftp://example.com".to_string()]);
+    assert_matches!(result, Err(ConfigError::InvalidArgument(_)));
+}
+
+#[test]
+fn test_normalize_rejects_missing_host() {
+    let result = normalize_cors_allow_origins(vec!["http://".to_string()]);
+    assert_matches!(result, Err(ConfigError::InvalidArgument(_)));
+}
+
+#[test]
+fn test_normalize_rejects_userinfo() {
+    let result = normalize_cors_allow_origins(vec!["http://user:pass@example.com".to_string()]);
+    assert_matches!(result, Err(ConfigError::InvalidArgument(_)));
+}
+
+#[test]
+fn test_normalize_strips_default_http_port() {
+    let result = normalize_cors_allow_origins(vec!["http://example.com:80".to_string()])
+        .expect("normalize should succeed");
+    assert_eq!(result, vec!["http://example.com".to_string()]);
+}
+
+#[test]
+fn test_normalize_strips_default_https_port() {
+    let result = normalize_cors_allow_origins(vec!["https://example.com:443".to_string()])
+        .expect("normalize should succeed");
+    assert_eq!(result, vec!["https://example.com".to_string()]);
+}
+
+#[test]
+fn test_normalize_preserves_non_default_port() {
+    let result = normalize_cors_allow_origins(vec!["http://example.com:8080".to_string()])
+        .expect("normalize should succeed");
+    assert_eq!(result, vec!["http://example.com:8080".to_string()]);
+}


### PR DESCRIPTION
Restacked branch - recreating PR after rebase to remove error-enum-and-mapping-tests commits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that increase coverage around config parsing/validation and CORS normalization; no production logic changes beyond wiring in the new test module.
> 
> **Overview**
> Adds new unit tests around `ServiceConfig::from_args` validation, including required `rpc_url`, rejecting zero `max_concurrent_requests`/`max_connections`, enforcing `--no-cors` vs `--cors-allow-origin` exclusivity, and verifying config-file defaults/CLI overrides.
> 
> Introduces a dedicated `cors_test.rs` suite (wired via `#[cfg(test)]` in `cors.rs`) to cover `build_cors_layer`, `cors_mode`, and `normalize_cors_allow_origins` behavior and edge cases (invalid schemes/hosts/userinfo and default-port normalization).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 694e96005fe30627ecb8a1e6e99c64571d6ab9e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->