### PR TITLE
apollo_propeller: fix UnitValidationError doc comment to say 'unit verification'

### DIFF
--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -135,7 +135,7 @@ pub enum CommitteeSetupError {
     DuplicatePeerIds,
 }
 
-/// Specific errors that can occur during shard verification.
+/// Specific errors that can occur during unit verification.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UnitValidationError {
     #[error("Self received a shard from myself (libp2p should not allow this)")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change correcting a misleading doc comment; no runtime behavior is affected.
> 
> **Overview**
> Updates the doc comment on `UnitValidationError` in `crates/apollo_propeller/src/types.rs` to correctly describe these as errors during **unit** verification (not shard verification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d6019c74dafdf2044935776882434225718a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->