### PR TITLE
apollo_propeller: fix tree.rs comments to use 'unit' instead of 'shard'

### DIFF
--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -135,15 +135,15 @@ impl PropellerScheduleManager {
             .ok_or(ScheduleError::ShardIndexOutOfBounds { shard_index: original_shard_index })
     }
 
-    /// Validates that a shard unit was received from the expected sender.
+    /// Validates that a unit was received from the expected sender.
     ///
-    /// Verifies that the sender is either the publisher (for direct shards) or the designated
-    /// broadcaster for this shard index.
+    /// Verifies that the sender is either the publisher (for direct units) or the designated
+    /// broadcaster for this unit's index.
     ///
     /// # Arguments
     ///
-    /// * `sender` - The peer ID that sent this shard unit
-    /// * `unit` - The shard unit to validate
+    /// * `sender` - The peer ID that sent this unit
+    /// * `unit` - The unit to validate
     pub fn validate_origin(
         &self,
         sender: PeerId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only changes in `tree.rs`; no behavior or interface changes, so risk is minimal.
> 
> **Overview**
> Updates documentation in `PropellerScheduleManager::validate_origin` to consistently refer to a "unit" (instead of "shard unit"), clarifying that validation checks the sender against either the publisher or the designated broadcaster for the unit index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f51d51f137b62ef52ef6d547a6016a62b4b183d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->