### PR TITLE
starknet_patricia_storage: rename mutable getters

### DIFF
--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -239,7 +239,8 @@ where
             NodeIndex::ROOT,
         );
 
-        let roots = self.storage.mget(&[&contracts_trie_root_key, &classes_trie_root_key]).await?;
+        let roots =
+            self.storage.mget_mut(&[&contracts_trie_root_key, &classes_trie_root_key]).await?;
         let contracts_trie_root_hash = extract_root_hash::<IndexLayoutContractState>(&roots[0])?;
         let classes_trie_root_hash = extract_root_hash::<IndexLayoutCompiledClassHash>(&roots[1])?;
 
@@ -291,7 +292,7 @@ impl<S: Storage> ForestMetadata for IndexDb<S> {
     }
 
     async fn get_from_storage(&mut self, db_key: DbKey) -> ForestResult<Option<DbValue>> {
-        Ok(self.storage.get(&db_key).await?)
+        Ok(self.storage.get_mut(&db_key).await?)
     }
 }
 

--- a/crates/starknet_committer/src/db/index_db/test_utils.rs
+++ b/crates/starknet_committer/src/db/index_db/test_utils.rs
@@ -156,7 +156,7 @@ async fn traverse_and_convert<FactsLeaf, IndexLeaf, KeyContext>(
     let facts_db_key = subtree.get_root_db_key::<FactsLeaf>(key_context);
 
     // Try to get the node from storage.
-    let filled_node_raw: Option<DbValue> = facts_storage.get(&facts_db_key).await.unwrap();
+    let filled_node_raw: Option<DbValue> = facts_storage.get_mut(&facts_db_key).await.unwrap();
 
     // Handle missing nodes based on the panic_on_missing_node flag.
     let Some(filled_node_raw) = filled_node_raw else {

--- a/crates/starknet_committer/src/db/mock_forest_storage.rs
+++ b/crates/starknet_committer/src/db/mock_forest_storage.rs
@@ -72,7 +72,7 @@ impl<S: Storage> ForestMetadata for MockForestStorage<S> {
     }
 
     async fn get_from_storage(&mut self, db_key: DbKey) -> ForestResult<Option<DbValue>> {
-        Ok(self.storage.get(&db_key).await?)
+        Ok(self.storage.get_mut(&db_key).await?)
     }
 }
 

--- a/crates/starknet_committer/src/db/trie_traversal.rs
+++ b/crates/starknet_committer/src/db/trie_traversal.rs
@@ -248,7 +248,7 @@ pub async fn get_roots_from_storage<'a, L: Leaf, Layout: NodeLayout<'a, L>>(
     let db_keys: Vec<DbKey> =
         subtrees.iter().map(|subtree| subtree.get_root_db_key::<L>(key_context)).collect();
 
-    let db_vals = storage.mget(&db_keys.iter().collect::<Vec<&DbKey>>()).await?;
+    let db_vals = storage.mget_mut(&db_keys.iter().collect::<Vec<&DbKey>>()).await?;
     for ((subtree, optional_val), db_key) in subtrees.iter().zip(db_vals.iter()).zip(db_keys) {
         let Some(val) = optional_val else { Err(StorageError::MissingKey(db_key))? };
         let filled_node =

--- a/crates/starknet_committer_cli/src/commands.rs
+++ b/crates/starknet_committer_cli/src/commands.rs
@@ -401,7 +401,7 @@ fn apply_interference<S: AsyncStorage>(
                     .iter()
                     .map(|k| DbKey((**k.0).to_bytes_be().to_vec()))
                     .collect::<Vec<_>>();
-                storage.mget(&keys.iter().collect::<Vec<&DbKey>>()).await.unwrap();
+                storage.mget_mut(&keys.iter().collect::<Vec<&DbKey>>()).await.unwrap();
             });
         }
     }

