### PR TITLE
apollo_network: move cooldown duration into RetryConfig

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
@@ -64,6 +64,7 @@
   "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.base_delay_millis": 2,
   "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.factor": 5,
   "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.max_delay_seconds": 5,
+  "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": 2000,
   "consensus_manager_config.network_config.discovery_config.heartbeat_interval": 100,
   "consensus_manager_config.network_config.idle_connection_timeout": 120,
   "consensus_manager_config.network_config.peer_manager_config.malicious_timeout_seconds": 0,

--- a/crates/apollo_deployments/resources/app_configs/mempool_p2p_config.json
+++ b/crates/apollo_deployments/resources/app_configs/mempool_p2p_config.json
@@ -10,6 +10,7 @@
   "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.base_delay_millis": 2,
   "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.factor": 5,
   "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.max_delay_seconds": 5,
+  "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": 2000,
   "mempool_p2p_config.network_config.discovery_config.heartbeat_interval": 100,
   "mempool_p2p_config.network_config.idle_connection_timeout": 120,
   "mempool_p2p_config.network_config.peer_manager_config.malicious_timeout_seconds": 0,

--- a/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
@@ -64,6 +64,7 @@
   "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.base_delay_millis": 2,
   "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.factor": 5,
   "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.max_delay_seconds": 5,
+  "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": 2000,
   "consensus_manager_config.network_config.discovery_config.heartbeat_interval": 100,
   "consensus_manager_config.network_config.idle_connection_timeout": 120,
   "consensus_manager_config.network_config.peer_manager_config.malicious_timeout_seconds": 0,

--- a/crates/apollo_deployments/resources/app_configs/replacer_mempool_p2p_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_mempool_p2p_config.json
@@ -10,6 +10,7 @@
   "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.base_delay_millis": 2,
   "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.factor": 5,
   "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.max_delay_seconds": 5,
+  "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": 2000,
   "mempool_p2p_config.network_config.discovery_config.heartbeat_interval": 100,
   "mempool_p2p_config.network_config.idle_connection_timeout": 120,
   "mempool_p2p_config.network_config.peer_manager_config.malicious_timeout_seconds": 0,

--- a/crates/apollo_deployments/resources/app_configs/replacer_state_sync_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_state_sync_config.json
@@ -26,6 +26,7 @@
   "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.base_delay_millis": 2,
   "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.factor": 5,
   "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.max_delay_seconds": 5,
+  "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": 2000,
   "state_sync_config.static_config.network_config.discovery_config.heartbeat_interval": 100,
   "state_sync_config.static_config.network_config.idle_connection_timeout": 120,
   "state_sync_config.static_config.network_config.peer_manager_config.malicious_timeout_seconds": 1,

--- a/crates/apollo_deployments/resources/app_configs/state_sync_config.json
+++ b/crates/apollo_deployments/resources/app_configs/state_sync_config.json
@@ -25,6 +25,7 @@
   "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.base_delay_millis": 2,
   "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.factor": 5,
   "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.max_delay_seconds": 5,
+  "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": 2000,
   "state_sync_config.static_config.network_config.discovery_config.heartbeat_interval": 100,
   "state_sync_config.static_config.network_config.idle_connection_timeout": 120,
   "state_sync_config.static_config.network_config.peer_manager_config.malicious_timeout_seconds": 1,

--- a/crates/apollo_network/src/discovery/behaviours/dialing/dial_peer.rs
+++ b/crates/apollo_network/src/discovery/behaviours/dialing/dial_peer.rs
@@ -25,11 +25,6 @@ use tracing::debug;
 
 use crate::discovery::{RetryConfig, ToOtherBehaviourEvent};
 
-/// How long to keep a `DialPeerStream` alive after a connection is established. If a redial is
-/// requested within this window the stream reuses its accumulated backoff. If the timer expires
-/// the connection is considered stable and the stream terminates.
-const COOLDOWN: Duration = Duration::from_millis(500);
-
 /// A stream that drives a single peer's dial lifecycle with exponential backoff.
 ///
 /// The stream emits `ToSwarm::Dial` events and terminates (`None`) once the
@@ -39,12 +34,13 @@ pub struct DialPeerStream {
     addresses: Vec<Multiaddr>,
     state: DialState,
     retry_strategy: ExponentialBackoff,
+    new_connection_stabilization: Duration,
     waker: Option<Waker>,
 }
 
 enum DialState {
     /// Waiting to dial (immediately or after backoff).
-    PendingDial { sleeper: Pin<Box<Sleep>> },
+    PendingDial { sleeper: Pin<Box<dyn Future<Output = ()> + Send>> },
     /// A dial attempt is in progress with the given connection id.
     Dialing(ConnectionId),
     /// Connection established, waiting for it to stabilize. If `request_redial` is called before
@@ -60,10 +56,9 @@ impl DialPeerStream {
         Self {
             peer_id,
             addresses,
-            state: DialState::PendingDial {
-                sleeper: Box::pin(tokio::time::sleep_until(Instant::now())),
-            },
+            state: DialState::PendingDial { sleeper: Box::pin(futures::future::ready(())) },
             retry_strategy: retry_config.strategy(),
+            new_connection_stabilization: retry_config.new_connection_stabilization_millis,
             waker: None,
         }
     }
@@ -125,7 +120,7 @@ impl DialPeerStream {
     fn enter_cooldown(&mut self) {
         self.state = DialState::CooldownBeforeDeletion {
             connection_stable_sleeper: Box::pin(tokio::time::sleep_until(
-                Instant::now() + COOLDOWN,
+                Instant::now() + self.new_connection_stabilization,
             )),
         };
         self.wake();

--- a/crates/apollo_network/src/discovery/discovery_test.rs
+++ b/crates/apollo_network/src/discovery/discovery_test.rs
@@ -37,6 +37,7 @@ const CONFIG_WITH_ZERO_HEARTBEAT_AND_SMALL_BOOTSTRAP_DIAL: DiscoveryConfig = Dis
         base_delay_millis: SMALL_SLEEP_MILLIS,
         max_delay_seconds: Duration::from_millis(SMALL_SLEEP_MILLIS),
         factor: 1,
+        new_connection_stabilization_millis: Duration::from_millis(2000),
     },
     heartbeat_interval: Duration::ZERO,
 };
@@ -53,6 +54,7 @@ const CONFIG_WITH_SMALL_HEARTBEAT_AND_LARGE_BOOTSTRAP_SLEEP: DiscoveryConfig = D
         base_delay_millis: LARGE_SLEEP_MILLIS,
         max_delay_seconds: Duration::from_millis(LARGE_SLEEP_MILLIS),
         factor: 1,
+        new_connection_stabilization_millis: Duration::from_millis(2000),
     },
     ..CONFIG_WITH_SMALL_HEARTBEAT_AND_BOOTSTRAP_SLEEP
 };

