### PR TITLE
apollo_propeller: rename shard_count to unit_count in should_build and should_receive

### DIFF
--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -94,15 +94,15 @@ impl PropellerScheduleManager {
         self.num_data_shards + self.num_coding_shards
     }
 
-    pub fn should_build(&self, shard_count: usize) -> bool {
-        shard_count >= self.num_data_shards
+    pub fn should_build(&self, unit_count: usize) -> bool {
+        unit_count >= self.num_data_shards
     }
 
-    pub fn should_receive(&self, shard_count: usize) -> bool {
+    pub fn should_receive(&self, unit_count: usize) -> bool {
         if self.get_node_count() <= 3 {
-            return self.should_build(shard_count);
+            return self.should_build(unit_count);
         }
-        shard_count >= 2 * self.num_data_shards
+        unit_count >= 2 * self.num_data_shards
     }
 
     /// Returns the peer responsible for broadcasting a specific shard.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a parameter rename in `should_build`/`should_receive` with no behavioral change, only minor potential for downstream compile fixes if any callers relied on naming semantics.
> 
> **Overview**
> Renames the `should_build`/`should_receive` threshold parameter from `shard_count` to `unit_count` in `PropellerScheduleManager`, aligning terminology with “units received” while keeping the same threshold logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b8b9638910efaa75635937e37e975145be80c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->