### PR TITLE
apollo_node: wire config manager dynamic config channel

### DIFF
--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -15,6 +15,7 @@ use apollo_consensus_manager::consensus_manager::{
 };
 use apollo_gateway::gateway::{create_gateway, Gateway};
 use apollo_http_server::http_server::{create_http_server, HttpServer};
+use apollo_infra::component_client::LocalComponentChannelClient;
 use apollo_l1_events::event_identifiers_to_track;
 use apollo_l1_events::l1_events_provider::L1EventsProvider;
 use apollo_l1_events::l1_scraper::L1EventsScraper;
@@ -41,7 +42,6 @@ use apollo_state_sync::{create_state_sync_and_runner, StateSync};
 use metrics_exporter_prometheus::PrometheusHandle;
 use papyrus_base_layer::cyclic_base_layer_wrapper::CyclicBaseLayerWrapper;
 use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerContract;
-use tokio::sync::watch;
 use tracing::info;
 
 use crate::clients::SequencerNodeClients;
@@ -79,6 +79,7 @@ pub async fn create_node_components(
     cli_args: Vec<String>,
 ) -> SequencerNodeComponents {
     info!("Creating node components.");
+
     let batcher = match config.components.batcher.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
@@ -159,41 +160,47 @@ pub async fn create_node_components(
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
     };
 
-    let (config_manager, config_manager_runner) =
-        match config.components.config_manager.execution_mode {
-            ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled => {
-                let node_dynamic_config = NodeDynamicConfig::from(config);
-                let config_manager_config = config
-                    .config_manager_config
-                    .as_ref()
-                    .expect("Config Manager config should be set");
-                // TODO(Arni): remove the config_manager.
-                let config_manager =
-                    ConfigManager::new(config_manager_config.clone(), node_dynamic_config.clone());
-                let (dynamic_config_tx, dynamic_config_rx) =
-                    watch::channel(node_dynamic_config.clone());
-                let config_manager_client = clients
-                    .get_config_manager_shared_client()
-                    .expect("Config Manager client should be available");
-                let config_manager_runner = ConfigManagerRunner::new(
-                    config_manager_config.clone(),
-                    config_manager_client,
-                    dynamic_config_tx,
-                    dynamic_config_rx,
-                    cli_args,
-                );
-                (Some(config_manager), Some(config_manager_runner))
-            }
-
-            ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled
-            | ReactiveComponentExecutionMode::Remote => {
-                panic!(
-                    "ConfigManager does not support remote mode - it's a local infrastructure \
-                     component"
-                );
-            }
-            ReactiveComponentExecutionMode::Disabled => (None, None),
-        };
+    // TODO(Arni): Move this block to the beginning of the function, as the
+    // config_manager_channel_client is needed by components created below.
+    let (config_manager, config_manager_runner, config_manager_channel_client) = match config
+        .components
+        .config_manager
+        .execution_mode
+    {
+        ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled => {
+            let node_dynamic_config = NodeDynamicConfig::from(config);
+            let config_manager_config =
+                config.config_manager_config.as_ref().expect("Config Manager config should be set");
+            // TODO(Arni): remove the config_manager.
+            let config_manager =
+                ConfigManager::new(config_manager_config.clone(), node_dynamic_config.clone());
+            let (dynamic_config_tx, channel_client) =
+                LocalComponentChannelClient::new_with_initial_value(node_dynamic_config.clone());
+            // TODO(Arni): Rename to config_manager_client after ConfigManagerChannelClient is
+            // renamed to ConfigManagerClient.
+            let config_manager_channel_client = Arc::new(channel_client);
+            let dynamic_config_rx = dynamic_config_tx.subscribe();
+            let config_manager_client = clients
+                .get_config_manager_shared_client()
+                .expect("Config Manager client should be available");
+            let config_manager_runner = ConfigManagerRunner::new(
+                config_manager_config.clone(),
+                config_manager_client,
+                dynamic_config_tx,
+                dynamic_config_rx,
+                cli_args,
+            );
+            (Some(config_manager), Some(config_manager_runner), Some(config_manager_channel_client))
+        }
+        ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled
+        | ReactiveComponentExecutionMode::Remote => {
+            panic!(
+                "ConfigManager does not support remote mode - it's a local infrastructure \
+                 component"
+            );
+        }
+        ReactiveComponentExecutionMode::Disabled => (None, None, None),
+    };
 
     let consensus_manager = match config.components.consensus_manager.execution_mode {
         ActiveComponentExecutionMode::Enabled => {
@@ -275,6 +282,8 @@ pub async fn create_node_components(
             let config_manager_client = clients
                 .get_config_manager_shared_client()
                 .expect("Config Manager client should be available");
+            let _config_manager_channel_client = config_manager_channel_client
+                .expect("Config Manager channel client should be available");
             let http_server_config =
                 config.http_server_config.as_ref().expect("HTTP Server config should be set");
             let gateway_client =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches node startup wiring for dynamic config propagation; incorrect channel/client wiring could cause missing runtime config updates or startup panics in enabled `http_server` setups.
> 
> **Overview**
> Wires the `ConfigManager` dynamic config watch channel through `apollo_infra` by creating a `LocalComponentChannelClient` alongside the existing `ConfigManagerRunner`, replacing the direct `tokio::sync::watch::channel` usage.
> 
> `create_node_components` now returns/threads this channel client (and asserts its presence when `http_server` is enabled), preparing other components to consume dynamic config updates via the new local channel abstraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55688a8d41f6d0017bef96062765059170cdc43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->