### PR TITLE
apollo_batcher,apollo_storage: validate STRK fee token during active bootstrap

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1601,6 +1601,17 @@ pub async fn create_batcher(
         )
         .expect("Failed to open batcher's storage");
 
+    // If bootstrap is still in progress (per storage), ensure `chain_info` STRK matches the
+    // embedded bootstrap ERC20. No-op once complete, even with `bootstrap_enabled` left true.
+    let bootstrap_state = crate::bootstrap::current_bootstrap_state(
+        &config.dynamic_config.bootstrap_config,
+        &storage_reader,
+    );
+    crate::bootstrap::validate_strk_fee_token_for_active_bootstrap(
+        &config.static_config.block_builder_config.chain_info,
+        bootstrap_state,
+    );
+
     let bootstrap_config = Arc::new(config.dynamic_config.bootstrap_config.clone());
 
     let storage_reader_server = create_bootstrap_storage_reader_server(

--- a/crates/apollo_batcher/src/bootstrap.rs
+++ b/crates/apollo_batcher/src/bootstrap.rs
@@ -51,22 +51,22 @@ const POST_FEE_TOKEN_SETUP_NONCE: u128 = PRE_FEE_TOKEN_SETUP_NONCE + 1;
 /// Class hash of the bootstrap account contract (not derived at runtime; update when the bundle
 /// changes).
 pub const BOOTSTRAP_ACCOUNT_CLASS_HASH: ClassHash = ClassHash(StarkHash::from_hex_unchecked(
-    "0x023f6d63bd54a867e571beb1f98b5461f7f58b7647c01b2b4fb4b00c157bc709",
+    "0x36584049d6c9c6e961ae9d87d69006f1379637b8093063b46720e499bbeb9dd",
 ));
 /// Class hash of the bootstrap ERC20 contract (not derived at runtime; update when the bundle
 /// changes).
 pub const BOOTSTRAP_ERC20_CLASS_HASH: ClassHash = ClassHash(StarkHash::from_hex_unchecked(
-    "0x0462b054af23d1f3b9da196a296ccdebfbabadee501bfb76e1c573cb93487abd",
+    "0x72c19ab0a7d7a46250611ebf7af7bfcfe1a330d60bee3e4a7784c56be043983",
 ));
 /// Deterministic address of the funded bootstrap account (deploy account: salt 0, empty calldata).
 pub const BOOTSTRAP_ACCOUNT_ADDRESS: ContractAddress =
     ContractAddress(PatriciaKey::from_hex_unchecked(
-        "0x007da0b84832f1b32dc0b99e90af24ec05d3940690a388a60cadcb610ecf4903",
+        "0x064faa09d24f6a46a5ee84ce82f10671c76a37360331198bb7eabc7eb33afda",
     ));
 /// Deterministic address of the STRK fee token (deploy from account, salt = nonce 1).
 pub const BOOTSTRAP_STRK_ADDRESS: ContractAddress =
     ContractAddress(PatriciaKey::from_hex_unchecked(
-        "0x055379e04f508603662acdde5385fa769a06bca9e73a914e6e6b4f4fea6336ec",
+        "0x00147c72fb4b344340f0ea15948cd438ad45caac3c8e8428b1e3493b13d41f00",
     ));
 
 /// When [`BootstrapState`] is not [`BootstrapState::NotInBootstrap`], ensures `chain_info` names

--- a/crates/apollo_batcher/src/bootstrap.rs
+++ b/crates/apollo_batcher/src/bootstrap.rs
@@ -4,6 +4,7 @@ pub use apollo_batcher_config::config::BootstrapConfig;
 pub use apollo_batcher_types::bootstrap_types::BootstrapState;
 use apollo_storage::state::StateStorageReader;
 use apollo_storage::{bootstrap_contracts, StorageReader};
+use blockifier::context::ChainInfo;
 use starknet_api::abi::abi_utils::{get_storage_var_address, selector_from_name};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, PatriciaKey};
 use starknet_api::data_availability::DataAvailabilityMode;
@@ -67,6 +68,37 @@ pub const BOOTSTRAP_STRK_ADDRESS: ContractAddress =
     ContractAddress(PatriciaKey::from_hex_unchecked(
         "0x055379e04f508603662acdde5385fa769a06bca9e73a914e6e6b4f4fea6336ec",
     ));
