### PR TITLE
apollo_dashboard,apollo_deployments: add top-level intervalSec to Alerts; use it in alert builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum",
 ]
 
 [[package]]

--- a/crates/apollo_dashboard/Cargo.toml
+++ b/crates/apollo_dashboard/Cargo.toml
@@ -44,6 +44,7 @@ indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 serde_with.workspace = true
+strum = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 apollo_batcher = { workspace = true, features = ["testing"] }

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1,1073 +1,23 @@
 {
+  "groups": [
+    {
+      "name": "evaluation_rate_default",
+      "intervalSec": 30
+    },
+    {
+      "name": "evaluation_rate_high",
+      "intervalSec": 10
+    },
+    {
+      "name": "evaluation_rate_low",
+      "intervalSec": 60
+    }
+  ],
   "alerts": [
-    {
-      "name": "batcher_storage_open_read_transactions",
-      "title": "batcher - High number of open read transactions",
-      "ruleGroup": "state_sync",
-      "expr": "max_over_time(batcher_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              7500.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "class_manager_storage_open_read_transactions",
-      "title": "class_manager - High number of open read transactions",
-      "ruleGroup": "state_sync",
-      "expr": "max_over_time(class_manager_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              7500.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "config_manager_update_error_increase",
-      "title": "Config manager update error increase",
-      "ruleGroup": "general",
-      "expr": "sum(increase(config_manager_update_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_proposal_fin_mismatch_once",
-      "title": "Consensus proposal fin mismatch occurred",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_proposal_fin_mismatch{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "cende_write_blob_failure_once",
-      "title": "Cende write blob failure once",
-      "ruleGroup": "consensus",
-      "expr": "increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "cende_write_prev_height_blob_latency_too_high",
-      "title": "Cende write prev height blob latency too high",
-      "ruleGroup": "consensus",
-      "expr": "(sum(rate(cende_write_prev_height_blob_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) / clamp_min(sum(rate(cende_write_prev_height_blob_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0), 0.0000001)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              3.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_conflicting_votes",
-      "title": "Consensus conflicting votes",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_conflicting_votes{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_decisions_reached_by_consensus_ratio",
-      "title": "Consensus decisions reached by consensus ratio",
-      "ruleGroup": "consensus",
-      "expr": "(sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) / clamp_min((sum(increase(consensus_decisions_reached_by_sync{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) + (sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)), 1)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.5
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_inbound_peer_evicted",
-      "title": "Consensus inbound peer evicted",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_inbound_peer_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              5.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_inbound_stream_buffer_full",
-      "title": "Consensus inbound stream buffer full",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_inbound_stream_buffer_full{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_inbound_stream_evicted",
-      "title": "Consensus inbound stream evicted",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_inbound_stream_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              5.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_l1_gas_price_provider_failure",
-      "title": "Consensus L1 gas price provider failure",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              5.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_l1_gas_price_provider_failure_once",
-      "title": "Consensus L1 gas price provider failure once",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_p2p_disconnections",
-      "title": "Consensus p2p disconnections",
-      "ruleGroup": "consensus",
-      "expr": "(sum(changes(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) / 2",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              10.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "consensus_retrospective_block_hash_mismatch",
-      "title": "Mismatched retrospective block hashes between the state sync and the batcher",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_retrospective_block_hash_mismatch{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p1",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "consensus_round_above_zero",
-      "title": "Consensus round above zero",
-      "ruleGroup": "consensus",
-      "expr": "increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_votes_num_sent_messages",
-      "title": "Consensus votes num sent messages",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(apollo_consensus_votes_num_sent_messages{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              20.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "eth_to_strk_error_count",
-      "title": "Eth to Strk error count",
-      "ruleGroup": "l1_gas_price",
-      "expr": "sum(increase(eth_to_strk_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              10.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "1m",
-      "intervalSec": 20,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "gateway_add_tx_idle_p2p_rpc",
-      "title": "Gateway add_tx idle (p2p+rpc)",
-      "ruleGroup": "gateway",
-      "expr": "sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.1
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "gateway_proof_archive_write_failure",
-      "title": "Gateway proof archive (GCS) write failure",
-      "ruleGroup": "gateway",
-      "expr": "sum(increase(gateway_proof_archive_write_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "pod_state_not_ready",
-      "title": "Pod status Not Ready",
-      "ruleGroup": "general",
-      "expr": "sum by (service_name) (label_replace(kube_pod_container_status_ready{cluster=~\"$cluster\", namespace=~\"$namespace\"}, \"service_name\", \"$1\", \"pod\", \"^sequencer-(.+)-(?:deployment|statefulset)-[a-z0-9]+(?:-[a-z0-9]+)?$\"))",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.1
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "60s",
-      "intervalSec": 10,
-      "severity": "p2",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "pod_state_crashloopbackoff",
-      "title": "Pod status CrashLoopBackOff",
-      "ruleGroup": "general",
-      "expr": "sum by(container, pod, namespace) (kube_pod_container_status_waiting_reason{cluster=~\"$cluster\", namespace=~\"$namespace\", reason=\"CrashLoopBackOff\"}) or absent(kube_pod_container_status_waiting_reason{cluster=~\"$cluster\", namespace=~\"$namespace\", reason=\"CrashLoopBackOff\"}) * 0",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "pod_high_cpu_utilization",
-      "title": "Pod High CPU Utilization ( >90% )",
-      "ruleGroup": "general",
-      "expr": "max(irate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) by (container, pod, namespace) / (max(container_spec_cpu_quota{cluster=~\"$cluster\", namespace=~\"$namespace\"}/100000) by (container, pod, namespace)) * 100",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              90.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "http_server_high_deprecated_transaction_failure_ratio",
-      "title": "http server high deprecated transaction failure ratio",
-      "ruleGroup": "http_server",
-      "expr": "increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.1
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "http_server_high_transaction_failure_ratio",
-      "title": "http server high transaction failure ratio",
-      "ruleGroup": "http_server",
-      "expr": "(increase(http_server_added_transactions_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) - increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.5
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "http_server_internal_error_once",
-      "title": "http server internal error once",
-      "ruleGroup": "http_server",
-      "expr": "increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "http_server_no_successful_transactions",
-      "title": "http server no successful transactions",
-      "ruleGroup": "http_server",
-      "expr": "sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.1
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "batcher_l1_events_provider_errors",
-      "title": "Batcher L1 events provider errors",
-      "ruleGroup": "batcher",
-      "expr": "sum(increase(batcher_l1_events_provider_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              10.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "l1_gas_price_scraper_reorg_detected",
-      "title": "L1 gas price scraper reorg detected",
-      "ruleGroup": "l1_gas_price",
-      "expr": "sum(increase(l1_gas_price_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "l1_gas_price_scraper_baselayer_error_count",
-      "title": "L1 gas price scraper baselayer error count",
-      "ruleGroup": "l1_gas_price",
-      "expr": "sum(increase(l1_gas_price_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "l1_message_scraper_baselayer_error_count",
-      "title": "L1 message scraper baselayer error count",
-      "ruleGroup": "l1_messages",
-      "expr": "sum(increase(l1_message_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              5.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "l1_message_scraper_reorg_detected",
-      "title": "L1 message scraper reorg detected",
-      "ruleGroup": "l1_messages",
-      "expr": "sum(increase(l1_message_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p1",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "mempool_add_tx_idle_p2p_rpc",
-      "title": "Mempool add_tx idle (p2p+rpc)",
-      "ruleGroup": "mempool",
-      "expr": "sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.1
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p1",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "mempool_p2p_disconnections",
-      "title": "Mempool p2p disconnections",
-      "ruleGroup": "mempool",
-      "expr": "(sum(changes(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) / 2",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              10.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "native_compilation_error",
-      "title": "Native compilation alert",
-      "ruleGroup": "batcher",
-      "expr": "sum(increase(native_compilation_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "periodic_ping",
-      "title": "Periodic Ping",
-      "ruleGroup": "general",
-      "expr": "(day_of_week() == bool 0) * (hour() == bool 7) * (minute() == bool 55)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "0s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "staking_epoch_id_mismatch",
-      "title": "Staking epoch ID mismatch between nodes",
-      "ruleGroup": "staking",
-      "expr": "max(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"}) - min(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "5m",
-      "intervalSec": 30,
-      "severity": "p3",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "sync_storage_open_read_transactions",
-      "title": "sync - High number of open read transactions",
-      "ruleGroup": "state_sync",
-      "expr": "max_over_time(sync_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              7500.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p4",
-      "observer_applicable": "false"
-    },
     {
       "name": "batched_transactions_stuck",
       "title": "Batched Transactions Stuck",
-      "ruleGroup": "batcher",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck-sampling_window_secs-expression$$$s])",
       "conditions": [
         {
@@ -1095,7 +45,7 @@
     {
       "name": "batched_transactions_stuck_long_time",
       "title": "Batched Transactions Stuck Long Time",
-      "ruleGroup": "batcher",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck_long_time-sampling_window_secs-expression$$$s])",
       "conditions": [
         {
@@ -1121,38 +71,10 @@
       "observer_applicable": "false"
     },
     {
-      "name": "consensus_block_number_progress_is_slow",
-      "title": "Consensus block number progress is slow",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              "$$$consensus_block_number_progress_is_slow-comparison_value$$$"
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$consensus_block_number_progress_is_slow-severity$$$",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "cende_write_blob_failure",
-      "title": "Cende write blob failure",
-      "ruleGroup": "consensus",
-      "expr": "increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
+      "name": "batcher_l1_events_provider_errors",
+      "title": "Batcher L1 events provider errors",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(batcher_l1_events_provider_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)",
       "conditions": [
         {
           "evaluator": {
@@ -1173,741 +95,13 @@
       ],
       "for": "30s",
       "intervalSec": 30,
-      "severity": "$$$cende_write_blob_failure-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_block_number_stuck",
-      "title": "Consensus Block Number Stuck",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$consensus_block_number_stuck-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_block_number_stuck_long_time",
-      "title": "Consensus Block Number Stuck Long Time",
-      "ruleGroup": "consensus",
-      "expr": "sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_p2p_not_enough_peers_for_quorum",
-      "title": "Consensus P2P Not Enough Peers For Quorum",
-      "ruleGroup": "consensus",
-      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[120s])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$consensus_p2p_not_enough_peers_for_quorum-severity$$$",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "consensus_p2p_not_enough_peers_for_quorum_long_time",
-      "title": "Consensus P2P Not Enough Peers For Quorum Long Time",
-      "ruleGroup": "consensus",
-      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "consensus_p2p_peer_down",
-      "title": "Consensus p2p peer down",
-      "ruleGroup": "consensus",
-      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              2.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$consensus_p2p_peer_down-severity$$$",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "consensus_round_above_zero_multiple_times",
-      "title": "Consensus round above zero multiple times",
-      "ruleGroup": "consensus",
-      "expr": "increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_round_above_zero_multiple_times-sampling_window_secs-expression$$$s])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              "$$$consensus_round_above_zero_multiple_times-comparison_value$$$"
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$consensus_round_above_zero_multiple_times-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "consensus_round_high",
-      "title": "Consensus round high",
-      "ruleGroup": "consensus",
-      "expr": "max_over_time(consensus_round{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              "$$$consensus_round_high-comparison_value$$$"
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$consensus_round_high-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "eth_to_strk_success_count",
-      "title": "Eth to Strk success count",
-      "ruleGroup": "l1_gas_price",
-      "expr": "increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$eth_to_strk_success_count-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "pod_state_high_memory_utilization",
-      "title": "Pod High Memory Utilization ( >70% )",
-      "ruleGroup": "general",
-      "expr": "max(container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              70.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p3",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "pod_state_critical_memory_utilization",
-      "title": "Pod Critical Memory Utilization ( >85% )",
-      "ruleGroup": "general",
-      "expr": "max(container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              85.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "pod_state_high_disk_utilization",
-      "title": "Pod High Disk Utilization ( >70% )",
-      "ruleGroup": "general",
-      "expr": "max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) / (min by (namespace,persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) + max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}))*100",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              70.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p3",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "pod_state_critical_disk_utilization",
-      "title": "Pod Critical Disk Utilization ( >90% )",
-      "ruleGroup": "general",
-      "expr": "max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) / (min by (namespace,persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) + max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}))*100",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              90.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p2",
-      "observer_applicable": "true"
-    },
-    {
-      "name": "http_server_avg_add_tx_latency",
-      "title": "High HTTP server average add_tx latency",
-      "ruleGroup": "http_server",
-      "expr": "rate(http_server_add_tx_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]) / clamp_min(rate(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]), 1/300)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              15.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$http_server_avg_add_tx_latency-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "http_server_min_add_tx_latency",
-      "title": "High HTTP server minimal add_tx latency",
-      "ruleGroup": "http_server",
-      "expr": "(sum(increase(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) > 0) * (sum(increase(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"1.0\"}[2m])) < 1)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$http_server_min_add_tx_latency-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "http_server_internal_error_ratio",
-      "title": "http server internal error ratio",
-      "ruleGroup": "http_server",
-      "expr": "increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.01
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$http_server_internal_error_ratio-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "gateway_low_successful_transaction_rate",
-      "title": "gateway low successful transaction rate",
-      "ruleGroup": "gateway",
-      "expr": "sum(increase(gateway_transactions_sent_to_mempool{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              5.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$gateway_low_successful_transaction_rate-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "http_server_p95_add_tx_latency",
-      "title": "High HTTP server P95 add_tx latency",
-      "ruleGroup": "http_server",
-      "expr": "histogram_quantile(0.95, sum(rate(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) by (le))",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              2.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "p5",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "high_empty_blocks_ratio",
-      "title": "High ratio of empty blocks",
-      "ruleGroup": "batcher",
-      "expr": "sum(increase(batcher_num_transaction_in_block_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"0.001\"}[$$$high_empty_blocks_ratio-zero_bucket-sampling_window_secs-expression$$$s])) / clamp_min(sum(increase(batcher_num_transaction_in_block_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$high_empty_blocks_ratio-total_count-sampling_window_secs-expression$$$s])), 1)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              "$$$high_empty_blocks_ratio-comparison_value$$$"
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$high_empty_blocks_ratio-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "l1_gas_price_provider_insufficient_history",
-      "title": "L1 gas price provider insufficient history",
-      "ruleGroup": "l1_gas_price",
-      "expr": "increase(l1_gas_price_provider_insufficient_history{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$l1_gas_price_provider_insufficient_history-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "l1_gas_price_scraper_success_count",
-      "title": "L1 gas price scraper success count",
-      "ruleGroup": "l1_gas_price",
-      "expr": "increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$l1_gas_price_scraper_success_count-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "l1_message_no_successes",
-      "title": "L1 message no successes",
-      "ruleGroup": "l1_gas_price",
-      "expr": "increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$l1_message_no_successes-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "mempool_evictions_count",
-      "title": "Mempool evictions count",
-      "ruleGroup": "mempool",
-      "expr": "mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\", drop_reason=\"evicted\"}",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$mempool_evictions_count-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "mempool_p2p_peer_down",
-      "title": "Mempool p2p peer down",
-      "ruleGroup": "mempool",
-      "expr": "max_over_time(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              2.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$mempool_p2p_peer_down-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "mempool_pool_size_increase",
-      "title": "Mempool pool size increase",
-      "ruleGroup": "mempool",
-      "expr": "mempool_pool_size{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              10000.0
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$mempool_pool_size_increase-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "mempool_transaction_drop_ratio",
-      "title": "Mempool transaction drop ratio",
-      "ruleGroup": "mempool",
-      "expr": "increase(mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]) / clamp_min(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]), 1)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.2
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$mempool_transaction_drop_ratio-severity$$$",
-      "observer_applicable": "false"
-    },
-    {
-      "name": "preconfirmed_block_not_written",
-      "title": "Preconfirmed block not written",
-      "ruleGroup": "batcher",
-      "expr": "increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              1.0
-            ],
-            "type": "lt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "intervalSec": 30,
-      "severity": "$$$preconfirmed_block_not_written-severity$$$",
+      "severity": "p4",
       "observer_applicable": "false"
     },
     {
       "name": "batcher_remote_server_number_of_connections",
       "title": "batcher - Remote server number of connections exceeds 80",
-      "ruleGroup": "batcher",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (batcher_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -1933,9 +127,121 @@
       "observer_applicable": "true"
     },
     {
+      "name": "batcher_storage_open_read_transactions",
+      "title": "batcher - High number of open read transactions",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(batcher_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              7500.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "cende_write_blob_failure",
+      "title": "Cende write blob failure",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              10.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$cende_write_blob_failure-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "cende_write_blob_failure_once",
+      "title": "Cende write blob failure once",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "cende_write_prev_height_blob_latency_too_high",
+      "title": "Cende write prev height blob latency too high",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(sum(rate(cende_write_prev_height_blob_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) / clamp_min(sum(rate(cende_write_prev_height_blob_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0), 0.0000001)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              3.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
       "name": "class_manager_remote_server_number_of_connections",
       "title": "class_manager - Remote server number of connections exceeds 80",
-      "ruleGroup": "general",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (class_manager_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -1961,9 +267,37 @@
       "observer_applicable": "true"
     },
     {
+      "name": "class_manager_storage_open_read_transactions",
+      "title": "class_manager - High number of open read transactions",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(class_manager_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              7500.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
       "name": "committer_remote_server_number_of_connections",
       "title": "committer - Remote server number of connections exceeds 80",
-      "ruleGroup": "consensus",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (committer_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -1991,7 +325,7 @@
     {
       "name": "config_manager_remote_server_number_of_connections",
       "title": "config_manager - Remote server number of connections exceeds 80",
-      "ruleGroup": "general",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (config_manager_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -2017,9 +351,737 @@
       "observer_applicable": "true"
     },
     {
+      "name": "config_manager_update_error_increase",
+      "title": "Config manager update error increase",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(config_manager_update_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_block_number_progress_is_slow",
+      "title": "Consensus block number progress is slow",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              "$$$consensus_block_number_progress_is_slow-comparison_value$$$"
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$consensus_block_number_progress_is_slow-severity$$$",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "consensus_block_number_stuck",
+      "title": "Consensus Block Number Stuck",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$consensus_block_number_stuck-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_block_number_stuck_long_time",
+      "title": "Consensus Block Number Stuck Long Time",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_conflicting_votes",
+      "title": "Consensus conflicting votes",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_conflicting_votes{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_decisions_reached_by_consensus_ratio",
+      "title": "Consensus decisions reached by consensus ratio",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) / clamp_min((sum(increase(consensus_decisions_reached_by_sync{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) + (sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)), 1)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.5
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_inbound_peer_evicted",
+      "title": "Consensus inbound peer evicted",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_inbound_peer_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              5.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_inbound_stream_buffer_full",
+      "title": "Consensus inbound stream buffer full",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_inbound_stream_buffer_full{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_inbound_stream_evicted",
+      "title": "Consensus inbound stream evicted",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_inbound_stream_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              5.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_l1_gas_price_provider_failure",
+      "title": "Consensus L1 gas price provider failure",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              5.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_l1_gas_price_provider_failure_once",
+      "title": "Consensus L1 gas price provider failure once",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_p2p_disconnections",
+      "title": "Consensus p2p disconnections",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(sum(changes(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) / 2",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              10.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "consensus_p2p_not_enough_peers_for_quorum",
+      "title": "Consensus P2P Not Enough Peers For Quorum",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[120s])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$consensus_p2p_not_enough_peers_for_quorum-severity$$$",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "consensus_p2p_not_enough_peers_for_quorum_long_time",
+      "title": "Consensus P2P Not Enough Peers For Quorum Long Time",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "consensus_p2p_peer_down",
+      "title": "Consensus p2p peer down",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              2.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$consensus_p2p_peer_down-severity$$$",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "consensus_proposal_fin_mismatch_once",
+      "title": "Consensus proposal fin mismatch occurred",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_proposal_fin_mismatch{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_retrospective_block_hash_mismatch",
+      "title": "Mismatched retrospective block hashes between the state sync and the batcher",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_retrospective_block_hash_mismatch{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p1",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "consensus_round_above_zero",
+      "title": "Consensus round above zero",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_round_above_zero_multiple_times",
+      "title": "Consensus round above zero multiple times",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_round_above_zero_multiple_times-sampling_window_secs-expression$$$s])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              "$$$consensus_round_above_zero_multiple_times-comparison_value$$$"
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$consensus_round_above_zero_multiple_times-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_round_high",
+      "title": "Consensus round high",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(consensus_round{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              "$$$consensus_round_high-comparison_value$$$"
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$consensus_round_high-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "consensus_votes_num_sent_messages",
+      "title": "Consensus votes num sent messages",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(apollo_consensus_votes_num_sent_messages{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              20.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "eth_to_strk_error_count",
+      "title": "Eth to Strk error count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(eth_to_strk_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              10.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "1m",
+      "intervalSec": 20,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "eth_to_strk_success_count",
+      "title": "Eth to Strk success count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$eth_to_strk_success_count-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "gateway_add_tx_idle_p2p_rpc",
+      "title": "Gateway add_tx idle (p2p+rpc)",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.1
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "gateway_low_successful_transaction_rate",
+      "title": "gateway low successful transaction rate",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(gateway_transactions_sent_to_mempool{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              5.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$gateway_low_successful_transaction_rate-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "gateway_proof_archive_write_failure",
+      "title": "Gateway proof archive (GCS) write failure",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(gateway_proof_archive_write_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
       "name": "gateway_remote_server_number_of_connections",
       "title": "gateway - Remote server number of connections exceeds 80",
-      "ruleGroup": "gateway",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (gateway_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -2045,15 +1107,15 @@
       "observer_applicable": "true"
     },
     {
-      "name": "l1_gas_price_remote_server_number_of_connections",
-      "title": "l1_gas_price - Remote server number of connections exceeds 80",
-      "ruleGroup": "l1_gas_price",
-      "expr": "sum by (namespace, pod) (l1_gas_price_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+      "name": "high_empty_blocks_ratio",
+      "title": "High ratio of empty blocks",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(batcher_num_transaction_in_block_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"0.001\"}[$$$high_empty_blocks_ratio-zero_bucket-sampling_window_secs-expression$$$s])) / clamp_min(sum(increase(batcher_num_transaction_in_block_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$high_empty_blocks_ratio-total_count-sampling_window_secs-expression$$$s])), 1)",
       "conditions": [
         {
           "evaluator": {
             "params": [
-              80.0
+              "$$$high_empty_blocks_ratio-comparison_value$$$"
             ],
             "type": "gt"
           },
@@ -2069,13 +1131,237 @@
       ],
       "for": "30s",
       "intervalSec": 30,
-      "severity": "p3",
-      "observer_applicable": "true"
+      "severity": "$$$high_empty_blocks_ratio-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_avg_add_tx_latency",
+      "title": "High HTTP server average add_tx latency",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "rate(http_server_add_tx_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]) / clamp_min(rate(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]), 1/300)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              15.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$http_server_avg_add_tx_latency-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_high_deprecated_transaction_failure_ratio",
+      "title": "http server high deprecated transaction failure ratio",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.1
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_high_transaction_failure_ratio",
+      "title": "http server high transaction failure ratio",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(increase(http_server_added_transactions_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) - increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.5
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_internal_error_once",
+      "title": "http server internal error once",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_internal_error_ratio",
+      "title": "http server internal error ratio",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.01
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$http_server_internal_error_ratio-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_min_add_tx_latency",
+      "title": "High HTTP server minimal add_tx latency",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(sum(increase(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) > 0) * (sum(increase(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"1.0\"}[2m])) < 1)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$http_server_min_add_tx_latency-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_no_successful_transactions",
+      "title": "http server no successful transactions",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.1
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "http_server_p95_add_tx_latency",
+      "title": "High HTTP server P95 add_tx latency",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "histogram_quantile(0.95, sum(rate(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) by (le))",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              2.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
     },
     {
       "name": "l1_events_remote_server_number_of_connections",
       "title": "l1_events - Remote server number of connections exceeds 80",
-      "ruleGroup": "l1_messages",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (l1_events_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -2101,10 +1387,38 @@
       "observer_applicable": "true"
     },
     {
-      "name": "mempool_remote_server_number_of_connections",
-      "title": "mempool - Remote server number of connections exceeds 80",
-      "ruleGroup": "mempool",
-      "expr": "sum by (namespace, pod) (mempool_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+      "name": "l1_gas_price_provider_insufficient_history",
+      "title": "L1 gas price provider insufficient history",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(l1_gas_price_provider_insufficient_history{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$l1_gas_price_provider_insufficient_history-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "l1_gas_price_remote_server_number_of_connections",
+      "title": "l1_gas_price - Remote server number of connections exceeds 80",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum by (namespace, pod) (l1_gas_price_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
           "evaluator": {
@@ -2129,9 +1443,289 @@
       "observer_applicable": "true"
     },
     {
+      "name": "l1_gas_price_scraper_baselayer_error_count",
+      "title": "L1 gas price scraper baselayer error count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(l1_gas_price_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "l1_gas_price_scraper_reorg_detected",
+      "title": "L1 gas price scraper reorg detected",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(l1_gas_price_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "l1_gas_price_scraper_success_count",
+      "title": "L1 gas price scraper success count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$l1_gas_price_scraper_success_count-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "l1_message_no_successes",
+      "title": "L1 message no successes",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$l1_message_no_successes-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "l1_message_scraper_baselayer_error_count",
+      "title": "L1 message scraper baselayer error count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(l1_message_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              5.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p5",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "l1_message_scraper_reorg_detected",
+      "title": "L1 message scraper reorg detected",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(l1_message_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p1",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "mempool_add_tx_idle_p2p_rpc",
+      "title": "Mempool add_tx idle (p2p+rpc)",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.1
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p1",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "mempool_evictions_count",
+      "title": "Mempool evictions count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\", drop_reason=\"evicted\"}",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$mempool_evictions_count-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "mempool_p2p_disconnections",
+      "title": "Mempool p2p disconnections",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(sum(changes(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) / 2",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              10.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "mempool_p2p_peer_down",
+      "title": "Mempool p2p peer down",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              2.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$mempool_p2p_peer_down-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
       "name": "mempool_p2p_remote_server_number_of_connections",
       "title": "mempool_p2p - Remote server number of connections exceeds 80",
-      "ruleGroup": "mempool",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (mempool_p2p_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -2157,9 +1751,289 @@
       "observer_applicable": "true"
     },
     {
+      "name": "mempool_pool_size_increase",
+      "title": "Mempool pool size increase",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "mempool_pool_size{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              10000.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$mempool_pool_size_increase-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "mempool_remote_server_number_of_connections",
+      "title": "mempool - Remote server number of connections exceeds 80",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum by (namespace, pod) (mempool_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              80.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p3",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "mempool_transaction_drop_ratio",
+      "title": "Mempool transaction drop ratio",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]) / clamp_min(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]), 1)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.2
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$mempool_transaction_drop_ratio-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "native_compilation_error",
+      "title": "Native compilation alert",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(native_compilation_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "periodic_ping",
+      "title": "Periodic Ping",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(day_of_week() == bool 0) * (hour() == bool 7) * (minute() == bool 55)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "0s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "pod_high_cpu_utilization",
+      "title": "Pod High CPU Utilization ( >90% )",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max(irate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) by (container, pod, namespace) / (max(container_spec_cpu_quota{cluster=~\"$cluster\", namespace=~\"$namespace\"}/100000) by (container, pod, namespace)) * 100",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              90.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "pod_state_crashloopbackoff",
+      "title": "Pod status CrashLoopBackOff",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum by(container, pod, namespace) (kube_pod_container_status_waiting_reason{cluster=~\"$cluster\", namespace=~\"$namespace\", reason=\"CrashLoopBackOff\"}) or absent(kube_pod_container_status_waiting_reason{cluster=~\"$cluster\", namespace=~\"$namespace\", reason=\"CrashLoopBackOff\"}) * 0",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "pod_state_critical_memory_utilization",
+      "title": "Pod Critical Memory Utilization ( >85% )",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max(container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              85.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "pod_state_high_memory_utilization",
+      "title": "Pod High Memory Utilization ( >70% )",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max(container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              70.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p3",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "preconfirmed_block_not_written",
+      "title": "Preconfirmed block not written",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "$$$preconfirmed_block_not_written-severity$$$",
+      "observer_applicable": "false"
+    },
+    {
       "name": "sierra_compiler_remote_server_number_of_connections",
       "title": "sierra_compiler - Remote server number of connections exceeds 80",
-      "ruleGroup": "batcher",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (sierra_compiler_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -2187,7 +2061,7 @@
     {
       "name": "signature_manager_remote_server_number_of_connections",
       "title": "signature_manager - Remote server number of connections exceeds 80",
-      "ruleGroup": "consensus",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "sum by (namespace, pod) (signature_manager_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
@@ -2213,15 +2087,15 @@
       "observer_applicable": "true"
     },
     {
-      "name": "state_sync_remote_server_number_of_connections",
-      "title": "state_sync - Remote server number of connections exceeds 80",
-      "ruleGroup": "state_sync",
-      "expr": "sum by (namespace, pod) (state_sync_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+      "name": "staking_epoch_id_mismatch",
+      "title": "Staking epoch ID mismatch between nodes",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"}) - min(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
       "conditions": [
         {
           "evaluator": {
             "params": [
-              80.0
+              0.0
             ],
             "type": "gt"
           },
@@ -2235,15 +2109,15 @@
           "type": "query"
         }
       ],
-      "for": "30s",
+      "for": "5m",
       "intervalSec": 30,
       "severity": "p3",
-      "observer_applicable": "true"
+      "observer_applicable": "false"
     },
     {
       "name": "state_sync_lag",
       "title": "State sync lag",
-      "ruleGroup": "state_sync",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"} - apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
       "conditions": [
         {
@@ -2269,9 +2143,37 @@
       "observer_applicable": "false"
     },
     {
+      "name": "state_sync_remote_server_number_of_connections",
+      "title": "state_sync - Remote server number of connections exceeds 80",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum by (namespace, pod) (state_sync_remote_number_of_connections{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              80.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p3",
+      "observer_applicable": "true"
+    },
+    {
       "name": "state_sync_stuck",
       "title": "State Sync Stuck",
-      "ruleGroup": "state_sync",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "increase(apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}[120s])",
       "conditions": [
         {
@@ -2299,7 +2201,7 @@
     {
       "name": "state_sync_stuck_long_time",
       "title": "State Sync Stuck Long Time",
-      "ruleGroup": "state_sync",
+      "ruleGroup": "evaluation_rate_default",
       "expr": "increase(apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s])",
       "conditions": [
         {
@@ -2322,6 +2224,118 @@
       "for": "30s",
       "intervalSec": 30,
       "severity": "p2",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "sync_storage_open_read_transactions",
+      "title": "sync - High number of open read transactions",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "max_over_time(sync_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              7500.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p4",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "pod_state_not_ready",
+      "title": "Pod status Not Ready",
+      "ruleGroup": "evaluation_rate_high",
+      "expr": "sum by (service_name) (label_replace(kube_pod_container_status_ready{cluster=~\"$cluster\", namespace=~\"$namespace\"}, \"service_name\", \"$1\", \"pod\", \"^sequencer-(.+)-(?:deployment|statefulset)-[a-z0-9]+(?:-[a-z0-9]+)?$\"))",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.1
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "60s",
+      "intervalSec": 10,
+      "severity": "p2",
+      "observer_applicable": "false"
+    },
+    {
+      "name": "pod_state_critical_disk_utilization",
+      "title": "Pod Critical Disk Utilization ( >90% )",
+      "ruleGroup": "evaluation_rate_low",
+      "expr": "max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) / (min by (namespace,persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) + max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}))*100",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              90.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p2",
+      "observer_applicable": "true"
+    },
+    {
+      "name": "pod_state_high_disk_utilization",
+      "title": "Pod High Disk Utilization ( >70% )",
+      "ruleGroup": "evaluation_rate_low",
+      "expr": "max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) / (min by (namespace,persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) + max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}))*100",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              70.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "intervalSec": 30,
+      "severity": "p3",
       "observer_applicable": "true"
     }
   ]

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -106,10 +106,10 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
     Alerts,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -128,7 +128,7 @@ fn get_consensus_decisions_reached_by_consensus_ratio() -> Alert {
     Alert::new(
         "consensus_decisions_reached_by_consensus_ratio",
         "Consensus decisions reached by consensus ratio",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         // Clamp to avoid divide by 0.
         format!(
             "(sum(increase({consensus}[10m])) or vector(0)) / \
@@ -149,7 +149,7 @@ fn get_consensus_inbound_stream_evicted_alert() -> Alert {
     Alert::new(
         "consensus_inbound_stream_evicted",
         "Consensus inbound stream evicted",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             CONSENSUS_INBOUND_STREAM_EVICTED.get_name_with_filter()
@@ -166,7 +166,7 @@ fn get_consensus_inbound_peer_evicted_alert() -> Alert {
     Alert::new(
         "consensus_inbound_peer_evicted",
         "Consensus inbound peer evicted",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             CONSENSUS_INBOUND_PEER_EVICTED.get_name_with_filter()
@@ -183,7 +183,7 @@ fn get_consensus_inbound_stream_buffer_full_alert() -> Alert {
     Alert::new(
         "consensus_inbound_stream_buffer_full",
         "Consensus inbound stream buffer full",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             CONSENSUS_INBOUND_STREAM_BUFFER_FULL.get_name_with_filter()
@@ -200,7 +200,7 @@ fn get_consensus_votes_num_sent_messages_alert() -> Alert {
     Alert::new(
         "consensus_votes_num_sent_messages",
         "Consensus votes num sent messages",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[20m])) or vector(0)",
             CONSENSUS_VOTES_NUM_SENT_MESSAGES.get_name_with_filter()
@@ -217,7 +217,7 @@ fn get_cende_write_prev_height_blob_latency_too_high() -> Alert {
     Alert::new(
         "cende_write_prev_height_blob_latency_too_high",
         "Cende write prev height blob latency too high",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "(sum(rate({}[20m])) or vector(0)) / clamp_min(sum(rate({}[20m])) or vector(0), \
              0.0000001)",
@@ -236,7 +236,7 @@ fn get_consensus_l1_gas_price_provider_failure() -> Alert {
     Alert::new(
         "consensus_l1_gas_price_provider_failure",
         "Consensus L1 gas price provider failure",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR.get_name_with_filter()
@@ -253,7 +253,7 @@ fn get_consensus_l1_gas_price_provider_failure_once() -> Alert {
     Alert::new(
         "consensus_l1_gas_price_provider_failure_once",
         "Consensus L1 gas price provider failure once",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR.get_name_with_filter()
@@ -270,7 +270,7 @@ fn get_consensus_proposal_fin_mismatch_once() -> Alert {
     Alert::new(
         "consensus_proposal_fin_mismatch_once",
         "Consensus proposal fin mismatch occurred",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             CONSENSUS_PROPOSAL_FIN_MISMATCH.get_name_with_filter()
@@ -287,7 +287,7 @@ fn get_consensus_conflicting_votes() -> Alert {
     Alert::new(
         "consensus_conflicting_votes",
         "Consensus conflicting votes",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[20m])) or vector(0)",
             CONSENSUS_CONFLICTING_VOTES.get_name_with_filter()
@@ -305,7 +305,7 @@ fn get_consensus_retrospective_block_hash_mismatch() -> Alert {
     Alert::new(
         "consensus_retrospective_block_hash_mismatch",
         "Mismatched retrospective block hashes between the state sync and the batcher",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[5m])) or vector(0)",
             CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH.get_name_with_filter()
@@ -322,7 +322,7 @@ fn get_eth_to_strk_error_count_alert() -> Alert {
     Alert::new(
         "eth_to_strk_error_count",
         "Eth to Strk error count",
-        AlertGroup::L1GasPrice,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             ETH_TO_STRK_ERROR_COUNT.get_name_with_filter()
@@ -339,7 +339,7 @@ fn get_l1_gas_price_scraper_baselayer_error_count_alert() -> Alert {
     Alert::new(
         "l1_gas_price_scraper_baselayer_error_count",
         "L1 gas price scraper baselayer error count",
-        AlertGroup::L1GasPrice,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[5m])) or vector(0)",
             L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT.get_name_with_filter()
@@ -356,7 +356,7 @@ fn get_l1_gas_price_reorg_detected_alert() -> Alert {
     Alert::new(
         "l1_gas_price_scraper_reorg_detected",
         "L1 gas price scraper reorg detected",
-        AlertGroup::L1GasPrice,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1m])) or vector(0)",
             L1_GAS_PRICE_SCRAPER_REORG_DETECTED.get_name_with_filter()
@@ -373,7 +373,7 @@ fn get_l1_message_scraper_baselayer_error_count_alert() -> Alert {
     Alert::new(
         "l1_message_scraper_baselayer_error_count",
         "L1 message scraper baselayer error count",
-        AlertGroup::L1Messages,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT.get_name_with_filter()
@@ -390,7 +390,7 @@ fn get_l1_message_scraper_reorg_detected_alert() -> Alert {
     Alert::new(
         "l1_message_scraper_reorg_detected",
         "L1 message scraper reorg detected",
-        AlertGroup::L1Messages,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1m])) or vector(0)",
             L1_MESSAGE_SCRAPER_REORG_DETECTED.get_name_with_filter()
@@ -407,7 +407,7 @@ fn get_l1_events_provider_errors_alert() -> Alert {
     Alert::new(
         "batcher_l1_events_provider_errors",
         "Batcher L1 events provider errors",
-        AlertGroup::Batcher,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[10m])) or vector(0)",
             BATCHER_L1_EVENTS_PROVIDER_ERRORS.get_name_with_filter()
@@ -425,7 +425,7 @@ fn get_native_compilation_error_increase() -> Alert {
     Alert::new(
         "native_compilation_error",
         "Native compilation alert",
-        AlertGroup::Batcher,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             NATIVE_COMPILATION_ERROR.get_name_with_filter()
@@ -443,7 +443,7 @@ fn get_consensus_p2p_disconnections() -> Alert {
     Alert::new(
         "consensus_p2p_disconnections",
         "Consensus p2p disconnections",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             // TODO(shahak): find a way to make this depend on num_validators
             // Dividing by two since this counts both disconnections and reconnections
@@ -463,7 +463,7 @@ fn get_mempool_p2p_disconnections() -> Alert {
     Alert::new(
         "mempool_p2p_disconnections",
         "Mempool p2p disconnections",
-        AlertGroup::Mempool,
+        EvaluationRate::Default,
         format!(
             // TODO(shahak): find a way to make this depend on num_validators
             // Dividing by two since this counts both disconnections and reconnections
@@ -484,7 +484,7 @@ fn create_storage_open_read_transactions_alert(storage_type: &str, metric_name: 
     Alert::new(
         format!("{storage_type}_storage_open_read_transactions"),
         format!("{storage_type} - High number of open read transactions"),
-        AlertGroup::StateSync,
+        EvaluationRate::Default,
         format!("max_over_time({}[1m])", metric_name),
         vec![AlertCondition::new(
             AlertComparisonOp::GreaterThan,
@@ -523,7 +523,7 @@ fn get_gateway_proof_archive_write_failure() -> Alert {
     Alert::new(
         "gateway_proof_archive_write_failure",
         "Gateway proof archive (GCS) write failure",
-        AlertGroup::Gateway,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[1h])) or vector(0)",
             GATEWAY_PROOF_ARCHIVE_WRITE_FAILURE.get_name_with_filter()
@@ -543,7 +543,7 @@ fn get_staking_epoch_id_mismatch_alert() -> Alert {
     Alert::new(
         "staking_epoch_id_mismatch",
         "Staking epoch ID mismatch between nodes",
-        AlertGroup::Staking,
+        EvaluationRate::Default,
         format!(
             "max({epoch_id}) - min({epoch_id})",
             epoch_id = STAKING_CURRENT_EPOCH_ID.get_name_with_filter()
@@ -560,62 +560,62 @@ fn get_all_remote_server_connection_alerts() -> Vec<Alert> {
     vec![
         get_remote_server_number_of_connections_alert(
             "batcher",
-            AlertGroup::Batcher,
+            EvaluationRate::Default,
             BATCHER_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "class_manager",
-            AlertGroup::General,
+            EvaluationRate::Default,
             CLASS_MANAGER_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "committer",
-            AlertGroup::Consensus,
+            EvaluationRate::Default,
             COMMITTER_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "config_manager",
-            AlertGroup::General,
+            EvaluationRate::Default,
             CONFIG_MANAGER_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "gateway",
-            AlertGroup::Gateway,
+            EvaluationRate::Default,
             GATEWAY_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "l1_gas_price",
-            AlertGroup::L1GasPrice,
+            EvaluationRate::Default,
             L1_GAS_PRICE_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "l1_events",
-            AlertGroup::L1Messages,
+            EvaluationRate::Default,
             L1_EVENTS_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "mempool",
-            AlertGroup::Mempool,
+            EvaluationRate::Default,
             MEMPOOL_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "mempool_p2p",
-            AlertGroup::Mempool,
+            EvaluationRate::Default,
             MEMPOOL_P2P_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "sierra_compiler",
-            AlertGroup::Batcher,
+            EvaluationRate::Default,
             SIERRA_COMPILER_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "signature_manager",
-            AlertGroup::Consensus,
+            EvaluationRate::Default,
             SIGNATURE_MANAGER_INFRA_METRICS.get_remote_server_metrics(),
         ),
         get_remote_server_number_of_connections_alert(
             "state_sync",
-            AlertGroup::StateSync,
+            EvaluationRate::Default,
             STATE_SYNC_INFRA_METRICS.get_remote_server_metrics(),
         ),
     ]

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_delay.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_delay.rs
@@ -14,9 +14,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -27,7 +27,7 @@ pub(crate) fn get_consensus_round_above_zero() -> Alert {
     Alert::new(
         "consensus_round_above_zero",
         "Consensus round above zero",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!("increase({}[1h])", CONSENSUS_ROUND_ABOVE_ZERO.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
@@ -44,7 +44,7 @@ pub(crate) fn get_consensus_round_above_zero_multiple_times() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Consensus round above zero multiple times",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         ExpressionOrExpressionWithPlaceholder::Placeholder(
             Template::new(expr_template_string),
             vec![format_sampling_window(ALERT_NAME)],
@@ -66,7 +66,7 @@ pub(crate) fn get_cende_write_blob_failure_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Cende write blob failure",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!("increase({}[1h])", CENDE_WRITE_BLOB_FAILURE.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
@@ -81,7 +81,7 @@ pub(crate) fn get_consensus_p2p_peer_down() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Consensus p2p peer down",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!("max_over_time({}[2m])", CONSENSUS_NUM_CONNECTED_PEERS.get_name_with_filter()),
         vec![AlertCondition::new(
             AlertComparisonOp::LessThan,
@@ -100,7 +100,7 @@ pub(crate) fn get_cende_write_blob_failure_once_alert() -> Alert {
     Alert::new(
         "cende_write_blob_failure_once",
         "Cende write blob failure once",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!("increase({}[1h])", CENDE_WRITE_BLOB_FAILURE.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
@@ -115,7 +115,7 @@ pub(crate) fn consensus_block_number_progress_is_slow() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Consensus block number progress is slow",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[2m])) or vector(0)",
             CONSENSUS_BLOCK_NUMBER.get_name_with_filter()

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
@@ -16,9 +16,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -38,7 +38,7 @@ fn get_consensus_block_number_stuck(
     Alert::new(
         &name,
         title,
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         ExpressionOrExpressionWithPlaceholder::Placeholder(
             Template::new(expr_template_string),
             vec![format_sampling_window(&name)],
@@ -72,7 +72,7 @@ fn get_batched_transactions_stuck(title: &'static str) -> Alert {
     Alert::new(
         &name,
         title,
-        AlertGroup::Batcher,
+        EvaluationRate::Default,
         ExpressionOrExpressionWithPlaceholder::Placeholder(
             Template::new(expr_template_string),
             vec![format_sampling_window(&name)],
@@ -100,7 +100,7 @@ fn get_consensus_p2p_not_enough_peers_for_quorum(
     Alert::new(
         title.to_lowercase().replace(' ', "_"),
         title,
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!(
             "max_over_time({}[{}s])",
             CONSENSUS_NUM_CONNECTED_PEERS.get_name_with_filter(),
@@ -142,7 +142,7 @@ pub(crate) fn get_consensus_round_high() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Consensus round high",
-        AlertGroup::Consensus,
+        EvaluationRate::Default,
         format!("max_over_time({}[2m])", CONSENSUS_ROUND.get_name_with_filter()),
         vec![AlertCondition::new(
             AlertComparisonOp::GreaterThan,

--- a/crates/apollo_dashboard/src/alert_scenarios/config_manager.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/config_manager.rs
@@ -5,9 +5,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -18,7 +18,7 @@ pub(crate) fn get_config_manager_update_error_increase() -> Alert {
     Alert::new(
         "config_manager_update_error_increase",
         "Config manager update error increase",
-        AlertGroup::General,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[5m])) or vector(0)",
             CONFIG_MANAGER_UPDATE_ERRORS.get_name_with_filter()

--- a/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
@@ -5,9 +5,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -30,7 +30,7 @@ pub(crate) fn get_general_pod_state_not_ready() -> Alert {
     Alert::new(
         "pod_state_not_ready",
         "Pod status Not Ready",
-        AlertGroup::General,
+        EvaluationRate::High,
         // kube_pod_container_status_ready value is 0 if the container is 'not ready', and 1
         // if the container is 'ready'. We replace the pod name with 'service_name' to group by the
         // service name using the label_replace function and the regex pattern. Summing across all
@@ -58,7 +58,7 @@ pub(crate) fn get_general_pod_state_crashloopbackoff() -> Alert {
     Alert::new(
         "pod_state_crashloopbackoff",
         "Pod status CrashLoopBackOff",
-        AlertGroup::General,
+        EvaluationRate::Default,
         format!(
             // Convert "NoData" to 0 using `absent`.
             "sum by(container, pod, namespace) ({}) or absent({}) * 0",
@@ -84,7 +84,7 @@ fn get_general_pod_memory_utilization(
     Alert::new(
         name,
         title,
-        AlertGroup::General,
+        EvaluationRate::Default,
         format!(
             // Calculates the memory usage percentage of each container in a pod, relative to its
             // memory limit. This expression compares the actual memory usage
@@ -127,7 +127,7 @@ pub(crate) fn get_general_pod_high_cpu_utilization() -> Alert {
     Alert::new(
         "pod_high_cpu_utilization",
         "Pod High CPU Utilization ( >90% )",
-        AlertGroup::General,
+        EvaluationRate::Default,
         format!(
             // Calculates CPU usage rate over 2 minutes per container, compared to its defined CPU
             // quota. Showing CPU pressure.
@@ -153,7 +153,7 @@ fn get_general_pod_disk_utilization(
     Alert::new(
         name,
         title,
-        AlertGroup::General,
+        EvaluationRate::Low,
         format!(
             "max by (namespace,persistentvolumeclaim) ({}) / (min by \
              (namespace,persistentvolumeclaim) ({}) + max by (namespace,persistentvolumeclaim) \
@@ -195,7 +195,7 @@ pub(crate) fn get_periodic_ping() -> Alert {
     Alert::new(
         "periodic_ping",
         "Periodic Ping",
-        AlertGroup::General,
+        EvaluationRate::Default,
         // Checks if the UTC time is 7:55 AM on Sunday.
         "(day_of_week() == bool 0) * (hour() == bool 7) * (minute() == bool 55)",
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -10,8 +10,8 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -23,7 +23,7 @@ pub(crate) fn get_eth_to_strk_success_count_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Eth to Strk success count",
-        AlertGroup::L1GasPrice,
+        EvaluationRate::Default,
         format!("increase({}[1h])", ETH_TO_STRK_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
@@ -39,7 +39,7 @@ pub(crate) fn get_l1_gas_price_scraper_success_count_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "L1 gas price scraper success count",
-        AlertGroup::L1GasPrice,
+        EvaluationRate::Default,
         format!("increase({}[1h])", L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
@@ -54,7 +54,7 @@ pub(crate) fn get_l1_gas_price_provider_insufficient_history_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "L1 gas price provider insufficient history",
-        AlertGroup::L1GasPrice,
+        EvaluationRate::Default,
         format!(
             "increase({}[1m])",
             L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY.get_name_with_filter()

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
@@ -6,8 +6,8 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -18,7 +18,7 @@ pub(crate) fn get_l1_message_scraper_no_successes_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "L1 message no successes",
-        AlertGroup::L1GasPrice,
+        EvaluationRate::Default,
         format!("increase({}[5m])", L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,

--- a/crates/apollo_dashboard/src/alert_scenarios/mempool_size.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/mempool_size.rs
@@ -11,8 +11,8 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -23,7 +23,7 @@ pub(crate) fn get_mempool_pool_size_increase() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Mempool pool size increase",
-        AlertGroup::Mempool,
+        EvaluationRate::Default,
         MEMPOOL_POOL_SIZE.get_name_with_filter().to_string(),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10000.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
@@ -44,7 +44,7 @@ pub(crate) fn get_mempool_evictions_count_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Mempool evictions count",
-        AlertGroup::Mempool,
+        EvaluationRate::Default,
         query_expr,
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,

--- a/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
@@ -6,8 +6,8 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -19,7 +19,7 @@ pub(crate) fn get_preconfirmed_block_not_written() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Preconfirmed block not written",
-        AlertGroup::Batcher,
+        EvaluationRate::Default,
         format!("increase({}[2m])", PRECONFIRMED_BLOCK_WRITTEN.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,

--- a/crates/apollo_dashboard/src/alert_scenarios/remote_server_connections.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/remote_server_connections.rs
@@ -5,9 +5,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -17,7 +17,7 @@ const MAX_CONNECTIONS: f64 = 80.0;
 
 pub(crate) fn get_remote_server_number_of_connections_alert(
     component_name: &str,
-    alert_group: AlertGroup,
+    alert_group: EvaluationRate,
     metrics: &RemoteServerMetrics,
 ) -> Alert {
     Alert::new(

--- a/crates/apollo_dashboard/src/alert_scenarios/sync_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/sync_halt.rs
@@ -11,9 +11,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -25,7 +25,7 @@ pub(crate) fn get_state_sync_lag() -> Alert {
     Alert::new(
         ALERT_NAME,
         "State sync lag",
-        AlertGroup::StateSync,
+        EvaluationRate::Default,
         format!(
             "{} - {}",
             CENTRAL_SYNC_CENTRAL_BLOCK_MARKER.get_name_with_filter(),
@@ -47,7 +47,7 @@ fn get_state_sync_stuck(
     Alert::new(
         alert_name.to_lowercase().replace(' ', "_"),
         alert_name,
-        AlertGroup::StateSync,
+        EvaluationRate::Default,
         format!(
             "increase({}[{}s])",
             STATE_SYNC_CLASS_MANAGER_MARKER.get_name_with_filter(),

--- a/crates/apollo_dashboard/src/alert_scenarios/tps.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/tps.rs
@@ -16,9 +16,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -27,7 +27,7 @@ use crate::alerts::{
 fn build_idle_alert(
     alert_name: &str,
     alert_title: &str,
-    alert_group: AlertGroup,
+    alert_group: EvaluationRate,
     metric_name_with_filter: &str,
     alert_severity: AlertSeverity,
 ) -> Alert {
@@ -53,7 +53,7 @@ pub(crate) fn get_http_server_no_successful_transactions() -> Alert {
     build_idle_alert(
         "http_server_no_successful_transactions",
         "http server no successful transactions",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         &ADDED_TRANSACTIONS_SUCCESS.get_name_with_filter(),
         AlertSeverity::Informational,
     )
@@ -63,7 +63,7 @@ pub(crate) fn get_gateway_add_tx_idle() -> Alert {
     build_idle_alert(
         "gateway_add_tx_idle_p2p_rpc",
         "Gateway add_tx idle (p2p+rpc)",
-        AlertGroup::Gateway,
+        EvaluationRate::Default,
         &GATEWAY_TRANSACTIONS_RECEIVED.get_name_with_filter(),
         AlertSeverity::Regular,
     )
@@ -73,7 +73,7 @@ pub(crate) fn get_mempool_add_tx_idle() -> Alert {
     build_idle_alert(
         "mempool_add_tx_idle_p2p_rpc",
         "Mempool add_tx idle (p2p+rpc)",
-        AlertGroup::Mempool,
+        EvaluationRate::Default,
         &MEMPOOL_TRANSACTIONS_RECEIVED.get_name_with_filter(),
         AlertSeverity::Sos,
     )
@@ -84,7 +84,7 @@ pub(crate) fn get_gateway_low_successful_transaction_rate() -> Alert {
     Alert::new(
         ALERT_NAME,
         "gateway low successful transaction rate",
-        AlertGroup::Gateway,
+        EvaluationRate::Default,
         format!(
             "sum(increase({}[10m])) or vector(0)",
             GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL.get_name_with_filter()

--- a/crates/apollo_dashboard/src/alert_scenarios/transaction_delays.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/transaction_delays.rs
@@ -15,8 +15,8 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -29,7 +29,7 @@ pub(crate) fn get_mempool_p2p_peer_down() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Mempool p2p peer down",
-        AlertGroup::Mempool,
+        EvaluationRate::Default,
         format!("max_over_time({}[2m])", MEMPOOL_P2P_NUM_CONNECTED_PEERS.get_name_with_filter()),
         vec![AlertCondition::new(
             AlertComparisonOp::LessThan,
@@ -54,7 +54,7 @@ pub(crate) fn get_http_server_avg_add_tx_latency_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "High HTTP server average add_tx latency",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         // The clamp_min is used to avoid division by zero, and the minimal value
         // is 1/300, which is the minimum value of a valid count rate over a 5-minute window.
         format!("rate({sum_metric}[5m]) / clamp_min(rate({count_metric}[5m]), 1/300)"),
@@ -77,7 +77,7 @@ pub(crate) fn get_http_server_min_add_tx_latency_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "High HTTP server minimal add_tx latency",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         // The lhs expr checks that there were transaction observations during the time window.
         // The rhs expr verifies that none of these observations had a latency of 1 second or less
         // (i.e., the le="1.0" bucket is empty).
@@ -101,7 +101,7 @@ pub(crate) fn get_http_server_p95_add_tx_latency_alert() -> Alert {
     Alert::new(
         "http_server_p95_add_tx_latency",
         "High HTTP server P95 add_tx latency",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         format!(
             "histogram_quantile(0.95, sum(rate({}[5m])) by (le))",
             HTTP_SERVER_ADD_TX_LATENCY.get_name_with_filter()
@@ -130,7 +130,7 @@ pub(crate) fn get_high_empty_blocks_ratio_alert() -> Alert {
     Alert::new(
         ALERT_NAME,
         "High ratio of empty blocks",
-        AlertGroup::Batcher,
+        EvaluationRate::Default,
         ExpressionOrExpressionWithPlaceholder::Placeholder(
             Template::new(expr_template_string),
             vec![

--- a/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
@@ -12,9 +12,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
     EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
@@ -26,7 +26,7 @@ pub(crate) fn get_http_server_high_deprecated_transaction_failure_ratio() -> Ale
     Alert::new(
         "http_server_high_deprecated_transaction_failure_ratio",
         "http server high deprecated transaction failure ratio",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         format!(
             "increase({}[1h]) / clamp_min(increase({}[1h]), 1)",
             ADDED_TRANSACTIONS_DEPRECATED_ERROR.get_name_with_filter(),
@@ -44,7 +44,7 @@ pub(crate) fn get_http_server_high_transaction_failure_ratio() -> Alert {
     Alert::new(
         "http_server_high_transaction_failure_ratio",
         "http server high transaction failure ratio",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         format!(
             "(increase({}[1h]) - increase({}[1h])) / clamp_min(increase({}[1h]), 1)",
             ADDED_TRANSACTIONS_FAILURE.get_name_with_filter(),
@@ -64,7 +64,7 @@ pub(crate) fn get_http_server_internal_error_ratio() -> Alert {
     Alert::new(
         ALERT_NAME,
         "http server internal error ratio",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         format!(
             "increase({}[1h]) / clamp_min(increase({}[1h]), 1)",
             ADDED_TRANSACTIONS_INTERNAL_ERROR.get_name_with_filter(),
@@ -83,7 +83,7 @@ pub(crate) fn get_mempool_transaction_drop_ratio() -> Alert {
     Alert::new(
         ALERT_NAME,
         "Mempool transaction drop ratio",
-        AlertGroup::Mempool,
+        EvaluationRate::Default,
         format!(
             "increase({}[10m]) / clamp_min(increase({}[10m]), 1)",
             MEMPOOL_TRANSACTIONS_DROPPED.get_name_with_filter(),
@@ -106,7 +106,7 @@ pub(crate) fn get_http_server_internal_error_once() -> Alert {
     Alert::new(
         "http_server_internal_error_once",
         "http server internal error once",
-        AlertGroup::HttpServer,
+        EvaluationRate::Default,
         format!(
             "increase({}[20m]) or vector(0)",
             ADDED_TRANSACTIONS_INTERNAL_ERROR.get_name_with_filter()

--- a/crates/apollo_dashboard/src/alerts.rs
+++ b/crates/apollo_dashboard/src/alerts.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
+use strum::{EnumIter, IntoEnumIterator};
 
 use crate::alert_placeholders::{
     ComparisonValueOrPlaceholder,
@@ -14,7 +15,7 @@ pub(crate) const EVALUATION_INTERVAL_SEC_DEFAULT: u64 = 30;
 pub(crate) const SECS_IN_MIN: u64 = 60;
 
 /// Alerts to be configured in the dashboard.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct Alerts {
     alerts: Vec<Alert>,
 }
@@ -39,7 +40,34 @@ impl Alerts {
                 panic!("Duplicate placeholder name found across alerts: {duplicate}")
             });
 
+        // Sort alerts lexicographically by name within each group so the JSON output is stable.
+        let mut alerts = alerts;
+        alerts.sort_by(|a, b| a.alert_group.cmp(&b.alert_group).then(a.name.cmp(&b.name)));
+
         Self { alerts }
+    }
+}
+
+impl Serialize for Alerts {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[derive(Serialize)]
+        struct GroupDef {
+            name: EvaluationRate,
+            #[serde(rename = "intervalSec")]
+            interval_sec: u64,
+        }
+        impl GroupDef {
+            fn new(rate: EvaluationRate) -> Self {
+                Self { interval_sec: rate.interval_sec(), name: rate }
+            }
+        }
+
+        let groups: Vec<GroupDef> = EvaluationRate::iter().map(GroupDef::new).collect();
+
+        let mut state = serializer.serialize_struct("Alerts", 2)?;
+        state.serialize_field("groups", &groups)?;
+        state.serialize_field("alerts", &self.alerts)?;
+        state.end()
     }
 }
 
@@ -152,19 +180,33 @@ impl Serialize for AlertCondition {
     }
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum AlertGroup {
-    Batcher,
-    Consensus,
-    Gateway,
-    General,
-    HttpServer,
-    L1GasPrice,
-    L1Messages,
-    Mempool,
-    Staking,
-    StateSync,
+/// Determines which Grafana rule group an alert belongs to, which controls its evaluation
+/// rate — the cadence at which Grafana checks the alert condition.
+///
+/// Variants are ordered alphabetically by their serialized name so that deriving `Ord` produces
+/// the same stable sort used when grouping alerts in the JSON output.
+#[derive(Debug, EnumIter, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub(crate) enum EvaluationRate {
+    /// Evaluated every 30 seconds. The default cadence for most production alerts.
+    #[serde(rename = "evaluation_rate_default")]
+    Default,
+    /// Evaluated every 10 seconds. For critical infrastructure state that must be detected
+    /// near-immediately (e.g., pod readiness).
+    #[serde(rename = "evaluation_rate_high")]
+    High,
+    /// Evaluated every 60 seconds. Reserved for low-urgency background checks.
+    #[serde(rename = "evaluation_rate_low")]
+    Low,
+}
+
+impl EvaluationRate {
+    pub(crate) fn interval_sec(&self) -> u64 {
+        match self {
+            Self::High => 10,
+            Self::Default => 30,
+            Self::Low => 60,
+        }
+    }
 }
 
 /// Describes the properties of an alert defined in grafana.
@@ -174,9 +216,9 @@ pub(crate) struct Alert {
     name: String,
     // The title that will be displayed.
     title: String,
-    // The group that the alert will be displayed under.
+    // The evaluation group this alert belongs to, which sets its check interval.
     #[serde(rename = "ruleGroup")]
-    alert_group: AlertGroup,
+    alert_group: EvaluationRate,
     // The expression to evaluate for the alert.
     expr: ExpressionOrExpressionWithPlaceholder,
     // The conditions that must be met for the alert to be triggered.
@@ -218,7 +260,7 @@ impl Alert {
     pub(crate) fn new(
         name: impl ToString,
         title: impl ToString,
-        alert_group: AlertGroup,
+        alert_group: EvaluationRate,
         expr: impl Into<ExpressionOrExpressionWithPlaceholder>,
         conditions: Vec<AlertCondition>,
         pending_duration: impl ToString,

--- a/crates/apollo_dashboard/src/dashboard_test.rs
+++ b/crates/apollo_dashboard/src/dashboard_test.rs
@@ -5,9 +5,9 @@ use crate::alerts::{
     Alert,
     AlertComparisonOp,
     AlertCondition,
-    AlertGroup,
     AlertLogicalOp,
     AlertSeverity,
+    EvaluationRate,
     ObserverApplicability,
 };
 use crate::panel::{Panel, PanelType, ThresholdMode, ThresholdStep, Thresholds, Unit};
@@ -17,7 +17,7 @@ fn serialize_alert() {
     let alert = Alert::new(
         "Name",
         "Message",
-        AlertGroup::Batcher,
+        EvaluationRate::Default,
         "max".to_string(),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         "5m",
@@ -30,7 +30,7 @@ fn serialize_alert() {
     let expected = serde_json::json!({
         "name": "Name",
         "title": "Message",
-        "ruleGroup": "batcher",
+        "ruleGroup": "evaluation_rate_default",
         "expr": "max",
         "conditions": [
             {

--- a/deployments/monitoring/src/builders/alert_builder.py
+++ b/deployments/monitoring/src/builders/alert_builder.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import collections
 import json
 import os
 import sys
@@ -20,12 +21,6 @@ from common.grafana10_objects import (
 )
 from common.logger import get_logger
 from grafana_client import GrafanaApi
-from grafana_client.client import (
-    GrafanaBadInputError,
-    GrafanaClientError,
-    GrafanaException,
-    GrafanaServerError,
-)
 from tenacity import before_sleep_log, retry, stop_after_attempt, wait_fixed
 
 # Global logger (initialized in alert_builder function)
@@ -69,7 +64,6 @@ def create_alert_rule(
     title: str,
     folder_uid: str,
     rule_group: str,
-    interval_sec: int,
     _for: str,
     expr: str,
     conditions: list[dict[str, any]],
@@ -82,7 +76,6 @@ def create_alert_rule(
     alert_rule["title"] = title
     alert_rule["folderUID"] = folder_uid
     alert_rule["ruleGroup"] = rule_group
-    alert_rule["intervalSec"] = interval_sec
     alert_rule["for"] = _for
     alert_rule["labels"] = labels
     alert_rule["data"] = [
@@ -98,6 +91,10 @@ def create_alert_rule(
     ]
     logger.debug(f"Alert rule created: {alert_rule}")
     return alert_rule
+
+
+def create_rule_group(name: str, interval_sec: int, rules: list[dict[str, any]]) -> dict[str, any]:
+    return {"name": name, "interval": interval_sec, "rules": rules}
 
 
 def get_all_folders(client: GrafanaApi) -> list[dict[str, any]]:
@@ -128,25 +125,14 @@ def create_folder_return_uid(client: GrafanaApi, title: str) -> str:
         return folder["uid"]
 
 
-def dump_alert(output_dir: str, alert: dict[str, any]) -> None:
-    alert_full_path = f"{output_dir}/{alert['name']}.json".lower().replace(" ", "_")
+def dump_rule_group(output_dir: str, rule_group: dict[str, any]) -> None:
+    group_full_path = f"{output_dir}/{rule_group['name']}.json".lower().replace(" ", "_")
     os.makedirs(output_dir, exist_ok=True)
-    ordered = {"title": alert["title"], **{k: v for k, v in alert.items() if k != "title"}}
-    with open(alert_full_path, "w") as f:
-        json.dump(ordered, f, indent=2)
-    # Format with professional colors: Alert (white bold), name (cyan), saved to (white bold), path (dim cyan)
+    with open(group_full_path, "w") as f:
+        json.dump(rule_group, f, indent=2)
     logger.info(
-        f'[bold white]Alert[/bold white] "[blue]{alert["name"]}[/blue]" [bold white]saved to[/bold white] [dim white]{alert_full_path}[/dim white]'
+        f'[bold white]Rule group[/bold white] "[blue]{rule_group["name"]}[/blue]" [bold white]saved to[/bold white] [dim white]{group_full_path}[/dim white]'
     )
-
-
-def get_alert_rule_group(client: GrafanaApi, folder_uid: str, group_uid: str) -> str:
-    logger.debug(f'Getting alert rule group "{group_uid}"')
-    rule_group = client.alertingprovisioning.get_rule_group(
-        folder_uid=folder_uid, group_uid=group_uid
-    )
-    logger.debug(f"Got alert group: {rule_group}")
-    return rule_group
 
 
 @retry(
@@ -296,7 +282,10 @@ def alert_builder(args: argparse.Namespace):
         # Exit cleanly without traceback
         sys.exit(1)
 
-    alerts = []
+    interval_sec = dev_alerts["intervalSec"]
+
+    # group_name -> list of alert rules (preserving insertion order within each group)
+    groups: dict[str, list[dict[str, any]]] = collections.defaultdict(list)
 
     for dev_alert in dev_alerts["alerts"]:
         # Apply config overrides to replace placeholders
@@ -315,13 +304,14 @@ def alert_builder(args: argparse.Namespace):
             )
         else:
             expr = remove_expr_placeholder(expr=dev_alert["expr"])
-        alerts.append(
+
+        group_name = dev_alert["ruleGroup"]
+        groups[group_name].append(
             create_alert_rule(
                 name=dev_alert["name"],
                 title=dev_alert["title"],
                 folder_uid=folder_uid,
-                interval_sec=dev_alert["intervalSec"],
-                rule_group=dev_alert["ruleGroup"],
+                rule_group=group_name,
                 _for=dev_alert["for"],
                 expr=expr,
                 conditions=dev_alert["conditions"],
@@ -333,66 +323,31 @@ def alert_builder(args: argparse.Namespace):
             )
         )
 
-    alerts.sort(key=lambda a: a["title"])
+    rule_groups = [
+        create_rule_group(
+            name=group_name,
+            interval_sec=interval_sec,
+            rules=sorted(rules, key=lambda a: a["name"]),
+        )
+        for group_name, rules in sorted(groups.items())
+    ]
 
-    for alert in alerts:
+    for rule_group in rule_groups:
         if args.debug:
-            logger.debug(json.dumps(alert))
+            logger.debug(json.dumps(rule_group))
         if not args.dry_run:
-            alert_created_or_exists = False
             try:
-                client.alertingprovisioning.create_alertrule(
-                    alertrule=alert,
-                    disable_provenance=True,
-                )
-                logger.info(f'Alert "{alert["name"]}" uploaded to Grafana successfully')
-                alert_created_or_exists = True
-
-            except GrafanaBadInputError as e:
-                if "alerting.alert-rule.conflict" in e.message:
-                    logger.info(f'Alert "{alert["name"]}" already exists. Skipping creation.')
-                    alert_created_or_exists = True
-                else:
-                    # Handle other bad input errors
-                    logger.error(
-                        f'Failed to create alert "{alert["name"]}". Bad input: {e.message}'
-                    )
-            except GrafanaClientError as e:
-                # Handle other client-side errors (e.g., invalid request)
-                logger.error(f'Failed to create alert "{alert["name"]}". Client error: {e.message}')
-            except GrafanaServerError as e:
-                # Handle server-side errors (5xx errors)
-                logger.error(f'Failed to create alert "{alert["name"]}". Server error: {e.message}')
-            except GrafanaException as e:
-                # Catch any other Grafana-related exceptions
-                logger.error(
-                    f'Failed to create alert "{alert["name"]}". Grafana error: {e.message}'
+                update_alert_rule_group(
+                    client=client,
+                    folder_uid=folder_uid,
+                    group_uid=rule_group["name"],
+                    alertrule_group=rule_group,
                 )
             except Exception as e:
-                # Catch any other exceptions (non-Grafana-related)
-                logger.error(f'Failed to create alert "{alert["name"]}". Unexpected error: {e}')
-
-            # Only update rule group interval if alert was successfully created or already exists
-            if alert_created_or_exists:
-                try:
-                    group_uid = alert["ruleGroup"]
-                    rule_group = get_alert_rule_group(
-                        client=client, folder_uid=folder_uid, group_uid=group_uid
-                    )
-                    if rule_group["interval"] != alert["intervalSec"]:
-                        rule_group["interval"] = alert["intervalSec"]
-                        update_alert_rule_group(
-                            client=client,
-                            folder_uid=folder_uid,
-                            group_uid=group_uid,
-                            alertrule_group=rule_group,
-                        )
-                        logger.info(f'Alert rule group "{group_uid}" updated successfully')
-                except Exception as e:
-                    logger.error(f'Failed to update alert rule group "{alert["ruleGroup"]}". {e}')
+                logger.error(f'Failed to update rule group "{rule_group["name"]}". {e}')
 
         if args.out_dir:
             output_dir = f"{args.out_dir}/alerts"
-            dump_alert(output_dir=output_dir, alert=alert)
+            dump_rule_group(output_dir=output_dir, rule_group=rule_group)
 
     logger.info("Done building grafana alerts")

--- a/deployments/sequencer/src/constructs/grafana.py
+++ b/deployments/sequencer/src/constructs/grafana.py
@@ -105,10 +105,7 @@ class GrafanaAlertRuleGroupConstruct(GrafanaBaseConstruct):
         super().__init__(scope, id, cluster, namespace)
 
         self.grafana_alert_group = grafana_alert_rule_group
-        self.grafana_alert_files = self.grafana_alert_group.get_alert_files()
-        self.hash_value = generate_random_hash(from_string=f"{self.cluster}-{self.namespace}")
-        self.custom_name = f"{self.namespace}-arg-{self.hash_value}"
-        self._get_shared_grafana_alert_rule_group()
+        self._create_alert_rule_group_crds()
 
     def _exec_err_state_enum_selector(self, exec_err_state: str) -> Optional[str]:
         """Convert string to ExecErrState enum."""
@@ -167,33 +164,30 @@ class GrafanaAlertRuleGroupConstruct(GrafanaBaseConstruct):
             ],
         )
 
-    def _get_shared_grafana_alert_rule_group_spec(self):
-        """Build the spec for the alert rule group."""
-        loaded_alert_rules = [
-            self.grafana_alert_group.load(str(alert_file))
-            for alert_file in self.grafana_alert_files
-        ]
-        # Keep rule order deterministic so generated YAML has stable PR diffs.
-        loaded_alert_rules.sort(key=lambda rule: rule["title"].lower())
-        rules = [
-            self._get_shared_grafana_alert_rule_group_rules(alert_rule)
-            for alert_rule in loaded_alert_rules
-        ]
+    def _create_alert_rule_group_crds(self):
+        """Create one SharedGrafanaAlertRuleGroup CRD per rule group."""
+        for group_file in sorted(self.grafana_alert_group.get_alert_files()):
+            group_data = self.grafana_alert_group.load(str(group_file))
+            group_name = group_data["name"]
+            interval_sec = group_data["interval"]
+            # Keep rule order deterministic so generated YAML has stable PR diffs.
+            rules_data = sorted(group_data["rules"], key=lambda rule: rule["name"])
 
-        return SharedGrafanaAlertRuleGroupSpec(
-            name=self.custom_name,
-            instance_selector=SharedGrafanaAlertRuleGroupSpecInstanceSelector(),
-            interval="1m",
-            editable=False,
-            folder_ref=self.cluster,
-            rules=rules,
-        )
+            k8s_group_name = group_name.replace("_", "-")
+            custom_name = f"{self.namespace}-arg-{k8s_group_name}"
 
-    def _get_shared_grafana_alert_rule_group(self):
-        """Create the SharedGrafanaAlertRuleGroup resource."""
-        return SharedGrafanaAlertRuleGroup(
-            self,
-            self.node.id,
-            metadata=self._get_api_object_metadata(name=self.custom_name),
-            spec=self._get_shared_grafana_alert_rule_group_spec(),
-        )
+            rules = [self._get_shared_grafana_alert_rule_group_rules(rule) for rule in rules_data]
+            spec = SharedGrafanaAlertRuleGroupSpec(
+                name=custom_name,
+                instance_selector=SharedGrafanaAlertRuleGroupSpecInstanceSelector(),
+                interval=f"{interval_sec}s",
+                editable=False,
+                folder_ref=self.cluster,
+                rules=rules,
+            )
+            SharedGrafanaAlertRuleGroup(
+                self,
+                custom_name,
+                metadata=self._get_api_object_metadata(name=custom_name),
+                spec=spec,
+            )


### PR DESCRIPTION
Move the evaluation interval from a per-alert field to a top-level field
on the Alerts struct. The interval is group-scoped in Grafana, so a single
value for all alerts is the correct model.

Also restructure alert_builder.py to upload/dump per rule-group instead of
per individual alert, using the top-level intervalSec as the group interval.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the alert JSON schema and the provisioning/deployment flow (grouped updates and per-group CRDs), which could alter alert evaluation cadence or cause missing/duplicated rules if grouping or intervals are misapplied.
> 
> **Overview**
> Updates the generated `dev_grafana_alerts.json` schema to include top-level `groups` (with per-group evaluation intervals) and moves alerts into these rule groups (`evaluation_rate_high/default/low`), along with various severity/observer applicability tweaks driven by the regrouping.
> 
> Replaces `AlertGroup` with `EvaluationRate` in the Rust alert definitions, adds deterministic sorting, and changes `Alerts` serialization to emit the new `groups + alerts` structure.
> 
> Refactors `alert_builder.py` and the sequencer Grafana construct to provision alerts **per rule group** (one group file/CRD per group) and to set the rule-group interval once, rather than per alert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c5d81d44ff11a6d8be544ffd52879cbe18724f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->