### PR TITLE
apollo_storage: store transaction outputs in MDBX instead of mmap

### DIFF
--- a/crates/apollo_storage/src/body/body_test.rs
+++ b/crates/apollo_storage/src/body/body_test.rs
@@ -405,8 +405,4 @@ fn update_offset_table() {
         last_tx_metadata.tx_location.next_offset(),
         file_offset_table.get(&txn.txn, &OffsetKind::Transaction).unwrap().unwrap()
     );
-    assert_eq!(
-        last_tx_metadata.tx_output_location.next_offset(),
-        file_offset_table.get(&txn.txn, &OffsetKind::TransactionOutput).unwrap().unwrap()
-    );
 }

--- a/crates/apollo_storage/src/body/mod.rs
+++ b/crates/apollo_storage/src/body/mod.rs
@@ -84,6 +84,8 @@ type TransactionHashToIdxTable<'env> =
 type ContractAddressEventsIndexKey = (ContractAddress, TransactionIndex);
 type ContractAddressEventsIndexTable<'env> =
     TableHandle<'env, ContractAddressEventsIndexKey, NoVersionValueWrapper<NoValue>, CommonPrefix>;
+type TransactionOutputsTable<'env> =
+    TableHandle<'env, TransactionIndex, VersionZeroWrapper<TransactionOutput>, SimpleTable>;
 type TransactionEventsTable<'env> =
     TableHandle<'env, TransactionIndex, VersionZeroWrapper<LocationInFile>, SimpleTable>;
 
@@ -220,12 +222,8 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         &self,
         transaction_index: TransactionIndex,
     ) -> StorageResult<Option<TransactionOutput>> {
-        let Some(tx_metadata) = self.get_transaction_metadata(&transaction_index)? else {
-            return Ok(None);
-        };
-        let transaction_output =
-            self.file_handlers.get_transaction_output_unchecked(tx_metadata.tx_output_location)?;
-        Ok(Some(transaction_output))
+        let transaction_outputs_table = self.open_table(&self.tables.transaction_outputs)?;
+        Ok(transaction_outputs_table.get(&self.txn, &transaction_index)?)
     }
 
     fn get_transaction_idx_by_hash(
@@ -285,8 +283,22 @@ impl<Mode: TransactionKind> BodyStorageReader for StorageTxn<'_, Mode> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<Vec<TransactionOutput>>> {
-        let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
-        self.get_transaction_outputs_in_block(block_number, transaction_metadata_table)
+        if self.get_body_marker()? <= block_number {
+            return Ok(None);
+        }
+        let transaction_outputs_table = self.open_table(&self.tables.transaction_outputs)?;
+        let mut cursor = transaction_outputs_table.cursor(&self.txn)?;
+        let mut current_entry =
+            cursor.lower_bound(&TransactionIndex(block_number, TransactionOffsetInBlock(0)))?;
+        let mut result = Vec::new();
+        while let Some((TransactionIndex(current_block_number, _), tx_output)) = current_entry {
+            if current_block_number != block_number {
+                break;
+            }
+            result.push(tx_output);
+            current_entry = cursor.next()?;
+        }
+        Ok(Some(result))
     }
 
     fn get_block_transactions_count(
@@ -346,20 +358,6 @@ impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
             current_entry = cursor.next()?;
         }
         Ok(Some(res))
-    }
-
-    fn get_transaction_outputs_in_block(
-        &self,
-        block_number: BlockNumber,
-        transaction_metadata_table: TransactionMetadataTable<'env>,
-    ) -> StorageResult<Option<Vec<TransactionOutput>>> {
-        self.get_vector_of_transaction_objects(
-            block_number,
-            transaction_metadata_table,
-            |tx_metadata, file_handlers| {
-                file_handlers.get_transaction_output_unchecked(tx_metadata.tx_output_location)
-            },
-        )
     }
 
     fn get_transactions_in_block(
@@ -429,6 +427,7 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
             let transaction_hash_to_idx_table =
                 self.open_table(&self.tables.transaction_hash_to_idx)?;
             let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
+            let transaction_outputs_table = self.open_table(&self.tables.transaction_outputs)?;
             let file_offset_table = self.txn.open_table(&self.tables.file_offsets)?;
 
             write_transactions(
@@ -438,6 +437,7 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
                 &file_offset_table,
                 &transaction_hash_to_idx_table,
                 &transaction_metadata_table,
+                &transaction_outputs_table,
                 block_number,
             )?;
         }
