### PR TITLE
apollo_propeller: fix SignatureVerificationError error message to say 'unit'

### DIFF
--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -62,7 +62,7 @@ pub enum SignatureVerificationError {
          key cannot be extracted form the peer ID and needs to be provided explicitly."
     )]
     NoPublicKeyAvailable(PeerId),
-    #[error("Received a shard with an invalid signature. Sender should be reported...")]
+    #[error("Received a unit with an invalid signature. Sender should be reported...")]
     VerificationFailed,
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates an error string used for reporting invalid signatures, with no behavior or protocol changes.
> 
> **Overview**
> Updates `SignatureVerificationError::VerificationFailed`’s display message to say **"unit"** instead of **"shard"**, aligning the error text with current terminology when an invalid signature is received.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 042a7dea88a84b7b580141745d3774ff3257c56b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->