### PR TITLE
apollo_infra: create component clients with channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,7 @@ dependencies = [
  "apollo_state_sync_config",
  "async-trait",
  "mockall",
+ "paste",
  "serde",
  "strum",
  "thiserror 1.0.69",

--- a/crates/apollo_config_manager/src/config_manager_runner.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner.rs
@@ -32,7 +32,7 @@ pub struct ConfigManagerRunner {
     config_manager_client: SharedConfigManagerClient,
     dynamic_config_tx: Sender<NodeDynamicConfig>,
     // Keeps the receiver alive so the sender never observes a dead channel.
-    // TODO(Arni): Remove once LocalComponentChannelClient is held long-term (done in
+    // TODO(Arni): Remove once LocalComponentReaderClient is held long-term (done in
     // arni/http_server/add_client_to_server).
     _dynamic_config_rx: Receiver<NodeDynamicConfig>,
     cli_args: Vec<String>,

--- a/crates/apollo_config_manager_types/Cargo.toml
+++ b/crates/apollo_config_manager_types/Cargo.toml
@@ -17,6 +17,7 @@ apollo_consensus_orchestrator_config.workspace = true
 apollo_http_server_config.workspace = true
 apollo_infra.workspace = true
 apollo_mempool_config.workspace = true
+paste.workspace = true
 apollo_metrics.workspace = true
 apollo_node_config.workspace = true
 apollo_staking_config.workspace = true

--- a/crates/apollo_config_manager_types/src/communication.rs
+++ b/crates/apollo_config_manager_types/src/communication.rs
@@ -5,8 +5,18 @@ use apollo_class_manager_config::config::ClassManagerDynamicConfig;
 use apollo_consensus_config::config::ConsensusDynamicConfig;
 use apollo_consensus_orchestrator_config::config::ContextDynamicConfig;
 use apollo_http_server_config::config::HttpServerDynamicConfig;
-use apollo_infra::component_client::{ClientError, LocalComponentClient, RemoteComponentClient};
-use apollo_infra::component_definitions::{ComponentClient, PrioritizedRequest, RequestWrapper};
+use apollo_infra::component_client::{
+    ClientError,
+    LocalComponentClient,
+    LocalComponentReaderClient,
+    RemoteComponentClient,
+};
+use apollo_infra::component_definitions::{
+    ComponentClient,
+    ComponentReaderClient,
+    PrioritizedRequest,
+    RequestWrapper,
+};
 use apollo_infra::{
     handle_all_response_variants,
     impl_debug_for_infra_requests_and_responses,
@@ -32,7 +42,37 @@ pub type RemoteConfigManagerClient =
 pub type ConfigManagerClientResult<T> = Result<T, ConfigManagerClientError>;
 pub type ConfigManagerRequestWrapper = RequestWrapper<ConfigManagerRequest, ConfigManagerResponse>;
 pub type SharedConfigManagerClient = Arc<dyn ConfigManagerClient>;
+pub type LocalConfigManagerReaderClient = LocalComponentReaderClient<NodeDynamicConfig>;
 
+// Generates a `ConfigManagerReaderClient` method that reads a field from `NodeDynamicConfig`.
+// The method name is derived by prepending `get_` to the field name.
+macro_rules! impl_reader_client_getter {
+    ($field:ident, $return_type:ty) => {
+        paste::paste! {
+            fn [<get_ $field>](&self) -> ConfigManagerClientResult<$return_type> {
+                Ok(self
+                    .get_value()
+                    .$field
+                    .expect(concat!(stringify!($field), " dynamic config is not set")))
+            }
+        }
+    };
+}
+
+pub trait ConfigManagerReaderClient: ComponentReaderClient<NodeDynamicConfig> {
+    impl_reader_client_getter!(batcher_dynamic_config, BatcherDynamicConfig);
+    impl_reader_client_getter!(class_manager_dynamic_config, ClassManagerDynamicConfig);
+    impl_reader_client_getter!(consensus_dynamic_config, ConsensusDynamicConfig);
+    impl_reader_client_getter!(context_dynamic_config, ContextDynamicConfig);
+    impl_reader_client_getter!(http_server_dynamic_config, HttpServerDynamicConfig);
+    impl_reader_client_getter!(mempool_dynamic_config, MempoolDynamicConfig);
+    impl_reader_client_getter!(state_sync_dynamic_config, StateSyncDynamicConfig);
+    impl_reader_client_getter!(staking_manager_dynamic_config, StakingManagerDynamicConfig);
+}
+
+impl<T: ComponentReaderClient<NodeDynamicConfig>> ConfigManagerReaderClient for T {}
+
+// TODO(Arni): Deprecate this trait.
 #[cfg_attr(any(feature = "testing", test), mockall::automock)]
 #[async_trait]
 pub trait ConfigManagerClient: Send + Sync {

--- a/crates/apollo_infra/src/component_client/local_component_reader_client.rs
+++ b/crates/apollo_infra/src/component_client/local_component_reader_client.rs
@@ -1,0 +1,41 @@
+use tokio::sync::watch::{self, Receiver, Sender};
+
+use crate::component_definitions::ComponentReaderClient;
+
+#[cfg(test)]
+#[path = "local_component_reader_client_test.rs"]
+mod local_component_reader_client_test;
+
+/// A local client that reads the latest value from a [`tokio::sync::watch`]
+/// channel.
+#[derive(Clone)]
+pub struct LocalComponentReaderClient<T>
+where
+    T: Send + Clone,
+{
+    receiver: Receiver<T>,
+}
+
+impl<T> LocalComponentReaderClient<T>
+where
+    T: Send + Clone,
+{
+    pub fn new(receiver: Receiver<T>) -> Self {
+        Self { receiver }
+    }
+
+    pub fn new_with_initial_value(initial_value: T) -> (Sender<T>, Self) {
+        let (value_tx, receiver) = watch::channel(initial_value);
+        (value_tx, Self { receiver })
+    }
+}
+
+impl<T> ComponentReaderClient<T> for LocalComponentReaderClient<T>
+where
+    T: Send + Clone,
+{
+    fn get_value(&self) -> T {
+        // `borrow()` returns a reference to the value owned by the channel, hence we clone it.
+        self.receiver.borrow().clone()
+    }
+}

--- a/crates/apollo_infra/src/component_client/local_component_reader_client_test.rs
+++ b/crates/apollo_infra/src/component_client/local_component_reader_client_test.rs
@@ -1,0 +1,28 @@
+use tokio::sync::watch;
+
+use super::LocalComponentReaderClient;
+use crate::component_definitions::ComponentReaderClient;
+
+#[test]
+fn get_value_returns_initial_value() {
+    let (_, value_rx) = watch::channel(42u32);
+    let client = LocalComponentReaderClient::new(value_rx);
+    assert_eq!(client.get_value(), 42);
+}
+
+#[test]
+fn get_value_reflects_updated_value() {
+    let (value_tx, value_rx) = watch::channel(1u32);
+    let client = LocalComponentReaderClient::new(value_rx);
+    value_tx.send(99).unwrap();
+    assert_eq!(client.get_value(), 99);
+}
+
+#[test]
+fn cloned_client_shares_same_channel() {
+    let (value_tx, value_rx) = watch::channel(0u32);
+    let client_a = LocalComponentReaderClient::new(value_rx);
+    let client_b = client_a.clone();
+    value_tx.send(7).unwrap();
+    assert_eq!(client_a.get_value(), client_b.get_value());
+}

--- a/crates/apollo_infra/src/component_client/mod.rs
+++ b/crates/apollo_infra/src/component_client/mod.rs
@@ -1,7 +1,9 @@
 mod definitions;
 mod local_component_client;
+mod local_component_reader_client;
 pub mod remote_component_client;
 
 pub use definitions::*;
 pub use local_component_client::*;
+pub use local_component_reader_client::*;
 pub use remote_component_client::*;

--- a/crates/apollo_infra/src/component_definitions.rs
+++ b/crates/apollo_infra/src/component_definitions.rs
@@ -37,6 +37,18 @@ where
     async fn send(&self, request: Request) -> ClientResult<Response>;
 }
 
+/// A read-only client that synchronously reads the latest value of type `T`.
+///
+/// "Reader client" means a client that only reads — it has no write or mutate
+/// capabilities. Contrast with [`ComponentClient`], which sends requests and
+/// receives responses asynchronously.
+pub trait ComponentReaderClient<T>
+where
+    T: Send + Clone,
+{
+    fn get_value(&self) -> T;
+}
+
 pub async fn default_component_start_fn<T: ComponentStarter + ?Sized>() {
     info!("Starting component {} with the default starter.", short_type_name::<T>());
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new client abstractions and sync access patterns for dynamic config reads; while mostly additive, it changes public types/traits and uses `expect()` on missing config fields, which could surface as runtime panics if misused.
> 
> **Overview**
> Adds a new synchronous, read-only client abstraction `ComponentReaderClient` plus a `LocalComponentReaderClient` backed by `tokio::sync::watch`, including unit tests and module exports.
> 
> Extends `apollo_config_manager_types` with a new `ConfigManagerReaderClient` (and `SharedConfigManagerReaderClient`) that reads individual dynamic-config sections directly from the latest `NodeDynamicConfig` via macro-generated getters, while marking the existing async `ConfigManagerClient` as deprecated. Also updates `ConfigManagerRunner` comments and pulls in the `paste` dependency to support macro-based method generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2466d8a9dd19b4380b206d9353f85e82e854878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->