### PR TITLE
apollo_mempool_p2p: extract listen_and_handle_incoming_p2p_messages

### DIFF
--- a/crates/apollo_mempool_p2p/src/runner/mod.rs
+++ b/crates/apollo_mempool_p2p/src/runner/mod.rs
@@ -4,9 +4,13 @@ mod test;
 use std::sync::Arc;
 use std::time::Duration;
 
-use apollo_gateway_types::communication::{GatewayClientError, SharedGatewayClient};
+use apollo_gateway_types::communication::{
+    GatewayClientError,
+    GatewayClientResult,
+    SharedGatewayClient,
+};
 use apollo_gateway_types::errors::GatewayError;
-use apollo_gateway_types::gateway_types::GatewayInput;
+use apollo_gateway_types::gateway_types::{GatewayInput, GatewayOutput};
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_infra::component_server::WrapperServer;
 use apollo_mempool_p2p_types::communication::SharedMempoolP2pPropagatorClient;
@@ -16,18 +20,19 @@ use apollo_network::network_manager::{
     BroadcastTopicServer,
     NetworkError,
 };
+use apollo_network_types::network_types::BroadcastedMessageMetadata;
 use apollo_protobuf::mempool::RpcTransactionBatch;
 use async_trait::async_trait;
-use futures::future::BoxFuture;
-use futures::stream::FuturesUnordered;
+use futures::future::{BoxFuture, Future};
 use futures::StreamExt;
