### PR TITLE
apollo_network: expose add_epoch as a channel-based API on network manager

### DIFF
--- a/crates/apollo_network/src/network_manager/mod.rs
+++ b/crates/apollo_network/src/network_manager/mod.rs
@@ -39,6 +39,7 @@ use crate::utils::{is_localhost, make_multiaddr, StreamMap};
 use crate::{gossipsub_impl, mixed_behaviour, Bytes, NetworkConfig};
 
 const DEFAULT_ACTIVE_COMMITTEES_CAPACITY: usize = 2;
+const ADD_EPOCH_CHANNEL_CAPACITY: usize = 100;
 
 /// Errors that can occur during network operations.
 ///
@@ -112,6 +113,8 @@ pub struct GenericNetworkManager<SwarmT: SwarmTrait> {
     metrics: Option<NetworkMetrics>,
     bootstrap_peer_ids: HashSet<PeerId>,
     committee_store: ActiveCommittees,
+    add_epoch_sender: AddEpochSender,
+    add_epoch_receiver: AddEpochReceiver,
 }
 
 impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
@@ -178,18 +181,21 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
                 Some(broadcasted_message_metadata) = self.continue_propagation_receiver.next() => {
                     self.swarm.continue_propagation(broadcasted_message_metadata);
                 }
+                Some((epoch_id, members)) = self.add_epoch_receiver.next() => {
+                    self.handle_add_epoch(epoch_id, members);
+                }
             }
         }
     }
 
-    // TODO(AndrewL): return a channel from the constructor for adding epochs.
-    #[allow(dead_code)]
-    fn add_epoch(&mut self, epoch_id: EpochId, members: Vec<CommitteeMember>) {
-        // TODO(AndrewL): propagate this error instead of panicking.
-        let output = self
-            .committee_store
-            .add_epoch(epoch_id, members)
-            .expect("Committee members contain duplicate peer IDs");
+    fn handle_add_epoch(&mut self, epoch_id: EpochId, members: Vec<CommitteeMember>) {
+        let output = match self.committee_store.add_epoch(epoch_id, members) {
+            Ok(output) => output,
+            Err(error) => {
+                error!("Failed to add epoch: {error}");
+                return;
+            }
+        };
         let committee_peers: HashSet<PeerId> = output.allowed_peers.into_iter().collect();
         let mut whitelisted_peers = committee_peers.clone();
         whitelisted_peers.extend(&self.bootstrap_peer_ids);
@@ -197,7 +203,18 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         if let Some(discovery) = self.swarm.behaviour_mut().discovery.as_mut() {
             discovery.set_target_peers(committee_peers);
         }
-        todo!("Wire remaining AddEpochOutput fields to behaviours");
+        // TODO(AndrewL): wire remaining `AddEpochOutput` fields (new_committee, removed_committee)
+        // to the relevant behaviours.
+    }
+
+    /// Returns a sender for submitting new epoch committees to this network manager.
+    ///
+    /// Must be obtained before [`Self::run`] is called, since `run` consumes `self`. Callers may
+    /// pass members in any order — the committee store canonicalizes their order internally when
+    /// deriving the committee id. Errors from adding the epoch (e.g. duplicate epoch id, duplicate
+    /// peer id) are logged and not reported back to the sender.
+    pub fn add_epoch_sender(&self) -> AddEpochSender {
+        self.add_epoch_sender.clone()
     }
 
     // TODO(shahak): remove the advertised_multiaddr arg once we manage external addresses
@@ -220,6 +237,8 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             futures::channel::mpsc::channel(reported_peer_ids_buffer_size);
         let (continue_propagation_sender, continue_propagation_receiver) =
             futures::channel::mpsc::channel(broadcasted_message_metadata_buffer_size);
+        let (add_epoch_sender, add_epoch_receiver) =
+            futures::channel::mpsc::channel(ADD_EPOCH_CHANNEL_CAPACITY);
         Self {
             swarm,
             inbound_protocol_to_buffer_size: HashMap::new(),
@@ -239,6 +258,8 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             metrics,
             bootstrap_peer_ids,
             committee_store,
+            add_epoch_sender,
+            add_epoch_receiver,
         }
     }
 
@@ -1290,6 +1311,11 @@ impl NetworkManager {
         self.swarm.local_peer_id().to_string()
     }
 }
+
+/// Channel sender for submitting `(epoch_id, committee_members)` pairs to the network manager's
+/// event loop. Obtain via [`GenericNetworkManager::add_epoch_sender`].
+pub type AddEpochSender = Sender<(EpochId, Vec<CommitteeMember>)>;
+type AddEpochReceiver = Receiver<(EpochId, Vec<CommitteeMember>)>;
 
 pub type ReportSender = oneshot::Sender<()>;
 type ReportReceiver = oneshot::Receiver<()>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the network manager event loop and committee/whitelist updates; incorrect usage or unexpected channel traffic could lead to missed epoch updates or altered peer allowlists, but the change is localized and adds error logging instead of panics.
> 
> **Overview**
> Adds a channel-based API for epoch/committee updates in `GenericNetworkManager`: `generic_new` now creates an internal `add_epoch` mpsc channel, `run` listens for `(EpochId, Vec<CommitteeMember>)` messages, and callers can obtain a clone via `add_epoch_sender()`.
> 
> Replaces the old unused `add_epoch` method (which panicked on invalid committee input) with `handle_add_epoch`, which logs and drops invalid updates, then refreshes the peer allowlist/target peers based on the updated committee set (with remaining wiring still marked `todo!()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a0a923ab6c74703a9dcf3e32fcc9228fa981d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->