### PR TITLE
apollo_gateway_config: change allow client side proving default to False

### DIFF
--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -148,7 +148,7 @@ impl Default for StatelessTransactionValidatorConfig {
             max_contract_class_object_size: 4089446,
             min_sierra_version: VersionId::new(1, 1, 0),
             max_sierra_version: VersionId::new(1, 8, usize::MAX),
-            allow_client_side_proving: true,
+            allow_client_side_proving: false,
             max_proof_size: 480000,
         }
     }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2672,7 +2672,7 @@
   "gateway_config.static_config.stateless_tx_validator_config.allow_client_side_proving": {
     "description": "If true, allows transactions with non-empty proof_facts or proof fields.",
     "privacy": "Public",
-    "value": true
+    "value": false
   },
   "gateway_config.static_config.stateless_tx_validator_config.max_calldata_length": {
     "description": "Limitation of calldata length.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes a gateway transaction-validation default that can cause previously accepted transactions containing proof fields to be rejected unless explicitly re-enabled in config.
> 
> **Overview**
> **Default behavior change:** flips `stateless_tx_validator_config.allow_client_side_proving` from `true` to `false`, tightening stateless transaction validation to disallow non-empty `proof_facts`/`proof` fields unless configured otherwise.
> 
> Updates both the Rust default (`crates/apollo_gateway_config/src/config.rs`) and the published config schema default (`config_schema.json`) to keep generated docs/defaults in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbb803fee644380dd229fc4fc84949de327dc0ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->