### PR TITLE
apollo_propeller: fix PropellerScheduleManager doc comments to say 'units'

### DIFF
--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -16,9 +16,9 @@ use crate::UnitValidationError;
 /// - num_data_shards = floor((N-1)/3) where N is total number of nodes
 /// - num_data_shards represents both max faulty nodes AND number of data shards
 /// - Total shards = N-1 (num_data_shards data shards + (N-1-num_data_shards) coding shards)
-/// - Message is "built" when num_data_shards shards received (can reconstruct)
-/// - Message is "received" when 2*num_data_shards shards received (guarantees gossip property)
-/// - Each peer broadcasts received shards to all other peers (full mesh)
+/// - Message is "built" when num_data_shards units received (can reconstruct)
+/// - Message is "received" when 2*num_data_shards units received (guarantees gossip property)
+/// - Each peer broadcasts received units to all other peers (full mesh)
 #[derive(Debug, Clone)]
 pub struct PropellerScheduleManager {
     /// All nodes in the committee with their stake, sorted by peer_id


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Doc-only change that corrects terminology in `PropellerScheduleManager` comments; no runtime behavior is modified.
> 
> **Overview**
> Updates `PropellerScheduleManager` module-level doc comments to consistently describe Propeller thresholds and broadcasting in terms of received **units** (not “shards”), aligning the documentation with the protocol terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba71fe575066570a6b60b04f82b1ad5066de3902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->