### PR TITLE
apollo_integration_tests: add genesis params and configurable starting block

### DIFF
--- a/crates/apollo_integration_tests/src/bin/dummy_recorder.rs
+++ b/crates/apollo_integration_tests/src/bin/dummy_recorder.rs
@@ -11,7 +11,7 @@ async fn main() {
     configure_tracing().await;
 
     let socket_address = SocketAddr::from(([0, 0, 0, 0], RECORDER_PORT));
-    let join_handle = spawn_success_recorder(socket_address);
+    let join_handle = spawn_success_recorder(socket_address, 0);
     info!("Spawned the dummy success Recorder successfully!");
 
     join_handle.await.expect("The dummy success Recorder has panicked!!! :(");

--- a/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_central_and_p2p_sync_flow.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_central_and_p2p_sync_flow.rs
@@ -1,6 +1,7 @@
 use apollo_infra_utils::test_utils::TestIdentifier;
 use apollo_integration_tests::integration_test_manager::IntegrationTestManager;
 use apollo_integration_tests::integration_test_utils::integration_test_setup;
+use apollo_integration_tests::state_reader::GenesisParams;
 use apollo_node_config::component_execution_config::{
     ActiveComponentExecutionMode,
     ReactiveComponentExecutionMode,
@@ -28,6 +29,7 @@ async fn main() {
         N_HYBRID_SEQUENCERS,
         None,
         TestIdentifier::SyncFlowIntegrationTest,
+        GenesisParams::default(),
     )
     .await;
 

--- a/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_positive_flow.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_positive_flow.rs
@@ -1,6 +1,7 @@
 use apollo_infra_utils::test_utils::TestIdentifier;
 use apollo_integration_tests::integration_test_manager::IntegrationTestManager;
 use apollo_integration_tests::integration_test_utils::integration_test_setup;
+use apollo_integration_tests::state_reader::GenesisParams;
 use starknet_api::block::BlockNumber;
 use tracing::info;
 
@@ -24,6 +25,7 @@ async fn main() {
         N_HYBRID_SEQUENCERS,
         None,
         TestIdentifier::PositiveFlowIntegrationTest,
+        GenesisParams::default(),
     )
     .await;
 

--- a/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_flow.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_flow.rs
@@ -7,6 +7,7 @@ use apollo_integration_tests::integration_test_manager::{
     DEFAULT_SENDER_ACCOUNT,
 };
 use apollo_integration_tests::integration_test_utils::integration_test_setup;
+use apollo_integration_tests::state_reader::GenesisParams;
 use tracing::info;
 
 #[tokio::main]
@@ -32,6 +33,7 @@ async fn main() {
         N_HYBRID_SEQUENCERS,
         None,
         TestIdentifier::RestartFlowIntegrationTest,
+        GenesisParams::default(),
     )
     .await;
 

--- a/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_service_multiple_nodes_flow.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_service_multiple_nodes_flow.rs
@@ -5,6 +5,7 @@ use apollo_deployments::service::NodeService;
 use apollo_infra_utils::test_utils::TestIdentifier;
 use apollo_integration_tests::integration_test_manager::IntegrationTestManager;
 use apollo_integration_tests::integration_test_utils::integration_test_setup;
+use apollo_integration_tests::state_reader::GenesisParams;
 use starknet_api::block::BlockNumber;
 use static_assertions::const_assert;
 use strum::IntoEnumIterator;
@@ -35,6 +36,7 @@ async fn main() {
         N_HYBRID_SEQUENCERS,
         None,
         TestIdentifier::RestartServiceMultipleNodesFlowIntegrationTest,
+        GenesisParams::default(),
     )
     .await;
 

--- a/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_service_single_node_flow.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_restart_service_single_node_flow.rs
@@ -9,6 +9,7 @@ use apollo_integration_tests::integration_test_manager::{
     DEFAULT_SENDER_ACCOUNT,
 };
 use apollo_integration_tests::integration_test_utils::integration_test_setup;
+use apollo_integration_tests::state_reader::GenesisParams;
 use strum::IntoEnumIterator;
 use tracing::info;
 
@@ -35,6 +36,7 @@ async fn main() {
         N_HYBRID_SEQUENCERS,
         None,
         TestIdentifier::RestartServiceSingleNodeFlowIntegrationTest,
+        GenesisParams::default(),
     )
     .await;
 

--- a/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_revert_flow.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_end_to_end_integration_tests/integration_test_revert_flow.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use apollo_infra_utils::test_utils::TestIdentifier;
 use apollo_integration_tests::integration_test_manager::IntegrationTestManager;
 use apollo_integration_tests::integration_test_utils::integration_test_setup;
+use apollo_integration_tests::state_reader::GenesisParams;
 use apollo_node_config::definitions::ConfigPointersMap;
 use apollo_node_config::node_config::SequencerNodeConfig;
 use serde_json::Value;
@@ -40,6 +41,7 @@ async fn main() {
         N_HYBRID_SEQUENCERS,
         None,
         TestIdentifier::RevertFlowIntegrationTest,
+        GenesisParams::default(),
     )
     .await;
 

--- a/crates/apollo_integration_tests/src/bin/sequencer_node_setup.rs
+++ b/crates/apollo_integration_tests/src/bin/sequencer_node_setup.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use apollo_infra::trace_util::configure_tracing;
 use apollo_infra_utils::test_utils::TestIdentifier;
 use apollo_integration_tests::integration_test_manager::IntegrationTestManager;
+use apollo_integration_tests::state_reader::GenesisParams;
 use apollo_integration_tests::storage::CustomPaths;
 use clap::Parser;
 use tokio::fs::create_dir_all;
@@ -31,6 +32,7 @@ async fn main() {
         Some(custom_paths),
         // TODO(Tsabary/Nadin): add a different identifier.
         TestIdentifier::PositiveFlowIntegrationTest,
+        GenesisParams::default(),
     )
     .await;
 

--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -57,7 +57,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, instrument, Instrument};
 use url::Url;
 
-use crate::state_reader::{StorageTestHandles, StorageTestSetup};
+use crate::state_reader::{GenesisParams, StorageTestHandles, StorageTestSetup};
 use crate::utils::{
     create_consensus_manager_configs_from_network_configs,
     create_mempool_p2p_configs,
@@ -248,10 +248,10 @@ impl FlowSequencerSetup {
     ) -> Self {
         let path = None;
         let StorageTestSetup { storage_config, storage_handles } =
-            StorageTestSetup::new(accounts, &chain_info, path);
+            StorageTestSetup::new(accounts, &chain_info, path, GenesisParams::default());
 
         let (recorder_url, _join_handle) =
-            spawn_local_success_recorder(available_ports.get_next_port());
+            spawn_local_success_recorder(available_ports.get_next_port(), 0);
         consensus_manager_config.cende_config.recorder_url = recorder_url;
 
         let (eth_to_strk_oracle_url_headers, _join_handle) =

--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -62,7 +62,7 @@ use crate::node_component_configs::{
     create_hybrid_component_configs,
 };
 use crate::sequencer_simulator_utils::SequencerSimulator;
-use crate::state_reader::StorageTestHandles;
+use crate::state_reader::{GenesisParams, StorageTestHandles};
 use crate::storage::{get_integration_test_storage, CustomPaths};
 use crate::utils::{
     create_consensus_manager_configs_from_network_configs,
@@ -383,6 +383,8 @@ pub struct IntegrationTestManager {
     // Ethereum base layer coupled with an Anvil server instance, the server is dropped when the
     // instance is dropped.
     anvil_base_layer: AnvilBaseLayer,
+    #[allow(dead_code)]
+    genesis_block_number: BlockNumber,
 }
 
 impl IntegrationTestManager {
@@ -392,9 +394,11 @@ impl IntegrationTestManager {
         num_of_hybrid_nodes: usize,
         custom_paths: Option<CustomPaths>,
         test_unique_id: TestIdentifier,
+        genesis_params: GenesisParams,
     ) -> Self {
         let tx_generator = create_integration_test_tx_generator();
 
+        let genesis_block_number = genesis_params.initial_block_number;
         let (sequencers_setup, node_indices) = get_sequencer_setup_configs(
             &tx_generator,
             num_of_consolidated_nodes,
@@ -402,6 +406,7 @@ impl IntegrationTestManager {
             num_of_hybrid_nodes,
             custom_paths,
             test_unique_id,
+            genesis_params,
         )
         .await;
 
@@ -439,7 +444,14 @@ impl IntegrationTestManager {
         let idle_nodes = create_map(sequencers_setup, |node| node.get_node_index());
         let running_nodes = HashMap::new();
 
-        Self { node_indices, idle_nodes, running_nodes, tx_generator, anvil_base_layer }
+        Self {
+            node_indices,
+            idle_nodes,
+            running_nodes,
+            tx_generator,
+            anvil_base_layer,
+            genesis_block_number,
+        }
     }
 
     pub fn get_idle_nodes(&self) -> &HashMap<usize, NodeSetup> {
@@ -1218,6 +1230,7 @@ async fn get_sequencer_setup_configs(
     num_of_hybrid_nodes: usize,
     custom_paths: Option<CustomPaths>,
     test_unique_id: TestIdentifier,
+    genesis_params: GenesisParams,
 ) -> (Vec<NodeSetup>, HashSet<usize>) {
     let mut available_ports_generator = AvailablePortsGenerator::new(test_unique_id.into());
 
@@ -1292,8 +1305,10 @@ async fn get_sequencer_setup_configs(
 
     // TODO(tsabary): Move these to the start of the test and propagate their values when relevant.
     // All nodes use the same recorder_url and eth_to_strk_oracle_url.
-    let (recorder_url, _join_handle) =
-        spawn_local_success_recorder(base_layer_ports.get_next_port());
+    let (recorder_url, _join_handle) = spawn_local_success_recorder(
+        base_layer_ports.get_next_port(),
+        genesis_params.initial_block_number.0,
+    );
     let (eth_to_strk_oracle_url, _join_handle_eth_to_strk_oracle) =
         spawn_local_eth_to_strk_oracle(base_layer_ports.get_next_port());
 
@@ -1324,6 +1339,7 @@ async fn get_sequencer_setup_configs(
             custom_paths.clone(),
             accounts.to_vec(),
             &chain_info,
+            genesis_params.clone(),
         );
 
         // Per node, create the executables constituting it.

--- a/crates/apollo_integration_tests/src/state_reader.rs
+++ b/crates/apollo_integration_tests/src/state_reader.rs
@@ -6,9 +6,12 @@ use apollo_class_manager::{ClassStorage, FsClassStorage};
 use apollo_class_manager_config::config::FsClassStorageConfig;
 use apollo_proof_manager::test_utils::FsProofStorageBuilderForTesting;
 use apollo_proof_manager_config::config::ProofManagerConfig;
+use apollo_storage::block_hash::BlockHashStorageWriter;
 use apollo_storage::body::BodyStorageWriter;
 use apollo_storage::class::ClassStorageWriter;
+use apollo_storage::class_manager::ClassManagerStorageWriter;
 use apollo_storage::compiled_class::CasmStorageWriter;
+use apollo_storage::global_root_marker::GlobalRootMarkerStorageWriter;
 use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::partial_block_hash::PartialBlockHashComponentsStorageWriter;
 use apollo_storage::state::StateStorageWriter;
@@ -25,6 +28,7 @@ use mempool_test_utils::starknet_api_test_utils::{AccountTransactionGenerator, C
 use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::block::{
     BlockBody,
+    BlockHash,
     BlockHeader,
     BlockHeaderWithoutHash,
     BlockNumber,
@@ -65,12 +69,19 @@ use strum::IntoEnumIterator;
 use tempfile::TempDir;
 
 use crate::storage::StorageExecutablePaths;
+use crate::utils::initialize_committer_storage;
 
 pub type TempDirHandlePair = (TempDir, TempDir);
 type ContractClassesMap = (
     Vec<(ClassHash, DeprecatedContractClass)>,
     Vec<(ClassHash, (SierraContractClass, CasmContractClass))>,
 );
+
+#[derive(Clone, Default)]
+pub struct GenesisParams {
+    pub initial_block_number: BlockNumber,
+    pub block_hash_seeds: Vec<(BlockNumber, BlockHash)>,
+}
 
 pub(crate) const BATCHER_DB_PATH_SUFFIX: &str = "batcher";
 pub(crate) const CLASS_MANAGER_DB_PATH_SUFFIX: &str = "class_manager";
@@ -152,6 +163,7 @@ impl StorageTestSetup {
         test_defined_accounts: Vec<AccountTransactionGenerator>,
         chain_info: &ChainInfo,
         storage_exec_paths: Option<StorageExecutablePaths>,
+        genesis_params: GenesisParams,
     ) -> Self {
         let preset_test_contracts = PresetTestContracts::new();
         // TODO(yair): Avoid cloning.
@@ -170,6 +182,7 @@ impl StorageTestSetup {
             &test_defined_accounts,
             preset_test_contracts.clone(),
             &classes,
+            &genesis_params,
         );
 
         let state_sync_db_path =
@@ -188,6 +201,7 @@ impl StorageTestSetup {
             &test_defined_accounts,
             preset_test_contracts,
             &classes,
+            &genesis_params,
         );
 
         let fs_class_storage_db_path =
@@ -230,6 +244,22 @@ impl StorageTestSetup {
             storage_exec_paths.as_ref().map(|p| p.get_committer_path_with_db_suffix());
         let (committer_db_path, committer_storage_handle) =
             create_dir_for_testing(committer_db_path);
+
+        // The committer's RocksDB starts at offset 0. When the genesis block is > 0, pre-initialize
+        // the offset so the committer accepts commitment requests starting at initial_block_number.
+        if genesis_params.initial_block_number.0 > 0 {
+            let db_path = committer_db_path.clone();
+            let initial_block_number = genesis_params.initial_block_number;
+            std::thread::spawn(move || {
+                tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap()
+                    .block_on(initialize_committer_storage(db_path, initial_block_number));
+            })
+            .join()
+            .unwrap();
+        }
+
         Self {
             storage_config: StorageTestConfig::new(
                 batcher_storage_config,
@@ -334,16 +364,27 @@ fn initialize_papyrus_test_state(
     test_defined_accounts: &[AccountTransactionGenerator],
     preset_test_contracts: PresetTestContracts,
     classes: &TestClasses,
+    genesis_params: &GenesisParams,
 ) {
-    let state_diff = prepare_state_diff(chain_info, test_defined_accounts, &preset_test_contracts);
-
-    write_state_to_apollo_storage(storage_writer, state_diff, classes)
+    let state_diff = prepare_state_diff(
+        chain_info,
+        test_defined_accounts,
+        &preset_test_contracts,
+        &genesis_params.block_hash_seeds,
+    );
+    write_state_to_apollo_storage(
+        storage_writer,
+        state_diff,
+        classes,
+        genesis_params.initial_block_number,
+    )
 }
 
 fn prepare_state_diff(
     chain_info: &ChainInfo,
     test_defined_accounts: &[AccountTransactionGenerator],
     preset_test_contracts: &PresetTestContracts,
+    block_hash_seeds: &[(BlockNumber, BlockHash)],
 ) -> ThinStateDiff {
     let mut state_diff_builder = ThinStateDiffBuilder::new(chain_info);
     let PresetTestContracts { default_test_contracts, erc20_contract } = preset_test_contracts;
@@ -375,7 +416,23 @@ fn prepare_state_diff(
     state_diff_builder
         .inject_undeployed_accounts_into_state(undeployed_accounts_contracts.as_slice());
 
-    state_diff_builder.build()
+    let mut state_diff = state_diff_builder.build();
+
+    // Populate the block hash contract with the block hash seeds if given. Used for integration
+    // tests that begin with a non-zero block number.
+    if !block_hash_seeds.is_empty() {
+        let block_hash_contract_address = VersionedConstants::latest_constants()
+            .os_constants
+            .os_contract_addresses
+            .block_hash_contract_address();
+        let seeds_entry = state_diff.storage_diffs.entry(block_hash_contract_address).or_default();
+        for (block_number, block_hash) in block_hash_seeds {
+            let key = StorageKey::from(block_number.0);
+            seeds_entry.insert(key, block_hash.0);
+        }
+    }
+
+    state_diff
 }
 
 fn prepare_contract_classes(
@@ -408,8 +465,44 @@ fn write_state_to_apollo_storage(
     storage_writer: &mut StorageWriter,
     state_diff: ThinStateDiff,
     classes: &TestClasses,
+    initial_block_number: BlockNumber,
 ) {
-    let block_number = BlockNumber(0);
+    // Storage requires sequential block writes from 0. When initial_block_number > 0, write
+    // empty placeholder blocks first so that all markers reach initial_block_number.
+    if initial_block_number.0 > 0 {
+        let mut write_txn = storage_writer.begin_rw_txn().unwrap();
+        for placeholder_block_number in (0..initial_block_number.0).map(BlockNumber) {
+            let placeholder_header = BlockHeader {
+                block_header_without_hash: BlockHeaderWithoutHash {
+                    block_number: placeholder_block_number,
+                    ..Default::default()
+                },
+                // Use block_number + 1 as a unique stand-in for the block hash, avoiding 0x0
+                // which is reserved for the genesis block's default hash.
+                block_hash: BlockHash((placeholder_block_number.0 + 1).into()),
+                ..Default::default()
+            };
+            write_txn = write_txn
+                .append_header(placeholder_block_number, &placeholder_header)
+                .unwrap()
+                .append_body(placeholder_block_number, BlockBody::default())
+                .unwrap()
+                .append_state_diff(placeholder_block_number, ThinStateDiff::default())
+                .unwrap()
+                .append_classes(placeholder_block_number, &[], &[])
+                .unwrap()
+                // Populate the block hashes table used by the batcher with placeholder blocks.
+                .set_block_hash(&placeholder_block_number, placeholder_header.block_hash)
+                .unwrap()
+                // Advance the global root marker so the batcher skips commitment tasks for
+                // placeholder blocks on startup.
+                .checked_increment_global_root_marker(placeholder_block_number)
+                .unwrap();
+        }
+        write_txn.commit().unwrap();
+    }
+
+    let block_number = initial_block_number;
     let block_header = test_block_header(block_number, state_diff.len());
     let TestClasses { cairo0_contract_classes, cairo1_contract_classes } = classes;
     let cairo0_contract_classes: Vec<_> =
@@ -444,6 +537,14 @@ fn write_state_to_apollo_storage(
         .append_classes(block_number, &sierras, &cairo0_contract_classes)
         .unwrap()
         .set_partial_block_hash_components(&block_number, &partial_block_hash)
+        .unwrap()
+        // Advance the class manager marker past the pre-populated genesis block so the p2p sync
+        // class stream starts from the first newly produced block.
+        .update_class_manager_block_marker(&block_number.unchecked_next())
+        .unwrap()
+        // Reset the compiled class marker to 0 to account for the placeholder block initialization
+        // advancing it to initial block number while P2P sync expects it to be 0.
+        .update_compiled_class_marker(&BlockNumber(0))
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/apollo_integration_tests/src/storage.rs
+++ b/crates/apollo_integration_tests/src/storage.rs
@@ -5,6 +5,7 @@ use mempool_test_utils::starknet_api_test_utils::AccountTransactionGenerator;
 
 use crate::executable_setup::NodeExecutableId;
 use crate::state_reader::{
+    GenesisParams,
     StorageTestConfig,
     StorageTestSetup,
     BATCHER_DB_PATH_SUFFIX,
@@ -117,13 +118,14 @@ pub fn get_integration_test_storage(
     custom_paths: Option<CustomPaths>,
     accounts: Vec<AccountTransactionGenerator>,
     chain_info: &ChainInfo,
+    genesis_params: GenesisParams,
 ) -> StorageTestSetup {
     let storage_exec_paths = custom_paths.as_ref().and_then(|paths| {
         paths.get_db_base().map(|db_base| StorageExecutablePaths::new(db_base, node_index))
     });
 
     let StorageTestSetup { mut storage_config, storage_handles } =
-        StorageTestSetup::new(accounts, chain_info, storage_exec_paths);
+        StorageTestSetup::new(accounts, chain_info, storage_exec_paths, genesis_params);
 
     // Allow overriding the path with a custom prefix for Docker mode in system tests.
     if let Some(paths) = custom_paths {

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -476,7 +476,10 @@ pub(crate) fn create_consensus_manager_configs_from_network_configs(
 }
 
 // Creates a local recorder server that always returns a success status.
-pub fn spawn_success_recorder(socket_address: SocketAddr) -> JoinHandle<()> {
+pub fn spawn_success_recorder(
+    socket_address: SocketAddr,
+    initial_block_number: u64,
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         let router = Router::new()
             .route(
@@ -501,10 +504,10 @@ pub fn spawn_success_recorder(socket_address: SocketAddr) -> JoinHandle<()> {
             )
             .route(
                 RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH,
-                get(|| {
-                    async {
+                get(move || {
+                    async move {
                         debug!("Received a request for get_latest_received_block.");
-                        Json(serde_json::json!({ "block_number": 0 }))
+                        Json(serde_json::json!({ "block_number": initial_block_number }))
                     }
                     .instrument(tracing::debug_span!("success recorder get_latest_received_block"))
                 }),
@@ -514,10 +517,10 @@ pub fn spawn_success_recorder(socket_address: SocketAddr) -> JoinHandle<()> {
     })
 }
 
-pub fn spawn_local_success_recorder(port: u16) -> (Url, JoinHandle<()>) {
+pub fn spawn_local_success_recorder(port: u16, initial_block_number: u64) -> (Url, JoinHandle<()>) {
     let socket_address = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
     let url = Url::parse(&format!("http://{socket_address}")).unwrap();
-    let join_handle = spawn_success_recorder(socket_address);
+    let join_handle = spawn_success_recorder(socket_address, initial_block_number);
     (url, join_handle)
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes test storage initialization and mock recorder behavior to support non-zero genesis block heights, which can affect marker offsets and block-hash assumptions across multiple components in integration tests.
> 
> **Overview**
> Adds configurable `GenesisParams` to `apollo_integration_tests`, threading an `initial_block_number` (and optional block-hash seeds) through `IntegrationTestManager`/storage setup so integration tests can start from a non-zero “genesis” height.
> 
> Updates storage seeding to write placeholder blocks up to `initial_block_number`, pre-initialize the committer offset, seed the OS block-hash contract when provided, and adjust storage markers (class manager/compiled class/global root) to keep P2P sync and batcher/committer behavior consistent.
> 
> Makes the local success recorder return the configured latest received block number, and updates all integration test binaries and helpers to pass the new parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7159af5a92b2797fcf8a56ad5c2bb10d7c40dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->