--- a/crates/apollo_network/src/discovery/mod.rs
+++ b/crates/apollo_network/src/discovery/mod.rs
@@ -116,6 +116,7 @@ pub struct Behaviour {
 ///         base_delay_millis: 100,
 ///         max_delay_seconds: Duration::from_secs(10),
 ///         factor: 2,
+///         new_connection_stabilization_millis: Duration::from_millis(2000),
 ///     },
 ///     heartbeat_interval: Duration::from_millis(500),
 /// };
@@ -180,6 +181,7 @@ impl SerializeConfig for DiscoveryConfig {
 ///     base_delay_millis: 2,                          // double each time
 ///     max_delay_seconds: Duration::from_millis(100), // Cap at 0.1 seconds
 ///     factor: 7,                                     // start with 7ms
+///     new_connection_stabilization_millis: Duration::from_millis(2000),
 /// };
 ///
 /// let mut strategy = aggressive.strategy();
@@ -200,11 +202,21 @@ pub struct RetryConfig {
 
     /// Multiplication factor for the exponential backoff.
     pub factor: u64,
+
+    /// Milliseconds to wait on a new connection before treating it as stable. Redials within
+    /// this window (e.g. from an immediately refused connection) use accumulated backoff.
+    #[serde(deserialize_with = "deserialize_milliseconds_to_duration")]
+    pub new_connection_stabilization_millis: Duration,
 }
 
 impl Default for RetryConfig {
     fn default() -> Self {
-        Self { base_delay_millis: 2, max_delay_seconds: Duration::from_secs(5), factor: 5 }
+        Self {
+            base_delay_millis: 2,
+            max_delay_seconds: Duration::from_secs(5),
+            factor: 5,
+            new_connection_stabilization_millis: Duration::from_millis(2000),
+        }
     }
 }
 
@@ -227,6 +239,12 @@ impl SerializeConfig for RetryConfig {
                 "factor",
                 &self.factor,
                 "The factor for the exponential backoff strategy.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "new_connection_stabilization_millis",
+                &self.new_connection_stabilization_millis.as_millis(),
+                "Milliseconds to wait on a new connection before treating it as stable.",
                 ParamPrivacyInput::Public,
             ),
         ])

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2819,6 +2819,11 @@
     "privacy": "Public",
     "value": 5
   },
+  "consensus_manager_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": {
+    "description": "Milliseconds to wait on a new connection before treating it as stable.",
+    "privacy": "Public",
+    "value": 2000
+  },
   "consensus_manager_config.network_config.discovery_config.heartbeat_interval": {
     "description": "The interval between each discovery (Kademlia) query in milliseconds.",
     "privacy": "Public",
@@ -3469,6 +3474,11 @@
     "privacy": "Public",
     "value": 5
   },
+  "mempool_p2p_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": {
+    "description": "Milliseconds to wait on a new connection before treating it as stable.",
+    "privacy": "Public",
+    "value": 2000
+  },
   "mempool_p2p_config.network_config.discovery_config.heartbeat_interval": {
     "description": "The interval between each discovery (Kademlia) query in milliseconds.",
     "privacy": "Public",
@@ -3773,6 +3783,11 @@
     "description": "The maximum delay in seconds for the exponential backoff strategy.",
     "privacy": "Public",
     "value": 5
+  },
+  "state_sync_config.static_config.network_config.discovery_config.bootstrap_dial_retry_config.new_connection_stabilization_millis": {
+    "description": "Milliseconds to wait on a new connection before treating it as stable.",
+    "privacy": "Public",
+    "value": 2000
   },
   "state_sync_config.static_config.network_config.discovery_config.heartbeat_interval": {
     "description": "The interval between each discovery (Kademlia) query in milliseconds.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dialing retry timing by replacing a hardcoded post-connect cooldown with a configurable `RetryConfig.cooldown_seconds` (defaulting to 2s), which can affect how quickly backoff resets and how aggressively peers are re-dialed after short-lived connections.
> 
> **Overview**
> Moves the post-connection dial *cooldown window* from a hardcoded constant in `DialPeerStream` to a new configurable `RetryConfig.cooldown_seconds`, and uses this value when deciding when a connection is “stable” and the dial stream can terminate.
> 
> Extends `RetryConfig` with `cooldown_seconds` (including serde/`SerializeConfig` support and updated defaults/docs) and updates discovery tests/config fixtures to provide the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c55fc2bc7d2154a51336874145ae16bce9d39e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->