### PR TITLE
delete combinators section

### DIFF
--- a/style.md
+++ b/style.md
@@ -588,22 +588,3 @@ if let Some(n) =  &maybe_name { // `n` is of type `&String`.
 
 println!("{:?}", maybe_name);
 ```
-
-### Combinators
-
-Avoid side-effects in pure combinators, like `map`, `filter` or `zip` --- use control flow (`for`/`if`/`match`) instead.
-Using the non-pure `for_each` combinator is also fine but only for one-liners.
-
-```rust
-// BAD
-// Even if rust allows the closure to mutate self, it's surprising to do this inside a transformer like `map`.
-let new_vec = old_vec.map(|num| self.mutate_self(num))
-
-// GOOD
-let new_vec = Vec::with_capacity(old_vec.len());
-for num in old_vec {
-    let new_num = self.mutate_self(num);
-    new_vec.push(new_num);
-}
-```
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or APIs.
> 
> **Overview**
> Removes the `Combinators` guidance section from `style.md`, including the recommendation to avoid side effects in `map`/`filter`/`zip` and the accompanying BAD/GOOD example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 694e16cef22c69405ae4b68217284096cb21dec3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->