### PR TITLE
scripts: add install_compiler_binaries.sh

### DIFF
--- a/deployments/images/base/Dockerfile
+++ b/deployments/images/base/Dockerfile
@@ -8,6 +8,7 @@ FROM ubuntu:24.04 AS base
 
 COPY scripts/install_build_tools.sh scripts/install_build_tools.sh
 COPY scripts/install_cargo_tools.sh scripts/install_cargo_tools.sh
+COPY scripts/install_llvm19.sh scripts/install_llvm19.sh
 COPY scripts/dependencies.sh scripts/dependencies.sh
 COPY scripts/apt_utils.sh scripts/apt_utils.sh
 COPY scripts/cargo_tool_utils.sh scripts/cargo_tool_utils.sh
@@ -39,4 +40,4 @@ RUN ${VIRTUAL_ENV}/bin/pip install -r scripts/requirements.txt
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 # Cleanup.
-RUN rm -f scripts/install_build_tools.sh scripts/install_cargo_tools.sh scripts/cargo_tool_utils.sh scripts/dependencies.sh scripts/apt_utils.sh scripts/requirements.txt
+RUN rm -f scripts/install_build_tools.sh scripts/install_cargo_tools.sh scripts/install_llvm19.sh scripts/cargo_tool_utils.sh scripts/dependencies.sh scripts/apt_utils.sh scripts/requirements.txt

--- a/scripts/compiler_versions.sh
+++ b/scripts/compiler_versions.sh
@@ -1,0 +1,34 @@
+#!/bin/env bash
+# Reads compiler binary versions from version files (the single source of truth).
+# Source this script to get $SIERRA_COMPILE_VERSION and $NATIVE_COMPILE_VERSION.
+
+COMPILER_VERSIONS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${COMPILER_VERSIONS_SCRIPT_DIR}/.." && pwd)"
+
+# Reads and validates a semver-shaped version from a one-line text file.
+# Trims surrounding whitespace; rejects anything that isn't `<num>.<num>.<num>`
+# with an optional `-<pre-release>` suffix. The validation matters because the
+# returned value flows into both `cargo install --version "$VAR"` and per-version
+# install-root paths; a whitespace-separated value would be split by cargo's
+# argument parser and `..` would let path construction escape the install root.
+_compiler_versions_semver_re='^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'
+_compiler_versions_read() {
+    # Sets the named-by-arg-1 variable to the validated version read from arg 2.
+    # Returns 1 (and prints to stderr) on a malformed file. The caller checks
+    # the return code; we cannot rely on `exit` because this function is
+    # invoked from `source compiler_versions.sh`, where an exit inside a
+    # subshell wouldn't propagate to the parent.
+    local out_var=$1 file=$2 raw value
+    raw=$(<"$file")
+    value=$(printf '%s' "$raw" | tr -d '[:space:]')
+    if [[ ! "$value" =~ $_compiler_versions_semver_re ]]; then
+        echo "Error: invalid version in $file: '$raw'" >&2
+        return 1
+    fi
+    printf -v "$out_var" '%s' "$value"
+}
+
+_compiler_versions_read SIERRA_COMPILE_VERSION \
+    "$REPO_ROOT/crates/apollo_infra_utils/src/cairo_compiler_version.txt" || return 1
+_compiler_versions_read NATIVE_COMPILE_VERSION \
+    "$REPO_ROOT/crates/apollo_compile_to_native/src/native_compiler_version.txt" || return 1

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -35,43 +35,10 @@ function install_essential_deps_linux() {
     log_step "dependencies" "Essential Linux dependencies installed successfully"
 }
 
-function setup_llvm_deps() {
-    log_step "dependencies" "Setting up LLVM 19 dependencies..."
-    case "$(uname)" in
-    Darwin)
-        echo "Detected macOS, using Homebrew..."
-        brew update
-        brew install llvm@19
-        ;;
-    Linux)
-        echo "Detected Linux, using apt..."
-        $SUDO bash -c "$(declare -f apt_update_with_retry); $(declare -f apt_install_with_retry)"'
-        echo "Downloading LLVM installation script..."
-        curl https://apt.llvm.org/llvm.sh -Lo llvm.sh
-        echo "Running LLVM 19 installation script..."
-        bash ./llvm.sh 19 all
-        rm -f ./llvm.sh
-        echo "Installing LLVM-related packages (MLIR, Polly, etc.)..."
-        apt_update_with_retry && apt_install_with_retry -y \
-            libgmp3-dev \
-            libmlir-19-dev \
-            libpolly-19-dev \
-            libzstd-dev \
-            mlir-19-tools
-        '
-        ;;
-    *)
-        echo "Error: Unsupported operating system"
-        exit 1
-        ;;
-    esac
-    log_step "dependencies" "LLVM 19 dependencies setup completed"
-}
-
 function main() {
     log_step "dependencies" "Starting dependencies installation..."
     [ "$(uname)" = "Linux" ] && install_essential_deps_linux
-    setup_llvm_deps
+    "${SCRIPT_DIR}/install_llvm19.sh"
     log_step "dependencies" "All dependencies installed successfully!"
 }
 

