### PR TITLE
blockifier: fix llvm and native dependency in docker

### DIFF
--- a/crates/blockifier_reexecution/replay/Dockerfile
+++ b/crates/blockifier_reexecution/replay/Dockerfile
@@ -1,0 +1,103 @@
+# crates/blockifier_reexecution/replay/Dockerfile
+#
+# Self-contained Dockerfile for building the blockifier_reexecution rpc-replay tool
+# with Cairo Native support.
+#
+# Build:
+#   docker build -f crates/blockifier_reexecution/replay/Dockerfile -t blockifier-reexecution .
+#
+# Run:
+#   docker run --rm blockifier-reexecution rpc-replay -n <RPC_URL> -c testnet --start-block 800000
+
+# =============================================================================
+# Stage 1: Base image with Rust toolchain and LLVM 19 (for Cairo Native)
+# =============================================================================
+FROM ubuntu:24.04 AS base
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    git \
+    libclang-dev \
+    libgmp-dev \
+    libssl-dev \
+    libzstd-dev \
+    pkg-config \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install LLVM 19 (required for Cairo Native compilation).
+RUN curl https://apt.llvm.org/llvm.sh -Lo llvm.sh \
+    && bash ./llvm.sh 19 all \
+    && rm -f ./llvm.sh
+
+ENV LLVM_SYS_191_PREFIX="/usr/lib/llvm-19/"
+ENV MLIR_SYS_190_PREFIX="/usr/lib/llvm-19/"
+ENV TABLEGEN_190_PREFIX="/usr/lib/llvm-19/"
+
+ENV RUSTUP_HOME=/var/tmp/rust
+ENV CARGO_HOME=${RUSTUP_HOME}
+ENV PATH="${RUSTUP_HOME}/bin:${PATH}"
+
+COPY rust-toolchain.toml rust-toolchain.toml
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none \
+    && rustup toolchain install \
+    && cargo install cargo-chef \
+    && rm rust-toolchain.toml
+
+# =============================================================================
+# Stage 2: Planner - prepare cargo-chef recipe
+# =============================================================================
+FROM base AS planner
+WORKDIR /app
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# =============================================================================
+# Stage 3: Builder - compile the binary
+# =============================================================================
+FROM base AS builder
+WORKDIR /app
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release -p blockifier_reexecution --features cairo_native --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release -p blockifier_reexecution --features cairo_native
+
+# =============================================================================
+# Stage 4: Final runtime image
+# =============================================================================
+FROM ubuntu:24.04 AS final_stage
+
+# ca-certificates: HTTPS requests
+# binutils, libc6-dev: required by starknet-native-compile at runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    binutils \
+    libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV ID=1001
+WORKDIR /app
+
+# Copy the binary and both compilers (Sierra-to-CASM and Sierra-to-Native).
+COPY --from=builder /app/target/release/blockifier_reexecution ./target/release/blockifier_reexecution
+COPY --from=builder /app/target/release/shared_executables/starknet-sierra-compile ./target/release/shared_executables/starknet-sierra-compile
+COPY --from=builder /app/target/release/shared_executables/starknet-native-compile ./target/release/shared_executables/starknet-native-compile
+COPY --from=builder /usr/bin/tini /usr/bin/tini
+
+RUN set -ex; \
+    groupadd --gid ${ID} reexecution; \
+    useradd --gid ${ID} --uid ${ID} --no-create-home reexecution
+
+USER reexecution
+
+ENTRYPOINT ["sh", "-c", "exec tini -- /app/target/release/blockifier_reexecution \"$@\"", "--"]

--- a/crates/blockifier_reexecution/replay/Dockerfile
+++ b/crates/blockifier_reexecution/replay/Dockerfile
@@ -25,18 +25,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgmp-dev \
     libssl-dev \
     libzstd-dev \
+    lsb-release \
     pkg-config \
     python3 \
     python3-dev \
     python3-pip \
     python3-venv \
+    software-properties-common \
     tini \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Install LLVM 19 (required for Cairo Native compilation).
 RUN curl https://apt.llvm.org/llvm.sh -Lo llvm.sh \
     && bash ./llvm.sh 19 all \
