### PR TITLE
apollo_network_benchmark: fixed theoretical throughput metric in rr mode

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/handlers.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/handlers.rs
@@ -54,7 +54,6 @@ pub async fn send_stress_test_messages(
 
     let mut message_index = 0;
     let mut message = create_message(args.runner.id, size_bytes);
-    update_broadcast_metrics(message.len(), heartbeat);
 
     let mut interval = tokio::time::interval(heartbeat);
     loop {
@@ -67,6 +66,7 @@ pub async fn send_stress_test_messages(
         };
 
         if should_broadcast_now {
+            update_broadcast_metrics(message.len(), heartbeat);
             message.metadata.time = SystemTime::now();
             message.metadata.message_index = message_index;
             let message_clone = message.clone().into();
@@ -83,6 +83,8 @@ pub async fn send_stress_test_messages(
                 args.user.mode
             );
             message_index += 1;
+        } else {
+            BROADCAST_MESSAGE_THROUGHPUT.set(0.0);
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to benchmark metrics reporting with no impact on message sending/receiving behavior or protocol logic.
> 
> **Overview**
> Fixes `broadcast_message_theoretical_throughput` reporting so it only reflects *actual* broadcast activity.
> 
> `send_stress_test_messages` now updates theoretical heartbeat/throughput metrics only when the node is actively broadcasting, and explicitly sets throughput to `0.0` on non-broadcast rounds (e.g., in `Mode::RoundRobin`) to avoid overstating capacity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 698f8e15db00fbe81f24a878f74d8f3f12aa983f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->