### PR TITLE
apollo_propeller: rename test_duplicate_shard_rejected to test_duplicate_unit_rejected

### DIFF
--- a/crates/apollo_propeller/src/unit_validator_test.rs
+++ b/crates/apollo_propeller/src/unit_validator_test.rs
@@ -135,7 +135,7 @@ fn test_validation_fails_with_wrong_signature() {
 }
 
 #[rstest]
-fn test_duplicate_shard_rejected() {
+fn test_duplicate_unit_rejected() {
     let mut env = build_env(1);
     let unit = unit(&env, env.local_peer);
     env.validator.validate_unit(env.publisher, &unit).unwrap();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only rename with no functional or behavioral changes to validation logic.
> 
> **Overview**
> Renames the unit validator test `test_duplicate_shard_rejected` to `test_duplicate_unit_rejected` to match the `DuplicateUnit` error it asserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd417e6c1fa2859a45e81c6d520cff13223efd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->