### PR TITLE
echonet: L1Manager Changes for Prices

### DIFF
--- a/echonet/l1_logic/l1_manager.py
+++ b/echonet/l1_logic/l1_manager.py
@@ -19,21 +19,28 @@ class L1Manager:
     Manages L1 block data indexed by block number and provides mock RPC responses.
 
     - get_block_number: returns _mock_l1_head_number (eth_blockNumber; always increasing).
-    - get_logs: returns logs for all stored blocks in the requested range, or empty logs list if empty.
+    - get_logs: L1_HANDLER logs from _pending_logs only (gated on echonet block height).
     - get_block_by_number: stored L1 tx data or default block.
 
-    The mock L1 head number is the source of truth for the gas price scraper.
+    The mock L1 head number is the source of truth for the gas price scraper and events scraper.
     It is incremented by set_gas_price_target (once per L2 block) and synced upward by set_new_tx
-    when real L1 block numbers are stored.
+    when real L1 block numbers are stored, ensuring the gas price scraper never gets stuck after
+    a real→mock-head transition.
     """
 
     L1_SCRAPER_FINALITY_CONFIG_VALUE = 10
+    # Entries in _l1_tx_data_by_block more than this many blocks behind the current
+    # get_block_by_number request are evicted to keep the map bounded in size.
+    _BLOCK_DATA_CLEANUP_BUFFER = 20
 
     @dataclass(frozen=True)
     class L1TxData:
         block_number: int
         block_data: dict
         logs_result: list[dict]
+        # Minimum echonet block number that must be reached before these logs are exposed.
+        # Derived from the mainnet block where the L1_HANDLER tx appeared: source_block_number - 2.
+        required_echonet_block: int
 
     def default_l1_block(self, block_number_hex: str) -> dict:
         block: dict = {
@@ -74,11 +81,12 @@ class L1Manager:
         self,
         l1_client: L1Client,
         get_last_proved_block_callback: Callable[[], tuple[int, int]],
+        get_last_echonet_block_callback: Callable[[], Optional[int]],
     ):
         self.logger = get_logger("l1_manager")
         self.l1_client = l1_client
-        self.blocks: dict[int, L1Manager.L1TxData] = {}
         self.get_last_proved_block_callback = get_last_proved_block_callback
+        self.get_last_echonet_block_callback = get_last_echonet_block_callback
         self._gas_price_target: Optional[tuple[int, int]] = None  # (base_fee_wei, blob_fee_wei)
         # Mock L1 head (eth_blockNumber) when no real L1 blocks are stored.
         # Incremented each time set_gas_price_target is called so the L1 gas price scraper
@@ -86,6 +94,17 @@ class L1Manager:
         self._mock_l1_head_number: int = DEFAULT_L1_BLOCK_NUMBER
         # L2 block timestamp corresponding to the current gas price target.
         self._l2_block_timestamp: int = 0
+        # Highest real L1 block number stored via the normal path. Used to detect out-of-order
+        # blocks: if a new block arrives at X < _max_real_block, the events scraper has already
+        # advanced past X and will never find it through a normal range query.
+        self._max_real_block: int = 0
+        # Fetched L1 block + logs per L1 block number. Logs are delivered only via _pending_logs,
+        # not by scanning this map in get_logs (avoids duplicate delivery vs injection).
+        self._l1_tx_data_by_block: dict[int, L1Manager.L1TxData] = {}
+        # Logs from real L1 blocks, injected into the next get_logs response
+        # regardless of range so the events scraper receives them. Each entry pairs the log dict
+        # with the required_echonet_block threshold that must be reached before it is exposed.
+        self._pending_logs: list[tuple[dict, int]] = []
         # Condition used to implement long-polling in get_block_number.
         # Notified whenever _mock_l1_head_number changes so waiting scrapers wake up
         # immediately instead of hammering echonet with rapid polls.
@@ -108,11 +127,19 @@ class L1Manager:
             f"l2_timestamp={l2_timestamp}, mock_l1_head_number={self._mock_l1_head_number}"
         )
 
-    def set_new_tx(self, feeder_gateway_tx: dict, l2_block_timestamp: int) -> None:
+    def set_new_tx(
+        self, feeder_gateway_tx: dict, l2_block_timestamp: int, source_block_number: int
+    ) -> None:
         """
         Gets a feeder gateway transaction and its block timestamp,
         fetches the relevant L1 data, and stores it by block number.
