### PR TITLE
apollo_propeller: rename ShardValidationError to UnitValidationError

### DIFF
--- a/crates/apollo_propeller/src/lib.rs
+++ b/crates/apollo_propeller/src/lib.rs
@@ -49,8 +49,8 @@ pub use types::{
     ReconstructionError,
     ScheduleError,
     ShardIndex,
-    ShardValidationError,
     UnitPublishError,
+    UnitValidationError,
 };
 pub use unit::{PropellerUnit, Shard, ShardsOfPeer};
 pub use unit_validator::UnitValidator;

--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -14,7 +14,7 @@ use crate::types::{
     Event,
     MessageRoot,
     ReconstructionError,
-    ShardValidationError,
+    UnitValidationError,
     VerifiedFields,
 };
 use crate::unit::{PropellerUnit, ShardsOfPeer};
@@ -22,7 +22,7 @@ use crate::unit_validator::UnitValidator;
 use crate::{MerkleProof, ShardIndex};
 
 pub type UnitToValidate = (PeerId, PropellerUnit);
-type ValidationResult = (Result<(), ShardValidationError>, UnitValidator, PropellerUnit);
+type ValidationResult = (Result<(), UnitValidationError>, UnitValidator, PropellerUnit);
 type ReconstructionResult = Result<ReconstructionOutput, ReconstructionError>;
 
 #[derive(Debug)]

--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -8,7 +8,7 @@ use libp2p::identity::PeerId;
 use starknet_api::staking::StakingWeight;
 
 use crate::types::{CommitteeSetupError, ScheduleError, ShardIndex};
-use crate::ShardValidationError;
+use crate::UnitValidationError;
 
 // TODO(AndrewL): add the concept of shard_owner when naming
 
