### PR TITLE
apollo_propeller: fix get_peer_for_shard_index doc comment to say 'unit'

### DIFF
--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -105,15 +105,15 @@ impl PropellerScheduleManager {
         unit_count >= 2 * self.num_data_shards
     }
 
-    /// Returns the peer responsible for broadcasting a specific shard.
+    /// Returns the peer responsible for broadcasting a specific unit.
     ///
-    /// In the Propeller protocol, each shard is assigned to a specific peer (excluding the
+    /// In the Propeller protocol, each unit is assigned to a specific peer (excluding the
     /// publisher). This method maps a shard index to its designated broadcaster.
     ///
     /// # Arguments
     ///
     /// * `publisher` - The peer ID of the node that published the original message
-    /// * `shard_index` - The index of the shard (0-based, ranges from 0 to total_shards-1)
+    /// * `shard_index` - The index of the unit (0-based, ranges from 0 to total_shards-1)
     pub fn get_peer_for_shard_index(
         &self,
         publisher: &PeerId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only wording changes with no behavior or API modifications.
> 
> **Overview**
> Updates the Rustdoc for `PropellerScheduleManager::get_peer_for_shard_index` to consistently refer to broadcasting a *unit* (not a shard), aligning terminology with the Propeller protocol description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e3ad4abf4cfdc5a801922775b1062a4799d1f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->