### PR TITLE
starknet_patricia_storage: define storage task trait

### DIFF
--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinError;
 use validator::Validate;
 
 use crate::errors::DeserializationError;
+use crate::reads_collector_storage::ReadsCollectorStorage;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DbKey(pub Vec<u8>);
@@ -118,6 +119,21 @@ pub trait ImmutableReadOnlyStorage: Send + Sync {
         &self,
         keys: &[&DbKey],
     ) -> impl Future<Output = PatriciaStorageResult<Vec<Option<DbValue>>>> + Send;
+}
+
+/// Defines the output type of a [StorageTask], split out so `gather` can reference `T::Output`
+/// without requiring a lifetime parameter.
+pub trait StorageTaskOutput<S: ImmutableReadOnlyStorage>: Send {
+    type Output: Send;
+}
+
+/// A unit of work that reads from storage concurrently.
+/// Implementors hold all data needed to perform the read and produce an output.
+pub trait StorageTask<'a, S: ImmutableReadOnlyStorage + 'a>: StorageTaskOutput<S> + Send {
+    fn run_with_storage(
+        self,
+        storage: &mut ReadsCollectorStorage<'a, S>,
+    ) -> impl Future<Output = Self::Output> + Send;
 }
 
 /// A read-only view of a storage. Does not assume concurrent access is possible.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new public async traits (`StorageTask`/`StorageTaskOutput`) and a new `async-trait` dependency, which may require downstream implementors to adjust and could affect compilation/lifetimes in consumer crates.
> 
> **Overview**
> Adds a new abstraction for concurrent read workloads by introducing `StorageTaskOutput` and an `async_trait`-based `StorageTask` that runs against a `ReadsCollectorStorage` wrapper.
> 
> Updates `starknet_patricia_storage` dependencies (`Cargo.toml`/`Cargo.lock`) to include `async-trait` to support the new async trait API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acaee4df5e95e0c87b300dfcb4d3880b20686b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->