### PR TITLE
echonet: L1Manager gas price target and mock L1 head

### DIFF
--- a/echonet/constants.py
+++ b/echonet/constants.py
@@ -23,6 +23,9 @@ IGNORED_L2_GAS_MISMATCH_ATTESTATION_CALLDATA = (
     "0x10398fe631af9ab2311840432d507bf7ef4b959ae967f1507928f5afe888a99"
 )
 
+# Fallback virtual L1 block number when no real L1 blocks are stored.
+# Must be above bpo2_start_block_number (9504747) so the BPO2 blob fee formula applies.
+DEFAULT_L1_BLOCK_NUMBER = 22_000_000
 # eip7892::BPO2_BASE_UPDATE_FRACTION in alloy-eips (used by the Rust scraper via
 # eip7840::BlobParams::bpo2().calc_blob_fee).
 BPO2_UPDATE_FRACTION = 11_684_671

--- a/echonet/l1_logic/l1_manager.py
+++ b/echonet/l1_logic/l1_manager.py
@@ -1,13 +1,16 @@
+import threading
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Optional
 
 from echonet.constants import (
+    DEFAULT_L1_BLOCK_NUMBER,
     STATE_BLOCK_HASH_SELECTOR,
     STATE_BLOCK_NUMBER_SELECTOR,
 )
 from echonet.helpers import format_hex, rpc_response
 from echonet.l1_logic.l1_blocks import L1Blocks
 from echonet.l1_logic.l1_client import L1Client
+from echonet.l1_logic.l1_gas_price import L1GasPrice
 from echonet.logger import get_logger
 
 
@@ -15,9 +18,13 @@ class L1Manager:
     """
     Manages L1 block data indexed by block number and provides mock RPC responses.
 
-    - get_block_number: returns the latest stored block number, or None if empty.
+    - get_block_number: returns _mock_l1_head_number (eth_blockNumber; always increasing).
     - get_logs: returns logs for all stored blocks in the requested range, or empty logs list if empty.
-    - get_block_by_number: returns block data and cleans up older blocks, or default block if not found.
+    - get_block_by_number: stored L1 tx data or default block.
+
+    The mock L1 head number is the source of truth for the gas price scraper.
+    It is incremented by set_gas_price_target (once per L2 block) and synced upward by set_new_tx
+    when real L1 block numbers are stored.
     """
 
     L1_SCRAPER_FINALITY_CONFIG_VALUE = 10
@@ -28,9 +35,8 @@ class L1Manager:
         block_data: dict
         logs_result: list[dict]
 
