### PR TITLE
starknet_transaction_prover: surface upstream RPC error codes 41 and 42

### DIFF
--- a/crates/starknet_transaction_prover/src/errors.rs
+++ b/crates/starknet_transaction_prover/src/errors.rs
@@ -7,6 +7,7 @@ use starknet_os::errors::StarknetOsError;
 use starknet_os::io::os_output::OsOutputError;
 use starknet_patricia_storage::errors::SerializationError;
 use starknet_proof_verifier::ProgramOutputError;
+use starknet_rust::providers::jsonrpc::{HttpTransportError, JsonRpcClientError};
 use starknet_rust::providers::ProviderError;
 use thiserror::Error;
 
@@ -48,13 +49,35 @@ pub enum ProofProviderError {
     #[error("Invalid state diff: {0}")]
     InvalidStateDiff(String),
     #[error("RPC provider error: {0}")]
-    Rpc(#[from] ProviderError),
+    Rpc(ProviderError),
+    #[error("Upstream JSON-RPC error (code {code}): {message}")]
+    UpstreamRpcError { code: i64, message: String, data: Option<serde_json::Value> },
     #[error(transparent)]
     SerializationError(#[from] SerializationError),
     #[error("Invalid RPC proof response: {0}")]
     InvalidProofResponse(String),
     #[error("Block commitment error: {0}")]
     BlockCommitmentError(String),
+}
+
+/// If the provider error wraps a raw JSON-RPC error (unrecognized by starknet-rs), surface it as
+/// [`ProofProviderError::UpstreamRpcError`] so the original code and message are forwarded.
+/// Otherwise fall back to [`ProofProviderError::Rpc`].
+impl From<ProviderError> for ProofProviderError {
+    fn from(err: ProviderError) -> Self {
+        if let ProviderError::Other(ref inner) = err {
+            if let Some(JsonRpcClientError::JsonRpcError(rpc_err)) =
+                inner.as_any().downcast_ref::<JsonRpcClientError<HttpTransportError>>()
+            {
+                return ProofProviderError::UpstreamRpcError {
+                    code: rpc_err.code,
+                    message: rpc_err.message.clone(),
+                    data: rpc_err.data.clone(),
+                };
+            }
+        }
+        ProofProviderError::Rpc(err)
+    }
 }
 
 #[derive(Debug, Error)]

--- a/crates/starknet_transaction_prover/src/server/errors.rs
+++ b/crates/starknet_transaction_prover/src/server/errors.rs
@@ -10,7 +10,12 @@ use jsonrpsee::types::error::ErrorCode::InternalError;
 use jsonrpsee::types::error::INTERNAL_ERROR_MSG;
 use jsonrpsee::types::ErrorObjectOwned;
 
-use crate::errors::VirtualSnosProverError;
+use crate::errors::{
+    ProofProviderError,
+    RunnerError,
+    VirtualBlockExecutorError,
+    VirtualSnosProverError,
+};
 
 // Starknet RPC v0.10 error codes.
 
@@ -56,37 +61,59 @@ pub fn internal_server_error(err: impl std::fmt::Display) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(InternalError.code(), INTERNAL_ERROR_MSG, Some(err.to_string()))
 }
 
+/// Troubleshooting hint appended to out-of-gas errors. The most common cause is users picking a
+/// gas amount that's too small for their transaction; this points them at `starknet_estimateFee`
+/// or a safe upper bound.
+const OUT_OF_GAS_HINT: &str = "This is likely caused by l2_gas.max_amount being too low. Set it \
+                               to the value from starknet_estimateFee, or use 100000000 \
+                               (0x5f5e100) as a safe upper bound (sufficient for ~1 million Cairo \
+                               steps).";
+
+/// Builds an out-of-gas error response, prefixing the upstream `reason` so callers see the
+/// original revert message together with the troubleshooting hint.
+fn out_of_gas_error(reason: &str) -> ErrorObjectOwned {
+    invalid_transaction_input(format!("{reason}\n\n{OUT_OF_GAS_HINT}"))
+}
+
+/// Maps a [`RunnerError`] to a JSON-RPC error, surfacing known upstream error
+/// codes instead of hiding them behind -32603.
+fn runner_error_to_rpc(err: RunnerError) -> ErrorObjectOwned {
+    match err {
+        RunnerError::VirtualBlockExecutor(VirtualBlockExecutorError::TransactionReverted(
+            _,
+            ref reason,
+        )) if reason.contains("Out of gas") => out_of_gas_error(reason),
+        RunnerError::ProofProvider(ProofProviderError::UpstreamRpcError {
+            code,
+            message,
+            data,
+        }) => {
+            let rpc_code = i32::try_from(code).unwrap_or(InternalError.code());
+            if rpc_code >= 0 {
+                // Positive codes are user-facing Starknet application errors — forward the
+                // upstream code, message, and any data (e.g. nonce details for code 41) as-is.
+                ErrorObjectOwned::owned(rpc_code, message, data)
+            } else {
+                // Negative codes are JSON-RPC infrastructure errors — hide behind -32603.
+                internal_server_error(format!(
+                    "Upstream JSON-RPC error (code {rpc_code}): {message}"
+                ))
+            }
+        }
+        other => internal_server_error(other),
+    }
+}
+
 impl From<VirtualSnosProverError> for ErrorObjectOwned {
     fn from(err: VirtualSnosProverError) -> Self {
-        match &err {
-            VirtualSnosProverError::InvalidTransactionType(msg) => {
-                unsupported_tx_version(msg.clone())
-            }
-            VirtualSnosProverError::InvalidTransactionInput(msg) => {
-                invalid_transaction_input(msg.clone())
-            }
+        match err {
+            VirtualSnosProverError::InvalidTransactionType(msg) => unsupported_tx_version(msg),
+            VirtualSnosProverError::InvalidTransactionInput(msg) => invalid_transaction_input(msg),
             VirtualSnosProverError::ValidationError(msg) => {
                 // Check if it's a pending block error.
-                if msg.contains("Pending") {
-                    block_not_found()
-                } else {
-                    validation_failure(msg.clone())
-                }
+                if msg.contains("Pending") { block_not_found() } else { validation_failure(msg) }
             }
-            VirtualSnosProverError::RunnerError(e) => {
-                let message = e.to_string();
-                if message.contains("Out of gas") {
-                    invalid_transaction_input(
-                        "Transaction reverted: out of gas. This is likely caused by \
-                         l2_gas.max_amount being too low. Set it to the value from \
-                         starknet_estimateFee, or use 100000000 (0x5f5e100) as a safe upper bound \
-                         (sufficient for ~1 million Cairo steps)."
-                            .to_string(),
-                    )
-                } else {
-                    internal_server_error(e)
-                }
-            }
+            VirtualSnosProverError::RunnerError(e) => runner_error_to_rpc(*e),
             #[cfg(feature = "stwo_proving")]
             VirtualSnosProverError::ProvingError(e) => internal_server_error(e),
             VirtualSnosProverError::OutputParseError(e) => internal_server_error(e),


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how upstream execution/storage-proof failures are translated into JSON-RPC responses, which can affect client-visible error codes and messages. Logic is localized to error handling but may alter behavior for some failure modes if parsing/downcasting misses cases.
> 
> **Overview**
> Updates the proving API to **surface upstream node failures as explicit JSON-RPC errors** instead of collapsing them into internal errors.
> 
> Adds spec + server support for `TRANSACTION_EXECUTION_ERROR` (code `41`, with detail string) and `STORAGE_PROOF_NOT_SUPPORTED` (code `42`), including OpenRPC spec updates and test coverage.
> 
> Implements new error plumbing to extract raw upstream JSON-RPC error codes/messages from storage-proof RPC calls, and to map upstream `starknet_simulateTransactions` execution failures into the new transaction execution error response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0349f21e48339377f90d0678db5aa50cb0dbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->