### PR TITLE
apollo_p2p_sync: remove code duplication in p2p sync failure tests

### DIFF
--- a/crates/apollo_p2p_sync/src/client/class_test.rs
+++ b/crates/apollo_p2p_sync/src/client/class_test.rs
@@ -27,6 +27,7 @@ use starknet_api::deprecated_contract_class::{
 use starknet_api::state::SierraContractClass;
 
 use super::test_utils::{
+    build_header_and_state_diff_query_actions,
     random_header,
     run_test,
     wait_for_marker,
@@ -317,29 +318,9 @@ async fn validate_class_sync_fails(
     classes: Vec<Option<(ApiContractClass, ClassHash)>>,
 ) {
     let mut rng = get_rng();
-
-    // TODO(noamsp): remove code duplication with state diff test.
-    let mut actions = vec![
-        Action::RunP2pSync,
-        // We already validate the header query content in other tests.
-        Action::ReceiveQuery(Box::new(|_query| ()), DataType::Header),
-    ];
-
-    // Send headers with corresponding state diff length
-    for (i, state_diff_length) in header_state_diff_lengths.iter().copied().enumerate() {
-        actions.push(Action::SendHeader(DataOrFin(Some(random_header(
-            &mut rng,
-            BlockNumber(i.try_into().unwrap()),
-            Some(state_diff_length),
-            None,
-        )))));
-    }
-    actions.push(Action::SendHeader(DataOrFin(None)));
-
-    actions.push(
-        // We already validate the state diff query content in other tests.
-        Action::ReceiveQuery(Box::new(|_query| ()), DataType::StateDiff),
-    );
+    // We already validate the header and state diff query content in other tests.
+    let mut actions =
+        build_header_and_state_diff_query_actions(&mut rng, &header_state_diff_lengths);
 
     // Send state diff chunks.
     for state_diff_chunk in state_diff_chunks {

--- a/crates/apollo_p2p_sync/src/client/state_diff_test.rs
+++ b/crates/apollo_p2p_sync/src/client/state_diff_test.rs
@@ -21,6 +21,7 @@ use starknet_api::state::{StorageKey, ThinStateDiff};
 use starknet_types_core::felt::Felt;
 
 use super::test_utils::{
+    build_header_and_state_diff_query_actions,
     random_header,
     run_test,
     wait_for_marker,
@@ -327,28 +328,9 @@ async fn validate_state_diff_fails(
     state_diff_chunks: Vec<Option<StateDiffChunk>>,
 ) {
     let mut rng = get_rng();
-
-    let mut actions = vec![
-        Action::RunP2pSync,
-        // We already validate the header query content in other tests.
-        Action::ReceiveQuery(Box::new(|_query| ()), DataType::Header),
-    ];
-
-    // Send headers with corresponding state diff length
-    for (i, state_diff_length) in header_state_diff_lengths.iter().copied().enumerate() {
-        actions.push(Action::SendHeader(DataOrFin(Some(random_header(
-            &mut rng,
-            BlockNumber(i.try_into().unwrap()),
-            Some(state_diff_length),
-            None,
-        )))));
-    }
-    actions.push(Action::SendHeader(DataOrFin(None)));
-
-    actions.push(
-        // We already validate the state diff query content in other tests.
-        Action::ReceiveQuery(Box::new(|_query| ()), DataType::StateDiff),
-    );
+    // We already validate the header and state diff query content in other tests.
+    let mut actions =
+        build_header_and_state_diff_query_actions(&mut rng, &header_state_diff_lengths);
 
     // Send state diff chunks.
     for state_diff_chunk in state_diff_chunks {

--- a/crates/apollo_p2p_sync/src/client/test_utils.rs
+++ b/crates/apollo_p2p_sync/src/client/test_utils.rs
@@ -349,6 +349,29 @@ pub async fn run_test(
     }
 }
 
+/// Builds the initial actions common to failure tests: run sync, receive the header query, send
+/// headers with the given state diff lengths (followed by Fin), and receive the state diff query.
+pub fn build_header_and_state_diff_query_actions(
+    rng: &mut ChaCha8Rng,
+    header_state_diff_lengths: &[usize],
+) -> Vec<Action> {
+    let mut actions = vec![
+        Action::RunP2pSync,
+        Action::ReceiveQuery(Box::new(|_query| ()), DataType::Header),
+    ];
+    for (i, state_diff_length) in header_state_diff_lengths.iter().copied().enumerate() {
+        actions.push(Action::SendHeader(DataOrFin(Some(random_header(
+            rng,
+            BlockNumber(i.try_into().unwrap()),
+            Some(state_diff_length),
+            None,
+        )))));
+    }
+    actions.push(Action::SendHeader(DataOrFin(None)));
+    actions.push(Action::ReceiveQuery(Box::new(|_query| ()), DataType::StateDiff));
+    actions
+}
+
 pub fn random_header(
     rng: &mut ChaCha8Rng,
     block_number: BlockNumber,


### PR DESCRIPTION
## Summary
- Extract `build_header_and_state_diff_query_actions` helper to `test_utils.rs`
- Eliminates the duplicated header-send + state-diff-query setup shared by `validate_state_diff_fails` and `validate_class_sync_fails`

## Test plan
- [ ] `cargo test -p apollo_p2p_sync` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a test-only refactor that extracts duplicated action setup into a shared helper, without changing sync/client runtime logic.
> 
> **Overview**
> Refactors p2p sync *failure tests* to remove duplicated setup logic for the header + state-diff phases.
> 
> Introduces `build_header_and_state_diff_query_actions` in `test_utils.rs` and updates `validate_state_diff_fails` and `validate_class_sync_fails` to use it, keeping the same sequence of actions while centralizing the common header sending and state-diff query initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd0846143bb278b089efaf3f868b604f0e464856. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->