### PR TITLE
apollo_propeller: rename ShardSignatureVerificationError to SignatureVerificationError

### DIFF
--- a/crates/apollo_propeller/src/signature.rs
+++ b/crates/apollo_propeller/src/signature.rs
@@ -5,7 +5,7 @@
 
 use libp2p::identity::{Keypair, PeerId, PublicKey};
 
-use crate::types::{CommitteeId, MessageRoot, ShardSignatureVerificationError, UnitPublishError};
+use crate::types::{CommitteeId, MessageRoot, SignatureVerificationError, UnitPublishError};
 
 // TODO(AndrewL): Consider removing these (consult gossipsub code )
 pub const SIGNING_PREFIX: &[u8] = b"<propeller>";
@@ -31,13 +31,13 @@ pub fn verify_message_id_signature(
     nonce: u64,
     signature: &[u8],
     public_key: &PublicKey,
-) -> Result<(), ShardSignatureVerificationError> {
+) -> Result<(), SignatureVerificationError> {
     if signature.is_empty() {
-        return Err(ShardSignatureVerificationError::VerificationFailed);
+        return Err(SignatureVerificationError::VerificationFailed);
     }
     let msg = build_signed_payload(message_id, committee_id, nonce);
     let signature_valid = public_key.verify(&msg, signature);
-    if signature_valid { Ok(()) } else { Err(ShardSignatureVerificationError::VerificationFailed) }
+    if signature_valid { Ok(()) } else { Err(SignatureVerificationError::VerificationFailed) }
 }
 
 pub fn try_extract_public_key_from_peer_id(peer_id: &PeerId) -> Option<PublicKey> {

--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -54,9 +54,9 @@ pub struct VerifiedFields {
     pub nonce: u64,
 }
 
-/// Errors that can occur when verifying a shard signature.
+/// Errors that can occur when verifying a unit signature.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum ShardSignatureVerificationError {
+pub enum SignatureVerificationError {
     #[error(
         "We could not find a public key for signer/publisher {0}. This suggests that the public \
          key cannot be extracted form the peer ID and needs to be provided explicitly."
@@ -152,7 +152,7 @@ pub enum UnitValidationError {
     )]
     UnexpectedSender { expected_sender: PeerId, shard_index: ShardIndex },
     #[error("Shard failed signature verification: {0}")]
-    SignatureVerificationFailed(ShardSignatureVerificationError),
+    SignatureVerificationFailed(SignatureVerificationError),
     #[error("Shard failed Merkle proof verification")]
     MerkleProofVerificationFailed,
     #[error("Shards have inconsistent lengths")]

--- a/crates/apollo_propeller/src/unit_validator.rs
+++ b/crates/apollo_propeller/src/unit_validator.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use libp2p::identity::PublicKey;
 use libp2p::PeerId;
 
-use crate::types::{CommitteeId, ShardSignatureVerificationError, VerifiedFields};
+use crate::types::{CommitteeId, SignatureVerificationError, VerifiedFields};
 use crate::{
     signature,
     MessageRoot,
@@ -56,16 +56,13 @@ impl UnitValidator {
     /// This is a performance optimization to avoid verifying the signature if we have already
     /// verified the signature for this message. This optimization is possible because the publisher
     /// signs the merkle root of the message, which is shared by all units.
-    fn verify_signature(
-        &mut self,
-        unit: &PropellerUnit,
-    ) -> Result<(), ShardSignatureVerificationError> {
+    fn verify_signature(&mut self, unit: &PropellerUnit) -> Result<(), SignatureVerificationError> {
         if let Some(verified_fields) = &self.verified_fields {
             let VerifiedFields { signature, nonce } = verified_fields;
             return if signature == unit.signature() && *nonce == unit.nonce() {
                 Ok(())
             } else {
-                Err(ShardSignatureVerificationError::VerificationFailed)
+                Err(SignatureVerificationError::VerificationFailed)
             };
         }
 

--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -6,7 +6,7 @@ use libp2p::PeerId;
 use rstest::rstest;
 use starknet_api::staking::StakingWeight;
 
-use crate::types::ShardSignatureVerificationError;
+use crate::types::SignatureVerificationError;
 use crate::{
     CommitteeId,
     MerkleTree,
@@ -129,7 +129,7 @@ fn test_validation_fails_with_wrong_signature() {
     assert!(matches!(
         env.validator.validate_unit(env.publisher, &unit),
         Err(UnitValidationError::SignatureVerificationFailed(
-            ShardSignatureVerificationError::VerificationFailed
+            SignatureVerificationError::VerificationFailed
         ))
     ));
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename-only change that updates type names and error wiring without altering signature validation behavior.
> 
> **Overview**
> Renames the signature verification error enum from `ShardSignatureVerificationError` to `SignatureVerificationError` and updates affected APIs (`signature::verify_message_id_signature`, `UnitValidator::verify_signature`) plus `UnitValidationError::SignatureVerificationFailed` to use the new type.
> 
> Adjusts unit validator tests to assert on the renamed error variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b13250f6441690c2e70b82be18424b2a133049d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->