### PR TITLE
apollo_infra: move test utils to relevant module

### DIFF
--- a/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
@@ -24,8 +24,8 @@ use rstest::rstest;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use starknet_types_core::felt::Felt;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpListener;
 use tokio::sync::mpsc::channel;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task;
@@ -60,19 +60,23 @@ use crate::serde_utils::SerdeWrapper;
 use crate::tests::test_utils::{
     available_ports_factory,
     client_socket_keepalive_time,
+    connect_zombie,
     dummy_remote_server_config,
     test_a_b_functionality,
     ComponentA,
+    ComponentAClient,
     ComponentAClientTrait,
     ComponentARequest,
     ComponentAResponse,
     ComponentB,
+    ComponentBClient,
     ComponentBClientTrait,
     ComponentBRequest,
     ComponentBResponse,
     ResultA,
     ResultB,
     ValueB,
+    MAX_CONCURRENCY,
     TEST_LOCAL_CLIENT_METRICS,
     TEST_LOCAL_SERVER_METRICS,
     TEST_REMOTE_CLIENT_METRICS,
@@ -80,15 +84,11 @@ use crate::tests::test_utils::{
     VALID_VALUE_A,
 };
 
-type ComponentAClient = RemoteComponentClient<ComponentARequest, ComponentAResponse>;
-type ComponentBClient = RemoteComponentClient<ComponentBRequest, ComponentBResponse>;
-
 const MOCK_SERVER_ERROR: &str = "mock server error";
 const ARBITRARY_DATA: &str = "arbitrary data";
 // ServerError::RequestDeserializationFailure error message.
 const DESERIALIZE_REQ_ERROR_MESSAGE: &str = "Could not deserialize client request";
 const BAD_REQUEST_ERROR_MESSAGE: &str = "Got status code: 400 Bad Request";
-const MAX_CONCURRENCY: usize = 10;
 const FAST_FAILING_CLIENT_CONFIG: RemoteClientConfig = RemoteClientConfig {
     retries: 0,
     idle_connections: 0,
@@ -637,55 +637,6 @@ async fn retry_request() {
     );
     let expected_error_contained_keywords = [StatusCode::IM_A_TEAPOT.as_str()];
     verify_error(a_client_no_retry.clone(), &expected_error_contained_keywords).await;
-}
-
-/// Connects a raw TCP stream to `addr`, performs the HTTP/2 connection preface and SETTINGS
-/// exchange, then returns the stream without ever responding to PING frames — simulating a
-/// zombie connection.
-async fn connect_zombie(addr: SocketAddr) -> TcpStream {
-    let mut stream = TcpStream::connect(addr).await.unwrap();
-
-    // HTTP/2 client connection preface.
-    stream.write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").await.unwrap();
-    // Empty SETTINGS frame: length=0, type=0x4 (SETTINGS), flags=0x0, stream_id=0.
-    stream.write_all(&[0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]).await.unwrap();
-
-    // Read server frames, accumulating bytes to handle fragmentation. Once we see the
-    // server's SETTINGS frame, respond with SETTINGS_ACK and stop — becoming a zombie that
-    // ignores all subsequent frames (including PING).
-    let mut buf = Vec::new();
-    let mut tmp = [0u8; 4096];
-    'done: loop {
-        let n = stream.read(&mut tmp).await.unwrap();
-        if n == 0 {
-            break;
-        }
-        buf.extend_from_slice(&tmp[..n]);
-
-        let mut pos = 0;
-        while pos + 9 <= buf.len() {
-            let length = (usize::from(buf[pos]) << 16)
-                | (usize::from(buf[pos + 1]) << 8)
-                | usize::from(buf[pos + 2]);
-            if pos + 9 + length > buf.len() {
-                break; // incomplete frame, read more
-            }
-            let frame_type = buf[pos + 3];
-            let flags = buf[pos + 4];
-            if frame_type == 0x04 /* SETTINGS */ && flags & 0x01 == 0
-            // not ACK
-            {
-                // Send SETTINGS_ACK and stop responding to anything.
-                stream
-                    .write_all(&[0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00])
-                    .await
-                    .unwrap();
-                break 'done;
-            }
-            pos += 9 + length;
-        }
-    }
-    stream
 }
 
 /// Verifies that the server closes a zombie connection after the keepalive interval and

