### PR TITLE
blockifier: non empty opcodes in fee tests

### DIFF
--- a/crates/blockifier/src/fee/fee_test.rs
+++ b/crates/blockifier/src/fee/fee_test.rs
@@ -28,6 +28,7 @@ use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use crate::blockifier::block::validated_gas_prices;
 use crate::blockifier_versioned_constants::VersionedConstants;
 use crate::context::BlockContext;
+use crate::execution::call_info::OpcodeName;
 use crate::fee::fee_checks::{FeeCheckError, FeeCheckReportFields, PostExecutionReport};
 use crate::fee::fee_utils::{get_extended_vm_resources_cost, get_fee_by_gas_vector};
 use crate::fee::receipt::TransactionReceipt;
@@ -50,8 +51,7 @@ fn test_simple_get_vm_resource_usage(
     let mut vm_resource_usage = get_extended_vm_resource_usage();
     let n_reverted_steps = 15;
 
-    // Positive flow.
-    // Verify calculation - in our case, n_steps is the heaviest resource.
+    // Positive flow, n_steps is the heaviest resource.
     let vm_usage_in_l1_gas = (versioned_constants.vm_resource_fee_cost().n_steps
         * (u64_from_usize(vm_resource_usage.vm_resources.n_steps + n_reverted_steps)))
     .ceil()
@@ -72,22 +72,40 @@ fn test_simple_get_vm_resource_usage(
         )
     );
 
-    // Another positive flow, this time the heaviest resource is range_check_builtin.
+    // Another positive flow, this time the heaviest resource is the range_check builtin.
+    // Set n_steps just below range_check count, and clear opcodes so only builtins compete.
     let n_reverted_steps = 0;
-    vm_resource_usage.vm_resources.n_steps = vm_resource_usage
+    let range_check_count = *vm_resource_usage
         .vm_resources
         .builtin_instance_counter
         .get(&BuiltinName::range_check)
-        .unwrap()
-        - 1;
-    let vm_usage_in_l1_gas = u64_from_usize(
-        *vm_resource_usage
-            .vm_resources
-            .builtin_instance_counter
-            .get(&BuiltinName::range_check)
-            .unwrap(),
-    )
-    .into();
+        .unwrap();
+    vm_resource_usage.vm_resources.n_steps = range_check_count - 1;
+    vm_resource_usage.opcode_instance_counter.clear();
+    // In create_for_account_testing all builtin costs = 1, so gas equals the raw count.
+    let vm_usage_in_l1_gas = u64_from_usize(range_check_count).into();
+    let expected_gas_vector = gas_vector_from_vm_usage(
+        vm_usage_in_l1_gas,
+        &gas_vector_computation_mode,
+        &versioned_constants,
+    );
+    assert_eq!(
+        expected_gas_vector,
+        get_extended_vm_resources_cost(
+            &versioned_constants,
+            &vm_resource_usage,
+            n_reverted_steps,
+            &gas_vector_computation_mode
+        )
+    );
+
+    // Another positive flow, this time the heaviest resource is the blake opcode.
+    // Blake is priced in sierra gas and converted to L1 gas, unlike VM builtins which have
+    // a direct L1 gas price in the versioned constants.
+    vm_resource_usage.opcode_instance_counter.insert(OpcodeName::blake, 1);
+    let blake_sierra_gas_cost = versioned_constants.os_constants.gas_costs.builtins.blake;
+    let vm_usage_in_l1_gas =
+        versioned_constants.sierra_gas_to_l1_gas_amount_round_up(GasAmount(blake_sierra_gas_cost));
     let expected_gas_vector = gas_vector_from_vm_usage(
         vm_usage_in_l1_gas,
         &gas_vector_computation_mode,

--- a/crates/blockifier/src/test_utils.rs
+++ b/crates/blockifier/src/test_utils.rs
@@ -53,7 +53,12 @@ use strum::EnumCount;
 
 use crate::abi::constants;
 use crate::blockifier_versioned_constants::VersionedConstants;
-use crate::execution::call_info::{ExecutionSummary, ExtendedExecutionResources, OpcodeCounterMap};
+use crate::execution::call_info::{
+    ExecutionSummary,
+    ExtendedExecutionResources,
+    OpcodeCounterMap,
+    OpcodeName,
+};
 use crate::execution::contract_class::TrackedResource;
 use crate::execution::entry_point::CallEntryPoint;
 use crate::execution::syscalls::vm_syscall_utils::{
@@ -430,8 +435,7 @@ pub fn get_extended_vm_resource_usage() -> ExtendedExecutionResources {
                 (BuiltinName::poseidon, 1),
             ]),
         },
-        // TODO(AvivG): test with non-default opcode instance counter.
-        opcode_instance_counter: OpcodeCounterMap::default(),
+        opcode_instance_counter: OpcodeCounterMap::from([(OpcodeName::blake, 1)]),
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test utilities and fee calculation tests, mainly expanding coverage for opcode-based resource pricing.
> 
> **Overview**
> Extends fee/resource usage tests to cover cases where the **heaviest Cairo primitive is an opcode** (adds a `blake` opcode scenario) and clarifies the builtin-vs-opcode pricing expectations.
> 
> Updates `get_extended_vm_resource_usage()` test fixture to return a **non-empty** `opcode_instance_counter` by default (includes `OpcodeName::blake`), and adjusts the existing "range_check heaviest" test to clear opcodes so builtins are isolated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 216988a5a0f184647e93618e936914f92c61817b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->