### PR TITLE
blockifier: add benchmarking and only-native feature flags

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -589,6 +589,7 @@ fn build_call_info(include_opcodes: bool) -> CallInfo {
             (SyscallSelector::StorageWrite, SyscallUsage { call_count: 4, linear_factor: 0 }),
             (SyscallSelector::EmitEvent, SyscallUsage { call_count: 2, linear_factor: 0 }),
         ]),
+        ..Default::default()
     }
 }
 

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -16,6 +16,8 @@ cairo_native = [
   "dep:apollo_compile_to_native",
   "dep:cairo-native",
 ]
+benchmarking = []
+only-native = ["cairo_native"]
 mocks = []
 native_blockifier = []
 node_api = []

--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -160,12 +160,14 @@ impl EventSummary {
     }
 }
 
+#[cfg_attr(feature = "transaction_serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, Default, derive_more::AddAssign, PartialEq)]
 pub struct CallSummary {
     pub n_calls: u64,
     pub n_calls_running_native: u64,
 }
 
+#[cfg_attr(feature = "transaction_serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ExecutionSummary {
     pub charged_resources: ChargedResources,
@@ -449,6 +451,8 @@ pub struct CallInfo {
     pub tracked_resource: TrackedResource,
 
     // Additional information gathered during execution.
+    #[cfg(feature = "benchmarking")]
+    pub time: std::time::Duration,
     pub storage_access_tracker: StorageAccessTracker,
     // Tracks how many times each cairo primitive (builtin or opcode) was called during execution
     // (excluding inner calls). Used by the bouncer to decide when to close a block.

--- a/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
+++ b/crates/blockifier/src/execution/deprecated_entry_point_execution.rs
@@ -295,6 +295,8 @@ pub fn finalize_execution(
             accessed_storage_keys: syscall_handler.accessed_keys,
             ..Default::default()
         },
+        #[cfg(feature = "benchmarking")]
+        time: Default::default(),
         builtin_counters: extended_resources_without_inner_calls.prover_cairo_primitives(),
         syscalls_usage: syscall_handler.syscalls_usage,
     })

--- a/crates/blockifier/src/execution/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/entry_point_execution.rs
@@ -520,6 +520,8 @@ pub fn finalize_execution(
         tracked_resource,
         resources: extended_resources,
         storage_access_tracker: syscall_handler_base.storage_access_tracker,
+        #[cfg(feature = "benchmarking")]
+        time: Default::default(),
         builtin_counters: extended_resources_without_inner_calls.prover_cairo_primitives(),
         syscalls_usage: syscall_handler_base.syscalls_usage,
     })

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -119,7 +119,10 @@ pub fn execute_entry_point_call(
     state: &mut dyn State,
     context: &mut EntryPointExecutionContext,
 ) -> EntryPointExecutionResult<CallInfo> {
-    match compiled_class {
+    #[cfg(feature = "benchmarking")]
+    let pre_time = std::time::Instant::now();
+
+    let result = match compiled_class {
         RunnableCompiledClass::V0(compiled_class) => {
             deprecated_entry_point_execution::execute_entry_point_call(
                 call,
@@ -133,7 +136,9 @@ pub fn execute_entry_point_call(
         }
         #[cfg(feature = "cairo_native")]
         RunnableCompiledClass::V1Native(compiled_class) => {
-            if context.tracked_resource_stack.last() == Some(&TrackedResource::CairoSteps) {
+            if context.tracked_resource_stack.last() == Some(&TrackedResource::CairoSteps)
+                && !cfg!(feature = "only-native")
+            {
                 // We cannot run native with cairo steps as the tracked resources (it's a vm
                 // resource).
                 entry_point_execution::execute_entry_point_call(
@@ -151,7 +156,17 @@ pub fn execute_entry_point_call(
                 )
             }
         }
+    };
+
+    #[cfg(feature = "benchmarking")]
+    {
+        let mut call_info = result?;
+        call_info.time = pre_time.elapsed();
+        Ok(call_info)
     }
+
+    #[cfg(not(feature = "benchmarking"))]
+    result
 }
 
 pub fn update_remaining_gas(remaining_gas: &mut u64, call_info: &CallInfo) {

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -121,6 +121,8 @@ fn create_callinfo(
         inner_calls: syscall_handler.base.inner_calls,
         storage_access_tracker: syscall_handler.base.storage_access_tracker,
         tracked_resource: TrackedResource::SierraGas,
+        #[cfg(feature = "benchmarking")]
+        time: Default::default(),
         builtin_counters: entry_point_primitive_counters,
         syscalls_usage: syscall_handler.base.syscalls_usage,
     })

--- a/crates/starknet_committer_and_os_cli/src/block_hash_cli/tests/objects.rs
+++ b/crates/starknet_committer_and_os_cli/src/block_hash_cli/tests/objects.rs
@@ -225,6 +225,7 @@ fn create_call_info(
             (cairo_vm::types::builtin_name::BuiltinName::pedersen, 5),
         ]),
         syscalls_usage: HashMap::new(),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Adds two new feature flags:
- \`benchmarking\`: gates time/call_counter fields on CallInfo and
  EntryPointExecutionContext for execution profiling
- \`only-native\`: forces native execution path even when tracked
  resource is CairoSteps

Zero behavior change without flags enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low impact by default, but when enabled this changes execution-path selection (forcing native execution) and adds new data fields to `CallInfo`, which could affect consumers expecting a stable struct layout/serialization behind feature gates.
> 
> **Overview**
> Adds two new opt-in feature flags to `blockifier`: **`benchmarking`** and **`only-native`**.
> 
> With `benchmarking` enabled, execution populates per-call profiling metadata (`time` and `call_counter`) on `CallInfo`, backed by a counter in `EntryPointExecutionContext`. With `only-native` enabled (and `cairo_native`), the dispatcher no longer falls back to the VM path for `TrackedResource::CairoSteps`, forcing the native executor.
> 
> Updates tests/fixtures to construct `CallInfo` via `..Default::default()` so new optional fields don’t break compilation, and derives serde for `CallSummary`/`ExecutionSummary` when `transaction_serde` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d74bec97b0759aaf72939914c5b4fb3051f54d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->