@@ -508,6 +508,7 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
             let transaction_metadata_table = self.open_table(&self.tables.transaction_metadata)?;
             let transaction_hash_to_idx_table =
                 self.open_table(&self.tables.transaction_hash_to_idx)?;
+            let transaction_outputs_table = self.open_table(&self.tables.transaction_outputs)?;
 
             let transactions = self
                 .get_block_transactions(block_number)?
@@ -523,6 +524,7 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
                 let tx_index = TransactionIndex(block_number, TransactionOffsetInBlock(offset));
                 transaction_hash_to_idx_table.delete(&self.txn, tx_hash)?;
                 transaction_metadata_table.delete(&self.txn, &tx_index)?;
+                transaction_outputs_table.delete(&self.txn, &tx_index)?;
             }
             Some((transactions, transaction_outputs, transaction_hashes))
         };
@@ -587,6 +589,7 @@ impl BodyStorageWriter for StorageTxn<'_, RW> {
 
 // TODO(dvir): consider enforcing that the block_body transactions, transaction_outputs and
 // transaction_hashes to be the same size.
+#[allow(clippy::too_many_arguments)]
 fn write_transactions<'env>(
     block_body: &BlockBody,
     txn: &DbTransaction<'env, RW>,
@@ -594,6 +597,7 @@ fn write_transactions<'env>(
     file_offset_table: &'env FileOffsetsTable<'env>,
     transaction_hash_to_idx_table: &'env TransactionHashToIdxTable<'env>,
     transaction_metadata_table: &'env TransactionMetadataTable<'env>,
+    transaction_outputs_table: &'env TransactionOutputsTable<'env>,
     block_number: BlockNumber,
 ) -> StorageResult<()> {
     for (index, ((tx, tx_output), tx_hash)) in block_body
@@ -606,22 +610,17 @@ fn write_transactions<'env>(
         let tx_offset_in_block = TransactionOffsetInBlock(index);
         let transaction_index = TransactionIndex(block_number, tx_offset_in_block);
         let tx_location = file_handlers.append_transaction(tx);
-        let tx_output_location = file_handlers.append_transaction_output(tx_output);
         transaction_hash_to_idx_table.insert(txn, tx_hash, &transaction_index)?;
+        transaction_outputs_table.insert(txn, &transaction_index, tx_output)?;
         transaction_metadata_table.append(
             txn,
             &transaction_index,
-            &TransactionMetadata { tx_location, tx_output_location, tx_hash: *tx_hash },
+            &TransactionMetadata { tx_location, tx_hash: *tx_hash },
         )?;
 
         // If this is the last iteration, update the file offset table.
         if index == block_body.transactions.len() - 1 {
             file_offset_table.upsert(txn, &OffsetKind::Transaction, &tx_location.next_offset())?;
-            file_offset_table.upsert(
-                txn,
-                &OffsetKind::TransactionOutput,
-                &tx_output_location.next_offset(),
-            )?;
         }
     }
 

--- a/crates/apollo_storage/src/db/mod.rs
+++ b/crates/apollo_storage/src/db/mod.rs
@@ -43,7 +43,7 @@ use self::table_types::{DbCursor, DbCursorTrait};
 use crate::db::table_types::TableType;
 
 // Maximum number of Sub-Databases.
