### PR TITLE
apollo_l1_gas_price: rate oracle query checks status code

### DIFF
--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
@@ -125,6 +125,13 @@ impl ExchangeRateOracleClient {
                         .headers(headers.peek_secret().clone())
                         .send()
                         .await?;
+                    if !response.status().is_success() {
+                        return Err(ExchangeRateOracleClientError::RequestError(format!(
+                            "Request failed with status {}: {}",
+                            response.status(),
+                            response.text().await?
+                        )));
+                    }
                     let body = response.text().await?;
                     let rate = resolve_query(body)?;
                     Ok::<_, ExchangeRateOracleClientError>(rate)

--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle_test.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle_test.rs
@@ -12,8 +12,17 @@ use url::Url;
 use crate::exchange_rate_oracle::{ExchangeRateOracleClient, ExchangeRateOracleConfig};
 
 async fn make_server(server: &mut ServerGuard, body: serde_json::Value) -> Mock {
+    make_server_with_status(server, body, 200).await
+}
+
+async fn make_server_with_status(
+    server: &mut ServerGuard,
+    body: serde_json::Value,
+    status: usize,
+) -> Mock {
     server
-        .mock("GET", mockito::Matcher::Any) // Match any GET request.
+        .mock("GET", mockito::Matcher::Any)
+        .with_status(status)
         .with_header("Content-Type", "application/json")
         .with_body(body.to_string())
         .create()
@@ -217,5 +226,40 @@ async fn eth_to_fri_rate_two_urls() {
             Err(e) => panic!("Unexpected error: {e:?}"),
         }
         tokio::task::yield_now().await; // Don't block the executor.
+    }
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_non_success_status_code() {
+    const LAG_INTERVAL_SECONDS: u64 = 60;
+    const TIMESTAMP: u64 = 1234567890;
+
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock_response =
+        make_server_with_status(&mut server, json!({"error": "rate limit exceeded"}), 429).await;
+
+    let url_and_headers =
+        UrlAndHeaders { url: Url::parse(&server.url()).unwrap(), headers: BTreeMap::new() };
+    let config = ExchangeRateOracleConfig {
+        url_header_list: Some(vec![url_and_headers.into()]),
+        lag_interval_seconds: LAG_INTERVAL_SECONDS,
+        ..Default::default()
+    };
+    let client = ExchangeRateOracleClient::new(config);
+
+    // First call triggers the background query and returns QueryNotReadyError.
+    assert!(matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    ));
+    // Wait for the query to resolve with AllUrlsFailedError.
+    loop {
+        match client.fetch_rate(TIMESTAMP).await {
+            Err(ExchangeRateOracleClientError::QueryNotReadyError(_)) => {}
+            Err(ExchangeRateOracleClientError::AllUrlsFailedError(..)) => break,
+            other => panic!("Expected AllUrlsFailedError, got: {other:?}"),
+        }
+        tokio::task::yield_now().await;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change to oracle HTTP error handling plus a focused test; behavior only changes for non-success status codes which now fail fast instead of attempting to parse the body as a valid rate.
> 
> **Overview**
> Updates `EthToStrkOracleClient` to explicitly treat non-2xx HTTP responses as failures, returning `RequestError` that includes the status code and response body.
> 
> Extends the oracle tests with a helper to mock arbitrary status codes and adds coverage ensuring a 429 response ultimately results in `AllUrlsFailedError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab12e89c16565a248ec83e3f1eb9a86e74e36774. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->