### PR TITLE
echonet: share json parse func

### DIFF
--- a/crates/apollo_mempool/Cargo.toml
+++ b/crates/apollo_mempool/Cargo.toml
@@ -39,6 +39,7 @@ rand.workspace = true
 reqwest.workspace = true
 reqwest-middleware.workspace = true
 reqwest-retry.workspace = true
+serde.workspace = true
 starknet_api.workspace = true
 strum = { workspace = true, features = ["derive"] }
 tokio.workspace = true

--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -26,6 +26,7 @@ use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{Jitter, RetryTransientMiddleware};
+use serde::de::DeserializeOwned;
 use starknet_api::block::{GasPrice, ReplayMetadata};
 use starknet_api::core::ContractAddress;
 use starknet_api::rpc_transaction::InternalRpcTransaction;
@@ -198,7 +199,7 @@ impl MempoolCommunicationWrapper {
             }
         };
 
-        match self.try_fetch_tx_block_metadata(&url).await {
+        match self.try_fetch_json::<TxBlockMetadata>(&url).await {
             Ok(tx_block_metadata) => {
                 self.mempool.update_tx_block_metadata(tx_hash, tx_block_metadata);
                 true
@@ -210,15 +211,12 @@ impl MempoolCommunicationWrapper {
         }
     }
 
-    async fn try_fetch_tx_block_metadata(
-        &self,
-        url: &reqwest::Url,
-    ) -> Result<TxBlockMetadata, String> {
+    async fn try_fetch_json<T: DeserializeOwned>(&self, url: &reqwest::Url) -> Result<T, String> {
         const REQUEST_TIMEOUT_SECS: u64 = 2;
         let response = self
             .echonet_client
             .get(url.as_str())
-            .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .send()
             .await
             .map_err(|e| format!("request failed: {}", e))?;
@@ -227,7 +225,7 @@ impl MempoolCommunicationWrapper {
             return Err(format!("HTTP {}", response.status()));
         }
 
-        response.json::<TxBlockMetadata>().await.map_err(|e| format!("invalid response: {}", e))
+        response.json::<T>().await.map_err(|e| format!("invalid response: {}", e))
     }
 }
 

--- a/crates/apollo_mempool/src/recorder_integration_test.rs
+++ b/crates/apollo_mempool/src/recorder_integration_test.rs
@@ -23,7 +23,7 @@ use crate::mempool::Mempool;
 
 // Starts a mock HTTP server that simulates the recorder's get_tx_block_metadata endpoint.
 // Returns the base URL (e.g., "http://127.0.0.1:12345").
-async fn start_mock_recorder(response: Result<TxBlockMetadata, StatusCode>) -> String {
+async fn mock_tx_metadata_recorder(response: Result<TxBlockMetadata, StatusCode>) -> String {
     let app = Router::new().route(
         "/echonet/get_tx_block_metadata",
         get(move || async move {
@@ -65,8 +65,8 @@ fn create_mempool_communication_wrapper(recorder_url: String) -> MempoolCommunic
 #[rstest]
 #[tokio::test]
 async fn test_fetch_tx_block_metadata_success() {
-    let recorder_url = start_mock_recorder(Ok(TxBlockMetadata {
-        timestamp: 1000u64,
+    let recorder_url = mock_tx_metadata_recorder(Ok(TxBlockMetadata {
+        timestamp: 1000,
         block_number: BlockNumber(1234),
     }))
     .await;
@@ -81,7 +81,7 @@ async fn test_fetch_tx_block_metadata_success() {
 #[rstest]
 #[tokio::test]
 async fn test_fetch_tx_block_metadata_fails_on_http_error() {
-    let recorder_url = start_mock_recorder(Err(StatusCode::INTERNAL_SERVER_ERROR)).await;
+    let recorder_url = mock_tx_metadata_recorder(Err(StatusCode::INTERNAL_SERVER_ERROR)).await;
     let mut wrapper = create_mempool_communication_wrapper(recorder_url);
 
     let tx_hash = TransactionHash::default();
@@ -94,8 +94,8 @@ async fn test_fetch_tx_block_metadata_fails_on_http_error() {
 #[rstest]
 #[tokio::test]
 async fn test_add_tx_with_recorder_integration() {
-    let recorder_url = start_mock_recorder(Ok(TxBlockMetadata {
-        timestamp: 1000u64,
+    let recorder_url = mock_tx_metadata_recorder(Ok(TxBlockMetadata {
+        timestamp: 1000,
         block_number: BlockNumber(1234),
     }))
     .await;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes HTTP JSON deserialization for the recorder fetch path; behavior should be unchanged aside from minor type/timeout cleanup. Risk is limited to potential subtle deserialization or trait-bound issues at compile/runtime.
> 
> **Overview**
> Refactors the Echonet recorder fetch in `apollo_mempool` to use a reusable `try_fetch_json<T: DeserializeOwned>` helper instead of a `TxBlockMetadata`-specific function, and adds `serde` as a direct dependency to support the generic bound.
> 
> Cleans up the recorder integration test helper naming and minor literal formatting while keeping the same success/error coverage for `fetch_and_update_tx_block_metadata`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5fe888c5a1e70ca3b37a360e56485537c2d5e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->