### PR TITLE
starknet_committer_and_os_cli: add TreeKey trait and TreeRequest struct for snap sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12482,6 +12482,7 @@ version = "0.0.0"
 dependencies = [
  "apollo_infra_utils",
  "apollo_starknet_os_program",
+ "apollo_storage",
  "assert_matches",
  "blockifier",
  "cairo-lang-starknet-classes",

--- a/crates/starknet_committer_and_os_cli/Cargo.toml
+++ b/crates/starknet_committer_and_os_cli/Cargo.toml
@@ -10,6 +10,7 @@ description = "Cli for the committer package."
 workspace = true
 
 [dev-dependencies]
+apollo_storage = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 criterion = { workspace = true, features = ["html_reports"] }
 futures.workspace = true
@@ -19,6 +20,7 @@ tempfile.workspace = true
 # TODO(Amos): Add `testing` feature and move Python test dependencies under it.
 [dependencies]
 apollo_infra_utils.workspace = true
+apollo_storage.workspace = true
 # The 'test_programs' feature should be moved under `testing` feature, when it exists.
 apollo_starknet_os_program = { workspace = true, features = ["test_programs"] }
 blockifier.workspace = true

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
@@ -1,3 +1,6 @@
+use apollo_storage::StorageReader;
+use starknet_api::block::BlockNumber;
+use starknet_committer::block_committer::input::StateDiff;
 use starknet_types_core::felt::Felt;
 
 #[cfg(test)]
@@ -25,4 +28,38 @@ fn compute_actual_end(start: Felt, last_key: Felt) -> Felt {
         max_contained_bits.min(trailing_zeros)
     };
     start + Felt::TWO.pow(exponent) - Felt::ONE
+}
+
+/// Identifies which Patricia tree a request targets.
+/// Trait for Patricia tree key types used in `TreeRequest`.
+///
+/// `Context` carries any per-request metadata needed by `scan`.
+#[allow(dead_code)]
+trait TreeKey: Copy + Into<Felt> + Send + Sync + 'static {
+    type Context: Clone + Send + Sync + 'static;
+
+    /// Converts a `Felt` to the key type, assuming it is a valid key.
+    fn from_felt(felt: Felt) -> Self;
+
+    /// Scans entries in `[start, end]` at `block_target` and returns `(state_diff, actual_end)`.
+    ///
+    /// `actual_end` is the inclusive end of the largest aligned Patricia subtree starting at the
+    /// leaf `start` that is fully covered by the scan. The number of entries is ≤ `size_limit`.
+    fn scan(
+        reader: &StorageReader,
+        request: &TreeRequest<Self>,
+        block_target: BlockNumber,
+        size_limit: usize,
+    ) -> (StateDiff, Felt);
+}
+
+/// A request to populate a subtree of a particular tree.
+///
+/// `start` and `end` are both inclusive. For a valid subtree the range must satisfy:
+/// `size = end - start + 1` is a power of two and `start % size == 0`.
+#[allow(dead_code)]
+struct TreeRequest<K: TreeKey> {
+    context: K::Context,
+    start: K,
+    end: K,
 }


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive, currently-unused types plus a new dependency; low behavioral risk aside from potential build/dependency integration issues.
> 
> **Overview**
> Adds a new generic abstraction for snap-sync trie population by introducing the `TreeKey` trait (with a `scan` API over storage at a target block) and a typed `TreeRequest` struct carrying per-trie context plus `[start,end]` key ranges.
> 
> Wires in the required `apollo_storage` dependency (including `testing` feature for dev) and updates `Cargo.lock` to support storage-backed scanning in the CLI crate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e325ed8d11b27290c0fb37e08fbcd8bc14172fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->