### PR TITLE
apollo_infra: test cleanups

### DIFF
--- a/crates/apollo_infra/src/tests/component_a_b_fixture.rs
+++ b/crates/apollo_infra/src/tests/component_a_b_fixture.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+
+use apollo_metrics::generate_permutation_labels;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
+use tokio::sync::Semaphore;
+
+use crate::component_client::ClientResult;
+use crate::component_definitions::{ComponentRequestHandler, ComponentStarter, PrioritizedRequest};
+use crate::requests::LABEL_NAME_REQUEST_VARIANT;
+use crate::{impl_debug_for_infra_requests_and_responses, impl_labeled_request};
+
+pub(crate) type ValueA = Felt;
+pub(crate) type ValueB = Felt;
+pub(crate) type ResultA = ClientResult<ValueA>;
+pub(crate) type ResultB = ClientResult<ValueB>;
+
+pub(crate) const VALID_VALUE_A: ValueA = Felt::ONE;
+
+#[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
+#[strum_discriminants(
+    name(ComponentARequestLabelValue),
+    derive(IntoStaticStr, EnumIter, VariantNames),
+    strum(serialize_all = "snake_case")
+)]
+pub(crate) enum ComponentARequest {
+    AGetValue,
+}
+
+generate_permutation_labels! {
+    COMPONENT_A_REQUEST_LABELS,
+    (LABEL_NAME_REQUEST_VARIANT, ComponentARequestLabelValue),
+}
+
+impl_debug_for_infra_requests_and_responses!(ComponentARequest);
+impl_labeled_request!(ComponentARequest, ComponentARequestLabelValue);
+impl PrioritizedRequest for ComponentARequest {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) enum ComponentAResponse {
+    AGetValue(ValueA),
+}
+
+#[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
+#[strum_discriminants(
+    name(ComponentBRequestLabelValue),
+    derive(IntoStaticStr, EnumIter, VariantNames),
+    strum(serialize_all = "snake_case")
+)]
+pub(crate) enum ComponentBRequest {
+    BGetValue,
+    BSetValue(ValueB),
+}
+
+generate_permutation_labels! {
+    COMPONENT_B_REQUEST_LABELS,
+    (LABEL_NAME_REQUEST_VARIANT, ComponentBRequestLabelValue),
+}
+
+impl_debug_for_infra_requests_and_responses!(ComponentBRequest);
+impl_labeled_request!(ComponentBRequest, ComponentBRequestLabelValue);
+impl PrioritizedRequest for ComponentBRequest {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) enum ComponentBResponse {
+    BGetValue(ValueB),
+    BSetValue,
+}
+
+#[async_trait]
+pub(crate) trait ComponentAClientTrait: Send + Sync {
+    async fn a_get_value(&self) -> ResultA;
+}
+
+#[async_trait]
+pub(crate) trait ComponentBClientTrait: Send + Sync {
+    async fn b_get_value(&self) -> ResultB;
+    async fn b_set_value(&self, value: ValueB) -> ClientResult<()>;
+}
+
+pub(crate) struct ComponentA {
+    b: Box<dyn ComponentBClientTrait>,
+    sem: Option<Arc<Semaphore>>,
+}
+
+impl ComponentA {
+    pub(crate) fn new(b: Box<dyn ComponentBClientTrait>) -> Self {
+        Self { b, sem: None }
+    }
+
+    pub(crate) async fn a_get_value(&self) -> ValueA {
+        self.b.b_get_value().await.unwrap()
+    }
+
+    pub(crate) fn with_semaphore(b: Box<dyn ComponentBClientTrait>, sem: Arc<Semaphore>) -> Self {
+        Self { b, sem: Some(sem) }
+    }
+}
+
+impl ComponentStarter for ComponentA {}
+
+pub(crate) struct ComponentB {
+    value: ValueB,
+    _a: Box<dyn ComponentAClientTrait>,
+}
+
+impl ComponentB {
+    pub(crate) fn new(value: ValueB, a: Box<dyn ComponentAClientTrait>) -> Self {
+        Self { value, _a: a }
+    }
+
+    pub(crate) fn b_get_value(&self) -> ValueB {
+        self.value
+    }
+
+    pub(crate) fn b_set_value(&mut self, value: ValueB) {
+        self.value = value;
+    }
+}
+
+impl ComponentStarter for ComponentB {}
+
+pub(crate) async fn test_a_b_functionality(
+    a_client: impl ComponentAClientTrait,
+    b_client: impl ComponentBClientTrait,
+    expected_value: ValueA,
+) {
+    assert_eq!(a_client.a_get_value().await.unwrap(), expected_value);
+
+    let new_expected_value: ValueA = expected_value + 1;
+    assert!(b_client.b_set_value(new_expected_value).await.is_ok());
+    assert_eq!(a_client.a_get_value().await.unwrap(), new_expected_value);
+}
+
+#[async_trait]
+impl ComponentRequestHandler<ComponentARequest, ComponentAResponse> for ComponentA {
+    async fn handle_request(&mut self, request: ComponentARequest) -> ComponentAResponse {
+        match request {
+            ComponentARequest::AGetValue => {
+                if let Some(sem) = &self.sem {
+                    let _permit = sem.clone().acquire_owned().await.unwrap();
+                    let v = self.a_get_value().await;
+                    ComponentAResponse::AGetValue(v)
+                } else {
+                    ComponentAResponse::AGetValue(self.a_get_value().await)
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ComponentRequestHandler<ComponentBRequest, ComponentBResponse> for ComponentB {
+    async fn handle_request(&mut self, request: ComponentBRequest) -> ComponentBResponse {
+        match request {
+            ComponentBRequest::BGetValue => ComponentBResponse::BGetValue(self.b_get_value()),
+            ComponentBRequest::BSetValue(value) => {
+                self.b_set_value(value);
+                ComponentBResponse::BSetValue
+            }
+        }
+    }
+}

--- a/crates/apollo_infra/src/tests/concurrent_servers.rs
+++ b/crates/apollo_infra/src/tests/concurrent_servers.rs
@@ -158,10 +158,9 @@ async fn setup_concurrent_remote_test() -> RemoteConcurrentComponentClient {
     let socket = available_ports_factory(unique_u16!()).get_next_local_host_socket();
     let remote_client_config = RemoteClientConfig::default();
 
-    let max_concurrency = 10;
     let mut concurrent_remote_server = RemoteComponentServer::new(
         local_client.clone(),
-        dummy_remote_server_config(socket.ip(), max_concurrency),
+        dummy_remote_server_config(socket.ip()),
         socket.port(),
         &TEST_REMOTE_SERVER_METRICS,
     );

--- a/crates/apollo_infra/src/tests/local_component_client_server.rs
+++ b/crates/apollo_infra/src/tests/local_component_client_server.rs
@@ -6,7 +6,7 @@ use tokio::task;
 use crate::component_client::{ClientError, ClientResult, LocalComponentClient};
 use crate::component_definitions::{ComponentClient, RequestWrapper};
 use crate::component_server::{ComponentServerStarter, LocalComponentServer, LocalServerConfig};
-use crate::tests::{
+use crate::tests::component_a_b_fixture::{
     test_a_b_functionality,
     ComponentA,
     ComponentAClientTrait,
@@ -20,9 +20,8 @@ use crate::tests::{
     ResultB,
     ValueA,
     ValueB,
-    TEST_LOCAL_CLIENT_METRICS,
-    TEST_LOCAL_SERVER_METRICS,
 };
+use crate::tests::{TEST_LOCAL_CLIENT_METRICS, TEST_LOCAL_SERVER_METRICS};
 
 type ComponentAClient = LocalComponentClient<ComponentARequest, ComponentAResponse>;
 type ComponentBClient = LocalComponentClient<ComponentBRequest, ComponentBResponse>;

--- a/crates/apollo_infra/src/tests/mod.rs
+++ b/crates/apollo_infra/src/tests/mod.rs
@@ -1,15 +1,6 @@
-mod concurrent_servers_test;
-mod local_component_client_server_test;
-mod local_request_prioritization;
-mod remote_component_client_server_test;
-mod server_metrics_test;
-mod test_utils;
-
 use std::net::IpAddr;
-use std::sync::Arc;
 
 use apollo_infra_utils::test_utils::{AvailablePorts, TestIdentifier};
-use apollo_metrics::generate_permutation_labels;
 use apollo_metrics::metrics::{
     LabeledMetricHistogram,
     MetricCounter,
@@ -17,14 +8,7 @@ use apollo_metrics::metrics::{
     MetricHistogram,
     MetricScope,
 };
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use starknet_types_core::felt::Felt;
-use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
-use tokio::sync::Semaphore;
 
-use crate::component_client::ClientResult;
-use crate::component_definitions::{ComponentRequestHandler, ComponentStarter, PrioritizedRequest};
 use crate::component_server::RemoteServerConfig;
 use crate::metrics::{
     LocalClientMetrics,
@@ -32,13 +16,16 @@ use crate::metrics::{
     RemoteClientMetrics,
     RemoteServerMetrics,
 };
-use crate::requests::LABEL_NAME_REQUEST_VARIANT;
-use crate::{impl_debug_for_infra_requests_and_responses, impl_labeled_request};
+use crate::tests::component_a_b_fixture::{COMPONENT_A_REQUEST_LABELS, COMPONENT_B_REQUEST_LABELS};
 
-pub(crate) type ValueA = Felt;
-pub(crate) type ValueB = Felt;
-pub(crate) type ResultA = ClientResult<ValueA>;
-pub(crate) type ResultB = ClientResult<ValueB>;
+pub(crate) mod component_a_b_fixture;
+mod concurrent_servers;
+mod local_component_client_server;
+mod local_request_prioritization;
+mod remote_component_client_server;
+mod remote_server_timeouts;
+mod server_metrics;
+mod test_utils;
 
 // Define mock local server metrics.
 const TEST_MSGS_RECEIVED: MetricCounter = MetricCounter::new(
@@ -173,7 +160,6 @@ pub(crate) const TEST_REMOTE_CLIENT_METRICS: RemoteClientMetrics = RemoteClientM
     &TEST_REMOTE_CLIENT_COMMUNICATION_FAILURE_TIMES,
 );
 
-// Define mock local client metrics.
 const TEST_LOCAL_CLIENT_RESPONSE_TIMES: LabeledMetricHistogram = LabeledMetricHistogram::new(
     MetricScope::Infra,
     "test_local_client_response_times",
@@ -188,158 +174,16 @@ pub(crate) const TEST_LOCAL_CLIENT_METRICS: LocalClientMetrics =
 // Each test that binds ports should use a different instance_index to get disjoint port ranges.
 // This is necessary to allow running tests concurrently in different processes, which do not have a
 // shared memory.
-fn available_ports_factory(instance_index: u16) -> AvailablePorts {
+pub(crate) fn available_ports_factory(instance_index: u16) -> AvailablePorts {
     AvailablePorts::new(TestIdentifier::InfraUnitTests.into(), instance_index)
 }
 
-#[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
-#[strum_discriminants(
-    name(ComponentARequestLabelValue),
-    derive(IntoStaticStr, EnumIter, VariantNames),
-    strum(serialize_all = "snake_case")
-)]
-pub enum ComponentARequest {
-    AGetValue,
-}
-
-generate_permutation_labels! {
-    COMPONENT_A_REQUEST_LABELS,
-    (LABEL_NAME_REQUEST_VARIANT, ComponentARequestLabelValue),
-}
-
-impl_debug_for_infra_requests_and_responses!(ComponentARequest);
-impl_labeled_request!(ComponentARequest, ComponentARequestLabelValue);
-impl PrioritizedRequest for ComponentARequest {}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum ComponentAResponse {
-    AGetValue(ValueA),
-}
-
-#[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
-#[strum_discriminants(
-    name(ComponentBRequestLabelValue),
-    derive(IntoStaticStr, EnumIter, VariantNames),
-    strum(serialize_all = "snake_case")
-)]
-pub enum ComponentBRequest {
-    BGetValue,
-    BSetValue(ValueB),
-}
-
-generate_permutation_labels! {
-    COMPONENT_B_REQUEST_LABELS,
-    (LABEL_NAME_REQUEST_VARIANT, ComponentBRequestLabelValue),
-}
-
-impl_debug_for_infra_requests_and_responses!(ComponentBRequest);
-impl_labeled_request!(ComponentBRequest, ComponentBRequestLabelValue);
-impl PrioritizedRequest for ComponentBRequest {}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum ComponentBResponse {
-    BGetValue(ValueB),
-    BSetValue,
-}
-
-#[async_trait]
-pub(crate) trait ComponentAClientTrait: Send + Sync {
-    async fn a_get_value(&self) -> ResultA;
-}
-
-#[async_trait]
-pub(crate) trait ComponentBClientTrait: Send + Sync {
-    async fn b_get_value(&self) -> ResultB;
-    async fn b_set_value(&self, value: ValueB) -> ClientResult<()>;
-}
-
-pub(crate) struct ComponentA {
-    b: Box<dyn ComponentBClientTrait>,
-    sem: Option<Arc<Semaphore>>,
-}
-
-impl ComponentA {
-    pub fn new(b: Box<dyn ComponentBClientTrait>) -> Self {
-        Self { b, sem: None }
+pub(crate) fn dummy_remote_server_config(ip: IpAddr) -> RemoteServerConfig {
+    RemoteServerConfig {
+        bind_ip: ip,
+        // arbitrary value
+        max_streams_per_connection: 5,
+        set_tcp_nodelay: true,
+        ..Default::default()
     }
-
-    pub async fn a_get_value(&self) -> ValueA {
-        self.b.b_get_value().await.unwrap()
-    }
-
-    pub fn with_semaphore(b: Box<dyn ComponentBClientTrait>, sem: Arc<Semaphore>) -> Self {
-        Self { b, sem: Some(sem) }
-    }
-}
-
-impl ComponentStarter for ComponentA {}
-
-pub(crate) struct ComponentB {
-    value: ValueB,
-    _a: Box<dyn ComponentAClientTrait>,
-}
-
-impl ComponentB {
-    pub fn new(value: ValueB, a: Box<dyn ComponentAClientTrait>) -> Self {
-        Self { value, _a: a }
-    }
-
-    pub fn b_get_value(&self) -> ValueB {
-        self.value
-    }
-
-    pub fn b_set_value(&mut self, value: ValueB) {
-        self.value = value;
-    }
-}
-
-impl ComponentStarter for ComponentB {}
-
-pub(crate) async fn test_a_b_functionality(
-    a_client: impl ComponentAClientTrait,
-    b_client: impl ComponentBClientTrait,
-    expected_value: ValueA,
-) {
-    // Check the setup value in component B through client A.
-    assert_eq!(a_client.a_get_value().await.unwrap(), expected_value);
-
-    let new_expected_value: ValueA = expected_value + 1;
-    // Check that setting a new value to component B succeeds.
-    assert!(b_client.b_set_value(new_expected_value).await.is_ok());
-    // Check the new value in component B through client A.
-    assert_eq!(a_client.a_get_value().await.unwrap(), new_expected_value);
-}
-
-#[async_trait]
-impl ComponentRequestHandler<ComponentARequest, ComponentAResponse> for ComponentA {
-    async fn handle_request(&mut self, request: ComponentARequest) -> ComponentAResponse {
-        match request {
-            ComponentARequest::AGetValue => {
-                if let Some(sem) = &self.sem {
-                    let _permit = sem.clone().acquire_owned().await.unwrap();
-                    let v = self.a_get_value().await;
-                    ComponentAResponse::AGetValue(v)
-                } else {
-                    ComponentAResponse::AGetValue(self.a_get_value().await)
-                }
-            }
-        }
-    }
-}
-
-#[async_trait]
-impl ComponentRequestHandler<ComponentBRequest, ComponentBResponse> for ComponentB {
-    async fn handle_request(&mut self, request: ComponentBRequest) -> ComponentBResponse {
-        match request {
-            ComponentBRequest::BGetValue => ComponentBResponse::BGetValue(self.b_get_value()),
-            ComponentBRequest::BSetValue(value) => {
-                self.b_set_value(value);
-                ComponentBResponse::BSetValue
-            }
-        }
-    }
-}
-
-fn dummy_remote_server_config(ip: IpAddr, max_concurrency: usize) -> RemoteServerConfig {
-    RemoteServerConfig { bind_ip: ip, max_concurrency, ..Default::default() }
 }

--- a/crates/apollo_infra/src/tests/remote_component_client_server.rs
+++ b/crates/apollo_infra/src/tests/remote_component_client_server.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::future::ready;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use std::time::Duration;
 
 use apollo_infra_utils::run_until::run_until;
 use apollo_proc_macros::unique_u16;
@@ -29,7 +28,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::channel;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task;
-use tokio::time::{sleep, timeout};
+use tokio::time::{sleep, timeout, Duration};
 
 use crate::component_client::remote_component_client::TCP_IDLE_TIMEOUT_FACTOR;
 use crate::component_client::{
@@ -57,10 +56,7 @@ use crate::component_server::{
     RemoteServerConfig,
 };
 use crate::serde_utils::SerdeWrapper;
-use crate::tests::test_utils::client_socket_keepalive_time;
-use crate::tests::{
-    available_ports_factory,
-    dummy_remote_server_config,
+use crate::tests::component_a_b_fixture::{
     test_a_b_functionality,
     ComponentA,
     ComponentAClientTrait,
@@ -72,8 +68,13 @@ use crate::tests::{
     ComponentBResponse,
     ResultA,
     ResultB,
-    ValueA,
     ValueB,
+    VALID_VALUE_A,
+};
+use crate::tests::test_utils::client_socket_keepalive_time;
+use crate::tests::{
+    available_ports_factory,
+    dummy_remote_server_config,
     TEST_LOCAL_CLIENT_METRICS,
     TEST_LOCAL_SERVER_METRICS,
     TEST_REMOTE_CLIENT_METRICS,
@@ -88,7 +89,6 @@ const ARBITRARY_DATA: &str = "arbitrary data";
 // ServerError::RequestDeserializationFailure error message.
 const DESERIALIZE_REQ_ERROR_MESSAGE: &str = "Could not deserialize client request";
 const BAD_REQUEST_ERROR_MESSAGE: &str = "Got status code: 400 Bad Request";
-const VALID_VALUE_A: ValueA = Felt::ONE;
 const MAX_CONCURRENCY: usize = 10;
 const FAST_FAILING_CLIENT_CONFIG: RemoteClientConfig = RemoteClientConfig {
     retries: 0,
@@ -194,7 +194,7 @@ where
     )
 }
 
-/// Ensures the remote client respects the server’s concurrency cap:
+/// Ensures the remote client respects the server's concurrency cap:
 /// - Two in-flight requests exhaust the limit and a third is **immediately rejected** with `503
 ///   Service Unavailable` and the message `"Server is busy addressing previous requests"`.
 /// - After releasing permits on the shared semaphore, a subsequent request succeeds.
@@ -216,7 +216,7 @@ async fn remote_connection_concurrency() {
     // Shared semaphore used inside ComponentA::handle_request
     let semaphore = Arc::new(Semaphore::new(0));
 
-    // pass the semaphore into the server’s ComponentA
+    // pass the semaphore into the server's ComponentA
     setup_for_tests(setup_value, a_socket, b_socket, 2, Some(semaphore.clone())).await;
 
     let client1 = RemoteComponentClient::<ComponentARequest, ComponentAResponse>::new(
@@ -393,13 +393,13 @@ async fn setup_for_tests(
 
     let mut component_a_remote_server = RemoteComponentServer::new(
         a_local_client,
-        dummy_remote_server_config(a_socket.ip(), max_concurrency),
+        dummy_remote_server_config(a_socket.ip()),
         a_socket.port(),
         &TEST_REMOTE_SERVER_METRICS,
     );
     let mut component_b_remote_server = RemoteComponentServer::new(
         b_local_client,
-        dummy_remote_server_config(b_socket.ip(), max_concurrency),
+        dummy_remote_server_config(b_socket.ip()),
         b_socket.port(),
         &TEST_REMOTE_SERVER_METRICS,
     );
@@ -709,7 +709,7 @@ async fn zombie_connection_is_evicted() {
     let config = RemoteServerConfig {
         keepalive_interval_ms: KEEPALIVE_INTERVAL_MS,
         keepalive_timeout_ms: KEEPALIVE_TIMEOUT_MS,
-        ..dummy_remote_server_config(socket.ip(), MAX_CONCURRENCY)
+        ..dummy_remote_server_config(socket.ip())
     };
     let mut server = RemoteComponentServer::new(
         local_client,

--- a/crates/apollo_infra/src/tests/remote_server_timeouts.rs
+++ b/crates/apollo_infra/src/tests/remote_server_timeouts.rs
@@ -1,0 +1,222 @@
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use apollo_proc_macros::unique_u16;
+use bytes::Bytes;
+use http::StatusCode;
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder as Http2ServerBuilder;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc::channel;
+use tokio::sync::Mutex;
+use tokio::task;
+use tokio::time::{sleep, timeout};
+
+use crate::component_client::{
+    ClientError,
+    LocalComponentClient,
+    RemoteClientConfig,
+    RemoteComponentClient,
+};
+use crate::component_definitions::{ComponentClient, RequestWrapper};
+use crate::component_server::{ComponentServerStarter, RemoteComponentServer, RemoteServerConfig};
+use crate::serde_utils::SerdeWrapper;
+use crate::tests::component_a_b_fixture::{ComponentARequest, ComponentAResponse, VALID_VALUE_A};
+use crate::tests::{
+    available_ports_factory,
+    dummy_remote_server_config,
+    TEST_LOCAL_CLIENT_METRICS,
+    TEST_REMOTE_CLIENT_METRICS,
+    TEST_REMOTE_SERVER_METRICS,
+};
+
+type ComponentAClient = RemoteComponentClient<ComponentARequest, ComponentAResponse>;
+
+#[tokio::test]
+async fn retry_request() {
+    let socket = available_ports_factory(unique_u16!()).get_next_local_host_socket();
+    // Spawn a server that responds with OK every other request.
+    task::spawn(async move {
+        let should_send_ok = Arc::new(Mutex::new(false));
+        async fn handler(
+            _http_request: Request<Incoming>,
+            should_send_ok: Arc<Mutex<bool>>,
+        ) -> Result<Response<Full<Bytes>>, Infallible> {
+            let mut should_send_ok = should_send_ok.lock().await;
+            let body = ComponentAResponse::AGetValue(VALID_VALUE_A);
+            let ret = if *should_send_ok {
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Full::new(Bytes::from(
+                        SerdeWrapper::new(body).wrapper_serialize().unwrap(),
+                    )))
+                    .unwrap()
+            } else {
+                Response::builder()
+                    .status(StatusCode::IM_A_TEAPOT)
+                    .body(Full::new(Bytes::from(
+                        SerdeWrapper::new(body).wrapper_serialize().unwrap(),
+                    )))
+                    .unwrap()
+            };
+            *should_send_ok = !*should_send_ok;
+            Ok(ret)
+        }
+
+        let listener = TcpListener::bind(&socket).await.unwrap();
+        loop {
+            let Ok((stream, _)) = listener.accept().await else { continue };
+            let io = TokioIo::new(stream);
+            let should_send_ok = should_send_ok.clone();
+            let service = service_fn(move |req| {
+                let should_send_ok = should_send_ok.clone();
+                async move { handler(req, should_send_ok).await }
+            });
+            tokio::spawn(async move {
+                let _ = Http2ServerBuilder::new(TokioExecutor::new())
+                    .http2()
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+    // Todo(uriel): Get rid of this
+    // Ensure the server starts running.
+    task::yield_now().await;
+
+    // The initial server state is 'false', hence the first attempt returns an error and
+    // sets the server state to 'true'. The second attempt (first retry) therefore returns a
+    // 'success', while setting the server state to 'false' yet again.
+    let retry_config = RemoteClientConfig { retries: 1, ..Default::default() };
+    let a_client_retry = ComponentAClient::new(
+        retry_config,
+        &socket.ip().to_string(),
+        socket.port(),
+        &TEST_REMOTE_CLIENT_METRICS,
+    );
+    let ComponentAResponse::AGetValue(value) =
+        a_client_retry.send(ComponentARequest::AGetValue).await.unwrap();
+    assert_eq!(value, VALID_VALUE_A);
+
+    // The current server state is 'false', hence the first and only attempt returns an error.
+    let no_retry_config = RemoteClientConfig { retries: 0, ..Default::default() };
+    let a_client_no_retry = ComponentAClient::new(
+        no_retry_config,
+        &socket.ip().to_string(),
+        socket.port(),
+        &TEST_REMOTE_CLIENT_METRICS,
+    );
+    let Err(error): Result<ComponentAResponse, ClientError> =
+        a_client_no_retry.send(ComponentARequest::AGetValue).await
+    else {
+        panic!("Expected an error.");
+    };
+    assert!(
+        error.to_string().contains(StatusCode::IM_A_TEAPOT.as_str()),
+        "Expected IM_A_TEAPOT in error, got: {error}"
+    );
+}
+
+/// Connects a raw TCP stream to `addr`, performs the HTTP/2 connection preface and SETTINGS
+/// exchange, then returns the stream without ever responding to PING frames — simulating a
+/// zombie connection.
+async fn connect_zombie(addr: SocketAddr) -> TcpStream {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+
+    // HTTP/2 client connection preface.
+    stream.write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").await.unwrap();
+    // Empty SETTINGS frame: length=0, type=0x4 (SETTINGS), flags=0x0, stream_id=0.
+    stream.write_all(&[0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]).await.unwrap();
+
+    // Read server frames, accumulating bytes to handle fragmentation. Once we see the
+    // server's SETTINGS frame, respond with SETTINGS_ACK and stop — becoming a zombie that
+    // ignores all subsequent frames (including PING).
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 4096];
+    'done: loop {
+        let n = stream.read(&mut tmp).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+
+        let mut pos = 0;
+        while pos + 9 <= buf.len() {
+            let length = (usize::from(buf[pos]) << 16)
+                | (usize::from(buf[pos + 1]) << 8)
+                | usize::from(buf[pos + 2]);
+            if pos + 9 + length > buf.len() {
+                break; // incomplete frame, read more
+            }
+            let frame_type = buf[pos + 3];
+            let flags = buf[pos + 4];
+            if frame_type == 0x04 /* SETTINGS */ && flags & 0x01 == 0
+            // not ACK
+            {
+                // Send SETTINGS_ACK and stop responding to anything.
+                stream
+                    .write_all(&[0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00])
+                    .await
+                    .unwrap();
+                break 'done;
+            }
+            pos += 9 + length;
+        }
+    }
+    stream
+}
+
+/// Verifies that the server closes a zombie connection after the keepalive interval and
+/// timeout elapse without receiving a PING response.
+#[tokio::test]
+async fn zombie_connection_is_evicted() {
+    const KEEPALIVE_INTERVAL_MS: u64 = 100;
+    const KEEPALIVE_TIMEOUT_MS: u64 = 100;
+    const MARGIN_MS: u64 = 500;
+
+    let socket = available_ports_factory(unique_u16!()).get_next_local_host_socket();
+
+    // Start a RemoteComponentServer with very short keepalive values.
+    // The local channel receiver is intentionally dropped — no requests will be sent.
+    let (tx, _rx) = channel::<RequestWrapper<ComponentARequest, ComponentAResponse>>(32);
+    let local_client = LocalComponentClient::<ComponentARequest, ComponentAResponse>::new(
+        tx,
+        &TEST_LOCAL_CLIENT_METRICS,
+    );
+    let config = RemoteServerConfig {
+        keepalive_interval_ms: KEEPALIVE_INTERVAL_MS,
+        keepalive_timeout_ms: KEEPALIVE_TIMEOUT_MS,
+        ..dummy_remote_server_config(socket.ip())
+    };
+    let mut server = RemoteComponentServer::new(
+        local_client,
+        config,
+        socket.port(),
+        &TEST_REMOTE_SERVER_METRICS,
+    );
+    task::spawn(async move { server.start().await });
+    task::yield_now().await;
+
+    let mut zombie = connect_zombie(socket).await;
+
+    // Wait for the keepalive cycle to fire and time out.
+    sleep(Duration::from_millis(KEEPALIVE_INTERVAL_MS + KEEPALIVE_TIMEOUT_MS + MARGIN_MS)).await;
+
+    // The server should have closed the connection; read_to_end should return quickly with
+    // whatever GOAWAY bytes were sent, and then EOF.
+    let mut remainder = Vec::new();
+    let read_result =
+        timeout(Duration::from_millis(MARGIN_MS), zombie.read_to_end(&mut remainder)).await;
+    assert!(
+        read_result.is_ok(),
+        "Server should have closed the zombie connection after keepalive timeout, but the \
+         connection is still open"
+    );
+}

--- a/crates/apollo_infra/src/tests/server_metrics.rs
+++ b/crates/apollo_infra/src/tests/server_metrics.rs
@@ -180,7 +180,7 @@ async fn setup_remote_server_test(
 
     let mut remote_server = RemoteComponentServer::new(
         local_client.clone(),
-        dummy_remote_server_config(socket.ip(), max_concurrency),
+        dummy_remote_server_config(socket.ip()),
         socket.port(),
         &TEST_REMOTE_SERVER_METRICS,
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are isolated to test code and helpers; primary risk is test flakiness due to added timing-sensitive keepalive/zombie-connection assertions.
> 
> **Overview**
> **Test scaffolding was reorganized** by extracting the Component A/B request/response types, labels, client traits, and helper assertions into a shared `component_a_b_fixture` module and updating existing tests to import from it.
> 
> **Remote server test configuration was simplified** by changing `dummy_remote_server_config` to no longer take `max_concurrency` and instead set basic connection defaults (e.g. `max_streams_per_connection`, `set_tcp_nodelay`), with call sites updated accordingly.
> 
> **New remote timeout/keepalive tests were added** in `remote_server_timeouts` (including retry behavior and eviction of "zombie" HTTP/2 connections that don’t respond to PING), and existing remote client/server tests were adjusted to use the shared fixture constants and imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d9ec944ce27aa793bfa0700d0f8c4b719acbb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->