### PR TITLE
apollo_config_manager: remove config manager client from runner

### DIFF
--- a/crates/apollo_config_manager/src/config_manager_runner.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner.rs
@@ -6,7 +6,6 @@ use apollo_config::presentation::get_config_presentation;
 use apollo_config::validators::validate_path_exists;
 use apollo_config::{CONFIG_FILE_ARG, CONFIG_FILE_SHORT_ARG_NAME};
 use apollo_config_manager_config::config::ConfigManagerConfig;
-use apollo_config_manager_types::communication::SharedConfigManagerClient;
 use apollo_infra::component_definitions::{default_component_start_fn, ComponentStarter};
 use apollo_infra::component_server::WrapperServer;
 use apollo_node_config::config_utils::load_and_validate_config;
@@ -17,7 +16,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use tokio::sync::watch::Sender;
 use tokio::time::{interval, Duration as TokioDuration, Interval};
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use crate::metrics::{register_metrics, CONFIG_MANAGER_UPDATE_ERRORS};
 
@@ -29,7 +28,6 @@ pub mod config_manager_runner_tests;
 
 pub struct ConfigManagerRunner {
     config_manager_config: ConfigManagerConfig,
-    config_manager_client: SharedConfigManagerClient,
     dynamic_config_tx: Sender<NodeDynamicConfig>,
     cli_args: Vec<String>,
 }
@@ -59,11 +57,10 @@ impl ComponentStarter for ConfigManagerRunner {
 impl ConfigManagerRunner {
     pub fn new(
         config_manager_config: ConfigManagerConfig,
-        config_manager_client: SharedConfigManagerClient,
         dynamic_config_tx: Sender<NodeDynamicConfig>,
         cli_args: Vec<String>,
     ) -> Self {
-        Self { config_manager_config, config_manager_client, dynamic_config_tx, cli_args }
+        Self { config_manager_config, dynamic_config_tx, cli_args }
     }
 
     /// Monitors config files for changes via file system events and periodic polling.
@@ -132,24 +129,14 @@ impl ConfigManagerRunner {
                 return false;
             }
             log_config_diff(current, &node_dynamic_config);
-            // TODO(Arni): Remove this clone once the config_manager_client block below is removed.
-            *current = node_dynamic_config.clone();
+            *current = node_dynamic_config;
             true
         });
 
-        if !changed {
-            return Ok(());
+        if changed {
+            info!("Successfully updated dynamic config");
         }
-
-        debug!("Successfully sent node dynamic config to the channel");
-        // TODO(Arni): Remove this block once config_manager_client is removed from the runner.
-        match self.config_manager_client.set_node_dynamic_config(node_dynamic_config).await {
-            Ok(()) => {
-                info!("Successfully updated dynamic config");
-                Ok(())
-            }
-            Err(e) => Err(format!("Failed to update dynamic config: {:?}", e).into()),
-        }
+        Ok(())
     }
 
     /// Extracts config file paths from CLI arguments.

--- a/crates/apollo_config_manager/src/config_manager_runner_tests.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner_tests.rs
@@ -1,13 +1,8 @@
 use std::fs;
-use std::sync::Arc;
 use std::time::Duration;
 
 use apollo_config::CONFIG_FILE_ARG;
 use apollo_config_manager_config::config::ConfigManagerConfig;
-use apollo_config_manager_types::communication::{
-    MockConfigManagerClient,
-    SharedConfigManagerClient,
-};
 use apollo_consensus_config::config::ConsensusDynamicConfig;
 use apollo_node_config::config_utils::DeploymentBaseAppConfig;
 use apollo_node_config::definitions::ConfigPointersMap;
@@ -15,7 +10,6 @@ use apollo_node_config::node_config::{NodeDynamicConfig, SequencerNodeConfig};
 use serde_json::Value;
 use starknet_api::core::ContractAddress;
 use tempfile::NamedTempFile;
-use tokio::sync::mpsc::channel;
 use tokio::sync::watch;
 use tokio::task::yield_now;
 use tokio::time::{interval, timeout};
