### PR TITLE
apollo_p2p_sync: remove unresolvable consider-verifying TODOs

### DIFF
--- a/crates/apollo_p2p_sync/src/client/class_test.rs
+++ b/crates/apollo_p2p_sync/src/client/class_test.rs
@@ -254,8 +254,6 @@ fn create_random_state_diff_chunk_with_class(
     }
 }
 
-// TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(NotEnoughClasses)
-// was returned from parse_data_for_block. We currently dont have a way to check this.
 #[tokio::test]
 async fn not_enough_classes() {
     let mut rng = get_rng();
@@ -272,8 +270,6 @@ async fn not_enough_classes() {
     .await;
 }
 
-// TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(ClassNotInStateDiff)
-// was returned from parse_data_for_block. We currently dont have a way to check this.
 #[tokio::test]
 async fn class_not_in_state_diff() {
     let mut rng = get_rng();
@@ -287,8 +283,6 @@ async fn class_not_in_state_diff() {
     .await;
 }
 
-// TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(DuplicateClass)
-// was returned from parse_data_for_block. We currently dont have a way to check this.
 #[tokio::test]
 async fn duplicate_classes() {
     let mut rng = get_rng();

--- a/crates/apollo_p2p_sync/src/client/state_diff_test.rs
+++ b/crates/apollo_p2p_sync/src/client/state_diff_test.rs
@@ -202,15 +202,11 @@ async fn state_diff_basic_flow() {
     .await;
 }
 
-// TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(EmptyStateDiffPart) was
-// returned from parse_data_for_block. We currently dont have a way to check this.
 #[tokio::test]
 async fn state_diff_empty_state_diff() {
     validate_state_diff_fails(vec![1], vec![Some(StateDiffChunk::default())]).await;
 }
 
-// TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(WrongStateDiffLength) was
-// returned from parse_data_for_block. We currently dont have a way to check this.
 #[tokio::test]
 async fn state_diff_stopped_in_middle() {
     validate_state_diff_fails(
@@ -223,8 +219,6 @@ async fn state_diff_stopped_in_middle() {
     .await;
 }
 
-// TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(WrongStateDiffLength) was
-// returned from parse_data_for_block. We currently dont have a way to check this.
 #[tokio::test]
 async fn state_diff_not_split_correctly() {
     validate_state_diff_fails(
@@ -242,8 +236,6 @@ async fn state_diff_not_split_correctly() {
     .await;
 }
 
-// TODO(noamsp): Consider verifying that ParseDataError::BadPeerError(ConflictingStateDiffParts)
-// was returned from parse_data_for_block. We currently dont have a way to check this.
 #[tokio::test]
 async fn state_diff_conflicting() {
     validate_state_diff_fails(


### PR DESCRIPTION
## Summary
- Remove seven "Consider verifying that `ParseDataError::BadPeerError(X)` was returned" comments in `class_test` and `state_diff_test`
- The test infrastructure does not expose individual error types from `parse_data_for_block`, so these TODOs cannot be resolved as written
- The existing `ValidateReportSent` check is sufficient: each test scenario uniquely determines the error variant by construction

## Test plan
- [ ] `cargo test -p apollo_p2p_sync` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in test code; no production logic or behavior changes, so risk is minimal.
> 
> **Overview**
> Removes several "consider verifying `ParseDataError::BadPeerError(...)`" TODO comments from `class_test.rs` and `state_diff_test.rs` where the current test harness cannot assert the exact `parse_data_for_block` error variant.
> 
> Test behavior remains the same, continuing to validate failure cases via `ValidateReportSent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55147dd3fd80ffdc8f3e6b3068685748797d3958. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->