### PR TITLE
apollo_propeller: rename received_shards param to received_units in reconstruct_data_shards

### DIFF
--- a/crates/apollo_propeller/src/engine.rs
+++ b/crates/apollo_propeller/src/engine.rs
@@ -333,7 +333,7 @@ impl Engine {
     /// Handle a send error from the handler.
     fn handle_send_error(&mut self, peer_id: PeerId, error: String) {
         // TODO(AndrewL): Consider a re-try mechanism.
-        self.emit_event(Event::ShardSendFailed {
+        self.emit_event(Event::UnitSendFailed {
             sent_from: None,
             sent_to: Some(peer_id),
             error: UnitPublishError::HandlerError(error),
@@ -349,7 +349,7 @@ impl Engine {
     // TODO(AndrewL): consider working with ConnectionId instead of PeerId here.
     fn emit_handler_event(&mut self, peer_id: PeerId, event: HandlerIn) {
         if !self.connected_peers.contains(&peer_id) {
-            self.emit_event(Event::ShardSendFailed {
+            self.emit_event(Event::UnitSendFailed {
                 sent_from: None,
                 sent_to: Some(peer_id),
                 error: UnitPublishError::NotConnectedToPeer(peer_id),

--- a/crates/apollo_propeller/src/sharding.rs
+++ b/crates/apollo_propeller/src/sharding.rs
@@ -15,7 +15,7 @@ use crate::types::{CommitteeId, ReconstructionError, ShardIndex, UnitPublishErro
 use crate::unit::{PropellerUnit, Shard, ShardsOfPeer};
 use crate::{signature, MerkleProof, MerkleTree, MessageRoot};
 
-/// Rebuild a message from received shards using erasure coding.
+/// Rebuild a message from received units using erasure coding.
 ///
 /// Returns the reconstructed message, the caller's shards, and the Merkle proof.
 // TODO(AndrewL): Use the fact that ECC is systematic (i.e. data shards are embedded verbatim in
@@ -26,13 +26,13 @@ use crate::{signature, MerkleProof, MerkleTree, MessageRoot};
 // reconstructing data shards and then regenerating coding shards separately.
 // <github.com/AndersTrier/reed-solomon-simd/issues/65>
 pub fn reconstruct_data_shards(
-    received_shards: Vec<PropellerUnit>,
+    received_units: Vec<PropellerUnit>,
     message_root: MessageRoot,
     my_shard_index: usize,
     data_count: usize,
     coding_count: usize,
 ) -> Result<(Vec<u8>, ShardsOfPeer, MerkleProof), ReconstructionError> {
-    let shards_for_reconstruction: Vec<(usize, Vec<u8>)> = received_shards
+    let shards_for_reconstruction: Vec<(usize, Vec<u8>)> = received_units
         .into_iter()
         .map(|mut msg| {
             let index: usize =

--- a/crates/apollo_propeller/src/signature.rs
+++ b/crates/apollo_propeller/src/signature.rs
@@ -5,7 +5,7 @@
 
 use libp2p::identity::{Keypair, PeerId, PublicKey};
 
-use crate::types::{CommitteeId, MessageRoot, ShardSignatureVerificationError, UnitPublishError};
+use crate::types::{CommitteeId, MessageRoot, SignatureVerificationError, UnitPublishError};
 
 // TODO(AndrewL): Consider removing these (consult gossipsub code )
 pub const SIGNING_PREFIX: &[u8] = b"<propeller>";
@@ -31,13 +31,13 @@ pub fn verify_message_id_signature(
     nonce: u64,
     signature: &[u8],
     public_key: &PublicKey,
-) -> Result<(), ShardSignatureVerificationError> {
+) -> Result<(), SignatureVerificationError> {
     if signature.is_empty() {
-        return Err(ShardSignatureVerificationError::VerificationFailed);
+        return Err(SignatureVerificationError::VerificationFailed);
     }
     let msg = build_signed_payload(message_id, committee_id, nonce);
     let signature_valid = public_key.verify(&msg, signature);
-    if signature_valid { Ok(()) } else { Err(ShardSignatureVerificationError::VerificationFailed) }
+    if signature_valid { Ok(()) } else { Err(SignatureVerificationError::VerificationFailed) }
 }
 
 pub fn try_extract_public_key_from_peer_id(peer_id: &PeerId) -> Option<PublicKey> {

--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -21,11 +21,11 @@ pub enum Event {
         publisher: PeerId,
         error: ReconstructionError,
     },
-    /// Failed to send a shard to a peer.
-    ShardSendFailed { sent_from: Option<PeerId>, sent_to: Option<PeerId>, error: UnitPublishError },
-    /// Failed to verify shard
-    ShardValidationFailed {
-        /// The sender of the shard that filed verification. They should be reported.
+    /// Failed to send a unit to a peer.
+    UnitSendFailed { sent_from: Option<PeerId>, sent_to: Option<PeerId>, error: UnitPublishError },
+    /// Failed to verify unit.
+    UnitValidationFailed {
+        /// The sender of the unit that failed verification. They should be reported.
         sender: PeerId,
         claimed_root: MessageRoot,
         claimed_publisher: PeerId,

--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -54,9 +54,9 @@ pub struct VerifiedFields {
     pub nonce: u64,
 }
 
-/// Errors that can occur when verifying a shard signature.
+/// Errors that can occur when verifying a unit signature.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum ShardSignatureVerificationError {
+pub enum SignatureVerificationError {
     #[error(
         "We could not find a public key for signer/publisher {0}. This suggests that the public \
          key cannot be extracted form the peer ID and needs to be provided explicitly."
@@ -152,7 +152,7 @@ pub enum UnitValidationError {
     )]
     UnexpectedSender { expected_sender: PeerId, shard_index: ShardIndex },
     #[error("Shard failed signature verification: {0}")]
-    SignatureVerificationFailed(ShardSignatureVerificationError),
+    SignatureVerificationFailed(SignatureVerificationError),
     #[error("Shard failed Merkle proof verification")]
     MerkleProofVerificationFailed,
     #[error("Shards have inconsistent lengths")]

--- a/crates/apollo_propeller/src/unit_validator.rs
+++ b/crates/apollo_propeller/src/unit_validator.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use libp2p::identity::PublicKey;
 use libp2p::PeerId;
 
-use crate::types::{CommitteeId, ShardSignatureVerificationError, VerifiedFields};
+use crate::types::{CommitteeId, SignatureVerificationError, VerifiedFields};
 use crate::{
     signature,
     MessageRoot,
@@ -56,16 +56,13 @@ impl UnitValidator {
     /// This is a performance optimization to avoid verifying the signature if we have already
     /// verified the signature for this message. This optimization is possible because the publisher
     /// signs the merkle root of the message, which is shared by all units.
-    fn verify_signature(
-        &mut self,
-        unit: &PropellerUnit,
-    ) -> Result<(), ShardSignatureVerificationError> {
+    fn verify_signature(&mut self, unit: &PropellerUnit) -> Result<(), SignatureVerificationError> {
         if let Some(verified_fields) = &self.verified_fields {
             let VerifiedFields { signature, nonce } = verified_fields;
             return if signature == unit.signature() && *nonce == unit.nonce() {
                 Ok(())
             } else {
-                Err(ShardSignatureVerificationError::VerificationFailed)
+                Err(SignatureVerificationError::VerificationFailed)
             };
         }
 

--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -6,7 +6,7 @@ use libp2p::PeerId;
 use rstest::rstest;
 use starknet_api::staking::StakingWeight;
 
-use crate::types::ShardSignatureVerificationError;
+use crate::types::SignatureVerificationError;
 use crate::{
     CommitteeId,
     MerkleTree,
@@ -129,7 +129,7 @@ fn test_validation_fails_with_wrong_signature() {
     assert!(matches!(
         env.validator.validate_unit(env.publisher, &unit),
         Err(UnitValidationError::SignatureVerificationFailed(
-            ShardSignatureVerificationError::VerificationFailed
+            SignatureVerificationError::VerificationFailed
         ))
     ));
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename/documentation tweak with no functional behavior changes. Risk is limited to potential downstream compile breakage if any callers weren’t updated in the same change.
> 
> **Overview**
> Updates `reconstruct_data_shards` in `sharding.rs` to use the clearer `received_units` parameter name (instead of `received_shards`) and adjusts the function’s doc comment to refer to *units* rather than shards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a2da22f6dbf7cc8abb554a2e0e912232f8560d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->