@@ -88,10 +82,6 @@ fn update_config_file(temp_file: &NamedTempFile) -> String {
 #[tokio::test]
 async fn config_manager_runner_update_config_with_changed_values() {
     let (dynamic_config_tx, dynamic_config_rx) = watch::channel(NodeDynamicConfig::default());
-    // Set a mock config manager client to expect the update dynamic config request.
-    let mut mock_client = MockConfigManagerClient::new();
-    mock_client.expect_set_node_dynamic_config().times(2).return_const(Ok(()));
-    let config_manager_client: SharedConfigManagerClient = Arc::new(mock_client);
 
     // Set a config manager config.
     let config_manager_config = ConfigManagerConfig::default();
@@ -100,12 +90,8 @@ async fn config_manager_runner_update_config_with_changed_values() {
     let (temp_file, cli_args, validator_id_value) = create_temp_config_file_and_args();
 
     // Create a config manager runner and update the config.
-    let mut config_manager_runner = ConfigManagerRunner::new(
-        config_manager_config,
-        config_manager_client,
-        dynamic_config_tx,
-        cli_args,
-    );
+    let mut config_manager_runner =
+        ConfigManagerRunner::new(config_manager_config, dynamic_config_tx, cli_args);
 
     // Helper function to convert a hex string to a u128.
     fn hex_to_u128(s: &str) -> u128 {
@@ -121,9 +107,6 @@ async fn config_manager_runner_update_config_with_changed_values() {
     assert!(first_update_config_result.is_ok(), "First update_config should succeed");
     let first_dynamic_config_from_channel = dynamic_config_rx.borrow().clone();
 
-    // Note: We do not validate the method `set_node_dynamic_config` of the mock config manager
-    // client is called with the correct config. This method is soon to be replaced by the channel
-    // client. It could be tested using `.withf` predicate on the mock config manager client.
     assert_eq!(
         first_dynamic_config_from_channel.consensus_dynamic_config.as_ref().unwrap().validator_id,
         expected_validator_id,
@@ -154,24 +137,10 @@ async fn watcher_triggers_update_on_file_change() {
     // Prepare temp config file and CLI args.
     let (temp_file, cli_args, _) = create_temp_config_file_and_args();
 
-    // Channel to observe that update_config was called.
-    let (tx, mut rx) = channel(1);
+    let (dynamic_config_tx, mut dynamic_config_rx) = watch::channel(NodeDynamicConfig::default());
 
-    let (dynamic_config_tx, dynamic_config_rx) = watch::channel(NodeDynamicConfig::default());
-    let mut mock_client = MockConfigManagerClient::new();
-    mock_client.expect_set_node_dynamic_config().times(1).returning(move |_| {
-        let _ = tx.blocking_send(());
-        Ok(())
-    });
-
-    let client: SharedConfigManagerClient = Arc::new(mock_client);
-
-    let mut runner = ConfigManagerRunner::new(
-        ConfigManagerConfig::default(),
-        client,
-        dynamic_config_tx,
-        cli_args,
-    );
+    let mut runner =
+        ConfigManagerRunner::new(ConfigManagerConfig::default(), dynamic_config_tx, cli_args);
 
     // Spawn watcher loop in background task.
     tokio::spawn(async move {
@@ -183,10 +152,11 @@ async fn watcher_triggers_update_on_file_change() {
     // Modify the config file to trigger an event.
     let _ = update_config_file(&temp_file);
 
-    // Wait until the update call is observed or timeout.
-    timeout(Duration::from_secs(TEST_TIMEOUT_SECS), rx.recv())
+    // Wait until the channel receives a new config or timeout.
+    timeout(Duration::from_secs(TEST_TIMEOUT_SECS), dynamic_config_rx.changed())
         .await
-        .expect("update_config was not called within timeout");
+        .expect("Dynamic config was not updated within timeout")
+        .expect("Watch channel closed unexpectedly");
 }
 
 #[traced_test]

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -172,12 +172,8 @@ pub async fn create_node_components(
                 let config_manager =
                     ConfigManager::new(config_manager_config.clone(), node_dynamic_config.clone());
                 let dynamic_config_tx = dynamic_config_channels.take_tx();
-                let config_manager_client = clients
-                    .get_config_manager_shared_client()
-                    .expect("Config Manager client should be available");
                 let config_manager_runner = ConfigManagerRunner::new(
                     config_manager_config.clone(),
-                    config_manager_client,
                     dynamic_config_tx,
                     cli_args,
                 );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the runtime config update propagation path by removing the RPC/client side effect from `ConfigManagerRunner`, so any code still relying on `set_node_dynamic_config` being called by the runner could stop receiving updates. The behavior is otherwise simple and covered by updated tests, but it touches live config reload flow.
> 
> **Overview**
> **Removes `ConfigManagerRunner`'s dependency on the config-manager client.** The runner now only updates `NodeDynamicConfig` via the watch channel (and logs success when the value actually changes), instead of also calling `set_node_dynamic_config`.
> 
> Tests and node component wiring are updated accordingly: runner construction no longer passes a mock/shared client, and the filesystem watcher test now asserts updates by waiting for `watch::Receiver::changed()` rather than observing a mocked client call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3b3803845a3711c279b4a3ca00bd30fdbfd76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->