### PR TITLE
echonet: rename replay functions before getting block metadata

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -81,7 +81,7 @@ use futures::FutureExt;
 use indexmap::{IndexMap, IndexSet};
 #[cfg(test)]
 use mockall::automock;
-use starknet_api::block::{BlockHash, BlockNumber, UnixTimestamp};
+use starknet_api::block::{BlockHash, BlockNumber, ReplayMetadata};
 use starknet_api::block_hash::block_hash_calculator::{
     PartialBlockHash,
     PartialBlockHashComponents,
@@ -626,13 +626,13 @@ impl Batcher {
     }
 
     #[instrument(skip(self), err)]
-    pub async fn get_batch_timestamp(&self) -> BatcherResult<UnixTimestamp> {
+    pub async fn get_block_metadata(&self) -> BatcherResult<ReplayMetadata> {
         let mempool_client = self.mempool_client.as_ref().expect(
             "Mempool client must be present in non-validation-only mode. Unreachable code when \
              validation-only mode is enabled.",
         );
-        mempool_client.resolve_batch_timestamp().await.map_err(|err| {
-            error!("Failed to get timestamp from mempool: {err}");
+        mempool_client.resolve_block_metadata().await.map_err(|err| {
+            error!("Failed to get block metadata from mempool: {err}");
             BatcherError::InternalError
         })
     }

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1903,7 +1903,7 @@ async fn validation_only_propose_block_returns_not_supported() {
 #[should_panic(expected = "Mempool client must be present in non-validation-only mode.")]
 async fn validation_only_get_batch_timestamp_panics() {
     let batcher = create_batcher(validation_only_mock_dependencies()).await;
-    batcher.get_batch_timestamp().await.unwrap();
+    batcher.get_block_metadata().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -55,8 +55,8 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
             BatcherRequest::RevertBlock(input) => {
                 BatcherResponse::RevertBlock(self.revert_block(input).await)
             }
-            BatcherRequest::GetBatchTimestamp => {
-                BatcherResponse::GetBatchTimestamp(self.get_batch_timestamp().await)
+            BatcherRequest::GetBlockMetadata => {
+                BatcherResponse::GetBlockMetadata(self.get_block_metadata().await)
             }
         }
     }

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
 use mockall::automock;
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{BlockHash, BlockNumber, UnixTimestamp};
+use starknet_api::block::{BlockHash, BlockNumber, ReplayMetadata};
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use thiserror::Error;
 
@@ -89,7 +89,7 @@ pub trait BatcherClient: Send + Sync {
     ) -> BatcherClientResult<SendTxsForProposalStatus>;
     /// Reverts the block with the given block number, only if it is the last in the storage.
     async fn revert_block(&self, input: RevertBlockInput) -> BatcherClientResult<()>;
-    async fn get_batch_timestamp(&self) -> BatcherClientResult<UnixTimestamp>;
+    async fn get_block_metadata(&self) -> BatcherClientResult<ReplayMetadata>;
 }
 
 #[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
@@ -112,7 +112,7 @@ pub enum BatcherRequest {
     DecisionReached(DecisionReachedInput),
     AddSyncBlock(SyncBlock),
     RevertBlock(RevertBlockInput),
-    GetBatchTimestamp,
+    GetBlockMetadata,
 }
 impl_debug_for_infra_requests_and_responses!(BatcherRequest);
 impl_labeled_request!(BatcherRequest, BatcherRequestLabelValue);
@@ -137,7 +137,7 @@ pub enum BatcherResponse {
     DecisionReached(BatcherResult<Box<DecisionReachedResponse>>),
     AddSyncBlock(BatcherResult<()>),
     RevertBlock(BatcherResult<()>),
-    GetBatchTimestamp(BatcherResult<u64>),
+    GetBlockMetadata(BatcherResult<ReplayMetadata>),
 }
 impl_debug_for_infra_requests_and_responses!(BatcherResponse);
 
@@ -322,13 +322,13 @@ where
         )
     }
 
-    async fn get_batch_timestamp(&self) -> BatcherClientResult<UnixTimestamp> {
-        let request = BatcherRequest::GetBatchTimestamp;
+    async fn get_block_metadata(&self) -> BatcherClientResult<ReplayMetadata> {
+        let request = BatcherRequest::GetBlockMetadata;
         handle_all_response_variants!(
             self,
             request,
             BatcherResponse,
-            GetBatchTimestamp,
+            GetBlockMetadata,
             BatcherClientError,
             BatcherError,
             Direct

--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -28,7 +28,7 @@ use apollo_protobuf::consensus::{
 };
 use apollo_time::time::{Clock, DateTime};
 use apollo_transaction_converter::TransactionConverterError;
-use starknet_api::block::GasPrice;
+use starknet_api::block::{GasPrice, ReplayMetadata};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
@@ -71,8 +71,8 @@ pub(crate) struct ProposalBuildArguments {
     pub proposal_round: Round,
     pub retrospective_block_hash_deadline: DateTime,
     pub retrospective_block_hash_retry_interval_millis: Duration,
-    // If true, for echonet mode, use the timestamp from the original block.
-    pub override_timestamp: bool,
+    // If true, for echonet mode, use the metadata of the original block.
+    pub override_block_metadata: bool,
     pub override_l2_gas_price_fri: Option<u128>,
     pub min_l2_gas_price_per_height: Vec<PricePerHeight>,
     pub compare_retrospective_block_hash: bool,
@@ -130,29 +130,30 @@ pub(crate) async fn build_proposal(
     Ok(proposal_commitment)
 }
 
-async fn get_proposal_timestamp(
-    override_timestamp: bool,
+async fn get_proposal_metadata(
+    override_block_metadata: bool,
     batcher: &dyn BatcherClient,
     clock: &dyn Clock,
-) -> u64 {
-    if override_timestamp {
-        match batcher.get_batch_timestamp().await {
-            Ok(timestamp) => return timestamp,
+) -> ReplayMetadata {
+    if override_block_metadata {
+        match batcher.get_block_metadata().await {
+            Ok(block_metadata) => return block_metadata,
             Err(err) => {
                 warn!("Failed to get timestamp from batcher, falling back to clock time: {err:?}");
             }
         }
     }
-    clock.unix_now()
+    ReplayMetadata { timestamp: clock.unix_now(), block_number: None }
 }
 
 async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResult<ProposalInit> {
-    let timestamp = get_proposal_timestamp(
-        args.override_timestamp,
+    let proposal_metadata = get_proposal_metadata(
+        args.override_block_metadata,
         args.deps.batcher.as_ref(),
         args.deps.clock.as_ref(),
     )
     .await;
+    let timestamp = proposal_metadata.timestamp;
     let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
         args.deps.l1_gas_price_provider.clone(),
         timestamp,

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -550,7 +550,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 self.config.static_config.build_proposal_time_ratio_for_retrospective_block_hash,
             );
 
-        let override_timestamp = match self.config.static_config.behavior_mode {
+        let override_block_metadata = match self.config.static_config.behavior_mode {
             BehaviorMode::Echonet => true,
             BehaviorMode::Starknet => false,
         };
@@ -576,7 +576,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 .config
                 .static_config
                 .retrospective_block_hash_retry_interval_millis,
-            override_timestamp,
+            override_block_metadata,
             override_l2_gas_price_fri: self.config.dynamic_config.override_l2_gas_price_fri,
             min_l2_gas_price_per_height: self
                 .config

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -461,7 +461,7 @@ pub(crate) struct TestProposalBuildArguments {
     pub proposal_round: Round,
     pub retrospective_block_hash_deadline: DateTime,
     pub retrospective_block_hash_retry_interval_millis: Duration,
-    pub override_timestamp: bool,
+    pub override_block_metadata: bool,
     pub override_l2_gas_price_fri: Option<u128>,
     pub min_l2_gas_price_per_height: Vec<PricePerHeight>,
     pub compare_retrospective_block_hash: bool,
@@ -487,7 +487,7 @@ impl From<TestProposalBuildArguments> for ProposalBuildArguments {
             retrospective_block_hash_deadline: args.retrospective_block_hash_deadline,
             retrospective_block_hash_retry_interval_millis: args
                 .retrospective_block_hash_retry_interval_millis,
-            override_timestamp: args.override_timestamp,
+            override_block_metadata: args.override_block_metadata,
             override_l2_gas_price_fri: args.override_l2_gas_price_fri,
             min_l2_gas_price_per_height: args.min_l2_gas_price_per_height,
             compare_retrospective_block_hash: args.compare_retrospective_block_hash,
@@ -518,7 +518,7 @@ pub(crate) fn create_proposal_build_arguments()
     let cancel_token = CancellationToken::new();
     let previous_proposal_init = None;
     let proposal_round = 0;
-    let override_timestamp = false;
+    let override_block_metadata = false;
 
     (
         TestProposalBuildArguments {
@@ -538,7 +538,7 @@ pub(crate) fn create_proposal_build_arguments()
             proposal_round,
             retrospective_block_hash_deadline,
             retrospective_block_hash_retry_interval_millis,
-            override_timestamp,
+            override_block_metadata,
             override_l2_gas_price_fri: None,
             min_l2_gas_price_per_height: vec![],
             compare_retrospective_block_hash: true,

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -2133,32 +2133,6 @@
           "extra_params": {}
         },
         {
-          "title": "get_batch_timestamp (client-side)",
-          "description": "client-side infra metrics for request type get_batch_timestamp",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
-          "title": "get_batch_timestamp (server-side)",
-          "description": "server-side infra metrics for request type get_batch_timestamp",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
           "title": "get_block_hash (client-side)",
           "description": "client-side infra metrics for request type get_block_hash",
           "type": "timeseries",
@@ -2181,6 +2155,32 @@
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_metadata (client-side)",
+          "description": "client-side infra metrics for request type get_block_metadata",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_metadata (server-side)",
+          "description": "server-side infra metrics for request type get_block_metadata",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },
@@ -3571,28 +3571,28 @@
           "extra_params": {}
         },
         {
-          "title": "resolve_batch_timestamp (client-side)",
-          "description": "client-side infra metrics for request type resolve_batch_timestamp",
+          "title": "resolve_block_metadata (client-side)",
+          "description": "client-side infra metrics for request type resolve_block_metadata",
           "type": "timeseries",
           "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },
         {
-          "title": "resolve_batch_timestamp (server-side)",
-          "description": "server-side infra metrics for request type resolve_batch_timestamp",
+          "title": "resolve_block_metadata (server-side)",
+          "description": "server-side infra metrics for request type resolve_block_metadata",
           "type": "timeseries",
           "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_queueing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_queueing_times_secs\", \"le\", \".*\"))"
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_queueing_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },

--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -26,7 +26,7 @@ use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{Jitter, RetryTransientMiddleware};
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::{GasPrice, ReplayMetadata};
 use starknet_api::core::ContractAddress;
 use starknet_api::rpc_transaction::InternalRpcTransaction;
 use starknet_api::transaction::TransactionHash;
@@ -171,8 +171,12 @@ impl MempoolCommunicationWrapper {
         self.mempool.mempool_snapshot()
     }
 
-    fn resolve_batch_timestamp(&mut self) -> MempoolResult<UnixTimestamp> {
-        Ok(self.mempool.resolve_batch_timestamp())
+    fn resolve_block_metadata(&mut self) -> MempoolResult<ReplayMetadata> {
+        let block_metadata = self.mempool.resolve_block_metadata();
+        Ok(ReplayMetadata {
+            timestamp: block_metadata.timestamp,
+            block_number: block_metadata.block_number,
+        })
     }
 
     // Fetches tx block metadata from recorder and updates mempool.
@@ -256,8 +260,8 @@ impl ComponentRequestHandler<MempoolRequest, MempoolResponse> for MempoolCommuni
             MempoolRequest::GetMempoolSnapshot() => {
                 MempoolResponse::GetMempoolSnapshot(self.mempool_snapshot())
             }
-            MempoolRequest::ResolveBatchTimestamp => {
-                MempoolResponse::ResolveBatchTimestamp(self.resolve_batch_timestamp())
+            MempoolRequest::ResolveBlockMetadata => {
+                MempoolResponse::ResolveBlockMetadata(self.resolve_block_metadata())
             }
         }
     }

--- a/crates/apollo_mempool/src/fifo_mempool_test.rs
+++ b/crates/apollo_mempool/src/fifo_mempool_test.rs
@@ -238,13 +238,13 @@ fn test_resolve_batch_timestamp_persists_after_queue_emptied(mut mempool: Mempoo
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 
     // Consume all txs, emptying the queue.
     get_txs_and_assert_expected(&mut mempool, 2, &[input1.tx, input2.tx]);
 
     // Timestamp should persist after queue is emptied.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 }
 
 #[rstest]
@@ -264,7 +264,7 @@ fn test_get_txs_does_not_return_txs_with_different_timestamp(mut mempool: Mempoo
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 
     // Request one transaction from the first timestamp batch.
     get_txs_and_assert_expected(&mut mempool, 1, &[input1.tx]);
@@ -272,11 +272,11 @@ fn test_get_txs_does_not_return_txs_with_different_timestamp(mut mempool: Mempoo
     // get_txs pauses at the timestamp boundary; only returns remaining txs with timestamp 1000.
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx]);
 
-    // Without resolving batch timestamp, get_txs returns empty (next txs have timestamp 1001).
+    // Without resolving block metadata, get_txs returns empty (next txs have timestamp 1001).
     assert_eq!(mempool.get_txs(10).unwrap(), vec![]);
 
     // Resolve to advance to timestamp 1001.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx]);
 }
 
@@ -290,7 +290,7 @@ fn test_get_txs_same_block_spans_multiple_chunks(mut mempool: Mempool) {
         add_tx(&mut mempool, &input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     // First chunk: block builder fetches 100 txs.
     let chunk1 = mempool.get_txs(100).unwrap();
     assert_eq!(chunk1.len(), 100);
@@ -319,18 +319,18 @@ fn test_get_txs_pauses_once_on_block_number_gap(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx, input2.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input3.tx]);
 
     // Block 4 is missing.
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
 
     // Block 5 is present.
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input4.tx, input5.tx]);
 }
 
@@ -349,17 +349,17 @@ fn test_get_txs_returns_empty_result_with_gaps(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 
     for _ in 0..19 {
-        assert_eq!(mempool.resolve_batch_timestamp(), 300);
+        assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
         assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input3.tx]);
 }
 
@@ -369,16 +369,16 @@ fn test_get_txs_after_queue_emptied_still_resolves_new_tx(mut mempool: Mempool) 
     mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(100, 1));
     add_tx(&mut mempool, &input1);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
 
     let input2 = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
     mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(200, 2));
     add_tx(&mut mempool, &input2);
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 }
 
@@ -397,15 +397,15 @@ fn test_rewind_partial_block_then_continue_to_next_block(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 3, &[input1.tx, input2.tx, input3.tx.clone()]);
 
     // Only tx 1 and 2 are committed; tx3 rewinds.
     commit_block(&mut mempool, [("0x1", 2)], []);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx]);
-    assert_eq!(mempool.resolve_batch_timestamp(), 2000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 2000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input5.tx]);
 }
 
@@ -421,18 +421,18 @@ fn test_realign_to_earlier_block_after_rewind(mut mempool: Mempool) {
     add_tx(&mut mempool, &input2);
 
     // Drain block 1. Expected_block_number = 2.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, std::slice::from_ref(&input1.tx));
 
     // Rewind tx of block 1. Expected_block_number is still 2.
     commit_block(&mut mempool, [], []);
 
     // Realign to block 1.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input1.tx]);
 
     // Now expected_block_number has advanced to 2 again; block-2 tx is next.
-    assert_eq!(mempool.resolve_batch_timestamp(), 2000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 2000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx]);
 }
 
@@ -453,7 +453,7 @@ fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     // Fetch tx1 and tx2; leave tx3 in queue.
     get_txs_and_assert_expected(&mut mempool, 2, &[input1.tx, input2.tx.clone()]);
 
@@ -464,16 +464,16 @@ fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
     add_tx(&mut mempool, &input4);
 
     // Rewound tx2 is at the front → timestamp must still be 1000, not 1001.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx, input3.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 1, &[input4.tx]);
 }
 
 #[rstest]
 fn test_resolve_batch_timestamp_returns_zero_when_never_had_transactions(mut mempool: Mempool) {
-    assert_eq!(mempool.resolve_batch_timestamp(), 0);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 0);
 }
 
 #[rstest]
@@ -491,7 +491,7 @@ fn test_rewind_many_transactions_from_same_address(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(
         &mut mempool,
         10,
@@ -501,12 +501,12 @@ fn test_rewind_many_transactions_from_same_address(mut mempool: Mempool) {
     // Commit only nonces 0 and 1; nonces 2, 3, 4 are rewound.
     commit_block(&mut mempool, [("0x1", 2)], []);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx, input5.tx]);
 
     commit_block(&mut mempool, [("0x1", 5)], []);
     // Queue should now be empty
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[]);
 }
 
