### PR TITLE
apollo_network: move e2e discovery test to integration tests

### DIFF
--- a/crates/apollo_network/Cargo.toml
+++ b/crates/apollo_network/Cargo.toml
@@ -63,5 +63,9 @@ tokio = { workspace = true, features = ["full", "sync", "test-util"] }
 tokio-stream.workspace = true
 waker-fn.workspace = true
 
+[[test]]
+name = "e2e_discovery_test"
+required-features = ["testing"]
+
 [lints]
 workspace = true

--- a/crates/apollo_network/src/lib.rs
+++ b/crates/apollo_network/src/lib.rs
@@ -199,15 +199,19 @@ mod config_test;
 pub mod discovery;
 #[cfg(test)]
 mod e2e_broadcast_test;
-#[cfg(test)]
-mod e2e_discovery_test;
 mod event_tracker;
 pub mod gossipsub_impl;
 pub mod metrics;
 pub mod misconduct_score;
+#[cfg(any(test, feature = "testing"))]
+pub mod mixed_behaviour;
+#[cfg(not(any(test, feature = "testing")))]
 mod mixed_behaviour;
 pub mod network_manager;
 pub mod peer_manager;
+#[cfg(any(test, feature = "testing"))]
+pub mod prune_dead_connections;
+#[cfg(not(any(test, feature = "testing")))]
 mod prune_dead_connections;
 pub mod sqmr;
 #[cfg(test)]
@@ -244,6 +248,9 @@ use validator::{Validate, ValidationError};
 
 use crate::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
 
+#[cfg(any(test, feature = "testing"))]
+pub type Bytes = Vec<u8>;
+#[cfg(not(any(test, feature = "testing")))]
 pub(crate) type Bytes = Vec<u8>;
 
 // TODO(Shahak): add peer manager config to the network config

--- a/crates/apollo_network/src/network_manager/mod.rs
+++ b/crates/apollo_network/src/network_manager/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(test)]
-pub(crate) mod swarm_trait;
-#[cfg(not(test))]
+#[cfg(any(test, feature = "testing"))]
+pub mod swarm_trait;
+#[cfg(not(any(test, feature = "testing")))]
 mod swarm_trait;
 #[cfg(test)]
 mod test;
@@ -196,7 +196,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
 
     // TODO(shahak): remove the advertised_multiaddr arg once we manage external addresses
     // in a behaviour.
-    pub(crate) fn generic_new(
+    pub fn generic_new(
         mut swarm: SwarmT,
         advertised_multiaddr: Option<Multiaddr>,
         metrics: Option<NetworkMetrics>,

--- a/crates/apollo_network/tests/e2e_discovery_test.rs
+++ b/crates/apollo_network/tests/e2e_discovery_test.rs
@@ -3,6 +3,17 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+use apollo_network::discovery::DiscoveryConfig;
+use apollo_network::gossipsub_impl::Topic;
+use apollo_network::misconduct_score::MisconductScore;
+use apollo_network::mixed_behaviour::{self, MixedBehaviour};
+use apollo_network::network_manager::swarm_trait::{Event, SwarmTrait};
+use apollo_network::network_manager::GenericNetworkManager;
+use apollo_network::peer_manager::PeerManagerConfig;
+use apollo_network::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
+use apollo_network::sqmr::behaviour::SessionIdNotFoundError;
+use apollo_network::sqmr::{self, InboundSessionId, OutboundSessionId, SessionId};
+use apollo_network::Bytes;
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
 use libp2p::core::multiaddr::Protocol;
 use libp2p::gossipsub::{MessageId, PublishError, SubscriptionError, TopicHash};
@@ -12,18 +23,6 @@ use libp2p_swarm_test::SwarmExt;
 use starknet_api::core::ChainId;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::time::{self, Instant, MissedTickBehavior};
-
-use crate::discovery::DiscoveryConfig;
-use crate::gossipsub_impl::Topic;
-use crate::misconduct_score::MisconductScore;
-use crate::mixed_behaviour::{self, MixedBehaviour};
-use crate::network_manager::swarm_trait::{Event, SwarmTrait};
-use crate::network_manager::GenericNetworkManager;
-use crate::peer_manager::PeerManagerConfig;
-use crate::prune_dead_connections::{DEFAULT_PING_INTERVAL, DEFAULT_PING_TIMEOUT};
-use crate::sqmr::behaviour::SessionIdNotFoundError;
-use crate::sqmr::{self, InboundSessionId, OutboundSessionId, SessionId};
-use crate::Bytes;
 
 const MESSAGE_METADATA_BUFFER_SIZE: usize = 100;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily test relocation and visibility tweaks, with production behavior unchanged; main risk is minor API surface expansion (`GenericNetworkManager::generic_new` and test-only `pub` exports) affecting downstream compilation expectations.
> 
> **Overview**
> Moves the discovery end-to-end test out of the crate unit-test module into an integration test (`tests/e2e_discovery_test.rs`) and wires it into Cargo as an explicit `[[test]]` that runs only with the `testing` feature.
> 
> To support the integration test, several previously crate-private internals are made accessible under `cfg(any(test, feature = "testing"))` (e.g., `mixed_behaviour`, `prune_dead_connections`, `Bytes`, and `network_manager::swarm_trait`), and `GenericNetworkManager::generic_new` is promoted to `pub` so the integration test can construct managers directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ab2227397befd3ce5f11d42a2cef3e228bea20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->