### PR TITLE
starknet_patricia_storage: add as_gatherable_storage to storage trait

### DIFF
--- a/crates/starknet_committer_cli/src/args.rs
+++ b/crates/starknet_committer_cli/src/args.rs
@@ -230,7 +230,7 @@ pub struct CachedStorageArgs<InnerStorageArgs: StorageFromArgs> {
 impl<InnerStorageArgs: StorageFromArgs + Sync> StorageFromArgs
     for CachedStorageArgs<InnerStorageArgs>
 where
-    InnerStorageArgs::Storage: ImmutableReadOnlyStorage,
+    InnerStorageArgs::Storage: ImmutableReadOnlyStorage + 'static,
 {
     type Storage = CachedStorage<InnerStorageArgs::Storage>;
 

--- a/crates/starknet_patricia_storage/src/aerospike_storage.rs
+++ b/crates/starknet_patricia_storage/src/aerospike_storage.rs
@@ -33,6 +33,7 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    GatherableStorage,
     ImmutableReadOnlyStorage,
     NoStats,
     PatriciaStorageResult,
@@ -255,4 +256,10 @@ impl Storage for AerospikeStorage {
     fn get_async_self(&self) -> Option<impl AsyncStorage> {
         Some(self.clone())
     }
+
+    fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage> {
+        Some(self)
+    }
 }
+
+impl GatherableStorage for AerospikeStorage {}

--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -102,6 +102,11 @@ impl Storage for MapStorage {
         // Need a concrete Option type.
         None::<NullStorage>
     }
+
+    fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage> {
+        // Return None to avoid using the MapStorage concurrently; the reads are fast anyway.
+        None::<&mut NullStorage>
+    }
 }
 
 /// A storage wrapper that adds an LRU cache to an underlying storage.
@@ -342,7 +347,7 @@ impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
     }
 }
 
-impl<S: Storage> Storage for CachedStorage<S> {
+impl<S: Storage + ImmutableReadOnlyStorage + 'static> Storage for CachedStorage<S> {
     type Stats = CachedStorageStats<S::Stats>;
     type Config = CachedStorageConfig<S::Config>;
 
@@ -413,5 +418,9 @@ impl<S: Storage> Storage for CachedStorage<S> {
     fn get_async_self(&self) -> Option<impl AsyncStorage> {
         // Need a concrete Option type.
         None::<NullStorage>
+    }
+
+    fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage> {
+        Some(self)
     }
 }

--- a/crates/starknet_patricia_storage/src/mdbx_storage.rs
+++ b/crates/starknet_patricia_storage/src/mdbx_storage.rs
@@ -22,6 +22,7 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    GatherableStorage,
     ImmutableReadOnlyStorage,
     PatriciaStorageResult,
     ReadOnlyStorage,
@@ -190,4 +191,10 @@ impl Storage for MdbxStorage {
     fn get_async_self(&self) -> Option<impl AsyncStorage> {
         Some(self.clone())
     }
+
+    fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage> {
+        Some(self)
+    }
 }
+
+impl GatherableStorage for MdbxStorage {}

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -27,6 +27,7 @@ use crate::storage_trait::{
     DbOperation,
     DbOperationMap,
     DbValue,
+    GatherableStorage,
     ImmutableReadOnlyStorage,
     PatriciaStorageError,
     PatriciaStorageResult,
@@ -375,4 +376,10 @@ impl Storage for RocksDbStorage {
     fn get_async_self(&self) -> Option<impl AsyncStorage> {
         Some(self.clone())
     }
+
+    fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage> {
+        Some(self)
+    }
 }
+
+impl GatherableStorage for RocksDbStorage {}

--- a/crates/starknet_patricia_storage/src/short_key_storage.rs
+++ b/crates/starknet_patricia_storage/src/short_key_storage.rs
@@ -10,7 +10,9 @@ use crate::storage_trait::{
     DbOperationMap,
     DbValue,
     EmptyStorageConfig,
+    GatherableStorage,
     ImmutableReadOnlyStorage,
+    NullStorage,
     PatriciaStorageResult,
     ReadOnlyStorage,
     Storage,
@@ -120,6 +122,10 @@ macro_rules! define_short_key_storage {
 
             fn get_async_self(&self) -> Option<impl AsyncStorage> {
                 Some($name::new(self.storage.get_async_self()?))
+            }
+
+            fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage> {
+                None::<&mut NullStorage>
             }
         }
 

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -248,6 +248,10 @@ pub trait Storage: ReadOnlyStorage {
 
     /// If the storage is async, returns an instance of the async storage.
     fn get_async_self(&self) -> Option<impl AsyncStorage>;
+
+    /// If the storage supports concurrent task execution via [GatherableStorage::gather], returns
+    /// a mutable reference to it. Returns `None` otherwise.
+    fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage>;
 }
 
 /// A trait wrapper for [Storage] that supports concurrency.
@@ -327,7 +331,13 @@ impl Storage for NullStorage {
     fn get_async_self(&self) -> Option<impl AsyncStorage> {
         Some(self.clone())
     }
+
+    fn as_gatherable_storage(&mut self) -> Option<&mut impl GatherableStorage> {
+        Some(self)
+    }
 }
+
+impl GatherableStorage for NullStorage {}
 
 #[derive(Debug)]
 pub struct DbKeyPrefix(Cow<'static, [u8]>);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `Storage` trait API by adding `as_immutable_read_only`, requiring updates across all storage implementations and potentially affecting downstream crates that implement `Storage`. Additional `'static` bounds on cached storages may surface compile-time breakages but should not change runtime behavior.
> 
> **Overview**
> Adds a new `Storage::as_immutable_read_only(&mut self)` hook to optionally expose a storage as `ImmutableReadOnlyStorage`, enabling callers to run concurrent read tasks when supported.
> 
> Updates built-in backends (`AerospikeStorage`, `MdbxStorage`, `RocksDbStorage`, `CachedStorage`, `NullStorage`, `MapStorage`, and short-key wrappers) to implement the new method, and tightens `CachedStorage`/CLI cached-storage generic bounds to require `ImmutableReadOnlyStorage + 'static` on the inner storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61acaf419050866c4204469f9297fea214662edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->