-    && rm -f ./llvm.sh
+    && rm -f ./llvm.sh \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        libgmp3-dev \
+        libmlir-19-dev \
+        libpolly-19-dev \
+        mlir-19-tools \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LLVM_SYS_191_PREFIX="/usr/lib/llvm-19/"
 ENV MLIR_SYS_190_PREFIX="/usr/lib/llvm-19/"
@@ -66,6 +75,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM base AS builder
 WORKDIR /app
 
+COPY rust-toolchain.toml rust-toolchain.toml
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release -p blockifier_reexecution --features cairo_native --recipe-path recipe.json
 

--- a/crates/blockifier_reexecution/replay/README.md
+++ b/crates/blockifier_reexecution/replay/README.md
@@ -1,0 +1,94 @@
+# RPC Replay
+
+Continuously reexecutes blocks via RPC with Cairo Native enabled on all contracts,
+comparing the resulting state diffs against the original chain to verify correctness.
+
+## CLI Usage
+
+```bash
+cargo run --release -p blockifier_reexecution -- \
+  rpc-replay \
+  -n <RPC_URL> \
+  -c <CHAIN_ID> \
+  --start-block <BLOCK_NUMBER> \
+  --end-block <BLOCK_NUMBER> \   # optional, omit to run forever
+  --parallelism <N>              # default: 1
+```
+
+### Parameters
+
+| Parameter       | Description                                                    |
+|-----------------|----------------------------------------------------------------|
+| `-n`            | RPC endpoint URL (e.g. `http://juno:6060`)                     |
+| `-c`            | Chain ID: `testnet`, `mainnet`, or `integration`               |
+| `--start-block` | First block to reexecute                                       |
+| `--end-block`   | Last block (inclusive). Omit to run indefinitely                |
+| `--parallelism` | Number of parallel worker threads (default: 1)                 |
+
+### Native Compilation
+
+Cairo Native is controlled at build time via the `cairo_native` feature flag.
+When enabled, all Sierra contracts are compiled to native before execution.
+The `ContractClassManager` is shared across all workers, so native compilations
+are cached and reused across blocks.
+
+## Cloud Deployment
+
+### Build and push the Docker image
+
+From the repo root:
+
+```bash
+docker build -f crates/blockifier_reexecution/replay/Dockerfile -t blockifier-reexecution .
+docker tag blockifier-reexecution us-central1-docker.pkg.dev/starkware-dev/sequencer/blockifier-reexecution:<TAG>
+docker push us-central1-docker.pkg.dev/starkware-dev/sequencer/blockifier-reexecution:<TAG>
+```
+
+### Deploy to Kubernetes
+
+1. Copy `job.yaml` and update it for your environment:
+   - Set `image` to your registry image
+   - Set `RPC_URL` to a fullnode RPC in the same cluster (e.g. `http://pathfinder.starknet-testnet-full-nodes:9545/rpc/v0_10`)
+   - Set `CHAIN_ID` to `testnet`, `mainnet`, or `integration`
+   - Set `START_BLOCK` to the block you want to start from
+   - Set `END_BLOCK` or leave empty to run forever
+   - Set `PARALLELISM` based on available resources
+
+2. Create a namespace and deploy:
+
+```bash
+kubectl create namespace rpc-replay
+kubectl apply -f job.yaml -n rpc-replay
+```
+
+3. Monitor progress:
+
+```bash
+kubectl logs -f job/blockifier-reexecution -n rpc-replay
+```
+
+### Configuration
+
+All parameters are configured via environment variables in `job.yaml`:
+
+| Env Var       | Description                              | Default              |
+|---------------|------------------------------------------|----------------------|
+| `RPC_URL`     | Starknet RPC endpoint                    | `http://juno:6060`   |
+| `CHAIN_ID`    | Chain identifier                         | `testnet`            |
+| `START_BLOCK` | First block to replay                    | `800000`             |
+| `END_BLOCK`   | Last block (empty = run forever)         | (empty)              |
+| `PARALLELISM` | Number of worker threads                 | `4`                  |
+
+### Resource Sizing
+
+- The shared `ContractClassManager` caches compiled native classes across all
+  workers, so memory grows with the number of unique contracts encountered.
+- CPU and memory scale with `PARALLELISM` — tune based on observed usage.
+- The RPC fullnode should be in the same cluster to avoid network latency.
+
+### Output
+
+- `stdout`: per-block pass/fail messages (e.g. `Block 800000 passed.`)
+- `stderr`: detailed state diff mismatches with colored diffs, and error messages
+
+On mismatch, the full expected vs actual state diff is printed to stderr.

