### PR TITLE
blockifier: remove stale L2 gas price validation

### DIFF
--- a/crates/apollo_rpc_execution/src/lib.rs
+++ b/crates/apollo_rpc_execution/src/lib.rs
@@ -27,7 +27,7 @@ use apollo_config::dumping::{ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use apollo_storage::header::HeaderStorageReader;
 use apollo_storage::{StorageError, StorageReader};
-use blockifier::blockifier::block::{pre_process_block, validated_gas_prices};
+use blockifier::blockifier::block::pre_process_block;
 use blockifier::blockifier_versioned_constants::{VersionedConstants, VersionedConstantsError};
 use blockifier::bouncer::BouncerConfig;
 use blockifier::context::{BlockContext, ChainInfo, FeeTokenAddresses, TransactionContext};
@@ -57,6 +57,8 @@ use starknet_api::block::{
     BlockHashAndNumber,
     BlockInfo,
     BlockNumber,
+    GasPriceVector,
+    GasPrices,
     NonzeroGasPrice,
     StarknetVersion,
 };
@@ -375,14 +377,24 @@ fn create_block_context(
         use_kzg_da,
         block_number,
         // TODO(yair): What to do about blocks pre 0.13.1 where the data gas price were 0?
-        gas_prices: validated_gas_prices(
-            NonzeroGasPrice::new(l1_gas_price.price_in_wei).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l1_gas_price.price_in_fri).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l1_data_gas_price.price_in_wei).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l1_data_gas_price.price_in_fri).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l2_gas_price.price_in_wei).unwrap_or(NonzeroGasPrice::MIN),
-            NonzeroGasPrice::new(l2_gas_price.price_in_fri).unwrap_or(NonzeroGasPrice::MIN),
-        ),
+        gas_prices: GasPrices {
+            eth_gas_prices: GasPriceVector {
+                l1_gas_price: NonzeroGasPrice::new(l1_gas_price.price_in_wei)
+                    .unwrap_or(NonzeroGasPrice::MIN),
+                l1_data_gas_price: NonzeroGasPrice::new(l1_data_gas_price.price_in_wei)
+                    .unwrap_or(NonzeroGasPrice::MIN),
+                l2_gas_price: NonzeroGasPrice::new(l2_gas_price.price_in_wei)
+                    .unwrap_or(NonzeroGasPrice::MIN),
+            },
+            strk_gas_prices: GasPriceVector {
+                l1_gas_price: NonzeroGasPrice::new(l1_gas_price.price_in_fri)
+                    .unwrap_or(NonzeroGasPrice::MIN),
+                l1_data_gas_price: NonzeroGasPrice::new(l1_data_gas_price.price_in_fri)
+                    .unwrap_or(NonzeroGasPrice::MIN),
+                l2_gas_price: NonzeroGasPrice::new(l2_gas_price.price_in_fri)
+                    .unwrap_or(NonzeroGasPrice::MIN),
+            },
+        },
         starknet_version,
     };
     let chain_info = ChainInfo {

--- a/crates/blockifier/src/blockifier/block.rs
+++ b/crates/blockifier/src/blockifier/block.rs
@@ -1,73 +1,14 @@
-use log::warn;
-use starknet_api::block::{
-    BlockHashAndNumber,
-    BlockNumber,
-    GasPrice,
-    GasPriceVector,
-    GasPrices,
-    NonzeroGasPrice,
-};
+use starknet_api::block::{BlockHashAndNumber, BlockNumber};
 use starknet_api::state::StorageKey;
-use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 
 use crate::abi::constants;
-use crate::blockifier_versioned_constants::{OsConstants, VersionedConstants};
+use crate::blockifier_versioned_constants::OsConstants;
 use crate::state::errors::StateError;
 use crate::state::state_api::{State, StateResult};
 
 #[cfg(test)]
 #[path = "block_test.rs"]
 pub mod block_test;
-
-/// Warns if the submitted gas prices do not match the expected gas prices.
-fn validate_l2_gas_price(gas_prices: &GasPrices) {
-    // TODO(Aner): fix backwards compatibility.
-    let eth_l2_gas_price = gas_prices.eth_gas_prices.l2_gas_price;
-    let expected_eth_l2_gas_price = VersionedConstants::latest_constants()
-        .convert_l1_to_l2_gas_price_round_up(gas_prices.eth_gas_prices.l1_gas_price.into());
-    if GasPrice::from(eth_l2_gas_price) != expected_eth_l2_gas_price {
-        // TODO(Aner): change to panic! Requires fixing several tests.
-        warn!(
-            "eth_l2_gas_price {eth_l2_gas_price} does not match expected eth_l2_gas_price \
-             {expected_eth_l2_gas_price}."
-        )
-    }
-    let strk_l2_gas_price = gas_prices.strk_gas_prices.l2_gas_price;
-    let expected_strk_l2_gas_price = VersionedConstants::latest_constants()
-        .convert_l1_to_l2_gas_price_round_up(gas_prices.strk_gas_prices.l1_gas_price.into());
-    if GasPrice::from(strk_l2_gas_price) != expected_strk_l2_gas_price {
-        // TODO(Aner): change to panic! Requires fixing test_discounted_gas_overdraft
-        warn!(
-            "strk_l2_gas_price {strk_l2_gas_price} does not match expected strk_l2_gas_price \
-             {expected_strk_l2_gas_price}."
-        )
-    }
-}
-
-pub fn validated_gas_prices(
-    eth_l1_gas_price: NonzeroGasPrice,
-    strk_l1_gas_price: NonzeroGasPrice,
-    eth_l1_data_gas_price: NonzeroGasPrice,
-    strk_l1_data_gas_price: NonzeroGasPrice,
-    eth_l2_gas_price: NonzeroGasPrice,
-    strk_l2_gas_price: NonzeroGasPrice,
-) -> GasPrices {
-    let gas_prices = GasPrices {
-        eth_gas_prices: GasPriceVector {
-            l1_gas_price: eth_l1_gas_price,
-            l1_data_gas_price: eth_l1_data_gas_price,
-            l2_gas_price: eth_l2_gas_price,
-        },
-        strk_gas_prices: GasPriceVector {
-            l1_gas_price: strk_l1_gas_price,
-            l1_data_gas_price: strk_l1_data_gas_price,
-            l2_gas_price: strk_l2_gas_price,
-        },
-    };
-    validate_l2_gas_price(&gas_prices);
-
-    gas_prices
-}
 
 // Block pre-processing.
 // Writes the hash of the (current_block_number - N) block under its block number in the dedicated

--- a/crates/blockifier/src/fee/fee_test.rs
+++ b/crates/blockifier/src/fee/fee_test.rs
@@ -3,7 +3,7 @@ use blockifier_test_utils::cairo_versions::CairoVersion;
 use blockifier_test_utils::contracts::FeatureContract;
 use cairo_vm::types::builtin_name::BuiltinName;
 use rstest::rstest;
-use starknet_api::block::{FeeType, GasPrice, NonzeroGasPrice};
+use starknet_api::block::{FeeType, GasPrice, GasPriceVector, GasPrices, NonzeroGasPrice};
 use starknet_api::execution_resources::{GasAmount, GasVector};
 use starknet_api::invoke_tx_args;
 use starknet_api::test_utils::{
@@ -25,7 +25,6 @@ use starknet_api::transaction::fields::{
 };
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 
-use crate::blockifier::block::validated_gas_prices;
 use crate::blockifier_versioned_constants::VersionedConstants;
 use crate::context::BlockContext;
 use crate::fee::fee_checks::{FeeCheckError, FeeCheckReportFields, PostExecutionReport};
@@ -189,21 +188,24 @@ fn test_discounted_gas_overdraft(
         NonzeroGasPrice::try_from(data_gas_price).unwrap(),
     );
     let mut block_context = BlockContext::create_for_account_testing();
-    block_context.block_info.gas_prices = validated_gas_prices(
-        DEFAULT_ETH_L1_GAS_PRICE,
-        gas_price,
-        DEFAULT_ETH_L1_DATA_GAS_PRICE,
-        data_gas_price,
-        VersionedConstants::latest_constants()
-            .convert_l1_to_l2_gas_price_round_up(DEFAULT_ETH_L1_GAS_PRICE.into())
-            .try_into()
-            .unwrap(),
-        // TODO(Aner): fix test parameters to allow using `gas_price` here.
-        VersionedConstants::latest_constants()
-            .convert_l1_to_l2_gas_price_round_up(DEFAULT_STRK_L1_GAS_PRICE.into())
-            .try_into()
-            .unwrap(),
-    );
+    block_context.block_info.gas_prices = GasPrices {
+        eth_gas_prices: GasPriceVector {
+            l1_gas_price: DEFAULT_ETH_L1_GAS_PRICE,
+            l1_data_gas_price: DEFAULT_ETH_L1_DATA_GAS_PRICE,
+            l2_gas_price: VersionedConstants::latest_constants()
+                .convert_l1_to_l2_gas_price_round_up(DEFAULT_ETH_L1_GAS_PRICE.into())
+                .try_into()
+                .unwrap(),
+        },
+        strk_gas_prices: GasPriceVector {
+            l1_gas_price: gas_price,
+            l1_data_gas_price: data_gas_price,
+            l2_gas_price: VersionedConstants::latest_constants()
+                .convert_l1_to_l2_gas_price_round_up(DEFAULT_STRK_L1_GAS_PRICE.into())
+                .try_into()
+                .unwrap(),
+        },
+    };
 
     let account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0);
     let mut state = test_state(&block_context.chain_info, BALANCE, &[(account, 1)]);
@@ -325,14 +327,18 @@ fn test_get_fee_by_gas_vector_regression(
     #[case] expected_fee_strk: u128,
 ) {
     let mut block_info = BlockContext::create_for_account_testing().block_info;
-    block_info.gas_prices = validated_gas_prices(
-        1_u8.try_into().unwrap(),
-        2_u8.try_into().unwrap(),
-        3_u8.try_into().unwrap(),
-        4_u8.try_into().unwrap(),
-        5_u8.try_into().unwrap(),
-        6_u8.try_into().unwrap(),
-    );
+    block_info.gas_prices = GasPrices {
+        eth_gas_prices: GasPriceVector {
+            l1_gas_price: 1_u8.try_into().unwrap(),
+            l1_data_gas_price: 3_u8.try_into().unwrap(),
+            l2_gas_price: 5_u8.try_into().unwrap(),
+        },
+        strk_gas_prices: GasPriceVector {
+            l1_gas_price: 2_u8.try_into().unwrap(),
+            l1_data_gas_price: 4_u8.try_into().unwrap(),
+            l2_gas_price: 6_u8.try_into().unwrap(),
+        },
+    };
     let gas_vector =
         GasVector { l1_gas: l1_gas.into(), l1_data_gas: l1_data_gas.into(), l2_gas: l2_gas.into() };
     assert_eq!(
@@ -359,14 +365,18 @@ fn test_get_fee_by_gas_vector_overflow(
 ) {
     let huge_gas_price = NonzeroGasPrice::try_from(2_u128 * u128::from(u64::MAX)).unwrap();
     let mut block_info = BlockContext::create_for_account_testing().block_info;
-    block_info.gas_prices = validated_gas_prices(
-        huge_gas_price,
-        huge_gas_price,
-        huge_gas_price,
-        huge_gas_price,
-        huge_gas_price,
-        huge_gas_price,
-    );
+    block_info.gas_prices = GasPrices {
+        eth_gas_prices: GasPriceVector {
+            l1_gas_price: huge_gas_price,
+            l1_data_gas_price: huge_gas_price,
+            l2_gas_price: huge_gas_price,
+        },
+        strk_gas_prices: GasPriceVector {
+            l1_gas_price: huge_gas_price,
+            l1_data_gas_price: huge_gas_price,
+            l2_gas_price: huge_gas_price,
+        },
+    };
     let gas_vector =
         GasVector { l1_gas: l1_gas.into(), l1_data_gas: l1_data_gas.into(), l2_gas: l2_gas.into() };
     assert_eq!(

--- a/crates/blockifier_reexecution/src/state_reader/rpc_objects.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_objects.rs
@@ -1,4 +1,3 @@
-use blockifier::blockifier::block::validated_gas_prices;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use starknet_api::block::{
@@ -8,6 +7,8 @@ use starknet_api::block::{
     BlockTimestamp,
     GasPrice,
     GasPricePerToken,
+    GasPriceVector,
+    GasPrices,
     NonzeroGasPrice,
 };
 use starknet_api::core::{
@@ -104,14 +105,18 @@ impl TryInto<BlockInfo> for BlockHeader {
             block_number: self.block_number,
             sequencer_address: self.sequencer_address,
             block_timestamp: self.timestamp,
-            gas_prices: validated_gas_prices(
-                parse_gas_price(self.l1_gas_price.price_in_wei)?,
-                parse_gas_price(self.l1_gas_price.price_in_fri)?,
-                parse_gas_price(self.l1_data_gas_price.price_in_wei)?,
-                parse_gas_price(self.l1_data_gas_price.price_in_fri)?,
-                parse_gas_price(self.l2_gas_price.price_in_wei)?,
-                parse_gas_price(self.l2_gas_price.price_in_fri)?,
-            ),
+            gas_prices: GasPrices {
+                eth_gas_prices: GasPriceVector {
+                    l1_gas_price: parse_gas_price(self.l1_gas_price.price_in_wei)?,
+                    l1_data_gas_price: parse_gas_price(self.l1_data_gas_price.price_in_wei)?,
+                    l2_gas_price: parse_gas_price(self.l2_gas_price.price_in_wei)?,
+                },
+                strk_gas_prices: GasPriceVector {
+                    l1_gas_price: parse_gas_price(self.l1_gas_price.price_in_fri)?,
+                    l1_data_gas_price: parse_gas_price(self.l1_data_gas_price.price_in_fri)?,
+                    l2_gas_price: parse_gas_price(self.l2_gas_price.price_in_fri)?,
+                },
+            },
             use_kzg_da: self.l1_da_mode.is_use_kzg_da(),
             starknet_version: self.starknet_version.try_into()?,
         })

--- a/crates/native_blockifier/src/py_state_diff.rs
+++ b/crates/native_blockifier/src/py_state_diff.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use blockifier::blockifier::block::validated_gas_prices;
 use blockifier::blockifier_versioned_constants::VersionedConstants;
 use blockifier::state::cached_state::CommitmentStateDiff;
 use indexmap::IndexMap;
@@ -12,6 +11,8 @@ use starknet_api::block::{
     BlockNumber,
     BlockTimestamp,
     GasPrice,
+    GasPriceVector,
+    GasPrices,
     NonzeroGasPrice,
     StarknetVersion,
 };
@@ -192,54 +193,64 @@ impl TryFrom<PyBlockInfo> for BlockInfo {
             block_number: BlockNumber(block_info.block_number),
             block_timestamp: BlockTimestamp(block_info.block_timestamp),
             sequencer_address: ContractAddress::try_from(block_info.sequencer_address.0)?,
-            gas_prices: validated_gas_prices(
-                NonzeroGasPrice::try_from(block_info.l1_gas_price.price_in_wei).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL1GasPriceWei(
-                            block_info.l1_gas_price.price_in_wei,
-                        ),
+            gas_prices: GasPrices {
+                eth_gas_prices: GasPriceVector {
+                    l1_gas_price: NonzeroGasPrice::try_from(block_info.l1_gas_price.price_in_wei)
+                        .map_err(|_| {
+                        NativeBlockifierInputError::InvalidNativeBlockifierInputError(
+                            InvalidNativeBlockifierInputError::InvalidL1GasPriceWei(
+                                block_info.l1_gas_price.price_in_wei,
+                            ),
+                        )
+                    })?,
+                    l1_data_gas_price: NonzeroGasPrice::try_from(
+                        block_info.l1_data_gas_price.price_in_wei,
                     )
-                })?,
-                NonzeroGasPrice::try_from(block_info.l1_gas_price.price_in_fri).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL1GasPriceFri(
-                            block_info.l1_gas_price.price_in_fri,
-                        ),
-                    )
-                })?,
-                NonzeroGasPrice::try_from(block_info.l1_data_gas_price.price_in_wei).map_err(
-                    |_| {
+                    .map_err(|_| {
                         NativeBlockifierInputError::InvalidNativeBlockifierInputError(
                             InvalidNativeBlockifierInputError::InvalidL1DataGasPriceWei(
                                 block_info.l1_data_gas_price.price_in_wei,
                             ),
                         )
-                    },
-                )?,
-                NonzeroGasPrice::try_from(block_info.l1_data_gas_price.price_in_fri).map_err(
-                    |_| {
+                    })?,
+                    l2_gas_price: NonzeroGasPrice::try_from(block_info.l2_gas_price.price_in_wei)
+                        .map_err(|_| {
+                        NativeBlockifierInputError::InvalidNativeBlockifierInputError(
+                            InvalidNativeBlockifierInputError::InvalidL2GasPriceWei(
+                                block_info.l2_gas_price.price_in_wei,
+                            ),
+                        )
+                    })?,
+                },
+                strk_gas_prices: GasPriceVector {
+                    l1_gas_price: NonzeroGasPrice::try_from(block_info.l1_gas_price.price_in_fri)
+                        .map_err(|_| {
+                        NativeBlockifierInputError::InvalidNativeBlockifierInputError(
+                            InvalidNativeBlockifierInputError::InvalidL1GasPriceFri(
+                                block_info.l1_gas_price.price_in_fri,
+                            ),
+                        )
+                    })?,
+                    l1_data_gas_price: NonzeroGasPrice::try_from(
+                        block_info.l1_data_gas_price.price_in_fri,
+                    )
+                    .map_err(|_| {
                         NativeBlockifierInputError::InvalidNativeBlockifierInputError(
                             InvalidNativeBlockifierInputError::InvalidL1DataGasPriceFri(
                                 block_info.l1_data_gas_price.price_in_fri,
                             ),
                         )
-                    },
-                )?,
-                NonzeroGasPrice::try_from(block_info.l2_gas_price.price_in_wei).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL2GasPriceWei(
-                            block_info.l2_gas_price.price_in_wei,
-                        ),
-                    )
-                })?,
-                NonzeroGasPrice::try_from(block_info.l2_gas_price.price_in_fri).map_err(|_| {
-                    NativeBlockifierInputError::InvalidNativeBlockifierInputError(
-                        InvalidNativeBlockifierInputError::InvalidL2GasPriceFri(
-                            block_info.l2_gas_price.price_in_fri,
-                        ),
-                    )
-                })?,
-            ),
+                    })?,
+                    l2_gas_price: NonzeroGasPrice::try_from(block_info.l2_gas_price.price_in_fri)
+                        .map_err(|_| {
+                        NativeBlockifierInputError::InvalidNativeBlockifierInputError(
+                            InvalidNativeBlockifierInputError::InvalidL2GasPriceFri(
+                                block_info.l2_gas_price.price_in_fri,
+                            ),
+                        )
+                    })?,
+                },
+            },
             use_kzg_da: block_info.use_kzg_da,
             starknet_version: block_info.starknet_version.try_into().unwrap_or_default(),
         })


