### PR TITLE
apollo_signature_manager: refactor into config-driven SignatureManager enum

### DIFF
--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -521,7 +521,11 @@ pub async fn create_node_components(
     let signature_manager = match config.components.signature_manager.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-            Some(create_signature_manager())
+            let signature_manager_config = config
+                .signature_manager_config
+                .as_ref()
+                .expect("Signature Manager config should be set");
+            Some(create_signature_manager(signature_manager_config).await)
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
     };

--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -5,42 +5,55 @@ pub mod config;
 pub mod metrics;
 pub mod signature_manager;
 
-use std::ops::Deref;
-
 use apollo_infra::component_definitions::ComponentStarter;
+use apollo_network_types::network_types::PeerId;
+use apollo_signature_manager_types::SignatureManagerResult;
 use async_trait::async_trait;
+use starknet_api::block::BlockHash;
+use starknet_api::crypto::utils::{Challenge, RawSignature};
 
+use crate::config::{KeySourceConfig, SignatureManagerConfig};
 use crate::signature_manager::{GenericSignatureManager, LocalKeyStore};
 
 #[derive(Clone, Debug)]
-pub struct LocalKeyStoreSignatureManager(pub GenericSignatureManager<LocalKeyStore>);
+pub enum SignatureManager {
+    Local(GenericSignatureManager<LocalKeyStore>),
+}
 
-impl LocalKeyStoreSignatureManager {
-    pub fn new() -> Self {
-        Self(GenericSignatureManager::new(LocalKeyStore::new_for_testing()))
+impl SignatureManager {
+    pub async fn sign_identification(
+        &self,
+        peer_id: PeerId,
+        challenge: Challenge,
+    ) -> SignatureManagerResult<RawSignature> {
+        match self {
+            Self::Local(sm) => sm.sign_identification(peer_id, challenge).await,
+        }
+    }
+
+    pub async fn sign_precommit_vote(
+        &self,
+        block_hash: BlockHash,
+    ) -> SignatureManagerResult<RawSignature> {
+        match self {
+            Self::Local(sm) => sm.sign_precommit_vote(block_hash).await,
+        }
     }
 }
 
-impl Default for LocalKeyStoreSignatureManager {
-    fn default() -> Self {
-        Self::new()
+/// Creates a `SignatureManager` configured according to `config`.
+pub async fn create_signature_manager(config: &SignatureManagerConfig) -> SignatureManager {
+    match &config.key_source {
+        KeySourceConfig::Testing => {
+            SignatureManager::Local(GenericSignatureManager::new(LocalKeyStore::new_for_testing()))
+        }
+        KeySourceConfig::GoogleSecretManager { .. } => {
+            panic!(
+                "KeySourceConfig::GoogleSecretManager requires the 'gsm' feature flag to be \
+                 enabled when building apollo_signature_manager"
+            )
+        }
     }
-}
-
-impl Deref for LocalKeyStoreSignatureManager {
-    type Target = GenericSignatureManager<LocalKeyStore>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-pub use LocalKeyStoreSignatureManager as SignatureManager;
-
-// TODO(Elin): understand how key store would look in production and better define the way the
-// signature manager is created.
-pub fn create_signature_manager() -> SignatureManager {
-    SignatureManager::new()
 }
 
 #[async_trait]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because `SignatureManager` construction and API shape changed (now config-driven and async), which can break callers and introduce runtime panics if configuration is missing or mismatched with `KeySourceConfig` variants/features.
> 
> **Overview**
> Refactors `apollo_signature_manager` from a `LocalKeyStoreSignatureManager` newtype into a config-driven `SignatureManager` enum, and exposes explicit async signing methods (`sign_identification`, `sign_precommit_vote`) instead of relying on `Deref`.
> 
> Updates node component wiring to require `signature_manager_config` and to `await` an async `create_signature_manager(&SignatureManagerConfig)` constructor, with a hard failure for unsupported key sources (e.g., GSM without the `gsm` feature).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15349123e2cc3d1249638d9ede66c878512cd0c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->