### PR TITLE
apollo_dashboard: remove per-alert intervalSec field

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -38,7 +38,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$batched_transactions_stuck-severity$$$",
       "observer_applicable": "false"
     },
@@ -66,7 +65,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$batched_transactions_stuck_long_time-severity$$$",
       "observer_applicable": "false"
     },
@@ -94,7 +92,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -122,7 +119,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -150,7 +146,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -178,7 +173,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$cende_write_blob_failure-severity$$$",
       "observer_applicable": "false"
     },
@@ -206,7 +200,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -234,7 +227,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -262,7 +254,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -290,7 +281,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -318,7 +308,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -346,7 +335,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -374,7 +362,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "false"
     },
@@ -402,7 +389,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$consensus_block_number_progress_is_slow-severity$$$",
       "observer_applicable": "true"
     },
@@ -430,7 +416,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$consensus_block_number_stuck-severity$$$",
       "observer_applicable": "false"
     },
@@ -458,7 +443,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "false"
     },
@@ -486,7 +470,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -514,7 +497,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -542,7 +524,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -570,7 +551,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -598,7 +578,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -626,7 +605,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -654,7 +632,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -682,7 +659,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "true"
     },
@@ -710,7 +686,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$consensus_p2p_not_enough_peers_for_quorum-severity$$$",
       "observer_applicable": "true"
     },
@@ -738,7 +713,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -766,7 +740,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$consensus_p2p_peer_down-severity$$$",
       "observer_applicable": "true"
     },
@@ -794,7 +767,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -822,7 +794,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p1",
       "observer_applicable": "true"
     },
@@ -850,7 +821,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -878,7 +848,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$consensus_round_above_zero_multiple_times-severity$$$",
       "observer_applicable": "false"
     },
@@ -906,7 +875,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$consensus_round_high-severity$$$",
       "observer_applicable": "false"
     },
@@ -934,7 +902,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -962,7 +929,6 @@
         }
       ],
       "for": "1m",
-      "intervalSec": 20,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -990,7 +956,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$eth_to_strk_success_count-severity$$$",
       "observer_applicable": "false"
     },
@@ -1018,7 +983,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "false"
     },
@@ -1046,7 +1010,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$gateway_low_successful_transaction_rate-severity$$$",
       "observer_applicable": "false"
     },
@@ -1074,7 +1037,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -1102,7 +1064,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -1130,7 +1091,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$high_empty_blocks_ratio-severity$$$",
       "observer_applicable": "false"
     },
@@ -1158,7 +1118,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$http_server_avg_add_tx_latency-severity$$$",
       "observer_applicable": "false"
     },
@@ -1186,7 +1145,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -1214,7 +1172,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -1242,7 +1199,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -1270,7 +1226,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$http_server_internal_error_ratio-severity$$$",
       "observer_applicable": "false"
     },
@@ -1298,7 +1253,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$http_server_min_add_tx_latency-severity$$$",
       "observer_applicable": "false"
     },
@@ -1326,7 +1280,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -1354,7 +1307,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -1382,7 +1334,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -1410,7 +1361,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$l1_gas_price_provider_insufficient_history-severity$$$",
       "observer_applicable": "false"
     },
@@ -1438,7 +1388,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -1466,7 +1415,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -1494,7 +1442,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -1522,7 +1469,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$l1_gas_price_scraper_success_count-severity$$$",
       "observer_applicable": "false"
     },
@@ -1550,7 +1496,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$l1_message_no_successes-severity$$$",
       "observer_applicable": "false"
     },
@@ -1578,7 +1523,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p5",
       "observer_applicable": "false"
     },
@@ -1606,7 +1550,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p1",
       "observer_applicable": "false"
     },
@@ -1634,7 +1577,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p1",
       "observer_applicable": "false"
     },
@@ -1662,7 +1604,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$mempool_evictions_count-severity$$$",
       "observer_applicable": "false"
     },
@@ -1690,7 +1631,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -1718,7 +1658,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$mempool_p2p_peer_down-severity$$$",
       "observer_applicable": "false"
     },