--- a/crates/starknet_patricia_storage/src/aerospike_storage.rs
+++ b/crates/starknet_patricia_storage/src/aerospike_storage.rs
@@ -130,7 +130,7 @@ impl AerospikeStorage {
 }
 
 impl ReadOnlyStorage for AerospikeStorage {
-    async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         let record = self
             .client
             .get(&self.config.read_policy, &self.get_key(key.clone())?, Bins::All)
@@ -138,7 +138,7 @@ impl ReadOnlyStorage for AerospikeStorage {
         self.extract_value(&record)
     }
 
-    async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         let mut ops = Vec::new();
         for key in keys.iter() {
             ops.push(BatchOperation::read(

--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -37,11 +37,11 @@ pub struct BorrowedStorage<'a, S: Storage> {
 }
 
 impl ReadOnlyStorage for MapStorage {
-    async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(self.0.get(key).cloned())
     }
 
-    async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         Ok(keys.iter().map(|key| self.0.get(key).cloned()).collect())
     }
 }
@@ -255,19 +255,19 @@ impl<S: Storage> CachedStorage<S> {
 }
 
 impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
-    async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         self.reads += 1;
         if let Some(cached_value) = self.cache.get(key) {
             self.cached_reads += 1;
             return Ok(cached_value.clone());
         }
 
-        let storage_value = self.storage.get(key).await?;
+        let storage_value = self.storage.get_mut(key).await?;
         self.cache.put(key.clone(), storage_value.clone());
         Ok(storage_value)
     }
 
-    async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         let mut values = vec![None; keys.len()]; // The None values are placeholders.
         let mut keys_to_fetch = Vec::new();
         let mut indices_to_fetch = Vec::new();
@@ -285,7 +285,7 @@ impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
         self.cached_reads +=
             u128::try_from(keys.len() - keys_to_fetch.len()).expect("usize should fit in u128");
 
