### PR TITLE
starknet_committer_and_os_cli: add snap sync scan tests

### DIFF
--- a/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync_test.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync_test.rs
@@ -1,7 +1,44 @@
-use starknet_api::{class_hash, patricia_key};
+use std::collections::HashMap;
+
+use apollo_storage::state::StateStorageWriter;
+use apollo_storage::test_utils::get_test_storage;
+use indexmap::IndexMap;
+use starknet_api::block::BlockNumber;
+use starknet_api::core::{ClassHash, ContractAddress};
+use starknet_api::state::{StorageKey, ThinStateDiff};
+use starknet_api::{
+    class_hash,
+    compiled_class_hash,
+    contract_address,
+    nonce,
+    patricia_key,
+    storage_key,
+};
+use starknet_committer::block_committer::input::{
+    StarknetStorageKey,
+    StarknetStorageValue,
+    StateDiff,
+};
+use starknet_committer::patricia_merkle_tree::types::CompiledClassHash as CommitterCompiledClassHash;
 use starknet_types_core::felt::Felt;
 
-use super::{compute_actual_end, shrink_to_actual_end};
+use super::{compute_actual_end, shrink_to_actual_end, TreeKey, TreeRequest};
+
+// Key positions and values shared across all scan tests.
+const ENTRY_KEY_1: u64 = 1;
+const ENTRY_KEY_2: u64 = 2;
+const ENTRY_VALUE_1_BLOCK_0: u64 = 10;
+const ENTRY_VALUE_1_BLOCK_1: u64 = 99;
+const ENTRY_VALUE_2: u64 = 20;
+
+const BLOCK_0_ENTRIES: [(u64, u64); 2] =
+    [(ENTRY_KEY_1, ENTRY_VALUE_1_BLOCK_0), (ENTRY_KEY_2, ENTRY_VALUE_2)];
+const BLOCK_1_ENTRIES: [(u64, u64); 1] = [(ENTRY_KEY_1, ENTRY_VALUE_1_BLOCK_1)];
+// size_limit=1 at block 0: only ENTRY_KEY_1 returned.
+const EXPECTED_SCANNED_ENTRIES: [(u64, u64); 1] = [(ENTRY_KEY_1, ENTRY_VALUE_1_BLOCK_0)];
+// With size_limit=1 the last entry is ENTRY_KEY_1=1:
+// shrink_to_actual_end snaps to the subtree [0, 1], so actual_end=1.
+const EXPECTED_ACTUAL_END: Felt = Felt::ONE;
 
 #[test]
 fn test_compute_actual_end_single_element() {
@@ -78,4 +115,144 @@ fn test_shrink_to_actual_end_at_limit_truncates() {
         vec![(class_hash!(0_u64), ()), (class_hash!(1_u64), ()), (class_hash!(2_u64), ()),]
     );
     assert_eq!(actual_end, Felt::from(3u64));
+}
+
+/// Sets up storage with two blocks, runs a scan at block 0 and asserts both `actual_end` and the
+/// returned `StateDiff`.
+fn run_scan_testing<K: TreeKey>(
+    diff_at_block_0: ThinStateDiff,
+    diff_at_block_1: ThinStateDiff,
+    context: K::Context,
+    size_limit: usize,
+    expected_state_diff: StateDiff,
+) {
+    let ((reader, mut writer), _temp_dir) = get_test_storage();
+    let mut txn = writer.begin_rw_txn().unwrap();
+    txn = txn.append_state_diff(BlockNumber(0), diff_at_block_0).unwrap();
+    txn = txn.append_state_diff(BlockNumber(1), diff_at_block_1).unwrap();
+    txn.commit().unwrap();
+
+    let request = TreeRequest { context, start: patricia_key!(0_u64), end: patricia_key!(255_u64) };
+    let (state_diff, actual_end) = K::scan(&reader, &request, BlockNumber(0), size_limit);
+    assert_eq!(actual_end, EXPECTED_ACTUAL_END);
+    assert_eq!(state_diff, expected_state_diff);
+}
+
+#[test]
+fn test_class_hash_scan() {
+    run_scan_testing::<ClassHash>(
+        ThinStateDiff {
+            class_hash_to_compiled_class_hash: BLOCK_0_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (class_hash!(key), compiled_class_hash!(value)))
+                .collect(),
+            ..Default::default()
+        },
+        // Block 1 updates class_hash!(ENTRY_KEY_1); scanning at block 0 must return the original
+        // value.
+        ThinStateDiff {
+            class_hash_to_compiled_class_hash: BLOCK_1_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (class_hash!(key), compiled_class_hash!(value)))
+                .collect(),
+            ..Default::default()
+        },
+        (),
+        1,
+        StateDiff {
+            class_hash_to_compiled_class_hash: EXPECTED_SCANNED_ENTRIES
+                .into_iter()
+                .map(|(key, value)| {
+                    (class_hash!(key), CommitterCompiledClassHash(Felt::from(value)))
+                })
+                .collect(),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_contract_address_scan() {
+    run_scan_testing::<ContractAddress>(
+        ThinStateDiff {
+            deployed_contracts: BLOCK_0_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (contract_address!(key), class_hash!(value)))
+                .collect(),
+            nonces: BLOCK_0_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (contract_address!(key), nonce!(value)))
+                .collect(),
+            ..Default::default()
+        },
+        ThinStateDiff {
+            deployed_contracts: BLOCK_1_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (contract_address!(key), class_hash!(value)))
+                .collect(),
+            nonces: BLOCK_1_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (contract_address!(key), nonce!(value)))
+                .collect(),
+            ..Default::default()
+        },
+        (),
+        // size_limit=2 implies internal class hash limit of 1.
+        2,
+        StateDiff {
+            address_to_class_hash: EXPECTED_SCANNED_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (contract_address!(key), class_hash!(value)))
+                .collect(),
+            address_to_nonce: EXPECTED_SCANNED_ENTRIES
+                .into_iter()
+                .map(|(key, value)| (contract_address!(key), nonce!(value)))
+                .collect(),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_storage_key_scan() {
+    let contract = contract_address!(1_u64);
+    run_scan_testing::<StorageKey>(
+        ThinStateDiff {
+            storage_diffs: IndexMap::from([(
+                contract,
+                BLOCK_0_ENTRIES
+                    .into_iter()
+                    .map(|(key, value)| (storage_key!(key), Felt::from(value)))
+                    .collect(),
+            )]),
+            ..Default::default()
+        },
+        ThinStateDiff {
+            storage_diffs: IndexMap::from([(
+                contract,
+                BLOCK_1_ENTRIES
+                    .into_iter()
+                    .map(|(key, value)| (storage_key!(key), Felt::from(value)))
+                    .collect(),
+            )]),
+            ..Default::default()
+        },
+        contract,
+        1,
+        StateDiff {
+            storage_updates: HashMap::from([(
+                contract,
+                EXPECTED_SCANNED_ENTRIES
+                    .into_iter()
+                    .map(|(key, value)| {
+                        (
+                            StarknetStorageKey(storage_key!(key)),
+                            StarknetStorageValue(Felt::from(value)),
+                        )
+                    })
+                    .collect(),
+            )]),
+            ..Default::default()
+        },
+    );
 }


### PR DESCRIPTION
Adds run_scan_testing helper and test_class_hash_scan,
test_contract_address_scan, and test_storage_key_scan tests that
verify the TreeKey::scan implementations against a two-block storage.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that increase coverage for snap-sync scanning logic without altering production code paths.
> 
> **Overview**
> Adds integration-style scan tests in `snap_sync_test.rs` that populate a two-block test storage and validate `TreeKey::scan` behavior at a target block.
> 
> Introduces a reusable `run_scan_testing` helper plus fixtures to assert both the returned `StateDiff` and the computed `actual_end` for `ClassHash`, `ContractAddress` (including nonce fetch and `size_limit/2` behavior), and `StorageKey` scans, ensuring later-block updates don’t affect scans at block 0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9951e53491fe339d08deb0bde903bcf1fbeda8de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->