### PR TITLE
apollo_network: add cooldown state to DialPeerStream to prevent tight redial loops

### DIFF
--- a/crates/apollo_network/src/discovery/behaviours/dialing/behaviour.rs
+++ b/crates/apollo_network/src/discovery/behaviours/dialing/behaviour.rs
@@ -22,9 +22,9 @@ use crate::discovery::{RetryConfig, ToOtherBehaviourEvent};
 /// with exponential backoff on failure.
 ///
 /// Each peer gets its own [`DialPeerStream`] that drives the dial lifecycle.
-/// Streams terminate once a connection is established. This behaviour does not
-/// re-dial peers after disconnection — callers must call
-/// [`request_dial`](Self::request_dial) again if reconnection is desired.
+/// Streams enter a cooldown after a connection is established; if a redial is
+/// requested during cooldown the stream resumes with accumulated backoff,
+/// otherwise it terminates once the connection stabilizes.
 pub struct DialingBehaviour {
     retry_config: RetryConfig,
     peers: SelectAll<DialPeerStream>,
@@ -38,11 +38,17 @@ impl DialingBehaviour {
 
     /// Request dialing a peer at the given addresses.
     ///
-    /// Creates a new [`DialPeerStream`] for the peer. If a stream for this peer already
-    /// exists (pending or in-progress), it is cancelled and replaced.
+    /// Creates a new [`DialPeerStream`] for the peer. If an active stream already exists, updates
+    /// its addresses and requests a redial.
     pub fn request_dial(&mut self, peer_id: PeerId, addresses: Vec<Multiaddr>) {
-        self.cancel_dial(&peer_id);
-        self.peers.push(DialPeerStream::new(&self.retry_config, peer_id, addresses));
+        let active_stream =
+            self.peers.iter_mut().find(|s| *s.peer_id() == peer_id && !s.is_cancelled());
+        match active_stream {
+            None => {
+                self.peers.push(DialPeerStream::new(&self.retry_config, peer_id, addresses));
+            }
+            Some(stream) => stream.request_redial(addresses),
+        }
         if let Some(waker) = self.waker.take() {
             waker.wake();
         }

--- a/crates/apollo_network/src/discovery/behaviours/dialing/dial_peer.rs
+++ b/crates/apollo_network/src/discovery/behaviours/dialing/dial_peer.rs
@@ -4,6 +4,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
+use std::time::Duration;
 
 use futures::Stream;
 use libp2p::swarm::behaviour::ConnectionEstablished;
@@ -16,10 +17,15 @@ use tracing::debug;
 
 use crate::discovery::{RetryConfig, ToOtherBehaviourEvent};
 
+/// How long to keep a `DialPeerStream` alive after a connection is established. If a redial is
+/// requested within this window the stream reuses its accumulated backoff. If the timer expires
+/// the connection is considered stable and the stream terminates.
+const COOLDOWN: Duration = Duration::from_millis(500);
+
 /// A stream that drives a single peer's dial lifecycle with exponential backoff.
 ///
-/// The stream emits `ToSwarm::Dial` events and terminates (`None`) once a
-/// connection is established or the dial is cancelled.
+/// The stream emits `ToSwarm::Dial` events and terminates (`None`) once the
+/// dial is cancelled or a connection stabilizes (remains up through a cooldown period).
 pub struct DialPeerStream {
     peer_id: PeerId,
     addresses: Vec<Multiaddr>,
@@ -33,9 +39,12 @@ enum DialState {
     PendingDial { sleeper: Pin<Box<Sleep>> },
     /// A dial attempt is in progress with the given connection id.
     Dialing(ConnectionId),
-    /// Terminal state - connection was established after the request, no guarantee if it's still
-    /// connected.
-    Done,
+    /// Connection established, waiting for it to stabilize. If `request_redial` is called before
+    /// the timer fires the stream transitions back to `PendingDial` with accumulated backoff. If
+    /// the timer expires the connection is considered stable and the stream terminates.
+    CooldownBeforeDeletion { connection_stable_sleeper: Pin<Box<Sleep>> },
+    /// Terminal state — the stream was explicitly cancelled by the caller.
+    Cancelled,
 }
 
 impl DialPeerStream {
@@ -55,18 +64,27 @@ impl DialPeerStream {
         &self.peer_id
     }
 
+    /// Returns `true` if the stream was explicitly cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        matches!(self.state, DialState::Cancelled)
+    }
+
     /// Mark this stream for termination. The next poll will return `None`.
     pub fn cancel(&mut self) {
-        self.state = DialState::Done;
+        self.state = DialState::Cancelled;
         self.wake();
     }
 
     pub fn on_swarm_event(&mut self, event: FromSwarm<'_>) {
         match event {
             FromSwarm::ConnectionEstablished(ConnectionEstablished { peer_id, .. })
-                if peer_id == self.peer_id =>
+                if peer_id == self.peer_id && !self.is_cancelled() =>
             {
-                self.state = DialState::Done;
+                self.state = DialState::CooldownBeforeDeletion {
+                    connection_stable_sleeper: Box::pin(tokio::time::sleep_until(
+                        Instant::now() + COOLDOWN,
+                    )),
+                };
                 self.wake();
             }
             FromSwarm::DialFailure(DialFailure {
@@ -75,18 +93,33 @@ impl DialPeerStream {
                 if !matches!(self.state, DialState::Dialing(id) if id == connection_id) {
                     return;
                 }
-                let backoff = self
-                    .retry_strategy
-                    .next()
-                    .expect("A bounded ExponentialBackoff is an infinite iterator");
-                self.state = DialState::PendingDial {
-                    sleeper: Box::pin(tokio::time::sleep_until(Instant::now() + backoff)),
-                };
-                debug!(?self.peer_id, ?backoff, "Dial failed, scheduling retry");
-                self.wake();
+                self.schedule_retry();
             }
             _ => {}
         }
+    }
+
+    /// Re-request dialing this peer with updated addresses. Only takes effect if the stream is in
+    /// `CooldownBeforeDeletion` (i.e., a connection was previously established). The next dial will
+    /// use the accumulated backoff from the retry strategy.
+    pub fn request_redial(&mut self, addresses: Vec<Multiaddr>) {
+        self.addresses = addresses;
+        if !matches!(self.state, DialState::CooldownBeforeDeletion { .. }) {
+            return;
+        }
+        self.schedule_retry();
+    }
+
+    fn schedule_retry(&mut self) {
+        let backoff = self
+            .retry_strategy
+            .next()
+            .expect("A bounded ExponentialBackoff is an infinite iterator");
+        self.state = DialState::PendingDial {
+            sleeper: Box::pin(tokio::time::sleep_until(Instant::now() + backoff)),
+        };
+        debug!(?self.peer_id, ?backoff, "Scheduling retry");
+        self.wake();
     }
 
     fn wake(&mut self) {
@@ -116,12 +149,18 @@ impl Stream for DialPeerStream {
         self.waker = Some(cx.waker().clone());
 
         match &mut self.state {
-            DialState::Done => Poll::Ready(None),
             DialState::Dialing(_) => Poll::Pending,
             DialState::PendingDial { sleeper } => match sleeper.as_mut().poll(cx) {
                 Poll::Ready(()) => Poll::Ready(Some(self.emit_dial())),
                 Poll::Pending => Poll::Pending,
             },
+            DialState::Cancelled => Poll::Ready(None),
+            DialState::CooldownBeforeDeletion { connection_stable_sleeper } => {
+                match connection_stable_sleeper.as_mut().poll(cx) {
+                    Poll::Ready(()) => Poll::Ready(None),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes peer dialing lifecycle and retry timing, which could affect connection stability and reconnection behavior under churn. Risk is moderate due to new state transitions and timing-dependent logic in libp2p swarm events.
> 
> **Overview**
> Adds a post-connect *cooldown* phase to `DialPeerStream` so a stream lingers briefly after `ConnectionEstablished`, allowing rapid reconnect/redial requests to reuse the existing backoff instead of terminating immediately.
> 
> Updates `DialingBehaviour::request_dial` to **stop cancelling/replacing** an existing stream; it now calls `request_redial` to update addresses and only triggers a new dial if the stream is in the cooldown/connected window, with retry scheduling centralized via `schedule_retry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 899997e72ec00c2452e3b7f21035c00fc75a5eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->