### PR DESCRIPTION
## Summary
- Remove `validate_l2_gas_price` and the `validated_gas_prices` wrapper from blockifier
- Replace all callers with direct `GasPrices` struct construction

## Why

L2 gas prices are set by the **EIP-1559 fee market** in the consensus orchestrator (`fee_market/mod.rs`), independently of L1 gas prices. The removed validation checked that L2 prices equal `ceil(L1_price * conversion_ratio)` from `VersionedConstants` — this was the **old derivation method** before the fee market was introduced.

Since the fee market is the source of truth, this validation **always fires** on real mainnet blocks (actual L2 prices are ~15.8x higher than the formula expects), producing noisy warning logs in:
- The tx prover (on every block re-execution)
- RPC execution (`eth_call`-like queries)
- Block reexecution / state reconstruction

The TODOs to "change to panic" would have broken all of these paths.

## Test plan
- [x] `cargo check` passes for all affected crates
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes a stale L2 gas price validation/warning path; primary risk is unintended differences in gas price wiring where callers previously relied on the helper.
> 
> **Overview**
> Removes `validate_l2_gas_price` and the `validated_gas_prices` helper from `blockifier`, eliminating noisy L2 gas-price mismatch warnings based on the old L1→L2 derivation.
> 
> Updates all call sites (RPC execution, reexecution state reader, native python bindings, and fee tests) to build `GasPrices`/`GasPriceVector` directly when constructing `BlockInfo`/`BlockContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0493b7992f6e19a887c86081ca9fc2bacf908d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->