### PR TITLE
apollo_http_server: add client with channel to http server

### DIFF
--- a/crates/apollo_http_server/src/http_server.rs
+++ b/crates/apollo_http_server/src/http_server.rs
@@ -3,7 +3,11 @@ use std::net::SocketAddr;
 use std::string::String;
 use std::time::Duration;
 
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::{
+    ConfigManagerReaderClient,
+    LocalConfigManagerReaderClient,
+    SharedConfigManagerClient,
+};
 use apollo_gateway_types::communication::{GatewayClientError, SharedGatewayClient};
 use apollo_gateway_types::deprecated_gateway_error::{
     KnownStarknetErrorCode,
@@ -63,6 +67,7 @@ const CLIENT_REGION_HEADER: &str = "X-Client-Region";
 pub struct HttpServer {
     config: HttpServerConfig,
     app_state: AppState,
+    // TODO(Arni): Remove this field once the deprecated SharedConfigManagerClient is removed.
     config_manager_client: SharedConfigManagerClient,
     dynamic_config_tx: Sender<HttpServerDynamicConfig>,
 }
@@ -70,16 +75,28 @@ pub struct HttpServer {
 #[derive(Clone)]
 pub struct AppState {
     gateway_client: SharedGatewayClient,
+    config_manager_reader_client: LocalConfigManagerReaderClient,
     dynamic_config_rx: Receiver<HttpServerDynamicConfig>,
 }
 
 impl AppState {
     fn get_dynamic_config(&self) -> HttpServerDynamicConfig {
+        let config_from_reader = self.config_manager_reader_client.get_http_server_dynamic_config();
         // `borrow()` returns a reference to the value owned by the channel, hence we clone it.
         let config = {
             let config = self.dynamic_config_rx.borrow();
             config.clone()
         };
+        let config_from_reader =
+            config_from_reader.expect("Failed to get http server dynamic config from reader");
+        if config_from_reader != config {
+            warn!(
+                "Http server dynamic config from reader differs from config from dynamic_config_rx"
+            );
+        }
+        // TODO(Arni): Remove config from dynamic_config_rx and use config_from_reader directly
+        // once the deprecated SharedConfigManagerClient is removed
+        // (done in arni/http_server/remove_deprecated_config_manager_shared_client).
         config
     }
 }
@@ -88,11 +105,13 @@ impl HttpServer {
     pub fn new(
         config: HttpServerConfig,
         config_manager_client: SharedConfigManagerClient,
+        config_manager_reader_client: LocalConfigManagerReaderClient,
         gateway_client: SharedGatewayClient,
     ) -> Self {
         let (dynamic_config_tx, dynamic_config_rx) =
             channel::<HttpServerDynamicConfig>(config.dynamic_config.clone());
-        let app_state = AppState { gateway_client, dynamic_config_rx };
+        let app_state =
+            AppState { gateway_client, config_manager_reader_client, dynamic_config_rx };
         HttpServer { config, app_state, config_manager_client, dynamic_config_tx }
     }
 
@@ -336,9 +355,10 @@ fn record_added_transactions(add_tx_result: &HttpServerResult<GatewayOutput>, re
 pub fn create_http_server(
     config: HttpServerConfig,
     config_manager_client: SharedConfigManagerClient,
+    config_manager_reader_client: LocalConfigManagerReaderClient,
     gateway_client: SharedGatewayClient,
 ) -> HttpServer {
-    HttpServer::new(config, config_manager_client, gateway_client)
+    HttpServer::new(config, config_manager_client, config_manager_reader_client, gateway_client)
 }
 
 #[async_trait]

--- a/crates/apollo_http_server/src/http_server_test.rs
+++ b/crates/apollo_http_server/src/http_server_test.rs
@@ -36,6 +36,7 @@ use crate::test_utils::{
     deprecated_gateway_invoke_tx,
     deprecated_gateway_invoke_tx_client_side_proving,
     get_mock_config_manager_client,
+    get_mock_config_manager_reader_client,
     rpc_invoke_tx,
     GatewayTransaction,
     HttpClientServerSetupBuilder,
@@ -102,6 +103,7 @@ async fn allow_new_txs() {
 
     let http_client = HttpClientServerSetupBuilder::new(unique_u16!())
         .with_mock_config_manager_client(get_mock_config_manager_client(false))
+        .with_mock_config_manager_reader_client(get_mock_config_manager_reader_client(false))
         .build()
         .await;
 

--- a/crates/apollo_http_server/src/test_utils.rs
+++ b/crates/apollo_http_server/src/test_utils.rs
@@ -2,7 +2,10 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::{
+    MockConfigManagerClient,
+    MockConfigManagerReaderClient,
+};
 use apollo_gateway_types::communication::MockGatewayClient;
 use apollo_gateway_types::gateway_types::GatewayOutput;
 use apollo_http_server_config::config::{
@@ -114,6 +117,7 @@ pub fn create_http_server_config(socket: SocketAddr) -> HttpServerConfig {
 pub struct HttpClientServerSetupBuilder {
     http_server_config: HttpServerConfig,
     mock_config_manager_client: Option<MockConfigManagerClient>,
+    mock_config_manager_reader_client: Option<MockConfigManagerReaderClient>,
     mock_gateway_client: Option<MockGatewayClient>,
 }
 
@@ -136,7 +140,12 @@ impl HttpClientServerSetupBuilder {
 
     // If a custom http server config is needed, don't hesitate to make this method public.
     fn new_from_http_server_config(http_server_config: HttpServerConfig) -> Self {
-        Self { http_server_config, mock_config_manager_client: None, mock_gateway_client: None }
+        Self {
+            http_server_config,
+            mock_config_manager_client: None,
+            mock_config_manager_reader_client: None,
+            mock_gateway_client: None,
+        }
     }
 
     pub fn with_max_request_body_size(mut self, max_request_body_size: usize) -> Self {
@@ -152,6 +161,14 @@ impl HttpClientServerSetupBuilder {
         self
     }
 
+    pub fn with_mock_config_manager_reader_client(
+        mut self,
+        mock: MockConfigManagerReaderClient,
+    ) -> Self {
+        self.mock_config_manager_reader_client = Some(mock);
+        self
+    }
+
     pub fn with_mock_gateway_client(mut self, mock_gateway_client: MockGatewayClient) -> Self {
         self.mock_gateway_client = Some(mock_gateway_client);
         self
@@ -162,6 +179,10 @@ impl HttpClientServerSetupBuilder {
         let config_manager_client = Arc::new(
             self.mock_config_manager_client.unwrap_or_else(|| get_mock_config_manager_client(true)),
         );
+        let config_manager_reader_client = Arc::new(
+            self.mock_config_manager_reader_client
+                .unwrap_or_else(|| get_mock_config_manager_reader_client(true)),
+        );
         let gateway_client = Arc::new(self.mock_gateway_client.unwrap_or_default());
 
         // Spawn an http server wrapped in a retry mechanism.
@@ -171,6 +192,7 @@ impl HttpClientServerSetupBuilder {
             let mut http_server = HttpServer::new(
                 self.http_server_config.clone(),
                 config_manager_client.clone(),
+                config_manager_reader_client.clone(),
                 gateway_client.clone(),
             );
             // Spawn the server.
@@ -275,4 +297,15 @@ pub fn get_mock_config_manager_client(accept_new_txs: bool) -> MockConfigManager
         .expect_get_http_server_dynamic_config()
         .returning(move || Ok(HttpServerDynamicConfig { accept_new_txs, ..Default::default() }));
     mock_config_manager_client
+}
+
+// A mock config manager reader client returning an http server dynamic config that
+// accepts/rejects transactions for an unlimited number of requests.
+pub fn get_mock_config_manager_reader_client(
+    accept_new_txs: bool,
+) -> MockConfigManagerReaderClient {
+    let mut mock = MockConfigManagerReaderClient::new();
+    mock.expect_get_http_server_dynamic_config()
+        .returning(move || Ok(HttpServerDynamicConfig { accept_new_txs, ..Default::default() }));
+    mock
 }

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -274,6 +274,9 @@ pub async fn create_node_components(
             let config_manager_client = clients
                 .get_config_manager_shared_client()
                 .expect("Config Manager client should be available");
+            let config_manager_reader_client = clients
+                .get_config_manager_reader_client()
+                .expect("Config Manager reader client should be available");
             let http_server_config =
                 config.http_server_config.as_ref().expect("HTTP Server config should be set");
             let gateway_client =
@@ -282,6 +285,7 @@ pub async fn create_node_components(
             Some(create_http_server(
                 http_server_config.clone(),
                 config_manager_client,
+                config_manager_reader_client,
                 gateway_client,
             ))
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `HttpServer` obtains dynamic configuration (adding a second source with `expect`-based failure) and updates construction/wiring across node startup and tests, which could impact runtime availability if the reader client isn’t provided or diverges.
> 
> **Overview**
> `HttpServer` now accepts and stores a `SharedConfigManagerReaderClient` in `AppState`, and `get_dynamic_config()` fetches the dynamic config from this reader, `expect`s it to be available, and warns if it differs from the existing `dynamic_config_rx` value.
> 
> Construction/wiring is updated accordingly: `create_http_server()`/`HttpServer::new()` take the new reader client, node component creation passes it via `get_config_manager_reader_client()`, and http-server tests/utilities add builder support plus mocks for the new reader client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646823f5f8b406f2f3361aed742a2d8bbb4e026d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->