### PR TITLE
apollo_node_config: handle --help and --version flags cleanly

### DIFF
--- a/crates/apollo_node_config/src/config_utils.rs
+++ b/crates/apollo_node_config/src/config_utils.rs
@@ -8,6 +8,7 @@ use apollo_config::validators::create_validation_error;
 use apollo_config::{ConfigError, ParamPath, SerializedParam, FIELD_SEPARATOR, IS_NONE_MARK};
 use apollo_infra_utils::dumping::serialize_to_file;
 use apollo_infra_utils::path::resolve_project_relative_path;
+use clap::error::ErrorKind;
 use serde_json::{Map, Value};
 use tracing::{error, info};
 use validator::ValidationError;
@@ -212,6 +213,12 @@ pub fn load_and_validate_config(
 ) -> Result<SequencerNodeConfig, ConfigError> {
     let config_load_result = SequencerNodeConfig::load_and_process(args);
     if let Err(error) = config_load_result {
+        if let ConfigError::CommandInput(clap_err) = &error {
+            if matches!(clap_err.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+                // --help and --version should print to stdout and exit cleanly.
+                clap_err.exit();
+            }
+        }
         error!("Failed loading configuration: {error}");
         return Err(error);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change limited to CLI error handling, ensuring help/version output exits successfully without affecting config parsing/validation paths.
> 
> **Overview**
> `load_and_validate_config` now detects clap `DisplayHelp`/`DisplayVersion` errors and calls `clap_err.exit()` so `--help`/`--version` print to stdout and terminate cleanly instead of being logged/returned as configuration load failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629f443ba6cf128af2446c98a347865282f190bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->