-    @staticmethod
-    def default_l1_block(block_number_hex: str) -> dict:
-        return {
+    def default_l1_block(self, block_number_hex: str) -> dict:
+        block: dict = {
             "number": block_number_hex,
             "hash": format_hex(0),
             "parentHash": format_hex(0),
@@ -43,7 +49,13 @@ class L1Manager:
             "difficulty": "0x0",
             "gasLimit": "0x0",
             "gasUsed": "0x0",
-            "timestamp": "0x0",
+            # set_gas_price_target is called with the NEXT feeder block's timestamp
+            # (T_next ≈ T_current + block_interval). The mock L1 timestamp must be ≤ T_current
+            # so the Rust lag-margin lookup (lag=0) finds a qualifying block. 30s is safely
+            # above the ~2s block interval and well below the 900s max_time_gap.
+            "timestamp": hex(max(0, self._l2_block_timestamp - 30))
+            if self._l2_block_timestamp
+            else "0x0",
             "extraData": "0x",
             "mixHash": format_hex(0),
             "nonce": format_hex(0, 16),
@@ -51,14 +63,50 @@ class L1Manager:
             "transactions": [],
             "uncles": [],
         }
+        if self._gas_price_target:
+            base_fee_wei, blob_fee_wei = self._gas_price_target
+            block["baseFeePerGas"] = hex(base_fee_wei)
+            block["excessBlobGas"] = hex(L1GasPrice.excess_blob_gas_for_fee(blob_fee_wei))
+            block["blobGasUsed"] = "0x0"
+        return block
 
     def __init__(
-        self, l1_client: L1Client, get_last_proved_block_callback: Callable[[], tuple[int, int]]
+        self,
+        l1_client: L1Client,
+        get_last_proved_block_callback: Callable[[], tuple[int, int]],
     ):
         self.logger = get_logger("l1_manager")
         self.l1_client = l1_client
         self.blocks: dict[int, L1Manager.L1TxData] = {}
         self.get_last_proved_block_callback = get_last_proved_block_callback
+        self._gas_price_target: Optional[tuple[int, int]] = None  # (base_fee_wei, blob_fee_wei)
+        # Mock L1 head (eth_blockNumber) when no real L1 blocks are stored.
+        # Incremented each time set_gas_price_target is called so the L1 gas price scraper
+        # sees a new block number and re-fetches, picking up the updated prices.
+        self._mock_l1_head_number: int = DEFAULT_L1_BLOCK_NUMBER
+        # L2 block timestamp corresponding to the current gas price target.
+        self._l2_block_timestamp: int = 0
+        # Condition used to implement long-polling in get_block_number.
+        # Notified whenever _mock_l1_head_number changes so waiting scrapers wake up
+        # immediately instead of hammering echonet with rapid polls.
+        self._mock_l1_head_updated = threading.Condition()
+
+    def _set_mock_l1_head_number(self, value: int) -> None:
+        with self._mock_l1_head_updated:
+            self._mock_l1_head_number = value
+            self._mock_l1_head_updated.notify_all()
+
+    def set_gas_price_target(
+        self, base_fee_wei: int, blob_fee_wei: int, l2_timestamp: int = 0
+    ) -> None:
+        """Set the gas prices returned by default_l1_block for the current sequencing target."""
+        self._gas_price_target = (base_fee_wei, blob_fee_wei)
+        self._l2_block_timestamp = l2_timestamp
+        self._set_mock_l1_head_number(self._mock_l1_head_number + 1)
+        self.logger.info(
+            f"Gas price target updated: base_fee_wei={base_fee_wei}, blob_fee_wei={blob_fee_wei}, "
+            f"l2_timestamp={l2_timestamp}, mock_l1_head_number={self._mock_l1_head_number}"
+        )
 
     def set_new_tx(self, feeder_gateway_tx: dict, l2_block_timestamp: int) -> None:
         """
@@ -79,13 +127,20 @@ class L1Manager:
 
         logs = logs_response.get("result", [])
         self.blocks[l1_block_number] = L1Manager.L1TxData(l1_block_number, l1_block_data, logs)
+
+        # Sync mock L1 head upward to cover the real L1 block so the gas price scraper advances.
+        synced_mock_l1_head = l1_block_number + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE
+        if synced_mock_l1_head > self._mock_l1_head_number:
+            self._set_mock_l1_head_number(synced_mock_l1_head)
+
         self.logger.debug(
             f"Stored L1 data for block {l1_block_number}, for L2 tx {feeder_gateway_tx['transaction_hash']}"
         )
 
     def clear_stored_blocks(self) -> None:
         self.blocks.clear()
-        self.logger.debug("Cleared all stored L1 blocks")
+        self._set_mock_l1_head_number(DEFAULT_L1_BLOCK_NUMBER)
+        self.logger.debug("Cleared all stored L1 blocks and reset mock L1 head number")
 
     # Mock RPC responses.
 
@@ -130,18 +185,18 @@ class L1Manager:
         return rpc_response(self.default_l1_block(block_number_hex))
 
     def get_block_number(self) -> dict:
-        """Returns the latest stored block number, or None if empty."""
-        if not self.blocks:
-            self.logger.debug("get_block_number: no blocks stored, returning None")
-            return rpc_response(None)
+        """Return mock L1 head (eth_blockNumber), blocking until it changes or timeout elapses.
 
-        latest_block_number = max(self.blocks.keys())
-        finalized_block_number = latest_block_number + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE
-        self.logger.debug(
-            f"get_block_number: returning finalized_block_number={finalized_block_number} "
-            f"(latest_block_number={latest_block_number} + finality={L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE})"
-        )
-        return rpc_response(hex(finalized_block_number))
+        Long-polling: the scraper (polling_interval=0) calls this in a tight loop. By waiting
+        here instead of returning immediately, we avoid hammering echonet with hundreds of
+        requests per second while still waking up within milliseconds of a new block.
+        notify_all() is used so both the gas price scraper and the events scraper unblock.
+        """
+        with self._mock_l1_head_updated:
+            self._mock_l1_head_updated.wait(timeout=0.5)
+            head = self._mock_l1_head_number
+        self.logger.debug(f"get_block_number: returning mock_l1_head_number={head}")
+        return rpc_response(hex(head))
 
     def get_call(self, params: dict) -> dict:
         """

--- a/echonet/l1_logic/tests/test_l1_manager.py
+++ b/echonet/l1_logic/tests/test_l1_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 from test_utils import L1TestUtils
 
+from echonet.constants import DEFAULT_L1_BLOCK_NUMBER
 from echonet.l1_logic.l1_blocks import L1Blocks
 from echonet.l1_logic.l1_client import L1Client
 from echonet.l1_logic.l1_manager import L1Manager
@@ -43,8 +44,11 @@ class TestL1Manager(unittest.TestCase):
             self.manager.set_new_tx({"transaction_hash": l1_block_number_hex}, 0)
 
     def test_empty_queue_returns_defaults(self):
+        # get_block_number returns the default mock L1 head (eth_blockNumber) when no blocks are stored.
         block_number = self.manager.get_block_number()
-        self.assertEqual(block_number, {"jsonrpc": "2.0", "id": "1", "result": None})
+        self.assertEqual(
+            block_number, {"jsonrpc": "2.0", "id": "1", "result": hex(DEFAULT_L1_BLOCK_NUMBER)}
+        )
 
         block_number_hex = hex(1)
         block = self.manager.get_block_by_number(block_number_hex)
@@ -53,7 +57,7 @@ class TestL1Manager(unittest.TestCase):
             {
                 "jsonrpc": "2.0",
                 "id": "1",
-                "result": L1Manager.default_l1_block(block_number_hex),
+                "result": self.manager.default_l1_block(block_number_hex),
             },
         )
 
