### PR TITLE
apollo_propeller: rename shards_received metric to units_received

### DIFF
--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -243,7 +243,7 @@ impl Engine {
 
         // Track received unit.
         if let Some(metrics) = &self.metrics {
-            metrics.shards_received.increment(1);
+            metrics.units_received.increment(1);
         }
 
         // Check if committee is registered.

--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -233,7 +233,7 @@ impl MessageProcessor {
         // TODO(AndrewL): track task handle to abort the task if the timeout is reached or
         // finalization occurs.
         tokio::task::spawn_blocking(move || {
-            let result = validator.validate_shard(sender, &unit);
+            let result = validator.validate_unit(sender, &unit);
             (result, validator, unit)
         })
         .await

--- a/crates/apollo_propeller/src/metrics.rs
+++ b/crates/apollo_propeller/src/metrics.rs
@@ -6,13 +6,13 @@ use apollo_metrics::metrics::MetricCounter;
 
 /// Propeller protocol metrics
 pub struct PropellerMetrics {
-    /// Total number of shards received from peers
-    pub shards_received: MetricCounter,
+    /// Total number of units received from peers
+    pub units_received: MetricCounter,
 }
 
 impl PropellerMetrics {
     /// Register all metrics with the metrics system
     pub fn register(&self) {
-        self.shards_received.register();
+        self.units_received.register();
     }
 }

--- a/crates/apollo_propeller/src/unit_validator.rs
+++ b/crates/apollo_propeller/src/unit_validator.rs
@@ -85,7 +85,7 @@ impl UnitValidator {
         result
     }
 
-    pub fn validate_shard(
+    pub fn validate_unit(
         &mut self,
         sender: PeerId,
         unit: &PropellerUnit,

--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -119,7 +119,7 @@ fn unit(env: &TestEnv, owner: PeerId) -> PropellerUnit {
 fn test_validation_of_legal_unit() {
     let mut env = build_env(1);
     let unit = unit(&env, env.local_peer);
-    env.validator.validate_shard(env.publisher, &unit).unwrap();
+    env.validator.validate_unit(env.publisher, &unit).unwrap();
 }
 
 #[rstest]
@@ -127,7 +127,7 @@ fn test_validation_fails_with_wrong_signature() {
     let mut env = build_env(1);
     let unit = custom_unit(&env, env.local_peer, true);
     assert!(matches!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::SignatureVerificationFailed(
             ShardSignatureVerificationError::VerificationFailed
         ))
@@ -138,9 +138,9 @@ fn test_validation_fails_with_wrong_signature() {
 fn test_duplicate_shard_rejected() {
     let mut env = build_env(1);
     let unit = unit(&env, env.local_peer);
-    env.validator.validate_shard(env.publisher, &unit).unwrap();
+    env.validator.validate_unit(env.publisher, &unit).unwrap();
     assert!(matches!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::DuplicateShard)
     ));
 }
@@ -198,7 +198,7 @@ fn test_unit_source_validation(
     let mut env = build_env(1);
     let my_unit = unit(&env, owner.id(&env));
     let sender_id = sender.id(&env);
-    let result = env.validator.validate_shard(sender_id, &my_unit);
+    let result = env.validator.validate_unit(sender_id, &my_unit);
     let hop1 = (sender == Sender::Publisher) && (owner == UnitOwner::LocalPeer);
     let hop2_a = (sender == Sender::OtherPeer1) && (owner == UnitOwner::OtherPeer1);
     let hop2_b = (sender == Sender::OtherPeer2) && (owner == UnitOwner::OtherPeer2);
@@ -215,7 +215,7 @@ fn test_tampered_proof_fails_verification() {
     let mut unit = unit(&env, env.local_peer);
     unit.shards_mut().0[0].0.push(42);
 
-    let result = env.validator.validate_shard(env.publisher, &unit);
+    let result = env.validator.validate_unit(env.publisher, &unit);
     result.unwrap_err();
 }
 
@@ -234,7 +234,7 @@ fn test_unexpected_shard_count_rejected() {
     let unit = unit(&env, env.local_peer);
 
     assert_eq!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::UnexpectedShardCount {
             expected_shard_count: 1,
             actual_shard_count: 2,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename of a metrics counter and its registration; only affects metric naming/field access and not protocol behavior.
> 
> **Overview**
> Renames the Propeller receive counter from `shards_received` to `units_received` and updates the engine to increment the new metric when handling incoming `PropellerUnit`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df847e003ce74fc6456910ba064629454b7bc3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->