### PR TITLE
apollo_propeller: fix UnitValidationError error messages to say 'unit' instead of 'shard'

### DIFF
--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -138,22 +138,22 @@ pub enum CommitteeSetupError {
 /// Specific errors that can occur during unit verification.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UnitValidationError {
-    #[error("Self received a shard from myself (libp2p should not allow this)")]
+    #[error("Self received a unit from myself (libp2p should not allow this)")]
     SelfSending,
-    #[error("Publisher should not receive their own shard")]
+    #[error("Publisher should not receive their own unit")]
     ReceivedSelfPublishedShard,
-    #[error("Received shard that is already in cache (duplicate)")]
+    #[error("Received unit that is already in cache (duplicate)")]
     DuplicateShard,
-    #[error("Received shard but error getting parent in tree topology: {0}")]
+    #[error("Received unit but error getting parent in tree topology: {0}")]
     ScheduleManagerError(ScheduleError),
     #[error(
-        "Shard failed parent verification (expected sender = {expected_sender}, shard index = \
+        "Unit failed parent verification (expected sender = {expected_sender}, shard index = \
          {shard_index:?})"
     )]
     UnexpectedSender { expected_sender: PeerId, shard_index: ShardIndex },
-    #[error("Shard failed signature verification: {0}")]
+    #[error("Unit failed signature verification: {0}")]
     SignatureVerificationFailed(SignatureVerificationError),
-    #[error("Shard failed Merkle proof verification")]
+    #[error("Unit failed Merkle proof verification")]
     MerkleProofVerificationFailed,
     #[error("Shards have inconsistent lengths")]
     UnequalShardLengths,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: string-only changes to `UnitValidationError` display messages; no logic, data flow, or protocol behavior is modified.
> 
> **Overview**
> Updates `UnitValidationError`’s `thiserror` strings in `types.rs` to consistently refer to a *unit* rather than a *shard* (e.g., self-send, self-publish, duplicate cache entry, schedule/parent verification, signature, and Merkle proof failures). This is a user-facing diagnostics/observability fix with no functional impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff06da085f0e3842163f0b7b78069a4af0598f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->