### PR TITLE
apollo_config_manager_types: rename ConfigManagerChannelClient to ConfigManagerClient

### DIFF
--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -257,7 +257,7 @@ pub async fn create_node_components(
 
     let http_server = match config.components.http_server.execution_mode {
         ActiveComponentExecutionMode::Enabled => {
-            let config_manager_reader_client = clients
+            let config_manager_client = clients
                 .get_config_manager_reader_client()
                 .expect("Config Manager reader client should be available");
             let http_server_config =
@@ -267,7 +267,7 @@ pub async fn create_node_components(
 
             Some(create_http_server(
                 http_server_config.clone(),
-                config_manager_reader_client,
+                config_manager_client,
                 gateway_client,
             ))
         }


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a mechanical rename, but it touches wiring/types across many core components (node client plumbing, consensus/state-sync/mempool/batcher/http-server), so a mismatch in client mode or trait bounds could break runtime startup or tests.
> 
> **Overview**
> Renames the config manager “reader” client API to a single `ConfigManagerClient` (`SharedConfigManagerClient`, `LocalConfigManagerClient`) and updates the trait + blanket impl in `apollo_config_manager_types`.
> 
> Propagates the new client type through component constructors and dynamic-config providers in `batcher`, `class_manager`, `consensus`/`consensus_manager`/`orchestrator`, `http_server`, `mempool`, `staking`, and `state_sync`, plus updates node client plumbing (`get_config_manager_client`) and all affected mocks/tests/bench helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9f70888084d1f33d8a9c801e724f89a5f454fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->