### PR TITLE
apollo_signature_manager: wire GsmKeyStore into SignatureManager enum

### DIFF
--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -1,9 +1,9 @@
 // TODO(Aviv): Delete this mod and use utils from type-rs
 mod blake_utils;
 pub mod communication;
+pub mod config;
 #[cfg(feature = "gsm")]
 pub mod gsm_key_store;
-pub mod config;
 pub mod metrics;
 pub mod signature_manager;
 
@@ -15,11 +15,15 @@ use starknet_api::block::BlockHash;
 use starknet_api::crypto::utils::{Challenge, RawSignature};
 
 use crate::config::{KeySourceConfig, SignatureManagerConfig};
+#[cfg(feature = "gsm")]
+use crate::gsm_key_store::GsmKeyStore;
 use crate::signature_manager::{GenericSignatureManager, LocalKeyStore};
 
 #[derive(Clone, Debug)]
 pub enum SignatureManager {
     Local(GenericSignatureManager<LocalKeyStore>),
+    #[cfg(feature = "gsm")]
+    Gsm(GenericSignatureManager<GsmKeyStore>),
 }
 
 impl SignatureManager {
@@ -30,6 +34,8 @@ impl SignatureManager {
     ) -> SignatureManagerResult<RawSignature> {
         match self {
             Self::Local(sm) => sm.sign_identification(peer_id, challenge).await,
+            #[cfg(feature = "gsm")]
+            Self::Gsm(sm) => sm.sign_identification(peer_id, challenge).await,
         }
     }
 
@@ -39,6 +45,8 @@ impl SignatureManager {
     ) -> SignatureManagerResult<RawSignature> {
         match self {
             Self::Local(sm) => sm.sign_precommit_vote(block_hash).await,
+            #[cfg(feature = "gsm")]
+            Self::Gsm(sm) => sm.sign_precommit_vote(block_hash).await,
         }
     }
 }
@@ -46,9 +54,17 @@ impl SignatureManager {
 /// Creates a `SignatureManager` configured according to `config`.
 pub async fn create_signature_manager(config: &SignatureManagerConfig) -> SignatureManager {
     match &config.key_source {
-        KeySourceConfig::Testing => {
-            SignatureManager::Local(GenericSignatureManager::new(LocalKeyStore::new_for_testing()))
+        KeySourceConfig::Testing => SignatureManager::Local(GenericSignatureManager::new(
+            LocalKeyStore::new_for_testing(),
+        )),
+        #[cfg(feature = "gsm")]
+        KeySourceConfig::GoogleSecretManager { secret_name } => {
+            let gsm_key_store = GsmKeyStore::new(secret_name.clone())
+                .await
+                .expect("Failed to initialise GsmKeyStore");
+            SignatureManager::Gsm(GenericSignatureManager::new(gsm_key_store))
         }
+        #[cfg(not(feature = "gsm"))]
         KeySourceConfig::GoogleSecretManager { .. } => {
             panic!(
                 "KeySourceConfig::GoogleSecretManager requires the 'gsm' feature flag to be \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new Google Secret Manager-backed signing path behind the `gsm` feature flag, which changes how private keys can be sourced and initialized at runtime. Risk is moderate due to interaction with external secret retrieval and potential startup/credential misconfiguration.
> 
> **Overview**
> Adds a new `SignatureManager::Gsm` variant (gated by the `gsm` feature) and wires it through the existing `sign_identification` and `sign_precommit_vote` call paths.
> 
> Updates `create_signature_manager` to construct a `GsmKeyStore` and return the GSM-backed signature manager when `KeySourceConfig::GoogleSecretManager` is selected; when the feature is disabled it continues to `panic!` with a clearer message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6a86e71a17134ffd32f1b915da89ef5d2cb69b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->