### PR TITLE
apollo_network: make peer access control enforcement always active

### DIFF
--- a/crates/apollo_network/src/e2e_broadcast_test.rs
+++ b/crates/apollo_network/src/e2e_broadcast_test.rs
@@ -1,9 +1,10 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use futures::{FutureExt, StreamExt};
 use libp2p::core::multiaddr::Protocol;
 use libp2p::swarm::SwarmEvent;
-use libp2p::{Multiaddr, Swarm};
+use libp2p::{Multiaddr, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt;
 use starknet_api::core::ChainId;
 
@@ -62,6 +63,7 @@ fn create_network_manager(
         None,
         MESSAGE_METADATA_BUFFER_SIZE,
         MESSAGE_METADATA_BUFFER_SIZE,
+        HashSet::new(),
     )
 }
 
@@ -93,14 +95,24 @@ async fn broadcast_subscriber_end_to_end_test() {
     let topic2 = Topic::new("TOPIC2");
     let mut bootstrap_swarm = create_swarm(None);
     let address = get_listen_address(&mut bootstrap_swarm).await;
-    let bootstrap_peer_multiaddr = address.with_p2p(*bootstrap_swarm.local_peer_id()).unwrap();
-    let bootstrap_network_manager = create_network_manager(bootstrap_swarm);
+    let bootstrap_peer_id = *bootstrap_swarm.local_peer_id();
+    let bootstrap_peer_multiaddr = address.with_p2p(bootstrap_peer_id).unwrap();
+
     // Don't poll subscriber swarms before wrapping in network managers — polling would
     // discard the initial RequestDial events from bootstrapping before the network
     // manager is ready to route them.
-    let mut network_manager1 =
-        create_network_manager(create_swarm(Some(bootstrap_peer_multiaddr.clone())));
-    let mut network_manager2 = create_network_manager(create_swarm(Some(bootstrap_peer_multiaddr)));
+    let mut swarm1 = create_swarm(Some(bootstrap_peer_multiaddr.clone()));
+    let mut swarm2 = create_swarm(Some(bootstrap_peer_multiaddr));
+
+    let all_peers: HashSet<PeerId> =
+        HashSet::from([bootstrap_peer_id, *swarm1.local_peer_id(), *swarm2.local_peer_id()]);
+    bootstrap_swarm.behaviour_mut().peer_access_control.set_allowed_peers(all_peers.clone());
+    swarm1.behaviour_mut().peer_access_control.set_allowed_peers(all_peers.clone());
+    swarm2.behaviour_mut().peer_access_control.set_allowed_peers(all_peers);
+
+    let bootstrap_network_manager = create_network_manager(bootstrap_swarm);
+    let mut network_manager1 = create_network_manager(swarm1);
+    let mut network_manager2 = create_network_manager(swarm2);
 
     let mut subscriber_channels1_1 =
         network_manager1.register_broadcast_topic::<Number>(topic1.clone(), BUFFER_SIZE).unwrap();

--- a/crates/apollo_network/src/mixed_behaviour.rs
+++ b/crates/apollo_network/src/mixed_behaviour.rs
@@ -1,5 +1,6 @@
 // TODO(shahak): Erase main_behaviour and make this a separate module.
 
+use std::collections::HashSet;
 use std::convert::Infallible;
 use std::time::Duration;
 
@@ -111,9 +112,16 @@ impl MixedBehaviour {
                     .collect()
             });
 
+        let mut peer_access_control = peer_access_control::Behaviour::new();
+        if let Some(ref peers) = bootstrap_peers_with_ids {
+            let bootstrap_peer_ids: HashSet<PeerId> =
+                peers.iter().map(|(peer_id, _)| *peer_id).collect();
+            peer_access_control.set_allowed_peers(bootstrap_peer_ids);
+        }
+
         Self {
             limits: connection_limits::Behaviour::new(connection_limits),
-            peer_access_control: peer_access_control::Behaviour::new(),
+            peer_access_control,
             peer_manager: peer_manager::PeerManager::new(peer_manager_config),
             discovery: bootstrap_peers_with_ids
                 .map(|peers| discovery::Behaviour::new(local_peer_id, discovery_config, peers))

--- a/crates/apollo_network/src/network_manager/mod.rs
+++ b/crates/apollo_network/src/network_manager/mod.rs
@@ -22,6 +22,7 @@ use futures::stream::{FuturesUnordered, Map, Stream};
 use futures::{pin_mut, FutureExt, Sink, SinkExt, StreamExt};
 use libp2p::gossipsub::{SubscriptionError, TopicHash};
 use libp2p::identity::Keypair;
+use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{noise, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder};
 use tracing::{debug, error, trace, warn};
@@ -109,6 +110,7 @@ pub struct GenericNetworkManager<SwarmT: SwarmTrait> {
     continue_propagation_sender: Sender<BroadcastedMessageMetadata>,
     continue_propagation_receiver: Receiver<BroadcastedMessageMetadata>,
     metrics: Option<NetworkMetrics>,
+    bootstrap_peer_ids: HashSet<PeerId>,
     committee_store: ActiveCommittees,
 }
 
@@ -188,10 +190,12 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             .committee_store
             .add_epoch(epoch_id, members)
             .expect("Committee members contain duplicate peer IDs");
-        let allowed_peers: HashSet<PeerId> = output.allowed_peers.into_iter().collect();
-        self.swarm.behaviour_mut().peer_access_control.set_allowed_peers(allowed_peers.clone());
+        let committee_peers: HashSet<PeerId> = output.allowed_peers.into_iter().collect();
+        let mut whitelisted_peers = committee_peers.clone();
+        whitelisted_peers.extend(&self.bootstrap_peer_ids);
+        self.swarm.behaviour_mut().peer_access_control.set_allowed_peers(whitelisted_peers);
         if let Some(discovery) = self.swarm.behaviour_mut().discovery.as_mut() {
-            discovery.set_target_peers(allowed_peers);
+            discovery.set_target_peers(committee_peers);
         }
         todo!("Wire remaining AddEpochOutput fields to behaviours");
     }
