### PR TITLE
apollo_propeller: rename shard_count/total_shards to unit_count/total_units

### DIFF
--- a/crates/apollo_propeller/src/message_processor.rs
+++ b/crates/apollo_propeller/src/message_processor.rs
@@ -323,7 +323,7 @@ impl MessageProcessor {
     fn handle_reconstruction_output(
         &self,
         output: ReconstructionOutput,
-        shard_count: usize,
+        unit_count: usize,
         state: &mut ReconstructionState,
     ) -> ControlFlow<()> {
         let ReconstructionOutput { message, my_shards, my_shard_proof } = output;
@@ -352,8 +352,8 @@ impl MessageProcessor {
             self.broadcast_unit(&reconstructed_unit);
         }
 
-        let total_shards = shard_count + usize::from(should_broadcast);
-        state.transition_to_post(message, total_shards);
+        let total_units = unit_count + usize::from(should_broadcast);
+        state.transition_to_post(message, total_units);
 
         match state.maybe_emit(&self.tree_manager) {
             AddUnitAction::Emit(message) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk rename-only change that updates variable/parameter names used to track held items during reconstruction and emit-threshold logic; no behavioral changes intended.
> 
> **Overview**
> Renames reconstruction counter variables in `MessageProcessor::handle_reconstruction_output` from `shard_count/total_shards` to `unit_count/total_units` to better reflect that the code is counting *units held* (including an optional self-broadcast) when transitioning to `PostConstruction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7267fc7fe97c598f006bbf5047106cc370d639e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->