--- a/crates/blockifier_reexecution/replay/job.yaml
+++ b/crates/blockifier_reexecution/replay/job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: blockifier-reexecution
+  labels:
+    app: blockifier-reexecution
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: blockifier-reexecution
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: blockifier-reexecution
+          image: IMAGE_PLACEHOLDER
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              ARGS="rpc-replay -n ${RPC_URL} -c ${CHAIN_ID} --start-block ${START_BLOCK} --parallelism ${PARALLELISM}"
+              if [ -n "${END_BLOCK}" ]; then
+                ARGS="${ARGS} --end-block ${END_BLOCK}"
+              fi
+              exec ./blockifier_reexecution ${ARGS}
+          env:
+            - name: RPC_URL
+              value: "http://juno:6060"
+            - name: CHAIN_ID
+              value: "testnet"
+            - name: START_BLOCK
+              value: "800000"
+            # Leave empty to run forever.
+            - name: END_BLOCK
+              value: ""
+            - name: PARALLELISM
+              value: "4"
+          resources:
+            requests:
+              cpu: "16"
+              memory: "32Gi"
+            limits:
+              cpu: "16"
+              memory: "32Gi"

--- a/crates/blockifier_reexecution/src/cli.rs
+++ b/crates/blockifier_reexecution/src/cli.rs
@@ -148,6 +148,24 @@ pub enum Command {
         directory_path: Option<String>,
     },
 
+    /// Continuously reexecute blocks via RPC and verify state diff correctness.
+    RpcReplay {
+        #[clap(flatten)]
+        rpc_args: RpcArgs,
+
+        /// First block to reexecute.
+        #[clap(long)]
+        start_block: u64,
+
+        /// Last block to reexecute (inclusive). If omitted, runs forever.
+        #[clap(long)]
+        end_block: Option<u64>,
+
+        /// Number of blocks to process in parallel.
+        #[clap(long, default_value = "1")]
+        parallelism: usize,
+    },
+
     // Download all (selected) blocks from the gc bucket.
     DownloadFiles {
         /// Block numbers. If not specified, blocks are retrieved from

--- a/crates/blockifier_reexecution/src/cli.rs
+++ b/crates/blockifier_reexecution/src/cli.rs
@@ -164,6 +164,11 @@ pub enum Command {
         /// Number of blocks to process in parallel.
         #[clap(long, default_value = "1")]
         parallelism: usize,
+
+        /// Run each block twice (native and CASM) and compare the resulting state diffs.
+        /// Requires the cairo_native feature.
+        #[clap(long)]
+        compare_native: bool,
     },
 
     // Download all (selected) blocks from the gc bucket.

--- a/crates/blockifier_reexecution/src/lib.rs
+++ b/crates/blockifier_reexecution/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod compile;
 pub mod errors;
+pub mod rpc_replay;
 pub mod serde_utils;
 pub mod state_reader;
 pub mod utils;

--- a/crates/blockifier_reexecution/src/main.rs
+++ b/crates/blockifier_reexecution/src/main.rs
@@ -10,6 +10,7 @@ use blockifier_reexecution::cli::{
     TransactionInput,
     FULL_RESOURCES_DIR,
 };
+use blockifier_reexecution::rpc_replay::run_rpc_replay;
 use blockifier_reexecution::state_reader::config::RpcStateReaderConfig;
 use blockifier_reexecution::state_reader::offline_state_reader::OfflineConsecutiveStateReaders;
 use blockifier_reexecution::state_reader::reexecution_state_reader::ConsecutiveReexecutionStateReaders;
@@ -277,6 +278,19 @@ async fn main() {
             }
 
             println!("All blocks downloaded successfully to {directory_path}.");
+        }
+
+        Command::RpcReplay { rpc_args, start_block, end_block, parallelism } => {
+            let chain_id = rpc_args.parse_chain_id();
+            run_rpc_replay(
+                rpc_args.node_url,
+                chain_id,
+                start_block,
+                end_block,
+                parallelism,
+                contract_class_manager,
+            )
+            .await;
         }
     }
 }

