### PR TITLE
apollo_consensus_orchestrator: escalate block info conversion failure to error in finalize_decision

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -411,7 +411,11 @@ impl SequencerConsensusContext {
 
         // The conversion should never fail, if we already managed to get a decision.
         let Ok(cende_block_info) = convert_to_sn_api_block_info(init) else {
-            warn!("Failed to convert block info to SN API block info at height {height}: {init:?}");
+            error!(
+                "Failed to convert block info to SN API block info at height {height}: {init:?}. \
+                 The block was committed, but state sync and preparing the blob for the next \
+                 height will be skipped."
+            );
             return;
         };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes log severity/message on an already-handled early-return path, with no functional behavior changes beyond observability.
> 
> **Overview**
> After a block is committed in `finalize_decision`, failure to `convert_to_sn_api_block_info(init)` is now logged with `error!` (instead of `warn!`) and includes a message explaining that **state sync update** and **blob preparation for the next height** will be skipped before returning early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe20d39b60bea87181d564f36e8edb299d79a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->