@@ -538,7 +538,7 @@ fn test_expired_popped_txs_are_not_rewound() {
     fake_clock.advance(Duration::from_secs(65));
 
     // Both txs are popped then pruned as expired, so no tx should be returned.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![]);
 
     // Commit should not rewind expired popped txs back into queue.
@@ -562,13 +562,13 @@ fn test_rejected_tx_removes_same_address_from_fifo_queue(mut mempool: Mempool) {
     }
 
     // Stage only the first tx (timestamp 1000).
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[rejected_tx.tx]);
 
     // Reject tx. In FIFO, this removes same-address queued txs.
     commit_block(&mut mempool, [], [tx_hash!(1)]);
 
     // Next timestamp batch should include only the other address tx.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 10, &[other_address_tx.tx]);
 }

--- a/crates/apollo_mempool/src/fifo_transaction_queue.rs
+++ b/crates/apollo_mempool/src/fifo_transaction_queue.rs
@@ -8,7 +8,7 @@ use starknet_api::transaction::TransactionHash;
 use tracing::debug;
 
 use crate::mempool::TransactionReference;
-use crate::transaction_queue_trait::{RewindData, TransactionQueueTrait};
+use crate::transaction_queue_trait::{BlockMetadata, RewindData, TransactionQueueTrait};
 
 /// A FIFO (First-In-First-Out) transaction queue that orders transactions by arrival time.
 /// Used in Echonet mode to preserve the original transaction order from the source chain.
