### PR TITLE
apollo_deployments: lower mempool p2p max concurrent gateway requests

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/mempool_p2p_config.json
+++ b/crates/apollo_deployments/resources/app_configs/mempool_p2p_config.json
@@ -1,5 +1,5 @@
 {
-  "mempool_p2p_config.max_concurrent_gateway_requests": 10000,
+  "mempool_p2p_config.max_concurrent_gateway_requests": 100,
   "mempool_p2p_config.max_transaction_batch_size": 75,
   "mempool_p2p_config.network_buffer_size": 10000,
   "mempool_p2p_config.network_config.advertised_multiaddr.#is_none": "",

--- a/crates/apollo_deployments/resources/app_configs/replacer_mempool_p2p_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_mempool_p2p_config.json
@@ -1,5 +1,5 @@
 {
-  "mempool_p2p_config.max_concurrent_gateway_requests": 10000,
+  "mempool_p2p_config.max_concurrent_gateway_requests": 100,
   "mempool_p2p_config.max_transaction_batch_size": 75,
   "mempool_p2p_config.network_buffer_size": 10000,
   "mempool_p2p_config.network_config.advertised_multiaddr": "$$$_MEMPOOL_P2P_CONFIG-NETWORK_CONFIG-ADVERTISED_MULTIADDR_$$$",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it may reduce throughput/availability under load by throttling gateway request concurrency.
> 
> **Overview**
> Lowers `mempool_p2p_config.max_concurrent_gateway_requests` from **10000** to **100** in both `mempool_p2p_config.json` and `replacer_mempool_p2p_config.json`, effectively throttling mempool P2P gateway request concurrency across deployments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8145dd56f2a885428722dfb36f9057d5394531dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->