### PR TITLE
add section on expect vs allow

### DIFF
--- a/style.md
+++ b/style.md
@@ -461,6 +461,20 @@ completes successfully --- otherwise the task will _detach_ from the process.
 - When implementing a future, if you return `Poll::Pending`, you _must_ store the context somewhere
 and wake it when the future stops being pending. Otherwise, the future will be forever stuck
 
+### `#[expect]` over `#[allow]`
+
+Prefer `#[expect(...)]` over `#[allow(...)]`. `#[expect]` enforces that the suppressed lint is actually triggered, so the compiler will warn you when the attribute is no longer needed.
+
+```rust
+// BAD - If the function is later used, this attribute silently lingers.
+#[allow(unused)]
+fn foo() {}
+
+// GOOD - If the function is later used, the compiler warns that the `expect` is unnecessary.
+#[expect(unused)]
+fn foo() {}
+```
+
 ### Macros
 
 Only use macros if non-macro alternatives are not feasible and when _really_ necessary (like when writing a domain-specific language).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified.
> 
> **Overview**
> Adds a new `style.md` guideline section recommending `#[expect(...)]` over `#[allow(...)]` for lint suppression, with a short rationale and example showing how `#[expect]` prevents stale suppressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1d0981132d9e4436b4e43bd6023e681795290bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->