### PR TITLE
starknet_patricia_storage: cache reads with gatherable storage

### DIFF
--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -5,11 +5,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use apollo_config::dumping::{prepend_sub_config_name, ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use async_trait::async_trait;
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationErrors};
 
 use crate::storage_trait::{
+    run_tasks_and_collect_reads,
     AsyncStorage,
     DbHashMap,
     DbKey,
@@ -17,6 +19,7 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    GatherableStorage,
     ImmutableReadOnlyStorage,
     NoStats,
     NullStorage,
@@ -25,6 +28,7 @@ use crate::storage_trait::{
     Storage,
     StorageConfigTrait,
     StorageStats,
+    StorageTask,
 };
 
 // 10M entries.
@@ -274,6 +278,21 @@ impl<S: Storage + ImmutableReadOnlyStorage> ImmutableReadOnlyStorage for CachedS
         });
 
         Ok(values)
+    }
+}
+
+#[async_trait]
+impl<S: Storage + ImmutableReadOnlyStorage + 'static> GatherableStorage for CachedStorage<S> {
+    async fn gather<T>(&mut self, tasks: Vec<T>) -> Vec<T::Output>
+    where
+        T: for<'s> StorageTask<'s, Self> + Send,
+        Self: Sized,
+    {
+        let (reads, outputs) = run_tasks_and_collect_reads(&*self, tasks).await;
+        for (key, value) in reads {
+            self.cache.put(key, Some(value));
+        }
+        outputs
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `CachedStorage` read-path behavior by caching keys read during concurrent `gather` tasks, which can affect cache contents, memory usage, and performance characteristics. Functional risk is moderate since it touches core storage wrappers but is scoped to read caching.
> 
> **Overview**
> `CachedStorage` now overrides `ImmutableReadOnlyStorage::gather` to run concurrent `StorageTask`s via `run_tasks_and_collect_reads` and **backfill the LRU cache** with any values read by those tasks.
> 
> This enables read results from gathered workloads to be reused by subsequent `get`/`mget` calls (previously gathered reads were discarded for caching purposes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c33a3fa92ecffa618f24ce8460492d046a8d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->