+
+/// When [`BootstrapState`] is not [`BootstrapState::NotInBootstrap`], ensures `chain_info` names
+/// the same STRK fee token the bootstrap deploy will create. Skips when bootstrap is finished or
+/// disabled (see `current_bootstrap_state`).
+pub(crate) fn validate_strk_fee_token_for_active_bootstrap(
+    chain_info: &ChainInfo,
+    state: BootstrapState,
+) {
+    match state {
+        BootstrapState::NotInBootstrap => {}
+        BootstrapState::DeclareContracts
+        | BootstrapState::DeployAccount
+        | BootstrapState::DeployFeeToken => {
+            let expected = bootstrap_contracts::bootstrap_strk_fee_token_contract_address();
+            let configured = chain_info.fee_token_addresses.strk_fee_token_address;
+            if configured == ContractAddress::default() {
+                panic!(
+                    "While bootstrap is in progress ({state:?}), strk_fee_token_address must be \
+                     set to the embedded bootstrap ERC20 address {expected:?} (got default/zero)."
+                );
+            }
+            if configured != expected {
+                panic!(
+                    "While bootstrap is in progress ({state:?}), strk_fee_token_address \
+                     ({configured:?}) must match the embedded bootstrap ERC20 address \
+                     ({expected:?})."
+                );
+            }
+        }
+    }
+}
 
 /// Derives the current bootstrap phase from chain storage and config.
 ///

--- a/crates/apollo_batcher/src/bootstrap_test.rs
+++ b/crates/apollo_batcher/src/bootstrap_test.rs
@@ -1,8 +1,10 @@
 //! Checked-in bootstrap class hashes and addresses live in [`crate::bootstrap`] (`BOOTSTRAP_*`,
 //! not derived at runtime). Tests derive the same values and assert they match.
 
+use apollo_storage::state::StateStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
 use apollo_storage::{bootstrap_contracts, StorageReader};
+use blockifier::context::ChainInfo;
 use indexmap::IndexMap;
 use starknet_api::abi::abi_utils::get_storage_var_address;
 use starknet_api::block::BlockNumber;
