### PR TITLE
apollo_protobuf: fix PropellerUnit proto comments to say 'unit' instead of 'shard'

### DIFF
--- a/crates/apollo_protobuf/src/proto/p2p/proto/propeller/propeller.proto
+++ b/crates/apollo_protobuf/src/proto/p2p/proto/propeller/propeller.proto
@@ -30,11 +30,11 @@ message ShardsOfPeer {
 message PropellerUnit {
     // The shards assigned to this unit's peer.
     ShardsOfPeer shards = 1;
-    // The position of this shard in the erasure coding scheme.
+    // The position of this unit in the erasure coding scheme.
     uint64 index = 2;
-    // The Merkle root of all shards, used to verify shard integrity.
+    // The Merkle root of all units, used to verify unit integrity.
     Hash256 merkle_root = 3;
-    // The Merkle proof that this shard belongs to the tree with the given root.
+    // The Merkle proof that this unit belongs to the tree with the given root.
     MerkleProof merkle_proof = 4;
     // The peer ID of the original publisher who created and signed this unit.
     PeerID publisher = 5;

--- a/crates/apollo_protobuf/src/protobuf/protoc_output.rs
+++ b/crates/apollo_protobuf/src/protobuf/protoc_output.rs
@@ -1064,13 +1064,13 @@ pub struct PropellerUnit {
     /// The shards assigned to this unit's peer.
     #[prost(message, optional, tag = "1")]
     pub shards: ::core::option::Option<ShardsOfPeer>,
-    /// The position of this shard in the erasure coding scheme.
+    /// The position of this unit in the erasure coding scheme.
     #[prost(uint64, tag = "2")]
     pub index: u64,
-    /// The Merkle root of all shards, used to verify shard integrity.
+    /// The Merkle root of all units, used to verify unit integrity.
     #[prost(message, optional, tag = "3")]
     pub merkle_root: ::core::option::Option<Hash256>,
-    /// The Merkle proof that this shard belongs to the tree with the given root.
+    /// The Merkle proof that this unit belongs to the tree with the given root.
     #[prost(message, optional, tag = "4")]
     pub merkle_proof: ::core::option::Option<MerkleProof>,
     /// The peer ID of the original publisher who created and signed this unit.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates documentation comments in the `PropellerUnit` protobuf definition and its generated Rust output, with no schema or runtime behavior changes.
> 
> **Overview**
> Clarifies the `PropellerUnit` protobuf documentation by replacing incorrect references to a *shard* with the correct concept of a *unit* (for `index`, `merkle_root`, and `merkle_proof`).
> 
> Regenerates/updates the corresponding comments in `protoc_output.rs` to match the corrected proto comments; message fields and tags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccce666593223357a92b4f2f51cb07c48d1a9c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->