### PR TITLE
echonet: fetch block metadata from echonet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,9 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "pretty_assertions",
+ "reqwest 0.12.24",
  "rstest",
+ "serde",
  "serde_json",
  "starknet-types-core",
  "starknet_api",
@@ -1578,6 +1580,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
+ "url",
  "validator",
 ]
 

--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -33,6 +33,7 @@ use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::transaction::TransactionHash;
+use starknet_api::versioned_constants_logic::effective_starknet_version;
 use starknet_api::StarknetApiError;
 use strum::{EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use tokio_util::sync::CancellationToken;
@@ -137,13 +138,28 @@ async fn get_proposal_metadata(
 ) -> ReplayMetadata {
     if override_block_metadata {
         match batcher.get_block_metadata().await {
-            Ok(block_metadata) => return block_metadata,
+            Ok(block_metadata) => {
+                info!(
+                    "Received block metadata from echonet: timestamp={}, block_number={:?}",
+                    block_metadata.timestamp, block_metadata.block_number,
+                );
+                return block_metadata;
+            }
             Err(err) => {
-                warn!("Failed to get timestamp from batcher, falling back to clock time: {err:?}");
+                warn!(
+                    "Failed to get block metadata from batcher, falling back to defaults: {err:?}"
+                );
             }
         }
     }
-    ReplayMetadata { timestamp: clock.unix_now(), block_number: None }
+    ReplayMetadata {
+        timestamp: clock.unix_now(),
+        block_number: None,
+        l1_gas_price_wei: GasPrice::default(),
+        l1_data_gas_price_wei: GasPrice::default(),
+        l1_gas_price_fri: GasPrice::default(),
+        l1_data_gas_price_fri: GasPrice::default(),
+    }
 }
 
 async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResult<ProposalInit> {
@@ -153,14 +169,39 @@ async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResul
         args.deps.clock.as_ref(),
     )
     .await;
+    let starknet_version = effective_starknet_version();
+    info!(
+        "Proposal metadata for height {}: starknet_version={}, timestamp={}, \
+         override_block_metadata={}",
+        args.build_param.height,
+        starknet_version,
+        proposal_metadata.timestamp,
+        args.override_block_metadata,
+    );
     let timestamp = proposal_metadata.timestamp;
-    let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
-        args.deps.l1_gas_price_provider.clone(),
-        timestamp,
-        args.previous_proposal_init.as_ref(),
-        &args.gas_price_params,
-    )
-    .await;
+    let (l1_gas_price_wei, l1_data_gas_price_wei, l1_gas_price_fri, l1_data_gas_price_fri) =
+        if args.override_block_metadata {
+            (
+                proposal_metadata.l1_gas_price_wei,
+                proposal_metadata.l1_data_gas_price_wei,
+                proposal_metadata.l1_gas_price_fri,
+                proposal_metadata.l1_data_gas_price_fri,
+            )
+        } else {
+            let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
+                args.deps.l1_gas_price_provider.clone(),
+                timestamp,
+                args.previous_proposal_init.as_ref(),
+                &args.gas_price_params,
+            )
+            .await;
+            (
+                l1_prices_wei.l1_gas_price,
+                l1_prices_wei.l1_data_gas_price,
+                l1_prices_fri.l1_gas_price,
+                l1_prices_fri.l1_data_gas_price,
+            )
+        };
     let init = ProposalInit {
         height: args.build_param.height,
         round: args.build_param.round,
@@ -170,11 +211,11 @@ async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResul
         timestamp,
         l1_da_mode: args.l1_da_mode,
         l2_gas_price_fri: args.l2_gas_price,
-        l1_gas_price_wei: l1_prices_wei.l1_gas_price,
-        l1_data_gas_price_wei: l1_prices_wei.l1_data_gas_price,
-        l1_gas_price_fri: l1_prices_fri.l1_gas_price,
-        l1_data_gas_price_fri: l1_prices_fri.l1_data_gas_price,
-        starknet_version: starknet_api::block::StarknetVersion::LATEST,
+        l1_gas_price_wei,
+        l1_data_gas_price_wei,
+        l1_gas_price_fri,
+        l1_data_gas_price_fri,
+        starknet_version,
         // TODO(Asmaa): Put the real value once we have it.
         version_constant_commitment: Default::default(),
     };

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -740,6 +740,7 @@ fn central_blob() -> AerospikeBlob {
 
     let blob_parameters = BlobParameters {
         block_info: block_info(),
+        starknet_version: StarknetVersion::LATEST,
         state_diff: thin_state_diff(),
         compressed_state_diff: Some(commitment_state_diff()),
         transactions_with_execution_infos,
@@ -771,6 +772,7 @@ fn central_blob_with_empty_or_none_fields() -> AerospikeBlob {
     let mock_class_manager = MockClassManagerClient::new();
     let blob_parameters = BlobParameters {
         block_info: block_info(),
+        starknet_version: StarknetVersion::LATEST,
         state_diff: thin_state_diff(),
         compressed_state_diff: None,
         transactions_with_execution_infos: vec![],

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -357,6 +357,7 @@ pub struct InternalTransactionWithReceipt {
 #[derive(Debug, Default)]
 pub struct BlobParameters {
     pub(crate) block_info: BlockInfo,
+    pub(crate) starknet_version: StarknetVersion,
     pub(crate) state_diff: ThinStateDiff,
     pub(crate) compressed_state_diff: Option<CommitmentStateDiff>,
     pub(crate) bouncer_weights: BouncerWeights,
@@ -381,7 +382,7 @@ impl AerospikeBlob {
         let block_timestamp = blob_parameters.block_info.block_timestamp.0;
 
         let block_info =
-            CentralBlockInfo::from((blob_parameters.block_info, StarknetVersion::LATEST));
+            CentralBlockInfo::from((blob_parameters.block_info, blob_parameters.starknet_version));
         let state_diff = CentralStateDiff::from((blob_parameters.state_diff, block_info.clone()));
         let compressed_state_diff =
             blob_parameters.compressed_state_diff.map(|compressed_state_diff| {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -438,6 +438,7 @@ impl SequencerConsensusContext {
             .cende_ambassador
             .prepare_blob_for_next_height(BlobParameters {
                 block_info: cende_block_info,
+                starknet_version: init.starknet_version,
                 state_diff,
                 compressed_state_diff: central_objects.compressed_state_diff,
                 transactions_with_execution_infos,

--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -42,6 +42,8 @@ google-cloud-storage.workspace = true
 mempool_test_utils.workspace = true
 mockall.workspace = true
 num-rational.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+serde.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::SharedClassManagerClient;
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::config::GatewayConfig;
 use apollo_gateway_types::deprecated_gateway_error::{
     KnownStarknetErrorCode,
@@ -29,6 +30,7 @@ use apollo_transaction_converter::{
 };
 use async_trait::async_trait;
 use blockifier::state::contract_class_manager::ContractClassManager;
+use starknet_api::block::StarknetVersion;
 use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
@@ -38,6 +40,7 @@ use starknet_api::rpc_transaction::{
 };
 use starknet_api::transaction::fields::{Proof, ProofFacts, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
+use starknet_api::versioned_constants_logic::set_effective_latest_version;
 use starknet_types_core::felt::Felt;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
@@ -178,6 +181,40 @@ impl<
     pub async fn start(&self) {
         register_metrics();
         self.proof_archive_writer.connect().await;
+        if self.config.static_config.behavior_mode == BehaviorMode::Echonet {
+            self.set_effective_starknet_version_from_echonet().await;
+        }
+    }
+
+    async fn set_effective_starknet_version_from_echonet(&self) {
+        let url: reqwest::Url = self
+            .config
+            .static_config
+            .recorder_url
+            .join("echonet/get_starknet_version")
+            .expect("recorder_url is validated at config load; joining a static path cannot fail")
+            .as_str()
+            .parse()
+            .expect("valid URL");
+
+        match reqwest::get(url).await {
+            Ok(response) if response.status().is_success() => match response.text().await {
+                Ok(version_str) => match StarknetVersion::try_from(version_str.trim()) {
+                    Ok(version) => {
+                        info!("Setting effective Starknet version from echonet: {version}");
+                        set_effective_latest_version(version);
+                    }
+                    Err(e) => {
+                        warn!("Failed to parse starknet version '{version_str}' from echonet: {e}")
+                    }
+                },
+                Err(e) => warn!("Failed to read echonet starknet version response: {e}"),
+            },
+            Ok(response) => {
+                warn!("Echonet get_starknet_version returned HTTP {}", response.status())
+            }
+            Err(e) => warn!("Failed to fetch starknet version from echonet: {e}"),
+        }
     }
 
     #[sequencer_latency_histogram(GATEWAY_ADD_TX_LATENCY, true)]

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::sync::{Arc, LazyLock};
 
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::dumping::SerializeConfig;
 use apollo_config::loading::load_and_process_config;
 use apollo_gateway_config::config::{
@@ -139,6 +140,8 @@ fn mock_dependencies() -> MockDependencies {
             block_declare: false,
             authorized_declarer_accounts: None,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
+            behavior_mode: BehaviorMode::Starknet,
+            recorder_url: "https://recorder_url".parse().unwrap(),
         },
         ..Default::default()
     };

--- a/crates/apollo_gateway_config/Cargo.toml
+++ b/crates/apollo_gateway_config/Cargo.toml
@@ -10,6 +10,7 @@ description = "Configuration types for Apollo gateway"
 apollo_compilation_utils.workspace = true
 apollo_config.workspace = true
 blockifier.workspace = true
+url.workspace = true
 cairo-lang-starknet-classes.workspace = true
 serde = { workspace = true, features = ["derive"] }
 starknet-types-core.workspace = true

--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::converters::{
     deserialize_comma_separated_str,
     serialize_optional_comma_separated,
@@ -18,6 +19,7 @@ use blockifier::context::ChainInfo;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_types_core::felt::Felt;
+use url::Url;
 use validator::Validate;
 
 use crate::compiler_version::VersionId;
@@ -37,6 +39,8 @@ pub struct GatewayStaticConfig {
     #[serde(default, deserialize_with = "deserialize_comma_separated_str")]
     pub authorized_declarer_accounts: Option<Vec<ContractAddress>>,
     pub proof_archive_writer_config: ProofArchiveWriterConfig,
+    pub behavior_mode: BehaviorMode,
+    pub recorder_url: Url,
 }
 
 impl Default for GatewayStaticConfig {
@@ -52,6 +56,10 @@ impl Default for GatewayStaticConfig {
             block_declare: false,
             authorized_declarer_accounts: None,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
+            behavior_mode: BehaviorMode::Starknet,
+            recorder_url: "https://recorder_url"
+                .parse::<Url>()
+                .expect("recorder_url must be a valid URL"),
         }
     }
 }
@@ -89,6 +97,21 @@ impl SerializeConfig for GatewayStaticConfig {
             self.proof_archive_writer_config.dump(),
             "proof_archive_writer_config",
         ));
+        dump.extend(BTreeMap::from_iter([
+            ser_param(
+                "behavior_mode",
+                &self.behavior_mode,
+                "Behavior mode: 'starknet' for production, 'echonet' for test/replay mode.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "recorder_url",
+                &self.recorder_url,
+                "The URL of the recorder service (used in Echonet mode to fetch the initial \
+                 Starknet version).",
+                ParamPrivacyInput::Public,
+            ),
+        ]));
         dump
     }
 }

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -20,6 +20,7 @@ use apollo_class_manager_config::config::{
     FsClassStorageConfig,
 };
 use apollo_committer_config::config::ApolloCommitterConfig;
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::converters::UrlAndHeaders;
 use apollo_config_manager_config::config::ConfigManagerConfig;
 use apollo_consensus_config::config::{
@@ -738,6 +739,8 @@ pub fn create_gateway_config(
             block_declare: false,
             authorized_declarer_accounts: None,
             proof_archive_writer_config,
+            behavior_mode: BehaviorMode::Starknet,
+            recorder_url: "https://recorder_url".parse().unwrap(),
         },
         ..Default::default()
     }

--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -27,6 +27,7 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{Jitter, RetryTransientMiddleware};
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use starknet_api::block::{GasPrice, ReplayMetadata};
 use starknet_api::core::ContractAddress;
 use starknet_api::rpc_transaction::InternalRpcTransaction;
@@ -35,6 +36,15 @@ use tracing::warn;
 
 use crate::mempool::Mempool;
 use crate::metrics::register_metrics;
+
+/// The fields returned by `echonet/get_block_metadata`.
+#[derive(Clone, Deserialize, Serialize)]
+pub(crate) struct BlockProposalParams {
+    pub l1_gas_price_wei: GasPrice,
+    pub l1_data_gas_price_wei: GasPrice,
+    pub l1_gas_price_fri: GasPrice,
+    pub l1_data_gas_price_fri: GasPrice,
+}
 
 pub type LocalMempoolServer =
     LocalComponentServer<MempoolCommunicationWrapper, MempoolRequest, MempoolResponse>;
@@ -172,12 +182,45 @@ impl MempoolCommunicationWrapper {
         self.mempool.mempool_snapshot()
     }
 
-    fn resolve_block_metadata(&mut self) -> MempoolResult<ReplayMetadata> {
+    pub(crate) async fn resolve_block_metadata(&mut self) -> MempoolResult<ReplayMetadata> {
         let block_metadata = self.mempool.resolve_block_metadata();
-        Ok(ReplayMetadata {
+        let default_metadata = ReplayMetadata {
             timestamp: block_metadata.timestamp,
             block_number: block_metadata.block_number,
-        })
+            l1_gas_price_wei: GasPrice::default(),
+            l1_data_gas_price_wei: GasPrice::default(),
+            l1_gas_price_fri: GasPrice::default(),
+            l1_data_gas_price_fri: GasPrice::default(),
+        };
+
+        if !self.mempool.is_fifo() {
+            return Ok(default_metadata);
+        }
+
+        let Some(block_number) = block_metadata.block_number else {
+            return Ok(default_metadata);
+        };
+        let url = self
+            .mempool
+            .config
+            .static_config
+            .recorder_url
+            .join(&format!("echonet/get_block_metadata?block_number={}", block_number.0))
+            .expect("recorder_url is validated at config load; joining a static path cannot fail");
+
+        match self.try_fetch_json::<BlockProposalParams>(&url).await {
+            Ok(echonet_metadata) => Ok(ReplayMetadata {
+                l1_gas_price_wei: echonet_metadata.l1_gas_price_wei,
+                l1_data_gas_price_wei: echonet_metadata.l1_data_gas_price_wei,
+                l1_gas_price_fri: echonet_metadata.l1_gas_price_fri,
+                l1_data_gas_price_fri: echonet_metadata.l1_data_gas_price_fri,
+                ..default_metadata
+            }),
+            Err(e) => {
+                warn!("Failed to fetch block metadata for block {}: {}", block_number, e);
+                Ok(default_metadata)
+            }
+        }
     }
 
     // Fetches tx block metadata from recorder and updates mempool.
@@ -259,7 +302,7 @@ impl ComponentRequestHandler<MempoolRequest, MempoolResponse> for MempoolCommuni
                 MempoolResponse::GetMempoolSnapshot(self.mempool_snapshot())
             }
             MempoolRequest::ResolveBlockMetadata => {
-                MempoolResponse::ResolveBlockMetadata(self.resolve_block_metadata())
+                MempoolResponse::ResolveBlockMetadata(self.resolve_block_metadata().await)
             }
         }
     }

--- a/crates/apollo_mempool/src/recorder_integration_test.rs
+++ b/crates/apollo_mempool/src/recorder_integration_test.rs
@@ -13,26 +13,47 @@ use axum::routing::get;
 use axum::Router;
 use reqwest::Url;
 use rstest::rstest;
-use starknet_api::block::BlockNumber;
+use starknet_api::block::{BlockNumber, GasPrice};
 use starknet_api::transaction::TransactionHash;
 use tokio::net::TcpListener;
 
 use crate::add_tx_input;
-use crate::communication::MempoolCommunicationWrapper;
+use crate::communication::{BlockProposalParams, MempoolCommunicationWrapper};
 use crate::mempool::Mempool;
 
-// Starts a mock HTTP server that simulates the recorder's get_tx_block_metadata endpoint.
+// Starts a mock HTTP server simulating the recorder's get_tx_block_metadata endpoint.
 // Returns the base URL (e.g., "http://127.0.0.1:12345").
-async fn mock_tx_metadata_recorder(response: Result<TxBlockMetadata, StatusCode>) -> String {
-    let app = Router::new().route(
-        "/echonet/get_tx_block_metadata",
-        get(move || async move {
-            match response {
-                Ok(metadata) => (StatusCode::OK, Json(metadata)).into_response(),
-                Err(status) => status.into_response(),
-            }
-        }),
-    );
+async fn mock_tx_metadata_recorder(
+    tx_metadata_response: Result<TxBlockMetadata, StatusCode>,
+) -> String {
+    mock_recorder(tx_metadata_response, Err(StatusCode::NOT_FOUND)).await
+}
+
+// Starts a mock HTTP server simulating both recorder endpoints.
+// Returns the base URL (e.g., "http://127.0.0.1:12345").
+async fn mock_recorder(
+    tx_metadata_response: Result<TxBlockMetadata, StatusCode>,
+    block_metadata_response: Result<BlockProposalParams, StatusCode>,
+) -> String {
+    let app = Router::new()
+        .route(
+            "/echonet/get_tx_block_metadata",
+            get(move || async move {
+                match tx_metadata_response {
+                    Ok(metadata) => (StatusCode::OK, Json(metadata)).into_response(),
+                    Err(status) => status.into_response(),
+                }
+            }),
+        )
+        .route(
+            "/echonet/get_block_metadata",
+            get(move || async move {
+                match block_metadata_response {
+                    Ok(metadata) => (StatusCode::OK, Json(metadata)).into_response(),
+                    Err(status) => status.into_response(),
+                }
+            }),
+        );
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -105,4 +126,63 @@ async fn test_add_tx_with_recorder_integration() {
     let args_wrapper = AddTransactionArgsWrapper { args: tx_args, p2p_message_metadata: None };
 
     wrapper.add_tx(args_wrapper).await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_resolve_block_metadata_echonet_success() {
+    // Mempool provides timestamp and block_number via tx_metadata.
+    let timestamp = 1000;
+    let block_number = BlockNumber(1234);
+    let tx_metadata = TxBlockMetadata { timestamp, block_number };
+
+    // Echonet provides gas prices.
+    let l1_gas_price_wei = GasPrice(100);
+    let l1_data_gas_price_wei = GasPrice(200);
+    let l1_gas_price_fri = GasPrice(300);
+    let l1_data_gas_price_fri = GasPrice(400);
+    let block_metadata = BlockProposalParams {
+        l1_gas_price_wei,
+        l1_data_gas_price_wei,
+        l1_gas_price_fri,
+        l1_data_gas_price_fri,
+    };
+
+    let recorder_url = mock_recorder(Ok(tx_metadata), Ok(block_metadata)).await;
+    let mut wrapper = create_mempool_communication_wrapper(recorder_url);
+
+    let tx_args = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let args_wrapper = AddTransactionArgsWrapper { args: tx_args, p2p_message_metadata: None };
+    wrapper.add_tx(args_wrapper).await.unwrap();
+
+    let result = wrapper.resolve_block_metadata().await.unwrap();
+
+    // timestamp and block_number come from mempool, not echonet.
+    assert_eq!(result.timestamp, timestamp);
+    assert_eq!(result.block_number, Some(block_number));
+    // Gas prices come from echonet.
+    assert_eq!(result.l1_gas_price_wei, l1_gas_price_wei);
+    assert_eq!(result.l1_data_gas_price_wei, l1_data_gas_price_wei);
+    assert_eq!(result.l1_gas_price_fri, l1_gas_price_fri);
+    assert_eq!(result.l1_data_gas_price_fri, l1_data_gas_price_fri);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_resolve_block_metadata_echonet_falls_back_on_http_error() {
+    let tx_metadata = TxBlockMetadata { timestamp: 1000, block_number: BlockNumber(1234) };
+
+    let recorder_url = mock_recorder(Ok(tx_metadata), Err(StatusCode::INTERNAL_SERVER_ERROR)).await;
+    let mut wrapper = create_mempool_communication_wrapper(recorder_url);
+
+    let tx_args = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let args_wrapper = AddTransactionArgsWrapper { args: tx_args, p2p_message_metadata: None };
+    wrapper.add_tx(args_wrapper).await.unwrap();
+
+    let result = wrapper.resolve_block_metadata().await.unwrap();
+
+    assert_eq!(result.l1_gas_price_wei, GasPrice::default());
+    assert_eq!(result.l1_data_gas_price_wei, GasPrice::default());
+    assert_eq!(result.l1_gas_price_fri, GasPrice::default());
+    assert_eq!(result.l1_data_gas_price_fri, GasPrice::default());
 }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2944,6 +2944,11 @@
     "privacy": "TemporaryValue",
     "value": true
   },
+  "gateway_config.static_config.behavior_mode": {
+    "description": "Behavior mode: 'starknet' for production, 'echonet' for test/replay mode.",
+    "pointer_target": "behavior_mode",
+    "privacy": "Public"
+  },
   "gateway_config.static_config.block_declare": {
     "description": "If true, the gateway will block declare transactions.",
     "privacy": "Public",
@@ -3023,6 +3028,11 @@
     "description": "The name of the bucket to write proofs to. An empty string indicates a test environment that does not connect to GCS.",
     "privacy": "Public",
     "value": "proof-archive"
+  },
+  "gateway_config.static_config.recorder_url": {
+    "description": "The URL of the recorder service (used in Echonet mode to fetch the initial Starknet version).",
+    "pointer_target": "recorder_url",
+    "privacy": "Public"
   },
   "gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap": {
     "description": "The maximum allowed gap between the account nonce and the transaction nonce.",

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -151,6 +151,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
             set_pointing_param_paths(&[
                 "consensus_manager_config.cende_config.recorder_url",
                 "batcher_config.static_config.pre_confirmed_cende_config.recorder_url",
+                "gateway_config.static_config.recorder_url",
                 "mempool_config.static_config.recorder_url",
             ]),
         ),
@@ -211,6 +212,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
         ),
         set_pointing_param_paths(&[
             "consensus_manager_config.context_config.static_config.behavior_mode",
+            "gateway_config.static_config.behavior_mode",
             "mempool_config.static_config.behavior_mode",
         ]),
     ));

--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -449,6 +449,7 @@ impl VersionedConstants {
     // TODO(Arni): Consider replacing each call to this function with `latest_with_overrides`, and
     // squashing the functions together.
     /// Returns the latest versioned constants, applying the given overrides.
+    /// In Echonet mode, "latest" is the version set via `set_effective_latest_version`.
     pub fn get_versioned_constants(
         versioned_constants_overrides: Option<VersionedConstantsOverrides>,
     ) -> Self {

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -713,6 +713,10 @@ pub struct BlockSignature(pub Signature);
 pub struct ReplayMetadata {
     pub timestamp: UnixTimestamp,
     pub block_number: Option<BlockNumber>,
+    pub l1_gas_price_wei: GasPrice,
+    pub l1_data_gas_price_wei: GasPrice,
+    pub l1_gas_price_fri: GasPrice,
+    pub l1_data_gas_price_fri: GasPrice,
 }
 
 /// The error type returned from the block verification functions.

--- a/crates/starknet_api/src/versioned_constants_logic.rs
+++ b/crates/starknet_api/src/versioned_constants_logic.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 #[cfg(any(test, feature = "testing"))]
 use std::path::Path;
+use std::sync::OnceLock;
 
 #[cfg(any(test, feature = "testing"))]
 use expect_test::expect_file;
@@ -19,6 +20,25 @@ use strum::IntoEnumIterator;
 
 use crate::block::StarknetVersion;
 
+/// Process-wide override for the "latest" Starknet version.
+/// Set once at startup in Echonet mode so all versioned-constants lookups use the replayed
+/// network's version instead of the compile-time LATEST.
+static EFFECTIVE_LATEST_VERSION: OnceLock<StarknetVersion> = OnceLock::new();
+
+/// Sets the effective latest Starknet version for this process.
+/// In Echonet replay mode the gateway calls this once at startup so all versioned-constants
+/// lookups use the replayed network's version rather than the compile-time LATEST.
+pub fn set_effective_latest_version(version: StarknetVersion) {
+    // Ignore if already set — this is a write-once value.
+    EFFECTIVE_LATEST_VERSION.set(version).ok();
+}
+
+/// Returns the effective latest Starknet version: the value set via
+/// `set_effective_latest_version` if in Echonet mode, otherwise the compile-time LATEST.
+pub fn effective_starknet_version() -> StarknetVersion {
+    EFFECTIVE_LATEST_VERSION.get().copied().unwrap_or(StarknetVersion::LATEST)
+}
+
 pub trait VersionedConstantsTrait: Debug {
     type Error: Debug;
 
@@ -30,7 +50,12 @@ pub trait VersionedConstantsTrait: Debug {
 
     /// Gets the constants that shipped with the current version of the Starknet.
     /// To use custom constants, initialize the struct from a file using `from_path`.
-    fn latest_constants() -> &'static Self;
+    fn latest_constants() -> &'static Self {
+        let version = effective_starknet_version();
+        Self::get(&version).unwrap_or_else(|_| {
+            Self::get(&StarknetVersion::LATEST).expect("Latest version should support VC.")
+        })
+    }
 
     /// Gets the constants for the specified Starknet version.
     fn get(version: &StarknetVersion) -> Result<&'static Self, Self::Error>;
@@ -170,11 +195,6 @@ macro_rules! define_versioned_constants_inner {
                     },)*
                     _ => Err(Self::Error::InvalidStarknetVersion(*version)),
                 }
-            }
-
-            fn latest_constants() -> &'static Self {
-                Self::get(&starknet_api::block::StarknetVersion::LATEST)
-                    .expect("Latest version should support VC.")
             }
 
             fn get(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes proposal initialization metadata (gas prices + Starknet version) and introduces process-wide versioned-constants overrides plus new HTTP calls to the recorder in Echonet mode, which could affect consensus/mempool behavior if misconfigured or unavailable.
> 
> **Overview**
> In **Echonet (replay) mode**, proposal building now uses recorder-provided block metadata: `ReplayMetadata` is extended to include L1 gas/data gas prices (wei + fri), and the mempool fetches these prices from `echonet/get_block_metadata` based on the resolved `block_number`, falling back to defaults on errors.
> 
> The gateway gains `behavior_mode` and `recorder_url` static config and, when running in Echonet, fetches the replayed `StarknetVersion` from `echonet/get_starknet_version` at startup and sets a process-wide *effective* latest version; versioned-constants lookups now respect this effective version. Consensus/cende plumbing is updated to propagate `starknet_version` through `ProposalInit` into blob preparation, and node config schema/pointers are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0378781b91d8d36489e82e3a03e379a17ff10974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->