### PR TITLE
apollo_batcher: create alert for preconfirmed block write failure

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1879,8 +1879,8 @@
     {
       "name": "preconfirmed_block_not_written",
       "title": "Preconfirmed block not written",
-      "ruleGroup": "batcher",
-      "expr": "increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
+      "ruleGroup": "consensus",
+      "expr": "increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])",
       "conditions": [
         {
           "evaluator": {
@@ -1902,6 +1902,34 @@
       "for": "30s",
       "intervalSec": 30,
       "severity": "$$$preconfirmed_block_not_written-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "preconfirmed_block_write_failure",
+      "title": "Preconfirmed block write failure",
+      "ruleGroup": "consensus",
+      "expr": "sum(increase(batcher_preconfirmed_block_write_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              10.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
       "observer_applicable": "false"
     },
     {

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -79,7 +79,10 @@ use crate::alert_scenarios::mempool_size::{
     get_mempool_evictions_count_alert,
     get_mempool_pool_size_increase,
 };
-use crate::alert_scenarios::preconfirmed::get_preconfirmed_block_not_written;
+use crate::alert_scenarios::preconfirmed::{
+    get_preconfirmed_block_not_written,
+    get_preconfirmed_block_write_failure,
+};
 use crate::alert_scenarios::remote_server_connections::get_remote_server_number_of_connections_alert;
 use crate::alert_scenarios::sync_halt::{get_state_sync_lag, get_state_sync_stuck_vec};
 use crate::alert_scenarios::tps::{
@@ -688,6 +691,7 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_mempool_pool_size_increase());
     alerts.push(get_mempool_transaction_drop_ratio());
     alerts.push(get_preconfirmed_block_not_written());
+    alerts.push(get_preconfirmed_block_write_failure());
     alerts.append(&mut get_all_remote_server_connection_alerts());
     alerts.push(get_state_sync_lag());
     alerts.append(&mut get_state_sync_stuck_vec());

--- a/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
@@ -1,4 +1,4 @@
-use apollo_batcher::metrics::PRECONFIRMED_BLOCK_WRITTEN;
+use apollo_batcher::metrics::{PRECONFIRMED_BLOCK_WRITE_FAILURE, PRECONFIRMED_BLOCK_WRITTEN};
 use apollo_metrics::metrics::MetricQueryName;
 
 use crate::alert_placeholders::SeverityValueOrPlaceholder;
@@ -8,10 +8,29 @@ use crate::alerts::{
     AlertCondition,
     AlertGroup,
     AlertLogicalOp,
+    AlertSeverity,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
+
+/// Too many preconfirmed block write failures in the last hour.
+pub(crate) fn get_preconfirmed_block_write_failure() -> Alert {
+    Alert::new(
+        "preconfirmed_block_write_failure",
+        "Preconfirmed block write failure",
+        AlertGroup::Consensus,
+        format!(
+            "sum(increase({}[1h])) or vector(0)",
+            PRECONFIRMED_BLOCK_WRITE_FAILURE.get_name_with_filter()
+        ),
+        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
+        PENDING_DURATION_DEFAULT,
+        EVALUATION_INTERVAL_SEC_DEFAULT,
+        AlertSeverity::WorkingHours,
+        ObserverApplicability::NotApplicable,
+    )
+}
 
 /// No preconfirmed block was written in the last 10 minutes.
 pub(crate) fn get_preconfirmed_block_not_written() -> Alert {
@@ -19,8 +38,8 @@ pub(crate) fn get_preconfirmed_block_not_written() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Preconfirmed block not written",
-        AlertGroup::Batcher,
-        format!("increase({}[2m])", PRECONFIRMED_BLOCK_WRITTEN.get_name_with_filter()),
+        AlertGroup::Consensus,
+        format!("increase({}[10m])", PRECONFIRMED_BLOCK_WRITTEN.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         EVALUATION_INTERVAL_SEC_DEFAULT,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to observability/alerting rules (PromQL, thresholds, grouping) and do not affect runtime behavior beyond when alerts fire.
> 
> **Overview**
> Adds a new `preconfirmed_block_write_failure` alert that pages when `batcher_preconfirmed_block_write_failure` exceeds a threshold over the last hour (wired into both the Rust alert registry and `dev_grafana_alerts.json`).
> 
> Retunes the existing `preconfirmed_block_not_written` alert by moving it from the `batcher` group to **`consensus`** and widening its lookback window from **2m to 10m**, reducing sensitivity to short gaps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c86a9953762119b7791bafd13fadb854fff55e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->