### PR TITLE
starknet_api: panic on unused conversion of l1_hander transaction

### DIFF
--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -172,18 +172,10 @@ impl TryFrom<(Transaction, &ChainId)> for executable_transaction::Transaction {
                     executable_transaction::InvokeTransaction { tx, tx_hash },
                 ),
             )),
-            Transaction::L1Handler(tx) => Ok(executable_transaction::Transaction::L1Handler(
-                executable_transaction::L1HandlerTransaction {
-                    tx,
-                    tx_hash,
-                    // TODO(yael): The paid fee should be an input from the l1_handler.
-                    paid_fee_on_l1: Fee(1),
-                },
-            )),
             _ => {
                 unimplemented!(
-                    "Unsupported transaction type. Only DeployAccount, Invoke and L1Handler are \
-                     currently supported. tx: {:?}",
+                    "Unsupported transaction type. Only DeployAccount and Invoke are currently \
+                     supported. tx: {:?}",
                     tx
                 )
             }

--- a/crates/starknet_api/src/transaction_test.rs
+++ b/crates/starknet_api/src/transaction_test.rs
@@ -6,7 +6,6 @@ use crate::core::ChainId;
 use crate::executable_transaction::{
     AccountTransaction,
     InvokeTransaction,
-    L1HandlerTransaction,
     Transaction as ExecutableTransaction,
 };
 use crate::execution_resources::GasAmount;
@@ -68,25 +67,6 @@ fn test_invoke_executable_transaction_conversion(mut transactions_data: Vec<Tran
             tx: invoke_tx,
             tx_hash: transaction_data.transaction_hash,
         }));
-
-    verify_transaction_conversion(&transaction_data.transaction, expected_executable_tx);
-}
-
-#[rstest]
-fn test_l1_handler_executable_transaction_conversion(
-    mut transactions_data: Vec<TransactionTestData>,
-) {
-    // Extract L1 Handler transaction data.
-    let transaction_data = transactions_data.remove(11);
-    let Transaction::L1Handler(l1_handler_tx) = transaction_data.transaction.clone() else {
-        panic!("Transaction_hash.json is expected to have L1 Handler as the 12th transaction.")
-    };
-
-    let expected_executable_tx = ExecutableTransaction::L1Handler(L1HandlerTransaction {
-        tx: l1_handler_tx,
-        tx_hash: transaction_data.transaction_hash,
-        paid_fee_on_l1: Fee(1),
-    });
 
     verify_transaction_conversion(&transaction_data.transaction, expected_executable_tx);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes transaction conversion behavior by making `Transaction`→`executable_transaction::Transaction` panic for `L1Handler`, which can break callers that previously relied on this conversion path. Scope is small but touches transaction handling and test coverage.
> 
> **Overview**
> Stops converting `Transaction::L1Handler` into an `executable_transaction::Transaction` (removing the hardcoded `paid_fee_on_l1: Fee(1)` placeholder) and updates the panic message to only claim support for `DeployAccount` and `Invoke`.
> 
> Removes the `L1Handler` conversion test and its import, leaving coverage for `Invoke` conversion unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed18618b18a54bbe40d9373d8c0abfbd5e9bfbed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->