--- a/scripts/install_compiler_binaries.sh
+++ b/scripts/install_compiler_binaries.sh
@@ -1,0 +1,175 @@
+#!/bin/env bash
+# Installs Sierra compiler binaries (starknet-sierra-compile, starknet-native-compile).
+# Versions are read from plain text files (the single source of truth for both Rust and shell).
+#
+# Each version is installed under its own --root so multiple versions can coexist:
+#   ${CARGO_TOOLS_ROOT:-$CARGO_HOME/tools}/<binary>-<version>/bin/<binary>
+# The script does not put anything on $PATH; callers that need the binary on
+# $PATH should use --dest.
+#
+# Usage:
+#   scripts/install_compiler_binaries.sh                              # Install both
+#   scripts/install_compiler_binaries.sh --sierra                     # Sierra only
+#   scripts/install_compiler_binaries.sh --native                     # Native only
+#   scripts/install_compiler_binaries.sh --dest /path/to/dir          # Stage at fixed path
+#   scripts/install_compiler_binaries.sh --auto-install-llvm          # If LLVM 19 missing,
+#                                                                     # run install_llvm19.sh
+#
+# --dest stages a copy at a caller-specified fixed path. Use for artifact
+# pipelines that require a stable known location (e.g. binaries to be uploaded
+# as build artifacts with a fixed object key).
+#
+# --auto-install-llvm opts into running scripts/install_llvm19.sh (which uses
+# sudo apt) when LLVM 19 is missing. Default is to fail with a clear message;
+# this avoids surprising callers with a system-package install side-effect.
+#
+# Stdout: absolute path of each installed binary, one per line.
+# Stderr: progress logs (so stdout stays parseable).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# Source common apt utilities (for log_step).
+if [ -f "${SCRIPT_DIR}/apt_utils.sh" ]; then
+    source "${SCRIPT_DIR}/apt_utils.sh"
+elif [ -f "./apt_utils.sh" ]; then
+    source "./apt_utils.sh"
+else
+    echo "Error: apt_utils.sh not found in ${SCRIPT_DIR} or current directory" >&2
+    exit 1
+fi
+
+# Source compiler version variables (provides $REPO_ROOT, $SIERRA_COMPILE_VERSION,
+# $NATIVE_COMPILE_VERSION). The sourced script validates the version strings.
+source "${SCRIPT_DIR}/compiler_versions.sh"
+
+# Parse arguments.
+INSTALL_SIERRA=false
+INSTALL_NATIVE=false
+DEST_DIR=""
+AUTO_INSTALL_LLVM=false
+explicit_selection=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --sierra) INSTALL_SIERRA=true; explicit_selection=true ;;
+        --native) INSTALL_NATIVE=true; explicit_selection=true ;;
+        --dest) DEST_DIR="$2"; shift ;;
+        --auto-install-llvm) AUTO_INSTALL_LLVM=true ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+if ! $explicit_selection; then
+    INSTALL_SIERRA=true
+    INSTALL_NATIVE=true
+fi
+
+CARGO_TOOLS_ROOT="${CARGO_TOOLS_ROOT:-${CARGO_HOME:-$HOME/.cargo}/tools}"
+
+# LLVM/MLIR env vars are normally set by .cargo/config.toml, but `cargo install`
+# runs outside the workspace so they must be exported explicitly. We read the
+# three known LLVM-tooling variables from an explicit allow-list and validate
+# each value: cargo install runs untrusted build scripts, so any env var
+# leakage from this function would let a malicious .cargo/config.toml change
+# influence the install environment (e.g. LD_PRELOAD-adjacent attacks).
+readonly _LLVM_ENV_VARS=(LLVM_SYS_191_PREFIX MLIR_SYS_190_PREFIX TABLEGEN_190_PREFIX)
+readonly _LLVM_PATH_RE='^[A-Za-z0-9_/.:-]+$'
+function export_llvm_env_vars() {
+    # If the caller already provided all three vars in the environment (e.g.
+    # Dockerfiles use `ENV`), trust them and skip the config.toml lookup.
+    # Cargo install will receive them via the normal inheritance.
+    local name all_set=true
+    for name in "${_LLVM_ENV_VARS[@]}"; do
+        if [ -z "${!name+x}" ]; then
+            all_set=false
+            break
+        fi
+    done
+    if $all_set; then
+        return 0
+    fi
+
+    # Otherwise read them from .cargo/config.toml. The fields are constrained
+    # to a known allow-list (no greedy regex), and each value is validated
+    # against a path-shape pattern: cargo install runs untrusted build
+    # scripts, so leakage from this function would let a malicious config.toml
+    # influence the install environment (e.g. LD_PRELOAD-adjacent attacks).
+    local config_file="$REPO_ROOT/.cargo/config.toml"
+    if [ ! -f "$config_file" ]; then
+        echo "Error: missing LLVM env vars and ${config_file} not found." >&2
+        echo "       Set ${_LLVM_ENV_VARS[*]} in the environment, or run from a workspace with .cargo/config.toml." >&2
+        exit 1
+    fi
+    local value
+    for name in "${_LLVM_ENV_VARS[@]}"; do
+        value=$(sed -nE "s/^${name}[[:space:]]*=[[:space:]]*\"([^\"]*)\".*/\\1/p" "$config_file")
+        if [ -z "$value" ]; then
+            echo "Error: ${name} not found in ${config_file}" >&2
+            exit 1
+        fi
+        if [[ ! "$value" =~ $_LLVM_PATH_RE ]]; then
+            echo "Error: ${name} has unexpected value in ${config_file}: '${value}'" >&2
+            exit 1
+        fi
+        export "$name=$value"
+    done
+}
+
+# Atomic copy: write to a temp file in the destination directory then rename.
+# Avoids a parallel reader catching a half-written binary.
+function atomic_install() {
+    local src=$1 dst=$2
+    mkdir -p "$(dirname "$dst")"
+    local tmp="${dst}.tmp.$$"
+    cp "$src" "$tmp"
+    mv -f "$tmp" "$dst"
+}
+
+# Install <binary> at <version> into a per-version --root.
+# Reuses an existing install (caches across branch swaps); stages a copy at
+# caller-requested DEST_DIR if requested; prints the absolute installed path
+# on stdout.
+function install_compiler_if_needed() {
+    local binary_name=$1
+    local version=$2
+    local install_root="${CARGO_TOOLS_ROOT}/${binary_name}-${version}"
+    local versioned_binary="${install_root}/bin/${binary_name}"
+
+    if [ -x "$versioned_binary" ]; then
+        log_step "install_compiler_binaries" "${binary_name} ${version} already installed, skipping" >&2
+    else
+        log_step "install_compiler_binaries" "Installing ${binary_name} ${version}..." >&2
+        cargo install --locked --root "$install_root" "$binary_name" --version "$version" >&2
+        log_step "install_compiler_binaries" "Installed ${binary_name} ${version}" >&2
+    fi
+
+    # Optional caller-requested copy at a fixed path (artifact pipelines).
+    if [ -n "$DEST_DIR" ]; then
+        atomic_install "$versioned_binary" "$DEST_DIR/${binary_name}"
+    fi
+
+    echo "$versioned_binary"
+}
+
+if $INSTALL_SIERRA; then
+    install_compiler_if_needed "starknet-sierra-compile" "$SIERRA_COMPILE_VERSION"
+fi
+
+if $INSTALL_NATIVE; then
+    # starknet-native-compile requires LLVM 19. By default we fail with a clear
+    # message rather than silently invoking sudo apt; pass --auto-install-llvm
+    # to opt into the system-level install via install_llvm19.sh.
+    if ! command -v llvm-config-19 &>/dev/null; then
+        if $AUTO_INSTALL_LLVM; then
+            log_step "install_compiler_binaries" "LLVM 19 not found; --auto-install-llvm set, running install_llvm19.sh..." >&2
+            "${SCRIPT_DIR}/install_llvm19.sh" >&2
+        else
+            echo "Error: LLVM 19 not installed (llvm-config-19 not on PATH)." >&2
+            echo "       Run scripts/install_llvm19.sh first, or pass --auto-install-llvm to run it now." >&2
+            exit 1
+        fi
+    fi
+    export_llvm_env_vars
+    install_compiler_if_needed "starknet-native-compile" "$NATIVE_COMPILE_VERSION"
+fi

