### PR TITLE
apollo_storage: add scan_storage_keys_for_contract

### DIFF
--- a/crates/apollo_storage/src/state/mod.rs
+++ b/crates/apollo_storage/src/state/mod.rs
@@ -564,6 +564,21 @@ impl<'env, Mode: TransactionKind> StateReader<'env, Mode> {
         let mut cursor = self.deployed_contracts_table.cursor(self.txn)?;
         scan_at_block(&mut cursor, start, end, block_target, limit)
     }
+
+    /// Returns all storage values for `addr` in the key range [`start_key`, `end`] at
+    /// `scan_at_block`, up to `limit` entries.
+    pub fn scan_storage_keys_for_contract(
+        &self,
+        addr: ContractAddress,
+        start: StorageKey,
+        end: StorageKey,
+        block_target: BlockNumber,
+        limit: usize,
+    ) -> StorageResult<Vec<(StorageKey, Felt)>> {
+        let mut cursor = self.storage_table.cursor(self.txn)?;
+        let entries = scan_at_block(&mut cursor, (addr, start), (addr, end), block_target, limit)?;
+        Ok(entries.into_iter().map(|((_, key), value)| (key, value)).collect())
+    }
 }
 
 impl StateStorageWriter for StorageTxn<'_, RW> {

--- a/crates/apollo_storage/src/state/state_test.rs
+++ b/crates/apollo_storage/src/state/state_test.rs
@@ -8,7 +8,7 @@ use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::StarkHash;
-use starknet_api::state::{SierraContractClass, StateNumber, ThinStateDiff};
+use starknet_api::state::{SierraContractClass, StateNumber, StorageKey, ThinStateDiff};
 use starknet_api::{class_hash, compiled_class_hash, contract_address, felt, storage_key};
 use starknet_types_core::felt::Felt;
 
@@ -1057,6 +1057,40 @@ scan_cases!(
         assert_eq!(
             state_reader
                 .scan_contract_class_hashes_in_range(start, end, block_target, limit)
+                .unwrap(),
+            expected,
+        );
+    }
+);
+
+scan_cases!(
+    key_macro = storage_key,
+    value_macro = felt,
+    fn test_scan_storage_keys_for_contract(
+        #[case] start: StorageKey,
+        #[case] end: StorageKey,
+        #[case] synced_block: BlockNumber,
+        #[case] limit: usize,
+        #[case] expected: Vec<(StorageKey, Felt)>,
+    ) {
+        let addr = contract_address!("0x1");
+        let ((reader, mut writer), _temp_dir) = get_test_storage();
+        write_two_block_state_diffs(
+            &mut writer,
+            ThinStateDiff {
+                storage_diffs: IndexMap::from([(addr, block_0_entries!())]),
+                ..Default::default()
+            },
+            ThinStateDiff {
+                storage_diffs: IndexMap::from([(addr, block_1_entries!())]),
+                ..Default::default()
+            },
+        );
+        let txn = reader.begin_ro_txn().unwrap();
+        let state_reader = txn.get_state_reader().unwrap();
+        assert_eq!(
+            state_reader
+                .scan_storage_keys_for_contract(addr, start, end, synced_block, limit)
                 .unwrap(),
             expected,
         );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only state query and accompanying tests, without changing write paths or storage formats.
> 
> **Overview**
> Adds `StateReader::scan_storage_keys_for_contract`, a new API to scan a single contract’s storage keys over a `[start, end]` range at a target block (with a `limit`), built on the existing `scan_at_block` cursor helper.
> 
> Extends the `scan_at_block` test matrix to cover this new storage scan behavior across blocks, empty ranges, and limit truncation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 691906dea42290e055a6790b6f8fa5405f4d3fe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->