### PR TITLE
error types should have a Error suffix

### DIFF
--- a/style.md
+++ b/style.md
@@ -166,9 +166,14 @@ async fn test_delayed_operation() {
 
 ## Error Handling & Safety
 
+
 Use `Result<T, E>` for recoverable errors and `panic!` only for bugs.
+
 Use `todo!` for to-be-completed code sections.
+
 Don't use `unreachable!` and `unimplemented!`, as they are very similar in meaning to `panic!` and `todo!` and it's not worth the headache of figuring which one fits better.
+
+Error structs and enums should have names ending with `Error` (e.g. `StorageError`, `ParseTransactionError`).
 
 ### expect message
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that affects naming conventions but does not modify runtime code.
> 
> **Overview**
> Updates `style.md` error-handling guidelines by adding a naming convention: error structs/enums should use an `*Error` suffix (e.g. `StorageError`, `ParseTransactionError`).
> 
> Also adds minor spacing/formatting around the “Error Handling & Safety” section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeee8ee6a9430ce593eacbbbaddf542ecc86828e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->