+use starknet_api::rpc_transaction::RpcTransaction;
 use tokio::sync::Semaphore;
 use tokio::time::MissedTickBehavior::Delay;
 use tracing::{debug, warn};
 
 pub struct MempoolP2pRunner {
-    network_future: BoxFuture<'static, Result<(), NetworkError>>,
-    broadcasted_topic_server: BroadcastTopicServer<RpcTransactionBatch>,
+    network_future: Option<BoxFuture<'static, Result<(), NetworkError>>>,
+    broadcasted_topic_server: Option<BroadcastTopicServer<RpcTransactionBatch>>,
     broadcast_topic_client: BroadcastTopicClient<RpcTransactionBatch>,
     gateway_client: SharedGatewayClient,
     mempool_p2p_propagator_client: SharedMempoolP2pPropagatorClient,
@@ -46,8 +51,8 @@ impl MempoolP2pRunner {
         max_concurrent_gateway_requests: usize,
     ) -> Self {
         Self {
-            network_future,
-            broadcasted_topic_server,
+            network_future: Some(network_future),
+            broadcasted_topic_server: Some(broadcasted_topic_server),
             broadcast_topic_client,
             gateway_client,
             mempool_p2p_propagator_client,
@@ -60,88 +65,42 @@ impl MempoolP2pRunner {
 #[async_trait]
 impl ComponentStarter for MempoolP2pRunner {
     async fn start(&mut self) {
-        let gateway_semaphore = Arc::new(Semaphore::new(self.max_concurrent_gateway_requests));
-        let mut gateway_futures = FuturesUnordered::new();
-        let mut broadcast_queued_txs_handle =
-            tokio::spawn(broadcast_queued_transactions_every_tick(
-                self.mempool_p2p_propagator_client.clone(),
-                self.transaction_batch_rate_millis,
-            ));
-        loop {
-            tokio::select! {
-                res = &mut self.network_future => {
-                    res.expect("Mempool P2P network failed");
-                    unreachable!("Network manager's run should never return");
-                }
-                res = &mut broadcast_queued_txs_handle => {
-                    res.expect("Broadcast task panicked");
-                    unreachable!("The broadcast task runs an infinite loop, so it should never return");
-                }
-                Some(result) = gateway_futures.next() => {
-                    match result {
-                        Ok(_) => {}
-                        Err(gateway_client_error) => {
-                            // TODO(shahak): Analyze the error to see if it's the tx's fault or an
-                            // internal error. Widen GatewayError's variants if necessary.
-                            if let GatewayClientError::GatewayError(
-                                GatewayError::DeprecatedGatewayError{p2p_message_metadata: Some(p2p_message_metadata), ..}
-                            ) = gateway_client_error {
-                                warn!(
-                                    "Gateway rejected transaction we received from another peer. Reporting peer: {:?}.", p2p_message_metadata
-                                );
-                                if let Err(e) = self.broadcast_topic_client.report_peer(p2p_message_metadata.clone()).await {
-                                    warn!("Failed to report peer: {:?}", e);
-                                }
-                            } else {
-                                warn!(
-                                    "Failed sending transaction to gateway. {:?}",
-                                    gateway_client_error
-                                );
-                            }
-                        }
-                    }
-                }
-                Some((message_result, broadcasted_message_metadata)) = self.broadcasted_topic_server.next() => {
-                    match message_result {
-                        Ok(message) => {
-                            // TODO(alonl): consider calculating the tx_hash and printing it instead of the entire tx.
-                            debug!("Received transaction batch from network, forwarding to gateway. Batch: {:?}", message.0);
-                            for rpc_tx in message.0 {
-                                let permit = match gateway_semaphore.clone().try_acquire_owned() {
-                                    Ok(permit) => permit,
-                                    Err(_) => {
-                                        warn!(
-                                            "Rejecting transaction due to backpressure. \
-                                             Transaction: {rpc_tx:?}"
-                                        );
-                                        continue;
-                                    }
-                                };
-                                let gateway_client = self.gateway_client.clone();
-                                let message_metadata = Some(broadcasted_message_metadata.clone());
-                                gateway_futures.push(async move {
-                                    let _permit = permit;
-                                    gateway_client.add_tx(
-                                        GatewayInput { rpc_tx, message_metadata }
-                                    ).await
-                                });
-                            }
-                        }
-                        Err(e) => {
-                            warn!("Received a faulty transaction from network: {:?}. Attempting to report the sending peer {:?}", e, broadcasted_message_metadata);
-                            if let Err(e) = self.broadcast_topic_client.report_peer(broadcasted_message_metadata).await {
-                                warn!("Failed to report peer: {:?}", e);
-                            }
-                        }
-                    }
-                }
+        let network_future =
+            self.network_future.take().expect("start() should only be called once");
+        let network_handle = tokio::task::spawn(network_future);
+
+        let broadcast_queued_txs_handle = tokio::spawn(broadcast_queued_transactions_every_tick(
+            self.mempool_p2p_propagator_client.clone(),
+            self.transaction_batch_rate_millis,
+        ));
+
+        let broadcasted_topic_server =
+            self.broadcasted_topic_server.take().expect("start() should only be called once");
+        let incoming_messages_handle = tokio::spawn(listen_and_handle_incoming_p2p_messages(
+            broadcasted_topic_server,
+            self.gateway_client.clone(),
+            self.broadcast_topic_client.clone(),
+            self.max_concurrent_gateway_requests,
+        ));
+
+        tokio::select! {
+            res = network_handle => {
+                res.expect("Mempool P2P network panicked").expect("Mempool P2P network failed");
+                unreachable!("Network manager's run should never return");
+            }
+            res = broadcast_queued_txs_handle => {
+                res.expect("Broadcast task panicked");
+                unreachable!("The broadcast task runs an infinite loop, so it should never return");
+            }
+            res = incoming_messages_handle => {
+                res.expect("Incoming messages task panicked");
+                unreachable!("The incoming messages task runs an infinite loop, so it should never return");
             }
         }
     }
 }
 
 pub type MempoolP2pRunnerServer = WrapperServer<MempoolP2pRunner>;
-
 async fn broadcast_queued_transactions_every_tick(
     client: SharedMempoolP2pPropagatorClient,
     rate: Duration,
@@ -157,6 +116,111 @@ async fn broadcast_queued_transactions_every_tick(
                 "MempoolP2pPropagatorClient denied BroadcastQueuedTransactions request. Will \
                  retry at the next interval. Error: {err:?}"
             );
+        }
+    }
+}
+
+async fn listen_and_handle_incoming_p2p_messages(
+    mut broadcasted_topic_server: BroadcastTopicServer<RpcTransactionBatch>,
+    gateway_client: SharedGatewayClient,
+    mut broadcast_topic_client: BroadcastTopicClient<RpcTransactionBatch>,
+    max_concurrent_gateway_requests: usize,
+) {
+    let gateway_semaphore = Arc::new(Semaphore::new(max_concurrent_gateway_requests));
+    let mut gateway_futures = tokio::task::JoinSet::new();
+
+    while let Some((message_result, broadcasted_message_metadata)) =
+        broadcasted_topic_server.next().await
+    {
+        while let Some(join_result) = gateway_futures.try_join_next() {
+            join_result.expect("Gateway client add_tx task should not panic");
+        }
+
+        match message_result {
+            Ok(message) => {
+                // TODO(alonl): consider calculating the tx_hash and printing it instead of the
+                // entire tx.
+                debug!(
+                    "Received transaction batch from network, forwarding to gateway. Batch: {:?}",
+                    message.0
+                );
+                for rpc_tx in message.0 {
+                    if let Some(future) = try_create_gateway_future_for_incoming_tx(
+                        rpc_tx,
+                        gateway_client.clone(),
+                        &gateway_semaphore,
+                        broadcast_topic_client.clone(),
+                        broadcasted_message_metadata.clone(),
+                    ) {
+                        gateway_futures.spawn(future);
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Received a faulty transaction from network: {:?}. Attempting to report the \
+                     sending peer {:?}",
+                    e, broadcasted_message_metadata
+                );
+                if let Err(e) =
+                    broadcast_topic_client.report_peer(broadcasted_message_metadata).await
+                {
+                    warn!("Failed to report peer: {:?}", e);
+                }
+            }
+        }
+    }
+}
+
+fn try_create_gateway_future_for_incoming_tx(
+    rpc_tx: RpcTransaction,
+    gateway_client: SharedGatewayClient,
+    gateway_semaphore: &Arc<Semaphore>,
+    broadcast_topic_client: BroadcastTopicClient<RpcTransactionBatch>,
+    broadcasted_message_metadata: BroadcastedMessageMetadata,
+) -> Option<impl Future<Output = ()>> {
+    let permit = match gateway_semaphore.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            warn!("Rejecting transaction due to backpressure. Transaction: {:?}", rpc_tx);
+            return None;
+        }
+    };
+    let message_metadata = Some(broadcasted_message_metadata);
+    Some(async move {
+        let _permit = permit;
+        let result = gateway_client.add_tx(GatewayInput { rpc_tx, message_metadata }).await;
+        handle_gateway_result(result, broadcast_topic_client).await;
+    })
+}
+
+async fn handle_gateway_result(
+    result: GatewayClientResult<GatewayOutput>,
+    mut broadcast_topic_client: BroadcastTopicClient<RpcTransactionBatch>,
+) {
+    match result {
+        Ok(_) => {}
+        Err(gateway_client_error) => {
+            // TODO(shahak): Analyze the error to see if it's the tx's fault or an
+            // internal error. Widen GatewayError's variants if necessary.
+            if let GatewayClientError::GatewayError(GatewayError::DeprecatedGatewayError {
+                p2p_message_metadata: Some(p2p_message_metadata),
+                ..
+            }) = gateway_client_error
+            {
+                warn!(
+                    "Gateway rejected transaction we received from another peer. Reporting peer: \
+                     {:?}.",
+                    p2p_message_metadata
+                );
+                if let Err(e) =
+                    broadcast_topic_client.report_peer(p2p_message_metadata.clone()).await
+                {
+                    warn!("Failed to report peer: {:?}", e);
+                }
+            } else {
+                warn!("Failed sending transaction to gateway. {:?}", gateway_client_error);
+            }
         }
     }
 }

--- a/crates/apollo_mempool_p2p/src/runner/test.rs
+++ b/crates/apollo_mempool_p2p/src/runner/test.rs
@@ -63,7 +63,7 @@ fn setup(
 async fn run_panics_when_network_future_returns() {
     let network_future = ready(Ok(())).boxed();
     let gateway_client = Arc::new(MockGatewayClient::new());
-    let (mut mempool_p2p_runner, _) = setup(
+    let (mut mempool_p2p_runner, _mock_network) = setup(
         network_future,
         gateway_client,
         Arc::new(MockMempoolP2pPropagatorClient::new()),
@@ -79,7 +79,7 @@ async fn run_panics_when_network_future_returns_error() {
     let network_future =
         ready(Err(NetworkError::DialError(libp2p::swarm::DialError::Aborted))).boxed();
     let gateway_client = Arc::new(MockGatewayClient::new());
-    let (mut mempool_p2p_runner, _) = setup(
+    let (mut mempool_p2p_runner, _mock_network) = setup(
         network_future,
         gateway_client,
         Arc::new(MockMempoolP2pPropagatorClient::new()),
@@ -190,11 +190,15 @@ async fn incoming_p2p_tx_fails_on_gateway_client() {
 
     res.await.expect("Failed to send message");
 
+    let runner_handle = tokio::spawn(async move {
+        mempool_p2p_runner.start().await;
+    });
+
     tokio::select! {
         // if the runner fails, there was a network issue => panic.
         // if the runner returns successfully, we panic because the runner should never terminate.
-        res = tokio::time::timeout(Duration::from_secs(5), mempool_p2p_runner.start()) => {
-            res.expect("Test timed out (MempoolP2pRunner took too long to start)");
+        res = tokio::time::timeout(Duration::from_secs(5), runner_handle) => {
+            res.unwrap().expect("Runner task panicked");
             panic!("MempoolP2pRunner terminated");
         },
         // if a message was received on this oneshot channel, the gateway client received the tx.


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the runner’s async orchestration/concurrency around forwarding incoming P2P transactions to the gateway, which could affect backpressure and error-reporting behavior under load.
> 
> **Overview**
> Refactors `MempoolP2pRunner::start` to spawn the network future, periodic broadcast loop, and a new dedicated incoming-message task, and enforces single-start semantics by storing the network future and topic server as `Option` and `take()`ing them.
> 
> Extracts incoming P2P batch handling into `listen_and_handle_incoming_p2p_messages`, switching per-tx gateway forwarding to a `tokio::task::JoinSet` with helpers (`create_gateway_future_for_incoming_tx`, `handle_gateway_result`) to centralize backpressure rejection and peer-reporting when the gateway rejects a relayed tx.
> 
> Updates the gateway-rejection test to run the runner in a spawned task and apply the timeout to the join handle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19e8f95b9f5e8ad4faee94cc4d476194fb893317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->