### PR TITLE
apollo_propeller: rename maybe_broadcast_my_shard to maybe_broadcast_my_unit

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -206,7 +206,7 @@ impl MessageProcessor {
                 continue;
             }
 
-            self.maybe_broadcast_my_shard(&unit, &state);
+            self.maybe_broadcast_my_unit(&unit, &state);
 
             let action = state.add_unit(unit, self.my_shard_index, &self.tree_manager);
             if self.handle_action(action, &mut state).await.is_break() {
@@ -242,7 +242,7 @@ impl MessageProcessor {
 
     /// Broadcasts our unit to peers the first time we see it. In PostConstruction this is a no-op
     /// because reconstruction already triggered the broadcast.
-    fn maybe_broadcast_my_shard(&self, unit: &PropellerUnit, state: &ReconstructionState) {
+    fn maybe_broadcast_my_unit(&self, unit: &PropellerUnit, state: &ReconstructionState) {
         if unit.index() == self.my_shard_index && !state.did_broadcast_my_unit() {
             self.broadcast_unit(unit);
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename in `MessageProcessor`; behavior is unchanged aside from updated method naming and call site.
> 
> **Overview**
> Renames the `MessageProcessor` helper that conditionally broadcasts the local shard/unit from `maybe_broadcast_my_shard` to `maybe_broadcast_my_unit`, updating the single call site and the function definition/comments accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59138cc6e015c40ad67ae843b7fd3a1bd136586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->