### PR TITLE
Change pod_state_high_disk_utilization alert threshold

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1318,14 +1318,14 @@
     },
     {
       "name": "pod_state_high_disk_utilization",
-      "title": "Pod High Disk Utilization ( >70% )",
+      "title": "Pod High Disk Utilization (day only)",
       "ruleGroup": "general",
       "expr": "max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) / (min by (namespace,persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) + max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}))*100",
       "conditions": [
         {
           "evaluator": {
             "params": [
-              70.0
+              85.0
             ],
             "type": "gt"
           },

--- a/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
@@ -170,8 +170,8 @@ pub(crate) fn get_general_pod_disk_utilization_vec() -> Vec<Alert> {
     vec![
         get_general_pod_disk_utilization(
             "pod_state_high_disk_utilization",
-            "Pod High Disk Utilization ( >70% )",
-            70.0,
+            "Pod High Disk Utilization (day only)",
+            85.0,
             AlertSeverity::DayOnly,
         ),
         get_general_pod_disk_utilization(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk configuration change limited to alerting behavior; it only adjusts when the `pod_state_high_disk_utilization` alert fires and how it’s labeled.
> 
> **Overview**
> Updates the `pod_state_high_disk_utilization` *day-only* disk alert to be less sensitive by raising its trigger threshold from **70% to 85%** and renaming the alert title to reflect its day-only severity.
> 
> Keeps the Grafana JSON (`dev_grafana_alerts.json`) and the Rust alert scenario definition (`infra_alerts.rs`) in sync with the new title/threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f58bfac30937308d8154366251a78ee0bdb5a7d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->