### PR TITLE
apollo_infra,apollo_node: get_local_client panics for non-local clients

### DIFF
--- a/crates/apollo_infra/src/component_client/definitions.rs
+++ b/crates/apollo_infra/src/component_client/definitions.rs
@@ -37,12 +37,12 @@ where
     Request: Send + Serialize,
     Response: Send + DeserializeOwned,
 {
-    // TODO(Arni): This should return a non-optional client and panic whenever the client is not
-    // local (i.e., it is remote or disabled).
-    pub fn get_local_client(&self) -> Option<LocalComponentClient<Request, Response>> {
+    pub fn get_local_client(&self) -> LocalComponentClient<Request, Response> {
         match self {
-            Client::Local(client) => Some(client.clone()),
-            Client::Remote(_) | Client::Disabled => None,
+            Client::Local(client) => client.clone(),
+            Client::Remote(_) | Client::Disabled => {
+                panic!("Expected a local client, but got a remote or disabled client.")
+            }
         }
     }
 }

--- a/crates/apollo_node/src/clients.rs
+++ b/crates/apollo_node/src/clients.rs
@@ -156,7 +156,7 @@ macro_rules! get_shared_client {
 impl SequencerNodeClients {
     pub fn get_batcher_local_client(
         &self,
-    ) -> Option<LocalComponentClient<BatcherRequest, BatcherResponse>> {
+    ) -> LocalComponentClient<BatcherRequest, BatcherResponse> {
         self.batcher_client.get_local_client()
     }
 
@@ -166,7 +166,7 @@ impl SequencerNodeClients {
 
     pub fn get_class_manager_local_client(
         &self,
-    ) -> Option<LocalComponentClient<ClassManagerRequest, ClassManagerResponse>> {
+    ) -> LocalComponentClient<ClassManagerRequest, ClassManagerResponse> {
         self.class_manager_client.get_local_client()
     }
 
@@ -176,7 +176,7 @@ impl SequencerNodeClients {
 
     pub fn get_committer_local_client(
         &self,
-    ) -> Option<LocalComponentClient<CommitterRequest, CommitterResponse>> {
+    ) -> LocalComponentClient<CommitterRequest, CommitterResponse> {
         self.committer_client.get_local_client()
     }
 
@@ -186,7 +186,7 @@ impl SequencerNodeClients {
 
     pub fn get_gateway_local_client(
         &self,
-    ) -> Option<LocalComponentClient<GatewayRequest, GatewayResponse>> {
+    ) -> LocalComponentClient<GatewayRequest, GatewayResponse> {
         self.gateway_client.get_local_client()
     }
 
@@ -196,13 +196,13 @@ impl SequencerNodeClients {
 
     pub fn get_l1_events_provider_local_client(
         &self,
-    ) -> Option<LocalComponentClient<L1EventsProviderRequest, L1EventsProviderResponse>> {
+    ) -> LocalComponentClient<L1EventsProviderRequest, L1EventsProviderResponse> {
         self.l1_events_provider_client.get_local_client()
     }
 
     pub fn get_l1_gas_price_provider_local_client(
         &self,
-    ) -> Option<LocalComponentClient<L1GasPriceRequest, L1GasPriceResponse>> {
+    ) -> LocalComponentClient<L1GasPriceRequest, L1GasPriceResponse> {
         self.l1_gas_price_client.get_local_client()
     }
 
@@ -216,7 +216,7 @@ impl SequencerNodeClients {
 
     pub fn get_mempool_local_client(
         &self,
-    ) -> Option<LocalComponentClient<MempoolRequest, MempoolResponse>> {
+    ) -> LocalComponentClient<MempoolRequest, MempoolResponse> {
         self.mempool_client.get_local_client()
     }
 
@@ -226,8 +226,7 @@ impl SequencerNodeClients {
 
     pub fn get_mempool_p2p_propagator_local_client(
         &self,
-    ) -> Option<LocalComponentClient<MempoolP2pPropagatorRequest, MempoolP2pPropagatorResponse>>
-    {
+    ) -> LocalComponentClient<MempoolP2pPropagatorRequest, MempoolP2pPropagatorResponse> {
         self.mempool_p2p_propagator_client.get_local_client()
     }
 
@@ -239,7 +238,7 @@ impl SequencerNodeClients {
 
     pub fn get_proof_manager_local_client(
         &self,
-    ) -> Option<LocalComponentClient<ProofManagerRequest, ProofManagerResponse>> {
+    ) -> LocalComponentClient<ProofManagerRequest, ProofManagerResponse> {
         self.proof_manager_client.get_local_client()
     }
 
@@ -249,7 +248,7 @@ impl SequencerNodeClients {
 
     pub fn get_sierra_compiler_local_client(
         &self,
-    ) -> Option<LocalComponentClient<SierraCompilerRequest, SierraCompilerResponse>> {
+    ) -> LocalComponentClient<SierraCompilerRequest, SierraCompilerResponse> {
         self.sierra_compiler_client.get_local_client()
     }
 
@@ -259,7 +258,7 @@ impl SequencerNodeClients {
 
     pub fn get_signature_manager_local_client(
         &self,
-    ) -> Option<LocalComponentClient<SignatureManagerRequest, SignatureManagerResponse>> {
+    ) -> LocalComponentClient<SignatureManagerRequest, SignatureManagerResponse> {
         self.signature_manager_client.get_local_client()
     }
 
@@ -269,7 +268,7 @@ impl SequencerNodeClients {
 
     pub fn get_state_sync_local_client(
         &self,
-    ) -> Option<LocalComponentClient<StateSyncRequest, StateSyncResponse>> {
+    ) -> LocalComponentClient<StateSyncRequest, StateSyncResponse> {
         self.state_sync_client.get_local_client()
     }
 

--- a/crates/apollo_node/src/servers.rs
+++ b/crates/apollo_node/src/servers.rs
@@ -147,8 +147,7 @@ macro_rules! create_remote_server {
     ) => {
         match *$execution_mode {
             ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-                let local_client = $local_client_getter()
-                    .expect("Local client should be set for inbound remote connections.");
+                let local_client = $local_client_getter();
 
                 Some(Box::new(RemoteComponentServer::new(
                     local_client,


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multiple call sites from optional handling to hard panics when a non-local client is accessed, which can turn configuration/logic mistakes into runtime crashes. Risk is limited to client/server wiring paths but could affect node startup or remote-server enablement flows.
> 
> **Overview**
> **Enforces invariant that `get_local_client` is only used for local components.** `Client::get_local_client` now returns a `LocalComponentClient` directly and panics if the client is `Remote` or `Disabled`.
> 
> This propagates through `apollo_node` by changing all `SequencerNodeClients::*_local_client` getters to return non-optional locals, and simplifying `create_remote_server!` to stop `expect`-unwrapping an `Option` before constructing inbound `RemoteComponentServer`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70bf5ea16c1d29522e7f10d17f34eb24a1bc0033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->