### PR TITLE
apollo_propeller: fix PostConstruction doc comment to say 'units'

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -61,7 +61,7 @@ enum ReconstructionState {
         verified_fields: Option<VerifiedFields>,
     },
     /// Message was reconstructed but not yet delivered to the application. We keep collecting
-    /// shards until the emit threshold is reached, then emit the message.
+    /// units until the emit threshold is reached, then emit the message.
     // No need to track the unit indices after reconstruction (unit duplication already validated)
     PostConstruction { reconstructed_message: Option<Vec<u8>>, num_held_units: usize },
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that does not affect runtime behavior or data flow.
> 
> **Overview**
> Fixes a doc comment in `ReconstructionState::PostConstruction` to refer to collecting **units** (not “shards”) before emitting the reconstructed message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0a936dcd75d410829abebb1cf4e58bc87fd4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->