### PR TITLE
apollo_batcher: group block builder channel senders into BlockBuilderChannels

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -95,6 +95,7 @@ use tokio::task::AbortHandle;
 use tracing::{debug, error, info, instrument, trace, Instrument};
 
 use crate::block_builder::{
+    BlockBuilderChannels,
     BlockBuilderError,
     BlockBuilderExecutionParams,
     BlockBuilderFactory,
@@ -369,9 +370,11 @@ impl Batcher {
                 },
                 self.config.dynamic_config.native_classes_whitelist.clone(),
                 Box::new(tx_provider),
-                Some(output_tx_sender),
-                Some(candidate_tx_sender),
-                Some(pre_confirmed_tx_sender),
+                BlockBuilderChannels {
+                    output_content_sender: Some(output_tx_sender),
+                    candidate_tx_sender: Some(candidate_tx_sender),
+                    pre_confirmed_tx_sender: Some(pre_confirmed_tx_sender),
+                },
                 tokio::runtime::Handle::current(),
             )
             .map_err(|err| {
@@ -458,9 +461,11 @@ impl Batcher {
                 },
                 self.config.dynamic_config.native_classes_whitelist.clone(),
                 Box::new(tx_provider),
-                None,
-                None,
-                None,
+                BlockBuilderChannels {
+                    output_content_sender: None,
+                    candidate_tx_sender: None,
+                    pre_confirmed_tx_sender: None,
+                },
                 tokio::runtime::Handle::current(),
             )
             .map_err(|err| {

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -306,7 +306,7 @@ fn mock_create_builder_for_validate_block(
     build_block_result: BlockBuilderResult<BlockExecutionArtifacts>,
 ) {
     block_builder_factory.expect_create_block_builder().times(1).return_once(
-        |_, _, _, tx_provider, _, _, _, _| {
+        |_, _, _, tx_provider, _, _| {
             let block_builder = FakeValidateBlockBuilder {
                 tx_provider,
                 build_block_result: Some(build_block_result),
@@ -331,9 +331,9 @@ fn mock_create_builder_for_propose_block(
     build_block_result: BlockBuilderResult<BlockExecutionArtifacts>,
 ) {
     block_builder_factory.expect_create_block_builder().times(1).return_once(
-        move |_, _, _, tx_provider, output_content_sender, _, _, _| {
+        move |_, _, _, tx_provider, channels, _| {
             let block_builder = FakeProposeBlockBuilder {
-                output_content_sender: output_content_sender.unwrap(),
+                output_content_sender: channels.output_content_sender.unwrap(),
                 output_txs,
                 build_block_result: Some(build_block_result),
                 tx_provider,

--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -260,6 +260,14 @@ pub struct BlockBuilderExecutionParams {
     pub proposer_idle_detection_delay: Duration,
 }
 
+/// The optional channel senders used during block proposal (not validation).
+pub struct BlockBuilderChannels {
+    pub output_content_sender:
+        Option<tokio::sync::mpsc::UnboundedSender<InternalConsensusTransaction>>,
+    pub candidate_tx_sender: Option<CandidateTxSender>,
+    pub pre_confirmed_tx_sender: Option<PreconfirmedTxSender>,
+}
+
 pub struct BlockBuilder {
     // TODO(Yael 14/10/2024): make the executor thread safe and delete this mutex.
     executor: Arc<Mutex<dyn TransactionExecutorTrait>>,
@@ -770,19 +778,13 @@ pub type BatcherWorkerPool = Arc<WorkerPool<CachedState<ApolloStateReaderAndCont
 /// The BlockBuilderFactoryTrait is responsible for creating a new block builder.
 #[cfg_attr(test, automock)]
 pub trait BlockBuilderFactoryTrait: Send + Sync {
-    // TODO(noamsp): Investigate and remove this clippy warning.
-    #[allow(clippy::too_many_arguments)]
     fn create_block_builder(
         &self,
         block_metadata: BlockMetadata,
         execution_params: BlockBuilderExecutionParams,
         native_classes_whitelist: NativeClassesWhitelist,
         tx_provider: Box<dyn TransactionProvider>,
-        output_content_sender: Option<
-            tokio::sync::mpsc::UnboundedSender<InternalConsensusTransaction>,
-        >,
-        candidate_tx_sender: Option<CandidateTxSender>,
-        pre_confirmed_tx_sender: Option<PreconfirmedTxSender>,
+        channels: BlockBuilderChannels,
         runtime: tokio::runtime::Handle,
     ) -> BlockBuilderResult<(Box<dyn BlockBuilderTrait>, AbortSignalSender)>;
 }
@@ -797,7 +799,6 @@ pub struct BlockBuilderFactory {
 }
 
 impl BlockBuilderFactory {
-    // TODO(noamsp): Investigate and remove this clippy warning.
     fn preprocess_and_create_transaction_executor(
         &self,
         block_metadata: BlockMetadata,
@@ -850,11 +851,7 @@ impl BlockBuilderFactoryTrait for BlockBuilderFactory {
         execution_params: BlockBuilderExecutionParams,
         native_classes_whitelist: NativeClassesWhitelist,
         tx_provider: Box<dyn TransactionProvider>,
-        output_content_sender: Option<
-            tokio::sync::mpsc::UnboundedSender<InternalConsensusTransaction>,
-        >,
-        candidate_tx_sender: Option<CandidateTxSender>,
-        pre_confirmed_tx_sender: Option<PreconfirmedTxSender>,
+        channels: BlockBuilderChannels,
         runtime: tokio::runtime::Handle,
     ) -> BlockBuilderResult<(Box<dyn BlockBuilderTrait>, AbortSignalSender)> {
         let executor = self.preprocess_and_create_transaction_executor(
@@ -871,9 +868,9 @@ impl BlockBuilderFactoryTrait for BlockBuilderFactory {
         let block_builder = Box::new(BlockBuilder::new(
             executor,
             tx_provider,
-            output_content_sender,
-            candidate_tx_sender,
-            pre_confirmed_tx_sender,
+            channels.output_content_sender,
+            channels.candidate_tx_sender,
+            channels.pre_confirmed_tx_sender,
             abort_signal_receiver,
             transaction_converter,
             self.block_builder_config.n_concurrent_txs,


### PR DESCRIPTION
Introduce BlockBuilderChannels struct to group the three optional channel
senders (output_content_sender, candidate_tx_sender, pre_confirmed_tx_sender)
that are used during block proposal. This removes the too_many_arguments
clippy suppression from BlockBuilderFactoryTrait::create_block_builder,
resolving the associated TODOs.

https://claude.ai/code/session_01QF6MkAYgyQzaaRYumKrfmS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how optional proposal channel senders are passed into `create_block_builder`; behavior should be unchanged but any missed call-site updates would be caught at compile time.
> 
> **Overview**
> Refactors block builder creation to pass proposal-only channel senders as a single `BlockBuilderChannels` struct instead of three separate optional parameters.
> 
> Updates `Batcher` and associated tests/mocks to construct and consume `BlockBuilderChannels`, and simplifies `BlockBuilderFactoryTrait::create_block_builder` by removing the previous `too_many_arguments` suppression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44c7cc7d20668ca49182443da409af1b89144493. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->