-const MAX_DBS: u64 = 26;
+const MAX_DBS: u64 = 27;
 
 // Note that NO_TLS mode is used by default.
 type EnvironmentKind = WriteMap;

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -255,6 +255,7 @@ fn open_storage_internal(
         transaction_events: db_writer.create_simple_table("transaction_events")?,
         transaction_hash_to_idx: db_writer.create_simple_table("transaction_hash_to_idx")?,
         transaction_metadata: db_writer.create_simple_table("transaction_metadata")?,
+        transaction_outputs: db_writer.create_simple_table("transaction_outputs")?,
         block_hashes: db_writer.create_simple_table("block_hashes")?,
         global_root: db_writer.create_simple_table("global_root")?,
         partial_block_hashes_components: db_writer
@@ -692,6 +693,7 @@ struct_field_names! {
         // TODO(dvir): consider not saving transaction hash and calculating it from the transaction on demand.
         transaction_events: TableIdentifier<TransactionIndex, VersionZeroWrapper<LocationInFile>, SimpleTable>,
         transaction_metadata: TableIdentifier<TransactionIndex, VersionZeroWrapper<TransactionMetadata>, SimpleTable>,
+        transaction_outputs: TableIdentifier<TransactionIndex, VersionZeroWrapper<TransactionOutput>, SimpleTable>,
         block_hashes: TableIdentifier<BlockNumber, VersionZeroWrapper<BlockHash>, SimpleTable>,
         global_root: TableIdentifier<BlockNumber, NoVersionValueWrapper<GlobalRoot>, SimpleTable>,
 
@@ -726,7 +728,6 @@ use struct_field_names;
 pub struct TransactionMetadata {
     tx_hash: TransactionHash,
     tx_location: LocationInFile,
-    tx_output_location: LocationInFile,
 }
 
 // TODO(Yair): sort the variants alphabetically.
@@ -862,7 +863,6 @@ struct FileHandlers<Mode: TransactionKind> {
     contract_class: FileHandler<VersionZeroWrapper<SierraContractClass>, Mode>,
     casm: FileHandler<VersionZeroWrapper<CasmContractClass>, Mode>,
     deprecated_contract_class: FileHandler<VersionZeroWrapper<DeprecatedContractClass>, Mode>,
-    transaction_output: FileHandler<VersionZeroWrapper<TransactionOutput>, Mode>,
     transaction: FileHandler<VersionZeroWrapper<Transaction>, Mode>,
     events: FileHandler<VersionZeroWrapper<Vec<Event>>, Mode>,
 }
@@ -892,11 +892,6 @@ impl FileHandlers<RW> {
         self.clone().deprecated_contract_class.append(deprecated_contract_class)
     }
 
-    // Appends a thin transaction output to the corresponding file and returns its location.
-    fn append_transaction_output(&self, transaction_output: &TransactionOutput) -> LocationInFile {
-        self.clone().transaction_output.append(transaction_output)
-    }
-
     // Appends a transaction to the corresponding file and returns its location.
     fn append_transaction(&self, transaction: &Transaction) -> LocationInFile {
         self.clone().transaction.append(transaction)
@@ -915,7 +910,6 @@ impl FileHandlers<RW> {
         self.contract_class.flush();
         self.casm.flush();
         self.deprecated_contract_class.flush();
-        self.transaction_output.flush();
         self.transaction.flush();
         self.events.flush();
     }
@@ -929,7 +923,6 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
             ("contract_class".to_string(), self.contract_class.stats()),
             ("casm".to_string(), self.casm.stats()),
             ("deprecated_contract_class".to_string(), self.deprecated_contract_class.stats()),
-            ("transaction_output".to_string(), self.transaction_output.stats()),
             ("transaction".to_string(), self.transaction.stats()),
             ("events".to_string(), self.events.stats()),
         ])
@@ -970,17 +963,6 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
     ) -> StorageResult<DeprecatedContractClass> {
         self.deprecated_contract_class.get(location)?.ok_or(StorageError::DBInconsistency {
             msg: format!("DeprecatedContractClass at location {location:?} not found."),
-        })
-    }
-
-    // Returns the transaction output at the given location or an error in case it doesn't
-    // exist.
-    fn get_transaction_output_unchecked(
-        &self,
-        location: LocationInFile,
-    ) -> StorageResult<TransactionOutput> {
-        self.transaction_output.get(location)?.ok_or(StorageError::DBInconsistency {
-            msg: format!("TransactionOutput at location {location:?} not found."),
         })
     }
 
