### PR TITLE
apollo_consensus_orchestrator: validate builder address in ProposalInit against config

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -640,6 +640,7 @@ impl ConsensusContext for SequencerConsensusContext {
             std::cmp::Ordering::Equal => {
                 let proposal_init_validation = ProposalInitValidation {
                     height: init.height,
+                    builder_address: self.config.static_config.builder_address,
                     block_timestamp_window_seconds: self
                         .config
                         .static_config
@@ -876,6 +877,7 @@ impl ConsensusContext for SequencerConsensusContext {
         };
         let proposal_init_validation = ProposalInitValidation {
             height: init.height,
+            builder_address: self.config.static_config.builder_address,
             block_timestamp_window_seconds: self
                 .config
                 .static_config

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -27,6 +27,7 @@ use futures::channel::mpsc;
 use futures::StreamExt;
 use starknet_api::block::{BlockNumber, GasPrice};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
+use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
@@ -72,6 +73,7 @@ pub(crate) struct ProposalValidateArguments {
 #[derive(Clone, Debug)]
 pub(crate) struct ProposalInitValidation {
     pub height: BlockNumber,
+    pub builder_address: ContractAddress,
     pub block_timestamp_window_seconds: u64,
     pub previous_proposal_init: Option<PreviousProposalInitInfo>,
     pub l1_da_mode: L1DataAvailabilityMode,
@@ -284,6 +286,16 @@ async fn is_proposal_init_valid(
             init_proposed.clone(),
             proposal_init_validation.clone(),
             "ProposalInit validation failed".to_string(),
+        ));
+    }
+    if init_proposed.builder != proposal_init_validation.builder_address {
+        return Err(ValidateProposalError::InvalidProposalInit(
+            init_proposed.clone(),
+            proposal_init_validation.clone(),
+            format!(
+                "Builder address mismatch: expected={}, proposed={}",
+                proposal_init_validation.builder_address, init_proposed.builder
+            ),
         ));
     }
     let (l1_gas_prices_fri, _l1_gas_prices_wei) = get_l1_prices_in_fri_and_wei(

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
@@ -25,6 +25,7 @@ use futures::SinkExt;
 use rstest::rstest;
 use starknet_api::block::{BlockNumber, GasPrice};
 use starknet_api::block_hash::block_hash_calculator::{BlockHeaderCommitments, PartialBlockHash};
+use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
@@ -90,6 +91,7 @@ fn create_proposal_validate_arguments()
     let init = proposal_init(BlockNumber(0), 0);
     let proposal_init_validation = ProposalInitValidation {
         height: BlockNumber(0),
+        builder_address: ContractAddress::default(),
         block_timestamp_window_seconds: 60,
         previous_proposal_init: None,
         l1_da_mode: L1DataAvailabilityMode::Blob,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches consensus proposal validation logic and can cause proposals to be rejected if the configured builder address is incorrect or mismatched across nodes.
> 
> **Overview**
> Adds **builder address** to `ProposalInit` validation and rejects proposals whose `init.builder` doesn’t match the node’s configured `static_config.builder_address`.
> 
> Plumbs the configured builder address through `SequencerConsensusContext` into `ProposalInitValidation`, and updates validation tests to include the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abd64a43a8b79275803aae5863beb5f9dfb467a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->