### PR TITLE
starknet_committer: create storage tries concurrently based on wether storage is gatherable

### DIFF
--- a/crates/starknet_committer/src/db/forest_trait.rs
+++ b/crates/starknet_committer/src/db/forest_trait.rs
@@ -16,7 +16,6 @@ use starknet_patricia_storage::storage_trait::{
     DbOperationMap,
     DbValue,
     PatriciaStorageResult,
-    ReadOnlyStorage,
     Storage,
 };
 
@@ -98,8 +97,9 @@ pub(crate) async fn read_forest<'a, S, Layout>(
     config: ReaderConfig,
 ) -> ForestResult<(OriginalSkeletonForest<'a>, HashMap<NodeIndex, ContractState>)>
 where
-    S: ReadOnlyStorage,
+    S: Storage,
     Layout: DbLayout,
+    Layout::NodeLayout: Send + 'static,
 {
     let (contracts_trie, original_contracts_trie_leaves) =
         create_contracts_trie::<Layout::NodeLayout>(

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -200,7 +200,7 @@ where
 // TODO(Ariel): define an IndexDbInitialRead empty type, and check whether each tree is empty inside
 // create_xxx_trie.
 #[async_trait]
-impl<S: Storage, H: Send> ForestReader for IndexDb<S, H>
+impl<S: Storage, H: Send + 'static> ForestReader for IndexDb<S, H>
 where
     H: IndexLayoutHasher,
 {

--- a/crates/starknet_committer/src/db/trie_traversal.rs
+++ b/crates/starknet_committer/src/db/trie_traversal.rs
@@ -34,6 +34,7 @@ use starknet_patricia_storage::storage_trait::{
     GatherableStorage,
     ImmutableReadOnlyStorage,
     ReadOnlyStorage,
+    Storage,
     StorageTask,
     StorageTaskOutput,
 };
@@ -347,25 +348,37 @@ pub async fn create_original_skeleton_tree<'a, L: Leaf, Layout: NodeLayout<'a, L
     Ok(skeleton_tree)
 }
 
-pub async fn create_storage_tries<'a, Layout: NodeLayoutFor<StarknetStorageValue>>(
-    storage: &mut impl ReadOnlyStorage,
-    actual_storage_updates: &HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
+pub async fn create_storage_tries<'a, Layout>(
+    storage: &mut impl Storage,
+    actual_storage_updates: &'a HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
     original_contracts_trie_leaves: &HashMap<NodeIndex, ContractState>,
     config: &ReaderConfig,
-    storage_tries_sorted_indices: &HashMap<ContractAddress, SortedLeafIndices<'a>>,
+    storage_tries_sorted_indices: &'a HashMap<ContractAddress, SortedLeafIndices<'a>>,
 ) -> ForestResult<HashMap<ContractAddress, OriginalSkeletonTreeImpl<'a>>>
 where
+    Layout: NodeLayoutFor<StarknetStorageValue> + Send + 'static,
     <Layout as NodeLayoutFor<StarknetStorageValue>>::DbLeaf:
         HasStaticPrefix<KeyContext = ContractAddress>,
 {
-    create_storage_tries_sequentially::<Layout>(
-        storage,
-        actual_storage_updates,
-        original_contracts_trie_leaves,
-        config,
-        storage_tries_sorted_indices,
-    )
-    .await
+    if let Some(gatherable_storage) = storage.as_gatherable_storage() {
+        create_storage_tries_concurrently::<_, Layout>(
+            gatherable_storage,
+            actual_storage_updates,
+            original_contracts_trie_leaves,
+            config.warn_on_trivial_modifications(),
+            storage_tries_sorted_indices,
+        )
+        .await
+    } else {
+        create_storage_tries_sequentially::<Layout>(
+            storage,
+            actual_storage_updates,
+            original_contracts_trie_leaves,
+            config,
+            storage_tries_sorted_indices,
+        )
+        .await
+    }
 }
 
 /// Creates the contracts trie original skeleton.
@@ -505,7 +518,6 @@ where
     }
 }
 
-#[expect(dead_code)]
 async fn create_storage_tries_concurrently<'a, S, Layout>(
     storage: &mut S,
     actual_storage_updates: &'a HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a conditional concurrent read path for building storage tries, which can change execution order and stress storage implementations that claim `as_immutable_read_only()` support. Type bound changes (`Storage` vs `ReadOnlyStorage`, added `Send + 'static`) may also surface new compile-time or trait-object compatibility issues.
> 
> **Overview**
> `create_storage_tries` now **builds per-contract storage tries concurrently** when the underlying storage exposes an `ImmutableReadOnlyStorage` via `as_immutable_read_only()`, falling back to the previous sequential implementation otherwise.
> 
> To enable this, the forest read path is tightened to require `Storage` (not just `ReadOnlyStorage`) and adds `Send + 'static` bounds on the node layout/hasher types used by `IndexDb` and trie traversal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecf2a8ac12ced766b384e113c03c0c4dd2f77e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->