### PR TITLE
apollo_infra: http level timeout tests

### DIFF
--- a/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
@@ -878,3 +878,69 @@ async fn tcp_keepalive_idle_time_matches_config() {
         "TCP_KEEPIDLE should equal idle_timeout_ms * TCP_IDLE_TIMEOUT_FACTOR"
     );
 }
+
+/// Verifies that Hyper evicts an idle connection from its pool after `idle_timeout_ms`.
+///
+/// Since no pool timer is configured, eviction is triggered by the next pool checkout (the second
+/// request), not a background task. A new connection is detected by counting server-side accepts.
+#[tokio::test]
+async fn idle_connection_is_evicted_after_pool_timeout() {
+    const ARBITRARY_IDLE_TIMEOUT_MS: u64 = 100;
+    const MARGIN_MS: u64 = 300;
+
+    let socket = available_ports_factory(unique_u16!()).get_next_local_host_socket();
+    let accept_count = Arc::new(AtomicUsize::new(0));
+
+    {
+        let accept_count = accept_count.clone();
+        task::spawn(async move {
+            let listener = TcpListener::bind(socket).await.unwrap();
+            loop {
+                let Ok((stream, _)) = listener.accept().await else { continue };
+                accept_count.fetch_add(1, Ordering::SeqCst);
+                let io = TokioIo::new(stream);
+                let service = service_fn(|_req: Request<Incoming>| async {
+                    let body = ComponentAResponse::AGetValue(VALID_VALUE_A);
+                    Ok::<_, Infallible>(
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM)
+                            .body(Full::new(Bytes::from(
+                                SerdeWrapper::new(body).wrapper_serialize().unwrap(),
+                            )))
+                            .unwrap(),
+                    )
+                });
+                tokio::spawn(async move {
+                    let _ = Http2ServerBuilder::new(TokioExecutor::new())
+                        .http2()
+                        .serve_connection(io, service)
+                        .await;
+                });
+            }
+        });
+    }
+    task::yield_now().await;
+
+    let client = ComponentAClient::new(
+        RemoteClientConfig { idle_timeout_ms: ARBITRARY_IDLE_TIMEOUT_MS, ..Default::default() },
+        &socket.ip().to_string(),
+        socket.port(),
+        &TEST_REMOTE_CLIENT_METRICS,
+    );
+
+    // Establish connection C1.
+    client.a_get_value().await.expect("first request should succeed");
+    assert_eq!(accept_count.load(Ordering::SeqCst), 1, "C1 should have been accepted");
+
+    // Let the idle timeout expire.
+    sleep(Duration::from_millis(ARBITRARY_IDLE_TIMEOUT_MS + MARGIN_MS)).await;
+
+    // The next checkout detects C1 is expired, drops it, and opens a new connection C2.
+    client.a_get_value().await.expect("second request should succeed");
+    assert_eq!(
+        accept_count.load(Ordering::SeqCst),
+        2,
+        "idle timeout should have evicted C1 and caused a new connection C2"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new async integration test around Hyper’s idle connection pool behavior; no production logic changes, but timing-based assertions may be mildly flaky in CI.
> 
> **Overview**
> Adds a new Tokio test in `remote_component_client_server_test.rs` that **asserts Hyper evicts idle HTTP/2 connections from the client pool after `idle_timeout_ms`** by verifying a second request triggers a second server-side `accept()` once the timeout has elapsed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd4cc12bf114c23be56c04e6b10df92de191f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->