+
+        source_block_number is the mainnet L2 block the L1_HANDLER tx appeared in.
+        The stored data is gated: logs are not exposed via get_logs until
+        echonet has reached source_block_number - 2.
         """
+        required_echonet_block = source_block_number - 2
+
         l1_block_number = L1Blocks.find_l1_block_for_tx(
             feeder_gateway_tx, l2_block_timestamp, self.l1_client
         )
@@ -126,56 +153,113 @@ class L1Manager:
         assert logs_response, f"Logs must exist for block {l1_block_number}"
 
         logs = logs_response.get("result", [])
-        self.blocks[l1_block_number] = L1Manager.L1TxData(l1_block_number, l1_block_data, logs)
 
-        # Sync mock L1 head upward to cover the real L1 block so the gas price scraper advances.
-        synced_mock_l1_head = l1_block_number + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE
-        if synced_mock_l1_head > self._mock_l1_head_number:
-            self._set_mock_l1_head_number(synced_mock_l1_head)
+        # Logs are always delivered via pending injection (not range-based), because by the time
+        # the echonet gate opens the events scraper may have advanced past l1_block_number and
+        # would never pick them up from a range query. Pending injection fires on the next
+        # get_logs call regardless of the requested range.
+        #
+        # Guard against the same L1 block being processed twice (e.g. two consecutive L1_HANDLER
+        # txs that both originate from the same Ethereum block). The first call already adds ALL
+        # logs from that block to _pending_logs; a second call would duplicate them and cause the
+        # sequencer to see the same event twice.
+        if l1_block_number not in self._l1_tx_data_by_block:
+            self._l1_tx_data_by_block[l1_block_number] = L1Manager.L1TxData(
+                l1_block_number, l1_block_data, logs, required_echonet_block
+            )
+            self._pending_logs.extend((log, required_echonet_block) for log in logs)
+        else:
+            self.logger.debug(
+                f"Block {l1_block_number} already stored in pending logs, skipping duplicate"
+            )
+
+        # Still update the mock L1 head so the events scraper's range advances to cover
+        # this block (needed in case the gate happens to open before the scraper moves past).
+        events_scraper_safe_block = max(
+            self._max_real_block,
+            self._mock_l1_head_number - L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE,
+        )
+        if l1_block_number >= events_scraper_safe_block:
+            self._max_real_block = l1_block_number
+            synced_mock_l1_head = l1_block_number + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE
+            if synced_mock_l1_head > self._mock_l1_head_number:
+                self._set_mock_l1_head_number(synced_mock_l1_head)
+                self.logger.debug(
+                    f"Synced mock L1 head to {self._mock_l1_head_number} "
+                    f"(real block {l1_block_number})"
+                )
+        else:
+            self.logger.debug(
+                f"Block {l1_block_number} is behind events scraper position "
+                f"{events_scraper_safe_block} (max_real={self._max_real_block}, "
+                f"mock_l1_head={self._mock_l1_head_number})"
+            )
 
         self.logger.debug(
             f"Stored L1 data for block {l1_block_number}, for L2 tx {feeder_gateway_tx['transaction_hash']}"
         )
 
     def clear_stored_blocks(self) -> None:
-        self.blocks.clear()
+        self._l1_tx_data_by_block.clear()
+        self._pending_logs.clear()
+        self._max_real_block = 0
         self._set_mock_l1_head_number(DEFAULT_L1_BLOCK_NUMBER)
-        self.logger.debug("Cleared all stored L1 blocks and reset mock L1 head number")
+        self.logger.debug(
+            "Cleared all stored L1 blocks, pending logs, and reset mock L1 head number"
+        )
 
     # Mock RPC responses.
 
     def get_logs(self, params: dict) -> dict:
-        """Returns merged logs for stored blocks in [fromBlock, toBlock], or empty logs list if empty."""
+        """L1_HANDLER logs from _pending_logs (gated on echonet height). Range params are for logging only."""
         from_block = int(params["fromBlock"], 16)
         to_block = int(params["toBlock"], 16)
 
-        logs = []
-        for block_num in range(from_block, to_block + 1):
-            block = self.blocks.get(block_num)
-            if block:
-                logs.extend(block.logs_result)
+        last_echonet_block = self.get_last_echonet_block_callback()
+
+        logs: list[dict] = []
+
+        # L1_HANDLER logs: queued until echonet height >= source_block_number - 2, then injected
+        # on the next get_logs (range-independent; scraper may already be past the real L1 block).
+        if last_echonet_block:
+            ready = [log for log, req in self._pending_logs if last_echonet_block >= req]
+            if ready:
+                self.logger.info(
+                    f"get_logs: injecting {len(ready)} pending log(s) "
+                    f"(echonet_last={last_echonet_block})"
+                )
+                logs.extend(ready)
+            self._pending_logs = [
+                (log, req) for log, req in self._pending_logs if last_echonet_block < req
+            ]
 
         self.logger.debug(
-            f"get_logs: range [{from_block}, {to_block}] ({to_block - from_block + 1} blocks): {len(logs)} logs"
+            f"get_logs: range [{from_block}, {to_block}]: {len(logs)} logs "
+            f"(l1_tx_data_by_block={len(self._l1_tx_data_by_block)}, echonet_last={last_echonet_block}, "
+            f"still_pending={len(self._pending_logs)})"
         )
         return rpc_response(logs)
 
     def get_block_by_number(self, block_number_hex: str) -> dict:
-        """Returns block data for block_number, or default block if not found. Removes stored blocks that are much older than block_number."""
+        """Returns block data for block_number, or default block if not found."""
         block_number = int(block_number_hex, 16)
-        # Cleanup older blocks, but keep a buffer to avoid deleting blocks that haven't been scraped yet.
-        CLEANUP_BUFFER = L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE * 2
-        blocks_to_remove = [bn for bn in self.blocks.keys() if bn < block_number - CLEANUP_BUFFER]
-        for bn in blocks_to_remove:
-            del self.blocks[bn]
-
-        if blocks_to_remove:
-            self.logger.debug(f"get_block_by_number: cleaned up blocks {blocks_to_remove}")
-
-        block_data = self.blocks.get(block_number)
+        cutoff = block_number - self._BLOCK_DATA_CLEANUP_BUFFER
+        stale = [b for b in self._l1_tx_data_by_block if b < cutoff]
+        for b in stale:
+            del self._l1_tx_data_by_block[b]
+        block_data = self._l1_tx_data_by_block.get(block_number)
         if block_data:
             self.logger.debug(f"get_block_by_number({block_number}): returning block data")
-            return block_data.block_data
+            # Override hash and parentHash to 0x0 so real blocks form the same 0x0→0x0 chain
+            # as default blocks. The L1 scraper reorg detector checks
+            # new_block.parentHash == prev_block.hash; keeping all hashes at 0x0 prevents
+            # false reorgs at real↔default block boundaries regardless of scraper position
+            # or cleanup timing.
+            result = dict(block_data.block_data)
+            result["result"] = dict(result["result"])
+            result["result"]["hash"] = format_hex(0)
+            result["result"]["parentHash"] = format_hex(0)
+            return result
 
         # Returns default values when the block is not found.
         # During initialization, blocks from ~1 hour ago are fetched (startup_rewind_time_seconds).

--- a/echonet/l1_logic/tests/test_l1_manager.py
+++ b/echonet/l1_logic/tests/test_l1_manager.py
@@ -5,11 +5,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
 
 import unittest
+from typing import Optional
 from unittest.mock import Mock, patch
 
 from test_utils import L1TestUtils
 
 from echonet.constants import DEFAULT_L1_BLOCK_NUMBER
+from echonet.helpers import format_hex
 from echonet.l1_logic.l1_blocks import L1Blocks
 from echonet.l1_logic.l1_client import L1Client
 from echonet.l1_logic.l1_manager import L1Manager
@@ -19,14 +21,19 @@ class TestL1Manager(unittest.TestCase):
     def setUp(self):
         self.mock_client = Mock(spec=L1Client)
         # get_last_proved_block callback not used in these tests (only needed for get_call).
+        # get_last_echonet_block_callback returns a high value so all pending logs are immediately ready.
         self.manager = L1Manager(
-            l1_client=self.mock_client, get_last_proved_block_callback=lambda: (0, 0)
+            l1_client=self.mock_client,
+            get_last_proved_block_callback=lambda: (0, 0),
+            get_last_echonet_block_callback=lambda: 999_999_999,
         )
 
     def get_logs_input(self, fromBlock: int, toBlock: int) -> dict:
         return {"fromBlock": hex(fromBlock), "toBlock": hex(toBlock)}
 
-    def _mock_handle_feeder_tx_and_store_l1_block(self, l1_block_number: int):
+    def _mock_handle_feeder_tx_and_store_l1_block(
+        self, l1_block_number: int, source_block_number: int = 2
+    ):
         """Simulates processing a feeder gateway transaction and storing its matched L1 block data."""
         l1_block_number_hex = hex(l1_block_number)
         with patch.object(L1Blocks, "find_l1_block_for_tx") as mock_find_l1_block_for_tx:
@@ -41,7 +48,17 @@ class TestL1Manager(unittest.TestCase):
                 "id": "1",
                 "result": [{"blockNumber": l1_block_number_hex, "data": "0x"}],
             }
-            self.manager.set_new_tx({"transaction_hash": l1_block_number_hex}, 0)
+            self.manager.set_new_tx(
+                {"transaction_hash": l1_block_number_hex}, 0, source_block_number
+            )
+
+    def _make_manager_with_echonet_block(self, echonet_block: Optional[int]) -> L1Manager:
+        """Create an L1Manager that reports the given echonet block height."""
+        return L1Manager(
+            l1_client=self.mock_client,
+            get_last_proved_block_callback=lambda: (0, 0),
+            get_last_echonet_block_callback=lambda: echonet_block,
+        )
 
     def test_empty_queue_returns_defaults(self):
         # get_block_number returns the default mock L1 head (eth_blockNumber) when no blocks are stored.
@@ -70,7 +87,9 @@ class TestL1Manager(unittest.TestCase):
         mock_find_l1_block_for_tx.return_value = L1TestUtils.BLOCK_NUMBER
         self.mock_client.get_block_by_number.return_value = L1TestUtils.BLOCK_RPC_RESPONSE
         self.mock_client.get_logs.return_value = L1TestUtils.LOGS_RPC_RESPONSE
-        self.manager.set_new_tx(L1TestUtils.FEEDER_TX, L1TestUtils.L2_BLOCK_TIMESTAMP)
+        self.manager.set_new_tx(
+            L1TestUtils.FEEDER_TX, L1TestUtils.L2_BLOCK_TIMESTAMP, source_block_number=2
+        )
 
         # get_block_number returns mock L1 head synced to real block + finality.
         block_number = self.manager.get_block_number()
@@ -79,13 +98,16 @@ class TestL1Manager(unittest.TestCase):
             hex(L1TestUtils.BLOCK_NUMBER + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE),
         )
 
+        # get_block_by_number overrides hash and parentHash to 0x0 to avoid false reorgs.
         block = self.manager.get_block_by_number(L1TestUtils.BLOCK_NUMBER_HEX)
-        self.assertEqual(block, L1TestUtils.BLOCK_RPC_RESPONSE)
+        self.assertEqual(block["result"]["number"], L1TestUtils.BLOCK_NUMBER_HEX)
+        self.assertEqual(block["result"]["hash"], format_hex(0))
+        self.assertEqual(block["result"]["parentHash"], format_hex(0))
 
+        # Logs are injected via _pending_logs (range-independent).
         logs = self.manager.get_logs(
             self.get_logs_input(L1TestUtils.BLOCK_NUMBER, L1TestUtils.BLOCK_NUMBER)
         )
-
         self.assertEqual(logs, L1TestUtils.LOGS_RPC_RESPONSE)
 
     def test_multiple_blocks(self):
@@ -99,7 +121,7 @@ class TestL1Manager(unittest.TestCase):
         result = self.manager.get_block_number()
         self.assertEqual(result["result"], hex(DEFAULT_L1_BLOCK_NUMBER + 40))
 
-        # get_logs merges all logs in range.
+        # First get_logs call: all 3 pending logs injected (range-independent).
         result = self.manager.get_logs(self.get_logs_input(b10, b30))
         expected_logs = {
             "jsonrpc": "2.0",
@@ -112,16 +134,9 @@ class TestL1Manager(unittest.TestCase):
         }
         self.assertEqual(result, expected_logs)
 
-        # get_logs with partial range (only b20 exists in [b15, b25]).
-        b15 = DEFAULT_L1_BLOCK_NUMBER + 15
-        b25 = DEFAULT_L1_BLOCK_NUMBER + 25
-        result = self.manager.get_logs(self.get_logs_input(b15, b25))
-        expected_logs = {
-            "jsonrpc": "2.0",
-            "id": "1",
-            "result": [{"blockNumber": hex(b20), "data": "0x"}],
-        }
-        self.assertEqual(result, expected_logs)
+        # Second get_logs call: all pending logs were consumed; no new logs regardless of range.
+        result = self.manager.get_logs(self.get_logs_input(b10, b30))
+        self.assertEqual(result["result"], [])
 
     def test_cleanup_old_blocks(self):
         b10 = DEFAULT_L1_BLOCK_NUMBER + 10
@@ -130,25 +145,13 @@ class TestL1Manager(unittest.TestCase):
         for block_num in [b10, b20, b30]:
             self._mock_handle_feeder_tx_and_store_l1_block(block_num)
 
-        self.assertIn(b10, self.manager.blocks, "Block b10 should be stored")
-        self.assertIn(b20, self.manager.blocks, "Block b20 should be stored")
-        self.assertIn(b30, self.manager.blocks, "Block b30 should be stored")
+        self.assertIn(b10, self.manager._l1_tx_data_by_block, "Block b10 should be stored")
+        self.assertIn(b20, self.manager._l1_tx_data_by_block, "Block b20 should be stored")
+        self.assertIn(b30, self.manager._l1_tx_data_by_block, "Block b30 should be stored")
 
-        # Query DEFAULT+50: cleanup threshold = DEFAULT+30. b10 and b20 are strictly below
-        # the threshold and are evicted; b30 is exactly at the threshold and survives.
-        b50 = DEFAULT_L1_BLOCK_NUMBER + 50
-        self.manager.get_block_by_number(hex(b50))
-        self.assertNotIn(b10, self.manager.blocks, "Block b10 should be evicted")
-        self.assertNotIn(b20, self.manager.blocks, "Block b20 should be evicted")
-        self.assertIn(b30, self.manager.blocks, "Block b30 should survive cleanup")
-
-        # b30's stored data is still returned (not a default block fallback).
+        # b30's stored data is returned directly.
         result = self.manager.get_block_by_number(hex(b30))
         self.assertEqual(result["result"]["number"], hex(b30))
-
-        # Mock L1 head synced to b30 + finality = DEFAULT + 40.
-        result = self.manager.get_block_number()
-        self.assertEqual(result["result"], hex(DEFAULT_L1_BLOCK_NUMBER + 40))
 
     def test_clear_stored_blocks(self):
         # Setup with a block above DEFAULT so the mock head syncs.
@@ -208,6 +211,118 @@ class TestL1Manager(unittest.TestCase):
             self.manager.get_block_number()["result"],
             hex(DEFAULT_L1_BLOCK_NUMBER + 1),
         )
+
+    def test_behind_range_uses_high_mock_l1_head_when_no_real_blocks_stored(self):
+        """A real block arriving below the events scraper window does not reduce the mock head."""
+        # Advance mock head by setting gas price 20 times.
+        for _ in range(20):
+            self.manager.set_gas_price_target(1000, 2000)
+        high_mock_head = DEFAULT_L1_BLOCK_NUMBER + 20
+        self.assertEqual(self.manager.get_block_number()["result"], hex(high_mock_head))
+
+        # events_scraper_safe_block = max(0, high_mock_head - 10) = DEFAULT + 10.
+        # A real block at DEFAULT + 5 is below the safe window.
+        low_block = DEFAULT_L1_BLOCK_NUMBER + 5
+        self._mock_handle_feeder_tx_and_store_l1_block(low_block)
+
+        # Mock head stays at the high value; the late block does not pull it down.
+        self.assertEqual(self.manager.get_block_number()["result"], hex(high_mock_head))
+
+    def test_out_of_order_block_delivery(self):
+        """A block arriving behind the events scraper position is stored but does not advance mock head."""
+        high_block = DEFAULT_L1_BLOCK_NUMBER + 100
+        low_block = DEFAULT_L1_BLOCK_NUMBER + 5
+
+        # Store a high block to advance the mock head.
+        self._mock_handle_feeder_tx_and_store_l1_block(high_block)
+        high_mock_head = high_block + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE
+        self.assertEqual(self.manager.get_block_number()["result"], hex(high_mock_head))
+
+        # Deliver a lower block (behind events scraper safe position).
+        self._mock_handle_feeder_tx_and_store_l1_block(low_block)
+
+        # Mock head unchanged.
+        self.assertEqual(self.manager.get_block_number()["result"], hex(high_mock_head))
+
+        # The block is still stored and its log was added to _pending_logs then injected.
+        self.assertIn(low_block, self.manager._l1_tx_data_by_block)
+
+    def test_echonet_block_gate_withholds_logs_until_threshold(self):
+        """Logs from a real L1 block are withheld until echonet reaches source_block_number - 2."""
+        source_block_number = 10
+        required_echonet_block = source_block_number - 2  # = 8
+        l1_block_number = DEFAULT_L1_BLOCK_NUMBER + 1
+        l1_block_number_hex = hex(l1_block_number)
+        feeder_tx_hash = "0xabc"
+
+        self.mock_client.get_block_by_number.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {"number": l1_block_number_hex, "timestamp": "0x1"},
+        }
+        self.mock_client.get_logs.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": [{"blockNumber": l1_block_number_hex, "data": "0x"}],
+        }
+
+        with patch.object(L1Blocks, "find_l1_block_for_tx") as mock_find:
+            mock_find.return_value = l1_block_number
+
+            # Echonet below threshold: logs are withheld.
+            manager_below = self._make_manager_with_echonet_block(required_echonet_block - 1)
+            manager_below.set_new_tx(
+                {"transaction_hash": feeder_tx_hash}, 0, source_block_number
+            )
+            result = manager_below.get_logs(self.get_logs_input(0, l1_block_number))
+            self.assertEqual(result["result"], [])
+            self.assertEqual(len(manager_below._pending_logs), 1)
+
+            # Echonet at threshold: logs are released.
+            manager_at = self._make_manager_with_echonet_block(required_echonet_block)
+            manager_at.set_new_tx(
+                {"transaction_hash": feeder_tx_hash}, 0, source_block_number
+            )
+            result = manager_at.get_logs(self.get_logs_input(0, l1_block_number))
+            self.assertEqual(len(result["result"]), 1)
+            self.assertEqual(manager_at._pending_logs, [])
+
+    def test_echonet_block_gate_withholds_pending_logs_until_threshold(self):
+        """Pending logs remain in _pending_logs until the echonet block threshold is met."""
+        source_block_number = 20
+        required_echonet_block = source_block_number - 2  # = 18
+        l1_block_number = DEFAULT_L1_BLOCK_NUMBER + 1
+        l1_block_number_hex = hex(l1_block_number)
+
+        self.mock_client.get_block_by_number.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": {"number": l1_block_number_hex, "timestamp": "0x1"},
+        }
+        self.mock_client.get_logs.return_value = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "result": [{"blockNumber": l1_block_number_hex, "data": "0x"}],
+        }
+
+        with patch.object(L1Blocks, "find_l1_block_for_tx") as mock_find:
+            mock_find.return_value = l1_block_number
+
+            echonet_block = required_echonet_block - 1
+            manager = self._make_manager_with_echonet_block(echonet_block)
+            manager.set_new_tx({"transaction_hash": "0xdef"}, 0, source_block_number)
+
+            # First call: echonet below threshold, logs withheld.
+            result = manager.get_logs(self.get_logs_input(0, l1_block_number))
+            self.assertEqual(result["result"], [])
+            self.assertEqual(len(manager._pending_logs), 1)
+
+            # Advance echonet to threshold and retry.
+            manager.get_last_echonet_block_callback = lambda: required_echonet_block
+
+            result = manager.get_logs(self.get_logs_input(0, l1_block_number))
+            self.assertEqual(len(result["result"]), 1)
+            self.assertEqual(manager._pending_logs, [])
 
 
 if __name__ == "__main__":

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -730,4 +730,6 @@ def get_shared_context() -> "SharedContext":
 shared = get_shared_context()
 
 _l1_client = L1Client(api_key=CONFIG.l1.l1_provider_api_key)
-l1_manager: L1Manager = L1Manager(_l1_client, shared.get_last_proved_block_callback)
+l1_manager: L1Manager = L1Manager(
+    _l1_client, shared.get_last_proved_block_callback, shared.get_last_block
+)

--- a/echonet/transaction_sender.py
+++ b/echonet/transaction_sender.py
@@ -142,7 +142,7 @@ class TxTransformer:
                 f"Observed L1_HANDLER tx={tx['transaction_hash']} "
                 f"src_bn={tx_data.source_block_number} src_ts={tx_data.source_timestamp}"
             )
-            l1_manager.set_new_tx(tx, tx_data.source_timestamp)
+            l1_manager.set_new_tx(tx, tx_data.source_timestamp, tx_data.source_block_number)
             shared.record_sent_tx(tx["transaction_hash"], tx_data.source_block_number)
             return None
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how L1 events are surfaced to the events scraper (range-independent injection with height gating), which can affect event ordering/duplication if incorrect. Also alters block response fields (`hash`/`parentHash`) and mock-head advancement logic, potentially impacting scraper reorg and progress behavior.
> 
> **Overview**
> Updates `L1Manager` to decouple L1 log delivery from range scans: `get_logs` now only injects queued `L1_HANDLER` logs from `_pending_logs`, releasing them only once echonet reaches `source_block_number - 2` (using a new `get_last_echonet_block_callback`). `set_new_tx` now requires `source_block_number`, dedupes per-L1-block log injection, and adjusts mock-head syncing to handle out-of-order/late real L1 blocks without regressing the scraper window.
> 
> `get_block_by_number` now evicts old cached block data with a bounded buffer and forces returned real blocks to have `hash`/`parentHash` set to `0x0` to avoid false reorg detection at real↔default boundaries. Wiring is updated in `shared_context` and `transaction_sender`, and tests are expanded to cover pending-log gating, consumption, and out-of-order block behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f4415879f03c297ce0470072bf7ff0a96ab57d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->