### PR TITLE
apollo_l1_provider: fix CR comments of 13468

### DIFF
--- a/crates/apollo_l1_provider/src/l1_provider.rs
+++ b/crates/apollo_l1_provider/src/l1_provider.rs
@@ -241,9 +241,9 @@ impl L1Provider {
                     "Returned L1Handler txs: {:?}",
                     txs.iter()
                         .map(|tx| format!(
-                            "L2 tx hash: {}, L1-L2 msg hash: {}",
+                            "L2 tx hash: {}, Eth msg hash: {}",
                             tx.tx_hash,
-                            tx.tx.calc_msg_hash()
+                            tx.tx.calc_eth_msg_hash()
                         ))
                         .collect::<Vec<_>>()
                 );

--- a/crates/apollo_l1_provider/src/l1_scraper.rs
+++ b/crates/apollo_l1_provider/src/l1_scraper.rs
@@ -317,24 +317,20 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1Scraper<BaseLayer
                     .map_err(L1ScraperError::HashCalculationError)
             })
             .collect::<L1ScraperResult<Vec<_>, _>>()?;
-        // Used for debug. Collect the L2 hashes for events that are L1 handler transactions.
-        let l2_hashes = events.iter().filter_map(|event| match event {
-            Event::L1HandlerTransaction { l1_handler_tx, .. } => Some(l1_handler_tx.tx_hash),
-            _ => None,
-        });
-        // Collect the L1-L2 message hashes (keccak) for L1 handler transactions.
-        let l1_msg_hashes = events.iter().filter_map(|event| match event {
+        // Used for debug. Collect the L2 tx hashes and eth message hashes (keccak) for L1
+        // handler transactions.
+        let l2_tx_and_eth_msg_hashes = events.iter().filter_map(|event| match event {
             Event::L1HandlerTransaction { l1_handler_tx, .. } => {
-                Some(l1_handler_tx.tx.calc_msg_hash())
+                Some((l1_handler_tx.tx_hash, l1_handler_tx.tx.calc_eth_msg_hash()))
             }
             _ => None,
         });
 
-        let formatted_pairs = zip_eq(zip_eq(l1_messages_info, l2_hashes), l1_msg_hashes)
-            .map(|(((l1_hash, timestamp), l2_hash), l1_msg_hash)| {
+        let formatted_pairs = zip_eq(l1_messages_info, l2_tx_and_eth_msg_hashes)
+            .map(|((l1_hash, timestamp), (l2_hash, eth_msg_hash))| {
                 format!(
                     "L1 tx hash: {l1_hash:?}, L1 timestamp: {timestamp}, L2 tx hash: {l2_hash}, \
-                     L1-L2 msg hash: {l1_msg_hash}"
+                     Eth msg hash: {eth_msg_hash}"
                 )
             })
             .collect::<Vec<_>>();

--- a/crates/apollo_rpc/src/v0_8/api/api_impl.rs
+++ b/crates/apollo_rpc/src/v0_8/api/api_impl.rs
@@ -50,7 +50,7 @@ use starknet_api::core::{
     BLOCK_HASH_TABLE_ADDRESS,
 };
 use starknet_api::execution_utils::format_panic_data;
-use starknet_api::hash::{l1_handler_message_hash, L1L2MsgHash};
+use starknet_api::hash::EthL1L2MessageHash;
 use starknet_api::state::{StateNumber, StorageKey, ThinStateDiff as StarknetApiThinStateDiff};
 use starknet_api::transaction::fields::Fee;
 use starknet_api::transaction::{
@@ -310,9 +310,9 @@ impl JsonRpcServer for JsonRpcServerImpl {
                                 block_number,
                                 TransactionOffsetInBlock(transaction_offset),
                             );
-                            let msg_hash = match &transaction {
+                            let eth_msg_hash = match &transaction {
                                 Transaction::L1Handler(l1_handler_tx) => {
-                                    Some(l1_handler_tx.calc_msg_hash())
+                                    Some(l1_handler_tx.calc_eth_msg_hash())
                                 }
                                 _ => None,
                             };
@@ -324,7 +324,7 @@ impl JsonRpcServer for JsonRpcServerImpl {
                                     transaction_index,
                                     transaction_hash,
                                     transaction_version,
-                                    msg_hash,
+                                    eth_msg_hash,
                                 )?
                                 .into(),
                             })
@@ -559,14 +559,20 @@ impl JsonRpcServer for JsonRpcServerImpl {
                 StarknetApiTransaction::L1Handler(tx) => tx.version,
             };
 
-            let msg_hash = match tx {
+            let eth_msg_hash = match tx {
                 StarknetApiTransaction::L1Handler(l1_handler_tx) => {
-                    Some(l1_handler_tx.calc_msg_hash())
+                    Some(l1_handler_tx.calc_eth_msg_hash())
                 }
                 _ => None,
             };
 
-            get_non_pending_receipt(&txn, transaction_index, transaction_hash, tx_version, msg_hash)
+            get_non_pending_receipt(
+                &txn,
+                transaction_index,
+                transaction_hash,
+                tx_version,
+                eth_msg_hash,
+            )
         } else {
             // The transaction is not in any non-pending block. Search for it in the pending block
             // and if it's not found, return error.
@@ -1715,7 +1721,7 @@ fn get_non_pending_receipt<Mode: TransactionKind>(
     transaction_index: TransactionIndex,
     transaction_hash: TransactionHash,
     tx_version: TransactionVersion,
-    msg_hash: Option<L1L2MsgHash>,
+    eth_msg_hash: Option<EthL1L2MessageHash>,
 ) -> RpcResult<GeneralTransactionReceipt> {
     let block_number = transaction_index.0;
     let status = get_block_status(txn, block_number)?;
@@ -1735,7 +1741,7 @@ fn get_non_pending_receipt<Mode: TransactionKind>(
         .map_err(internal_server_error)?
         .ok_or_else(|| ErrorObjectOwned::from(TRANSACTION_HASH_NOT_FOUND))?;
 
-    let output = TransactionOutput::from((output, tx_version, msg_hash));
+    let output = TransactionOutput::from((output, tx_version, eth_msg_hash));
 
     Ok(GeneralTransactionReceipt::TransactionReceipt(TransactionReceipt {
         finality_status: status.into(),
@@ -1753,19 +1759,14 @@ fn client_receipt_to_rpc_pending_receipt(
     let transaction_hash = client_transaction.transaction_hash();
     let starknet_api_output =
         client_transaction_receipt.into_starknet_api_transaction_output(client_transaction);
-    let msg_hash = match client_transaction {
-        ClientTransaction::L1Handler(tx) => Some(l1_handler_message_hash(
-            &tx.contract_address,
-            tx.nonce,
-            &tx.entry_point_selector,
-            &tx.calldata,
-        )),
+    let eth_msg_hash = match client_transaction {
+        ClientTransaction::L1Handler(tx) => Some(tx.calc_eth_msg_hash()),
         _ => None,
     };
     let output = PendingTransactionOutput::try_from(TransactionOutput::from((
         starknet_api_output,
         client_transaction.transaction_version(),
-        msg_hash,
+        eth_msg_hash,
     )))?;
     Ok(GeneralTransactionReceipt::PendingTransactionReceipt(PendingTransactionReceipt {
         // ACCEPTED_ON_L2 is the only finality status of a pending transaction.

--- a/crates/apollo_rpc/src/v0_8/api/test.rs
+++ b/crates/apollo_rpc/src/v0_8/api/test.rs
@@ -100,7 +100,7 @@ use starknet_api::deprecated_contract_class::{
     FunctionAbiEntry,
     FunctionStateMutability,
 };
-use starknet_api::hash::{l1_handler_message_hash, L1L2MsgHash};
+use starknet_api::hash::EthL1L2MessageHash;
 use starknet_api::state::{SierraContractClass as StarknetApiContractClass, StateDiff};
 use starknet_api::transaction::{
     Event as StarknetApiEvent,
@@ -1266,11 +1266,13 @@ async fn get_transaction_status() {
         StarknetApiTransaction::L1Handler(tx) => tx.version,
     };
     let tx = block.body.transaction_outputs.index(0).clone();
-    let msg_hash = match tx {
-        starknet_api::transaction::TransactionOutput::L1Handler(_) => Some(L1L2MsgHash::default()),
+    let eth_msg_hash = match tx {
+        starknet_api::transaction::TransactionOutput::L1Handler(_) => {
+            Some(EthL1L2MessageHash::default())
+        }
         _ => None,
     };
-    let output = TransactionOutput::from((tx, transaction_version, msg_hash));
+    let output = TransactionOutput::from((tx, transaction_version, eth_msg_hash));
     let expected_status = TransactionStatus {
         finality_status: TransactionFinalityStatus::AcceptedOnL2,
         execution_status: output.execution_status().clone(),
@@ -1385,14 +1387,14 @@ async fn get_transaction_receipt() {
         StarknetApiTransaction::L1Handler(tx) => tx.version,
     };
     let tx = block.body.transactions.index(0).clone();
-    let msg_hash = match tx {
-        starknet_api::transaction::Transaction::L1Handler(tx) => Some(tx.calc_msg_hash()),
+    let eth_msg_hash = match tx {
+        starknet_api::transaction::Transaction::L1Handler(tx) => Some(tx.calc_eth_msg_hash()),
         _ => None,
     };
     let output = TransactionOutput::from((
         block.body.transaction_outputs.index(0).clone(),
         transaction_version,
-        msg_hash,
+        eth_msg_hash,
     ));
     let expected_receipt = TransactionReceipt {
         finality_status: TransactionFinalityStatus::AcceptedOnL2,
@@ -2216,21 +2218,16 @@ fn generate_client_transaction_client_receipt_rpc_transaction_and_rpc_receipt(
         let starknet_api_output = client_transaction_receipt
             .clone()
             .into_starknet_api_transaction_output(&client_transaction);
-        let msg_hash = match &client_transaction {
+        let eth_msg_hash = match &client_transaction {
             apollo_starknet_client::reader::objects::transaction::Transaction::L1Handler(tx) => {
-                Some(l1_handler_message_hash(
-                    &tx.contract_address,
-                    tx.nonce,
-                    &tx.entry_point_selector,
-                    &tx.calldata,
-                ))
+                Some(tx.calc_eth_msg_hash())
             }
             _ => None,
         };
         let maybe_output = PendingTransactionOutput::try_from(TransactionOutput::from((
             starknet_api_output,
             client_transaction.transaction_version(),
-            msg_hash,
+            eth_msg_hash,
         )));
         let Ok(output) = maybe_output else {
             continue;

--- a/crates/apollo_rpc/src/v0_8/transaction.rs
+++ b/crates/apollo_rpc/src/v0_8/transaction.rs
@@ -25,7 +25,7 @@ use starknet_api::core::{
 };
 use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
-use starknet_api::hash::L1L2MsgHash;
+use starknet_api::hash::EthL1L2MessageHash;
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
     AllResourceBounds,
@@ -861,7 +861,7 @@ pub struct L1HandlerTransactionOutput {
     #[serde(flatten)]
     pub execution_status: TransactionExecutionStatus,
     pub execution_resources: ExecutionResources,
-    pub message_hash: L1L2MsgHash,
+    pub message_hash: EthL1L2MessageHash,
 }
 
 // Note: This is not the same as the Builtins in starknet_api, the serialization of SegmentArena is
@@ -1052,18 +1052,22 @@ impl TransactionOutput {
     }
 }
 
-impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Option<L1L2MsgHash>)>
-    for TransactionOutput
+impl
+    From<(
+        starknet_api::transaction::TransactionOutput,
+        TransactionVersion,
+        Option<EthL1L2MessageHash>,
+    )> for TransactionOutput
 {
     #[cfg_attr(coverage_nightly, coverage_attribute)]
     fn from(
         tx_output_msg_hash: (
             starknet_api::transaction::TransactionOutput,
             TransactionVersion,
-            Option<L1L2MsgHash>,
+            Option<EthL1L2MessageHash>,
         ),
     ) -> Self {
-        let (tx_output, tx_version, maybe_msg_hash) = tx_output_msg_hash;
+        let (tx_output, tx_version, maybe_eth_msg_hash) = tx_output_msg_hash;
         // TODO(DanB): consider supporting match instead.
         let actual_fee = if tx_version == TransactionVersion::ZERO
             || tx_version == TransactionVersion::ONE
@@ -1121,7 +1125,7 @@ impl From<(starknet_api::transaction::TransactionOutput, TransactionVersion, Opt
                     events: l1_handler_tx_output.events,
                     execution_status: l1_handler_tx_output.execution_status,
                     execution_resources: l1_handler_tx_output.execution_resources.into(),
-                    message_hash: maybe_msg_hash
+                    message_hash: maybe_eth_msg_hash
                         .expect("Missing message hash to construct L1Handler output."),
                 })
             }

--- a/crates/apollo_rpc/src/v0_8/transaction_test.rs
+++ b/crates/apollo_rpc/src/v0_8/transaction_test.rs
@@ -5,10 +5,8 @@ use apollo_test_utils::{
     get_rng,
     GetTestInstance,
 };
-use pretty_assertions::assert_eq;
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::data_availability::DataAvailabilityMode;
-use starknet_api::hash::L1L2MsgHash;
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
     Calldata,
@@ -19,8 +17,7 @@ use starknet_api::transaction::fields::{
     Tip,
     TransactionSignature,
 };
-use starknet_api::transaction::{L1HandlerTransaction, Transaction};
-use starknet_api::{calldata, contract_address, felt, nonce};
+use starknet_api::transaction::Transaction;
 
 use super::{
     DeployAccountTransaction,
@@ -35,31 +32,6 @@ use super::{
     TransactionVersion1,
     TransactionVersion3,
 };
-
-lazy_static::lazy_static! {
-    // A transaction from MAINNET with tx hash 0x439e12f67962c353182d72b4af12c3f11eaba4b36e552aebcdcd6db66971bdb.
-    static ref L1_HANDLER_TX: L1HandlerTransaction = L1HandlerTransaction {
-        version: L1HandlerTransaction::VERSION,
-        nonce: nonce!(0x18e94d),
-        contract_address: contract_address!(
-            "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82"
-        ),
-        entry_point_selector: EntryPointSelector(felt!(
-            "0x1b64b1b3b690b43b9b514fb81377518f4039cd3e4f4914d8a6bdf01d679fb19"
-        )),
-        calldata: calldata![
-            felt!("0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419"),
-            felt!("0x455448"),
-            felt!("0xc27947400e26e534e677afc2e9b2ec1bab14fc89"),
-            felt!("0x4af4754baf89f1b8b449215a8ea7ce558824a33a5393eaa3829658549f2bfa2"),
-            felt!("0x9184e72a000"),
-            felt!("0x0")
-        ],
-    };
-}
-
-// The msg hash of the L1Handler transaction.
-const MSG_HASH: &str = "0x99b2a7830e1c860734b308d90bb05b0e09ecda0a2b243ecddb12c50bdebaa3a9";
 
 auto_impl_get_test_instance! {
     pub enum DeployAccountTransaction {
@@ -217,19 +189,4 @@ fn test_invoke_transaction_to_client_transaction() {
 
     let _invoke_transaction: client_transaction::InvokeTransaction =
         InvokeTransactionV3::get_test_instance(&mut get_rng()).into();
-}
-
-#[test]
-fn l1handler_msg_hash() {
-    let msg_hash = format!("{}", L1_HANDLER_TX.calc_msg_hash());
-    assert_eq!(msg_hash, MSG_HASH);
-}
-
-#[test]
-fn l1handler_msg_hash_serde() {
-    let ser = serde_json::to_string(MSG_HASH).unwrap();
-    assert_eq!(ser, "\"0x99b2a7830e1c860734b308d90bb05b0e09ecda0a2b243ecddb12c50bdebaa3a9\"");
-    let des = serde_json::from_str::<L1L2MsgHash>(&ser).unwrap();
-    let expected_hash = L1_HANDLER_TX.calc_msg_hash();
-    assert_eq!(des, expected_hash);
 }

--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -15,7 +15,7 @@ use starknet_api::core::{
     Nonce,
 };
 use starknet_api::execution_resources::{GasAmount, GasVector};
-use starknet_api::hash::StarkHash;
+use starknet_api::hash::{eth_l1_handler_message_hash, EthL1L2MessageHash, StarkHash};
 use starknet_api::transaction::fields::{
     AccountDeploymentData,
     Calldata,
@@ -152,6 +152,17 @@ pub struct L1HandlerTransaction {
     pub contract_address: ContractAddress,
     pub entry_point_selector: EntryPointSelector,
     pub calldata: Calldata,
+}
+
+impl L1HandlerTransaction {
+    pub fn calc_eth_msg_hash(&self) -> EthL1L2MessageHash {
+        eth_l1_handler_message_hash(
+            &self.contract_address,
+            self.nonce,
+            &self.entry_point_selector,
+            &self.calldata,
+        )
+    }
 }
 
 impl From<L1HandlerTransaction> for starknet_api::transaction::L1HandlerTransaction {

--- a/crates/starknet_api/src/hash.rs
+++ b/crates/starknet_api/src/hash.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[path = "hash_test.rs"]
+mod hash_test;
+
 use std::fmt::{Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
@@ -112,24 +116,24 @@ impl StateRoots {
     }
 }
 
-/// The hash of a L1 -> L2 message.
+/// The hash of a L1 -> L2 message, as it's stored on the Starknet Solidity contract.
 // The hash is Keccak256, so it doesn't fit in a Felt.
 #[derive(Clone, Default, Eq, PartialEq, Hash, PartialOrd, Ord)]
-pub struct L1L2MsgHash(pub [u8; 32]);
+pub struct EthL1L2MessageHash(pub [u8; 32]);
 
-impl Display for L1L2MsgHash {
+impl Display for EthL1L2MessageHash {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         write!(formatter, "0x{}", hex::encode(self.0))
     }
 }
 
-impl Debug for L1L2MsgHash {
+impl Debug for EthL1L2MessageHash {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         Display::fmt(self, formatter)
     }
 }
 
-impl Serialize for L1L2MsgHash {
+impl Serialize for EthL1L2MessageHash {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -138,7 +142,7 @@ impl Serialize for L1L2MsgHash {
     }
 }
 
-impl<'de> Deserialize<'de> for L1L2MsgHash {
+impl<'de> Deserialize<'de> for EthL1L2MessageHash {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -149,8 +153,8 @@ impl<'de> Deserialize<'de> for L1L2MsgHash {
 }
 
 impl L1HandlerTransaction {
-    pub fn calc_msg_hash(&self) -> L1L2MsgHash {
-        l1_handler_message_hash(
+    pub fn calc_eth_msg_hash(&self) -> EthL1L2MessageHash {
+        eth_l1_handler_message_hash(
             &self.contract_address,
             self.nonce,
             &self.entry_point_selector,
@@ -160,13 +164,12 @@ impl L1HandlerTransaction {
 }
 
 /// Calculating the message hash of L1 -> L2 message.
-/// For more info: <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/messaging-mechanism/#structure_and_hashing_l1-l2>
-pub fn l1_handler_message_hash(
+pub fn eth_l1_handler_message_hash(
     contract_address: &ContractAddress,
     nonce: Nonce,
     entry_point_selector: &EntryPointSelector,
     calldata: &Calldata,
-) -> L1L2MsgHash {
+) -> EthL1L2MessageHash {
     let (from_address, payload) =
         calldata.0.split_first().expect("Invalid calldata, expected at least from_address");
 
@@ -186,5 +189,5 @@ pub fn l1_handler_message_hash(
 
     let mut keccak = Keccak256::default();
     keccak.update(&encoded);
-    L1L2MsgHash(keccak.finalize().into())
+    EthL1L2MessageHash(keccak.finalize().into())
 }

--- a/crates/starknet_api/src/hash_test.rs
+++ b/crates/starknet_api/src/hash_test.rs
@@ -1,0 +1,44 @@
+use std::sync::LazyLock;
+
+use expect_test::expect;
+
+use super::EthL1L2MessageHash;
+use crate::core::EntryPointSelector;
+use crate::transaction::L1HandlerTransaction;
+use crate::{calldata, contract_address, felt, nonce};
+
+// A transaction from MAINNET with tx hash
+// 0x439e12f67962c353182d72b4af12c3f11eaba4b36e552aebcdcd6db66971bdb.
+static L1_HANDLER_TX: LazyLock<L1HandlerTransaction> = LazyLock::new(|| L1HandlerTransaction {
+    version: L1HandlerTransaction::VERSION,
+    nonce: nonce!(0x18e94d),
+    contract_address: contract_address!(
+        "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82"
+    ),
+    entry_point_selector: EntryPointSelector(felt!(
+        "0x1b64b1b3b690b43b9b514fb81377518f4039cd3e4f4914d8a6bdf01d679fb19"
+    )),
+    calldata: calldata![
+        felt!("0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419"),
+        felt!("0x455448"),
+        felt!("0xc27947400e26e534e677afc2e9b2ec1bab14fc89"),
+        felt!("0x4af4754baf89f1b8b449215a8ea7ce558824a33a5393eaa3829658549f2bfa2"),
+        felt!("0x9184e72a000"),
+        felt!("0x0")
+    ],
+});
+
+#[test]
+fn l1_handler_eth_msg_hash() {
+    let eth_msg_hash = format!("{}", L1_HANDLER_TX.calc_eth_msg_hash());
+    expect!["0x99b2a7830e1c860734b308d90bb05b0e09ecda0a2b243ecddb12c50bdebaa3a9"]
+        .assert_eq(&eth_msg_hash);
+}
+
+#[test]
+fn eth_l1l2_message_hash_serde() {
+    let eth_msg_hash = L1_HANDLER_TX.calc_eth_msg_hash();
+    let serialized = serde_json::to_string(&eth_msg_hash).unwrap();
+    let deserialized = serde_json::from_str::<EthL1L2MessageHash>(&serialized).unwrap();
+    assert_eq!(deserialized, eth_msg_hash);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches L1 handler message-hash calculation and receipt/output construction in `apollo_rpc`, which can impact client-visible RPC receipts if the hash differs or becomes missing. The change appears mostly a type/utility rename, but it spans multiple crates and pathways (pending + stored receipts).
> 
> **Overview**
> Standardizes L1→L2 message hashing terminology and types by renaming `L1L2MsgHash`/`calc_msg_hash`/`l1_handler_message_hash` to `EthL1L2MessageHash`/`calc_eth_msg_hash`/`eth_l1_handler_message_hash` in `starknet_api`.
> 
> Threads the new `Eth` message-hash type through RPC receipt/output construction (both pending and non-pending) and updates L1 provider/scraper debug logging to report **Eth message hashes** alongside L2 tx hashes.
> 
> Moves the L1 handler message-hash regression tests from `apollo_rpc` into `starknet_api` as `hash_test.rs`, validating the expected mainnet hash value and serde roundtrip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d1ebd1938e7e0e6c6e1a375931f6c00fa36962c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->