### PR TITLE
apollo_network: move e2e_broadcast_test to integration tests

### DIFF
--- a/crates/apollo_network/Cargo.toml
+++ b/crates/apollo_network/Cargo.toml
@@ -64,6 +64,10 @@ tokio-stream.workspace = true
 waker-fn.workspace = true
 
 [[test]]
+name = "e2e_broadcast_test"
+required-features = ["testing"]
+
+[[test]]
 name = "e2e_discovery_test"
 required-features = ["testing"]
 

--- a/crates/apollo_network/src/lib.rs
+++ b/crates/apollo_network/src/lib.rs
@@ -197,8 +197,6 @@ pub mod active_committees;
 #[cfg(test)]
 mod config_test;
 pub mod discovery;
-#[cfg(test)]
-mod e2e_broadcast_test;
 mod event_tracker;
 pub mod gossipsub_impl;
 pub mod metrics;

--- a/crates/apollo_network/tests/e2e_broadcast_test.rs
+++ b/crates/apollo_network/tests/e2e_broadcast_test.rs
@@ -1,20 +1,19 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
+use apollo_network::discovery::DiscoveryConfig;
+use apollo_network::gossipsub_impl::Topic;
+use apollo_network::mixed_behaviour::MixedBehaviour;
+use apollo_network::network_manager::{BroadcastTopicClientTrait, GenericNetworkManager};
+use apollo_network::peer_manager::PeerManagerConfig;
+use apollo_network::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
+use apollo_network::{sqmr, Bytes};
 use futures::{FutureExt, StreamExt};
 use libp2p::core::multiaddr::Protocol;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{Multiaddr, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt;
 use starknet_api::core::ChainId;
-
-use crate::discovery::DiscoveryConfig;
-use crate::gossipsub_impl::Topic;
-use crate::mixed_behaviour::MixedBehaviour;
-use crate::network_manager::{BroadcastTopicClientTrait, GenericNetworkManager};
-use crate::peer_manager::PeerManagerConfig;
-use crate::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
-use crate::{sqmr, Bytes};
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes test organization and build wiring (Cargo test target + imports) with no runtime code paths affected.
> 
> **Overview**
> Moves `e2e_broadcast_test` out of `src/lib.rs` unit-test modules into `crates/apollo_network/tests/` as an integration test.
> 
> Updates `Cargo.toml` to register the new `[[test]]` target gated behind the `testing` feature, and adjusts the test’s imports to use `apollo_network::...` instead of `crate::...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9393d59439cd09879609ed7c3559428065eedc8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->