### PR TITLE
apollo_propeller: rename DuplicateShard/ReceivedSelfPublishedShard variants

### DIFF
--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -156,7 +156,7 @@ impl PropellerScheduleManager {
         }
 
         if stated_publisher == local_peer_id {
-            return Err(UnitValidationError::ReceivedSelfPublishedShard);
+            return Err(UnitValidationError::ReceivedSelfPublishedUnit);
         }
 
         let expected_broadcaster_for_index = self

--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -141,9 +141,9 @@ pub enum UnitValidationError {
     #[error("Self received a unit from myself (libp2p should not allow this)")]
     SelfSending,
     #[error("Publisher should not receive their own unit")]
-    ReceivedSelfPublishedShard,
+    ReceivedSelfPublishedUnit,
     #[error("Received unit that is already in cache (duplicate)")]
-    DuplicateShard,
+    DuplicateUnit,
     #[error("Received unit but error getting parent in tree topology: {0}")]
     ScheduleManagerError(ScheduleError),
     #[error(

--- a/crates/apollo_propeller/src/unit_validator.rs
+++ b/crates/apollo_propeller/src/unit_validator.rs
@@ -93,7 +93,7 @@ impl UnitValidator {
         assert_eq!(self.message_root, unit.root(), "Message root mismatch");
 
         if self.received_indices.contains(&unit.index()) {
-            return Err(UnitValidationError::DuplicateShard);
+            return Err(UnitValidationError::DuplicateUnit);
         }
 
         self.schedule_manager.validate_origin(sender, unit.publisher(), unit.index())?;

--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -141,7 +141,7 @@ fn test_duplicate_shard_rejected() {
     env.validator.validate_unit(env.publisher, &unit).unwrap();
     assert!(matches!(
         env.validator.validate_unit(env.publisher, &unit),
-        Err(UnitValidationError::DuplicateShard)
+        Err(UnitValidationError::DuplicateUnit)
     ));
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a pure rename of `UnitValidationError` variants (and associated call sites/tests) with no behavior changes, but it may break downstream pattern matches if any external crates rely on the old names.
> 
> **Overview**
> Renames `UnitValidationError` variants to use *unit* terminology (`ReceivedSelfPublishedShard` -> `ReceivedSelfPublishedUnit`, `DuplicateShard` -> `DuplicateUnit`) and updates all internal references in `PropellerScheduleManager::validate_origin`, `UnitValidator::validate_unit`, and the unit validator tests to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d2616f4c5696e73c0ed442debe6689af2e209b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->