### PR TITLE
apollo_storage: add scan_compiled_class_hashes_in_range

### DIFF
--- a/crates/apollo_storage/src/state/mod.rs
+++ b/crates/apollo_storage/src/state/mod.rs
@@ -579,6 +579,18 @@ impl<'env, Mode: TransactionKind> StateReader<'env, Mode> {
         let entries = scan_at_block(&mut cursor, (addr, start), (addr, end), block_target, limit)?;
         Ok(entries.into_iter().map(|((_, key), value)| (key, value)).collect())
     }
+
+    /// Returns all compiled class hashes in [start, end] at `block_target`.
+    pub fn scan_compiled_class_hashes_in_range(
+        &self,
+        start: ClassHash,
+        end: ClassHash,
+        block_target: BlockNumber,
+        limit: usize,
+    ) -> StorageResult<Vec<(ClassHash, CompiledClassHash)>> {
+        let mut cursor = self.compiled_class_hash_table.cursor(self.txn)?;
+        scan_at_block(&mut cursor, start, end, block_target, limit)
+    }
 }
 
 impl StateStorageWriter for StorageTxn<'_, RW> {

--- a/crates/apollo_storage/src/state/state_test.rs
+++ b/crates/apollo_storage/src/state/state_test.rs
@@ -5,7 +5,7 @@ use indexmap::{indexmap, IndexMap};
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::block::BlockNumber;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::StarkHash;
 use starknet_api::state::{SierraContractClass, StateNumber, StorageKey, ThinStateDiff};
@@ -1091,6 +1091,39 @@ scan_cases!(
         assert_eq!(
             state_reader
                 .scan_storage_keys_for_contract(addr, start, end, synced_block, limit)
+                .unwrap(),
+            expected,
+        );
+    }
+);
+
+scan_cases!(
+    key_macro = class_hash,
+    value_macro = compiled_class_hash,
+    fn test_scan_compiled_class_hashes_in_range(
+        #[case] start: ClassHash,
+        #[case] end: ClassHash,
+        #[case] block_target: BlockNumber,
+        #[case] limit: usize,
+        #[case] expected: Vec<(ClassHash, CompiledClassHash)>,
+    ) {
+        let ((reader, mut writer), _temp_dir) = get_test_storage();
+        write_two_block_state_diffs(
+            &mut writer,
+            ThinStateDiff {
+                class_hash_to_compiled_class_hash: block_0_entries!(),
+                ..Default::default()
+            },
+            ThinStateDiff {
+                class_hash_to_compiled_class_hash: block_1_entries!(),
+                ..Default::default()
+            },
+        );
+        let txn = reader.begin_ro_txn().unwrap();
+        let state_reader = txn.get_state_reader().unwrap();
+        assert_eq!(
+            state_reader
+                .scan_compiled_class_hashes_in_range(start, end, block_target, limit)
                 .unwrap(),
             expected,
         );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a read-only API addition built on existing `scan_at_block` logic, plus tests; no write paths or schema changes.
> 
> **Overview**
> Adds `StateReader::scan_compiled_class_hashes_in_range` to return `(ClassHash, CompiledClassHash)` entries within a `[start, end]` range as of a given `block_target`, using the existing `scan_at_block` cursor scan.
> 
> Extends `state_test` with a new parametrized `scan_cases!` invocation to validate range/limit behavior for compiled class hash scanning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 024351d25ed122f1c0ad86ad9cb5a7e8d283c6c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->