@@ -73,9 +73,7 @@ pub struct FifoTransactionQueue {
     // Temporary map from transaction hash to metadata before the transaction is inserted to
     // queue.
     pending_metadata: HashMap<TransactionHash, TxBlockMetadata>,
-    // Tracks current proposal metadata in FIFO mode:
-    // - timestamp returned by resolve_timestamp()
-    // - expected block number for get_txs()
+    // Proposal state set by resolve_metadata(); gates which txs pop_ready_chunk() may return.
     current_proposal_state: Option<CurrentProposalState>,
 }
 
@@ -157,20 +155,25 @@ impl FifoTransactionQueue {
             .collect()
     }
 
-    /// Returns that head transaction's timestamp.
-    fn sync_proposal_state_from_queue_front_tx(&mut self) -> UnixTimestamp {
+    /// Syncs current_proposal_state from the head of the queue and returns
+    /// the resulting (timestamp, block_number).
+    fn sync_proposal_state_from_queue_front_tx(&mut self) -> BlockMetadata {
         let &front_tx = self
             .queue
             .front()
             .expect("FIFO sync_proposal_state_from_queue_front: queue must be non-empty");
 
         let Some(prev_state) = self.current_proposal_state else {
-            self.current_proposal_state = Some(CurrentProposalState {
+            let state = CurrentProposalState {
                 timestamp: front_tx.timestamp,
                 expected_block_number: front_tx.block_number,
                 emit_empty_block: false,
-            });
-            return front_tx.timestamp;
+            };
+            self.current_proposal_state = Some(state);
+            return BlockMetadata {
+                timestamp: state.timestamp,
+                block_number: Some(state.expected_block_number),
+            };
         };
 
         let (expected_block_number, emit_empty_block) =
@@ -191,12 +194,16 @@ impl FifoTransactionQueue {
                 (prev_state.expected_block_number, false)
             };
 
-        self.current_proposal_state = Some(CurrentProposalState {
+        let state = CurrentProposalState {
             timestamp: front_tx.timestamp,
             expected_block_number,
             emit_empty_block,
-        });
-        front_tx.timestamp
+        };
+        self.current_proposal_state = Some(state);
+        BlockMetadata {
+            timestamp: state.timestamp,
+            block_number: Some(state.expected_block_number),
+        }
     }
 }
 