@@ -68,7 +72,7 @@ class TestL1Manager(unittest.TestCase):
         self.mock_client.get_logs.return_value = L1TestUtils.LOGS_RPC_RESPONSE
         self.manager.set_new_tx(L1TestUtils.FEEDER_TX, L1TestUtils.L2_BLOCK_TIMESTAMP)
 
-        # Test.
+        # get_block_number returns mock L1 head synced to real block + finality.
         block_number = self.manager.get_block_number()
         self.assertEqual(
             block_number["result"],
@@ -85,71 +89,73 @@ class TestL1Manager(unittest.TestCase):
         self.assertEqual(logs, L1TestUtils.LOGS_RPC_RESPONSE)
 
     def test_multiple_blocks(self):
-        # Setup: add blocks 10, 20, 30.
-        for block_num in [10, 20, 30]:
+        b10 = DEFAULT_L1_BLOCK_NUMBER + 10
+        b20 = DEFAULT_L1_BLOCK_NUMBER + 20
+        b30 = DEFAULT_L1_BLOCK_NUMBER + 30
+        for block_num in [b10, b20, b30]:
             self._mock_handle_feeder_tx_and_store_l1_block(block_num)
 
-        # get_block_number returns latest block in manager + finality.
+        # Mock L1 head syncs to b30 + finality (10) = DEFAULT + 40.
         result = self.manager.get_block_number()
-        self.assertEqual(result["result"], hex(30 + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE))
+        self.assertEqual(result["result"], hex(DEFAULT_L1_BLOCK_NUMBER + 40))
 
         # get_logs merges all logs in range.
-        result = self.manager.get_logs(self.get_logs_input(10, 30))
+        result = self.manager.get_logs(self.get_logs_input(b10, b30))
         expected_logs = {
             "jsonrpc": "2.0",
             "id": "1",
             "result": [
-                {"blockNumber": hex(10), "data": "0x"},
-                {"blockNumber": hex(20), "data": "0x"},
-                {"blockNumber": hex(30), "data": "0x"},
+                {"blockNumber": hex(b10), "data": "0x"},
+                {"blockNumber": hex(b20), "data": "0x"},
+                {"blockNumber": hex(b30), "data": "0x"},
             ],
         }
         self.assertEqual(result, expected_logs)
 
-        # get_logs with partial range (only 20 exists in 15-25).
-        result = self.manager.get_logs(self.get_logs_input(15, 25))
+        # get_logs with partial range (only b20 exists in [b15, b25]).
+        b15 = DEFAULT_L1_BLOCK_NUMBER + 15
+        b25 = DEFAULT_L1_BLOCK_NUMBER + 25
+        result = self.manager.get_logs(self.get_logs_input(b15, b25))
         expected_logs = {
             "jsonrpc": "2.0",
             "id": "1",
-            "result": [{"blockNumber": hex(20), "data": "0x"}],
+            "result": [{"blockNumber": hex(b20), "data": "0x"}],
         }
         self.assertEqual(result, expected_logs)
 
     def test_cleanup_old_blocks(self):
-        # Setup: add blocks 10, 20, 30.
-        for block_num in [10, 20, 30]:
+        b10 = DEFAULT_L1_BLOCK_NUMBER + 10
+        b20 = DEFAULT_L1_BLOCK_NUMBER + 20
+        b30 = DEFAULT_L1_BLOCK_NUMBER + 30
+        for block_num in [b10, b20, b30]:
             self._mock_handle_feeder_tx_and_store_l1_block(block_num)
 
-        # get_block_by_number with cleanup buffer (2 * finality = 20)
-        # When requesting block 30, it keeps blocks >= (30 - 20) = 10
-        self.manager.get_block_by_number(hex(30))
+        self.assertIn(b10, self.manager.blocks, "Block b10 should be stored")
+        self.assertIn(b20, self.manager.blocks, "Block b20 should be stored")
+        self.assertIn(b30, self.manager.blocks, "Block b30 should be stored")
 
-        # Block 10 should still exist (within buffer of 30)
-        self.assertIn(10, self.manager.blocks, "Block 10 should be kept (within cleanup buffer)")
-        self.assertIn(20, self.manager.blocks, "Block 20 should be kept")
-        self.assertIn(30, self.manager.blocks, "Block 30 should be kept")
+        # Query DEFAULT+50: cleanup threshold = DEFAULT+30. b10 and b20 are strictly below
+        # the threshold and are evicted; b30 is exactly at the threshold and survives.
+        b50 = DEFAULT_L1_BLOCK_NUMBER + 50
+        self.manager.get_block_by_number(hex(b50))
+        self.assertNotIn(b10, self.manager.blocks, "Block b10 should be evicted")
+        self.assertNotIn(b20, self.manager.blocks, "Block b20 should be evicted")
+        self.assertIn(b30, self.manager.blocks, "Block b30 should survive cleanup")
 
-        # Now request block 50 - this should clean up block 10 (50 - 20 = 30, so blocks < 30 are removed)
-        self.manager.get_block_by_number(hex(50))
-        result = self.manager.get_block_by_number(hex(10))
-        # Block 10 was cleaned up, should return default block.
-        self.assertEqual(result["result"], L1Manager.default_l1_block(hex(10)))
-        result = self.manager.get_block_by_number(hex(20))
-        # Block 20 was also cleaned up
-        self.assertEqual(result["result"], L1Manager.default_l1_block(hex(20)))
-        result = self.manager.get_block_by_number(hex(30))
-        self.assertEqual(result["result"]["number"], hex(30))
+        # b30's stored data is still returned (not a default block fallback).
+        result = self.manager.get_block_by_number(hex(b30))
+        self.assertEqual(result["result"]["number"], hex(b30))
 
-        # get_block_number still returns 30 + finality.
+        # Mock L1 head synced to b30 + finality = DEFAULT + 40.
         result = self.manager.get_block_number()
-        self.assertEqual(result["result"], hex(30 + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE))
+        self.assertEqual(result["result"], hex(DEFAULT_L1_BLOCK_NUMBER + 40))
 
     def test_clear_stored_blocks(self):
-        # Setup.
-        block_num = 10
+        # Setup with a block above DEFAULT so the mock head syncs.
+        block_num = DEFAULT_L1_BLOCK_NUMBER + 10
         self._mock_handle_feeder_tx_and_store_l1_block(block_num)
 
-        # Verify block exists.
+        # Verify block exists; mock L1 head synced to block_num + finality.
         result = self.manager.get_block_number()
         self.assertEqual(
             result["result"], hex(block_num + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE)
@@ -157,15 +163,50 @@ class TestL1Manager(unittest.TestCase):
 
         self.manager.clear_stored_blocks()
 
-        # Verify blocks cleared (defaults returned).
+        # After clearing, mock L1 head is reset to DEFAULT_L1_BLOCK_NUMBER.
         result = self.manager.get_block_number()
-        self.assertEqual(result, {"jsonrpc": "2.0", "id": "1", "result": None})
-        result = self.manager.get_logs(self.get_logs_input(10, 10))
+        self.assertEqual(result["result"], hex(DEFAULT_L1_BLOCK_NUMBER))
+        result = self.manager.get_logs(self.get_logs_input(block_num, block_num))
         self.assertEqual(result, {"jsonrpc": "2.0", "id": "1", "result": []})
         result = self.manager.get_block_by_number(hex(block_num))
         self.assertEqual(
             result,
-            {"jsonrpc": "2.0", "id": "1", "result": L1Manager.default_l1_block(hex(block_num))},
+            {"jsonrpc": "2.0", "id": "1", "result": self.manager.default_l1_block(hex(block_num))},
+        )
+
+    def test_mock_l1_head_syncs_with_real_block(self):
+        """Mock L1 head tracks real L1 block number so the scraper does not get stuck."""
+        # Start with default mock L1 head.
+        self.assertEqual(
+            self.manager.get_block_number()["result"],
+            hex(DEFAULT_L1_BLOCK_NUMBER),
+        )
+
+        # Store a real block above DEFAULT.
+        real_block_num = DEFAULT_L1_BLOCK_NUMBER + 1000
+        self._mock_handle_feeder_tx_and_store_l1_block(real_block_num)
+
+        # Mock L1 head synced to real_block_num + finality.
+        self.assertEqual(
+            self.manager.get_block_number()["result"],
+            hex(real_block_num + L1Manager.L1_SCRAPER_FINALITY_CONFIG_VALUE),
+        )
+
+        # After clearing stored blocks, mock L1 head is reset to default.
+        # This ensures the events scraper re-initializes from a low block number after resync,
+        # so it doesn't skip real blocks that arrive after resync at positions below the old mock head.
+        self.manager.clear_stored_blocks()
+        self.assertEqual(
+            self.manager.get_block_number()["result"],
+            hex(DEFAULT_L1_BLOCK_NUMBER),
+        )
+
+        # set_gas_price_target increments from the reset default position.
+        self.manager.set_gas_price_target(1000, 2000, l2_timestamp=12345)
+
+        self.assertEqual(
+            self.manager.get_block_number()["result"],
+            hex(DEFAULT_L1_BLOCK_NUMBER + 1),
         )
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes mock `eth_blockNumber` semantics and introduces threaded long-polling plus synthetic fee fields, which may impact scraper behavior/timing if assumptions differ. Test coverage was updated, but integration timing/race conditions are the main risk.
> 
> **Overview**
> `L1Manager` now maintains a **monotonically increasing mock L1 head** (backed by new `DEFAULT_L1_BLOCK_NUMBER`) and changes `get_block_number` to long-poll on a condition variable, reducing tight-loop polling load while still unblocking scrapers promptly.
> 
> Adds `set_gas_price_target()` and extends the default/fallback L1 block returned by `get_block_by_number` to include **EIP-1559 base fee and blob fee context** (`baseFeePerGas`, derived `excessBlobGas`, timestamp), and syncs the mock head upward when real L1 blocks are stored/reset when clearing state. Unit tests are updated/expanded to assert the new head behavior, cleanup semantics, and reset/increment flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4786a9202cd0bd26a173a342eeb2b88c02b69ae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->