### PR TITLE
starknet_committer_and_os_cli: add Patricia key utilities for snap sync

### DIFF
--- a/crates/starknet_committer_and_os_cli/src/committer_cli.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli.rs
@@ -3,4 +3,5 @@ pub mod commands;
 pub mod filled_tree_output;
 pub mod parse_input;
 pub mod run_committer_cli;
+pub mod snap_sync;
 pub mod tests;

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
@@ -1,0 +1,28 @@
+use starknet_types_core::felt::Felt;
+
+#[cfg(test)]
+#[path = "snap_sync_test.rs"]
+mod snap_sync_test;
+
+/// Given the first leaf `start` and the felt of the last key seen (`last_key`), returns the
+/// inclusive end of the largest valid Patricia subtree starting at `start` that doesn't exceed
+/// `last_key`.
+///
+/// A valid Patricia subtree of size `2^k` requires `start % 2^k == 0`, so the size is capped
+/// by the alignment of `start`.
+#[cfg_attr(not(test), expect(dead_code))]
+fn compute_actual_end(start: Felt, last_key: Felt) -> Felt {
+    let covered = last_key - start + Felt::ONE;
+    // This is the largest number of bits, `x`, such that 2^x <= covered.
+    // This is an upper bound for k.
+    let max_contained_bits = u64::try_from(covered.bits()).expect("covered bits fits in u64") - 1;
+    let exponent = if start == Felt::ZERO {
+        max_contained_bits
+    } else {
+        // Equivalent to the largest `k` such that `2^k` divides `felt`.
+        let trailing_zeros =
+            start.to_biguint().trailing_zeros().expect("trailing_zeros called with zero");
+        max_contained_bits.min(trailing_zeros)
+    };
+    start + Felt::TWO.pow(exponent) - Felt::ONE
+}

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync_test.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync_test.rs
@@ -1,0 +1,49 @@
+use starknet_types_core::felt::Felt;
+
+use super::compute_actual_end;
+
+#[test]
+fn test_compute_actual_end_single_element() {
+    // start == last_key: covered=1, subtree_size=1, actual_end=start
+    assert_eq!(compute_actual_end(Felt::ZERO, Felt::ZERO), Felt::ZERO);
+    assert_eq!(compute_actual_end(Felt::from(5u64), Felt::from(5u64)), Felt::from(5u64));
+}
+
+#[test]
+fn test_compute_actual_end_covered_is_exact_power_of_two() {
+    // start=0, last_key=3: covered=4, subtree_size=4, actual_end=3
+    assert_eq!(compute_actual_end(Felt::ZERO, Felt::from(3u64)), Felt::from(3u64));
+    // start=0, last_key=7: covered=8, subtree_size=8, actual_end=7
+    assert_eq!(compute_actual_end(Felt::ZERO, Felt::from(7u64)), Felt::from(7u64));
+}
+
+#[test]
+fn test_compute_actual_end_covered_is_not_power_of_two() {
+    // start=0, last_key=4: covered=5, subtree_size=4, actual_end=3
+    assert_eq!(compute_actual_end(Felt::ZERO, Felt::from(4u64)), Felt::from(3u64));
+    // start=0, last_key=6: covered=7, subtree_size=4, actual_end=3
+    assert_eq!(compute_actual_end(Felt::ZERO, Felt::from(6u64)), Felt::from(3u64));
+    // start=0, last_key=14: covered=15, subtree_size=8, actual_end=7
+    assert_eq!(compute_actual_end(Felt::ZERO, Felt::from(14u64)), Felt::from(7u64));
+}
+
+#[test]
+fn test_compute_actual_end_non_zero_start() {
+    // start=8, last_key=12: covered=5, subtree_size=4, actual_end=8+4-1=11
+    assert_eq!(compute_actual_end(Felt::from(8u64), Felt::from(12u64)), Felt::from(11u64));
+    // start=8, last_key=15: covered=8, subtree_size=8, actual_end=8+8-1=15
+    assert_eq!(compute_actual_end(Felt::from(8u64), Felt::from(15u64)), Felt::from(15u64));
+    // start=8, last_key=16: covered=9, subtree_size=8, actual_end=8+8-1=15
+    assert_eq!(compute_actual_end(Felt::from(8u64), Felt::from(16u64)), Felt::from(15u64));
+}
+
+#[test]
+fn test_compute_actual_end_unaligned_start() {
+    // Alignment of 12 is 4, so the actual end is 12 + 4 - 1 = 15.
+    assert_eq!(compute_actual_end(Felt::from(12u64), Felt::from(31u64)), Felt::from(15u64));
+    // Alignment of 6 is 2, so the actual end is 6 + 2 - 1 = 7.
+    assert_eq!(compute_actual_end(Felt::from(6u64), Felt::from(15u64)), Felt::from(7u64));
+    // Alignment of 12 is 4, but the last key = 14 < 12 + 4 - 1 = 15.
+    // So the actual end is determined by the last key.
+    assert_eq!(compute_actual_end(Felt::from(12u64), Felt::from(14u64)), Felt::from(13u64));
+}


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new arithmetic logic for computing Patricia subtree boundaries and a new `num-bigint` dependency; mistakes here could cause incorrect snap-sync key range selection, though coverage is mitigated by unit tests.
> 
> **Overview**
> Adds a new `committer_cli::snap_sync` module with `compute_actual_end`, which computes the inclusive end key of the largest aligned Patricia subtree starting at `start` that does not pass `last_key` (for snap-sync range partitioning).
> 
> Introduces unit tests covering power-of-two, unaligned, and non-zero start cases, and adds the `num-bigint` dependency (via `Cargo.toml`/`Cargo.lock`) to support trailing-zero/alignment calculation on `Felt` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3f6c977743c0c5e0d8cc9fe532ffb7d4cd68f43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->