@@ -1037,14 +1019,6 @@ fn open_storage_files(
         deprecated_contract_class_offset,
     )?;
 
-    let transaction_output_offset =
-        table.get(&db_transaction, &OffsetKind::TransactionOutput)?.unwrap_or_default();
-    let (transaction_output_writer, transaction_output_reader) = open_file(
-        mmap_file_config.clone(),
-        db_config.path().join("transaction_output.dat"),
-        transaction_output_offset,
-    )?;
-
     let transaction_offset =
         table.get(&db_transaction, &OffsetKind::Transaction)?.unwrap_or_default();
     let (transaction_writer, transaction_reader) = open_file(
@@ -1063,7 +1037,6 @@ fn open_storage_files(
             contract_class: contract_class_writer,
             casm: casm_writer,
             deprecated_contract_class: deprecated_contract_class_writer,
-            transaction_output: transaction_output_writer,
             transaction: transaction_writer,
             events: events_writer,
         },
@@ -1072,7 +1045,6 @@ fn open_storage_files(
             contract_class: contract_class_reader,
             casm: casm_reader,
             deprecated_contract_class: deprecated_contract_class_reader,
-            transaction_output: transaction_output_reader,
             transaction: transaction_reader,
             events: events_reader,
         },

--- a/crates/apollo_storage/src/serialization/serializers.rs
+++ b/crates/apollo_storage/src/serialization/serializers.rs
@@ -463,7 +463,6 @@ auto_storage_serde! {
     pub struct TransactionMetadata {
         pub tx_hash: TransactionHash,
         pub tx_location: LocationInFile,
-        pub tx_output_location: LocationInFile,
     }
     pub enum Transaction {
         Declare(DeclareTransaction) = 0,

--- a/crates/apollo_storage/src/test_instances.rs
+++ b/crates/apollo_storage/src/test_instances.rs
@@ -81,7 +81,6 @@ auto_impl_get_test_instance! {
     pub struct TransactionMetadata{
         pub tx_hash: TransactionHash,
         pub tx_location: LocationInFile,
-        pub tx_output_location: LocationInFile,
     }
     struct TransactionIndex(pub BlockNumber, pub TransactionOffsetInBlock);
     pub struct Version{


### PR DESCRIPTION
## Summary
- Moves `TransactionOutput` storage from the `transaction_output.dat` mmap file to a new `transaction_outputs` MDBX table
- Removes `tx_output_location` from `TransactionMetadata` since outputs are now read directly from the table
- Removes the `transaction_output` file handler from `FileHandlers`
- Transaction outputs were significantly reduced in size after removing events, making MDBX storage appropriate

Stacked on #13462

## Test plan
- [x] All 266 `apollo_storage` unit tests pass
- [x] All downstream crates build (`apollo_reverts`, `apollo_central_sync`, `apollo_p2p_sync`, `apollo_rpc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk storage layout for `TransactionOutput` by introducing a new MDBX table and removing the mmap-backed output file/metadata pointer, which could impact read/write compatibility and revert correctness. The logic is straightforward but touches core persistence paths and table limits.
> 
> **Overview**
> **Stores `TransactionOutput` in MDBX instead of mmap.** Transaction outputs are now written to and read from a new `transaction_outputs` table keyed by `TransactionIndex`, rather than via `transaction_output.dat` locations.
> 
> `TransactionMetadata` no longer includes `tx_output_location`, the `transaction_output` file handler and related offset tracking are removed, and body writer/revert paths are updated to insert/delete outputs from the new table. Block-level output reads now iterate via an MDBX cursor, and the DB max table count is bumped (`MAX_DBS` 26→27) with tests/serializers updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07f5af766e418fd786e9019a47170c099831b392. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->