### PR TITLE
apollo_config_manager: add sender channel to the config manager runner

### DIFF
--- a/crates/apollo_config_manager/src/config_manager_runner.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner.rs
@@ -15,8 +15,9 @@ use async_trait::async_trait;
 use notify::{Config as NotifyConfig, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::Value;
 use tokio::sync::mpsc;
+use tokio::sync::watch::{Receiver, Sender};
 use tokio::time::{interval, Duration as TokioDuration, Interval};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::metrics::{register_metrics, CONFIG_MANAGER_UPDATE_ERRORS};
 
@@ -29,7 +30,11 @@ pub mod config_manager_runner_tests;
 pub struct ConfigManagerRunner {
     config_manager_config: ConfigManagerConfig,
     config_manager_client: SharedConfigManagerClient,
-    latest_node_dynamic_config: NodeDynamicConfig,
+    dynamic_config_tx: Sender<NodeDynamicConfig>,
+    // Keeps the receiver alive so the sender never observes a dead channel.
+    // TODO(Arni): Remove once LocalComponentChannelClient is held long-term (done in
+    // arni/http_server/add_client_to_server).
+    _dynamic_config_rx: Receiver<NodeDynamicConfig>,
     cli_args: Vec<String>,
 }
 
@@ -59,13 +64,15 @@ impl ConfigManagerRunner {
     pub fn new(
         config_manager_config: ConfigManagerConfig,
         config_manager_client: SharedConfigManagerClient,
-        initial_node_dynamic_config: NodeDynamicConfig,
+        dynamic_config_tx: Sender<NodeDynamicConfig>,
+        dynamic_config_rx: Receiver<NodeDynamicConfig>,
         cli_args: Vec<String>,
     ) -> Self {
         Self {
             config_manager_config,
             config_manager_client,
-            latest_node_dynamic_config: initial_node_dynamic_config,
+            dynamic_config_tx,
+            _dynamic_config_rx: dynamic_config_rx,
             cli_args,
         }
     }
@@ -123,7 +130,7 @@ impl ConfigManagerRunner {
     // TODO(Nadin): Define a proper result type instead of Box<dyn std::error::Error + Send + Sync>
     pub(crate) async fn update_config(
         &mut self,
-    ) -> Result<NodeDynamicConfig, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let config = load_and_validate_config(self.cli_args.clone(), false).map_err(|e| {
             CONFIG_MANAGER_UPDATE_ERRORS.increment(1);
             error!("ConfigManagerRunner: failed to update config: {e}");
@@ -131,46 +138,28 @@ impl ConfigManagerRunner {
         })?;
         let node_dynamic_config = NodeDynamicConfig::from(&config);
 
-        // Compare the previous and the newly read node dynamic config.
-        if self.latest_node_dynamic_config == node_dynamic_config {
-            // No change, so no action is needed.
-            Ok(node_dynamic_config)
-        } else {
-            // Log the diff between the latest and the new node dynamic config.
-            self.log_config_diff(&self.latest_node_dynamic_config, &node_dynamic_config);
-            // Update the latest node dynamic config.
-            self.latest_node_dynamic_config = node_dynamic_config.clone();
-            match self
-                .config_manager_client
-                .set_node_dynamic_config(node_dynamic_config.clone())
-                .await
-            {
-                Ok(()) => {
-                    info!("Successfully updated dynamic config");
-                    Ok(node_dynamic_config)
-                }
-                Err(e) => Err(format!("Failed to update dynamic config: {:?}", e).into()),
+        let changed = self.dynamic_config_tx.send_if_modified(|current| {
+            if current == &node_dynamic_config {
+                return false;
             }
+            log_config_diff(current, &node_dynamic_config);
+            // TODO(Arni): Remove this clone once the config_manager_client block below is removed.
+            *current = node_dynamic_config.clone();
+            true
+        });
+
+        if !changed {
+            return Ok(());
         }
-    }
 
-    fn log_config_diff(&self, old_config: &NodeDynamicConfig, new_config: &NodeDynamicConfig) {
-        let old_config = get_config_presentation(old_config, false).unwrap();
-        let new_config = get_config_presentation(new_config, false).unwrap();
-        let all_keys: BTreeSet<_> = old_config
-            .as_object()
-            .unwrap()
-            .keys()
-            .chain(new_config.as_object().unwrap().keys())
-            .collect();
-
-        for key in all_keys {
-            let old_value = old_config.as_object().unwrap().get(key).unwrap_or(&Value::Null);
-            let new_value = new_config.as_object().unwrap().get(key).unwrap_or(&Value::Null);
-
-            if old_value != new_value {
-                info!("ConfigManagerRunner: {key} changed from {old_value} to {new_value}");
+        debug!("Successfully sent node dynamic config to the channel");
+        // TODO(Arni): Remove this block once config_manager_client is removed from the runner.
+        match self.config_manager_client.set_node_dynamic_config(node_dynamic_config).await {
+            Ok(()) => {
+                info!("Successfully updated dynamic config");
+                Ok(())
             }
+            Err(e) => Err(format!("Failed to update dynamic config: {:?}", e).into()),
         }
     }
 
@@ -194,6 +183,26 @@ impl ConfigManagerRunner {
         }
 
         paths
+    }
+}
+
+fn log_config_diff(old_config: &NodeDynamicConfig, new_config: &NodeDynamicConfig) {
+    let old_config = get_config_presentation(old_config, false).unwrap();
+    let new_config = get_config_presentation(new_config, false).unwrap();
+    let all_keys: BTreeSet<_> = old_config
+        .as_object()
+        .unwrap()
+        .keys()
+        .chain(new_config.as_object().unwrap().keys())
+        .collect();
+
+    for key in all_keys {
+        let old_value = old_config.as_object().unwrap().get(key).unwrap_or(&Value::Null);
+        let new_value = new_config.as_object().unwrap().get(key).unwrap_or(&Value::Null);
+
+        if old_value != new_value {
+            info!("ConfigManagerRunner: {key} changed from {old_value} to {new_value}");
+        }
     }
 }
 

--- a/crates/apollo_config_manager/src/config_manager_runner_tests.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner_tests.rs
@@ -16,11 +16,12 @@ use serde_json::Value;
 use starknet_api::core::ContractAddress;
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc::channel;
+use tokio::sync::watch;
 use tokio::task::yield_now;
 use tokio::time::{interval, timeout};
 use tracing_test::traced_test;
 
-use crate::config_manager_runner::ConfigManagerRunner;
+use crate::config_manager_runner::{log_config_diff, ConfigManagerRunner};
 
 // An arbitrary hex-str config entry to be replaced.
 const VALIDATOR_ID_CONFIG_ENTRY: &str = "validator_id";
@@ -86,9 +87,10 @@ fn update_config_file(temp_file: &NamedTempFile) -> String {
 
 #[tokio::test]
 async fn config_manager_runner_update_config_with_changed_values() {
+    let (dynamic_config_tx, dynamic_config_rx) = watch::channel(NodeDynamicConfig::default());
     // Set a mock config manager client to expect the update dynamic config request.
     let mut mock_client = MockConfigManagerClient::new();
-    mock_client.expect_set_node_dynamic_config().times(1..).return_const(Ok(()));
+    mock_client.expect_set_node_dynamic_config().times(2).return_const(Ok(()));
     let config_manager_client: SharedConfigManagerClient = Arc::new(mock_client);
 
     // Set a config manager config.
@@ -97,13 +99,12 @@ async fn config_manager_runner_update_config_with_changed_values() {
     // Create a temporary config file and get the validator id value.
     let (temp_file, cli_args, validator_id_value) = create_temp_config_file_and_args();
 
-    let node_dynamic_config = NodeDynamicConfig::default();
-
     // Create a config manager runner and update the config.
     let mut config_manager_runner = ConfigManagerRunner::new(
         config_manager_config,
         config_manager_client,
-        node_dynamic_config,
+        dynamic_config_tx,
+        dynamic_config_rx.clone(),
         cli_args,
     );
 
@@ -117,13 +118,18 @@ async fn config_manager_runner_update_config_with_changed_values() {
     let expected_validator_id = ContractAddress::from(hex_to_u128(validator_id_value.as_str()));
 
     let first_update_config_result = config_manager_runner.update_config().await;
-    let first_dynamic_config =
-        first_update_config_result.expect("First update_config should succeed");
+
+    assert!(first_update_config_result.is_ok(), "First update_config should succeed");
+    let first_dynamic_config_from_channel = dynamic_config_rx.borrow().clone();
+
+    // Note: We do not validate the method `set_node_dynamic_config` of the mock config manager
+    // client is called with the correct config. This method is soon to be replaced by the channel
+    // client. It could be tested using `.withf` predicate on the mock config manager client.
     assert_eq!(
-        first_dynamic_config.consensus_dynamic_config.as_ref().unwrap().validator_id,
+        first_dynamic_config_from_channel.consensus_dynamic_config.as_ref().unwrap().validator_id,
         expected_validator_id,
         "First update_config: Validator id mismatch: {} != {}",
-        first_dynamic_config.consensus_dynamic_config.as_ref().unwrap().validator_id,
+        first_dynamic_config_from_channel.consensus_dynamic_config.as_ref().unwrap().validator_id,
         expected_validator_id
     );
 
@@ -132,13 +138,14 @@ async fn config_manager_runner_update_config_with_changed_values() {
     let expected_validator_id = ContractAddress::from(hex_to_u128(new_validator_id.as_str()));
 
     let second_update_config_result = config_manager_runner.update_config().await;
-    let second_dynamic_config =
-        second_update_config_result.expect("Second update_config should succeed");
+    assert!(second_update_config_result.is_ok(), "Second update_config should succeed");
+
+    let second_dynamic_config_from_channel = dynamic_config_rx.borrow().clone();
     assert_eq!(
-        second_dynamic_config.consensus_dynamic_config.as_ref().unwrap().validator_id,
+        second_dynamic_config_from_channel.consensus_dynamic_config.as_ref().unwrap().validator_id,
         expected_validator_id,
         "Second update_config: Validator id mismatch: {} != {}",
-        second_dynamic_config.consensus_dynamic_config.as_ref().unwrap().validator_id,
+        second_dynamic_config_from_channel.consensus_dynamic_config.as_ref().unwrap().validator_id,
         expected_validator_id
     );
 }
@@ -151,6 +158,7 @@ async fn watcher_triggers_update_on_file_change() {
     // Channel to observe that update_config was called.
     let (tx, mut rx) = channel(1);
 
+    let (dynamic_config_tx, dynamic_config_rx) = watch::channel(NodeDynamicConfig::default());
     let mut mock_client = MockConfigManagerClient::new();
     mock_client.expect_set_node_dynamic_config().times(1).returning(move |_| {
         let _ = tx.blocking_send(());
@@ -162,7 +170,8 @@ async fn watcher_triggers_update_on_file_change() {
     let mut runner = ConfigManagerRunner::new(
         ConfigManagerConfig::default(),
         client,
-        NodeDynamicConfig::default(),
+        dynamic_config_tx,
+        dynamic_config_rx,
         cli_args,
     );
 
@@ -201,15 +210,7 @@ fn log_config_diff_changes() {
         ..Default::default()
     };
 
-    let mock_client = MockConfigManagerClient::new();
-    let runner = ConfigManagerRunner::new(
-        ConfigManagerConfig::default(),
-        Arc::new(mock_client),
-        old_dynamic_config.clone(),
-        Vec::<String>::new(),
-    );
-
-    runner.log_config_diff(&old_dynamic_config, &new_dynamic_config);
+    log_config_diff(&old_dynamic_config, &new_dynamic_config);
 
     assert!(logs_contain("consensus_dynamic_config changed from"));
     assert!(logs_contain(r#""validator_id":"0x1""#));

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -41,6 +41,7 @@ use apollo_state_sync::{create_state_sync_and_runner, StateSync};
 use metrics_exporter_prometheus::PrometheusHandle;
 use papyrus_base_layer::cyclic_base_layer_wrapper::CyclicBaseLayerWrapper;
 use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerContract;
+use tokio::sync::watch;
 use tracing::info;
 
 use crate::clients::SequencerNodeClients;
@@ -166,18 +167,22 @@ pub async fn create_node_components(
                     .config_manager_config
                     .as_ref()
                     .expect("Config Manager config should be set");
-                let config_manger =
+                // TODO(Arni): remove the config_manager.
+                let config_manager =
                     ConfigManager::new(config_manager_config.clone(), node_dynamic_config.clone());
+                let (dynamic_config_tx, dynamic_config_rx) =
+                    watch::channel(node_dynamic_config.clone());
                 let config_manager_client = clients
                     .get_config_manager_shared_client()
                     .expect("Config Manager client should be available");
                 let config_manager_runner = ConfigManagerRunner::new(
                     config_manager_config.clone(),
                     config_manager_client,
-                    node_dynamic_config,
+                    dynamic_config_tx,
+                    dynamic_config_rx,
                     cli_args,
                 );
-                (Some(config_manger), Some(config_manager_runner))
+                (Some(config_manager), Some(config_manager_runner))
             }
 
             ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches live config reload/update flow by switching change detection to a `tokio::sync::watch` channel, which could affect when/if dynamic config updates propagate. Still calls the existing `config_manager_client` update path, but now only after channel state changes.
> 
> **Overview**
> `ConfigManagerRunner` now owns a `tokio::sync::watch` sender/receiver pair and uses it as the source of truth for the latest `NodeDynamicConfig`, replacing the prior internal `latest_node_dynamic_config` field.
> 
> `update_config` now returns `Result<()>`, computes diffs against the channel’s current value via `send_if_modified`, logs per-key changes through a new free `log_config_diff` helper, and only pushes updates (and calls `set_node_dynamic_config`) when the config actually changes. Node component wiring and runner tests are updated to create/pass the watch channel and validate updates by reading from it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c934fcbaa3b45980f10a03fe60d999d2e24b381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->