### PR TITLE
apollo_consensus_orchestrator: check WEI prices on top of FRI prices in proposal init

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -620,6 +620,38 @@ async fn gas_price_fri_out_of_range() {
     // TODO(guyn): How to check that the rejection is due to the l1_gas_price_fri mismatch?
 }
 
+#[tokio::test]
+async fn gas_price_wei_out_of_range() {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.setup_default_expectations();
+
+    deps.batcher
+        .expect_start_height()
+        .times(1)
+        .withf(|input| input.height == HEIGHT_0)
+        .return_const(Ok(()));
+    let mut context = deps.build_context();
+    context.set_height_and_round(HEIGHT_0, ROUND_0).await.unwrap();
+
+    // Receive a block info with l1_gas_price_wei that is outside the margin of error.
+    let (_content_sender, content_receiver) =
+        mpsc::channel(context.config.static_config.proposal_buffer_size);
+    let mut init_1 = proposal_init(HEIGHT_0, ROUND_0);
+    init_1.l1_gas_price_wei = init_1.l1_gas_price_wei.checked_mul_u128(2).unwrap();
+    // Use a large enough timeout to ensure fin_receiver was canceled due to invalid init,
+    // not due to a timeout.
+    let fin_receiver = context.validate_proposal(init_1, TIMEOUT * 100, content_receiver).await;
+    assert_eq!(fin_receiver.await, Err(Canceled));
+
+    // Do the same for data gas price.
+    let (_content_sender, content_receiver) =
+        mpsc::channel(context.config.static_config.proposal_buffer_size);
+    let mut init_2 = proposal_init(HEIGHT_0, ROUND_0);
+    init_2.l1_data_gas_price_wei = init_2.l1_data_gas_price_wei.checked_mul_u128(2).unwrap();
+    let fin_receiver = context.validate_proposal(init_2, TIMEOUT * 100, content_receiver).await;
+    assert_eq!(fin_receiver.await, Err(Canceled));
+}
+
 #[rstest]
 #[case::maximum(true)]
 #[case::minimum(false)]
@@ -1314,9 +1346,9 @@ async fn change_gas_price_overrides() {
     // Add the new overrides so validation passes.
     let mut modified_init = proposal_init(HEIGHT_1, ROUND_1);
     modified_init.l1_data_gas_price_fri = GasPrice(ODDLY_SPECIFIC_L1_DATA_GAS_PRICE);
-    // Note that the eth to fri conversion rate by default is 10^18 so we can just replace wei to
-    // fri 1:1.
-    modified_init.l1_data_gas_price_fri = GasPrice(ODDLY_SPECIFIC_L1_DATA_GAS_PRICE);
+    // The wei price is derived from the fri price using the eth to fri conversion rate.
+    modified_init.l1_data_gas_price_wei =
+        GasPrice(ODDLY_SPECIFIC_L1_DATA_GAS_PRICE).fri_to_wei(ETH_TO_FRI_RATE).unwrap();
 
     let content_receiver = send_proposal_to_validator_context(&mut context).await;
     let fin_receiver = context.validate_proposal(modified_init, TIMEOUT, content_receiver).await;

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -297,7 +297,7 @@ async fn is_proposal_init_valid(
             "ProposalInit validation failed".to_string(),
         ));
     }
-    let (l1_gas_prices_fri, _l1_gas_prices_wei) = get_l1_prices_in_fri_and_wei(
+    let (l1_gas_prices_fri, l1_gas_prices_wei) = get_l1_prices_in_fri_and_wei(
         l1_gas_price_provider,
         init_proposed.timestamp,
         proposal_init_validation.previous_proposal_init.as_ref(),
@@ -306,27 +306,26 @@ async fn is_proposal_init_valid(
     .await;
     let l1_gas_price_margin_percent =
         VersionedConstants::latest_constants().l1_gas_price_margin_percent.into();
-    debug!("L1 price info: {l1_gas_prices_fri:?}");
+    debug!("L1 price info: FRI: {l1_gas_prices_fri:?}, WEI: {l1_gas_prices_wei:?}");
 
-    let l1_gas_price_fri = l1_gas_prices_fri.l1_gas_price;
-    let l1_data_gas_price_fri = l1_gas_prices_fri.l1_data_gas_price;
-    let l1_gas_price_fri_proposed = init_proposed.l1_gas_price_fri;
-    let l1_data_gas_price_fri_proposed = init_proposed.l1_data_gas_price_fri;
-
-    if !(within_margin(l1_gas_price_fri_proposed, l1_gas_price_fri, l1_gas_price_margin_percent)
-        && within_margin(
-            l1_data_gas_price_fri_proposed,
-            l1_data_gas_price_fri,
-            l1_gas_price_margin_percent,
-        ))
+    let fri = &l1_gas_prices_fri;
+    let wei = &l1_gas_prices_wei;
+    let gas_price_checks = [
+        ("L1 gas price FRI", init_proposed.l1_gas_price_fri, fri.l1_gas_price),
+        ("L1 data gas price FRI", init_proposed.l1_data_gas_price_fri, fri.l1_data_gas_price),
+        ("L1 gas price WEI", init_proposed.l1_gas_price_wei, wei.l1_gas_price),
+        ("L1 data gas price WEI", init_proposed.l1_data_gas_price_wei, wei.l1_data_gas_price),
+    ];
+    if let Some((label, proposed, expected)) =
+        gas_price_checks.iter().find(|(_, proposed, expected)| {
+            !within_margin(*proposed, *expected, l1_gas_price_margin_percent)
+        })
     {
         return Err(ValidateProposalError::InvalidProposalInit(
             init_proposed.clone(),
             proposal_init_validation.clone(),
             format!(
-                "L1 gas price mismatch: expected L1 gas price FRI={l1_gas_price_fri}, \
-                 proposed={l1_gas_price_fri_proposed}, expected L1 data gas price \
-                 FRI={l1_data_gas_price_fri}, proposed={l1_data_gas_price_fri_proposed}, \
+                "{label} mismatch: expected={expected}, proposed={proposed}, \
                  l1_gas_price_margin_percent={l1_gas_price_margin_percent}"
             ),
         ));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightens consensus proposal validation by rejecting proposals whose L1 gas prices in WEI deviate beyond the allowed margin, which could cause more proposal cancellations if upstream price derivation/conversion is inconsistent.
> 
> **Overview**
> **Proposal init validation now checks both FRI and WEI L1 gas prices.** `is_proposal_init_valid` compares proposed `l1_gas_price_*` and `l1_data_gas_price_*` in *both* denominations against oracle-derived expectations within the configured margin, and expands debug/error messages to include WEI details.
> 
> Tests were updated to cover WEI out-of-range rejection and to ensure override-related tests set the corresponding WEI value derived from the FRI override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5115240e3f18fef1f25644ebf8761b2cef9d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->