--- a/scripts/install_llvm19.sh
+++ b/scripts/install_llvm19.sh
@@ -1,0 +1,95 @@
+#!/bin/env bash
+# Installs LLVM 19 + MLIR/Polly dev packages required by starknet-native-compile.
+# Idempotent: skips if llvm-config-19 is already on PATH.
+#
+# Sourced by both scripts/dependencies.sh and scripts/install_compiler_binaries.sh
+# (the latter as an opt-in self-recovery fallback when LLVM 19 is missing).
+
+set -e
+
+# Pinned SHA-256 of https://apt.llvm.org/llvm.sh. Recorded 2026-05-14.
+#
+# Why pin: llvm.sh runs as root in our CI / Docker builds. TLS authenticates the
+# server, but not the *content* — an apt.llvm.org compromise, hijacked DNS, or
+# even an accidental upstream regression could quietly serve a different script.
+# Pinning a SHA means we trust this specific reviewed version, not "whatever the
+# URL serves today".
+#
+# If sha256sum -c fails (loud build break), one of two things happened:
+#   1. apt.llvm.org legitimately updated llvm.sh. Read the new file, review the
+#      diff (compare against the previous pinned commit's version), confirm it's
+#      safe, then bump LLVM_SH_SHA256 below in a reviewed commit. This is the
+#      change-control event we want.
+#   2. The upstream or network is compromised. Do NOT bump the SHA until the
+#      cause is investigated.
+#
+# Same supply-chain hygiene as Cargo.lock pinning crate hashes.
+LLVM_SH_SHA256="14a4eda1349f23acf9dc0b564ed44b21bce3bd1703c78b5f7488870d7c6fe68f"
+
+[[ ${UID} == "0" ]] || SUDO="sudo"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [ -f "${SCRIPT_DIR}/apt_utils.sh" ]; then
+    source "${SCRIPT_DIR}/apt_utils.sh"
+elif [ -f "./apt_utils.sh" ]; then
+    source "./apt_utils.sh"
+else
+    echo "Error: apt_utils.sh not found in ${SCRIPT_DIR} or current directory" >&2
+    exit 1
+fi
+
+function install_llvm19() {
+    if command -v llvm-config-19 &>/dev/null; then
+        log_step "install_llvm19" "LLVM 19 already installed, skipping"
+        return 0
+    fi
+    log_step "install_llvm19" "Setting up LLVM 19 dependencies..."
+    case "$(uname)" in
+    Darwin)
+        echo "Detected macOS, using Homebrew..."
+        brew update
+        brew install llvm@19
+        ;;
+    Linux)
+        echo "Detected Linux, using apt..."
+        local workdir llvm_sh
+        workdir=$(mktemp -d)
+        llvm_sh="${workdir}/llvm.sh"
+        # Bash-specific RAII: the RETURN trap fires when this function returns
+        # (success, explicit return, or set -e early exit), guaranteeing cleanup
+        # regardless of which step below fails. Equivalent to try/finally scoped
+        # to the function.
+        trap 'rm -rf "$workdir"' RETURN
+        echo "Downloading LLVM installation script..."
+        curl --proto "=https" --tlsv1.2 --fail -L -o "$llvm_sh" https://apt.llvm.org/llvm.sh
+        echo "Verifying llvm.sh checksum..."
+        echo "${LLVM_SH_SHA256}  ${llvm_sh}" | sha256sum -c -
+        echo "Running LLVM 19 installation script..."
+        $SUDO bash "$llvm_sh" 19 all
+        echo "Installing LLVM-related packages (MLIR, Polly, etc.)..."
+        # `bash -c '...'` spawns a fresh shell that doesn't inherit functions
+        # from the parent shell, only exported env vars. The apt_utils.sh
+        # helpers sourced above therefore aren't reachable inside the sudo
+        # subshell. `declare -f` splices the function definitions into the
+        # subshell's script text so the apt_*_with_retry calls below resolve.
+        $SUDO bash -c "$(declare -f apt_update_with_retry); $(declare -f apt_install_with_retry)"'
+        apt_update_with_retry && apt_install_with_retry -y \
+            libgmp3-dev \
+            libmlir-19-dev \
+            libpolly-19-dev \
+            libzstd-dev \
+            mlir-19-tools
+        '
+        ;;
+    *)
+        echo "Error: Unsupported operating system" >&2
+        exit 1
+        ;;
+    esac
+    log_step "install_llvm19" "LLVM 19 installed successfully"
+}
+
+# Run when invoked directly; allow sourcing without auto-running.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    install_llvm19
+fi


### PR DESCRIPTION
New script to install Sierra compiler binaries (starknet-sierra-compile,
starknet-native-compile). Reads versions from .txt files, handles LLVM
env vars for native compile, and skips gracefully when LLVM 19 is missing.

Includes compiler_versions.sh helper that reads version .txt files.

Not yet called from install_cargo_tools.sh — wired up in a follow-up.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new standalone helper scripts without changing existing build/CI wiring; main risk is minor developer tooling friction if the install/symlink behavior differs from expectations.
> 
> **Overview**
> Adds `scripts/install_compiler_binaries.sh` to install `starknet-sierra-compile` and `starknet-native-compile` via `cargo install`, pinning versions from repo-owned `.txt` files and optionally copying the resulting binaries to a specified `--dest` directory.
> 
> Introduces `scripts/compiler_versions.sh` as a shared version source and updates the installer to support side-by-side versioned binaries (`<name>-<version>`), maintain a symlink to the active version, and *gracefully skip* native installation when LLVM 19 isn’t present (with explicit guidance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d319c68bac135c46036c0ac1faaa951b54624e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->