### PR TITLE
apollo_http_server: remove use of deprecated config manager shared client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,7 @@ dependencies = [
  "apollo_infra",
  "apollo_infra_utils",
  "apollo_metrics",
+ "apollo_node_config",
  "apollo_proc_macros",
  "assert_matches",
  "async-trait",

--- a/crates/apollo_http_server/Cargo.toml
+++ b/crates/apollo_http_server/Cargo.toml
@@ -25,6 +25,7 @@ apollo_gateway_types.workspace = true
 apollo_http_server_config.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
+apollo_node_config.workspace = true
 apollo_metrics.workspace = true
 apollo_proc_macros.workspace = true
 async-trait.workspace = true

--- a/crates/apollo_http_server/src/http_server.rs
+++ b/crates/apollo_http_server/src/http_server.rs
@@ -1,12 +1,10 @@
 use std::clone::Clone;
 use std::net::SocketAddr;
 use std::string::String;
-use std::time::Duration;
 
 use apollo_config_manager_types::communication::{
     ConfigManagerReaderClient,
     LocalConfigManagerReaderClient,
-    SharedConfigManagerClient,
 };
 use apollo_gateway_types::communication::{GatewayClientError, SharedGatewayClient};
 use apollo_gateway_types::deprecated_gateway_error::{
@@ -37,8 +35,6 @@ use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::serde_utils::bytes_from_hex_str;
 use starknet_api::transaction::fields::ValidResourceBounds;
 use tokio::net::TcpListener;
-use tokio::sync::watch::{channel, Receiver, Sender};
-use tokio::time;
 use tower_http::decompression::RequestDecompressionLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 use tracing::{debug, info, instrument, warn};
@@ -67,52 +63,30 @@ const CLIENT_REGION_HEADER: &str = "X-Client-Region";
 pub struct HttpServer {
     config: HttpServerConfig,
     app_state: AppState,
-    // TODO(Arni): Remove this field once the deprecated SharedConfigManagerClient is removed.
-    config_manager_client: SharedConfigManagerClient,
-    dynamic_config_tx: Sender<HttpServerDynamicConfig>,
 }
 
 #[derive(Clone)]
 pub struct AppState {
     gateway_client: SharedGatewayClient,
     config_manager_reader_client: LocalConfigManagerReaderClient,
-    dynamic_config_rx: Receiver<HttpServerDynamicConfig>,
 }
 
 impl AppState {
     fn get_dynamic_config(&self) -> HttpServerDynamicConfig {
-        let config_from_reader = self.config_manager_reader_client.get_http_server_dynamic_config();
-        // `borrow()` returns a reference to the value owned by the channel, hence we clone it.
-        let config = {
-            let config = self.dynamic_config_rx.borrow();
-            config.clone()
-        };
-        let config_from_reader =
-            config_from_reader.expect("Failed to get http server dynamic config from reader");
-        if config_from_reader != config {
-            warn!(
-                "Http server dynamic config from reader differs from config from dynamic_config_rx"
-            );
-        }
-        // TODO(Arni): Remove config from dynamic_config_rx and use config_from_reader directly
-        // once the deprecated SharedConfigManagerClient is removed
-        // (done in arni/http_server/remove_deprecated_config_manager_shared_client).
-        config
+        self.config_manager_reader_client
+            .get_http_server_dynamic_config()
+            .expect("Failed to get http server dynamic config")
     }
 }
 
 impl HttpServer {
     pub fn new(
         config: HttpServerConfig,
-        config_manager_client: SharedConfigManagerClient,
         config_manager_reader_client: LocalConfigManagerReaderClient,
         gateway_client: SharedGatewayClient,
     ) -> Self {
-        let (dynamic_config_tx, dynamic_config_rx) =
-            channel::<HttpServerDynamicConfig>(config.dynamic_config.clone());
-        let app_state =
-            AppState { gateway_client, config_manager_reader_client, dynamic_config_rx };
-        HttpServer { config, app_state, config_manager_client, dynamic_config_tx }
+        let app_state = AppState { gateway_client, config_manager_reader_client };
+        HttpServer { config, app_state }
     }
 
     pub async fn run(&mut self) -> Result<(), HttpServerRunError> {
@@ -123,16 +97,6 @@ impl HttpServer {
         let addr = SocketAddr::new(ip, port);
         let app = self.app();
         info!("HttpServer running using socket: {}", addr);
-
-        tokio::spawn(dynamic_config_poll(
-            self.dynamic_config_tx.clone(),
-            self.config_manager_client.clone(),
-            self.config.static_config.dynamic_config_poll_interval,
-        ));
-
-        // TODO(Tsabary): update the http server struct to hold optional fields of the
-        // dynamic_config_tx, config_manager_client, and a JoinHandle for the polling task.
-        // Then, use `set` and `take` to move these around as needed.
 
         // Create a server that runs forever.
         let listener = TcpListener::bind(&addr).await?;
@@ -354,11 +318,10 @@ fn record_added_transactions(add_tx_result: &HttpServerResult<GatewayOutput>, re
 
 pub fn create_http_server(
     config: HttpServerConfig,
-    config_manager_client: SharedConfigManagerClient,
     config_manager_reader_client: LocalConfigManagerReaderClient,
     gateway_client: SharedGatewayClient,
 ) -> HttpServer {
-    HttpServer::new(config, config_manager_client, config_manager_reader_client, gateway_client)
+    HttpServer::new(config, config_manager_reader_client, gateway_client)
 }
 
 #[async_trait]
@@ -380,21 +343,5 @@ fn increment_failure_metrics(err: &HttpServerError) {
             GatewayError::DeprecatedGatewayError { source, .. }) if source.is_internal())
     {
         ADDED_TRANSACTIONS_INTERNAL_ERROR.increment(1);
-    }
-}
-
-async fn dynamic_config_poll(
-    tx: Sender<HttpServerDynamicConfig>,
-    config_manager_client: SharedConfigManagerClient,
-    poll_interval: Duration,
-) {
-    let mut interval = time::interval(poll_interval);
-    loop {
-        interval.tick().await;
-        let dynamic_config_result = config_manager_client.get_http_server_dynamic_config().await;
-        // Make the config available if it was successfully updated.
-        if let Ok(dynamic_config) = dynamic_config_result {
-            let _ = tx.send(dynamic_config);
-        }
     }
 }

--- a/crates/apollo_http_server/src/http_server_test.rs
+++ b/crates/apollo_http_server/src/http_server_test.rs
@@ -13,6 +13,7 @@ use apollo_gateway_types::gateway_types::{
     GatewayOutput,
     InvokeGatewayOutput,
 };
+use apollo_http_server_config::config::HttpServerDynamicConfig;
 use apollo_infra::component_client::ClientError;
 use apollo_proc_macros::unique_u16;
 use axum::body::Bytes;
@@ -35,8 +36,6 @@ use crate::test_utils::{
     deprecated_gateway_deploy_account_tx,
     deprecated_gateway_invoke_tx,
     deprecated_gateway_invoke_tx_client_side_proving,
-    get_mock_config_manager_client,
-    get_mock_config_manager_reader_client,
     rpc_invoke_tx,
     GatewayTransaction,
     HttpClientServerSetupBuilder,
@@ -102,8 +101,10 @@ async fn allow_new_txs() {
     let tx = rpc_invoke_tx();
 
     let http_client = HttpClientServerSetupBuilder::new(unique_u16!())
-        .with_mock_config_manager_client(get_mock_config_manager_client(false))
-        .with_mock_config_manager_reader_client(get_mock_config_manager_reader_client(false))
+        .with_http_server_dynamic_config(HttpServerDynamicConfig {
+            accept_new_txs: false,
+            ..Default::default()
+        })
         .build()
         .await;
 

--- a/crates/apollo_http_server/src/test_utils.rs
+++ b/crates/apollo_http_server/src/test_utils.rs
@@ -2,10 +2,6 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
-use apollo_config_manager_types::communication::{
-    MockConfigManagerClient,
-    MockConfigManagerReaderClient,
-};
 use apollo_gateway_types::communication::MockGatewayClient;
 use apollo_gateway_types::gateway_types::GatewayOutput;
 use apollo_http_server_config::config::{
@@ -13,7 +9,9 @@ use apollo_http_server_config::config::{
     HttpServerDynamicConfig,
     DEFAULT_MAX_SIERRA_PROGRAM_SIZE,
 };
+use apollo_infra::component_client::LocalComponentReaderClient;
 use apollo_infra_utils::test_utils::{AvailablePorts, TestIdentifier};
+use apollo_node_config::node_config::NodeDynamicConfig;
 use blockifier_test_utils::cairo_versions::CairoVersion;
 use http::StatusCode;
 use mempool_test_utils::starknet_api_test_utils::{
@@ -116,8 +114,7 @@ pub fn create_http_server_config(socket: SocketAddr) -> HttpServerConfig {
 
 pub struct HttpClientServerSetupBuilder {
     http_server_config: HttpServerConfig,
-    mock_config_manager_client: Option<MockConfigManagerClient>,
-    mock_config_manager_reader_client: Option<MockConfigManagerReaderClient>,
+    http_server_dynamic_config: HttpServerDynamicConfig,
     mock_gateway_client: Option<MockGatewayClient>,
 }
 
@@ -142,8 +139,10 @@ impl HttpClientServerSetupBuilder {
     fn new_from_http_server_config(http_server_config: HttpServerConfig) -> Self {
         Self {
             http_server_config,
-            mock_config_manager_client: None,
-            mock_config_manager_reader_client: None,
+            http_server_dynamic_config: HttpServerDynamicConfig {
+                accept_new_txs: true,
+                ..Default::default()
+            },
             mock_gateway_client: None,
         }
     }
@@ -153,19 +152,8 @@ impl HttpClientServerSetupBuilder {
         self
     }
 
-    pub fn with_mock_config_manager_client(
-        mut self,
-        mock_config_manager_client: MockConfigManagerClient,
-    ) -> Self {
-        self.mock_config_manager_client = Some(mock_config_manager_client);
-        self
-    }
-
-    pub fn with_mock_config_manager_reader_client(
-        mut self,
-        mock: MockConfigManagerReaderClient,
-    ) -> Self {
-        self.mock_config_manager_reader_client = Some(mock);
+    pub fn with_http_server_dynamic_config(mut self, config: HttpServerDynamicConfig) -> Self {
+        self.http_server_dynamic_config = config;
         self
     }
 
@@ -176,13 +164,12 @@ impl HttpClientServerSetupBuilder {
 
     // Creates a client for testing the http server functionality.
     pub async fn build(self) -> HttpTestClient {
-        let config_manager_client = Arc::new(
-            self.mock_config_manager_client.unwrap_or_else(|| get_mock_config_manager_client(true)),
-        );
-        let config_manager_reader_client = Arc::new(
-            self.mock_config_manager_reader_client
-                .unwrap_or_else(|| get_mock_config_manager_reader_client(true)),
-        );
+        let node_dynamic_config = NodeDynamicConfig {
+            http_server_dynamic_config: Some(self.http_server_dynamic_config),
+            ..Default::default()
+        };
+        let (_, config_manager_reader_client) =
+            LocalComponentReaderClient::new_with_initial_value(node_dynamic_config);
         let gateway_client = Arc::new(self.mock_gateway_client.unwrap_or_default());
 
         // Spawn an http server wrapped in a retry mechanism.
@@ -191,7 +178,6 @@ impl HttpClientServerSetupBuilder {
             // Create the server struct (consumed by the spawned task).
             let mut http_server = HttpServer::new(
                 self.http_server_config.clone(),
-                config_manager_client.clone(),
                 config_manager_reader_client.clone(),
                 gateway_client.clone(),
             );
@@ -287,25 +273,4 @@ pub fn deprecated_gateway_deploy_account_tx() -> DeprecatedGatewayTransactionV3 
 
 pub fn deprecated_gateway_declare_tx() -> DeprecatedGatewayTransactionV3 {
     DeprecatedGatewayTransactionV3::from(declare_tx())
-}
-
-// A mock config manager client returning the an http server dynamic config that accepts/rejects
-// transactions for an unlimited number of requests.
-pub fn get_mock_config_manager_client(accept_new_txs: bool) -> MockConfigManagerClient {
-    let mut mock_config_manager_client = MockConfigManagerClient::new();
-    mock_config_manager_client
-        .expect_get_http_server_dynamic_config()
-        .returning(move || Ok(HttpServerDynamicConfig { accept_new_txs, ..Default::default() }));
-    mock_config_manager_client
-}
-
-// A mock config manager reader client returning an http server dynamic config that
-// accepts/rejects transactions for an unlimited number of requests.
-pub fn get_mock_config_manager_reader_client(
-    accept_new_txs: bool,
-) -> MockConfigManagerReaderClient {
-    let mut mock = MockConfigManagerReaderClient::new();
-    mock.expect_get_http_server_dynamic_config()
-        .returning(move || Ok(HttpServerDynamicConfig { accept_new_txs, ..Default::default() }));
-    mock
 }

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -271,9 +271,6 @@ pub async fn create_node_components(
 
     let http_server = match config.components.http_server.execution_mode {
         ActiveComponentExecutionMode::Enabled => {
-            let config_manager_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
             let config_manager_reader_client = clients
                 .get_config_manager_reader_client()
                 .expect("Config Manager reader client should be available");
@@ -284,7 +281,6 @@ pub async fn create_node_components(
 
             Some(create_http_server(
                 http_server_config.clone(),
-                config_manager_client,
                 config_manager_reader_client,
                 gateway_client,
             ))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `HttpServerDynamicConfig` is obtained at runtime (removing the polling/watch channel path) and updates component wiring, which could affect responsiveness to config updates if the reader client behavior differs.
> 
> **Overview**
> Removes the HTTP server’s dependency on the deprecated `SharedConfigManagerClient` by deleting the background dynamic-config polling task and the watch-channel plumbing.
> 
> `HttpServer` now reads `HttpServerDynamicConfig` directly from `SharedConfigManagerReaderClient`, and the node/component wiring plus test utilities are updated to construct the server with only the reader client (mocking only the reader in tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44907c11dd5bda2bec36df142f9bfc7984a383f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->