@@ -149,19 +149,19 @@ impl PropellerScheduleManager {
         sender: PeerId,
         stated_publisher: PeerId,
         stated_index: ShardIndex,
-    ) -> Result<(), ShardValidationError> {
+    ) -> Result<(), UnitValidationError> {
         let local_peer_id = self.get_local_peer_id();
         if local_peer_id == sender {
-            return Err(ShardValidationError::SelfSending);
+            return Err(UnitValidationError::SelfSending);
         }
 
         if stated_publisher == local_peer_id {
-            return Err(ShardValidationError::ReceivedSelfPublishedShard);
+            return Err(UnitValidationError::ReceivedSelfPublishedShard);
         }
 
         let expected_broadcaster_for_index = self
             .get_peer_for_shard_index(&stated_publisher, stated_index)
-            .map_err(ShardValidationError::ScheduleManagerError)?;
+            .map_err(UnitValidationError::ScheduleManagerError)?;
 
         if expected_broadcaster_for_index == local_peer_id && sender == stated_publisher {
             // I received my shard from the publisher
@@ -172,7 +172,7 @@ impl PropellerScheduleManager {
         }
         // TODO(AndrewL): Make sure that the returned error allows for
         // distinguishing between the two cases.
-        Err(ShardValidationError::UnexpectedSender {
+        Err(UnitValidationError::UnexpectedSender {
             expected_sender: expected_broadcaster_for_index,
             shard_index: stated_index,
         })

--- a/crates/apollo_propeller/src/tree_test.rs
+++ b/crates/apollo_propeller/src/tree_test.rs
@@ -3,7 +3,7 @@ use rstest::rstest;
 use starknet_api::staking::StakingWeight;
 
 use crate::tree::PropellerScheduleManager;
-use crate::types::{CommitteeSetupError, ScheduleError, ShardIndex, ShardValidationError};
+use crate::types::{CommitteeSetupError, ScheduleError, ShardIndex, UnitValidationError};
 
 // TODO(AndrewL): Move this to test_utils crate.
 pub fn get_peer_id(index: u8) -> PeerId {
@@ -103,7 +103,7 @@ fn get_result_for_validate_origin(
     sender_index: u8,
     publisher_index: u8,
     shard_index: u64,
-) -> Result<(), ShardValidationError> {
+) -> Result<(), UnitValidationError> {
     let schedule_manager = make_schedule_manager(local_index, num_nodes);
     let get_peer = |i: u8| {
         if i == u8::MAX {

--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -29,7 +29,7 @@ pub enum Event {
         sender: PeerId,
         claimed_root: MessageRoot,
         claimed_publisher: PeerId,
-        error: ShardValidationError,
+        error: UnitValidationError,
     },
     /// Message processing timed out before completion.
     MessageTimeout { committee_id: CommitteeId, publisher: PeerId, message_root: MessageRoot },
@@ -137,7 +137,7 @@ pub enum CommitteeSetupError {
 
 /// Specific errors that can occur during shard verification.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum ShardValidationError {
+pub enum UnitValidationError {
     #[error("Self received a shard from myself (libp2p should not allow this)")]
     SelfSending,
     #[error("Publisher should not receive their own shard")]

--- a/crates/apollo_propeller/src/unit.rs
+++ b/crates/apollo_propeller/src/unit.rs
@@ -13,7 +13,7 @@ use libp2p::core::PeerId;
 use prost::Message;
 
 use crate::types::{CommitteeId, MessageRoot, ShardIndex};
-use crate::{MerkleHash, MerkleProof, ShardValidationError};
+use crate::{MerkleHash, MerkleProof, UnitValidationError};
 
 /// A single erasure-coded fragment.
 #[derive(Debug, PartialEq, Clone)]
@@ -125,10 +125,10 @@ impl PropellerUnit {
     pub fn validate_shard_count(
         &self,
         expected_shard_count: usize,
-    ) -> Result<(), ShardValidationError> {
+    ) -> Result<(), UnitValidationError> {
         let actual_shard_count = self.shards.0.len();
         if actual_shard_count != expected_shard_count {
-            return Err(ShardValidationError::UnexpectedShardCount {
+            return Err(UnitValidationError::UnexpectedShardCount {
                 expected_shard_count,
                 actual_shard_count,
             });
@@ -136,13 +136,13 @@ impl PropellerUnit {
         Ok(())
     }
 
-    pub fn validate_shard_lengths(&self) -> Result<(), ShardValidationError> {
+    pub fn validate_shard_lengths(&self) -> Result<(), UnitValidationError> {
         let Some(first) = self.shards.0.first() else {
             return Ok(());
         };
         let expected_len = first.0.len();
         if self.shards.0.iter().any(|s| s.0.len() != expected_len) {
-            return Err(ShardValidationError::UnequalShardLengths);
+            return Err(UnitValidationError::UnequalShardLengths);
         }
         Ok(())
     }
@@ -150,7 +150,7 @@ impl PropellerUnit {
     pub fn validate_merkle_proof(
         &self,
         num_total_shards: usize,
-    ) -> Result<(), ShardValidationError> {
+    ) -> Result<(), UnitValidationError> {
         let proof = self.proof();
         let index = self.index().0.try_into().expect("u64 could not be converted to usize");
         // Encode as proto bytes because the Merkle tree leaves are the proto-encoded bytes
@@ -159,7 +159,7 @@ impl PropellerUnit {
         if proof.verify(&self.root().0, &leaf_data, index, num_total_shards) {
             Ok(())
         } else {
-            Err(ShardValidationError::MerkleProofVerificationFailed)
+            Err(UnitValidationError::MerkleProofVerificationFailed)
         }
     }
 }

--- a/crates/apollo_propeller/src/unit_validator.rs
+++ b/crates/apollo_propeller/src/unit_validator.rs
@@ -11,7 +11,7 @@ use crate::{
     PropellerScheduleManager,
     PropellerUnit,
     ShardIndex,
-    ShardValidationError,
+    UnitValidationError,
 };
 
 #[derive(Debug, Clone)]
@@ -89,14 +89,14 @@ impl UnitValidator {
         &mut self,
         sender: PeerId,
         unit: &PropellerUnit,
-    ) -> Result<(), ShardValidationError> {
+    ) -> Result<(), UnitValidationError> {
         // TODO(AndrewL): Think about how to correctly get rid of these assertions
         assert_eq!(self.committee_id, unit.committee_id(), "Committee mismatch");
         assert_eq!(self.publisher, unit.publisher(), "Publisher mismatch");
         assert_eq!(self.message_root, unit.root(), "Message root mismatch");
 
         if self.received_indices.contains(&unit.index()) {
-            return Err(ShardValidationError::DuplicateShard);
+            return Err(UnitValidationError::DuplicateShard);
         }
 
         self.schedule_manager.validate_origin(sender, unit.publisher(), unit.index())?;
@@ -105,7 +105,7 @@ impl UnitValidator {
         unit.validate_shard_count(1)?;
         unit.validate_shard_lengths()?;
         unit.validate_merkle_proof(self.schedule_manager.num_shards())?;
-        self.verify_signature(unit).map_err(ShardValidationError::SignatureVerificationFailed)?;
+        self.verify_signature(unit).map_err(UnitValidationError::SignatureVerificationFailed)?;
 
         // add for next time we see this unit's index
         self.received_indices.insert(unit.index());

--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -15,8 +15,8 @@ use crate::{
     PropellerUnit,
     Shard,
     ShardIndex,
-    ShardValidationError,
     ShardsOfPeer,
+    UnitValidationError,
     UnitValidator,
 };
 
@@ -128,7 +128,7 @@ fn test_validation_fails_with_wrong_signature() {
     let unit = custom_unit(&env, env.local_peer, true);
     assert!(matches!(
         env.validator.validate_unit(env.publisher, &unit),
-        Err(ShardValidationError::SignatureVerificationFailed(
+        Err(UnitValidationError::SignatureVerificationFailed(
             ShardSignatureVerificationError::VerificationFailed
         ))
     ));
@@ -141,7 +141,7 @@ fn test_duplicate_shard_rejected() {
     env.validator.validate_unit(env.publisher, &unit).unwrap();
     assert!(matches!(
         env.validator.validate_unit(env.publisher, &unit),
-        Err(ShardValidationError::DuplicateShard)
+        Err(UnitValidationError::DuplicateShard)
     ));
 }
 
@@ -225,7 +225,7 @@ fn test_unequal_shard_lengths_rejected() {
     let mut unit = unit(&env, env.local_peer);
     unit.shards_mut().0[1].0.push(0xFF);
 
-    assert_eq!(unit.validate_shard_lengths(), Err(ShardValidationError::UnequalShardLengths));
+    assert_eq!(unit.validate_shard_lengths(), Err(UnitValidationError::UnequalShardLengths));
 }
 
 #[rstest]
@@ -235,7 +235,7 @@ fn test_unexpected_shard_count_rejected() {
 
     assert_eq!(
         env.validator.validate_unit(env.publisher, &unit),
-        Err(ShardValidationError::UnexpectedShardCount {
+        Err(UnitValidationError::UnexpectedShardCount {
             expected_shard_count: 1,
             actual_shard_count: 2,
         })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk mechanical rename of a public error type; main impact is a compile-time breaking API change for downstream users importing/matching on `ShardValidationError`.
> 
> **Overview**
> Renames the shard/unit validation error type from `ShardValidationError` to `UnitValidationError` across the `apollo_propeller` crate, including public re-exports and all call sites.
> 
> Updates message processing, schedule/origin validation, unit validation helpers, and tests to use the new error name, and adjusts `Event::ShardValidationFailed` to carry `UnitValidationError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a614f4c14e9877f7e13d83835322617293a0c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->