@@ -226,7 +233,7 @@ impl TransactionQueueTrait for FifoTransactionQueue {
 
         let Some(current_state) = self.current_proposal_state.as_mut() else {
             panic!(
-                "FIFO pop_ready_chunk: missing proposal state; resolve_timestamp must run before \
+                "FIFO pop_ready_chunk: missing proposal state; resolve_metadata must run before \
                  get_txs for this queue"
             );
         };
@@ -365,23 +372,26 @@ impl TransactionQueueTrait for FifoTransactionQueue {
         0
     }
 
-    fn resolve_timestamp(&mut self) -> UnixTimestamp {
+    fn resolve_metadata(&mut self) -> BlockMetadata {
         if self.queue.front().is_some() {
             return self.sync_proposal_state_from_queue_front_tx();
         }
-        // Queue is empty: reuse previous timestamp if it exists, otherwise return 0.
+        // Queue is empty: reuse previous timestamp and block number if they exist.
         match self.current_proposal_state {
             Some(state) => {
                 debug!(
-                    "FIFO resolve_timestamp: queue empty, reusing last_timestamp={:?}, \
+                    "FIFO resolve_metadata: queue empty, reusing last_timestamp={:?}, \
                      expected_block={:?}",
                     state.timestamp, state.expected_block_number
                 );
-                state.timestamp
+                BlockMetadata {
+                    timestamp: state.timestamp,
+                    block_number: Some(state.expected_block_number),
+                }
             }
             None => {
-                debug!("FIFO resolve_timestamp: queue empty, no previous proposal state");
-                0
+                debug!("FIFO resolve_metadata: queue empty, no previous proposal state");
+                BlockMetadata { timestamp: 0, block_number: None }
             }
         }
     }

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -18,7 +18,7 @@ use apollo_mempool_types::mempool_types::{
 use apollo_time::time::{Clock, DateTime};
 use indexmap::IndexSet;
 use rand::{thread_rng, Rng};
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::GasPrice;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
@@ -47,7 +47,7 @@ use crate::metrics::{
     MEMPOOL_TRANSACTIONS_RECEIVED,
 };
 use crate::transaction_pool::TransactionPool;
-use crate::transaction_queue_trait::{RewindData, TransactionQueueTrait};
+use crate::transaction_queue_trait::{BlockMetadata, RewindData, TransactionQueueTrait};
 use crate::utils::try_increment_nonce;
 
 #[cfg(test)]
@@ -377,14 +377,18 @@ impl Mempool {
         matches!(self.config.static_config.behavior_mode, BehaviorMode::Echonet)
     }
 
-    pub fn resolve_batch_timestamp(&mut self) -> UnixTimestamp {
+    pub(crate) fn resolve_block_metadata(&mut self) -> BlockMetadata {
         if !self.is_fifo() {
             let timestamp = self.clock.unix_now();
-            debug!("Mempool resolve_batch_timestamp (Fee): timestamp={}", timestamp);
-            return timestamp;
+            debug!(
+                "Mempool resolve_block_metadata (Fee): timestamp={}. Block number is not tracked \
+                 in fee-priority mode.",
+                timestamp
+            );
+            return BlockMetadata { timestamp, block_number: None };
         }
 
-        self.tx_queue.resolve_timestamp()
+        self.tx_queue.resolve_metadata()
     }
 
     pub(crate) fn update_tx_block_metadata(

--- a/crates/apollo_mempool/src/test_utils.rs
+++ b/crates/apollo_mempool/src/test_utils.rs
@@ -328,9 +328,10 @@ pub fn get_txs_and_assert_expected(
     n_txs: usize,
     expected_txs: &[InternalRpcTransaction],
 ) {
-    // In FIFO mode, we need to resolve batch timestamp first to set the timestamp threshold.
+    // In FIFO mode, resolve_block_metadata must run before get_txs to set the current proposal
+    // state used to gate which transactions are eligible.
     if mempool.is_fifo() {
-        let _ = mempool.resolve_batch_timestamp();
+        let _ = mempool.resolve_block_metadata();
     }
     let txs = mempool.get_txs(n_txs).unwrap();
     assert_eq!(txs, expected_txs);

--- a/crates/apollo_mempool/src/transaction_queue_trait.rs
+++ b/crates/apollo_mempool/src/transaction_queue_trait.rs
@@ -2,11 +2,16 @@ use std::collections::HashMap;
 
 use apollo_mempool_types::mempool_types::{TransactionQueueSnapshot, TxBlockMetadata};
 use indexmap::IndexSet;
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::{BlockNumber, GasPrice, UnixTimestamp};
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::transaction::TransactionHash;
 
 use crate::mempool::TransactionReference;
+
+pub(crate) struct BlockMetadata {
+    pub timestamp: UnixTimestamp,
+    pub block_number: Option<BlockNumber>,
+}
 
 // Data needed for rewinding transactions back into the queue after a block commit.
 // Different queue types require different data.
@@ -67,10 +72,11 @@ pub trait TransactionQueueTrait: Send + Sync {
     // Default implementation is a no-op (for queues that don't support metadata updates).
     fn update_tx_block_metadata(&mut self, _tx_hash: TransactionHash, _metadata: TxBlockMetadata) {}
 
-    // Returns the sequencing timestamp and may update queue-internal state.
-    // Default implementation returns 0 for queues that don't use timestamp gating.
-    fn resolve_timestamp(&mut self) -> UnixTimestamp {
-        0
+    // Returns the block metadata and may update queue-internal state.
+    // Default implementation returns timestamp=0, block_number=None for queues that don't use
+    // timestamp gating.
+    fn resolve_metadata(&mut self) -> BlockMetadata {
+        BlockMetadata { timestamp: 0, block_number: None }
     }
 
     // Default implementation returns empty vec.

--- a/crates/apollo_mempool_types/src/communication.rs
+++ b/crates/apollo_mempool_types/src/communication.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
 use mockall::automock;
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::{GasPrice, ReplayMetadata};
 use starknet_api::core::ContractAddress;
 use starknet_api::rpc_transaction::InternalRpcTransaction;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
@@ -61,7 +61,7 @@ pub trait MempoolClient: Send + Sync {
     ) -> MempoolClientResult<bool>;
     async fn update_gas_price(&self, gas_price: GasPrice) -> MempoolClientResult<()>;
     async fn get_mempool_snapshot(&self) -> MempoolClientResult<MempoolSnapshot>;
-    async fn resolve_batch_timestamp(&self) -> MempoolClientResult<UnixTimestamp>;
+    async fn resolve_block_metadata(&self) -> MempoolClientResult<ReplayMetadata>;
 }
 
 #[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
@@ -79,7 +79,7 @@ pub enum MempoolRequest {
     // TODO(yair): Rename to `StartBlock` and add cleanup of staged txs.
     UpdateGasPrice(GasPrice),
     GetMempoolSnapshot(),
-    ResolveBatchTimestamp,
+    ResolveBlockMetadata,
 }
 impl_debug_for_infra_requests_and_responses!(MempoolRequest);
 impl_labeled_request!(MempoolRequest, MempoolRequestLabelValue);
@@ -94,7 +94,7 @@ impl PrioritizedRequest for MempoolRequest {
             | MempoolRequest::AccountTxInPoolOrRecentBlock(_)
             | MempoolRequest::UpdateGasPrice(_)
             | MempoolRequest::GetMempoolSnapshot()
-            | MempoolRequest::ResolveBatchTimestamp => RequestPriority::Normal,
+            | MempoolRequest::ResolveBlockMetadata => RequestPriority::Normal,
         }
     }
 }
@@ -108,7 +108,7 @@ pub enum MempoolResponse {
     AccountTxInPoolOrRecentBlock(MempoolResult<bool>),
     UpdateGasPrice(MempoolResult<()>),
     GetMempoolSnapshot(MempoolResult<MempoolSnapshot>),
-    ResolveBatchTimestamp(MempoolResult<UnixTimestamp>),
+    ResolveBlockMetadata(MempoolResult<ReplayMetadata>),
 }
 impl_debug_for_infra_requests_and_responses!(MempoolResponse);
 
@@ -219,13 +219,13 @@ where
         )
     }
 
-    async fn resolve_batch_timestamp(&self) -> MempoolClientResult<UnixTimestamp> {
-        let request = MempoolRequest::ResolveBatchTimestamp;
+    async fn resolve_block_metadata(&self) -> MempoolClientResult<ReplayMetadata> {
+        let request = MempoolRequest::ResolveBlockMetadata;
         handle_all_response_variants!(
             self,
             request,
             MempoolResponse,
-            ResolveBatchTimestamp,
+            ResolveBlockMetadata,
             MempoolClientError,
             MempoolError,
             Direct

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -707,6 +707,14 @@ pub struct BlockInfo {
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct BlockSignature(pub Signature);
 
+/// Metadata for a block proposal, for Echonet mode.
+/// `block_number` is `None` in fee-priority mode where block numbers are not tracked.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReplayMetadata {
+    pub timestamp: UnixTimestamp,
+    pub block_number: Option<BlockNumber>,
+}
+
 /// The error type returned from the block verification functions.
 #[derive(thiserror::Error, Clone, Debug)]
 pub enum BlockVerificationError {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Renames and widens the batcher↔mempool replay API from a timestamp-only call to `ReplayMetadata` (timestamp + optional block number), touching cross-crate request/response enums and consensus proposal initialization. Risk is mainly around breaking compatibility and incorrect metadata propagation in Echonet mode.
> 
> **Overview**
> Updates Echonet replay flow to fetch and pass **block proposal metadata** instead of a timestamp, introducing `starknet_api::block::ReplayMetadata { timestamp, block_number }` and threading it through the batcher/mempool client APIs.
> 
> This renames the corresponding infra requests/responses (`GetBatchTimestamp`→`GetBlockMetadata`, `ResolveBatchTimestamp`→`ResolveBlockMetadata`), updates FIFO queue gating to resolve full metadata (`resolve_timestamp`→`resolve_metadata`), and adjusts consensus proposal building/config flags (`override_timestamp`→`override_block_metadata`). Grafana dashboards and tests are updated to reflect the new request labels and behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e45ce02a32a6b59dc135ae1a0b17e9b821d87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->