### PR TITLE
apollo_propeller: fix remaining tree.rs comments to say 'unit' instead of 'shard'

### DIFF
--- a/crates/apollo_propeller/src/tree.rs
+++ b/crates/apollo_propeller/src/tree.rs
@@ -162,7 +162,7 @@ impl PropellerScheduleManager {
             .map_err(UnitValidationError::ScheduleManagerError)?;
 
         if expected_broadcaster_for_index == local_peer_id && sender == stated_publisher {
-            // I received my shard from the publisher
+            // I received my unit from the publisher
             return Ok(());
         }
         if sender == expected_broadcaster_for_index {
@@ -176,7 +176,7 @@ impl PropellerScheduleManager {
         })
     }
 
-    /// Create the initial broadcast list for message sharding.
+    /// Create the initial broadcast list for unit distribution.
     /// Returns a list of peer IDs for all peers except the publisher (local peer).
     pub fn make_broadcast_list(&self) -> Vec<PeerId> {
         let publisher = self.get_local_peer_id();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: comment-only updates with no behavior or API changes.
> 
> **Overview**
> Updates wording in `crates/apollo_propeller/src/tree.rs` comments to consistently refer to *units* (not *shards*), including `validate_origin` and the `make_broadcast_list` docstring, to better match current protocol terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b178f520bdc4a84231f61612a4608ad5a0d97847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->