--- a/crates/blockifier_reexecution/src/main.rs
+++ b/crates/blockifier_reexecution/src/main.rs
@@ -280,7 +280,7 @@ async fn main() {
             println!("All blocks downloaded successfully to {directory_path}.");
         }
 
-        Command::RpcReplay { rpc_args, start_block, end_block, parallelism } => {
+        Command::RpcReplay { rpc_args, start_block, end_block, parallelism, compare_native } => {
             let chain_id = rpc_args.parse_chain_id();
             run_rpc_replay(
                 rpc_args.node_url,
@@ -289,6 +289,7 @@ async fn main() {
                 end_block,
                 parallelism,
                 contract_class_manager,
+                compare_native,
             )
             .await;
         }

--- a/crates/blockifier_reexecution/src/rpc_replay.rs
+++ b/crates/blockifier_reexecution/src/rpc_replay.rs
@@ -1,0 +1,107 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use blockifier::context::ChainInfo;
+use blockifier::state::contract_class_manager::ContractClassManager;
+use starknet_api::block::BlockNumber;
+
+use crate::errors::{RPCStateReaderError, ReexecutionError, ReexecutionResult};
+use crate::state_reader::config::RpcStateReaderConfig;
+use crate::state_reader::reexecution_state_reader::ConsecutiveReexecutionStateReaders;
+use crate::state_reader::rpc_state_reader::ConsecutiveRpcStateReaders;
+use crate::utils::{compare_state_diffs, get_chain_info};
+
+/// Runs continuous RPC replay from `start_block` to `end_block` (or forever if `None`),
+/// using `parallelism` worker threads. Each block is reexecuted and the resulting state diff
+/// is compared against the expected one from the chain.
+pub async fn run_rpc_replay(
+    node_url: String,
+    chain_id: starknet_api::core::ChainId,
+    start_block: u64,
+    end_block: Option<u64>,
+    parallelism: usize,
+    contract_class_manager: ContractClassManager,
+) {
+    let rpc_state_reader_config = RpcStateReaderConfig::from_url(node_url);
+    let chain_info = get_chain_info(&chain_id, None);
+    let block_counter = Arc::new(AtomicU64::new(start_block));
+
+    println!(
+        "Starting RPC replay from block {start_block}{} with {parallelism} workers.",
+        end_block.map_or(" (indefinitely)".to_string(), |end| format!(" to {end}"))
+    );
+
+    let mut task_set = tokio::task::JoinSet::new();
+    for _ in 0..parallelism {
+        let counter = block_counter.clone();
+        let config = rpc_state_reader_config.clone();
+        let chain_info = chain_info.clone();
+        let contract_class_manager = contract_class_manager.clone();
+
+        task_set.spawn_blocking(move || {
+            replay_worker(counter, end_block, &config, &chain_info, &contract_class_manager);
+        });
+    }
+    task_set.join_all().await;
+}
+
+fn replay_worker(
+    block_counter: Arc<AtomicU64>,
+    end_block: Option<u64>,
+    config: &RpcStateReaderConfig,
+    chain_info: &ChainInfo,
+    contract_class_manager: &ContractClassManager,
+) {
+    loop {
+        let block_number = block_counter.fetch_add(1, Ordering::Relaxed);
+        if let Some(end) = end_block {
+            if block_number > end {
+                break;
+            }
+        }
+
+        // Wait-for-tip retry loop.
+        let result = loop {
+            match reexecute_block(block_number, config, chain_info, contract_class_manager) {
+                Err(ref e) if is_block_not_found(e) => {
+                    println!("Block {block_number} not found, waiting for chain tip...");
+                    std::thread::sleep(Duration::from_secs(1));
+                    continue;
+                }
+                result => break result,
+            }
+        };
+
+        match result {
+            Ok(true) => println!("Block {block_number} passed."),
+            Ok(false) => {} // Mismatch already logged inside.
+            Err(e) => eprintln!("ERROR block {block_number}: {e}"),
+        }
+    }
+}
+
+/// Reexecutes a single block via RPC and compares state diffs.
+/// Returns `Ok(true)` if diffs match, `Ok(false)` if mismatch (logged to stderr).
+fn reexecute_block(
+    block_number: u64,
+    config: &RpcStateReaderConfig,
+    chain_info: &ChainInfo,
+    contract_class_manager: &ContractClassManager,
+) -> ReexecutionResult<bool> {
+    let readers = ConsecutiveRpcStateReaders::new(
+        BlockNumber(block_number - 1),
+        Some(config.clone()),
+        chain_info.clone(),
+        false,
+        contract_class_manager.clone(),
+    );
+
+    let (_block_state, expected_state_diff, actual_state_diff) = readers.reexecute_block()?;
+
+    Ok(compare_state_diffs(expected_state_diff, actual_state_diff, Some(block_number)))
+}
+
+fn is_block_not_found(err: &ReexecutionError) -> bool {
+    matches!(err, ReexecutionError::Rpc(RPCStateReaderError::BlockNotFound(_)))
+}

--- a/crates/blockifier_reexecution/src/rpc_replay.rs
+++ b/crates/blockifier_reexecution/src/rpc_replay.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use blockifier::blockifier::config::{CairoNativeMode, ContractClassManagerConfig};
 use blockifier::context::ChainInfo;
 use blockifier::state::contract_class_manager::ContractClassManager;
 use starknet_api::block::BlockNumber;
@@ -22,28 +23,45 @@ pub async fn run_rpc_replay(
     end_block: Option<u64>,
     parallelism: usize,
     contract_class_manager: ContractClassManager,
+    compare_native: bool,
 ) {
     let rpc_state_reader_config = RpcStateReaderConfig::from_url(node_url);
     let chain_info = get_chain_info(&chain_id, None);
     let block_counter = Arc::new(AtomicU64::new(start_block));
 
+    let mode_description = if compare_native { " (compare native vs CASM)" } else { "" };
     println!(
-        "Starting RPC replay from block {start_block}{} with {parallelism} workers.",
+        "Starting RPC replay from block {start_block}{}{mode_description} with {parallelism} \
+         workers.",
         end_block.map_or(" (indefinitely)".to_string(), |end| format!(" to {end}"))
     );
+
+    let replay_mode = if compare_native {
+        let native_manager = create_contract_class_manager(CairoNativeMode::WaitOnCompilation);
+        let casm_manager = create_contract_class_manager(CairoNativeMode::Off);
+        ReplayMode::CompareNative { native_manager, casm_manager }
+    } else {
+        ReplayMode::Standard { contract_class_manager }
+    };
 
     let mut task_set = tokio::task::JoinSet::new();
     for _ in 0..parallelism {
         let counter = block_counter.clone();
         let config = rpc_state_reader_config.clone();
         let chain_info = chain_info.clone();
-        let contract_class_manager = contract_class_manager.clone();
+        let replay_mode = replay_mode.clone();
 
         task_set.spawn_blocking(move || {
-            replay_worker(counter, end_block, &config, &chain_info, &contract_class_manager);
+            replay_worker(counter, end_block, &config, &chain_info, &replay_mode);
         });
     }
     task_set.join_all().await;
+}
+
+#[derive(Clone)]
+enum ReplayMode {
+    Standard { contract_class_manager: ContractClassManager },
+    CompareNative { native_manager: ContractClassManager, casm_manager: ContractClassManager },
 }
 
 fn replay_worker(
@@ -51,7 +69,7 @@ fn replay_worker(
     end_block: Option<u64>,
     config: &RpcStateReaderConfig,
     chain_info: &ChainInfo,
-    contract_class_manager: &ContractClassManager,
+    replay_mode: &ReplayMode,
 ) {
     loop {
         let block_number = block_counter.fetch_add(1, Ordering::Relaxed);
@@ -61,17 +79,25 @@ fn replay_worker(
             }
         }
 
-        // Wait-for-tip retry loop.
-        let result = loop {
-            match reexecute_block(block_number, config, chain_info, contract_class_manager) {
-                Err(ref e) if is_block_not_found(e) => {
-                    println!("Block {block_number} not found, waiting for chain tip...");
-                    std::thread::sleep(Duration::from_secs(1));
-                    continue;
-                }
-                result => break result,
+        let result = retry_on_block_not_found(block_number, || match replay_mode {
+            ReplayMode::Standard { contract_class_manager } => {
+                reexecute_and_compare_to_chain(
+                    block_number,
+                    config,
+                    chain_info,
+                    contract_class_manager,
+                )
             }
-        };
+            ReplayMode::CompareNative { native_manager, casm_manager } => {
+                compare_native_vs_casm(
+                    block_number,
+                    config,
+                    chain_info,
+                    native_manager,
+                    casm_manager,
+                )
+            }
+        });
 
         match result {
             Ok(true) => println!("Block {block_number} passed."),
@@ -81,9 +107,24 @@ fn replay_worker(
     }
 }
 
-/// Reexecutes a single block via RPC and compares state diffs.
-/// Returns `Ok(true)` if diffs match, `Ok(false)` if mismatch (logged to stderr).
-fn reexecute_block(
+fn retry_on_block_not_found(
+    block_number: u64,
+    mut execute_block: impl FnMut() -> ReexecutionResult<bool>,
+) -> ReexecutionResult<bool> {
+    loop {
+        match execute_block() {
+            Err(ref e) if is_block_not_found(e) => {
+                println!("Block {block_number} not found, waiting for chain tip...");
+                std::thread::sleep(Duration::from_secs(1));
+                continue;
+            }
+            result => return result,
+        }
+    }
+}
+
+/// Reexecutes a single block via RPC and compares the actual state diff against the chain.
+fn reexecute_and_compare_to_chain(
     block_number: u64,
     config: &RpcStateReaderConfig,
     chain_info: &ChainInfo,
@@ -99,7 +140,60 @@ fn reexecute_block(
 
     let (_block_state, expected_state_diff, actual_state_diff) = readers.reexecute_block()?;
 
-    Ok(compare_state_diffs(expected_state_diff, actual_state_diff, Some(block_number)))
+    Ok(compare_state_diffs(expected_state_diff, actual_state_diff, Some(block_number), None))
+}
+
+fn create_contract_class_manager(cairo_native_mode: CairoNativeMode) -> ContractClassManager {
+    let mut config = ContractClassManagerConfig::default();
+    config.cairo_native_run_config.cairo_native_mode = cairo_native_mode;
+    ContractClassManager::start(config)
+}
+
+/// Reexecutes a single block twice — once with native and once with CASM — and compares the
+/// resulting state diffs against each other.
+#[cfg(feature = "cairo_native")]
+fn compare_native_vs_casm(
+    block_number: u64,
+    config: &RpcStateReaderConfig,
+    chain_info: &ChainInfo,
+    native_manager: &ContractClassManager,
+    casm_manager: &ContractClassManager,
+) -> ReexecutionResult<bool> {
+    let native_readers = ConsecutiveRpcStateReaders::new(
+        BlockNumber(block_number - 1),
+        Some(config.clone()),
+        chain_info.clone(),
+        false,
+        native_manager.clone(),
+    );
+    let (_block_state, _expected, native_state_diff) = native_readers.reexecute_block()?;
+
+    let casm_readers = ConsecutiveRpcStateReaders::new(
+        BlockNumber(block_number - 1),
+        Some(config.clone()),
+        chain_info.clone(),
+        false,
+        casm_manager.clone(),
+    );
+    let (_block_state, _expected, casm_state_diff) = casm_readers.reexecute_block()?;
+
+    Ok(compare_state_diffs(
+        native_state_diff,
+        casm_state_diff,
+        Some(block_number),
+        Some("native vs CASM"),
+    ))
+}
+
+#[cfg(not(feature = "cairo_native"))]
+fn compare_native_vs_casm(
+    _block_number: u64,
+    _config: &RpcStateReaderConfig,
+    _chain_info: &ChainInfo,
+    _native_manager: &ContractClassManager,
+    _casm_manager: &ContractClassManager,
+) -> ReexecutionResult<bool> {
+    panic!("--compare-native requires the cairo_native feature");
 }
 
 fn is_block_not_found(err: &ReexecutionError) -> bool {

--- a/crates/blockifier_reexecution/src/state_reader/reexecution_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/reexecution_state_reader.rs
@@ -1,5 +1,4 @@
 use apollo_rpc_execution::DEPRECATED_CONTRACT_SIERRA_SIZE;
-use assert_matches::assert_matches;
 use blockifier::blockifier::config::TransactionExecutorConfig;
 use blockifier::blockifier::transaction_executor::TransactionExecutor;
 use blockifier::state::cached_state::{CachedState, CommitmentStateDiff};
@@ -135,31 +134,31 @@ pub trait ConsecutiveReexecutionStateReaders<S: StateReader + Send + Sync + 'sta
 
     /// Reexecutes a block and returns the block state along with the expected and actual state
     /// diffs. Does not verify that the state diffs match.
-    fn reexecute_block(self) -> (Option<CachedState<S>>, CommitmentStateDiff, CommitmentStateDiff) {
-        let expected_state_diff = self.get_next_block_state_diff().unwrap();
+    fn reexecute_block(
+        self,
+    ) -> ReexecutionResult<(Option<CachedState<S>>, CommitmentStateDiff, CommitmentStateDiff)> {
+        let expected_state_diff = self.get_next_block_state_diff()?;
 
-        let all_txs_in_next_block = self.get_next_block_txs().unwrap();
+        let all_txs_in_next_block = self.get_next_block_txs()?;
 
-        let mut transaction_executor = self.pre_process_and_create_executor(None).unwrap();
+        let mut transaction_executor = self.pre_process_and_create_executor(None)?;
 
         let execution_results = transaction_executor.execute_txs(&all_txs_in_next_block, None);
         // Verify all transactions executed successfully.
-        for res in execution_results.iter() {
-            assert_matches!(res, Ok(_));
+        for res in execution_results {
+            res?;
         }
 
         // Finalize block and read actual statediff; using non_consuming_finalize to keep the
         // block_state.
-        let actual_state_diff = transaction_executor
-            .non_consuming_finalize()
-            .expect("Couldn't finalize block")
-            .state_diff;
+        let actual_state_diff = transaction_executor.non_consuming_finalize()?.state_diff;
 
-        (transaction_executor.block_state, expected_state_diff, actual_state_diff)
+        Ok((transaction_executor.block_state, expected_state_diff, actual_state_diff))
     }
 
     fn reexecute_and_verify_correctness(self) -> Option<CachedState<S>> {
-        let (block_state, expected_state_diff, actual_state_diff) = self.reexecute_block();
+        let (block_state, expected_state_diff, actual_state_diff) =
+            self.reexecute_block().unwrap();
 
         assert_eq_state_diff!(expected_state_diff, actual_state_diff);
 

--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -680,7 +680,7 @@ impl ConsecutiveRpcStateReaders {
             self.reexecute_block().unwrap();
 
         // Warn if state diffs don't match, but continue writing the file.
-        compare_state_diffs(expected_state_diff, actual_state_diff, Some(block_number.0));
+        compare_state_diffs(expected_state_diff, actual_state_diff, Some(block_number.0), None);
 
         let block_state = block_state.unwrap();
         let serializable_data_prev_block = SerializableDataPrevBlock {

--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -676,7 +676,8 @@ impl ConsecutiveRpcStateReaders {
         let old_block_hash = self.get_old_block_hash().unwrap();
 
         // Run the reexecution and get the state maps and contract class mapping.
-        let (block_state, expected_state_diff, actual_state_diff) = self.reexecute_block();
+        let (block_state, expected_state_diff, actual_state_diff) =
+            self.reexecute_block().unwrap();
 
         // Warn if state diffs don't match, but continue writing the file.
         let expected_comparable = ComparableStateDiff::from(expected_state_diff);

--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -74,10 +74,10 @@ use crate::state_reader::rpc_objects::{
     RPC_TRANSACTION_EXECUTION_ERROR,
 };
 use crate::utils::{
+    compare_state_diffs,
     disjoint_hashmap_union,
     get_chain_info,
     get_rpc_state_reader_config,
-    ComparableStateDiff,
 };
 
 pub const DEFAULT_RETRY_COUNT: usize = 3;
@@ -680,14 +680,7 @@ impl ConsecutiveRpcStateReaders {
             self.reexecute_block().unwrap();
 
         // Warn if state diffs don't match, but continue writing the file.
-        let expected_comparable = ComparableStateDiff::from(expected_state_diff);
-        let actual_comparable = ComparableStateDiff::from(actual_state_diff);
-        if expected_comparable != actual_comparable {
-            println!(
-                "WARNING: State diff mismatch for block {block_number}. Expected and actual state \
-                 diffs do not match."
-            );
-        }
+        compare_state_diffs(expected_state_diff, actual_state_diff, Some(block_number.0));
 
         let block_state = block_state.unwrap();
         let serializable_data_prev_block = SerializableDataPrevBlock {

--- a/crates/blockifier_reexecution/src/utils.rs
+++ b/crates/blockifier_reexecution/src/utils.rs
@@ -170,13 +170,38 @@ impl From<CommitmentStateDiff> for ComparableStateDiff {
     }
 }
 
+/// Compares two state diffs, ignoring insertion order. Returns `true` if they match.
+/// On mismatch, logs a detailed diff to stderr.
+pub fn compare_state_diffs(
+    expected_state_diff: CommitmentStateDiff,
+    actual_state_diff: CommitmentStateDiff,
+    block_number: Option<u64>,
+) -> bool {
+    let expected = ComparableStateDiff::from(expected_state_diff);
+    let actual = ComparableStateDiff::from(actual_state_diff);
+
+    if expected == actual {
+        true
+    } else {
+        let block_info =
+            block_number.map_or(String::new(), |num| format!(" block {num}"));
+        eprintln!(
+            "MISMATCH{block_info}:\n{}",
+            pretty_assertions::StrComparison::new(
+                &format!("{expected:#?}"),
+                &format!("{actual:#?}"),
+            )
+        );
+        false
+    }
+}
+
 /// Asserts equality between two `CommitmentStateDiff` structs, ignoring insertion order.
 #[macro_export]
 macro_rules! assert_eq_state_diff {
     ($expected_state_diff:expr, $actual_state_diff:expr $(,)?) => {
-        pretty_assertions::assert_eq!(
-            $crate::utils::ComparableStateDiff::from($expected_state_diff,),
-            $crate::utils::ComparableStateDiff::from($actual_state_diff,),
+        assert!(
+            $crate::utils::compare_state_diffs($expected_state_diff, $actual_state_diff, None),
             "Expected and actual state diffs do not match.",
         );
     };

--- a/crates/blockifier_reexecution/src/utils.rs
+++ b/crates/blockifier_reexecution/src/utils.rs
@@ -171,11 +171,13 @@ impl From<CommitmentStateDiff> for ComparableStateDiff {
 }
 
 /// Compares two state diffs, ignoring insertion order. Returns `true` if they match.
-/// On mismatch, logs a detailed diff to stderr.
+/// On mismatch, logs a detailed diff to stderr. An optional `context` label (e.g.,
+/// "native vs CASM") is included in the mismatch message.
 pub fn compare_state_diffs(
     expected_state_diff: CommitmentStateDiff,
     actual_state_diff: CommitmentStateDiff,
     block_number: Option<u64>,
+    context: Option<&str>,
 ) -> bool {
     let expected = ComparableStateDiff::from(expected_state_diff);
     let actual = ComparableStateDiff::from(actual_state_diff);
@@ -183,10 +185,10 @@ pub fn compare_state_diffs(
     if expected == actual {
         true
     } else {
-        let block_info =
-            block_number.map_or(String::new(), |num| format!(" block {num}"));
+        let block_info = block_number.map_or(String::new(), |num| format!(" block {num}"));
+        let context_info = context.map_or(String::new(), |ctx| format!(" ({ctx})"));
         eprintln!(
-            "MISMATCH{block_info}:\n{}",
+            "MISMATCH{block_info}{context_info}:\n{}",
             pretty_assertions::StrComparison::new(
                 &format!("{expected:#?}"),
                 &format!("{actual:#?}"),
@@ -201,7 +203,7 @@ pub fn compare_state_diffs(
 macro_rules! assert_eq_state_diff {
     ($expected_state_diff:expr, $actual_state_diff:expr $(,)?) => {
         assert!(
-            $crate::utils::compare_state_diffs($expected_state_diff, $actual_state_diff, None),
+            $crate::utils::compare_state_diffs($expected_state_diff, $actual_state_diff, None, None),
             "Expected and actual state diffs do not match.",
         );
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Docker build dependencies for `blockifier_reexecution` with Cairo Native; risk is mainly build breakage or larger images due to additional LLVM/MLIR packages.
> 
> **Overview**
> Fixes the `blockifier_reexecution` replay Docker image build by adding missing Ubuntu packages and LLVM/MLIR 19 components needed for Cairo Native compilation.
> 
> Also adjusts the multi-stage build to copy `rust-toolchain.toml` into the `builder` stage so `cargo-chef`/`cargo build` use the expected toolchain during compilation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13a36a29dea8ffa79b97d36608d4b8cf444a065c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->