### PR TITLE
apollo_propeller: rename validate_shard to validate_unit in UnitValidator

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -233,7 +233,7 @@ impl MessageProcessor {
         // TODO(AndrewL): track task handle to abort the task if the timeout is reached or
         // finalization occurs.
         tokio::task::spawn_blocking(move || {
-            let result = validator.validate_shard(sender, &unit);
+            let result = validator.validate_unit(sender, &unit);
             (result, validator, unit)
         })
         .await

--- a/crates/apollo_propeller/src/unit_validator.rs
+++ b/crates/apollo_propeller/src/unit_validator.rs
@@ -85,7 +85,7 @@ impl UnitValidator {
         result
     }
 
-    pub fn validate_shard(
+    pub fn validate_unit(
         &mut self,
         sender: PeerId,
         unit: &PropellerUnit,

--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -119,7 +119,7 @@ fn unit(env: &TestEnv, owner: PeerId) -> PropellerUnit {
 fn test_validation_of_legal_unit() {
     let mut env = build_env(1);
     let unit = unit(&env, env.local_peer);
-    env.validator.validate_shard(env.publisher, &unit).unwrap();
+    env.validator.validate_unit(env.publisher, &unit).unwrap();
 }
 
 #[rstest]
@@ -127,7 +127,7 @@ fn test_validation_fails_with_wrong_signature() {
     let mut env = build_env(1);
     let unit = custom_unit(&env, env.local_peer, true);
     assert!(matches!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::SignatureVerificationFailed(
             ShardSignatureVerificationError::VerificationFailed
         ))
@@ -138,9 +138,9 @@ fn test_validation_fails_with_wrong_signature() {
 fn test_duplicate_shard_rejected() {
     let mut env = build_env(1);
     let unit = unit(&env, env.local_peer);
-    env.validator.validate_shard(env.publisher, &unit).unwrap();
+    env.validator.validate_unit(env.publisher, &unit).unwrap();
     assert!(matches!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::DuplicateShard)
     ));
 }
@@ -198,7 +198,7 @@ fn test_unit_source_validation(
     let mut env = build_env(1);
     let my_unit = unit(&env, owner.id(&env));
     let sender_id = sender.id(&env);
-    let result = env.validator.validate_shard(sender_id, &my_unit);
+    let result = env.validator.validate_unit(sender_id, &my_unit);
     let hop1 = (sender == Sender::Publisher) && (owner == UnitOwner::LocalPeer);
     let hop2_a = (sender == Sender::OtherPeer1) && (owner == UnitOwner::OtherPeer1);
     let hop2_b = (sender == Sender::OtherPeer2) && (owner == UnitOwner::OtherPeer2);
@@ -215,7 +215,7 @@ fn test_tampered_proof_fails_verification() {
     let mut unit = unit(&env, env.local_peer);
     unit.shards_mut().0[0].0.push(42);
 
-    let result = env.validator.validate_shard(env.publisher, &unit);
+    let result = env.validator.validate_unit(env.publisher, &unit);
     result.unwrap_err();
 }
 
@@ -234,7 +234,7 @@ fn test_unexpected_shard_count_rejected() {
     let unit = unit(&env, env.local_peer);
 
     assert_eq!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::UnexpectedShardCount {
             expected_shard_count: 1,
             actual_shard_count: 2,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename-only API change: updates the validator method name and call sites without changing validation logic, but could break any external callers still using `validate_shard`.
> 
> **Overview**
> Renames `UnitValidator::validate_shard` to `validate_unit` and updates all in-crate call sites, including `MessageProcessor`’s blocking validation path and `unit_validator_test`.
> 
> No functional validation behavior is changed; this is a naming/API consistency update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72630f4003510be64f6664eed6784102132f2d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->