### PR TITLE
echonet: l1_gas_price base functions

### DIFF
--- a/echonet/constants.py
+++ b/echonet/constants.py
@@ -23,6 +23,12 @@ IGNORED_L2_GAS_MISMATCH_ATTESTATION_CALLDATA = (
     "0x10398fe631af9ab2311840432d507bf7ef4b959ae967f1507928f5afe888a99"
 )
 
+# eip7892::BPO2_BASE_UPDATE_FRACTION in alloy-eips (used by the Rust scraper via
+# eip7840::BlobParams::bpo2().calc_blob_fee).
+BPO2_UPDATE_FRACTION = 11_684_671
+# Upper bound on excessBlobGas for binary search (far above any realistic target fee).
+MAX_EXCESS_BLOB_GAS_SEARCH = BPO2_UPDATE_FRACTION * 200
+
 # ---------------------------------------------------------------------------
 # Echonet config file locations / names
 # ---------------------------------------------------------------------------

--- a/echonet/l1_logic/l1_gas_price.py
+++ b/echonet/l1_logic/l1_gas_price.py
@@ -1,0 +1,45 @@
+from echonet.constants import BPO2_UPDATE_FRACTION, MAX_EXCESS_BLOB_GAS_SEARCH
+
+
+class L1GasPrice:
+    @staticmethod
+    def bpo2_blob_fee_wei(excess_blob_gas: int) -> int:
+        """
+        Return the blob base fee in wei for a given `excess_blob_gas` under the BPO2 parameter.
+        The fee grows exponentially as excess blob gas grows.
+        BPO2 (Blob Parameter Option 2) is the blob configuration defined by EIP-7892.
+        This matches `eip7840::BlobParams::bpo2().calc_blob_fee` in `crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs`.
+        """
+        denominator = BPO2_UPDATE_FRACTION
+        i = 1
+        output = 0
+        accumulator = denominator
+        while accumulator > 0:
+            output += accumulator
+            accumulator = (accumulator * excess_blob_gas) // (denominator * i)
+            i += 1
+        return output // denominator
+
+    @staticmethod
+    def excess_blob_gas_for_fee(target_blob_fee_wei: int) -> int:
+        """
+        Inverse of `bpo2_blob_fee_wei`.
+        Given a target blob fee, returns an `excess_blob_gas` value whose computed fee
+        equals that target (or the closest fee below it if the target falls between two
+        fee steps). Due to integer floor division, many excess_blob_gas values map to
+        the same fee; this returns the smallest such value (the start of the plateau).
+        This is sufficient for echonet's use case: the value is only passed back through
+        `bpo2_blob_fee_wei`, which gives the same result for any point on the plateau.
+        """
+        if target_blob_fee_wei <= 1:
+            return 0
+        low, high = 0, MAX_EXCESS_BLOB_GAS_SEARCH
+        while low < high:
+            mid = (low + high) // 2
+            if L1GasPrice.bpo2_blob_fee_wei(mid) < target_blob_fee_wei:
+                low = mid + 1
+            else:
+                high = mid
+        if L1GasPrice.bpo2_blob_fee_wei(low) == target_blob_fee_wei:
+            return low
+        return low - 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches fee-calculation logic; incorrect math or search bounds could skew gas/fee-derived behavior. Changes are otherwise isolated to new helpers and constants.
> 
> **Overview**
> Adds EIP-7892 (BPO2) blob base-fee utilities to echonet.
> 
> Introduces new constants `BPO2_UPDATE_FRACTION` and `MAX_EXCESS_BLOB_GAS_SEARCH`, and a new `L1GasPrice` helper with `bpo2_blob_fee_wei(excess_blob_gas)` plus an inverse `excess_blob_gas_for_fee(target_blob_fee_wei)` implemented via binary search to match the Rust scraper’s fee calculation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcdfb7a71f99e8250fea1b60b0a2952e35c76f6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->