@@ -204,6 +208,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
         metrics: Option<NetworkMetrics>,
         broadcasted_message_metadata_buffer_size: usize,
         reported_peer_ids_buffer_size: usize,
+        bootstrap_peer_ids: HashSet<PeerId>,
     ) -> Self {
         let committee_store = ActiveCommittees::new(DEFAULT_ACTIVE_COMMITTEES_CAPACITY);
         let reported_peer_receivers = FuturesUnordered::new();
@@ -232,6 +237,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             continue_propagation_sender,
             continue_propagation_receiver,
             metrics,
+            bootstrap_peer_ids,
             committee_store,
         }
     }
@@ -1194,6 +1200,20 @@ impl NetworkManager {
         let listen_address = make_multiaddr(Ipv4Addr::UNSPECIFIED, port, None);
         debug!("Creating swarm with listen address: {listen_address:?}");
 
+        let bootstrap_peer_ids: HashSet<PeerId> = bootstrap_peer_multiaddr
+            .as_ref()
+            .map(|addrs| {
+                addrs
+                    .iter()
+                    .map(|addr| {
+                        DialOpts::from(addr.clone())
+                            .get_peer_id()
+                            .expect("bootstrap_peer_multiaddr doesn't have a peer id")
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let key_pair = match secret_key {
             Some(secret_key) => Keypair::ed25519_from_bytes(secret_key.expose_secret())
                 .expect("Error while parsing secret key"),
@@ -1240,6 +1260,7 @@ impl NetworkManager {
             metrics,
             broadcasted_message_metadata_buffer_size,
             reported_peer_ids_buffer_size,
+            bootstrap_peer_ids,
         )
     }
 

--- a/crates/apollo_network/src/network_manager/test.rs
+++ b/crates/apollo_network/src/network_manager/test.rs
@@ -230,6 +230,7 @@ async fn register_sqmr_protocol_client_and_use_channels() {
         None,
         MESSAGE_METADATA_BUFFER_SIZE,
         MESSAGE_METADATA_BUFFER_SIZE,
+        HashSet::new(),
     );
 
     // register subscriber and send payload
@@ -298,6 +299,7 @@ async fn process_incoming_query() {
         None,
         MESSAGE_METADATA_BUFFER_SIZE,
         MESSAGE_METADATA_BUFFER_SIZE,
+        HashSet::new(),
     );
 
     let mut inbound_payload_receiver = network_manager
@@ -340,6 +342,7 @@ async fn broadcast_message() {
         None,
         MESSAGE_METADATA_BUFFER_SIZE,
         MESSAGE_METADATA_BUFFER_SIZE,
+        HashSet::new(),
     );
 
     let mut broadcast_topic_client = network_manager
@@ -382,6 +385,7 @@ async fn receive_broadcasted_message_and_report_it() {
         None,
         MESSAGE_METADATA_BUFFER_SIZE,
         MESSAGE_METADATA_BUFFER_SIZE,
+        HashSet::new(),
     );
 
     let BroadcastTopicChannels {

--- a/crates/apollo_network/src/peer_access_control.rs
+++ b/crates/apollo_network/src/peer_access_control.rs
@@ -31,25 +31,16 @@ pub struct PeerNotAllowedError(PeerId);
 /// so all connections are denied.
 pub struct Behaviour {
     allowed_peers: HashSet<PeerId>,
-    // TODO(AndrewL): Default to true once all call-sites (e2e tests, NetworkManager bootstrap)
-    // wire `set_allowed_peers` with the correct peer set.
-    enforcement_active: bool,
     pending_disconnections: Vec<PeerId>,
     waker: Option<Waker>,
 }
 
 impl Behaviour {
     pub fn new() -> Self {
-        Self {
-            allowed_peers: HashSet::new(),
-            enforcement_active: false,
-            pending_disconnections: Vec::new(),
-            waker: None,
-        }
+        Self { allowed_peers: HashSet::new(), pending_disconnections: Vec::new(), waker: None }
     }
 
     pub fn set_allowed_peers(&mut self, peers: HashSet<PeerId>) {
-        self.enforcement_active = true;
         // Peers in the old set but not the new set should be disconnected. Requesting
         // disconnection for a peer that is not currently connected is a no-op in libp2p.
         let newly_disallowed: Vec<PeerId> =
@@ -72,7 +63,7 @@ impl Behaviour {
     }
 
     fn is_peer_allowed(&self, peer_id: &PeerId) -> bool {
-        !self.enforcement_active || self.allowed_peers.contains(peer_id)
+        self.allowed_peers.contains(peer_id)
     }
 
     fn deny_if_not_allowed(

--- a/crates/apollo_network/src/peer_access_control_test.rs
+++ b/crates/apollo_network/src/peer_access_control_test.rs
@@ -9,7 +9,7 @@ use libp2p::{Multiaddr, PeerId};
 use super::peer_access_control::Behaviour;
 
 #[test]
-fn allows_all_before_enforcement() {
+fn denies_all_with_empty_allowed_set() {
     let mut behaviour = Behaviour::new();
 
     let random_peer = PeerId::random();
@@ -19,7 +19,7 @@ fn allows_all_before_enforcement() {
         &Multiaddr::empty(),
         &Multiaddr::empty(),
     );
-    assert!(result.is_ok());
+    assert!(result.is_err());
 }
 
 #[test]

--- a/crates/apollo_network/tests/e2e_discovery_test.rs
+++ b/crates/apollo_network/tests/e2e_discovery_test.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::iter;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -48,7 +49,6 @@ async fn run_discovery_test(num_peers: usize, timeout: Duration) {
     let bootstrap_address = get_listen_address(&mut bootstrap_swarm).await;
     let bootstrap_peer_id = *bootstrap_swarm.local_peer_id();
     let bootstrap_multiaddr = bootstrap_address.with_p2p(bootstrap_peer_id).unwrap();
-    let bootstrap_network_manager = create_network_manager(bootstrap_swarm);
 
     // Create peer swarms without polling them to avoid discarding initial RequestDial events
     // from bootstrapping before the network manager is ready to route them.
@@ -59,6 +59,16 @@ async fn run_discovery_test(num_peers: usize, timeout: Duration) {
     // only as an initial discovery relay.
     let non_bootstrap_peer_ids: HashSet<PeerId> =
         swarms.iter().map(|s| *s.local_peer_id()).collect();
+
+    // Set allowed peers on all swarms so the whitelist permits connections.
+    let all_peer_ids: HashSet<PeerId> =
+        iter::once(bootstrap_peer_id).chain(non_bootstrap_peer_ids.iter().copied()).collect();
+    bootstrap_swarm.behaviour_mut().peer_access_control.set_allowed_peers(all_peer_ids.clone());
+    for swarm in &mut swarms {
+        swarm.behaviour_mut().peer_access_control.set_allowed_peers(all_peer_ids.clone());
+    }
+
+    let bootstrap_network_manager = create_network_manager(bootstrap_swarm);
 
     // Tell each swarm's discovery behaviour about all peers before wrapping.
     for swarm in &mut swarms {
@@ -417,6 +427,7 @@ fn create_network_manager(
         metrics,
         MESSAGE_METADATA_BUFFER_SIZE,
         MESSAGE_METADATA_BUFFER_SIZE,
+        HashSet::new(),
     )
 }
 
@@ -431,5 +442,6 @@ fn create_reporting_network_manager(
         metrics,
         MESSAGE_METADATA_BUFFER_SIZE,
         MESSAGE_METADATA_BUFFER_SIZE,
+        HashSet::new(),
     )
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Connection admission now defaults to deny unless peers are explicitly whitelisted, which can unintentionally partition nodes if call-sites fail to set the allowed set correctly. Changes also affect committee/bootstrapping peer selection, impacting connectivity and discovery behavior.
> 
> **Overview**
> **Peer access control is now always enforced**: `peer_access_control::Behaviour` no longer has an “enforcement inactive” mode, so an empty allowed set denies all inbound/outbound connections.
> 
> To keep bootstrapping working under the stricter default, `MixedBehaviour::new` pre-populates the whitelist with bootstrap peer IDs (when provided), and `NetworkManager::new` extracts and stores `bootstrap_peer_ids` so `add_epoch` whitelists *committee peers plus bootstrap peers* while discovery targets only committee peers. E2E discovery/broadcast tests were updated to explicitly set allowed peers on all swarms, and the unit test expectation was flipped to assert the default denies connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad3a0ce9b96dd68063c2bb89cc33db083d3f89c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->