### PR TITLE
add section when to return result

### DIFF
--- a/style.md
+++ b/style.md
@@ -175,6 +175,12 @@ Don't use `unreachable!` and `unimplemented!`, as they are very similar in meani
 
 Error structs and enums should have names ending with `Error` (e.g. `StorageError`, `ParseTransactionError`).
 
+### When to return `Result`
+
+Return a `Result` only when the caller is expected to handle the error. If a failure means the app cannot or should not continue, `panic!` immediately — do not propagate an error via `?` if you intend to `.unwrap()` it later; panicking at the source provides a more useful stack trace and eliminates boilerplate.
+
+Similarly, do not return a `Result` if the error is meant to be ignored. If a failure has no impact on the program's flow or integrity, handle it internally (e.g. log it). Forcing callers to write `let _ = ...` or `.ok()` just to silence the compiler obscures the function's true contract.
+
 ### expect message
 
 Write `expect` messages for code readers, not for the program runner. Explain _why_ the error should never happen, not _what_ is the error. State the invariant rather than saying that it broke.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior. Minor risk of shifting team conventions around error propagation/panics.
> 
> **Overview**
> Adds a new **“When to return `Result`”** section to `style.md`, advising to return `Result` only for errors callers are expected to handle.
> 
> Recommends **panicking at the source** when failure should abort, and **handling/logging internally** when errors are intentionally ignored, rather than forcing callers to discard results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e7c9a6c9ff605058031e8ec9fd18008edf426c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->