### PR TITLE
apollo_propeller: rename received_shards to received_units in ReconstructionState

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -56,7 +56,7 @@ enum AddUnitAction {
 /// Tracks reconstruction progress for a single message.
 enum ReconstructionState {
     PreConstruction {
-        received_shards: Vec<PropellerUnit>,
+        received_units: Vec<PropellerUnit>,
         did_broadcast_my_shard: bool,
         verified_fields: Option<VerifiedFields>,
     },
@@ -69,7 +69,7 @@ enum ReconstructionState {
 impl ReconstructionState {
     fn new() -> Self {
         Self::PreConstruction {
-            received_shards: Vec::new(),
+            received_units: Vec::new(),
             did_broadcast_my_shard: false,
             verified_fields: None,
         }
@@ -92,7 +92,7 @@ impl ReconstructionState {
         let is_my_shard = unit.index() == my_shard_index;
 
         match self {
-            Self::PreConstruction { received_shards, did_broadcast_my_shard, verified_fields } => {
+            Self::PreConstruction { received_units, did_broadcast_my_shard, verified_fields } => {
                 if is_my_shard {
                     *did_broadcast_my_shard = true;
                 }
@@ -102,9 +102,9 @@ impl ReconstructionState {
                         nonce: unit.nonce(),
                     });
                 }
-                received_shards.push(unit);
-                if tree_manager.should_build(received_shards.len()) {
-                    AddUnitAction::Reconstruct(std::mem::take(received_shards))
+                received_units.push(unit);
+                if tree_manager.should_build(received_units.len()) {
+                    AddUnitAction::Reconstruct(std::mem::take(received_units))
                 } else {
                     AddUnitAction::NoOp
                 }

--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -135,15 +135,15 @@ impl PropellerScheduleManager {
             .ok_or(ScheduleError::ShardIndexOutOfBounds { shard_index: original_shard_index })
     }
 
-    /// Validates that a shard unit was received from the expected sender.
+    /// Validates that a unit was received from the expected sender.
     ///
-    /// Verifies that the sender is either the publisher (for direct shards) or the designated
-    /// broadcaster for this shard index.
+    /// Verifies that the sender is either the publisher (for direct units) or the designated
+    /// broadcaster for this unit's index.
     ///
     /// # Arguments
     ///
-    /// * `sender` - The peer ID that sent this shard unit
-    /// * `unit` - The shard unit to validate
+    /// * `sender` - The peer ID that sent this unit
+    /// * `unit` - The unit to validate
     pub fn validate_origin(
         &self,
         sender: PeerId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename-only change within `ReconstructionState` bookkeeping; behavior should be unchanged aside from identifier updates.
> 
> **Overview**
> Renames the `ReconstructionState::PreConstruction` accumulator from `received_shards` to `received_units` and updates `add_unit`/`new` to use the new name.
> 
> No functional behavior changes are intended; this is a terminology cleanup to align internal state naming with `PropellerUnit` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9593a7de5270c564bdf70410ea9d0c4d96ef2783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->