### PR TITLE
blockifier,apollo_storage: remove unnecessary #[allow(unused)] attributes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,8 @@ jobs:
       # Run code style checks.
       - name: "Run TODO style"
         run: scripts/named_todos.py --commit_id ${{ github.event.pull_request.base.sha }}
+      - name: "Deny #[allow(unused)] (use #[expect(unused)] instead)"
+        run: scripts/deny_allow_unused.py --commit_id ${{ github.event.pull_request.base.sha }}
       - name: "Run clippy"
         run: scripts/run_tests.py --command clippy --changes_only --commit_id ${{ github.event.pull_request.base.sha }}
       - name: "Run cargo doc"

--- a/crates/apollo_consensus/src/manager_test.rs
+++ b/crates/apollo_consensus/src/manager_test.rs
@@ -796,7 +796,7 @@ async fn manager_successfully_syncs_when_higher_than_last_voted_height(
     const CURRENT_HEIGHT: BlockNumber = BlockNumber(LAST_VOTED_HEIGHT.0 + 1);
 
     let TestSubscriberChannels {
-        #[allow(unused)]
+        #[expect(unused)]
         // We need this to stay alive so that the network wont be automatically closed.
         mock_network,
         subscriber_channels,

--- a/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
+++ b/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
@@ -1,6 +1,6 @@
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 use std::sync::Arc;
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 use std::time::Instant;
 
 use apollo_storage::body::BodyStorageWriter;
@@ -8,12 +8,12 @@ use apollo_storage::class::ClassStorageWriter;
 use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::state::StateStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 use apollo_test_utils::{prometheus_is_contained, send_request};
 use jsonrpsee::Methods;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use pretty_assertions::assert_eq;
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 use prometheus_parse::Value::Counter;
 use starknet_api::block::{BlockBody, BlockHeader, BlockNumber};
 use starknet_api::state::ThinStateDiff;
@@ -46,7 +46,7 @@ fn get_method_and_version_test() {
 // TODO(victork): Update to use current jsonrpsee 0.24 API when re-enabling this test.
 // The API for creating MethodCallback and MethodResponse has changed significantly.
 #[ignore]
-#[allow(unused_imports, unused_variables)]
+#[expect(unused_imports, unused_variables)]
 #[test]
 fn logger_test() {
     let full_method_name = "starknet_V0_8_0_blockNumber";

--- a/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
+++ b/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
@@ -46,7 +46,6 @@ fn get_method_and_version_test() {
 // TODO(victork): Update to use current jsonrpsee 0.24 API when re-enabling this test.
 // The API for creating MethodCallback and MethodResponse has changed significantly.
 #[ignore]
-#[expect(unused_imports, unused_variables)]
 #[test]
 fn logger_test() {
     let full_method_name = "starknet_V0_8_0_blockNumber";

--- a/crates/apollo_storage/src/db/table_types/mod.rs
+++ b/crates/apollo_storage/src/db/table_types/mod.rs
@@ -8,7 +8,6 @@ use super::{DbResult, DbTransaction, TransactionKind, RW};
 
 mod dup_sort_tables;
 mod simple_table;
-#[allow(unused_imports)]
 pub(crate) use dup_sort_tables::CommonPrefix;
 pub(crate) use simple_table::SimpleTable;
 #[cfg(test)]

--- a/crates/apollo_storage/src/serialization/serializers.rs
+++ b/crates/apollo_storage/src/serialization/serializers.rs
@@ -558,7 +558,7 @@ auto_storage_serde! {
 ////////////////////////////////////////////////////////////////////////
 //  impl StorageSerde macro.
 ////////////////////////////////////////////////////////////////////////
-#[allow(unused_macro_rules)]
+#[expect(unused_macro_rules)]
 macro_rules! auto_storage_serde {
     () => {};
     // Tuple structs (no names associated with fields) - one field.

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -152,7 +152,6 @@ impl HashableNestedIntList for NestedFeltCounts {
 
 impl NestedFeltCounts {
     /// Builds a nested structure matching `layout`, consuming values from `bytecode`.
-    #[allow(unused)]
     pub fn new(bytecode_segment_lengths: &NestedIntList, bytecode: &[BigUintAsHex]) -> Self {
         let (base_node, consumed_felts) = Self::new_inner(bytecode_segment_lengths, bytecode, 0);
         assert_eq!(consumed_felts, bytecode.len());

--- a/crates/starknet_os_flow_tests/src/fuzz_tests.rs
+++ b/crates/starknet_os_flow_tests/src/fuzz_tests.rs
@@ -1179,7 +1179,7 @@ impl FuzzTestManager {
         initial_state.context.get_all_operation_tails(max_length, filter)
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     pub fn prettify_operations(&self) -> String {
         self.context.prettify_operations()
     }

--- a/crates/starknet_os_flow_tests/src/fuzz_tests.rs
+++ b/crates/starknet_os_flow_tests/src/fuzz_tests.rs
@@ -1179,7 +1179,7 @@ impl FuzzTestManager {
         initial_state.context.get_all_operation_tails(max_length, filter)
     }
 
-    #[expect(unused)]
+    #[cfg_attr(not(feature = "fuzz_test_debug"), expect(unused))]
     pub fn prettify_operations(&self) -> String {
         self.context.prettify_operations()
     }

--- a/scripts/deny_allow_unused.py
+++ b/scripts/deny_allow_unused.py
@@ -1,0 +1,77 @@
+#!/bin/env python3
+
+"""
+Enforces that `#[expect(unused*)]` is used instead of `#[allow(unused*)]` in Rust source files.
+
+With `#[expect(...)]`, the compiler warns (and CI errors via `-D warnings`) when the expectation is
+unfulfilled — i.e., when the item is no longer actually unused. This ensures allow-unused annotations
+stay in sync with reality.
+"""
+
+import argparse
+import os
+import re
+from typing import Optional
+
+from tests_utils import get_local_changes
+
+# Matches #[allow(unused...)], including inner attributes #![allow(unused...)].
+# Captures variants like: unused, unused_imports, unused_variables, unused_macro_rules, etc.
+ALLOW_UNUSED_PATTERN = re.compile(r"#!?\[allow\((unused\w*(?:\s*,\s*unused\w*)*)\s*(?:,\s*\w+)*\)]")
+
+
+def check_allow_unused(file_path: str) -> bool:
+    """
+    Checks that the file does not contain `#[allow(unused*)]` attributes.
+
+    Returns:
+        bool: True if the file is clean, False if violations were found.
+    """
+    violations = []
+    try:
+        with open(file_path, "r") as file:
+            for line_number, line in enumerate(file, start=1):
+                if ALLOW_UNUSED_PATTERN.search(line):
+                    violations.append((file_path, line_number, line.strip()))
+    except Exception as e:
+        print(f"Error while reading file {file_path}: {e}")
+        raise e
+
+    if violations:
+        print(f"{len(violations)} #[allow(unused*)] found (use #[expect(unused*)] instead):")
+        for file_path, line_number, line in violations:
+            print(f"  {file_path}:{line_number}: '{line}'")
+        return False
+    return True
+
+
+def enforce_no_allow_unused(commit_id: Optional[str]):
+    """
+    Enforce that modified Rust files use `#[expect(unused*)]` instead of `#[allow(unused*)]`.
+    If commit_id is provided, compares against that commit; otherwise, compares against HEAD.
+    """
+    local_changes = get_local_changes(".", commit_id=commit_id)
+    rust_files = [f for f in local_changes if f.endswith(".rs") and os.path.isfile(f)]
+    print(f"Checking for #[allow(unused*)] in modified Rust files: {rust_files}.")
+    successful_validation = all(check_allow_unused(file_path) for file_path in rust_files)
+    assert successful_validation, (
+        "Found #[allow(unused*)]. Use #[expect(unused*)] instead so the compiler warns when the "
+        "item is no longer unused."
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Enforce #[expect(unused*)] instead of #[allow(unused*)]."
+    )
+    parser.add_argument("--commit_id", type=str, help="GIT commit ID to compare against.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    enforce_no_allow_unused(commit_id=args.commit_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deny_allow_unused.py
+++ b/scripts/deny_allow_unused.py
@@ -15,9 +15,10 @@ from typing import Optional
 
 from tests_utils import get_local_changes
 
-# Matches #[allow(unused...)], including inner attributes #![allow(unused...)].
-# Captures variants like: unused, unused_imports, unused_variables, unused_macro_rules, etc.
-ALLOW_UNUSED_PATTERN = re.compile(r"#!?\[allow\((unused\w*(?:\s*,\s*unused\w*)*)\s*(?:,\s*\w+)*\)]")
+# Matches #[allow(...)] containing any bare unused* lint, regardless of position in the lint list.
+# Handles variants like: unused, unused_imports, unused_variables, unused_macro_rules, etc.
+# Excludes qualified lints like clippy::unused_async.
+ALLOW_UNUSED_PATTERN = re.compile(r"#!?\[allow\([^]]*(?<![:\w])unused\w*[^]]*\)]")
 
 
 def check_allow_unused(file_path: str) -> bool:

--- a/scripts/presubmit_fast_checks.py
+++ b/scripts/presubmit_fast_checks.py
@@ -11,6 +11,7 @@ from enum import Enum
 from os import path
 from typing import TypeVar
 
+from deny_allow_unused import enforce_no_allow_unused
 from named_todos import enforce_named_todos
 from run_tests import BaseCommand, run_test
 from utils import run_command
@@ -119,6 +120,23 @@ class TodosCheck(Check):
         return TodosCheck(from_commit_hash=args.from_commit_hash)
 
 
+class AllowUnusedCheck(Check):
+    def __init__(self, from_commit_hash: str):
+        assert from_commit_hash, "from_commit_hash is required for allow-unused check."
+        self.from_commit_hash = from_commit_hash
+
+    def run_check(self):
+        enforce_no_allow_unused(commit_id=self.from_commit_hash)
+
+    @classmethod
+    def required_args(cls: type[TCheck]) -> set[PresubmitArg]:
+        return {PresubmitArg.FROM_COMMIT_HASH}
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace):
+        return AllowUnusedCheck(from_commit_hash=args.from_commit_hash)
+
+
 class CargoLockCheck(ExternalCommandCheck):
     def __init__(self):
         super().__init__(
@@ -181,6 +199,7 @@ def main():
     all_check_classes = [
         GitSubmodulesCheck,
         TodosCheck,
+        AllowUnusedCheck,
         CargoLockCheck,
         RustFormatCheck,
         TaploCheck,


### PR DESCRIPTION
https://claude.ai/code/session_01Tt6w9shfh1UdU87Ui1ZhXf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily lint-annotation churn plus a new code-style check; failures would be limited to CI/presubmit gating when new `#[allow(unused*)]` is introduced.
> 
> **Overview**
> **Enforces stricter handling of unused-code suppressions in Rust.** CI and fast presubmit now run a new `deny_allow_unused` check that fails if modified `.rs` files contain `#[allow(unused*)]`, guiding contributors to use `#[expect(unused*)]` instead.
> 
> Updates several Rust modules/tests to replace `#[allow(unused*)]` with `#[expect(unused*)]` (and in one case gates the expectation behind a feature flag), removing a few now-unnecessary allow attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae96e22ec1c37e0259aa22086892797f8cd1bc8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->