@@ -21,6 +23,7 @@ use starknet_types_core::felt::Felt;
 use crate::bootstrap::{
     bootstrap_transactions_for_state,
     current_bootstrap_state,
+    validate_strk_fee_token_for_active_bootstrap,
     BootstrapConfig,
     BootstrapState,
     BOOTSTRAP_ACCOUNT_ADDRESS,
@@ -277,4 +280,34 @@ fn deterministic_addresses_are_consistent() {
     assert_eq!(BOOTSTRAP_STRK_ADDRESS, BOOTSTRAP_STRK_ADDRESS);
     assert_ne!(BOOTSTRAP_ACCOUNT_ADDRESS, ContractAddress::default());
     assert_ne!(BOOTSTRAP_STRK_ADDRESS, ContractAddress::default());
+}
+
+#[test]
+fn validate_strk_skipped_when_not_in_bootstrap_even_if_wrong_address() {
+    let mut chain_info = ChainInfo::default();
+    chain_info.fee_token_addresses.strk_fee_token_address = ContractAddress::from(1_u128);
+    validate_strk_fee_token_for_active_bootstrap(&chain_info, BootstrapState::NotInBootstrap);
+}
+
+#[test]
+fn validate_strk_accepts_expected_address_when_bootstrap_active() {
+    let mut chain_info = ChainInfo::default();
+    chain_info.fee_token_addresses.strk_fee_token_address =
+        bootstrap_contracts::bootstrap_strk_fee_token_contract_address();
+    validate_strk_fee_token_for_active_bootstrap(&chain_info, BootstrapState::DeployFeeToken);
+}
+
+#[test]
+#[should_panic(expected = "strk_fee_token_address must be set to the embedded bootstrap ERC20")]
+fn validate_strk_rejects_default_when_bootstrap_active() {
+    let chain_info = ChainInfo::default();
+    validate_strk_fee_token_for_active_bootstrap(&chain_info, BootstrapState::DeclareContracts);
+}
+
+#[test]
+#[should_panic(expected = "must match the embedded bootstrap ERC20 address")]
+fn validate_strk_rejects_mismatch_when_bootstrap_active() {
+    let mut chain_info = ChainInfo::default();
+    chain_info.fee_token_addresses.strk_fee_token_address = ContractAddress::from(1_u128);
+    validate_strk_fee_token_for_active_bootstrap(&chain_info, BootstrapState::DeployAccount);
 }

--- a/crates/apollo_storage/src/bootstrap_contracts.rs
+++ b/crates/apollo_storage/src/bootstrap_contracts.rs
@@ -7,12 +7,24 @@ use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass as CairoLangContractClass;
 use serde_json::from_str;
 use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
-use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::core::{
+    ClassHash,
+    CompiledClassHash,
+    ContractAddress,
+    Nonce,
+    calculate_contract_address,
+};
+use starknet_api::hash::StarkHash;
 use starknet_api::state::SierraContractClass;
+use starknet_api::transaction::fields::{Calldata, ContractAddressSalt};
 
 #[cfg(test)]
 #[path = "bootstrap_contracts_test.rs"]
 mod bootstrap_contracts_test;
+
+/// Account nonce after `deploy_account`; used as salt for STRK deploy (must stay in sync with
+/// `PRE_FEE_TOKEN_SETUP_NONCE` in the batcher bootstrap module).
+const PRE_FEE_TOKEN_SETUP_NONCE_U128: u128 = 1;
 
 const DUMMY_ACCOUNT_SIERRA_JSON: &str =
     include_str!("../resources/bootstrap_contracts/cairo1/sierra/dummy_account.sierra.json");
@@ -39,6 +51,10 @@ pub const BOOTSTRAP_ACCOUNT_COMPILED_CLASS_HASH: &str =
 /// (`bootstrap_erc20_compiled_class_hash`).
 pub const BOOTSTRAP_ERC20_COMPILED_CLASS_HASH: &str =
     "0x7352cd4c7c86d16bb9dbe28d286f78279e27017f731f8afe1562dede8a41cb3";
+/// Hex address of the bootstrap STRK fee token (`bootstrap_strk_fee_token_contract_address`).
+/// Must match `BOOTSTRAP_STRK_ADDRESS` in the batcher bootstrap module.
+pub const BOOTSTRAP_STRK_FEE_TOKEN_ADDRESS: &str =
+    "0x00147c72fb4b344340f0ea15948cd438ad45caac3c8e8428b1e3493b13d41f00";
 
 fn sierra_from_json(json: &str) -> SierraContractClass {
     let cairo_class: CairoLangContractClass = from_str(json).expect("Invalid Sierra JSON");
@@ -69,6 +85,18 @@ pub fn bootstrap_erc20_class_hash() -> ClassHash {
     bootstrap_erc20_sierra().calculate_class_hash()
 }
 
+/// Deterministic address of the bootstrap account (`deploy_account`: salt 0, empty calldata).
+pub fn bootstrap_account_contract_address() -> ContractAddress {
+    let account_class_hash = bootstrap_account_class_hash();
+    calculate_contract_address(
+        ContractAddressSalt::default(),
+        account_class_hash,
+        &Calldata::default(),
+        ContractAddress::default(),
+    )
+    .expect("Failed to calculate account contract address")
+}
+
 /// Returns the compiled class hash (V2) of the bootstrap account contract.
 pub fn bootstrap_account_compiled_class_hash() -> CompiledClassHash {
     casm_from_json(DUMMY_ACCOUNT_CASM_JSON).hash(&HashVersion::V2)
@@ -77,4 +105,21 @@ pub fn bootstrap_account_compiled_class_hash() -> CompiledClassHash {
 /// Returns the compiled class hash (V2) of the bootstrap ERC20 contract.
 pub fn bootstrap_erc20_compiled_class_hash() -> CompiledClassHash {
     casm_from_json(ERC20_TESTING_CASM_JSON).hash(&HashVersion::V2)
+}
+
+/// Deterministic address of the STRK fee token deployed during bootstrap (ERC20 from hardcoded
+/// Sierra; same `calculate_contract_address` rules as the batcher `BootstrapLayout`).
+pub fn bootstrap_strk_fee_token_contract_address() -> ContractAddress {
+    let erc20_class_hash = bootstrap_erc20_class_hash();
+    let account_address = bootstrap_account_contract_address();
+
+    let strk_deploy_nonce = Nonce(StarkHash::from(PRE_FEE_TOKEN_SETUP_NONCE_U128));
+    let strk_constructor_calldata = Calldata(vec![*account_address.0.key()].into());
+    calculate_contract_address(
+        ContractAddressSalt(strk_deploy_nonce.0),
+        erc20_class_hash,
+        &strk_constructor_calldata,
+        account_address,
+    )
+    .expect("Failed to calculate STRK fee token contract address")
 }

--- a/crates/apollo_storage/src/bootstrap_contracts_compile_test.rs
+++ b/crates/apollo_storage/src/bootstrap_contracts_compile_test.rs
@@ -44,6 +44,28 @@ fn read_expected_json(relative_to_manifest: &str) -> Value {
 fn bootstrap_erc20_cairo_matches_committed_sierra_and_casm() {
     let (sierra_bytes, casm_bytes) = compile_bootstrap_erc20();
 
+    if std::env::var("APOLLO_STORAGE_UPDATE_BOOTSTRAP_ERC20_ARTIFACTS").as_deref() == Ok("1") {
+        let sierra_path = manifest_dir()
+            .join("resources/bootstrap_contracts/cairo1/sierra/erc20_testing.sierra.json");
+        let casm_path = manifest_dir()
+            .join("resources/bootstrap_contracts/cairo1/compiled/erc20_testing.casm.json");
+        let got_sierra: Value =
+            serde_json::from_slice(&sierra_bytes).expect("compiled output is valid Sierra JSON");
+        let got_casm: Value =
+            serde_json::from_slice(&casm_bytes).expect("compiled output is valid CASM JSON");
+        std::fs::write(
+            &sierra_path,
+            serde_json::to_string_pretty(&got_sierra).expect("serialize sierra"),
+        )
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", sierra_path.display()));
+        std::fs::write(
+            &casm_path,
+            serde_json::to_string_pretty(&got_casm).expect("serialize casm"),
+        )
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", casm_path.display()));
+        return;
+    }
+
     let got_sierra: Value =
         serde_json::from_slice(&sierra_bytes).expect("compiled output is valid Sierra JSON");
     let expected_sierra =

--- a/crates/apollo_storage/src/bootstrap_contracts_test.rs
+++ b/crates/apollo_storage/src/bootstrap_contracts_test.rs
@@ -1,18 +1,28 @@
-use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, PatriciaKey};
 use starknet_types_core::felt::Felt;
 
 use crate::bootstrap_contracts::{
+    BOOTSTRAP_ACCOUNT_CLASS_HASH,
+    BOOTSTRAP_ACCOUNT_COMPILED_CLASS_HASH,
+    BOOTSTRAP_ERC20_CLASS_HASH,
+    BOOTSTRAP_ERC20_COMPILED_CLASS_HASH,
+    BOOTSTRAP_STRK_FEE_TOKEN_ADDRESS,
     bootstrap_account_class_hash,
     bootstrap_account_compiled_class_hash,
     bootstrap_account_sierra,
     bootstrap_erc20_class_hash,
     bootstrap_erc20_compiled_class_hash,
     bootstrap_erc20_sierra,
-    BOOTSTRAP_ACCOUNT_CLASS_HASH,
-    BOOTSTRAP_ACCOUNT_COMPILED_CLASS_HASH,
-    BOOTSTRAP_ERC20_CLASS_HASH,
-    BOOTSTRAP_ERC20_COMPILED_CLASS_HASH,
+    bootstrap_strk_fee_token_contract_address,
 };
+
+#[test]
+fn bootstrap_strk_fee_token_address_matches_hardcoded_layout() {
+    assert_eq!(
+        bootstrap_strk_fee_token_contract_address(),
+        ContractAddress(PatriciaKey::from_hex_unchecked(BOOTSTRAP_STRK_FEE_TOKEN_ADDRESS)),
+    );
+}
 
 /// Loads hardcoded Sierra/CASM via the public API (parse + conversion + CASM hash) and asserts
 /// stable hashes. Regenerating committed JSON or changing hash rules requires updating these


### PR DESCRIPTION
Add bootstrap_account_contract_address and bootstrap_strk_fee_token_contract_address in apollo_storage; validate in create_batcher using current_bootstrap_state (no-op after bootstrap completes). Tests and refresh embedded ERC20 hash constants in bootstrap_contracts_test.

Made-with: Cursor