### PR TITLE
blockifier_reexecution: override execute and validate max sierra gas in replay

### DIFF
--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -262,6 +262,8 @@ pub struct VersionedConstants {
     pub block_direct_execute_call: bool,
     pub ignore_inner_event_resources: bool,
     pub disable_deploy_in_validation_mode: bool,
+    #[cfg(feature = "reexecution")]
+    pub ignore_user_l2_gas_bound: bool,
 
     // Compiler settings.
     pub enable_reverts: bool,
@@ -304,6 +306,8 @@ impl From<RawVersionedConstants> for VersionedConstants {
             block_direct_execute_call: raw_vc.block_direct_execute_call,
             ignore_inner_event_resources: raw_vc.ignore_inner_event_resources,
             disable_deploy_in_validation_mode: raw_vc.disable_deploy_in_validation_mode,
+            #[cfg(feature = "reexecution")]
+            ignore_user_l2_gas_bound: false,
             enable_reverts: raw_vc.enable_reverts,
             enable_casm_hash_migration: raw_vc.enable_casm_hash_migration,
             block_casm_hash_v1_declares: raw_vc.block_casm_hash_v1_declares,
@@ -836,7 +840,7 @@ impl SyscallGasCost {
     }
 }
 
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "testing", feature = "reexecution"), derive(Clone))]
 #[derive(Debug, Default, PartialEq)]
 pub struct SyscallGasCosts {
     pub call_contract: SyscallGasCost,
@@ -915,7 +919,7 @@ impl SyscallGasCosts {
     }
 }
 
-#[cfg_attr(any(test, feature = "testing"), derive(Clone, Copy))]
+#[cfg_attr(any(test, feature = "testing", feature = "reexecution"), derive(Clone, Copy))]
 #[derive(Debug, Default, PartialEq)]
 pub struct BaseGasCosts {
     pub step_gas_cost: u64,
@@ -989,7 +993,7 @@ impl BuiltinGasCosts {
 }
 
 /// Gas cost constants. For more documentation see in core/os/constants.cairo.
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "testing", feature = "reexecution"), derive(Clone))]
 #[derive(Debug, Default, PartialEq)]
 pub struct GasCosts {
     pub base: BaseGasCosts,
@@ -1130,7 +1134,7 @@ impl GasCosts {
     }
 }
 
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "testing", feature = "reexecution"), derive(Clone))]
 #[derive(Debug, Default, PartialEq)]
 pub struct OsConstants {
     pub gas_costs: GasCosts,

--- a/crates/blockifier/src/context.rs
+++ b/crates/blockifier/src/context.rs
@@ -61,7 +61,13 @@ impl TransactionContext {
             TransactionInfo::Current(CurrentTransactionInfo {
                 resource_bounds: ValidResourceBounds::AllResources(AllResourceBounds { l2_gas, .. }),
                 ..
-            }) => l2_gas.max_amount,
+            }) => {
+                #[cfg(feature = "reexecution")]
+                if self.block_context.versioned_constants.ignore_user_l2_gas_bound {
+                    return self.block_context.versioned_constants.initial_gas_no_user_l2_bound();
+                }
+                l2_gas.max_amount
+            }
         }
     }
 

--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -322,6 +322,16 @@ impl RpcStateReader {
         let mut versioned_constants = self.get_versioned_constants()?;
         if let Some(version) = min_sierra_version_for_sierra_gas {
             versioned_constants.min_sierra_version_for_sierra_gas = version;
+            // When overriding min_sierra_version, contracts that normally run in CairoSteps
+            // mode (with effectively infinite gas) are forced into SierraGas mode, where gas
+            // is capped by execute/validate_max_sierra_gas. Raise these limits to match
+            // default_initial_gas_cost so these contracts don't hit out-of-gas errors.
+            let mut new_os_constants = (*versioned_constants.os_constants).clone();
+            let default_gas = new_os_constants.default_initial_gas_cost;
+            new_os_constants.execute_max_sierra_gas = default_gas;
+            new_os_constants.validate_max_sierra_gas = default_gas;
+            versioned_constants.os_constants = Arc::new(new_os_constants);
+            versioned_constants.ignore_user_l2_gas_bound = true;
         }
         Ok(BlockContext::new(
             self.get_block_info()?,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes gas-limit behavior during replay by overriding `execute_max_sierra_gas`/`validate_max_sierra_gas`, which can affect fidelity of reexecution results. The `Clone` derives are build-time gated and low risk but broaden feature-surface for copying constants.
> 
> **Overview**
> When `min_sierra_version_for_sierra_gas` is overridden during RPC reexecution, the block context now *also* bumps `execute_max_sierra_gas` and `validate_max_sierra_gas` to match `default_initial_gas_cost`, preventing contracts forced into Sierra-gas mode from failing with out-of-gas.
> 
> To support that override, several constants structs in `blockifier_versioned_constants` (`SyscallGasCosts`, `BaseGasCosts`, `GasCosts`, `OsConstants`) now derive `Clone` under the `reexecution` feature so the reexecution crate can safely clone and mutate OS constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a7c0db64651d654d1964585aa5e8a4d5d51a01d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->