### PR TITLE
apollo_propeller: fix typo 'form' to 'from' in SignatureVerificationError message

### DIFF
--- a/crates/apollo_propeller/src/types.rs
+++ b/crates/apollo_propeller/src/types.rs
@@ -59,7 +59,7 @@ pub struct VerifiedFields {
 pub enum SignatureVerificationError {
     #[error(
         "We could not find a public key for signer/publisher {0}. This suggests that the public \
-         key cannot be extracted form the peer ID and needs to be provided explicitly."
+         key cannot be extracted from the peer ID and needs to be provided explicitly."
     )]
     NoPublicKeyAvailable(PeerId),
     #[error("Received a unit with an invalid signature. Sender should be reported...")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only the human-readable error string for `SignatureVerificationError::NoPublicKeyAvailable`, with no functional or behavioral impact.
> 
> **Overview**
> Fixes a typo in the `SignatureVerificationError::NoPublicKeyAvailable` display message in `apollo_propeller` ("extracted form" → "extracted from").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b3477ebbf67c0c57a14d9c01f1178e674bbd11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->