### PR TITLE
apollo_signature_manager: remove KeyStore generic from SignatureManager

### DIFF
--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -4,43 +4,8 @@ pub mod communication;
 pub mod metrics;
 pub mod signature_manager;
 
-use std::ops::Deref;
+pub use crate::signature_manager::{LocalKeyStore, SignatureManager};
 
-use apollo_infra::component_definitions::ComponentStarter;
-use async_trait::async_trait;
-
-use crate::signature_manager::{LocalKeyStore, SignatureManager as GenericSignatureManager};
-
-#[derive(Clone, Debug)]
-pub struct LocalKeyStoreSignatureManager(pub GenericSignatureManager<LocalKeyStore>);
-
-impl LocalKeyStoreSignatureManager {
-    pub fn new() -> Self {
-        Self(GenericSignatureManager::new(LocalKeyStore::new_for_testing()))
-    }
-}
-
-impl Default for LocalKeyStoreSignatureManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Deref for LocalKeyStoreSignatureManager {
-    type Target = GenericSignatureManager<LocalKeyStore>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-pub use LocalKeyStoreSignatureManager as SignatureManager;
-
-// TODO(Elin): understand how key store would look in production and better define the way the
-// signature manager is created.
 pub fn create_signature_manager() -> SignatureManager {
-    SignatureManager::new()
+    SignatureManager::new(LocalKeyStore::new_for_testing())
 }
-
-#[async_trait]
-impl ComponentStarter for SignatureManager {}

--- a/crates/apollo_signature_manager/src/signature_manager.rs
+++ b/crates/apollo_signature_manager/src/signature_manager.rs
@@ -47,12 +47,12 @@ impl Deref for MessageDigest {
 
 /// Provides signing and signature verification functionality.
 #[derive(Clone, Debug)]
-pub struct SignatureManager<KS: KeyStore> {
-    pub keystore: KS,
+pub struct SignatureManager {
+    pub keystore: LocalKeyStore,
 }
 
-impl<KS: KeyStore> SignatureManager<KS> {
-    pub fn new(keystore: KS) -> Self {
+impl SignatureManager {
+    pub fn new(keystore: LocalKeyStore) -> Self {
         Self { keystore }
     }
 
@@ -83,7 +83,7 @@ impl<KS: KeyStore> SignatureManager<KS> {
 }
 
 #[async_trait]
-impl<KS: KeyStore> ComponentStarter for SignatureManager<KS> {}
+impl ComponentStarter for SignatureManager {}
 
 /// A simple in-memory key store.
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public `SignatureManager` type and constructor signature, which can break downstream code and affects component wiring, but the signing/verification logic remains largely unchanged.
> 
> **Overview**
> Simplifies `apollo_signature_manager` by removing the `KeyStore` generic from `SignatureManager` and making it always use `LocalKeyStore`.
> 
> `lib.rs` now re-exports `SignatureManager` directly and deletes the `LocalKeyStoreSignatureManager` wrapper; `create_signature_manager()` is updated to construct `SignatureManager` with `LocalKeyStore::new_for_testing()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34cbc7e203c7bb8026e86aa9d69db478f75ee597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->