### PR TITLE
apollo_propeller: rename num_held_shards to num_held_units

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -63,7 +63,7 @@ enum ReconstructionState {
     /// Message was reconstructed but not yet delivered to the application. We keep collecting
     /// shards until the emit threshold is reached, then emit the message.
     // No need to track the unit indices after reconstruction (unit duplication already validated)
-    PostConstruction { reconstructed_message: Option<Vec<u8>>, num_held_shards: usize },
+    PostConstruction { reconstructed_message: Option<Vec<u8>>, num_held_units: usize },
 }
 
 impl ReconstructionState {
@@ -111,9 +111,9 @@ impl ReconstructionState {
             }
             // During reconstruction we broadcast our unit, so receiving it back from the
             // network should not inflate the count.
-            Self::PostConstruction { num_held_shards, .. } => {
+            Self::PostConstruction { num_held_units, .. } => {
                 if !is_my_shard {
-                    *num_held_shards += 1;
+                    *num_held_units += 1;
                 }
                 self.maybe_emit(tree_manager)
             }
@@ -122,8 +122,8 @@ impl ReconstructionState {
 
     fn maybe_emit(&mut self, tree_manager: &PropellerScheduleManager) -> AddUnitAction {
         match self {
-            Self::PostConstruction { num_held_shards, reconstructed_message } => {
-                if tree_manager.should_receive(*num_held_shards) {
+            Self::PostConstruction { num_held_units, reconstructed_message } => {
+                if tree_manager.should_receive(*num_held_units) {
                     match reconstructed_message.take() {
                         Some(msg) => AddUnitAction::Emit(msg),
                         None => AddUnitAction::NoOp,
@@ -136,8 +136,8 @@ impl ReconstructionState {
         }
     }
 
-    fn transition_to_post(&mut self, message: Vec<u8>, num_held_shards: usize) {
-        *self = Self::PostConstruction { reconstructed_message: Some(message), num_held_shards };
+    fn transition_to_post(&mut self, message: Vec<u8>, num_held_units: usize) {
+        *self = Self::PostConstruction { reconstructed_message: Some(message), num_held_units };
     }
 }
 

--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -57,7 +57,7 @@ enum AddUnitAction {
 enum ReconstructionState {
     PreConstruction {
         received_units: Vec<PropellerUnit>,
-        did_broadcast_my_shard: bool,
+        did_broadcast_my_unit: bool,
         verified_fields: Option<VerifiedFields>,
     },
     /// Message was reconstructed but not yet delivered to the application. We keep collecting
@@ -70,14 +70,14 @@ impl ReconstructionState {
     fn new() -> Self {
         Self::PreConstruction {
             received_units: Vec::new(),
-            did_broadcast_my_shard: false,
+            did_broadcast_my_unit: false,
             verified_fields: None,
         }
     }
 
-    fn did_broadcast_my_shard(&self) -> bool {
+    fn did_broadcast_my_unit(&self) -> bool {
         match self {
-            Self::PreConstruction { did_broadcast_my_shard, .. } => *did_broadcast_my_shard,
+            Self::PreConstruction { did_broadcast_my_unit, .. } => *did_broadcast_my_unit,
             Self::PostConstruction { .. } => true,
         }
     }
@@ -92,9 +92,9 @@ impl ReconstructionState {
         let is_my_shard = unit.index() == my_shard_index;
 
         match self {
-            Self::PreConstruction { received_units, did_broadcast_my_shard, verified_fields } => {
+            Self::PreConstruction { received_units, did_broadcast_my_unit, verified_fields } => {
                 if is_my_shard {
-                    *did_broadcast_my_shard = true;
+                    *did_broadcast_my_unit = true;
                 }
                 if verified_fields.is_none() {
                     *verified_fields = Some(VerifiedFields {
@@ -243,7 +243,7 @@ impl MessageProcessor {
     /// Broadcasts our unit to peers the first time we see it. In PostConstruction this is a no-op
     /// because reconstruction already triggered the broadcast.
     fn maybe_broadcast_my_shard(&self, unit: &PropellerUnit, state: &ReconstructionState) {
-        if unit.index() == self.my_shard_index && !state.did_broadcast_my_shard() {
+        if unit.index() == self.my_shard_index && !state.did_broadcast_my_unit() {
             self.broadcast_unit(unit);
         }
     }
@@ -328,7 +328,7 @@ impl MessageProcessor {
     ) -> ControlFlow<()> {
         let ReconstructionOutput { message, my_shards, my_shard_proof } = output;
 
-        let should_broadcast = !state.did_broadcast_my_shard();
+        let should_broadcast = !state.did_broadcast_my_unit();
         if should_broadcast {
             let (signature, nonce) = match state {
                 ReconstructionState::PreConstruction { verified_fields, .. } => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a mechanical rename of a local state field/parameter with no behavioral changes; main risk is only missing a reference, which appears fully updated.
> 
> **Overview**
> Renames the `ReconstructionState::PostConstruction` counter from `num_held_shards` to `num_held_units` and updates related method parameters and logic (`add_unit`, `maybe_emit`, `transition_to_post`) in `message_processor.rs` for clearer terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c194e3c4f9eb9ee8062c280f1262a78bbbd804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->