### PR TITLE
apollo_propeller: rename shards param to units in reconstruct_blocking

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -298,7 +298,7 @@ impl MessageProcessor {
     }
 
     /// Offloads erasure-coding reconstruction to a blocking thread.
-    async fn reconstruct_blocking(&self, shards: Vec<PropellerUnit>) -> ReconstructionResult {
+    async fn reconstruct_blocking(&self, units: Vec<PropellerUnit>) -> ReconstructionResult {
         let message_root = self.message_root;
         let my_index: usize =
             self.my_shard_index.0.try_into().expect("Shard index could not be converted to usize");
@@ -308,7 +308,7 @@ impl MessageProcessor {
         // TODO(AndrewL): track task handle to abort the task if the timeout is reached or
         // finalization occurs.
         tokio::task::spawn_blocking(move || {
-            reconstruct_data_shards(shards, message_root, my_index, data_count, coding_count).map(
+            reconstruct_data_shards(units, message_root, my_index, data_count, coding_count).map(
                 |(message, my_shards, my_shard_proof)| ReconstructionOutput {
                     message,
                     my_shards,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a pure parameter rename in `MessageProcessor::reconstruct_blocking` with no behavioral or data-flow changes.
> 
> **Overview**
> Renames the `reconstruct_blocking` argument from `shards` to `units` in `message_processor.rs` to better match `PropellerUnit` terminology, updating the internal call to `reconstruct_data_shards` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d99d38b3ab4fe44f91dfb98e82833a25365c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->