@@ -1746,7 +1685,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -1774,7 +1712,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$mempool_pool_size_increase-severity$$$",
       "observer_applicable": "false"
     },
@@ -1802,7 +1739,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -1830,7 +1766,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$mempool_transaction_drop_ratio-severity$$$",
       "observer_applicable": "false"
     },
@@ -1858,7 +1793,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -1886,7 +1820,6 @@
         }
       ],
       "for": "0s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -1914,7 +1847,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -1942,7 +1874,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -1970,7 +1901,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -1998,7 +1928,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -2026,7 +1955,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$preconfirmed_block_not_written-severity$$$",
       "observer_applicable": "false"
     },
@@ -2054,7 +1982,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -2082,7 +2009,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -2110,7 +2036,6 @@
         }
       ],
       "for": "5m",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "false"
     },
@@ -2138,7 +2063,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "$$$state_sync_lag-severity$$$",
       "observer_applicable": "false"
     },
@@ -2166,7 +2090,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     },
@@ -2194,7 +2117,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -2222,7 +2144,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -2250,7 +2171,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p4",
       "observer_applicable": "false"
     },
@@ -2278,7 +2198,6 @@
         }
       ],
       "for": "60s",
-      "intervalSec": 10,
       "severity": "p2",
       "observer_applicable": "false"
     },
@@ -2306,7 +2225,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p2",
       "observer_applicable": "true"
     },
@@ -2334,7 +2252,6 @@
         }
       ],
       "for": "30s",
-      "intervalSec": 30,
       "severity": "p3",
       "observer_applicable": "true"
     }

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -111,7 +111,6 @@ use crate::alerts::{
     Alerts,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -139,7 +138,6 @@ fn get_consensus_decisions_reached_by_consensus_ratio() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 0.5, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -156,7 +154,6 @@ fn get_consensus_inbound_stream_evicted_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 5.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -173,7 +170,6 @@ fn get_consensus_inbound_peer_evicted_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 5.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -190,7 +186,6 @@ fn get_consensus_inbound_stream_buffer_full_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -207,7 +202,6 @@ fn get_consensus_votes_num_sent_messages_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 20.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -226,7 +220,6 @@ fn get_cende_write_prev_height_blob_latency_too_high() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 3.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -243,7 +236,6 @@ fn get_consensus_l1_gas_price_provider_failure() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 5.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -260,7 +252,6 @@ fn get_consensus_l1_gas_price_provider_failure_once() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -277,7 +268,6 @@ fn get_consensus_proposal_fin_mismatch_once() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -294,7 +284,6 @@ fn get_consensus_conflicting_votes() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         // TODO(matan): Increase severity once slashing is supported.
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
@@ -312,7 +301,6 @@ fn get_consensus_retrospective_block_hash_mismatch() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Sos,
         ObserverApplicability::Applicable,
     )
@@ -329,7 +317,6 @@ fn get_eth_to_strk_error_count_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         "1m",
-        20,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -346,7 +333,6 @@ fn get_l1_gas_price_scraper_baselayer_error_count_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -363,7 +349,6 @@ fn get_l1_gas_price_reorg_detected_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -380,7 +365,6 @@ fn get_l1_message_scraper_baselayer_error_count_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 5.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -397,7 +381,6 @@ fn get_l1_message_scraper_reorg_detected_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Sos,
         ObserverApplicability::NotApplicable,
     )
@@ -414,7 +397,6 @@ fn get_l1_events_provider_errors_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         // TODO(Arni): set a configurable severity, similar to `get_high_empty_blocks_ratio_alert`.
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
@@ -432,7 +414,6 @@ fn get_native_compilation_error_increase() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -452,7 +433,6 @@ fn get_consensus_p2p_disconnections() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::Applicable,
     )
