### PR TITLE
blockifier: introduce ContractExecutor abstaction

### DIFF
--- a/crates/blockifier/src/execution/native.rs
+++ b/crates/blockifier/src/execution/native.rs
@@ -1,5 +1,6 @@
 pub mod contract_class;
 pub mod entry_point_execution;
+pub mod executor;
 #[cfg(feature = "with-libfunc-profiling")]
 pub mod profiling;
 pub mod syscall_handler;

--- a/crates/blockifier/src/execution/native/contract_class.rs
+++ b/crates/blockifier/src/execution/native/contract_class.rs
@@ -10,6 +10,7 @@ use starknet_types_core::felt::Felt;
 use crate::execution::contract_class::{CompiledClassV1, EntryPointV1, NestedFeltCounts};
 use crate::execution::entry_point::EntryPointTypeAndSelector;
 use crate::execution::errors::PreExecutionError;
+use crate::execution::native::executor::ContractExecutor;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NativeCompiledClassV1(pub Arc<NativeCompiledClassV1Inner>);
 impl Deref for NativeCompiledClassV1 {
@@ -85,7 +86,7 @@ impl HashableCompiledClass<EntryPointV1, NestedFeltCounts> for NativeCompiledCla
 
 #[derive(Debug)]
 pub struct NativeCompiledClassV1Inner {
-    pub executor: AotContractExecutor,
+    pub executor: ContractExecutor,
     #[cfg(feature = "with-libfunc-profiling")]
     pub program: Option<Arc<cairo_lang_sierra::program::Program>>,
     casm: CompiledClassV1,
@@ -93,6 +94,7 @@ pub struct NativeCompiledClassV1Inner {
 
 impl NativeCompiledClassV1Inner {
     fn new(executor: AotContractExecutor, casm: CompiledClassV1) -> Self {
+        let executor = executor.into();
         NativeCompiledClassV1Inner {
             executor,
             #[cfg(feature = "with-libfunc-profiling")]

--- a/crates/blockifier/src/execution/native/executor.rs
+++ b/crates/blockifier/src/execution/native/executor.rs
@@ -1,0 +1,34 @@
+use cairo_native::execution_result::ContractExecutionResult;
+use cairo_native::executor::AotContractExecutor;
+use cairo_native::utils::BuiltinCosts;
+use starknet_types_core::felt::Felt;
+
+use crate::execution::native::syscall_handler::NativeSyscallHandler;
+
+#[derive(Debug)]
+pub enum ContractExecutor {
+    Aot(AotContractExecutor),
+}
+
+impl From<AotContractExecutor> for ContractExecutor {
+    fn from(value: AotContractExecutor) -> Self {
+        Self::Aot(value)
+    }
+}
+
+impl ContractExecutor {
+    pub fn run(
+        &self,
+        selector: Felt,
+        args: &[Felt],
+        gas: u64,
+        builtin_costs: Option<BuiltinCosts>,
+        syscall_handler: &mut NativeSyscallHandler<'_>,
+    ) -> cairo_native::error::Result<ContractExecutionResult> {
+        match self {
+            ContractExecutor::Aot(aot_contract_executor) => {
+                aot_contract_executor.run(selector, args, gas, builtin_costs, syscall_handler)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Wraps AotContractExecutor in a ContractExecutor enum to prepare for
alternative execution backends. Pure refactor — single variant, no
behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly changes types and indirection around the native executor while keeping the same `Aot` backend and `run` call path.
> 
> **Overview**
> Adds a new native `ContractExecutor` enum wrapper (currently only `Aot`) with a `run` method to centralize contract execution behind an abstraction.
> 
> Updates `NativeCompiledClassV1Inner` to store `ContractExecutor` instead of `AotContractExecutor`, converting via `From` in the constructor, and exports the new module from `execution/native.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992d84cfa68b1417e419bf94fd6070093065602c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->