### PR TITLE
apollo_node: move config manager block to top of create_node_components

### DIFF
--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -80,6 +80,49 @@ pub async fn create_node_components(
 ) -> SequencerNodeComponents {
     info!("Creating node components.");
 
+    // Create the config manager and runner first, as the config_manager_channel_client is used by
+    // other components below.
+    let (config_manager, config_manager_runner, config_manager_channel_client) = match config
+        .components
+        .config_manager
+        .execution_mode
+    {
+        ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled => {
+            let node_dynamic_config = NodeDynamicConfig::from(config);
+            let config_manager_config =
+                config.config_manager_config.as_ref().expect("Config Manager config should be set");
+            // TODO(Arni): remove the config_manager.
+            let config_manager =
+                ConfigManager::new(config_manager_config.clone(), node_dynamic_config.clone());
+            let (dynamic_config_tx, channel_client) =
+                LocalComponentChannelClient::new_with_initial_value(node_dynamic_config.clone());
+            // TODO(Arni): Rename to config_manager_client after ConfigManagerChannelClient is
+            // renamed to ConfigManagerClient.
+            let config_manager_channel_client = Arc::new(channel_client);
+            let value_rx_keep_alive = dynamic_config_tx.subscribe();
+            let config_manager_client = clients
+                .get_config_manager_shared_client()
+                .expect("Config Manager client should be available");
+            let config_manager_runner = ConfigManagerRunner::new(
+                config_manager_config.clone(),
+                config_manager_client,
+                dynamic_config_tx,
+                value_rx_keep_alive,
+                node_dynamic_config,
+                cli_args,
+            );
+            (Some(config_manager), Some(config_manager_runner), Some(config_manager_channel_client))
+        }
+        ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled
+        | ReactiveComponentExecutionMode::Remote => {
+            panic!(
+                "ConfigManager does not support remote mode - it's a local infrastructure \
+                 component"
+            );
+        }
+        ReactiveComponentExecutionMode::Disabled => (None, None, None),
+    };
+
     let batcher = match config.components.batcher.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
@@ -158,48 +201,6 @@ pub async fn create_node_components(
             .await,
         ),
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
-    };
-
-    // TODO(Arni): Move this block to the beginning of the function, as the
-    // config_manager_channel_client is needed by components created below.
-    let (config_manager, config_manager_runner, config_manager_channel_client) = match config
-        .components
-        .config_manager
-        .execution_mode
-    {
-        ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled => {
-            let node_dynamic_config = NodeDynamicConfig::from(config);
-            let config_manager_config =
-                config.config_manager_config.as_ref().expect("Config Manager config should be set");
-            // TODO(Arni): remove the config_manager.
-            let config_manager =
-                ConfigManager::new(config_manager_config.clone(), node_dynamic_config.clone());
-            let (dynamic_config_tx, channel_client) =
-                LocalComponentChannelClient::new_with_initial_value(node_dynamic_config.clone());
-            // TODO(Arni): Rename to config_manager_client after ConfigManagerChannelClient is
-            // renamed to ConfigManagerClient.
-            let config_manager_channel_client = Arc::new(channel_client);
-            let dynamic_config_rx = dynamic_config_tx.subscribe();
-            let config_manager_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
-            let config_manager_runner = ConfigManagerRunner::new(
-                config_manager_config.clone(),
-                config_manager_client,
-                dynamic_config_tx,
-                dynamic_config_rx,
-                cli_args,
-            );
-            (Some(config_manager), Some(config_manager_runner), Some(config_manager_channel_client))
-        }
-        ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled
-        | ReactiveComponentExecutionMode::Remote => {
-            panic!(
-                "ConfigManager does not support remote mode - it's a local infrastructure \
-                 component"
-            );
-        }
-        ReactiveComponentExecutionMode::Disabled => (None, None, None),
     };
 
     let consensus_manager = match config.components.consensus_manager.execution_mode {


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily reorders initialization in `create_node_components` to ensure the config manager channel client exists before dependent components are built; behavior should be unchanged aside from startup ordering.
> 
> **Overview**
> Moves `ConfigManager`/`ConfigManagerRunner` construction to the top of `create_node_components` so the `config_manager_channel_client` is available for later component setup.
> 
> While doing so, adjusts the local watch-channel receiver handling to keep it alive (`value_rx_keep_alive`) and updates the runner instantiation to pass through the initial `NodeDynamicConfig` alongside CLI args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642c24e917352a3751a3ffd7495be1cae7fcccbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->