@@ -472,7 +452,6 @@ fn get_mempool_p2p_disconnections() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -492,7 +471,6 @@ fn create_storage_open_read_transactions_alert(storage_type: &str, metric_name: 
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -530,7 +508,6 @@ fn get_gateway_proof_archive_write_failure() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )
@@ -550,7 +527,6 @@ fn get_staking_epoch_id_mismatch_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         "5m",
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::DayOnly,
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_delay.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_delay.rs
@@ -18,7 +18,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -31,7 +30,6 @@ pub(crate) fn get_consensus_round_above_zero() -> Alert {
         format!("increase({}[1h])", CONSENSUS_ROUND_ABOVE_ZERO.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -55,7 +53,6 @@ pub(crate) fn get_consensus_round_above_zero_multiple_times() -> Alert {
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -70,7 +67,6 @@ pub(crate) fn get_cende_write_blob_failure_alert() -> Alert {
         format!("increase({}[1h])", CENDE_WRITE_BLOB_FAILURE.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -90,7 +86,6 @@ pub(crate) fn get_consensus_p2p_peer_down() -> Alert {
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::Applicable,
     )
@@ -104,7 +99,6 @@ pub(crate) fn get_cende_write_blob_failure_once_alert() -> Alert {
         format!("increase({}[1h])", CENDE_WRITE_BLOB_FAILURE.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -126,7 +120,6 @@ pub(crate) fn consensus_block_number_progress_is_slow() -> Alert {
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::Applicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
@@ -20,7 +20,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
     SECS_IN_MIN,
 };
@@ -45,7 +44,6 @@ fn get_consensus_block_number_stuck(
         ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         alert_severity,
         ObserverApplicability::NotApplicable,
     )
@@ -79,7 +77,6 @@ fn get_batched_transactions_stuck(title: &'static str) -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(name.clone()),
         ObserverApplicability::NotApplicable,
     )
@@ -114,7 +111,6 @@ fn get_consensus_p2p_not_enough_peers_for_quorum(
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         alert_severity,
         ObserverApplicability::Applicable,
     )
@@ -150,7 +146,6 @@ pub(crate) fn get_consensus_round_high() -> Alert {
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/config_manager.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/config_manager.rs
@@ -9,7 +9,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -25,7 +24,6 @@ pub(crate) fn get_config_manager_update_error_increase() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Regular,
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
@@ -9,7 +9,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -48,7 +47,6 @@ pub(crate) fn get_general_pod_state_not_ready() -> Alert {
         // marked as not ready. To avoid alerting on these, we require the not-ready status to last
         // longer (e.g., 60 seconds).
         "60s",
-        10,
         AlertSeverity::Regular,
         ObserverApplicability::NotApplicable,
     )
@@ -69,7 +67,6 @@ pub(crate) fn get_general_pod_state_crashloopbackoff() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Regular,
         ObserverApplicability::Applicable,
     )
@@ -100,7 +97,6 @@ fn get_general_pod_memory_utilization(
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         severity,
         ObserverApplicability::Applicable,
     )
@@ -138,7 +134,6 @@ pub(crate) fn get_general_pod_high_cpu_utilization() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 90.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Regular,
         ObserverApplicability::Applicable,
     )
@@ -168,7 +163,6 @@ fn get_general_pod_disk_utilization(
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         severity,
         ObserverApplicability::Applicable,
     )
@@ -199,10 +193,7 @@ pub(crate) fn get_periodic_ping() -> Alert {
         // Checks if the UTC time is 7:55 AM on Sunday.
         "(day_of_week() == bool 0) * (hour() == bool 7) * (minute() == bool 55)",
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
-        // The alert will be evaluated every 30 seconds, which should suffice to catch the 1-minute
-        // long ping.
         "0s",
-        30,
         AlertSeverity::Regular,
         ObserverApplicability::Applicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -13,7 +13,6 @@ use crate::alerts::{
     AlertLogicalOp,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -27,7 +26,6 @@ pub(crate) fn get_eth_to_strk_success_count_alert() -> Alert {
         format!("increase({}[1h])", ETH_TO_STRK_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -43,7 +41,6 @@ pub(crate) fn get_l1_gas_price_scraper_success_count_alert() -> Alert {
         format!("increase({}[1h])", L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -61,7 +58,6 @@ pub(crate) fn get_l1_gas_price_provider_insufficient_history_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
@@ -9,7 +9,6 @@ use crate::alerts::{
     AlertLogicalOp,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -22,7 +21,6 @@ pub(crate) fn get_l1_message_scraper_no_successes_alert() -> Alert {
         format!("increase({}[5m])", L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/mempool_size.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/mempool_size.rs
@@ -14,7 +14,6 @@ use crate::alerts::{
     AlertLogicalOp,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -27,7 +26,6 @@ pub(crate) fn get_mempool_pool_size_increase() -> Alert {
         MEMPOOL_POOL_SIZE.get_name_with_filter().to_string(),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10000.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -48,7 +46,6 @@ pub(crate) fn get_mempool_evictions_count_alert() -> Alert {
         query_expr,
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
@@ -9,7 +9,6 @@ use crate::alerts::{
     AlertLogicalOp,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -23,7 +22,6 @@ pub(crate) fn get_preconfirmed_block_not_written() -> Alert {
         format!("increase({}[2m])", PRECONFIRMED_BLOCK_WRITTEN.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/remote_server_connections.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/remote_server_connections.rs
@@ -9,7 +9,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -34,7 +33,6 @@ pub(crate) fn get_remote_server_number_of_connections_alert(
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::DayOnly,
         ObserverApplicability::Applicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/sync_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/sync_halt.rs
@@ -15,7 +15,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
     SECS_IN_MIN,
 };
@@ -33,7 +32,6 @@ pub(crate) fn get_state_sync_lag() -> Alert {
         ), // Alert when the central sync is ahead of the class manager by more than 5 blocks
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 5.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -55,7 +53,6 @@ fn get_state_sync_stuck(
         ), // Alert is triggered when the class manager marker is not updated for {duration}s
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         alert_severity,
         ObserverApplicability::Applicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/tps.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/tps.rs
@@ -20,7 +20,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -43,7 +42,6 @@ fn build_idle_alert(
         ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 0.1, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         alert_severity,
         ObserverApplicability::NotApplicable,
     )
@@ -91,7 +89,6 @@ pub(crate) fn get_gateway_low_successful_transaction_rate() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 5.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/transaction_delays.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/transaction_delays.rs
@@ -18,7 +18,6 @@ use crate::alerts::{
     AlertLogicalOp,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -38,7 +37,6 @@ pub(crate) fn get_mempool_p2p_peer_down() -> Alert {
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -60,7 +58,6 @@ pub(crate) fn get_http_server_avg_add_tx_latency_alert() -> Alert {
         format!("rate({sum_metric}[5m]) / clamp_min(rate({count_metric}[5m]), 1/300)"),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 15.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -89,7 +86,6 @@ pub(crate) fn get_http_server_min_add_tx_latency_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -108,7 +104,6 @@ pub(crate) fn get_http_server_p95_add_tx_latency_alert() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 2.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::ConcreteValue(crate::alerts::AlertSeverity::Informational),
         ObserverApplicability::NotApplicable,
     )
@@ -144,7 +139,6 @@ pub(crate) fn get_high_empty_blocks_ratio_alert() -> Alert {
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
@@ -16,7 +16,6 @@ use crate::alerts::{
     AlertSeverity,
     EvaluationRate,
     ObserverApplicability,
-    EVALUATION_INTERVAL_SEC_DEFAULT,
     PENDING_DURATION_DEFAULT,
 };
 
@@ -34,7 +33,6 @@ pub(crate) fn get_http_server_high_deprecated_transaction_failure_ratio() -> Ale
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.1, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -53,7 +51,6 @@ pub(crate) fn get_http_server_high_transaction_failure_ratio() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.5, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,
     )
@@ -72,7 +69,6 @@ pub(crate) fn get_http_server_internal_error_ratio() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.01, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -96,7 +92,6 @@ pub(crate) fn get_mempool_transaction_drop_ratio() -> Alert {
             AlertLogicalOp::And,
         )],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
@@ -113,7 +108,6 @@ pub(crate) fn get_http_server_internal_error_once() -> Alert {
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
-        EVALUATION_INTERVAL_SEC_DEFAULT,
         AlertSeverity::WorkingHours,
         ObserverApplicability::NotApplicable,
     )

--- a/crates/apollo_dashboard/src/alerts.rs
+++ b/crates/apollo_dashboard/src/alerts.rs
@@ -11,7 +11,6 @@ use crate::alert_placeholders::{
 };
 
 pub(crate) const PENDING_DURATION_DEFAULT: &str = "30s";
-pub(crate) const EVALUATION_INTERVAL_SEC_DEFAULT: u64 = 30;
 pub(crate) const SECS_IN_MIN: u64 = 60;
 
 /// Alerts to be configured in the dashboard.
@@ -226,9 +225,6 @@ pub(crate) struct Alert {
     // The time duration for which the alert conditions must be true before an alert is triggered.
     #[serde(rename = "for")]
     pending_duration: String,
-    // The interval in sec between evaluations of the alert.
-    #[serde(rename = "intervalSec")]
-    evaluation_interval_sec: u64,
     // The severity level of the alert.
     severity: SeverityValueOrPlaceholder,
     // Indicates if relevant for observer nodes.
@@ -264,7 +260,6 @@ impl Alert {
         expr: impl Into<ExpressionOrExpressionWithPlaceholder>,
         conditions: Vec<AlertCondition>,
         pending_duration: impl ToString,
-        evaluation_interval_sec: u64,
         severity: impl Into<SeverityValueOrPlaceholder>,
         observer_applicable: ObserverApplicability,
     ) -> Self {
@@ -295,7 +290,6 @@ impl Alert {
             expr,
             conditions,
             pending_duration: pending_duration.to_string(),
-            evaluation_interval_sec,
             severity,
             observer_applicable,
             placeholder_names,

--- a/crates/apollo_dashboard/src/dashboard_test.rs
+++ b/crates/apollo_dashboard/src/dashboard_test.rs
@@ -21,7 +21,6 @@ fn serialize_alert() {
         "max".to_string(),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         "5m",
-        20,
         AlertSeverity::Sos,
         ObserverApplicability::Applicable,
     );
@@ -41,7 +40,6 @@ fn serialize_alert() {
             }
         ],
         "for": "5m",
-        "intervalSec": 20,
         "severity": "p1",
         "observer_applicable": "true"
     });

--- a/deployments/monitoring/src/builders/alert_builder.py
+++ b/deployments/monitoring/src/builders/alert_builder.py
@@ -282,7 +282,7 @@ def alert_builder(args: argparse.Namespace):
         # Exit cleanly without traceback
         sys.exit(1)
 
-    interval_sec = dev_alerts["intervalSec"]
+    group_intervals: dict[str, int] = {g["name"]: g["intervalSec"] for g in dev_alerts["groups"]}
 
     # group_name -> list of alert rules (preserving insertion order within each group)
     groups: dict[str, list[dict[str, any]]] = collections.defaultdict(list)
@@ -326,7 +326,7 @@ def alert_builder(args: argparse.Namespace):
     rule_groups = [
         create_rule_group(
             name=group_name,
-            interval_sec=interval_sec,
+            interval_sec=group_intervals[group_name],
             rules=sorted(rules, key=lambda a: a["name"]),
         )
         for group_name, rules in sorted(groups.items())


### PR DESCRIPTION
The interval is group-scoped in Grafana, not per-alert. Now that it lives
at the top level of the Alerts struct, remove the redundant
evaluation_interval_sec field from Alert and all call sites.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure configuration/serialization refactor that changes JSON shape and builder parsing, with minimal functional risk beyond mismatched interval/group names causing alert rule creation failures.
> 
> **Overview**
> Aligns alert serialization with Grafana’s group-scoped evaluation interval by **removing the per-alert `intervalSec` field** from the `Alert` struct and all Rust alert construction call sites.
> 
> Updates `dev_grafana_alerts.json` to drop `intervalSec` from each alert (keeping intervals only under `groups`), adjusts the serialization test accordingly, and updates the monitoring `alert_builder.py` to read `intervalSec` from each `ruleGroup` instead of a single top-level value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56caf8495a071f76d60be2aeea1f76fb0f331cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->