### PR TITLE
starknet_committer: create storage tries concurrently

### DIFF
--- a/crates/starknet_committer/src/db/trie_traversal.rs
+++ b/crates/starknet_committer/src/db/trie_traversal.rs
@@ -1,7 +1,9 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
+use async_trait::async_trait;
 use starknet_api::core::ContractAddress;
 use starknet_api::hash::HashOutput;
 use starknet_patricia::db_layout::{NodeLayout, NodeLayoutFor};
@@ -26,7 +28,15 @@ use starknet_patricia::patricia_merkle_tree::traversal::{
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
 use starknet_patricia_storage::db_object::{DBObject, EmptyKeyContext, HasStaticPrefix};
 use starknet_patricia_storage::errors::StorageError;
-use starknet_patricia_storage::storage_trait::{DbKey, ReadOnlyStorage};
+use starknet_patricia_storage::reads_collector_storage::ReadsCollectorStorage;
+use starknet_patricia_storage::storage_trait::{
+    DbKey,
+    GatherableStorage,
+    ImmutableReadOnlyStorage,
+    ReadOnlyStorage,
+    StorageTask,
+    StorageTaskOutput,
+};
 use tracing::warn;
 
 use crate::block_committer::input::{
@@ -452,6 +462,80 @@ where
         storage_tries.insert(*address, original_skeleton);
     }
     Ok(storage_tries)
+}
+
+/// Holds all data needed to build one storage trie concurrently.
+/// Implements [StorageTask] so that [GatherableStorage::gather] can drive it.
+struct TrieReadTask<'a, Layout: NodeLayoutFor<StarknetStorageValue>> {
+    address: ContractAddress,
+    updates: &'a LeafModifications<StarknetStorageValue>,
+    storage_root_hash: HashOutput,
+    sorted_leaf_indices: SortedLeafIndices<'a>,
+    warn_on_trivial_modifications: bool,
+    _layout: PhantomData<Layout>,
+}
+
+impl<'a, S, Layout> StorageTaskOutput<S> for TrieReadTask<'a, Layout>
+where
+    S: ImmutableReadOnlyStorage,
+    Layout: NodeLayoutFor<StarknetStorageValue> + Send + 'static,
+{
+    type Output = ForestResult<(ContractAddress, OriginalSkeletonTreeImpl<'a>)>;
+}
+
+#[async_trait]
+impl<'a, 's, S, Layout> StorageTask<'s, S> for TrieReadTask<'a, Layout>
+where
+    S: ImmutableReadOnlyStorage + 's,
+    Layout: NodeLayoutFor<StarknetStorageValue> + Send + 'static,
+    <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf:
+        HasStaticPrefix<KeyContext = ContractAddress>,
+{
+    async fn run_with_storage(self, storage: &mut ReadsCollectorStorage<'s, S>) -> Self::Output {
+        let skeleton = create_storage_trie::<Layout>(
+            storage,
+            self.address,
+            self.updates,
+            self.storage_root_hash,
+            self.sorted_leaf_indices,
+            self.warn_on_trivial_modifications,
+        )
+        .await?;
+        Ok((self.address, skeleton))
+    }
+}
+
+#[expect(dead_code)]
+async fn create_storage_tries_concurrently<'a, S, Layout>(
+    storage: &mut S,
+    actual_storage_updates: &'a HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
+    original_contracts_trie_leaves: &HashMap<NodeIndex, ContractState>,
+    warn_on_trivial_modifications: bool,
+    storage_tries_sorted_indices: &'a HashMap<ContractAddress, SortedLeafIndices<'a>>,
+) -> ForestResult<HashMap<ContractAddress, OriginalSkeletonTreeImpl<'a>>>
+where
+    S: GatherableStorage,
+    Layout: NodeLayoutFor<StarknetStorageValue> + Send + 'static,
+    <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf:
+        HasStaticPrefix<KeyContext = ContractAddress>,
+{
+    let mut tasks = Vec::new();
+    for (address, updates) in actual_storage_updates {
+        tasks.push(TrieReadTask::<Layout> {
+            address: *address,
+            updates,
+            storage_root_hash: original_contracts_trie_leaves
+                .get(&contract_address_into_node_index(address))
+                .ok_or(ForestError::MissingContractCurrentState(*address))?
+                .storage_root_hash,
+            sorted_leaf_indices: *storage_tries_sorted_indices
+                .get(address)
+                .ok_or(ForestError::MissingSortedLeafIndices(*address))?,
+            warn_on_trivial_modifications,
+            _layout: PhantomData,
+        });
+    }
+    storage.gather(tasks).await.into_iter().collect()
 }
 
 /// Helper function to create a storage trie for a single contract.

--- a/crates/starknet_patricia/src/db_layout.rs
+++ b/crates/starknet_patricia/src/db_layout.rs
@@ -18,7 +18,7 @@ pub trait NodeLayout<'a, L: Leaf> {
     /// 1. When [crate::patricia_merkle_tree::traversal::SubTreeTrait::create] is called in the
     ///    beginning of the original skeleton tree creation.
     /// 2. When Layout::get_db_object is called in the serialization of a FilledTree.
-    type NodeData: Clone + From<HashOutput>;
+    type NodeData: Clone + From<HashOutput> + Send;
 
     /// The context needed to deserialize the node from a raw
     /// [starknet_patricia_storage::storage_trait::DbValue].
@@ -35,7 +35,8 @@ pub trait NodeLayout<'a, L: Leaf> {
             'a,
             NodeData = Self::NodeData,
             NodeDeserializeContext = Self::DeserializationContext,
-        >;
+        > + Send
+        + Sync;
 
     /// Converts `FilledTree` nodes to db objects.
     ///


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new concurrent code path for building per-contract storage tries and tightens `NodeLayout` trait bounds (`Send`/`Sync`), which can affect implementors and has typical concurrency/correctness risks despite the new path currently being unused (`dead_code`).
> 
> **Overview**
> Adds scaffolding to build per-contract storage trie original skeletons concurrently via `ImmutableReadOnlyStorage::gather`: introduces `TrieReadTask` implementing `StorageTask` and a new `create_storage_tries_concurrently` helper that fans out one task per contract and collects results.
> 
> Updates `starknet_patricia::NodeLayout` to require `Send` on `NodeData` and `Send + Sync` on `SubTree` to support cross-task execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767c891a20379520733b6740eb7648348a536c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->