### PR TITLE
apollo_propeller: remove incorrect tree.rs module doc comment

### DIFF
--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -1,8 +1,6 @@
 //! Dynamic propeller tree computation logic.
 //!
 //! This module implements the core tree topology algorithm inspired by Solana's Turbine protocol.
-//! The tree is computed dynamically for each shard using deterministic seeded randomization
-//! based on the publisher and shard ID, making the network resilient to targeted attacks.
 
 use libp2p::identity::PeerId;
 use starknet_api::staking::StakingWeight;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change removing a misleading module-level comment; no runtime behavior or APIs are modified.
> 
> **Overview**
> Removes an incorrect `tree.rs` module doc comment claiming the propeller tree is computed via deterministic seeded randomization per shard, leaving the remaining module documentation intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae67f45f73fd8786bdda4096438c8607775b429a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->