### PR TITLE
ci,scripts: install LLVM before cargo tools

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -12,10 +12,10 @@ runs:
     - name: Setup Namespace Cache
       uses: ./.github/actions/namespace_cache
 
+    - name: Install cairo native.
+      uses: ./.github/actions/setup_native_deps
+
     - name: Install rust.
       uses: ./.github/actions/install_rust
       with:
         github_token: ${{ inputs.github_token }}
-
-    - name: Install cairo native.
-      uses: ./.github/actions/setup_native_deps

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -129,10 +129,11 @@ fi
 popd > /dev/null
 log_step "install_build_tools" "Project Rust toolchain ready: $(rustc --version)"
 
+log_step "install_build_tools" "Running dependencies.sh..."
+./dependencies.sh
+log_step "install_build_tools" "dependencies.sh completed"
 log_step "install_build_tools" "Running install_cargo_tools.sh..."
 ${SCRIPT_DIR}/install_cargo_tools.sh
 log_step "install_build_tools" "install_cargo_tools.sh completed"
-log_step "install_build_tools" "Running dependencies.sh..."
-./dependencies.sh
 
 log_step "install_build_tools" "All build tools installed successfully!"


### PR DESCRIPTION
Reorder bootstrap and install_build_tools.sh so LLVM 19 is installed
before cargo tools. This is needed because install_cargo_tools.sh will
install starknet-native-compile which requires LLVM to build.

Safe change: LLVM installation does not depend on Rust.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/build installation order; low code risk but can break developer/CI environments if the new sequencing has untested assumptions or OS-specific differences.
> 
> **Overview**
> Reorders CI/bootstrap and local build tooling installation so `scripts/dependencies.sh` (LLVM 19 + related native deps) runs *before* `install_cargo_tools.sh`, ensuring cargo-installed tools that compile native code (e.g., `starknet-native-compile`) have LLVM available.
> 
> In the `bootstrap` composite action, `setup_native_deps` is now executed before installing Rust to match the updated dependency ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1efda68af5a4f2bf3e6990707d726698c542de38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->