### PR TITLE
apollo_compilation_utils: add verify_compiler_binary

### DIFF
--- a/crates/apollo_compilation_utils/src/build_utils.rs
+++ b/crates/apollo_compilation_utils/src/build_utils.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::process::Command;
 
 use tempfile::TempDir;
@@ -63,4 +64,46 @@ pub fn install_compiler_binary(
     std::fs::remove_dir_all(temp_cargo_path).expect("Failed to remove the cargo directory.");
 
     println!("Successfully set executable file: {:?}", binary_path.display());
+}
+
+/// Verifies that a compiler binary is installed and has the required version.
+/// Panics with installation instructions if the binary is missing or has the wrong version.
+///
+/// Expects `--version` output in the form `<binary-name> <version>` (with optional
+/// trailing tokens). The match is anchored to the binary's own file name so that
+/// a misbehaving or substituted binary printing a stray dotted token elsewhere in
+/// its output cannot satisfy the check.
+pub fn verify_compiler_binary(binary_path: &Path, required_version: &str) {
+    let binary_name = binary_path.display();
+    let expected_prefix = binary_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_else(|| panic!("{binary_name} has no UTF-8 file name."));
+    let install_instructions =
+        "Run 'scripts/install_compiler_binaries.sh' to install the correct version.";
+    match Command::new(binary_path).arg("--version").output() {
+        Ok(output) => {
+            let version_output = String::from_utf8_lossy(&output.stdout);
+            // Expect "<binary-name> <version>" on the first non-empty line. Anchoring
+            // to <binary-name> avoids both substring false-positives ("1.0.1" vs
+            // "1.0.10") and adversarial padding (e.g. a banner that includes the
+            // required version elsewhere in stdout).
+            let first_line = version_output.lines().find(|line| !line.trim().is_empty());
+            let installed_version = first_line
+                .and_then(|line| line.strip_prefix(expected_prefix))
+                .map(|rest| rest.trim_start())
+                .and_then(|rest| rest.split_whitespace().next())
+                .unwrap_or("");
+            if installed_version != required_version {
+                panic!(
+                    "{binary_name} version {required_version} is required, but found: \
+                     {installed_version:?} (raw output: {version_output:?}). \
+                     {install_instructions}"
+                );
+            }
+        }
+        Err(_) => {
+            panic!("{binary_name} not found. {install_instructions}");
+        }
+    }
 }


### PR DESCRIPTION
New function that checks a compiler binary's version at runtime and
panics with installation instructions if missing or wrong version.
Added alongside the existing install_compiler_binary — no callers yet.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new, currently unused helper with straightforward `--version` parsing and panic messages; no existing behavior changes unless adopted by callers.
> 
> **Overview**
> Adds `verify_compiler_binary` to `apollo_compilation_utils` to **validate a compiler binary is present and matches an exact `required_version`** by running `--version` and extracting the version token.
> 
> On missing binary or version mismatch, it **panics with a clear message and install instructions** (no integration/callers added yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc149a57dfffdd54e660cc3f7ed356e62fbcccbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->