-        let fetched_values = self.storage.mget(keys_to_fetch.as_slice()).await?;
+        let fetched_values = self.storage.mget_mut(keys_to_fetch.as_slice()).await?;
         indices_to_fetch.iter().zip(keys_to_fetch).zip(fetched_values).for_each(
             |((index, key), value)| {
                 self.cache.put((*key).clone(), value.clone());

--- a/crates/starknet_patricia_storage/src/map_storage_test.rs
+++ b/crates/starknet_patricia_storage/src/map_storage_test.rs
@@ -23,21 +23,21 @@ async fn test_storage_impl(#[case] mut storage: impl Storage) {
 
     storage.set(key_1.clone(), val_1.clone()).await.unwrap();
     // storage = {1: 1}
-    assert_eq!(storage.get(&key_1.clone()).await.unwrap(), Some(val_1.clone()));
+    assert_eq!(storage.get_mut(&key_1.clone()).await.unwrap(), Some(val_1.clone()));
 
     storage.set(key_2.clone(), val_2.clone()).await.unwrap();
     storage.delete(&key_1).await.unwrap();
     // storage = {2: 2}
-    assert!(storage.get(&key_1.clone()).await.unwrap().is_none());
-    assert_eq!(storage.get(&key_2.clone()).await.unwrap(), Some(val_2.clone()));
+    assert!(storage.get_mut(&key_1.clone()).await.unwrap().is_none());
+    assert_eq!(storage.get_mut(&key_2.clone()).await.unwrap(), Some(val_2.clone()));
 
     storage
         .mset(HashMap::from([(key_1.clone(), val_1.clone()), (key_3.clone(), val_3.clone())]))
         .await
         .unwrap();
     // storage = {1:1, 2: 2, 3:3}
-    assert_eq!(storage.get(&key_2.clone()).await.unwrap(), Some(val_2.clone()));
-    let expected_stored_values = storage.mget(&[&key_1, &key_2, &key_3]).await.unwrap();
+    assert_eq!(storage.get_mut(&key_2.clone()).await.unwrap(), Some(val_2.clone()));
+    let expected_stored_values = storage.mget_mut(&[&key_1, &key_2, &key_3]).await.unwrap();
     assert_eq!(
         expected_stored_values,
         vec![Some(val_1.clone()), Some(val_2.clone()), Some(val_3.clone())]
@@ -45,5 +45,5 @@ async fn test_storage_impl(#[case] mut storage: impl Storage) {
 
     storage.delete(&key_2).await.unwrap();
     // storage = {1:1, 3:3}
-    assert!(storage.get(&key_2.clone()).await.unwrap().is_none());
+    assert!(storage.get_mut(&key_2.clone()).await.unwrap().is_none());
 }

--- a/crates/starknet_patricia_storage/src/mdbx_storage.rs
+++ b/crates/starknet_patricia_storage/src/mdbx_storage.rs
@@ -105,13 +105,13 @@ impl MdbxStorage {
 }
 
 impl ReadOnlyStorage for MdbxStorage {
-    async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         let txn = self.db.begin_ro_txn()?;
         let table = txn.open_table(None)?;
         Ok(txn.get(&table, &key.0)?.map(DbValue))
     }
 
-    async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         let txn = self.db.begin_ro_txn()?;
         let table = txn.open_table(None)?;
         let mut res = Vec::with_capacity(keys.len());

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -277,11 +277,11 @@ impl StorageStats for RocksDbStats {
 }
 
 impl ReadOnlyStorage for RocksDbStorage {
-    async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(self.db.get(&key.0)?.map(DbValue))
     }
 
-    async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         let raw_keys = keys.iter().map(|k| &k.0);
         let res = self
             .db

--- a/crates/starknet_patricia_storage/src/short_key_storage.rs
+++ b/crates/starknet_patricia_storage/src/short_key_storage.rs
@@ -49,16 +49,16 @@ macro_rules! define_short_key_storage {
         }
 
         impl<S: Storage> ReadOnlyStorage for $name<S> {
-            async fn get(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
-                self.storage.get(&Self::small_key(key)).await
+            async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+                self.storage.get_mut(&Self::small_key(key)).await
             }
 
-            async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+            async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
                 let small_keys = keys
                     .iter()
                     .map(|key| Self::small_key(key))
                     .collect::<Vec<_>>();
-                self.storage.mget(small_keys.iter().collect::<Vec<&DbKey>>().as_slice()).await
+                self.storage.mget_mut(small_keys.iter().collect::<Vec<&DbKey>>().as_slice()).await
             }
         }
 

--- a/crates/starknet_patricia_storage/src/storage_test.rs
+++ b/crates/starknet_patricia_storage/src/storage_test.rs
@@ -31,7 +31,7 @@ async fn test_storage_concurrent_access(#[case] mut storage: impl AsyncStorage) 
     tasks.join_all().await;
 
     for i in 0..10u8 {
-        assert_eq!(storage.get(&DbKey(vec![i])).await.unwrap(), Some(DbValue(vec![i])));
+        assert_eq!(storage.get_mut(&DbKey(vec![i])).await.unwrap(), Some(DbValue(vec![i])));
     }
 
     // Parallel reads from the storage while some writes are happening.
@@ -39,7 +39,7 @@ async fn test_storage_concurrent_access(#[case] mut storage: impl AsyncStorage) 
     for i in 0..10u8 {
         let mut cloned_storage = storage.clone();
         tasks.spawn(async move {
-            let result = cloned_storage.get(&DbKey(vec![i])).await.unwrap().unwrap().0[0];
+            let result = cloned_storage.get_mut(&DbKey(vec![i])).await.unwrap().unwrap().0[0];
             // The result is either the original value or the new value.
             assert!(result == i || result == i + 10);
         });

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -108,7 +108,7 @@ pub trait ReadOnlyStorage: Send + Sync {
     // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
     // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
     // for details.
-    fn get(
+    fn get_mut(
         &mut self,
         key: &DbKey,
     ) -> impl Future<Output = PatriciaStorageResult<Option<DbValue>>> + Send;
@@ -118,7 +118,7 @@ pub trait ReadOnlyStorage: Send + Sync {
     // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
     // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
     // for details.
-    fn mget(
+    fn mget_mut(
         &mut self,
         keys: &[&DbKey],
     ) -> impl Future<Output = PatriciaStorageResult<Vec<Option<DbValue>>>> + Send;
@@ -203,11 +203,11 @@ impl StorageConfigTrait for EmptyStorageConfig {}
 pub struct NullStorage;
 
 impl ReadOnlyStorage for NullStorage {
-    async fn get(&mut self, _key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
+    async fn get_mut(&mut self, _key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(None)
     }
 
-    async fn mget(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
         Ok(vec![None; keys.len()])
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core `ReadOnlyStorage` trait and all storage backends/callers, so any missed call site or downstream dependency could break builds. Runtime behavior should be unchanged aside from potential subtle caching/stat side effects tied to the renamed methods.
> 
> **Overview**
> **Renames the read-only storage API** by changing `ReadOnlyStorage::{get,mget}` to `ReadOnlyStorage::{get_mut,mget_mut}` and updating implementations across `MapStorage`, `CachedStorage`, `RocksDbStorage`, `MdbxStorage`, `AerospikeStorage`, `NullStorage`, and `short_key_storage`.
> 
> Updates all committer and CLI benchmark call sites (e.g., index DB root reads, trie traversal batch reads, and test utilities) plus unit/concurrency tests to use the new method names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ca1741631aee2aac814c3ed0b625ca072749de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->