### PR TITLE
apollo_propeller: fix sharding_test comment to say 'units' instead of 'shards'

### DIFF
--- a/crates/apollo_propeller/src/sharding_test.rs
+++ b/crates/apollo_propeller/src/sharding_test.rs
@@ -50,7 +50,7 @@ fn test_reconstruct_data_shards_success() {
     .unwrap();
     let message_root = units[0].root();
 
-    // Pick an arbitrary subset of shards (not just the first N).
+    // Pick an arbitrary subset of units (not just the first N).
     let received_indices: Vec<usize> = vec![1, 3, 5, 7, 9];
     let received_units: Vec<_> = received_indices.iter().map(|&i| units[i].clone()).collect();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only comment change with no behavior or API impact.
> 
> **Overview**
> Updates a misleading comment in `sharding_test.rs` to refer to selecting a subset of **units** rather than **shards** during reconstruction testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb48ca87403472299e076110c210205d9d6f4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->