### PR TITLE
apollo_gateway: extract GatewayAppState from GenericGateway

### DIFF
--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -125,6 +125,19 @@ pub struct GenericGateway<
     TTransactionConverter: TransactionConverterTrait,
     TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
 > {
+    // TODO(Arni): remove this once we properly update the gateway dynamic config.
+    #[allow(dead_code)]
+    config: Arc<GatewayConfig>,
+    gateway_app_state:
+        GatewayAppState<TStatelessValidator, TTransactionConverter, TStatefulValidatorFactory>,
+}
+
+#[derive(Clone)]
+struct GatewayAppState<
+    TStatelessValidator: StatelessTransactionValidatorTrait,
+    TTransactionConverter: TransactionConverterTrait,
+    TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
+> {
     config: Arc<GatewayConfig>,
     stateless_tx_validator: Arc<TStatelessValidator>,
     stateful_tx_validator_factory: Arc<TStatefulValidatorFactory>,
@@ -152,23 +165,34 @@ impl<
         stateless_tx_validator: Arc<TStatelessValidator>,
         proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
     ) -> Self {
+        let stateful_tx_validator_config =
+            config.static_config.stateful_tx_validator_config.clone();
+        let chain_info = config.static_config.chain_info.clone();
+        let contract_class_manager_config =
+            config.static_config.contract_class_manager_config.clone();
+        let config = Arc::new(config);
+
         Self {
-            config: Arc::new(config.clone()),
-            stateless_tx_validator,
-            stateful_tx_validator_factory: Arc::new(StatefulTransactionValidatorFactory {
-                config: config.static_config.stateful_tx_validator_config.clone(),
-                chain_info: config.static_config.chain_info.clone(),
-                state_reader_factory,
-                contract_class_manager: ContractClassManager::start(
-                    config.static_config.contract_class_manager_config.clone(),
-                ),
-            }),
-            mempool_client,
-            transaction_converter,
-            proof_archive_writer,
+            config: Arc::clone(&config),
+            gateway_app_state: GatewayAppState {
+                config,
+                stateless_tx_validator,
+                stateful_tx_validator_factory: Arc::new(StatefulTransactionValidatorFactory {
+                    config: stateful_tx_validator_config,
+                    chain_info,
+                    state_reader_factory,
+                    contract_class_manager: ContractClassManager::start(
+                        contract_class_manager_config,
+                    ),
+                }),
+                mempool_client,
+                transaction_converter,
+                proof_archive_writer,
+            },
         }
     }
 }
+
 impl<
     TStatelessValidator: StatelessTransactionValidatorTrait,
     TTransactionConverter: TransactionConverterTrait,
@@ -177,9 +201,24 @@ impl<
 {
     pub async fn start(&self) {
         register_metrics();
-        self.proof_archive_writer.connect().await;
+        self.gateway_app_state.proof_archive_writer.connect().await;
     }
 
+    pub async fn add_tx(
+        &self,
+        tx: RpcTransaction,
+        p2p_message_metadata: Option<BroadcastedMessageMetadata>,
+    ) -> GatewayResult<GatewayOutput> {
+        self.gateway_app_state.add_tx(tx, p2p_message_metadata).await
+    }
+}
+
+impl<
+    TStatelessValidator: StatelessTransactionValidatorTrait,
+    TTransactionConverter: TransactionConverterTrait,
+    TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
+> GatewayAppState<TStatelessValidator, TTransactionConverter, TStatefulValidatorFactory>
+{
     #[sequencer_latency_histogram(GATEWAY_ADD_TX_LATENCY, true)]
     pub async fn add_tx(
         &self,
@@ -401,6 +440,7 @@ impl<
 
         Ok((internal_tx, executable_tx, proof_data))
     }
+
     async fn await_verification_task_and_extract_proof_data(
         &self,
         verification_handle: Option<VerificationHandle>,

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -89,6 +89,7 @@ use starknet_types_core::felt::Felt;
 use strum::VariantNames;
 use tempfile::TempDir;
 
+use super::GatewayAppState;
 use crate::errors::{GatewayResult, StatelessTransactionValidatorError};
 use crate::gateway::GenericGateway;
 use crate::metrics::{
@@ -734,17 +735,23 @@ async fn add_tx_returns_error_when_extract_state_nonce_and_run_validations_fails
 
     let tx_args = invoke_args();
     setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
+    let config = Arc::new(mock_dependencies.config);
     let gateway = GenericGateway::<
         MockStatelessTransactionValidatorTrait,
         MockTransactionConverterTrait,
         MockStatefulTransactionValidatorFactoryTrait,
     > {
-        config: Arc::new(mock_dependencies.config),
-        stateless_tx_validator: Arc::new(mock_dependencies.mock_stateless_transaction_validator),
-        stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
-        mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
-        transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
-        proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
+        config: config.clone(),
+        gateway_app_state: GatewayAppState {
+            config,
+            stateless_tx_validator: Arc::new(
+                mock_dependencies.mock_stateless_transaction_validator,
+            ),
+            stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
+            mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
+            transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
+            proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
+        },
     };
 
     let result = gateway.add_tx(tx_args.get_rpc_tx(), None).await;
@@ -791,17 +798,23 @@ async fn add_tx_returns_error_when_instantiating_validator_fails(
 
     let tx_args = invoke_args();
     setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
+    let config = Arc::new(mock_dependencies.config);
     let gateway = GenericGateway::<
         MockStatelessTransactionValidatorTrait,
         MockTransactionConverterTrait,
         MockStatefulTransactionValidatorFactoryTrait,
     > {
-        config: Arc::new(mock_dependencies.config),
-        stateless_tx_validator: Arc::new(mock_dependencies.mock_stateless_transaction_validator),
-        stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
-        mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
-        transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
-        proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
+        config: config.clone(),
+        gateway_app_state: GatewayAppState {
+            config,
+            stateless_tx_validator: Arc::new(
+                mock_dependencies.mock_stateless_transaction_validator,
+            ),
+            stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
+            mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
+            transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
+            proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
+        },
     };
 
     let result = gateway.add_tx(tx_args.get_rpc_tx(), None).await;


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the gateway’s main transaction-ingest path by changing how core dependencies/config are owned and accessed, which could introduce subtle lifecycle or cloning issues despite no intended behavior change.
> 
> **Overview**
> **Refactors gateway internals** by moving `config`, validators, mempool client, transaction converter, and proof archive writer into a new `GatewayAppState` struct, and making `GenericGateway` a thin wrapper that delegates `start`/`add_tx` to it.
> 
> Updates `GenericGateway::new` to build the extracted state (including `StatefulTransactionValidatorFactory`) using a shared `Arc<GatewayConfig>`, and adjusts tests to construct `GenericGateway` via the new `GatewayAppState` field layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4ff4ae580a3b4da2677a1de14440a7a05b5cff5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->