### PR TITLE
apollo_propeller: rename ShardPublishError to UnitPublishError

### DIFF
--- a/crates/apollo_propeller/src/behaviour.rs
+++ b/crates/apollo_propeller/src/behaviour.rs
@@ -30,7 +30,7 @@ use crate::config::Config;
 use crate::engine::{Engine, EngineCommand, EngineOutput};
 use crate::handler::Handler;
 use crate::metrics::PropellerMetrics;
-use crate::types::{CommitteeId, CommitteeSetupError, Event, ShardPublishError};
+use crate::types::{CommitteeId, CommitteeSetupError, Event, UnitPublishError};
 
 /// The Propeller network behaviour.
 ///
@@ -117,7 +117,7 @@ impl Behaviour {
         &self,
         committee_id: CommitteeId,
         message: Vec<u8>,
-    ) -> oneshot::Receiver<Result<(), ShardPublishError>> {
+    ) -> oneshot::Receiver<Result<(), UnitPublishError>> {
         let (response_tx, response_rx) = oneshot::channel();
         let command = EngineCommand::Broadcast { committee_id, message, response_tx };
         self.engine_commands_tx.send(command).expect("Engine task has exited");

--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -243,7 +243,7 @@ impl Engine {
 
         // Track received unit.
         if let Some(metrics) = &self.metrics {
-            metrics.shards_received.increment(1);
+            metrics.units_received.increment(1);
         }
 
         // Check if committee is registered.

--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -23,7 +23,7 @@ use crate::sharding::create_units_to_publish;
 use crate::signature;
 use crate::time_cache::TimeCache;
 use crate::tree::PropellerScheduleManager;
-use crate::types::{CommitteeId, CommitteeSetupError, Event, MessageRoot, ShardPublishError};
+use crate::types::{CommitteeId, CommitteeSetupError, Event, MessageRoot, UnitPublishError};
 use crate::unit::PropellerUnit;
 
 #[cfg(test)]
@@ -34,8 +34,8 @@ mod engine_test;
 // Must be much bigger than the number of peers we expect to work with (2*committee_size).
 const PEER_NONCE_CACHE_SIZE: usize = 1000;
 
-type BroadcastResponseTx = oneshot::Sender<Result<(), ShardPublishError>>;
-type BroadcastResult = (Result<Vec<PropellerUnit>, ShardPublishError>, BroadcastResponseTx);
+type BroadcastResponseTx = oneshot::Sender<Result<(), UnitPublishError>>;
+type BroadcastResult = (Result<Vec<PropellerUnit>, UnitPublishError>, BroadcastResponseTx);
 
 // TODO(guyn): since the nonce is part of the MessageKey, there's a risk that getting a bad nonce
 // will cause a message processor to start working on a bad message, which later takes up resources
@@ -203,7 +203,7 @@ impl Engine {
         let Some(schedule_manager) =
             self.committees.get(&committee_id).map(|data| data.schedule_manager.clone())
         else {
-            let _ = response_tx.send(Err(ShardPublishError::CommitteeNotRegistered(committee_id)));
+            let _ = response_tx.send(Err(UnitPublishError::CommitteeNotRegistered(committee_id)));
             return;
         };
 
@@ -336,7 +336,7 @@ impl Engine {
         self.emit_event(Event::ShardSendFailed {
             sent_from: None,
             sent_to: Some(peer_id),
-            error: ShardPublishError::HandlerError(error),
+            error: UnitPublishError::HandlerError(error),
         });
     }
 
@@ -352,7 +352,7 @@ impl Engine {
             self.emit_event(Event::ShardSendFailed {
                 sent_from: None,
                 sent_to: Some(peer_id),
-                error: ShardPublishError::NotConnectedToPeer(peer_id),
+                error: UnitPublishError::NotConnectedToPeer(peer_id),
             });
             return;
         }
@@ -363,7 +363,7 @@ impl Engine {
 
     fn handle_broadcaster_result(
         &mut self,
-        result: Result<Vec<PropellerUnit>, ShardPublishError>,
+        result: Result<Vec<PropellerUnit>, UnitPublishError>,
         response: BroadcastResponseTx,
     ) {
         if let Err(error) = result.and_then(|units| self.broadcast_prepared_units(units)) {
@@ -449,7 +449,7 @@ impl Engine {
     fn broadcast_prepared_units(
         &mut self,
         units: Vec<PropellerUnit>,
-    ) -> Result<(), ShardPublishError> {
+    ) -> Result<(), UnitPublishError> {
         let Some(first_unit) = units.first() else {
             return Ok(());
         };
@@ -459,7 +459,7 @@ impl Engine {
         let schedule_manager = self
             .committees
             .get(&committee_id)
-            .ok_or(ShardPublishError::CommitteeNotRegistered(committee_id))?
+            .ok_or(UnitPublishError::CommitteeNotRegistered(committee_id))?
             .schedule_manager
             .clone();
 

--- a/crates/apollo_propeller/src/lib.rs
+++ b/crates/apollo_propeller/src/lib.rs
@@ -49,8 +49,8 @@ pub use types::{
     ReconstructionError,
     ScheduleError,
     ShardIndex,
-    ShardPublishError,
     ShardValidationError,
+    UnitPublishError,
 };
 pub use unit::{PropellerUnit, Shard, ShardsOfPeer};
 pub use unit_validator::UnitValidator;

--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -233,7 +233,7 @@ impl MessageProcessor {
         // TODO(AndrewL): track task handle to abort the task if the timeout is reached or
         // finalization occurs.
         tokio::task::spawn_blocking(move || {
-            let result = validator.validate_shard(sender, &unit);
+            let result = validator.validate_unit(sender, &unit);
             (result, validator, unit)
         })
         .await

--- a/crates/apollo_propeller/src/metrics.rs
+++ b/crates/apollo_propeller/src/metrics.rs
@@ -6,13 +6,13 @@ use apollo_metrics::metrics::MetricCounter;
 
 /// Propeller protocol metrics
 pub struct PropellerMetrics {
-    /// Total number of shards received from peers
-    pub shards_received: MetricCounter,
+    /// Total number of units received from peers
+    pub units_received: MetricCounter,
 }
 
 impl PropellerMetrics {
     /// Register all metrics with the metrics system
     pub fn register(&self) {
-        self.shards_received.register();
+        self.units_received.register();
     }
 }

--- a/crates/apollo_propeller/src/sharding.rs
+++ b/crates/apollo_propeller/src/sharding.rs
@@ -11,7 +11,7 @@ use libp2p::identity::{Keypair, PeerId};
 
 use crate::padding::{pad_message, unpad_message};
 use crate::reed_solomon::{combine_data_shards, generate_coding_shards, split_data_into_shards};
-use crate::types::{CommitteeId, ReconstructionError, ShardIndex, ShardPublishError};
+use crate::types::{CommitteeId, ReconstructionError, ShardIndex, UnitPublishError};
 use crate::unit::{PropellerUnit, Shard, ShardsOfPeer};
 use crate::{signature, MerkleProof, MerkleTree, MessageRoot};
 
@@ -97,12 +97,12 @@ pub fn create_units_to_publish(
     keypair: Keypair,
     num_data_shards: usize,
     num_coding_shards: usize,
-) -> Result<Vec<PropellerUnit>, ShardPublishError> {
+) -> Result<Vec<PropellerUnit>, UnitPublishError> {
     let publisher = PeerId::from(keypair.public());
 
     // The reed-solomon-simd crate requires the shard length to be even.
     let divisor =
-        NonZeroUsize::new(2 * num_data_shards).ok_or(ShardPublishError::InvalidDataSize)?;
+        NonZeroUsize::new(2 * num_data_shards).ok_or(UnitPublishError::InvalidDataSize)?;
     let message = pad_message(message, divisor);
 
     let data_shards = split_data_into_shards(message, num_data_shards)

--- a/crates/apollo_propeller/src/signature.rs
+++ b/crates/apollo_propeller/src/signature.rs
@@ -5,7 +5,7 @@
 
 use libp2p::identity::{Keypair, PeerId, PublicKey};
 
-use crate::types::{CommitteeId, MessageRoot, ShardPublishError, ShardSignatureVerificationError};
+use crate::types::{CommitteeId, MessageRoot, ShardSignatureVerificationError, UnitPublishError};
 
 // TODO(AndrewL): Consider removing these (consult gossipsub code )
 pub const SIGNING_PREFIX: &[u8] = b"<propeller>";
@@ -19,10 +19,10 @@ pub fn sign_message_id(
     committee_id: CommitteeId,
     nonce: u64,
     keypair: &Keypair,
-) -> Result<Vec<u8>, ShardPublishError> {
+) -> Result<Vec<u8>, UnitPublishError> {
     let msg = build_signed_payload(message_id, committee_id, nonce);
     // TODO(AndrewL): Use a transparent error type for this.
-    keypair.sign(&msg).map_err(|e| ShardPublishError::SigningFailed(e.to_string()))
+    keypair.sign(&msg).map_err(|e| UnitPublishError::SigningFailed(e.to_string()))
 }
 
 pub fn verify_message_id_signature(

--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -22,7 +22,7 @@ pub enum Event {
         error: ReconstructionError,
     },
     /// Failed to send a shard to a peer.
-    ShardSendFailed { sent_from: Option<PeerId>, sent_to: Option<PeerId>, error: ShardPublishError },
+    ShardSendFailed { sent_from: Option<PeerId>, sent_to: Option<PeerId>, error: UnitPublishError },
     /// Failed to verify shard
     ShardValidationFailed {
         /// The sender of the shard that filed verification. They should be reported.
@@ -84,9 +84,9 @@ pub enum ScheduleError {
     LocalPeerIsPublisher,
 }
 
-/// Errors that can occur when sending a shard.
+/// Errors that can occur when sending a unit.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum ShardPublishError {
+pub enum UnitPublishError {
     #[error("Local peer not in peer weights")]
     LocalPeerNotInPeerWeights,
     #[error(

--- a/crates/apollo_propeller/src/unit_validator.rs
+++ b/crates/apollo_propeller/src/unit_validator.rs
@@ -85,7 +85,7 @@ impl UnitValidator {
         result
     }
 
-    pub fn validate_shard(
+    pub fn validate_unit(
         &mut self,
         sender: PeerId,
         unit: &PropellerUnit,

--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -119,7 +119,7 @@ fn unit(env: &TestEnv, owner: PeerId) -> PropellerUnit {
 fn test_validation_of_legal_unit() {
     let mut env = build_env(1);
     let unit = unit(&env, env.local_peer);
-    env.validator.validate_shard(env.publisher, &unit).unwrap();
+    env.validator.validate_unit(env.publisher, &unit).unwrap();
 }
 
 #[rstest]
@@ -127,7 +127,7 @@ fn test_validation_fails_with_wrong_signature() {
     let mut env = build_env(1);
     let unit = custom_unit(&env, env.local_peer, true);
     assert!(matches!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::SignatureVerificationFailed(
             ShardSignatureVerificationError::VerificationFailed
         ))
@@ -138,9 +138,9 @@ fn test_validation_fails_with_wrong_signature() {
 fn test_duplicate_shard_rejected() {
     let mut env = build_env(1);
     let unit = unit(&env, env.local_peer);
-    env.validator.validate_shard(env.publisher, &unit).unwrap();
+    env.validator.validate_unit(env.publisher, &unit).unwrap();
     assert!(matches!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::DuplicateShard)
     ));
 }
@@ -198,7 +198,7 @@ fn test_unit_source_validation(
     let mut env = build_env(1);
     let my_unit = unit(&env, owner.id(&env));
     let sender_id = sender.id(&env);
-    let result = env.validator.validate_shard(sender_id, &my_unit);
+    let result = env.validator.validate_unit(sender_id, &my_unit);
     let hop1 = (sender == Sender::Publisher) && (owner == UnitOwner::LocalPeer);
     let hop2_a = (sender == Sender::OtherPeer1) && (owner == UnitOwner::OtherPeer1);
     let hop2_b = (sender == Sender::OtherPeer2) && (owner == UnitOwner::OtherPeer2);
@@ -215,7 +215,7 @@ fn test_tampered_proof_fails_verification() {
     let mut unit = unit(&env, env.local_peer);
     unit.shards_mut().0[0].0.push(42);
 
-    let result = env.validator.validate_shard(env.publisher, &unit);
+    let result = env.validator.validate_unit(env.publisher, &unit);
     result.unwrap_err();
 }
 
@@ -234,7 +234,7 @@ fn test_unexpected_shard_count_rejected() {
     let unit = unit(&env, env.local_peer);
 
     assert_eq!(
-        env.validator.validate_shard(env.publisher, &unit),
+        env.validator.validate_unit(env.publisher, &unit),
         Err(ShardValidationError::UnexpectedShardCount {
             expected_shard_count: 1,
             actual_shard_count: 2,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename/refactor of an internal error type; main risk is downstream compile breaks or missed references leading to inconsistent error reporting.
> 
> **Overview**
> Renames the broadcast/publish error type from `ShardPublishError` to `UnitPublishError` across the Propeller API surface and internals (behaviour, engine, sharding, signature, and exported `lib.rs` types).
> 
> Updates all broadcast-related method signatures, oneshot response types, and emitted `Event::ShardSendFailed` payloads to use the new error enum name without changing underlying control flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a52dbd802880d8b46e8916d0d7d409f092a38ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->