### PR TITLE
apollo_integration_tests: add fake cende and feeder server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "mockall",
  "papyrus_base_layer",
  "pretty_assertions",
+ "reqwest 0.12.24",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/apollo_integration_tests/Cargo.toml
+++ b/crates/apollo_integration_tests/Cargo.toml
@@ -89,6 +89,7 @@ apollo_l1_events_types = { workspace = true, features = ["testing"] }
 futures.workspace = true
 metrics.workspace = true
 mockall.workspace = true
+reqwest.workspace = true
 rstest.workspace = true
 
 [[bin]]

--- a/crates/apollo_integration_tests/src/fake_starknet_server.rs
+++ b/crates/apollo_integration_tests/src/fake_starknet_server.rs
@@ -1,0 +1,574 @@
+//! Fake HTTP server for integration testing.
+//!
+//! [`FakeStarknetServer`] binds on a random port and serves two sets of endpoints:
+//!
+//! - **Feeder gateway** (`/feeder_gateway/*`): mirrors the Starknet feeder gateway protocol, so a
+//!   `StarknetFeederGatewayClient` pointed at `server.url` works against it.
+//! - **Cende recorder** (`/cende_recorder/*`): mirrors the Cende recorder protocol, so a
+//!   `CendeAmbassador` pointed at `server.url` works against it.
+//!
+//! Both endpoint sets share a single [`FakeBlock`] store keyed by block number. Each block
+//! accumulates data from two independent sources:
+//!
+//! - **`block_hash`**: filled in when a later blob's `recent_block_hashes` references this block
+//!   number. Until a hash arrives the block is invisible to feeder endpoints and
+//!   `get_latest_received_block`.
+//! - **`feeder_json` / `state_update`**: seeded by test code with correctly-shaped feeder JSON.
+//!
+//! Either source may arrive first; each write touches only its own field so no data is lost.
+//!
+//! Serving rules:
+//! - `get_latest_received_block`: max block number whose `block_hash` is `Some`.
+//! - `get_block`: requires both `block_hash` and `feeder_json`. `feeder_json` is derived
+//!   automatically from the blob posted to `write_blob` (header fields only; transactions are
+//!   omitted). The `block_hash` field inside `feeder_json` is patched in when a later blob's
+//!   `recent_block_hashes` confirms it, so `get_block` becomes available at the same moment as
+//!   `get_state_update`.
+//! - `get_state_update`: requires both `block_hash` and `state_update`.
+//! - `get_signature`: always returns [`BLOCK_SIGNATURE_JSON`] (signature is deprecated).
+
+#[cfg(test)]
+#[path = "fake_starknet_server_test.rs"]
+mod fake_starknet_server_test;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Json, Query, State};
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::net::TcpListener;
+use url::Url;
+
+// Error JSON bodies matching the Starknet feeder gateway error wire format.
+pub const BLOCK_NOT_FOUND_JSON: &str =
+    r#"{"code":"StarknetErrorCode.BLOCK_NOT_FOUND","message":"Block not found"}"#;
+pub const UNDECLARED_CLASS_JSON: &str =
+    r#"{"code":"StarknetErrorCode.UNDECLARED_CLASS","message":"Undeclared class"}"#;
+/// Constant returned by `get_signature`; block signatures are deprecated.
+pub const BLOCK_SIGNATURE_JSON: &str =
+    r#"{"signature":["0x0","0x0"],"signature_input":{"block_hash":"0x0"}}"#;
+
+/// Per-block data accumulating from two independent sources: blob posts and test seeding.
+/// Fields are always written individually so earlier data is never overwritten by later writes.
+#[derive(Default)]
+pub struct FakeBlock {
+    /// Confirmed block hash. Set when a later blob's `recent_block_hashes` references this block.
+    /// `None` means the block's existence is recorded but its hash is not yet known.
+    pub block_hash: Option<String>,
+    /// Full feeder-format JSON for `GET /feeder_gateway/get_block`. Seeded by test code.
+    pub feeder_json: Option<Value>,
+    /// `StateUpdate`-shaped JSON for `GET /feeder_gateway/get_state_update`. Seeded by test code.
+    pub state_update: Option<Value>,
+}
+
+/// Mutable data shared between server handlers and the [`FakeStarknetServer`] owner.
+pub struct FakeServerState {
+    /// All known blocks, keyed by block number. A block entry is created the first time its number
+    /// appears in a blob post or is seeded by test code. Its `block_hash` is set when a later
+    /// blob's `recent_block_hashes` references it.
+    pub blocks: HashMap<u64, FakeBlock>,
+
+    /// Per-class-hash JSON responses for `get_class_by_hash`.
+    pub classes_json: HashMap<String, Value>,
+    /// Per-class-hash JSON responses for `get_compiled_class_by_class_hash`.
+    pub compiled_classes_json: HashMap<String, Value>,
+    /// Response for `get_state_update?blockNumber=pending`.
+    pub pending_data_json: Option<Value>,
+    /// Response for `get_public_key`.
+    pub sequencer_pub_key_json: Option<Value>,
+
+    /// When `false`, `POST /cende_recorder/write_blob` returns 500 without storing anything.
+    pub write_blob_should_succeed: bool,
+
+    /// Block numbers received via `POST /cende_recorder/write_pre_confirmed_block`.
+    pub pre_confirmed_block_numbers: HashSet<u64>,
+    /// When `false`, `POST /cende_recorder/write_pre_confirmed_block` returns 500.
+    pub write_pre_confirmed_block_should_succeed: bool,
+}
+
+impl FakeServerState {
+    fn new() -> Self {
+        Self {
+            blocks: HashMap::new(),
+            classes_json: HashMap::new(),
+            compiled_classes_json: HashMap::new(),
+            pending_data_json: None,
+            sequencer_pub_key_json: None,
+            write_blob_should_succeed: true,
+            pre_confirmed_block_numbers: HashSet::new(),
+            write_pre_confirmed_block_should_succeed: true,
+        }
+    }
+
+    /// The highest block number with a confirmed hash, or `None` if no block has a hash yet.
+    pub fn latest_cende_block_number(&self) -> Option<u64> {
+        self.blocks.iter().filter(|(_, b)| b.block_hash.is_some()).map(|(n, _)| *n).max()
+    }
+
+    /// Seeds a block with both a confirmed hash and full feeder JSON.
+    /// Uses field-level writes so it merges correctly with any data already in the entry.
+    pub fn seed_block(&mut self, block_number: u64, block_hash: &str, feeder_json: Value) {
+        let block = self.blocks.entry(block_number).or_default();
+        block.block_hash = Some(block_hash.to_string());
+        block.feeder_json = Some(feeder_json);
+    }
+}
+
+type SharedState = Arc<Mutex<FakeServerState>>;
+
+/// A combined fake HTTP server with feeder-gateway and Cende-recorder endpoints.
+///
+/// Binds on a random loopback port on construction. Point both
+/// `StarknetFeederGatewayClient` and `CendeAmbassador` at `server.url`.
+pub struct FakeStarknetServer {
+    /// Base URL of the server (e.g. `http://127.0.0.1:54321`).
+    pub url: Url,
+    /// Shared state: write here to configure responses, read here to inspect received blobs.
+    pub state: SharedState,
+    server_handle: tokio::task::JoinHandle<()>,
+}
+
+impl FakeStarknetServer {
+    /// Spawns the server on an OS-assigned port. Must be called from within a tokio runtime.
+    pub async fn new() -> Self {
+        let state: SharedState = Arc::new(Mutex::new(FakeServerState::new()));
+
+        let listener =
+            TcpListener::bind("127.0.0.1:0").await.expect("Failed to bind fake server port");
+        let addr = listener.local_addr().expect("Failed to read fake server local address");
+        let url = Url::parse(&format!("http://{addr}")).expect("Failed to parse fake server URL");
+
+        let app = build_router(state.clone());
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("Fake server crashed");
+        });
+
+        Self { url, state, server_handle }
+    }
+}
+
+impl Drop for FakeStarknetServer {
+    fn drop(&mut self) {
+        self.server_handle.abort();
+    }
+}
+
+fn build_router(state: SharedState) -> Router {
+    Router::new()
+        // Feeder gateway
+        .route("/feeder_gateway/get_block", get(handle_get_block))
+        .route("/feeder_gateway/get_class_by_hash", get(handle_get_class_by_hash))
+        .route(
+            "/feeder_gateway/get_compiled_class_by_class_hash",
+            get(handle_get_compiled_class_by_hash),
+        )
+        .route("/feeder_gateway/get_state_update", get(handle_get_state_update))
+        .route("/feeder_gateway/is_alive", get(handle_feeder_is_alive))
+        .route("/feeder_gateway/get_signature", get(handle_get_block_signature))
+        .route("/feeder_gateway/get_public_key", get(handle_get_public_key))
+        // Cende recorder
+        .route(
+            "/cende_recorder/get_latest_received_block",
+            get(handle_get_latest_received_block),
+        )
+        .route("/cende_recorder/write_blob", post(handle_write_blob))
+        .route(
+            "/cende_recorder/write_pre_confirmed_block",
+            post(handle_write_pre_confirmed_block),
+        )
+        .with_state(state)
+}
+
+// Feeder gateway handlers
+
+#[derive(Deserialize)]
+struct GetBlockParams {
+    #[serde(rename = "blockNumber")]
+    block_number: String,
+    #[serde(rename = "headerOnly")]
+    header_only: Option<String>,
+}
+
+async fn handle_get_block(
+    State(state): State<SharedState>,
+    Query(params): Query<GetBlockParams>,
+) -> impl IntoResponse {
+    let state = state.lock().expect("Fake server state poisoned");
+    // Only blocks with both a confirmed hash and feeder content are served.
+    let block = match params.block_number.as_str() {
+        "latest" => state
+            .blocks
+            .iter()
+            .filter(|(_, b)| b.block_hash.is_some() && b.feeder_json.is_some())
+            .max_by_key(|(n, _)| *n)
+            .map(|(_, b)| b),
+        other => other
+            .parse::<u64>()
+            .ok()
+            .and_then(|n| state.blocks.get(&n))
+            .filter(|b| b.block_hash.is_some() && b.feeder_json.is_some()),
+    };
+    let json = block.map(|b| {
+        let feeder_json = b.feeder_json.as_ref().expect("filtered for feeder_json.is_some()");
+        if params.header_only.as_deref() == Some("true") {
+            serde_json::json!({
+                "block_number": feeder_json.get("block_number"),
+                "block_hash": feeder_json.get("block_hash"),
+            })
+            .to_string()
+        } else {
+            feeder_json.to_string()
+        }
+    });
+    json_or_block_not_found(json)
+}
+
+#[derive(Deserialize)]
+struct ClassHashParams {
+    #[serde(rename = "classHash")]
+    class_hash: String,
+}
+
+async fn handle_get_class_by_hash(
+    State(state): State<SharedState>,
+    Query(params): Query<ClassHashParams>,
+) -> impl IntoResponse {
+    let state = state.lock().expect("Fake server state poisoned");
+    match state.classes_json.get(&params.class_hash) {
+        Some(json) => json_response(StatusCode::OK, json.to_string()),
+        None => json_response(StatusCode::BAD_REQUEST, UNDECLARED_CLASS_JSON.to_string()),
+    }
+}
+
+async fn handle_get_compiled_class_by_hash(
+    State(state): State<SharedState>,
+    Query(params): Query<ClassHashParams>,
+) -> impl IntoResponse {
+    let state = state.lock().expect("Fake server state poisoned");
+    match state.compiled_classes_json.get(&params.class_hash) {
+        Some(json) => json_response(StatusCode::OK, json.to_string()),
+        None => json_response(StatusCode::BAD_REQUEST, UNDECLARED_CLASS_JSON.to_string()),
+    }
+}
+
+#[derive(Deserialize)]
+struct GetStateUpdateParams {
+    #[serde(rename = "blockNumber")]
+    block_number: String,
+}
+
+async fn handle_get_state_update(
+    State(state): State<SharedState>,
+    Query(params): Query<GetStateUpdateParams>,
+) -> impl IntoResponse {
+    let state = state.lock().expect("Fake server state poisoned");
+    let json = if params.block_number == "pending" {
+        state.pending_data_json.as_ref().map(|v| v.to_string())
+    } else if let Ok(block_number) = params.block_number.parse::<u64>() {
+        state
+            .blocks
+            .get(&block_number)
+            .filter(|b| b.block_hash.is_some())
+            .and_then(|b| b.state_update.as_ref())
+            .map(|v| v.to_string())
+    } else {
+        None
+    };
+    json_or_block_not_found(json)
+}
+
+async fn handle_feeder_is_alive() -> impl IntoResponse {
+    (StatusCode::OK, "FeederGateway is alive!")
+}
+
+async fn handle_get_block_signature() -> impl IntoResponse {
+    // Block signatures are deprecated; always return a fixed constant.
+    json_response(StatusCode::OK, BLOCK_SIGNATURE_JSON.to_string())
+}
+
+async fn handle_get_public_key(State(state): State<SharedState>) -> impl IntoResponse {
+    let state = state.lock().expect("Fake server state poisoned");
+    match state.sequencer_pub_key_json.as_ref() {
+        Some(json) => json_response(StatusCode::OK, json.to_string()),
+        None => json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "\"Sequencer public key not configured\"".to_string(),
+        ),
+    }
+}
+
+// Cende recorder handlers
+
+async fn handle_get_latest_received_block(State(state): State<SharedState>) -> impl IntoResponse {
+    let state = state.lock().expect("Fake server state poisoned");
+    let body = serde_json::json!({ "block_number": state.latest_cende_block_number() });
+    json_response(StatusCode::OK, body.to_string())
+}
+
+async fn handle_write_blob(State(state): State<SharedState>, Json(blob): Json<Value>) -> Response {
+    let mut state = state.lock().expect("Fake server state poisoned");
+    if !state.write_blob_should_succeed {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    let Some(block_number) = blob.get("block_number").and_then(Value::as_u64) else {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"blob missing block_number"}"#.to_string(),
+        )
+        .into_response();
+    };
+    // Record the blob's block as existing, without a confirmed hash yet.
+    state.blocks.entry(block_number).or_default();
+    // Derive state_update and feeder_json from the blob's CentralStateDiff if not already set.
+    if let Some(central_state_diff) = blob.get("state_diff") {
+        let block = state.blocks.entry(block_number).or_default();
+        if block.state_update.is_none() {
+            let mut state_update = central_state_diff_to_feeder_state_update(central_state_diff);
+            // If the hash was already confirmed by an earlier blob, patch it in now.
+            if let Some(hash) = &block.block_hash {
+                state_update["block_hash"] = Value::String(hash.clone());
+            }
+            block.state_update = Some(state_update);
+        }
+        if block.feeder_json.is_none() {
+            let mut feeder_json = blob_to_feeder_block_json(&blob, block_number);
+            // If the hash was already confirmed by an earlier blob, patch it in now.
+            if let Some(hash) = &block.block_hash {
+                feeder_json["block_hash"] = Value::String(hash.clone());
+            }
+            block.feeder_json = Some(feeder_json);
+        }
+    }
+    // Fill in confirmed hashes for older blocks referenced by this blob.
+    if let Some(recent_hashes) = blob.get("recent_block_hashes").and_then(Value::as_array) {
+        for entry in recent_hashes {
+            let Some(n) = entry.get("block_number").and_then(Value::as_u64) else { continue };
+            let Some(h) = entry.get("block_hash").and_then(Value::as_str) else { continue };
+            let block = state.blocks.entry(n).or_default();
+            block.block_hash = Some(h.to_string());
+            // Patch the confirmed hash into any state_update already derived for this block.
+            if let Some(state_update) = &mut block.state_update {
+                state_update["block_hash"] = Value::String(h.to_string());
+            }
+            // Patch the confirmed hash into any feeder_json already derived for this block.
+            if let Some(feeder_json) = &mut block.feeder_json {
+                feeder_json["block_hash"] = Value::String(h.to_string());
+            }
+        }
+    }
+    StatusCode::OK.into_response()
+}
+
+async fn handle_write_pre_confirmed_block(
+    State(state): State<SharedState>,
+    Json(body): Json<Value>,
+) -> Response {
+    let mut state = state.lock().expect("Fake server state poisoned");
+    if !state.write_pre_confirmed_block_should_succeed {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    let Some(block_number) = body.get("block_number").and_then(Value::as_u64) else {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":"body missing block_number"}"#.to_string(),
+        )
+        .into_response();
+    };
+    state.pre_confirmed_block_numbers.insert(block_number);
+    StatusCode::OK.into_response()
+}
+
+// Helpers
+
+fn json_response(status: StatusCode, body: String) -> impl IntoResponse {
+    (status, [(header::CONTENT_TYPE, "application/json")], body)
+}
+
+fn json_or_block_not_found(json: Option<String>) -> impl IntoResponse {
+    match json {
+        Some(body) => json_response(StatusCode::OK, body),
+        None => json_response(StatusCode::BAD_REQUEST, BLOCK_NOT_FOUND_JSON.to_string()),
+    }
+}
+
+/// Derives a feeder-gateway `get_block` JSON from an `AerospikeBlob` JSON value.
+///
+/// The resulting JSON matches the `BlockPostV0_13_1` wire format so that a
+/// `StarknetFeederGatewayClient` (used by central sync) can deserialize it.
+///
+/// `block_hash` is initially `null` and is patched in later when a confirmed hash arrives via
+/// `recent_block_hashes` of a subsequent blob — exactly like `state_update`.
+///
+/// `parent_block_hash` is extracted from `recent_block_hashes` in the same blob: the entry whose
+/// `block_number == block_number - 1` carries the parent hash. Falls back to `"0x0"` if absent.
+fn blob_to_feeder_block_json(blob: &Value, block_number: u64) -> Value {
+    let block_info = blob.get("state_diff").and_then(|d| d.get("block_info"));
+
+    let parent_block_hash: Value = if block_number > 0 {
+        blob.get("recent_block_hashes")
+            .and_then(Value::as_array)
+            .and_then(|hashes| {
+                hashes.iter().find(|e| {
+                    e.get("block_number").and_then(Value::as_u64) == Some(block_number - 1)
+                })
+            })
+            .and_then(|e| e.get("block_hash"))
+            .cloned()
+            .unwrap_or_else(|| Value::String("0x0".to_string()))
+    } else {
+        Value::String("0x0".to_string())
+    };
+
+    // use_kzg_da maps to l1_da_mode: BLOB (kzg) or CALLDATA.
+    let l1_da_mode =
+        if block_info.and_then(|bi| bi.get("use_kzg_da")).and_then(Value::as_bool).unwrap_or(false)
+        {
+            "BLOB"
+        } else {
+            "CALLDATA"
+        };
+
+    // starknet_version is Option in the blob; default to a recent known value.
+    let starknet_version = block_info
+        .and_then(|bi| bi.get("starknet_version"))
+        .and_then(Value::as_str)
+        .unwrap_or("0.14.0");
+
+    let zero_gas_price = serde_json::json!({"price_in_wei": "0x1", "price_in_fri": "0x1"});
+    let get_gas_price = |key: &str| -> Value {
+        block_info.and_then(|bi| bi.get(key)).cloned().unwrap_or_else(|| zero_gas_price.clone())
+    };
+    let sequencer_address = block_info
+        .and_then(|bi| bi.get("sequencer_address"))
+        .cloned()
+        .unwrap_or_else(|| Value::String("0x0".to_string()));
+    let timestamp = block_info
+        .and_then(|bi| bi.get("block_timestamp"))
+        .cloned()
+        .unwrap_or(Value::Number(0u64.into()));
+
+    serde_json::json!({
+        // block_hash is null until the next blob's recent_block_hashes confirms it.
+        "block_hash": null,
+        "block_number": block_number,
+        "parent_block_hash": parent_block_hash,
+        "state_root": "0x0",
+        "status": "ACCEPTED_ON_L2",
+        // block_info field names match the feeder field names except block_timestamp -> timestamp.
+        "sequencer_address": sequencer_address,
+        "timestamp": timestamp,
+        "starknet_version": starknet_version,
+        "l1_da_mode": l1_da_mode,
+        // CentralResourcePrice serializes as {price_in_wei, price_in_fri}, same as GasPricePerToken.
+        "l1_gas_price": get_gas_price("l1_gas_price"),
+        "l1_data_gas_price": get_gas_price("l1_data_gas_price"),
+        "l2_gas_price": get_gas_price("l2_gas_price"),
+        // FeeMarketInfo fields map directly to the feeder's V0.14.0 additions.
+        "l2_gas_consumed": blob.get("fee_market_info").and_then(|fi| fi.get("l2_gas_consumed")).cloned().unwrap_or(Value::Number(0u64.into())),
+        "next_l2_gas_price": blob.get("fee_market_info").and_then(|fi| fi.get("next_l2_gas_price")).cloned().unwrap_or(Value::String("0x0".to_string())),
+        // Commitments are not available from the blob; use zero placeholders.
+        "transaction_commitment": "0x0",
+        "event_commitment": "0x0",
+        // Transactions are omitted: state sync only needs the block header to advance.
+        "transactions": [],
+        "transaction_receipts": [],
+    })
+}
+
+/// Converts a `CentralStateDiff` JSON value (as serialized in `AerospikeBlob`) into the feeder
+/// gateway `StateUpdate` format expected by `StarknetFeederGatewayClient`.
+///
+/// `block_hash` is initially `null` and is patched in later when a confirmed hash arrives via
+/// `recent_block_hashes` of a subsequent blob.
+fn central_state_diff_to_feeder_state_update(central_state_diff: &Value) -> Value {
+    // address_to_class_hash: Map<addr, hash> -> deployed_contracts: [{address, class_hash}]
+    let deployed_contracts: Vec<Value> = central_state_diff
+        .get("address_to_class_hash")
+        .and_then(Value::as_object)
+        .map(|map| {
+            map.iter()
+                .map(|(addr, hash)| serde_json::json!({"address": addr, "class_hash": hash}))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // nonces: Map<DA-mode, Map<addr, nonce>> -> nonces: Map<addr, nonce>  (merge all DA modes)
+    let nonces = central_state_diff
+        .get("nonces")
+        .and_then(Value::as_object)
+        .map(|da_map| {
+            let mut merged = serde_json::Map::new();
+            for per_mode in da_map.values() {
+                if let Some(addr_map) = per_mode.as_object() {
+                    merged.extend(addr_map.iter().map(|(k, v)| (k.clone(), v.clone())));
+                }
+            }
+            Value::Object(merged)
+        })
+        .unwrap_or(Value::Object(Default::default()));
+
+    // storage_updates: Map<DA-mode, Map<addr, Map<key,val>>> ->
+    //     storage_diffs: Map<addr, [{key,value}]>  (merge all DA modes)
+    let storage_diffs = central_state_diff
+        .get("storage_updates")
+        .and_then(Value::as_object)
+        .map(|da_map| {
+            let mut merged: serde_json::Map<String, Value> = serde_json::Map::new();
+            for per_mode in da_map.values() {
+                if let Some(addr_map) = per_mode.as_object() {
+                    for (addr, kv_map) in addr_map {
+                        let storage_entries: Vec<Value> = kv_map
+                            .as_object()
+                            .map(|m| {
+                                m.iter()
+                                    .map(|(key, val)| serde_json::json!({"key": key, "value": val}))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        merged
+                            .entry(addr.clone())
+                            .or_insert_with(|| Value::Array(vec![]))
+                            .as_array_mut()
+                            .expect("storage_diffs entry is always an array")
+                            .extend(storage_entries);
+                    }
+                }
+            }
+            Value::Object(merged)
+        })
+        .unwrap_or(Value::Object(Default::default()));
+
+    // class_hash_to_compiled_class_hash: Map<hash, compiled> ->
+    //     declared_classes: [{class_hash, compiled_class_hash}]
+    let declared_classes: Vec<Value> = central_state_diff
+        .get("class_hash_to_compiled_class_hash")
+        .and_then(Value::as_object)
+        .map(|map| {
+            map.iter()
+                .map(|(hash, compiled)| {
+                    serde_json::json!({"class_hash": hash, "compiled_class_hash": compiled})
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    serde_json::json!({
+        "block_hash": null,
+        "new_root": "0x0",
+        "old_root": "0x0",
+        "state_diff": {
+            "storage_diffs": storage_diffs,
+            "deployed_contracts": deployed_contracts,
+            "declared_classes": declared_classes,
+            "migrated_compiled_classes": [],
+            "old_declared_contracts": [],
+            "nonces": nonces,
+            "replaced_classes": [],
+        }
+    })
+}

--- a/crates/apollo_integration_tests/src/fake_starknet_server_test.rs
+++ b/crates/apollo_integration_tests/src/fake_starknet_server_test.rs
@@ -1,0 +1,999 @@
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+use super::FakeStarknetServer;
+use crate::fake_starknet_server::{BLOCK_NOT_FOUND_JSON, BLOCK_SIGNATURE_JSON};
+
+// Feeder tests
+
+#[tokio::test]
+async fn feeder_is_alive() {
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+    let (status, body) = get(&client, &url(&server, "/feeder_gateway/is_alive")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, "FeederGateway is alive!");
+}
+
+#[tokio::test]
+async fn get_block_by_number() {
+    const BLOCK_NUMBER1: u64 = 7;
+    const BLOCK_NUMBER2: u64 = 10;
+    const BAD_BLOCK_NUMBER: u64 = 99;
+    const {
+        assert!(BLOCK_NUMBER1 < BLOCK_NUMBER2);
+    }
+
+    let server = FakeStarknetServer::new().await;
+    let feeder_json1 = make_feeder_block(BLOCK_NUMBER1);
+    server.state.lock().unwrap().seed_block(
+        BLOCK_NUMBER1,
+        &format!("0x{BLOCK_NUMBER1:x}"),
+        feeder_json1.clone(),
+    );
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER1}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), feeder_json1);
+
+    let feeder_json2 = make_feeder_block(BLOCK_NUMBER2);
+    server.state.lock().unwrap().seed_block(
+        BLOCK_NUMBER2,
+        &format!("0x{BLOCK_NUMBER2:x}"),
+        feeder_json2.clone(),
+    );
+
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER2}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), feeder_json2);
+
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BAD_BLOCK_NUMBER}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, BLOCK_NOT_FOUND_JSON);
+}
+
+#[tokio::test]
+async fn get_latest_block_returns_highest_block_number() {
+    const BLOCK_NUMBER1: u64 = 3;
+    const BLOCK_NUMBER2: u64 = 5;
+    const BLOCK_NUMBER3: u64 = 7;
+    const {
+        assert!(BLOCK_NUMBER1 < BLOCK_NUMBER2);
+    }
+    const {
+        assert!(BLOCK_NUMBER2 < BLOCK_NUMBER3);
+    }
+
+    let server = FakeStarknetServer::new().await;
+    {
+        let mut state = server.state.lock().unwrap();
+        state.seed_block(
+            BLOCK_NUMBER3,
+            &format!("0x{BLOCK_NUMBER3:x}"),
+            make_feeder_block(BLOCK_NUMBER3),
+        );
+        state.seed_block(
+            BLOCK_NUMBER2,
+            &format!("0x{BLOCK_NUMBER2:x}"),
+            make_feeder_block(BLOCK_NUMBER2),
+        );
+        state.seed_block(
+            BLOCK_NUMBER1,
+            &format!("0x{BLOCK_NUMBER1:x}"),
+            make_feeder_block(BLOCK_NUMBER1),
+        );
+    }
+
+    let client = reqwest::Client::new();
+    let (status, body) =
+        get(&client, &url(&server, "/feeder_gateway/get_block?blockNumber=latest")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let returned: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(returned["block_number"], BLOCK_NUMBER3);
+}
+
+#[tokio::test]
+async fn get_latest_block_empty_store() {
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+    let (status, _) =
+        get(&client, &url(&server, "/feeder_gateway/get_block?blockNumber=latest")).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_block_header_only_true_returns_subset() {
+    const BLOCK_NUMBER: u64 = 16;
+    let server = FakeStarknetServer::new().await;
+    server.state.lock().unwrap().seed_block(
+        BLOCK_NUMBER,
+        &format!("0x{BLOCK_NUMBER:x}"),
+        make_feeder_block(BLOCK_NUMBER),
+    );
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(
+            &server,
+            &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}&headerOnly=true"),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let returned: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(returned["block_number"], BLOCK_NUMBER);
+    assert_eq!(returned["block_hash"], format!("0x{BLOCK_NUMBER:x}"));
+    // No extra fields beyond block_number and block_hash.
+    assert_eq!(returned.as_object().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn get_block_header_only_false_returns_full_block() {
+    const BLOCK_NUMBER: u64 = 16;
+    let server = FakeStarknetServer::new().await;
+    let feeder_json = make_feeder_block(BLOCK_NUMBER);
+    server.state.lock().unwrap().seed_block(
+        BLOCK_NUMBER,
+        &format!("0x{BLOCK_NUMBER:x}"),
+        feeder_json.clone(),
+    );
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(
+            &server,
+            &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}&headerOnly=false"),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), feeder_json);
+}
+
+#[tokio::test]
+async fn get_block_without_hash_returns_block_not_found() {
+    const BLOCK_NUMBER: u64 = 5;
+    let server = FakeStarknetServer::new().await;
+    // Seed feeder content but no block hash.
+    server.state.lock().unwrap().blocks.entry(BLOCK_NUMBER).or_default().feeder_json =
+        Some(make_feeder_block(BLOCK_NUMBER));
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, BLOCK_NOT_FOUND_JSON);
+}
+
+#[tokio::test]
+async fn get_block_without_feeder_content_returns_block_not_found() {
+    const BLOCK_NUMBER: u64 = 5;
+    let server = FakeStarknetServer::new().await;
+    // Set block hash but no feeder content.
+    server.state.lock().unwrap().blocks.entry(BLOCK_NUMBER).or_default().block_hash =
+        Some(format!("0x{BLOCK_NUMBER:x}"));
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, BLOCK_NOT_FOUND_JSON);
+}
+
+#[tokio::test]
+async fn get_state_update_returns_stored_state_update() {
+    const BLOCK_NUMBER: u64 = 2;
+    const BAD_BLOCK_NUMBER: u64 = 99;
+
+    let server = FakeStarknetServer::new().await;
+    let state_update = json!({"state_diff": {}});
+    {
+        let mut state = server.state.lock().unwrap();
+        let block = state.blocks.entry(BLOCK_NUMBER).or_default();
+        block.block_hash = Some(format!("0x{BLOCK_NUMBER:x}"));
+        block.state_update = Some(state_update.clone());
+    }
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_state_update?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), state_update);
+
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_state_update?blockNumber={BAD_BLOCK_NUMBER}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let error: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(error["code"], "StarknetErrorCode.BLOCK_NOT_FOUND");
+}
+
+#[tokio::test]
+async fn get_state_update_without_block_hash_returns_block_not_found() {
+    const BLOCK_NUMBER: u64 = 2;
+    let server = FakeStarknetServer::new().await;
+    // Seed state_update but no block hash.
+    server.state.lock().unwrap().blocks.entry(BLOCK_NUMBER).or_default().state_update =
+        Some(json!({"state_diff": {}}));
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_state_update?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, BLOCK_NOT_FOUND_JSON);
+}
+
+#[tokio::test]
+async fn get_state_update_pending_returns_pending_data() {
+    let server = FakeStarknetServer::new().await;
+    let pending = json!({"pending": true});
+    server.state.lock().unwrap().pending_data_json = Some(pending.clone());
+
+    let client = reqwest::Client::new();
+    let (status, body) =
+        get(&client, &url(&server, "/feeder_gateway/get_state_update?blockNumber=pending")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, pending.to_string());
+}
+
+#[tokio::test]
+async fn get_state_update_invalid_block_number_returns_block_not_found() {
+    let server = FakeStarknetServer::new().await;
+
+    let client = reqwest::Client::new();
+    let (status, body) =
+        get(&client, &url(&server, "/feeder_gateway/get_state_update?blockNumber=garbage")).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, BLOCK_NOT_FOUND_JSON);
+}
+
+#[tokio::test]
+async fn get_state_update_pending_not_configured_returns_block_not_found() {
+    let server = FakeStarknetServer::new().await;
+    // pending_data_json is None by default.
+
+    let client = reqwest::Client::new();
+    let (status, body) =
+        get(&client, &url(&server, "/feeder_gateway/get_state_update?blockNumber=pending")).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body, BLOCK_NOT_FOUND_JSON);
+}
+
+#[tokio::test]
+async fn get_signature_returns_constant() {
+    const BLOCK_NUMBER: u64 = 6;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_signature?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, BLOCK_SIGNATURE_JSON);
+}
+
+#[tokio::test]
+async fn get_class_by_hash_returns_class() {
+    const CLASS_HASH: &str = "0xabc";
+    const BAD_CLASS_HASH: &str = "0xdeadbeef";
+
+    let server = FakeStarknetServer::new().await;
+    let class = json!({"type": "CAIRO_1"});
+    server.state.lock().unwrap().classes_json.insert(CLASS_HASH.to_string(), class.clone());
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_class_by_hash?classHash={CLASS_HASH}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), class);
+
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_class_by_hash?classHash={BAD_CLASS_HASH}")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let error: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(error["code"], "StarknetErrorCode.UNDECLARED_CLASS");
+}
+
+#[tokio::test]
+async fn get_compiled_class_returns_compiled_class() {
+    const CLASS_HASH: &str = "0xdef";
+    const BAD_CLASS_HASH: &str = "0xunknown";
+
+    let server = FakeStarknetServer::new().await;
+    let compiled = json!({"bytecode": [1, 2, 3]});
+    server
+        .state
+        .lock()
+        .unwrap()
+        .compiled_classes_json
+        .insert(CLASS_HASH.to_string(), compiled.clone());
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(
+        &client,
+        &url(
+            &server,
+            &format!("/feeder_gateway/get_compiled_class_by_class_hash?classHash={CLASS_HASH}"),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), compiled);
+
+    let (status, body) = get(
+        &client,
+        &url(
+            &server,
+            &format!("/feeder_gateway/get_compiled_class_by_class_hash?classHash={BAD_CLASS_HASH}"),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let error: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(error["code"], "StarknetErrorCode.UNDECLARED_CLASS");
+}
+
+#[tokio::test]
+async fn get_public_key() {
+    const PUBLIC_KEY: &str = "0x123456";
+    let server = FakeStarknetServer::new().await;
+    let pub_key = json!(PUBLIC_KEY);
+    server.state.lock().unwrap().sequencer_pub_key_json = Some(pub_key.clone());
+
+    let client = reqwest::Client::new();
+    let (status, body) = get(&client, &url(&server, "/feeder_gateway/get_public_key")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), pub_key);
+}
+
+#[tokio::test]
+async fn get_public_key_not_configured() {
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+    let (status, _) = get(&client, &url(&server, "/feeder_gateway/get_public_key")).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// Cende tests
+
+#[tokio::test]
+async fn write_blob_records_block_without_hash() {
+    const BLOCK_NUMBER: u64 = 10;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    let status =
+        post_json(&client, &url(&server, "/cende_recorder/write_blob"), &make_blob(BLOCK_NUMBER))
+            .await;
+
+    assert_eq!(status, StatusCode::OK);
+    // The block exists in state but has no confirmed hash yet.
+    let state = server.state.lock().unwrap();
+    let block = state.blocks.get(&BLOCK_NUMBER).expect("block should exist after write_blob");
+    assert!(block.block_hash.is_none());
+    assert!(block.feeder_json.is_none());
+}
+
+#[tokio::test]
+async fn write_blob_failure_mode_returns_500_and_does_not_store() {
+    const BLOCK_NUMBER: u64 = 3;
+    let server = FakeStarknetServer::new().await;
+    server.state.lock().unwrap().write_blob_should_succeed = false;
+    let client = reqwest::Client::new();
+
+    let status =
+        post_json(&client, &url(&server, "/cende_recorder/write_blob"), &make_blob(BLOCK_NUMBER))
+            .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(server.state.lock().unwrap().blocks.is_empty());
+}
+
+#[tokio::test]
+async fn get_latest_received_block_empty_store() {
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+    let (status, body) =
+        get(&client, &url(&server, "/cende_recorder/get_latest_received_block")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let response: Value = serde_json::from_str(&body).unwrap();
+    assert!(response["block_number"].is_null());
+}
+
+#[tokio::test]
+async fn get_latest_received_block_returns_max_block_with_hash() {
+    const BLOCK_NUMBER1: u64 = 1;
+    const BLOCK_NUMBER2: u64 = 3;
+    const BLOCK_NUMBER3: u64 = 5;
+    const {
+        assert!(BLOCK_NUMBER1 < BLOCK_NUMBER2);
+    }
+    const {
+        assert!(BLOCK_NUMBER2 < BLOCK_NUMBER3);
+    }
+
+    let server = FakeStarknetServer::new().await;
+    {
+        let mut state = server.state.lock().unwrap();
+        // Set block hashes directly, simulating what recent_block_hashes would do.
+        state.blocks.entry(BLOCK_NUMBER1).or_default().block_hash =
+            Some(format!("0x{BLOCK_NUMBER1:x}"));
+        state.blocks.entry(BLOCK_NUMBER2).or_default().block_hash =
+            Some(format!("0x{BLOCK_NUMBER2:x}"));
+        state.blocks.entry(BLOCK_NUMBER3).or_default().block_hash =
+            Some(format!("0x{BLOCK_NUMBER3:x}"));
+    }
+
+    let client = reqwest::Client::new();
+    let (status, body) =
+        get(&client, &url(&server, "/cende_recorder/get_latest_received_block")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let response: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(response["block_number"], BLOCK_NUMBER3);
+}
+
+#[tokio::test]
+async fn get_latest_received_block_ignores_blocks_without_hash() {
+    const BLOCK_WITH_HASH: u64 = 3;
+    const BLOCK_WITHOUT_HASH: u64 = 5;
+    const {
+        assert!(BLOCK_WITH_HASH < BLOCK_WITHOUT_HASH);
+    }
+
+    let server = FakeStarknetServer::new().await;
+    {
+        let mut state = server.state.lock().unwrap();
+        state.blocks.entry(BLOCK_WITH_HASH).or_default().block_hash =
+            Some(format!("0x{BLOCK_WITH_HASH:x}"));
+        // BLOCK_WITHOUT_HASH exists but has no confirmed hash (as if only its blob was posted).
+        state.blocks.entry(BLOCK_WITHOUT_HASH).or_default();
+    }
+
+    let client = reqwest::Client::new();
+    let (status, body) =
+        get(&client, &url(&server, "/cende_recorder/get_latest_received_block")).await;
+
+    assert_eq!(status, StatusCode::OK);
+    // Only BLOCK_WITH_HASH counts.
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap()["block_number"], BLOCK_WITH_HASH);
+}
+
+#[tokio::test]
+async fn write_blob_with_recent_block_hashes_fills_in_hashes() {
+    const BLOB_BLOCK_NUMBER: u64 = 10;
+    const RECENT_BLOCK_NUMBER: u64 = 9;
+
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    let blob = make_blob_with_recent_hashes(
+        BLOB_BLOCK_NUMBER,
+        &[(RECENT_BLOCK_NUMBER, format!("0x{RECENT_BLOCK_NUMBER:x}"))],
+    );
+    let status = post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let state = server.state.lock().unwrap();
+    // The blob's own block has no hash yet.
+    assert!(state.blocks[&BLOB_BLOCK_NUMBER].block_hash.is_none());
+    // The referenced older block has its hash filled in.
+    assert_eq!(
+        state.blocks[&RECENT_BLOCK_NUMBER].block_hash,
+        Some(format!("0x{RECENT_BLOCK_NUMBER:x}"))
+    );
+}
+
+#[tokio::test]
+async fn write_blob_with_recent_hashes_updates_get_latest_received_block() {
+    const BLOB_BLOCK_NUMBER: u64 = 8;
+    const PREV_BLOCK_NUMBER: u64 = BLOB_BLOCK_NUMBER - 1;
+
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    let blob = make_blob_with_recent_hashes(
+        BLOB_BLOCK_NUMBER,
+        &[(PREV_BLOCK_NUMBER, format!("0x{PREV_BLOCK_NUMBER:x}"))],
+    );
+    let write_status = post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+    assert_eq!(write_status, StatusCode::OK);
+
+    // Only PREV_BLOCK_NUMBER has a confirmed hash; BLOB_BLOCK_NUMBER does not.
+    let (status, body) =
+        get(&client, &url(&server, "/cende_recorder/get_latest_received_block")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap()["block_number"], PREV_BLOCK_NUMBER);
+}
+
+#[tokio::test]
+async fn write_blob_without_recent_hashes_does_not_update_get_latest_received_block() {
+    const BLOCK_NUMBER: u64 = 8;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Blob with no recent_block_hashes: the block has no confirmed hash.
+    let write_status =
+        post_json(&client, &url(&server, "/cende_recorder/write_blob"), &make_blob(BLOCK_NUMBER))
+            .await;
+    assert_eq!(write_status, StatusCode::OK);
+
+    let (status, body) =
+        get(&client, &url(&server, "/cende_recorder/get_latest_received_block")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(serde_json::from_str::<Value>(&body).unwrap()["block_number"].is_null());
+}
+
+#[tokio::test]
+async fn write_blob_without_feeder_content_is_not_served_by_feeder() {
+    const BLOCK_NUMBER: u64 = 8;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Blob with recent_block_hashes gives BLOCK_NUMBER a hash, but no feeder content.
+    let blob = make_blob_with_recent_hashes(
+        BLOCK_NUMBER + 1,
+        &[(BLOCK_NUMBER, format!("0x{BLOCK_NUMBER:x}"))],
+    );
+    let write_status = post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+    assert_eq!(write_status, StatusCode::OK);
+
+    // Hash is known but feeder content is absent: feeder must not serve the block.
+    let (status, _) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn hash_set_before_feeder_content_merges_correctly() {
+    const BLOCK_NUMBER: u64 = 5;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Step 1: hash arrives via a later blob's recent_block_hashes.
+    let later_blob = make_blob_with_recent_hashes(
+        BLOCK_NUMBER + 1,
+        &[(BLOCK_NUMBER, format!("0x{BLOCK_NUMBER:x}"))],
+    );
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &later_blob).await;
+
+    // Step 2: feeder content seeded directly.
+    let feeder_json = make_feeder_block(BLOCK_NUMBER);
+    server.state.lock().unwrap().blocks.entry(BLOCK_NUMBER).or_default().feeder_json =
+        Some(feeder_json.clone());
+
+    // Both pieces are present: the block is now served by the feeder.
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), feeder_json);
+}
+
+#[tokio::test]
+async fn feeder_content_set_before_hash_merges_correctly() {
+    const BLOCK_NUMBER: u64 = 5;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Step 1: feeder content seeded first.
+    let feeder_json = make_feeder_block(BLOCK_NUMBER);
+    server.state.lock().unwrap().blocks.entry(BLOCK_NUMBER).or_default().feeder_json =
+        Some(feeder_json.clone());
+
+    // Block is not yet served (no hash).
+    let (status, _) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Step 2: hash arrives via a later blob's recent_block_hashes.
+    let later_blob = make_blob_with_recent_hashes(
+        BLOCK_NUMBER + 1,
+        &[(BLOCK_NUMBER, format!("0x{BLOCK_NUMBER:x}"))],
+    );
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &later_blob).await;
+
+    // Both pieces are now present: the block is served.
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(serde_json::from_str::<Value>(&body).unwrap(), feeder_json);
+}
+
+// State update derivation from blob state_diff
+
+#[tokio::test]
+async fn write_blob_derives_state_update_from_central_state_diff() {
+    const BLOCK_NUMBER: u64 = 5;
+    const NEXT_BLOCK_NUMBER: u64 = BLOCK_NUMBER + 1;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Blob for BLOCK_NUMBER carries a CentralStateDiff with both L1 and L2 DA-mode entries.
+    let blob = json!({
+        "block_number": BLOCK_NUMBER,
+        "state_diff": {
+            "address_to_class_hash": {"0x1": "0x10"},
+            "nonces": {
+                "L1": {"0x2": "0x20"},
+                "L2": {"0x22": "0x220"}
+            },
+            "storage_updates": {
+                "L1": {"0x3": {"0x30": "0x300"}},
+                "L2": {"0x33": {"0x330": "0x3300"}}
+            },
+            "class_hash_to_compiled_class_hash": {"0x4": "0x40"},
+            "block_info": {}
+        }
+    });
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+
+    // A later blob confirms BLOCK_NUMBER's hash via recent_block_hashes.
+    let later_blob = make_blob_with_recent_hashes(
+        NEXT_BLOCK_NUMBER,
+        &[(BLOCK_NUMBER, format!("0x{BLOCK_NUMBER:x}"))],
+    );
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &later_blob).await;
+
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_state_update?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let state_update: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(state_update["block_hash"], format!("0x{BLOCK_NUMBER:x}"));
+    let state_diff = &state_update["state_diff"];
+    assert_eq!(state_diff["deployed_contracts"], json!([{"address": "0x1", "class_hash": "0x10"}]));
+    // Nonces from both L1 and L2 are merged into a flat map.
+    assert_eq!(state_diff["nonces"], json!({"0x2": "0x20", "0x22": "0x220"}));
+    // Storage diffs from both L1 and L2 are merged into a flat map.
+    assert_eq!(
+        state_diff["storage_diffs"],
+        json!({"0x3": [{"key": "0x30", "value": "0x300"}], "0x33": [{"key": "0x330", "value": "0x3300"}]})
+    );
+    assert_eq!(
+        state_diff["declared_classes"],
+        json!([{"class_hash": "0x4", "compiled_class_hash": "0x40"}])
+    );
+    assert_eq!(state_diff["replaced_classes"], json!([]));
+    assert_eq!(state_diff["old_declared_contracts"], json!([]));
+}
+
+#[tokio::test]
+async fn write_blob_derives_feeder_json_from_block_info() {
+    const BLOCK_NUMBER: u64 = 5;
+    const NEXT_BLOCK_NUMBER: u64 = BLOCK_NUMBER + 1;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Blob for BLOCK_NUMBER carries a full block_info and fee_market_info.
+    // recent_block_hashes carries the parent (BLOCK_NUMBER - 1) hash.
+    let blob = json!({
+        "block_number": BLOCK_NUMBER,
+        "state_diff": {
+            "address_to_class_hash": {},
+            "nonces": {},
+            "storage_updates": {},
+            "class_hash_to_compiled_class_hash": {},
+            "block_info": {
+                "block_timestamp": 1700000000u64,
+                "use_kzg_da": true,
+                "sequencer_address": "0xabcd",
+                "starknet_version": "0.14.0",
+                "l1_gas_price": {"price_in_wei": "0x1", "price_in_fri": "0x2"},
+                "l1_data_gas_price": {"price_in_wei": "0x3", "price_in_fri": "0x4"},
+                "l2_gas_price": {"price_in_wei": "0x5", "price_in_fri": "0x6"}
+            }
+        },
+        "fee_market_info": {
+            "l2_gas_consumed": 0x1234u64,
+            "next_l2_gas_price": "0x5678"
+        },
+        "recent_block_hashes": [
+            {"block_number": BLOCK_NUMBER - 1, "block_hash": "0xparent"}
+        ]
+    });
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+
+    // Hash not yet confirmed: get_block returns 404.
+    let (status, _) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // A later blob confirms BLOCK_NUMBER's hash via recent_block_hashes.
+    let later_blob = make_blob_with_recent_hashes(
+        NEXT_BLOCK_NUMBER,
+        &[(BLOCK_NUMBER, format!("0x{BLOCK_NUMBER:x}"))],
+    );
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &later_blob).await;
+
+    // Now get_block should serve the derived feeder JSON.
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let block: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(block["block_number"], BLOCK_NUMBER);
+    assert_eq!(block["block_hash"], format!("0x{BLOCK_NUMBER:x}"));
+    assert_eq!(block["parent_block_hash"], "0xparent");
+    assert_eq!(block["timestamp"], 1700000000u64);
+    assert_eq!(block["l1_da_mode"], "BLOB");
+    assert_eq!(block["sequencer_address"], "0xabcd");
+    assert_eq!(block["starknet_version"], "0.14.0");
+    assert_eq!(block["l1_gas_price"], json!({"price_in_wei": "0x1", "price_in_fri": "0x2"}));
+    assert_eq!(block["l1_data_gas_price"], json!({"price_in_wei": "0x3", "price_in_fri": "0x4"}));
+    assert_eq!(block["l2_gas_price"], json!({"price_in_wei": "0x5", "price_in_fri": "0x6"}));
+    assert_eq!(block["l2_gas_consumed"], 0x1234u64);
+    assert_eq!(block["next_l2_gas_price"], "0x5678");
+    assert_eq!(block["status"], "ACCEPTED_ON_L2");
+}
+
+#[tokio::test]
+async fn feeder_json_hash_patched_when_hash_confirmed_before_blob() {
+    // Regression: if the hash arrives via recent_block_hashes before the block's own blob,
+    // the feeder_json derived from the blob must have block_hash patched in immediately,
+    // not left as null (which would pass the internal gate but serve a broken payload).
+    const BLOCK_NUMBER: u64 = 5;
+    const NEXT_BLOCK_NUMBER: u64 = BLOCK_NUMBER + 1;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Step 1: hash arrives first via a later blob's recent_block_hashes.
+    let later_blob = make_blob_with_recent_hashes(
+        NEXT_BLOCK_NUMBER,
+        &[(BLOCK_NUMBER, format!("0x{BLOCK_NUMBER:x}"))],
+    );
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &later_blob).await;
+
+    // Step 2: blob for BLOCK_NUMBER arrives with block_info.
+    let blob = json!({
+        "block_number": BLOCK_NUMBER,
+        "state_diff": {
+            "address_to_class_hash": {},
+            "nonces": {},
+            "storage_updates": {},
+            "class_hash_to_compiled_class_hash": {},
+            "block_info": {
+                "block_timestamp": 1700000001u64,
+                "use_kzg_da": false,
+                "sequencer_address": "0x1",
+                "starknet_version": "0.14.0",
+                "l1_gas_price": {"price_in_wei": "0x1", "price_in_fri": "0x1"},
+                "l1_data_gas_price": {"price_in_wei": "0x1", "price_in_fri": "0x1"},
+                "l2_gas_price": {"price_in_wei": "0x1", "price_in_fri": "0x1"}
+            }
+        },
+        "fee_market_info": {"l2_gas_consumed": 0u64, "next_l2_gas_price": "0x1"}
+    });
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+
+    // The block must be served with the confirmed hash, not null.
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_block?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let block: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(block["block_hash"], format!("0x{BLOCK_NUMBER:x}"));
+}
+
+#[tokio::test]
+async fn state_update_not_served_until_hash_confirmed() {
+    const BLOCK_NUMBER: u64 = 5;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Blob posted: state_diff known but hash not yet confirmed.
+    let blob = json!({
+        "block_number": BLOCK_NUMBER,
+        "state_diff": {
+            "address_to_class_hash": {},
+            "nonces": {},
+            "storage_updates": {},
+            "class_hash_to_compiled_class_hash": {},
+            "block_info": {}
+        }
+    });
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+
+    let (status, _) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_state_update?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn hash_confirmed_before_state_diff_patches_correctly() {
+    const BLOCK_NUMBER: u64 = 5;
+    const NEXT_BLOCK_NUMBER: u64 = BLOCK_NUMBER + 1;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    // Hash arrives first via a later blob.
+    let later_blob = make_blob_with_recent_hashes(
+        NEXT_BLOCK_NUMBER,
+        &[(BLOCK_NUMBER, format!("0x{BLOCK_NUMBER:x}"))],
+    );
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &later_blob).await;
+
+    // State diff arrives in the blob for BLOCK_NUMBER itself.
+    let blob = json!({
+        "block_number": BLOCK_NUMBER,
+        "state_diff": {
+            "address_to_class_hash": {"0x1": "0x10"},
+            "nonces": {},
+            "storage_updates": {},
+            "class_hash_to_compiled_class_hash": {},
+            "block_info": {}
+        }
+    });
+    post_json(&client, &url(&server, "/cende_recorder/write_blob"), &blob).await;
+
+    let (status, body) = get(
+        &client,
+        &url(&server, &format!("/feeder_gateway/get_state_update?blockNumber={BLOCK_NUMBER}")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let state_update: Value = serde_json::from_str(&body).unwrap();
+    // Hash was patched in at derivation time.
+    assert_eq!(state_update["block_hash"], format!("0x{BLOCK_NUMBER:x}"));
+    assert_eq!(
+        state_update["state_diff"]["deployed_contracts"],
+        json!([{"address": "0x1", "class_hash": "0x10"}])
+    );
+}
+
+// write_pre_confirmed_block tests
+
+#[tokio::test]
+async fn write_pre_confirmed_block_records_block_number() {
+    const BLOCK_NUMBER: u64 = 11;
+    let server = FakeStarknetServer::new().await;
+    let client = reqwest::Client::new();
+
+    let status = post_json(
+        &client,
+        &url(&server, "/cende_recorder/write_pre_confirmed_block"),
+        &make_blob(BLOCK_NUMBER),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(server.state.lock().unwrap().pre_confirmed_block_numbers.contains(&BLOCK_NUMBER));
+    // Does not affect the block store.
+    assert!(server.state.lock().unwrap().blocks.is_empty());
+}
+
+#[tokio::test]
+async fn write_pre_confirmed_block_failure_mode_returns_500_and_does_not_store() {
+    const BLOCK_NUMBER: u64 = 4;
+    let server = FakeStarknetServer::new().await;
+    server.state.lock().unwrap().write_pre_confirmed_block_should_succeed = false;
+    let client = reqwest::Client::new();
+
+    let status = post_json(
+        &client,
+        &url(&server, "/cende_recorder/write_pre_confirmed_block"),
+        &make_blob(BLOCK_NUMBER),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(server.state.lock().unwrap().pre_confirmed_block_numbers.is_empty());
+}
+
+// Helpers
+
+/// Minimal blob payload with only a block number, no recent_block_hashes.
+fn make_blob(block_number: u64) -> Value {
+    json!({ "block_number": block_number })
+}
+
+/// Blob payload carrying recent_block_hashes entries, as a real `AerospikeBlob` would.
+fn make_blob_with_recent_hashes(block_number: u64, recent: &[(u64, String)]) -> Value {
+    json!({
+        "block_number": block_number,
+        "recent_block_hashes": recent.iter().map(|(n, h)| json!({"block_number": n, "block_hash": h})).collect::<Vec<_>>(),
+    })
+}
+
+/// Minimal feeder-format block JSON with the fields required by feeder gateway handlers.
+fn make_feeder_block(block_number: u64) -> Value {
+    json!({ "block_number": block_number, "block_hash": format!("0x{block_number:x}") })
+}
+
+/// Returns `{server_url}{path}`, stripping the trailing slash that `Url` adds so paths
+/// with a leading slash don't produce double-slash URLs.
+fn url(server: &FakeStarknetServer, path: &str) -> String {
+    format!("{}{path}", server.url.as_str().trim_end_matches('/'))
+}
+
+async fn get(client: &reqwest::Client, url: &str) -> (StatusCode, String) {
+    let response = client.get(url).send().await.unwrap();
+    let status = response.status();
+    let body = response.text().await.unwrap();
+    (status, body)
+}
+
+async fn post_json(client: &reqwest::Client, url: &str, body: &Value) -> StatusCode {
+    client.post(url).json(body).send().await.unwrap().status()
+}

--- a/crates/apollo_integration_tests/src/lib.rs
+++ b/crates/apollo_integration_tests/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod executable_setup;
+pub mod fake_starknet_server;
 pub mod flow_test_setup;
 pub mod integration_test_manager;
 pub mod integration_test_utils;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to integration-test utilities (new fake HTTP server + tests) and a dev-dependency update, with no production code paths affected.
> 
> **Overview**
> Adds `FakeStarknetServer`, an axum-based in-process HTTP test server that emulates key `feeder_gateway/*` and `cende_recorder/*` endpoints backed by a shared per-block store (including state-update derivation from posted blob `state_diff`).
> 
> Updates `apollo_integration_tests` to expose the new module and adds extensive tokio tests validating endpoint behavior, error modes, and correct merging/patching of block hash + feeder/state-update data; introduces `reqwest` as a dev-dependency (and lockfile entry) to drive the HTTP assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413df22c1b90ddbd7eef64309e29a02225cc6b8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->