--- a/crates/apollo_infra/src/tests/test_utils.rs
+++ b/crates/apollo_infra/src/tests/test_utils.rs
@@ -17,9 +17,11 @@ use serde::{Deserialize, Serialize};
 use socket2::SockRef;
 use starknet_types_core::felt::Felt;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio::sync::Semaphore;
 
-use crate::component_client::ClientResult;
+use crate::component_client::{ClientResult, RemoteComponentClient};
 use crate::component_definitions::{ComponentRequestHandler, ComponentStarter, PrioritizedRequest};
 use crate::component_server::RemoteServerConfig;
 use crate::metrics::{
@@ -35,8 +37,11 @@ pub(crate) type ValueA = Felt;
 pub(crate) type ValueB = Felt;
 pub(crate) type ResultA = ClientResult<ValueA>;
 pub(crate) type ResultB = ClientResult<ValueB>;
+pub(crate) type ComponentAClient = RemoteComponentClient<ComponentARequest, ComponentAResponse>;
+pub(crate) type ComponentBClient = RemoteComponentClient<ComponentBRequest, ComponentBResponse>;
 
 pub(crate) const VALID_VALUE_A: ValueA = Felt::ONE;
+pub(crate) const MAX_CONCURRENCY: usize = 10;
 
 #[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
 #[strum_discriminants(
@@ -361,4 +366,53 @@ pub(crate) fn client_socket_keepalive_time(server_addr: SocketAddr) -> Option<Du
         }
     }
     None
+}
+
+/// Connects a raw TCP stream to `addr`, performs the HTTP/2 connection preface and SETTINGS
+/// exchange, then returns the stream without ever responding to PING frames — simulating a
+/// zombie connection.
+pub(crate) async fn connect_zombie(addr: SocketAddr) -> TcpStream {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+
+    // HTTP/2 client connection preface.
+    stream.write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").await.unwrap();
+    // Empty SETTINGS frame: length=0, type=0x4 (SETTINGS), flags=0x0, stream_id=0.
+    stream.write_all(&[0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]).await.unwrap();
+
+    // Read server frames, accumulating bytes to handle fragmentation. Once we see the
+    // server's SETTINGS frame, respond with SETTINGS_ACK and stop — becoming a zombie that
+    // ignores all subsequent frames (including PING).
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 4096];
+    'done: loop {
+        let n = stream.read(&mut tmp).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+
+        let mut pos = 0;
+        while pos + 9 <= buf.len() {
+            let length = (usize::from(buf[pos]) << 16)
+                | (usize::from(buf[pos + 1]) << 8)
+                | usize::from(buf[pos + 2]);
+            if pos + 9 + length > buf.len() {
+                break; // incomplete frame, read more
+            }
+            let frame_type = buf[pos + 3];
+            let flags = buf[pos + 4];
+            if frame_type == 0x04 /* SETTINGS */ && flags & 0x01 == 0
+            // not ACK
+            {
+                // Send SETTINGS_ACK and stop responding to anything.
+                stream
+                    .write_all(&[0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00])
+                    .await
+                    .unwrap();
+                break 'done;
+            }
+            pos += 9 + length;
+        }
+    }
+    stream
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk test-only refactor that moves shared helpers/types; main risk is minor compile/test breakage due to changed imports/visibility.
> 
> **Overview**
> Refactors `remote_component_client_server_test.rs` to reuse shared test utilities instead of defining them locally.
> 
> Moves the HTTP/2 zombie-connection helper `connect_zombie`, the `ComponentAClient`/`ComponentBClient` type aliases, and `MAX_CONCURRENCY` into `tests/test_utils.rs`, updating imports and removing now-unneeded `tokio` networking/io imports from the test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c69b0c4c9f09048018af79816f8e0bb789bcb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->