### PR TITLE
apollo_node: replace config manager client with channel client

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -34,7 +34,7 @@ use apollo_batcher_types::errors::BatcherError;
 use apollo_class_manager_types::SharedClassManagerClient;
 use apollo_committer_types::committer_types::RevertBlockResponse;
 use apollo_committer_types::communication::SharedCommitterClient;
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_infra::component_definitions::{default_component_start_fn, ComponentStarter};
 use apollo_l1_events_types::errors::{L1EventsProviderClientError, L1EventsProviderError};
 use apollo_l1_events_types::{SessionState, SharedL1EventsProviderClient};
@@ -158,7 +158,7 @@ pub struct Batcher {
     pub committer_client: SharedCommitterClient,
     pub l1_events_provider_client: SharedL1EventsProviderClient,
     pub mempool_client: Option<SharedMempoolClient>,
-    pub config_manager_client: SharedConfigManagerClient,
+    pub config_manager_client: SharedConfigManagerReaderClient,
 
     /// Used to create block builders.
     /// Using the factory pattern to allow for easier testing.
@@ -213,7 +213,7 @@ impl Batcher {
         committer_client: SharedCommitterClient,
         l1_events_provider_client: SharedL1EventsProviderClient,
         mempool_client: Option<SharedMempoolClient>,
-        config_manager_client: SharedConfigManagerClient,
+        config_manager_client: SharedConfigManagerReaderClient,
         block_builder_factory: Box<dyn BlockBuilderFactoryTrait>,
         pre_confirmed_block_writer_factory: Box<dyn PreconfirmedBlockWriterFactoryTrait>,
         commitment_manager: ApolloCommitmentManager,
@@ -1409,7 +1409,7 @@ fn log_txs_execution_result(
 }
 
 struct BatcherDynamicConfigProvider {
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 }
 
 #[async_trait]
@@ -1420,7 +1420,6 @@ impl DynamicConfigProvider for BatcherDynamicConfigProvider {
         let config = self
             .config_manager_client
             .get_batcher_dynamic_config()
-            .await
             .map_err(|e| DynamicConfigError(e.to_string()))?;
         Ok(config.storage_reader_server_dynamic_config)
     }
@@ -1435,7 +1434,7 @@ pub async fn create_batcher(
     class_manager_client: SharedClassManagerClient,
     pre_confirmed_cende_client: Arc<dyn PreconfirmedCendeClientTrait>,
     proof_manager_client: SharedProofManagerClient,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 ) -> Batcher {
     let storage_reader_server_config = ServerConfig {
         static_config: config.static_config.storage_reader_server_static_config.clone(),

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -28,7 +28,7 @@ use apollo_batcher_types::batcher_types::{
 };
 use apollo_batcher_types::errors::BatcherError;
 use apollo_committer_types::committer_types::CommitBlockRequest;
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_infra::component_client::ClientError;
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_l1_events_types::errors::{L1EventsProviderClientError, L1EventsProviderError};
@@ -273,7 +273,7 @@ async fn create_batcher_impl<R: BatcherStorageReader + 'static>(
     )
     .await;
 
-    let mut mock_config_manager = MockConfigManagerClient::new();
+    let mut mock_config_manager = MockConfigManagerReaderClient::new();
     mock_config_manager
         .expect_get_batcher_dynamic_config()
         .returning(|| Ok(BatcherDynamicConfig::default()));
@@ -314,7 +314,7 @@ async fn new_batcher_with_mempool_override(
         committer_client.clone(),
     )
     .await;
-    let mut mock_config_manager = MockConfigManagerClient::new();
+    let mut mock_config_manager = MockConfigManagerReaderClient::new();
     mock_config_manager
         .expect_get_batcher_dynamic_config()
         .returning(|| Ok(BatcherDynamicConfig::default()));

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -14,7 +14,6 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
         let dynamic_config = self
             .config_manager_client
             .get_batcher_dynamic_config()
-            .await
             .expect("Should be able to get batcher dynamic config");
         self.update_dynamic_config(dynamic_config);
 

--- a/crates/apollo_class_manager/src/class_manager.rs
+++ b/crates/apollo_class_manager/src/class_manager.rs
@@ -15,7 +15,7 @@ use apollo_compile_to_casm_types::{
     SharedSierraCompilerClient,
     SierraCompilerClientError,
 };
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_infra::component_definitions::{default_component_start_fn, ComponentStarter};
 use apollo_storage::storage_reader_server::{
     DynamicConfigError,
@@ -39,7 +39,7 @@ pub struct ClassManager<S: ClassStorage> {
     pub config: FsClassManagerConfig,
     pub compiler: SharedSierraCompilerClient,
     pub classes: CachedClassStorage<S>,
-    pub config_manager_client: SharedConfigManagerClient,
+    pub config_manager_client: SharedConfigManagerReaderClient,
 }
 
 impl<S> ClassManager<S>
@@ -51,7 +51,7 @@ where
         config: FsClassManagerConfig,
         compiler: SharedSierraCompilerClient,
         storage: S,
-        config_manager_client: SharedConfigManagerClient,
+        config_manager_client: SharedConfigManagerReaderClient,
     ) -> Self {
         let cached_class_storage_config =
             config.static_config.class_manager_config.cached_class_storage_config.clone();
@@ -190,7 +190,7 @@ where
 }
 
 struct ClassManagerDynamicConfigProvider {
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 }
 
 #[async_trait]
@@ -201,7 +201,6 @@ impl DynamicConfigProvider for ClassManagerDynamicConfigProvider {
         let config = self
             .config_manager_client
             .get_class_manager_dynamic_config()
-            .await
             .map_err(|e| DynamicConfigError(e.to_string()))?;
         Ok(config.storage_reader_server_dynamic_config)
     }
@@ -210,7 +209,7 @@ impl DynamicConfigProvider for ClassManagerDynamicConfigProvider {
 pub fn create_class_manager(
     config: FsClassManagerConfig,
     compiler_client: SharedSierraCompilerClient,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 ) -> FsClassManager {
     let dynamic_config_provider: SharedDynamicConfigProvider =
         Arc::new(ClassManagerDynamicConfigProvider {

--- a/crates/apollo_class_manager/src/class_manager_test.rs
+++ b/crates/apollo_class_manager/src/class_manager_test.rs
@@ -10,7 +10,7 @@ use apollo_class_manager_config::config::{
 };
 use apollo_class_manager_types::{ClassHashes, ClassManagerError};
 use apollo_compile_to_casm_types::{MockSierraCompilerClient, RawClass, RawExecutableClass};
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use assert_matches::assert_matches;
 use mockall::predicate::eq;
 use starknet_api::contract_class::ContractClass;
@@ -39,7 +39,7 @@ impl ClassManager<FsClassStorage> {
             dynamic_config: ClassManagerDynamicConfig::default(),
         };
 
-        let mock_config_manager_client = Arc::new(MockConfigManagerClient::new());
+        let mock_config_manager_client = Arc::new(MockConfigManagerReaderClient::new());
 
         ClassManager::new(
             fs_class_manager_config,

--- a/crates/apollo_class_manager/src/communication.rs
+++ b/crates/apollo_class_manager/src/communication.rs
@@ -23,7 +23,6 @@ impl ComponentRequestHandler<ClassManagerRequest, ClassManagerResponse> for Clas
             .0
             .config_manager_client
             .get_class_manager_dynamic_config()
-            .await
             .expect("Should be able to get class manager dynamic config");
         self.0.update_dynamic_config(dynamic_config);
 

--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -12,7 +12,7 @@ mod manager_test;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_consensus_config::config::{
     ConsensusConfig,
     ConsensusDynamicConfig,
@@ -67,7 +67,7 @@ pub struct RunConsensusArguments {
     /// Set to Byzantine by default. Using Honest means we trust all validators. Use with caution!
     pub quorum_type: QuorumType,
     /// Optional client for fetching dynamic consensus config between heights.
-    pub config_manager_client: Option<SharedConfigManagerClient>,
+    pub config_manager_client: Option<SharedConfigManagerReaderClient>,
     /// Storage used to persist last voted consensus height.
     // See MultiHeightManager foran explanation of why we have Arc<Mutex>>.
     pub last_voted_height_storage: Arc<Mutex<dyn HeightVotedStorageTrait>>,
@@ -130,7 +130,7 @@ where
     .await;
     loop {
         if let Some(client) = &run_consensus_args.config_manager_client {
-            match client.get_consensus_dynamic_config().await {
+            match client.get_consensus_dynamic_config() {
                 Ok(dynamic_cfg) => {
                     manager.set_dynamic_config(dynamic_cfg);
                 }

--- a/crates/apollo_consensus/src/manager_test.rs
+++ b/crates/apollo_consensus/src/manager_test.rs
@@ -4,7 +4,7 @@ use std::vec;
 
 use apollo_batcher_types::communication::BatcherClientError;
 use apollo_batcher_types::errors::BatcherError;
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_consensus_config::config::{
     ConsensusConfig,
     ConsensusDynamicConfig,
@@ -745,7 +745,7 @@ async fn run_consensus_dynamic_client_updates_validator_between_heights(
         .times(1);
 
     // Dynamic client mock: H1 -> VALIDATOR_ID, H2 -> PROPOSER_ID (order is important)
-    let mut mock_client = MockConfigManagerClient::new();
+    let mut mock_client = MockConfigManagerReaderClient::new();
     let validator_config = consensus_config.dynamic_config.clone();
     let proposer_config =
         ConsensusDynamicConfig { validator_id: *PROPOSER_ID, ..validator_config.clone() };

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use apollo_batcher_types::batcher_types::RevertBlockInput;
 use apollo_batcher_types::communication::SharedBatcherClient;
 use apollo_class_manager_types::SharedClassManagerClient;
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_consensus::storage::{get_voted_height_storage, HeightVotedStorageTrait};
 use apollo_consensus::stream_handler::StreamHandler;
 use apollo_consensus::votes_threshold::QuorumType;
@@ -90,7 +90,7 @@ pub struct ConsensusManager {
     pub class_manager_client: SharedClassManagerClient,
     pub proof_manager_client: SharedProofManagerClient,
     pub signature_manager_client: SharedSignatureManagerClient,
-    pub config_manager_client: SharedConfigManagerClient,
+    pub config_manager_client: SharedConfigManagerReaderClient,
     l1_gas_price_provider: Arc<dyn L1GasPriceProviderClient>,
     voted_height_storage: Arc<Mutex<dyn HeightVotedStorageTrait>>,
     committee_provider: Arc<dyn CommitteeProvider>,
@@ -102,7 +102,7 @@ pub struct ConsensusManagerArgs {
     pub state_sync_client: SharedStateSyncClient,
     pub class_manager_client: SharedClassManagerClient,
     pub signature_manager_client: SharedSignatureManagerClient,
-    pub config_manager_client: SharedConfigManagerClient,
+    pub config_manager_client: SharedConfigManagerReaderClient,
     pub l1_gas_price_provider: Arc<dyn L1GasPriceProviderClient>,
     pub proof_manager_client: SharedProofManagerClient,
     pub committee_provider: Arc<dyn CommitteeProvider>,
@@ -283,7 +283,7 @@ impl ConsensusManager {
         &self,
         votes_broadcast_channels: &BroadcastTopicChannels<Vote>,
         outbound_internal_sender: mpsc::Sender<(HeightAndRound, mpsc::Receiver<ProposalPart>)>,
-        config_manager_client: SharedConfigManagerClient,
+        config_manager_client: SharedConfigManagerReaderClient,
     ) -> SequencerConsensusContext {
         SequencerConsensusContext::new(
             self.config.context_config.clone(),
@@ -374,7 +374,7 @@ pub fn create_committee_provider(
     config: &ConsensusManagerConfig,
     batcher_client: SharedBatcherClient,
     state_sync_client: SharedStateSyncClient,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 ) -> Arc<dyn CommitteeProvider> {
     let staking_manager_config = config.staking_manager_config.clone();
     // TODO(Asmaa/Dafna): Create StakingContract according to config.
@@ -401,7 +401,7 @@ pub fn create_consensus_manager(
     class_manager_client: SharedClassManagerClient,
     proof_manager_client: SharedProofManagerClient,
     signature_manager_client: SharedSignatureManagerClient,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
     l1_gas_price_provider: Arc<dyn L1GasPriceProviderClient>,
     committee_provider: Arc<dyn CommitteeProvider>,
 ) -> ConsensusManager {

--- a/crates/apollo_consensus_manager/src/consensus_manager_test.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use apollo_batcher_types::batcher_types::{GetHeightResponse, RevertBlockInput};
 use apollo_batcher_types::communication::MockBatcherClient;
 use apollo_class_manager_types::MockClassManagerClient;
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_consensus::storage::MockHeightVotedStorageTrait;
 use apollo_consensus::test_utils::get_new_storage_config;
 use apollo_consensus_config::config::{ConsensusConfig, ConsensusStaticConfig};
@@ -68,7 +68,7 @@ async fn revert_batcher_blocks() {
             state_sync_client: Arc::new(MockStateSyncClient::new()),
             class_manager_client: Arc::new(MockClassManagerClient::new()),
             signature_manager_client: Arc::new(MockSignatureManagerClient::new()),
-            config_manager_client: Arc::new(MockConfigManagerClient::new()),
+            config_manager_client: Arc::new(MockConfigManagerReaderClient::new()),
             l1_gas_price_provider: Arc::new(MockL1GasPriceProviderClient::new()),
             proof_manager_client: Arc::new(MockProofManagerClient::new()),
             committee_provider: Arc::new(MockCommitteeProvider::new()),
@@ -114,7 +114,7 @@ async fn revert_voted_height_when_batcher_already_at_target() {
             state_sync_client: Arc::new(MockStateSyncClient::new()),
             class_manager_client: Arc::new(MockClassManagerClient::new()),
             signature_manager_client: Arc::new(MockSignatureManagerClient::new()),
-            config_manager_client: Arc::new(MockConfigManagerClient::new()),
+            config_manager_client: Arc::new(MockConfigManagerReaderClient::new()),
             l1_gas_price_provider: Arc::new(MockL1GasPriceProviderClient::new()),
             proof_manager_client: Arc::new(MockProofManagerClient::new()),
             committee_provider: Arc::new(MockCommitteeProvider::new()),
@@ -148,7 +148,7 @@ async fn no_reverts_without_config() {
         state_sync_client: Arc::new(MockStateSyncClient::new()),
         class_manager_client: Arc::new(MockClassManagerClient::new()),
         signature_manager_client: Arc::new(MockSignatureManagerClient::new()),
-        config_manager_client: Arc::new(MockConfigManagerClient::new()),
+        config_manager_client: Arc::new(MockConfigManagerReaderClient::new()),
         l1_gas_price_provider: Arc::new(MockL1GasPriceProviderClient::new()),
         proof_manager_client: Arc::new(MockProofManagerClient::new()),
         committee_provider: Arc::new(MockCommitteeProvider::new()),

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -20,7 +20,7 @@ use apollo_batcher_types::batcher_types::{
 use apollo_batcher_types::communication::{BatcherClient, BatcherClientError};
 use apollo_batcher_types::errors::BatcherError;
 use apollo_config::behavior_mode::BehaviorMode;
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_consensus::types::{ConsensusContext, ConsensusError, ProposalCommitment, Round};
 use apollo_consensus_orchestrator_config::config::ContextConfig;
 use apollo_l1_gas_price_types::L1GasPriceProviderClient;
@@ -243,7 +243,7 @@ pub struct SequencerConsensusContextDeps {
     pub outbound_proposal_sender: mpsc::Sender<(HeightAndRound, mpsc::Receiver<ProposalPart>)>,
     // Used to broadcast votes to other consensus nodes.
     pub vote_broadcast_client: BroadcastTopicClient<Vote>,
-    pub config_manager_client: Option<SharedConfigManagerClient>,
+    pub config_manager_client: Option<SharedConfigManagerReaderClient>,
 }
 
 #[derive(thiserror::Error, PartialEq, Debug)]
@@ -966,7 +966,7 @@ impl SequencerConsensusContext {
 
     async fn update_dynamic_config(&mut self) {
         if let Some(config_manager_client) = self.deps.config_manager_client.clone() {
-            let config_result = config_manager_client.get_context_dynamic_config().await;
+            let config_result = config_manager_client.get_context_dynamic_config();
             match config_result {
                 Ok(config) => {
                     self.config.dynamic_config = config;

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -12,7 +12,7 @@ use apollo_batcher_types::batcher_types::{
 };
 use apollo_batcher_types::communication::BatcherClientError;
 use apollo_batcher_types::errors::BatcherError;
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_consensus::types::{ConsensusContext, Round};
 use apollo_consensus_orchestrator_config::config::{
     ContextConfig,
@@ -1255,12 +1255,13 @@ async fn change_gas_price_overrides() {
     };
 }
 
-fn make_config_manager_client(provider_config: ContextDynamicConfig) -> MockConfigManagerClient {
-    let mut config_manager_client = MockConfigManagerClient::new();
+fn make_config_manager_client(
+    provider_config: ContextDynamicConfig,
+) -> MockConfigManagerReaderClient {
+    let mut config_manager_client = MockConfigManagerReaderClient::new();
     config_manager_client
         .expect_get_context_dynamic_config()
         .returning(move || Ok(provider_config.clone()));
-    config_manager_client.expect_set_node_dynamic_config().returning(|_| Ok(()));
     config_manager_client
 }
 
@@ -1281,7 +1282,7 @@ async fn test_dynamic_config_updates_min_gas_price() {
     deps.setup_default_expectations();
 
     // Create a mock config manager client that will return dynamic config
-    let mut mock_config_manager = MockConfigManagerClient::new();
+    let mut mock_config_manager = MockConfigManagerReaderClient::new();
 
     // Mock expects get_context_dynamic_config to be called twice (once per height change)
     // This is called inside set_height_and_round() -> update_dynamic_config() ->

--- a/crates/apollo_mempool/benches/utils.rs
+++ b/crates/apollo_mempool/benches/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_infra::component_server::{ComponentServerStarter, LocalServerConfig};
 use apollo_infra::metrics::{LocalClientMetrics, LocalServerMetrics};
 use apollo_mempool::communication::{create_mempool, LocalMempoolServer};
@@ -215,7 +215,7 @@ impl BenchTestSetup {
         let bench_p2p_client = Arc::new(BenchMempoolP2pPropagator);
 
         // Create mock config manager client for benchmark
-        let mut mock_config_manager = MockConfigManagerClient::new();
+        let mut mock_config_manager = MockConfigManagerReaderClient::new();
         let dynamic_config = self.config.mempool_config.dynamic_config.clone();
         mock_config_manager
             .expect_get_mempool_dynamic_config()

--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_infra::component_definitions::{ComponentRequestHandler, ComponentStarter};
 use apollo_infra::component_server::{LocalComponentServer, RemoteComponentServer};
 use apollo_mempool_config::config::MempoolConfig;
@@ -42,7 +42,7 @@ pub type RemoteMempoolServer = RemoteComponentServer<MempoolRequest, MempoolResp
 pub fn create_mempool(
     config: MempoolConfig,
     mempool_p2p_propagator_client: SharedMempoolP2pPropagatorClient,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 ) -> MempoolCommunicationWrapper {
     MempoolCommunicationWrapper::new(
         Mempool::new(config, Arc::new(DefaultClock)),
@@ -55,7 +55,7 @@ pub fn create_mempool(
 pub struct MempoolCommunicationWrapper {
     mempool: Mempool,
     mempool_p2p_propagator_client: SharedMempoolP2pPropagatorClient,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
     echonet_client: ClientWithMiddleware,
 }
 
@@ -63,7 +63,7 @@ impl MempoolCommunicationWrapper {
     pub fn new(
         mempool: Mempool,
         mempool_p2p_propagator_client: SharedMempoolP2pPropagatorClient,
-        config_manager_client: SharedConfigManagerClient,
+        config_manager_client: SharedConfigManagerReaderClient,
     ) -> Self {
         const MIN_RETRY_INTERVAL: Duration = Duration::from_millis(50);
         const MAX_RETRY_INTERVAL: Duration = Duration::from_millis(500);
@@ -112,7 +112,6 @@ impl MempoolCommunicationWrapper {
         let mempool_dynamic_config = self
             .config_manager_client
             .get_mempool_dynamic_config()
-            .await
             .expect("Should be able to get mempool dynamic config");
         self.mempool.update_dynamic_config(mempool_dynamic_config);
     }

--- a/crates/apollo_mempool/src/fee_mempool_test.rs
+++ b/crates/apollo_mempool/src/fee_mempool_test.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_infra::component_client::ClientError;
 use apollo_mempool_config::config::{MempoolConfig, MempoolDynamicConfig, MempoolStaticConfig};
 use apollo_mempool_p2p_types::communication::{
@@ -981,7 +981,7 @@ async fn test_new_tx_sent_to_p2p(mempool: Mempool) {
         .with(eq(tx_args.tx))
         .returning(|_| Ok(()));
 
-    let mock_config_manager = MockConfigManagerClient::new();
+    let mock_config_manager = MockConfigManagerReaderClient::new();
 
     let mut mempool_wrapper = MempoolCommunicationWrapper::new(
         mempool,
@@ -1010,7 +1010,7 @@ async fn test_propagated_tx_sent_to_p2p(mempool: Mempool) {
         .with(eq(expected_message_metadata.clone()))
         .returning(|_| Ok(()));
 
-    let mock_config_manager = MockConfigManagerClient::new();
+    let mock_config_manager = MockConfigManagerReaderClient::new();
 
     let mut mempool_wrapper = MempoolCommunicationWrapper::new(
         mempool,
@@ -1514,7 +1514,7 @@ async fn add_tx_tolerates_p2p_propagation_error(mempool: Mempool) {
         )))
     });
 
-    let mock_config_manager = MockConfigManagerClient::new();
+    let mock_config_manager = MockConfigManagerReaderClient::new();
 
     let mut mempool_wrapper = MempoolCommunicationWrapper::new(
         mempool,

--- a/crates/apollo_mempool/src/recorder_integration_test.rs
+++ b/crates/apollo_mempool/src/recorder_integration_test.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use apollo_config::behavior_mode::BehaviorMode;
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_mempool_config::config::{MempoolConfig, MempoolStaticConfig};
 use apollo_mempool_p2p_types::communication::MockMempoolP2pPropagatorClient;
 use apollo_mempool_types::communication::AddTransactionArgsWrapper;
@@ -57,7 +57,7 @@ fn create_mempool_communication_wrapper(recorder_url: String) -> MempoolCommunic
     let mut mock_p2p = MockMempoolP2pPropagatorClient::new();
     mock_p2p.expect_add_transaction().returning(|_| Ok(()));
 
-    let mock_config_manager = MockConfigManagerClient::new();
+    let mock_config_manager = MockConfigManagerReaderClient::new();
 
     MempoolCommunicationWrapper::new(mempool, Arc::new(mock_p2p), Arc::new(mock_config_manager))
 }

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -110,8 +110,8 @@ pub async fn create_node_components(
                 .get_proof_manager_shared_client()
                 .expect("Proof Manager client should be available");
             let config_manager_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
+                .get_config_manager_reader_client()
+                .expect("Config Manager reader client should be available");
             Some(
                 create_batcher(
                     batcher_config.clone(),
@@ -137,13 +137,13 @@ pub async fn create_node_components(
             let compiler_shared_client = clients
                 .get_sierra_compiler_shared_client()
                 .expect("Sierra Compiler client should be available");
-            let config_manager_shared_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
+            let config_manager_client = clients
+                .get_config_manager_reader_client()
+                .expect("Config Manager reader client should be available");
             Some(create_class_manager(
                 class_manager_config.clone(),
                 compiler_shared_client,
-                config_manager_shared_client,
+                config_manager_client,
             ))
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
@@ -215,8 +215,8 @@ pub async fn create_node_components(
                 .get_l1_gas_price_shared_client()
                 .expect("L1 gas price client should be available");
             let config_manager_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
+                .get_config_manager_reader_client()
+                .expect("Config Manager reader client should be available");
             let proof_manager_client = clients
                 .get_proof_manager_shared_client()
                 .expect("Proof Manager client should be available");
@@ -410,8 +410,8 @@ pub async fn create_node_components(
             let mempool_config =
                 config.mempool_config.as_ref().expect("Mempool config should be set");
             let config_manager_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
+                .get_config_manager_reader_client()
+                .expect("Config Manager reader client should be available");
             let mempool_p2p_propagator_client = clients
                 .get_mempool_p2p_propagator_shared_client()
                 .expect("Propagator client should be available");
@@ -546,8 +546,8 @@ pub async fn create_node_components(
                 .get_class_manager_shared_client()
                 .expect("Class Manager client should be available");
             let config_manager_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
+                .get_config_manager_reader_client()
+                .expect("Config Manager reader client should be available");
             let (state_sync, state_sync_runner) = create_state_sync_and_runner(
                 state_sync_config.clone(),
                 class_manager_client,

--- a/crates/apollo_staking/src/staking_manager.rs
+++ b/crates/apollo_staking/src/staking_manager.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use apollo_batcher_types::communication::SharedBatcherClient;
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_protobuf::consensus::Round;
 use apollo_staking_config::config::{
     get_config_for_epoch,
@@ -190,7 +190,7 @@ pub struct StakingManager {
 
     random_generator_factory: Arc<dyn BlockRandomGeneratorFactory>,
     dynamic_config: RwLock<StakingManagerDynamicConfig>,
-    config_manager_client: Option<SharedConfigManagerClient>,
+    config_manager_client: Option<SharedConfigManagerReaderClient>,
     use_only_actual_proposer_selection: bool,
     committee_member_metrics: Mutex<CommitteeMemberMetrics>,
 }
@@ -219,7 +219,7 @@ impl StakingManager {
         state_sync_client: SharedStateSyncClient,
         random_generator_factory: Arc<dyn BlockRandomGeneratorFactory>,
         config: StakingManagerConfig,
-        config_manager_client: Option<SharedConfigManagerClient>,
+        config_manager_client: Option<SharedConfigManagerReaderClient>,
     ) -> Self {
         register_metrics();
         Self {
@@ -245,7 +245,7 @@ impl StakingManager {
             return;
         };
 
-        match client.get_staking_manager_dynamic_config().await {
+        match client.get_staking_manager_dynamic_config() {
             Ok(new_config) => {
                 let mut dynamic_config = self.dynamic_config.write().expect("RwLock poisoned");
                 *dynamic_config = new_config;

--- a/crates/apollo_staking/src/staking_manager_test.rs
+++ b/crates/apollo_staking/src/staking_manager_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use apollo_batcher_types::communication::{BatcherClientError, MockBatcherClient};
 use apollo_batcher_types::errors::BatcherError;
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_staking_config::config::{
     CommitteeConfig,
     ConfiguredStaker,
@@ -295,7 +295,7 @@ async fn get_committee_applies_dynamic_config_changes(
     set_stakers(&mut contract, EPOCH_1, vec![STAKER_1, STAKER_2, STAKER_3]);
     set_stakers(&mut contract, EPOCH_2, vec![STAKER_1, STAKER_2, STAKER_3]);
 
-    let mut config_manager_client = MockConfigManagerClient::new();
+    let mut config_manager_client = MockConfigManagerReaderClient::new();
     config_manager_client
         .expect_get_staking_manager_dynamic_config()
         .times(1)

--- a/crates/apollo_state_sync/src/lib.rs
+++ b/crates/apollo_state_sync/src/lib.rs
@@ -6,7 +6,7 @@ use std::cmp::min;
 use std::sync::Arc;
 
 use apollo_class_manager_types::SharedClassManagerClient;
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_infra::component_definitions::{ComponentRequestHandler, ComponentStarter};
 use apollo_infra::component_server::{ConcurrentLocalComponentServer, RemoteComponentServer};
 use apollo_starknet_client::reader::{StarknetFeederGatewayClient, StarknetReader};
@@ -38,7 +38,7 @@ const BUFFER_SIZE: usize = 100000;
 pub fn create_state_sync_and_runner(
     config: StateSyncConfig,
     class_manager_client: SharedClassManagerClient,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 ) -> (StateSync, StateSyncRunner) {
     let (new_block_sender, new_block_receiver) = channel(BUFFER_SIZE);
     let (state_sync_runner, storage_reader) = StateSyncRunner::new(
@@ -58,7 +58,7 @@ pub struct StateSync {
     storage_reader: StorageReader,
     new_block_sender: Sender<SyncBlock>,
     starknet_client: Option<Arc<dyn StarknetReader + Send + Sync>>,
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
     dynamic_config: Arc<RwLock<StateSyncDynamicConfig>>,
 }
 
@@ -67,7 +67,7 @@ impl StateSync {
         storage_reader: StorageReader,
         new_block_sender: Sender<SyncBlock>,
         config: StateSyncConfig,
-        config_manager_client: SharedConfigManagerClient,
+        config_manager_client: SharedConfigManagerReaderClient,
     ) -> Self {
         let starknet_client = config.static_config.central_sync_client_config.map(|config| {
             let config = config.central_source_config;
@@ -94,7 +94,7 @@ impl StateSync {
     }
 
     async fn update_dynamic_config(&self) {
-        match self.config_manager_client.get_state_sync_dynamic_config().await {
+        match self.config_manager_client.get_state_sync_dynamic_config() {
             Ok(new_config) => {
                 let mut dynamic_config = self.dynamic_config.write().await;
                 *dynamic_config = new_config;

--- a/crates/apollo_state_sync/src/runner/mod.rs
+++ b/crates/apollo_state_sync/src/runner/mod.rs
@@ -7,7 +7,7 @@ use apollo_central_sync::sources::central::{CentralError, CentralSource};
 use apollo_central_sync::sources::pending::PendingSource;
 use apollo_central_sync::{StateSync as CentralStateSync, StateSyncError as CentralStateSyncError};
 use apollo_class_manager_types::SharedClassManagerClient;
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
+use apollo_config_manager_types::communication::SharedConfigManagerReaderClient;
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_infra::component_server::WrapperServer;
 use apollo_network::metrics::{NetworkMetrics, SqmrNetworkMetrics};
@@ -73,7 +73,7 @@ use tracing::instrument::Instrument;
 use tracing::{debug, info_span};
 
 struct StateSyncDynamicConfigProvider {
-    config_manager_client: SharedConfigManagerClient,
+    config_manager_client: SharedConfigManagerReaderClient,
 }
 
 #[async_trait]
@@ -84,7 +84,6 @@ impl DynamicConfigProvider for StateSyncDynamicConfigProvider {
         let config = self
             .config_manager_client
             .get_state_sync_dynamic_config()
-            .await
             .map_err(|e| DynamicConfigError(e.to_string()))?;
         Ok(config.storage_reader_server_dynamic_config)
     }
@@ -186,7 +185,7 @@ impl StateSyncRunner {
         config: StateSyncConfig,
         new_block_receiver: Receiver<SyncBlock>,
         class_manager_client: SharedClassManagerClient,
-        config_manager_client: SharedConfigManagerClient,
+        config_manager_client: SharedConfigManagerReaderClient,
     ) -> (Self, StorageReader) {
         let StateSyncConfig { static_config, dynamic_config } = config;
 

--- a/crates/apollo_state_sync/src/test.rs
+++ b/crates/apollo_state_sync/src/test.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use apollo_config_manager_types::communication::MockConfigManagerClient;
+use apollo_config_manager_types::communication::MockConfigManagerReaderClient;
 use apollo_infra::component_definitions::ComponentRequestHandler;
 use apollo_starknet_client::reader::{MockStarknetReader, StarknetReader};
 use apollo_state_sync_config::config::StateSyncDynamicConfig;
@@ -27,7 +27,7 @@ use crate::StateSync;
 
 fn setup() -> (StateSync, StorageWriter) {
     let ((storage_reader, storage_writer), _) = get_test_storage();
-    let mut config_manager_client = MockConfigManagerClient::new();
+    let mut config_manager_client = MockConfigManagerReaderClient::new();
     config_manager_client
         .expect_get_state_sync_dynamic_config()
         .returning(|| Ok(StateSyncDynamicConfig::default()));
@@ -141,7 +141,7 @@ async fn test_get_block_hash_fallback_to_starknet_client() {
     let starknet_client: Option<Arc<dyn StarknetReader + Send + Sync>> =
         Some(Arc::new(starknet_client));
     let ((storage_reader, _storage_writer), _) = get_test_storage();
-    let mut config_manager_client = MockConfigManagerClient::new();
+    let mut config_manager_client = MockConfigManagerReaderClient::new();
     // Set up expectation for get_state_sync_dynamic_config to return default config
     config_manager_client
         .expect_get_state_sync_dynamic_config()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broadly rewires multiple core components to use the synchronous `SharedConfigManagerReaderClient` (cached config reads) instead of the async request-based config manager client, which could affect when/where dynamic config refreshes happen. Main risk is integration/behavioral drift across consensus, batching, mempool, staking, and state-sync due to the interface change, not complex new logic.
> 
> **Overview**
> **Replaces dynamic-config plumbing across the node to use the cached config “reader” client.** Components (`batcher`, `class_manager`, `mempool`, `state_sync`, `staking_manager`, `consensus`/`consensus_manager`, and the consensus orchestrator context) now depend on `SharedConfigManagerReaderClient` and call `get_*_dynamic_config()` synchronously (dropping `.await`).
> 
> Node component wiring and tests/benches are updated accordingly (new `get_config_manager_reader_client()` accessor and `MockConfigManagerReaderClient`), including removing unused writer expectations like `set_node_dynamic_config` in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 875ad1ca63e6590641456239a6dda1fea05fd5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->