### PR TITLE
apollo_propeller: fix Event doc comments to say 'units' instead of 'shards'

### DIFF
--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -13,9 +13,9 @@ use crate::MerkleHash;
 /// Events emitted by the Propeller protocol to the application layer.
 #[derive(Debug, Clone)]
 pub enum Event {
-    /// A complete message has been reconstructed from shards.
+    /// A complete message has been reconstructed from units.
     MessageReceived { publisher: PeerId, message_root: MessageRoot, message: Vec<u8> },
-    /// Failed to reconstruct a message from shards.
+    /// Failed to reconstruct a message from units.
     MessageReconstructionFailed {
         message_root: MessageRoot,
         publisher: PeerId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that updates `Event` variant doc comments without modifying any runtime behavior.
> 
> **Overview**
> Updates `apollo_propeller` `Event` documentation to consistently refer to reconstructed data as *units* (not *shards*) for `MessageReceived` and `MessageReconstructionFailed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0894e0bce17342e0e128e986fca879cbd3dbea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->