### PR TITLE
apollo_p2p_sync: remove timeout from header parse_data_for_block

### DIFF
--- a/crates/apollo_p2p_sync/src/client/header.rs
+++ b/crates/apollo_p2p_sync/src/client/header.rs
@@ -11,7 +11,6 @@ use futures::{FutureExt, StreamExt};
 use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 use starknet_api::block_hash::block_hash_calculator::extract_event_count_from_concatenated_counts;
 use starknet_api::hash::StarkHash;
-use tokio::time::{timeout, Duration};
 use tracing::debug;
 
 use super::block_data_stream_builder::{
@@ -87,15 +86,12 @@ impl BlockDataStreamBuilder<SignedBlockHeader> for HeaderStreamBuilder {
         _storage_reader: &'a StorageReader,
     ) -> BoxFuture<'a, Result<Option<Self::Output>, ParseDataError>> {
         async move {
-            // TODO(noamsp): investigate and remove this timeout.
-            let maybe_signed_header =
-                timeout(Duration::from_secs(15), signed_headers_response_manager.next())
-                    .await
-                    .ok()
-                    .flatten()
-                    .ok_or(ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
-                        type_description: Self::TYPE_DESCRIPTION,
-                    }))?;
+            let maybe_signed_header = signed_headers_response_manager
+                .next()
+                .await
+                .ok_or(ParseDataError::BadPeer(BadPeerError::SessionEndedWithoutFin {
+                    type_description: Self::TYPE_DESCRIPTION,
+                }))?;
             let Some(signed_block_header) = maybe_signed_header?.0 else {
                 return Ok(None);
             };


### PR DESCRIPTION
## Summary
- Remove the 15-second `timeout()` wrapper around `next()` in `HeaderStreamBuilder::parse_data_for_block`
- The other protocols (state_diff, class, transaction) call `.next().await` directly without a timeout; headers should be consistent
- The network layer handles peer disconnection, making this workaround unnecessary

## Test plan
- [ ] `cargo test -p apollo_p2p_sync` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the 15s timeout while awaiting the next header, which could change sync liveness behavior if peers stall or never send `Fin`. Risk is moderate because it affects the header sync receive loop, though error handling for session end remains.
> 
> **Overview**
> Removes the 15-second `tokio::time::timeout` around `signed_headers_response_manager.next()` in `HeaderStreamBuilder::parse_data_for_block`, making header fetching wait indefinitely like the other sync protocols.
> 
> This also drops the associated `tokio::time` import and keeps the same `SessionEndedWithoutFin` handling when the response stream ends.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b97df2e2659a0457d80d433f1266d49de25a4034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->