### PR TITLE
apollo_mempool_p2p: extract broadcast_queued_transactions_every_tick

### DIFF
--- a/crates/apollo_mempool_p2p/src/runner/mod.rs
+++ b/crates/apollo_mempool_p2p/src/runner/mod.rs
@@ -62,20 +62,18 @@ impl ComponentStarter for MempoolP2pRunner {
     async fn start(&mut self) {
         let gateway_semaphore = Arc::new(Semaphore::new(self.max_concurrent_gateway_requests));
         let mut gateway_futures = FuturesUnordered::new();
-        let mut transaction_batch_broadcast_interval =
-            tokio::time::interval(self.transaction_batch_rate_millis);
-        transaction_batch_broadcast_interval.set_missed_tick_behavior(Delay);
-        transaction_batch_broadcast_interval.tick().await; // The first tick is ready immediately so we consume it.
+        let mut broadcast_queued_txs_handle = tokio::spawn(broadcast_queued_transactions_every_tick(
+            self.mempool_p2p_propagator_client.clone(),
+            self.transaction_batch_rate_millis,
+        ));
         loop {
             tokio::select! {
                 _ = &mut self.network_future => {
                     panic!("MempoolP2pRunner failed - network stopped unexpectedly");
                 }
-                _ = transaction_batch_broadcast_interval.tick() => {
-                    let result = self.mempool_p2p_propagator_client.broadcast_queued_transactions().await;
-                    if result.is_err() {
-                        warn!("MempoolP2pPropagatorClient denied BroadcastQueuedTransactions request: {result:?}");
-                    };
+                res = &mut broadcast_queued_txs_handle => {
+                    let _ = res.expect("Broadcast task panicked");
+                    panic!("broadcast_queued_transactions_every_tick unexpectedly stopped");
                 }
                 Some(result) = gateway_futures.next() => {
                     match result {
@@ -141,3 +139,22 @@ impl ComponentStarter for MempoolP2pRunner {
 }
 
 pub type MempoolP2pRunnerServer = WrapperServer<MempoolP2pRunner>;
+
+async fn broadcast_queued_transactions_every_tick(
+    client: SharedMempoolP2pPropagatorClient,
+    rate: Duration,
+) {
+    let mut interval = tokio::time::interval(rate);
+    interval.set_missed_tick_behavior(Delay);
+    interval.tick().await; // The first tick is ready immediately so we consume it.
+    loop {
+        interval.tick().await;
+        let result = client.broadcast_queued_transactions().await;
+        if let Err(err) = result {
+            warn!(
+                "MempoolP2pPropagatorClient denied BroadcastQueuedTransactions request. Will \
+                 retry at the next interval. Error: {err:?}"
+            );
+        }
+    }
+}

--- a/crates/apollo_mempool_p2p/src/runner/mod.rs
+++ b/crates/apollo_mempool_p2p/src/runner/mod.rs
@@ -62,18 +62,20 @@ impl ComponentStarter for MempoolP2pRunner {
     async fn start(&mut self) {
         let gateway_semaphore = Arc::new(Semaphore::new(self.max_concurrent_gateway_requests));
         let mut gateway_futures = FuturesUnordered::new();
-        let mut broadcast_queued_txs_handle = tokio::spawn(broadcast_queued_transactions_every_tick(
-            self.mempool_p2p_propagator_client.clone(),
-            self.transaction_batch_rate_millis,
-        ));
+        let mut broadcast_queued_txs_handle =
+            tokio::spawn(broadcast_queued_transactions_every_tick(
+                self.mempool_p2p_propagator_client.clone(),
+                self.transaction_batch_rate_millis,
+            ));
         loop {
             tokio::select! {
-                _ = &mut self.network_future => {
-                    panic!("MempoolP2pRunner failed - network stopped unexpectedly");
+                res = &mut self.network_future => {
+                    res.expect("Mempool P2P network failed");
+                    unreachable!("Network manager's run should never return");
                 }
                 res = &mut broadcast_queued_txs_handle => {
-                    let _ = res.expect("Broadcast task panicked");
-                    panic!("broadcast_queued_transactions_every_tick unexpectedly stopped");
+                    res.expect("Broadcast task panicked");
+                    unreachable!("The broadcast task runs an infinite loop, so it should never return");
                 }
                 Some(result) = gateway_futures.next() => {
                     match result {

--- a/crates/apollo_mempool_p2p/src/runner/test.rs
+++ b/crates/apollo_mempool_p2p/src/runner/test.rs
@@ -58,9 +58,9 @@ fn setup(
     (mempool_p2p_runner, mock_network)
 }
 
-#[test]
-#[should_panic]
-fn run_panics_when_network_future_returns() {
+#[tokio::test]
+#[should_panic(expected = "network stopped unexpectedly")]
+async fn run_panics_when_network_future_returns() {
     let network_future = ready(Ok(())).boxed();
     let gateway_client = Arc::new(MockGatewayClient::new());
     let (mut mempool_p2p_runner, _) = setup(
@@ -70,12 +70,12 @@ fn run_panics_when_network_future_returns() {
         MAX_TRANSACTION_BATCH_RATE,
         MAX_CONCURRENT_GATEWAY_REQUESTS,
     );
-    mempool_p2p_runner.start().now_or_never().unwrap();
+    mempool_p2p_runner.start().await;
 }
 
-#[test]
-#[should_panic]
-fn run_panics_when_network_future_returns_error() {
+#[tokio::test]
+#[should_panic(expected = "network stopped unexpectedly")]
+async fn run_panics_when_network_future_returns_error() {
     let network_future =
         ready(Err(NetworkError::DialError(libp2p::swarm::DialError::Aborted))).boxed();
     let gateway_client = Arc::new(MockGatewayClient::new());
@@ -86,7 +86,7 @@ fn run_panics_when_network_future_returns_error() {
         MAX_TRANSACTION_BATCH_RATE,
         MAX_CONCURRENT_GATEWAY_REQUESTS,
     );
-    mempool_p2p_runner.start().now_or_never().unwrap();
+    mempool_p2p_runner.start().await;
 }
 
 #[tokio::test]

--- a/crates/apollo_mempool_p2p/src/runner/test.rs
+++ b/crates/apollo_mempool_p2p/src/runner/test.rs
@@ -59,7 +59,7 @@ fn setup(
 }
 
 #[tokio::test]
-#[should_panic(expected = "network stopped unexpectedly")]
+#[should_panic(expected = "Network manager's run should never return")]
 async fn run_panics_when_network_future_returns() {
     let network_future = ready(Ok(())).boxed();
     let gateway_client = Arc::new(MockGatewayClient::new());
@@ -74,7 +74,7 @@ async fn run_panics_when_network_future_returns() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "network stopped unexpectedly")]
+#[should_panic(expected = "Mempool P2P network failed")]
 async fn run_panics_when_network_future_returns_error() {
     let network_future =
         ready(Err(NetworkError::DialError(libp2p::swarm::DialError::Aborted))).boxed();


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional surface area change, but it alters scheduling by moving periodic broadcasting into a separate spawned task and introduces new panic paths if that task exits unexpectedly.
> 
> **Overview**
> Extracts periodic `broadcast_queued_transactions` logic from the runner’s main `tokio::select!` loop into a dedicated `broadcast_queued_transactions_every_tick` task spawned at startup.
> 
> The new task owns the interval loop and logs/retries on errors, while the runner now monitors the join handle and panics if the broadcast task panics or stops unexpectedly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e5c63a537c9395439ed78d3548edb397e96fd43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->