### PR TITLE
apollo_signature_manager: rename generic SignatureManager struct

### DIFF
--- a/crates/apollo_signature_manager/Cargo.toml
+++ b/crates/apollo_signature_manager/Cargo.toml
@@ -19,12 +19,12 @@ async-trait.workspace = true
 blake2.workspace = true
 digest.workspace = true
 serde = { workspace = true, features = ["derive"] }
-validator.workspace = true
 starknet-core.workspace = true
 starknet-crypto.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
+validator.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 use apollo_infra::component_definitions::ComponentStarter;
 use async_trait::async_trait;
 
-use crate::signature_manager::{LocalKeyStore, SignatureManager as GenericSignatureManager};
+use crate::signature_manager::{GenericSignatureManager, LocalKeyStore};
 
 #[derive(Clone, Debug)]
 pub struct LocalKeyStoreSignatureManager(pub GenericSignatureManager<LocalKeyStore>);

--- a/crates/apollo_signature_manager/src/signature_manager.rs
+++ b/crates/apollo_signature_manager/src/signature_manager.rs
@@ -47,11 +47,11 @@ impl Deref for MessageDigest {
 
 /// Provides signing and signature verification functionality.
 #[derive(Clone, Debug)]
-pub struct SignatureManager<KS: KeyStore> {
+pub struct GenericSignatureManager<KS: KeyStore> {
     pub keystore: KS,
 }
 
-impl<KS: KeyStore> SignatureManager<KS> {
+impl<KS: KeyStore> GenericSignatureManager<KS> {
     pub fn new(keystore: KS) -> Self {
         Self { keystore }
     }
@@ -83,7 +83,7 @@ impl<KS: KeyStore> SignatureManager<KS> {
 }
 
 #[async_trait]
-impl<KS: KeyStore> ComponentStarter for SignatureManager<KS> {}
+impl<KS: KeyStore> ComponentStarter for GenericSignatureManager<KS> {}
 
 /// A simple in-memory key store.
 #[derive(Clone, Copy, Debug)]

--- a/crates/apollo_signature_manager/src/signature_manager_test.rs
+++ b/crates/apollo_signature_manager/src/signature_manager_test.rs
@@ -9,8 +9,8 @@ use starknet_core::crypto::Signature;
 use crate::signature_manager::{
     verify_identity,
     verify_precommit_vote_signature,
+    GenericSignatureManager,
     LocalKeyStore,
-    SignatureManager,
 };
 
 #[derive(Clone, Debug)]
@@ -53,7 +53,7 @@ fn test_verify_precommit_vote_signature_invalid() {
 #[tokio::test]
 async fn test_sign_identification() {
     let key_store = LocalKeyStore::new_for_testing();
-    let signature_manager = SignatureManager::new(key_store);
+    let signature_manager = GenericSignatureManager::new(key_store);
 
     let PeerIdentity { peer_id, challenge } = PeerIdentity::new();
     let signature = signature_manager.sign_identification(peer_id, challenge).await.unwrap();
@@ -68,7 +68,7 @@ async fn test_sign_identification() {
 #[tokio::test]
 async fn test_sign_precommit_vote() {
     let key_store = LocalKeyStore::new_for_testing();
-    let signature_manager = SignatureManager::new(key_store);
+    let signature_manager = GenericSignatureManager::new(key_store);
 
     let block_hash = BlockHash(felt!("0x1234"));
     let signature = signature_manager.sign_precommit_vote(block_hash).await.unwrap();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor: primarily a type rename and import updates, with no changes to signing/verification logic.
> 
> **Overview**
> Renames the generic signing implementation from `SignatureManager<KS>` to `GenericSignatureManager<KS>` to reduce naming ambiguity with the exported concrete `SignatureManager` wrapper.
> 
> Updates internal imports/exports and signature-manager unit tests to use the new type name; functional behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74625aafac08c2ac20d2ab74fa584460acbdb210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->