### PR TITLE
apollo_network: skip bootstrap peers when cancelling stale target dials

### DIFF
--- a/crates/apollo_network/src/discovery/behaviours/bootstrapping/mod.rs
+++ b/crates/apollo_network/src/discovery/behaviours/bootstrapping/mod.rs
@@ -118,6 +118,10 @@ impl NetworkBehaviour for BootstrappingBehaviour {
 }
 
 impl BootstrappingBehaviour {
+    pub fn is_bootstrap_peer(&self, peer_id: &PeerId) -> bool {
+        self.bootstrap_peers.contains_key(peer_id)
+    }
+
     pub fn new(local_peer_id: PeerId, bootstrap_peers: Vec<(PeerId, Multiaddr)>) -> Self {
         let unique_peer_ids: std::collections::HashSet<_> =
             bootstrap_peers.iter().map(|(id, _)| id).collect();

--- a/crates/apollo_network/src/discovery/discovery_test.rs
+++ b/crates/apollo_network/src/discovery/discovery_test.rs
@@ -482,14 +482,12 @@ async fn set_target_peers_does_not_cancel_bootstrap_dials(
     );
 }
 
-// TODO(AndrewL): cancel_dial is origin-agnostic — it cancels ALL DialPeerStreams for a peer,
-// including bootstrap-originated ones. If a bootstrap peer overlaps with the target set and is
-// then removed from targets, its bootstrap dial is killed too. BootstrappingBehaviour only
-// re-emits RequestDial on ConnectionClosed (not on cancellation), so the peer becomes
-// permanently unreachable. This test documents the current (buggy) behavior.
+/// Verifies that removing a bootstrap peer from the target set does not cancel its
+/// bootstrap-originated dial. This is the overlapping case: the bootstrap peer was temporarily
+/// in the target set and then removed.
 #[rstest::rstest]
 #[tokio::test]
-async fn set_target_peers_cancels_bootstrap_dial_when_bootstrap_peer_overlaps_with_targets(
+async fn set_target_peers_does_not_cancel_bootstrap_dial_even_when_peer_was_in_target_set(
     #[values(CONFIG_WITH_LARGE_HEARTBEAT_AND_SMALL_BOOTSTRAP_SLEEP)] config: DiscoveryConfig,
     bootstrap_peer_id: PeerId,
     bootstrap_peer_address: Multiaddr,
@@ -514,12 +512,14 @@ async fn set_target_peers_cancels_bootstrap_dial_when_bootstrap_peer_overlaps_wi
     behaviour.set_target_peers(HashSet::from([bootstrap_peer_id]));
     behaviour.set_target_peers(HashSet::new());
 
-    // Advance time well past the retry backoff.
-    tokio::time::pause();
-    tokio::time::advance(config.bootstrap_dial_retry_config.max_delay_seconds + TIMEOUT_EPSILON)
-        .await;
-    tokio::time::resume();
-
-    // THIS IS THE BUG: The bootstrap dial was cancelled — no re-dial occurs.
-    assert_no_event(&mut behaviour);
+    // Verify the bootstrap peer is still re-dialed after backoff.
+    let event = check_event_happens_after_given_duration(
+        &mut behaviour,
+        config.bootstrap_dial_retry_config.max_delay_seconds,
+    )
+    .await;
+    assert_matches!(
+        event,
+        ToSwarm::Dial { opts } if opts.get_peer_id() == Some(bootstrap_peer_id)
+    );
 }

--- a/crates/apollo_network/src/discovery/mod.rs
+++ b/crates/apollo_network/src/discovery/mod.rs
@@ -259,7 +259,9 @@ impl Behaviour {
     pub fn set_target_peers(&mut self, peers: std::collections::HashSet<PeerId>) {
         let removed_peers = self.kad_requesting.set_target_peers(peers);
         for peer_id in &removed_peers {
-            self.dialing.cancel_dial(peer_id);
+            if !self.boot_strapping.is_bootstrap_peer(peer_id) {
+                self.dialing.cancel_dial(peer_id);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dial-cancellation semantics in discovery so bootstrap peers keep retrying even when removed from the target set; could alter connection churn and retry behavior in edge cases with overlapping target/bootstrap peers.
> 
> **Overview**
> Discovery no longer cancels in-flight dial attempts for peers that are configured as **bootstrap peers** when the target set is updated.
> 
> `BootstrappingBehaviour` exposes `is_bootstrap_peer`, and `Behaviour::set_target_peers` now skips `dialing.cancel_dial` for removed peers that are bootstrap peers, ensuring bootstrap retry/backoff continues even in the *overlapping* case where a bootstrap peer was temporarily included in (and then removed from) the target set.
> 
> Tests were updated to assert the corrected behavior by expecting a re-dial after backoff instead of documenting the prior cancellation bug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 898b66cb890ba907777d5b1038805bdcd04f562f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->