### PR TITLE
apollo_propeller: rename local vars shards/shard_count to units/unit_count in handle_action

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -279,11 +279,11 @@ impl MessageProcessor {
                     message,
                 })
             }
-            AddUnitAction::Reconstruct(shards) => {
-                let shard_count = shards.len();
-                trace!("[MSG_PROC] Starting reconstruction with {} shards", shard_count);
-                match self.reconstruct_blocking(shards).await {
-                    Ok(output) => self.handle_reconstruction_output(output, shard_count, state),
+            AddUnitAction::Reconstruct(units) => {
+                let unit_count = units.len();
+                trace!("[MSG_PROC] Starting reconstruction with {} units", unit_count);
+                match self.reconstruct_blocking(units).await {
+                    Ok(output) => self.handle_reconstruction_output(output, unit_count, state),
                     Err(e) => {
                         error!("[MSG_PROC] Reconstruction failed: {:?}", e);
                         self.emit_and_finalize(Event::MessageReconstructionFailed {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor limited to local variable names and log output; no behavior or data-flow changes expected.
> 
> **Overview**
> Renames the `handle_action` reconstruction branch locals from `shards`/`shard_count` to `units`/`unit_count` and updates the associated trace log message for clearer terminology alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a059dfa2ff696939b07aea5e6a42b369a071ecf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->