### PR TITLE
apollo_infra: rename and move definition of tcp keepalive factor

### DIFF
--- a/crates/apollo_infra/src/component_client/remote_component_client.rs
+++ b/crates/apollo_infra/src/component_client/remote_component_client.rs
@@ -18,7 +18,6 @@ use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioTimer};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use static_assertions::const_assert;
 use tokio::sync::Mutex;
 use tokio::time::Instant;
 use tracing::field::{display, Empty};
@@ -32,6 +31,7 @@ use crate::component_definitions::{
     ServerError,
     APPLICATION_OCTET_STREAM,
     REQUEST_ID_HEADER,
+    TCP_KEEPALIVE_FACTOR,
 };
 use crate::metrics::RemoteClientMetrics;
 use crate::requests::LabeledRequest;
@@ -45,10 +45,6 @@ pub const DEFAULT_RETRIES: usize = 15;
 pub const REQUEST_TIMEOUT_ERROR_MESSAGE: &str = "request timed out";
 
 const DEFAULT_IDLE_CONNECTIONS: usize = 10;
-pub(crate) const TCP_IDLE_TIMEOUT_FACTOR: f64 = 1.5;
-// Ensure tcp connection timeout is greater than http2 connection timeout by requiring a factor
-// greater than 1.
-const_assert!(TCP_IDLE_TIMEOUT_FACTOR > 1.0);
 
 // 8 MiB — bounds memory materialized from a single response as defense in depth.
 const DEFAULT_MAX_RESPONSE_BODY_BYTES: usize = 8 * 1024 * 1024;
@@ -66,7 +62,7 @@ pub struct RemoteClientConfig {
     pub retries: usize,
     pub idle_connections: usize,
     // Determines client connection timeouts. Used plainly for HTTP/2 connections, and with a
-    // `TCP_IDLE_TIMEOUT_FACTOR` for TCP connections.
+    // `TCP_KEEPALIVE_FACTOR` for TCP connections.
     #[validate(custom(function = "validate_tcp_exceeds_http_keepalive"))]
     pub keepalive_timeout_ms: u64,
     pub attempts_per_log: usize,
@@ -97,12 +93,12 @@ impl Default for RemoteClientConfig {
 
 /// Validates that the TCP keepalive duration (at second granularity, as the OS stores
 /// `TCP_KEEPIDLE` in whole seconds) is greater than or equal to the HTTP keepalive duration
-/// (millisecond granularity). If the configured `keepalive_timeout_ms * TCP_IDLE_TIMEOUT_FACTOR` is
+/// (millisecond granularity). If the configured `keepalive_timeout_ms * TCP_KEEPALIVE_FACTOR` is
 /// less than 1 second, truncation to whole seconds yields 0 s, making the TCP keepalive shorter
 /// than the HTTP keepalive.
 fn validate_tcp_exceeds_http_keepalive(keepalive_timeout_ms: u64) -> Result<(), ValidationError> {
     let http_keepalive = Duration::from_millis(keepalive_timeout_ms);
-    let tcp_keepalive_raw = http_keepalive.mul_f64(TCP_IDLE_TIMEOUT_FACTOR);
+    let tcp_keepalive_raw = http_keepalive.mul_f64(TCP_KEEPALIVE_FACTOR);
     // TCP_KEEPIDLE is stored in whole seconds; fractional seconds are truncated by the OS.
     let tcp_keepalive = Duration::from_secs(tcp_keepalive_raw.as_secs());
     if tcp_keepalive >= http_keepalive {
@@ -112,7 +108,7 @@ fn validate_tcp_exceeds_http_keepalive(keepalive_timeout_ms: u64) -> Result<(), 
             format!(
                 "TCP keepalive ({} s) is shorter than HTTP keepalive ({keepalive_timeout_ms} ms): \
                  increase keepalive_timeout_ms so that keepalive_timeout_ms * \
-                 {TCP_IDLE_TIMEOUT_FACTOR} rounds to at least {keepalive_timeout_ms} ms",
+                 {TCP_KEEPALIVE_FACTOR} rounds to at least {keepalive_timeout_ms} ms",
                 tcp_keepalive.as_secs(),
             ),
             "tcp_keepalive_shorter_than_http_keepalive",
@@ -230,7 +226,7 @@ where
         let mut connector = HttpConnector::new();
         connector.set_nodelay(config.set_tcp_nodelay);
         connector.set_connect_timeout(Some(Duration::from_millis(config.connection_timeout_ms)));
-        connector.set_keepalive(Some(idle_timeout.mul_f64(TCP_IDLE_TIMEOUT_FACTOR)));
+        connector.set_keepalive(Some(idle_timeout.mul_f64(TCP_KEEPALIVE_FACTOR)));
 
         // Server-side HTTP/2 keepalive uses PING frames; the `h2` stack automatically ACKs
         // inbound pings. We still need a real timer so `pool_idle_timeout` schedules evictions

--- a/crates/apollo_infra/src/component_definitions.rs
+++ b/crates/apollo_infra/src/component_definitions.rs
@@ -6,6 +6,7 @@ use derive_more::{Display, FromStr};
 use rand::random;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use static_assertions::const_assert;
 use thiserror::Error;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::Instant;
@@ -16,6 +17,11 @@ use crate::requests::LabeledRequest;
 
 pub(crate) const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
 pub const BUSY_PREVIOUS_REQUESTS_MSG: &str = "Server is busy addressing previous requests";
+
+pub(crate) const TCP_KEEPALIVE_FACTOR: f64 = 1.5;
+// Ensure tcp connection timeout is greater than http2 connection timeout by requiring a factor
+// greater than 1.
+const_assert!(TCP_KEEPALIVE_FACTOR > 1.0);
 
 #[async_trait]
 pub trait ComponentRequestHandler<Request, Response> {

--- a/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
@@ -24,8 +24,8 @@ use rstest::rstest;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use starknet_types_core::felt::Felt;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpListener;
 use tokio::sync::mpsc::channel;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task;
@@ -60,19 +60,23 @@ use crate::serde_utils::SerdeWrapper;
 use crate::tests::test_utils::{
     available_ports_factory,
     client_socket_keepalive_time,
+    connect_zombie,
     dummy_remote_server_config,
     test_a_b_functionality,
     ComponentA,
+    ComponentAClient,
     ComponentAClientTrait,
     ComponentARequest,
     ComponentAResponse,
     ComponentB,
+    ComponentBClient,
     ComponentBClientTrait,
     ComponentBRequest,
     ComponentBResponse,
     ResultA,
     ResultB,
     ValueB,
+    MAX_CONCURRENCY,
     TEST_LOCAL_CLIENT_METRICS,
     TEST_LOCAL_SERVER_METRICS,
     TEST_REMOTE_CLIENT_METRICS,
@@ -80,15 +84,11 @@ use crate::tests::test_utils::{
     VALID_VALUE_A,
 };
 
-type ComponentAClient = RemoteComponentClient<ComponentARequest, ComponentAResponse>;
-type ComponentBClient = RemoteComponentClient<ComponentBRequest, ComponentBResponse>;
-
 const MOCK_SERVER_ERROR: &str = "mock server error";
 const ARBITRARY_DATA: &str = "arbitrary data";
 // ServerError::RequestDeserializationFailure error message.
 const DESERIALIZE_REQ_ERROR_MESSAGE: &str = "Could not deserialize client request";
 const BAD_REQUEST_ERROR_MESSAGE: &str = "Got status code: 400 Bad Request";
-const MAX_CONCURRENCY: usize = 10;
 const FAST_FAILING_CLIENT_CONFIG: RemoteClientConfig = RemoteClientConfig {
     retries: 0,
     idle_connections: 0,
@@ -637,55 +637,6 @@ async fn retry_request() {
     );
     let expected_error_contained_keywords = [StatusCode::IM_A_TEAPOT.as_str()];
     verify_error(a_client_no_retry.clone(), &expected_error_contained_keywords).await;
-}
-
-/// Connects a raw TCP stream to `addr`, performs the HTTP/2 connection preface and SETTINGS
-/// exchange, then returns the stream without ever responding to PING frames — simulating a
-/// zombie connection.
-async fn connect_zombie(addr: SocketAddr) -> TcpStream {
-    let mut stream = TcpStream::connect(addr).await.unwrap();
-
-    // HTTP/2 client connection preface.
-    stream.write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").await.unwrap();
-    // Empty SETTINGS frame: length=0, type=0x4 (SETTINGS), flags=0x0, stream_id=0.
-    stream.write_all(&[0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]).await.unwrap();
-
-    // Read server frames, accumulating bytes to handle fragmentation. Once we see the
-    // server's SETTINGS frame, respond with SETTINGS_ACK and stop — becoming a zombie that
-    // ignores all subsequent frames (including PING).
-    let mut buf = Vec::new();
-    let mut tmp = [0u8; 4096];
-    'done: loop {
-        let n = stream.read(&mut tmp).await.unwrap();
-        if n == 0 {
-            break;
-        }
-        buf.extend_from_slice(&tmp[..n]);
-
-        let mut pos = 0;
-        while pos + 9 <= buf.len() {
-            let length = (usize::from(buf[pos]) << 16)
-                | (usize::from(buf[pos + 1]) << 8)
-                | usize::from(buf[pos + 2]);
-            if pos + 9 + length > buf.len() {
-                break; // incomplete frame, read more
-            }
-            let frame_type = buf[pos + 3];
-            let flags = buf[pos + 4];
-            if frame_type == 0x04 /* SETTINGS */ && flags & 0x01 == 0
-            // not ACK
-            {
-                // Send SETTINGS_ACK and stop responding to anything.
-                stream
-                    .write_all(&[0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00])
-                    .await
-                    .unwrap();
-                break 'done;
-            }
-            pos += 9 + length;
-        }
-    }
-    stream
 }
 
 /// Verifies that the server closes a zombie connection after the keepalive interval and

--- a/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
@@ -31,7 +31,6 @@ use tokio::sync::{Mutex, Semaphore};
 use tokio::task;
 use tokio::time::{sleep, timeout};
 
-use crate::component_client::remote_component_client::TCP_IDLE_TIMEOUT_FACTOR;
 use crate::component_client::{
     ClientError,
     ClientResult,
@@ -48,6 +47,7 @@ use crate::component_definitions::{
     APPLICATION_OCTET_STREAM,
     BUSY_PREVIOUS_REQUESTS_MSG,
     REQUEST_ID_HEADER,
+    TCP_KEEPALIVE_FACTOR,
 };
 use crate::component_server::{
     ComponentServerStarter,
@@ -688,7 +688,7 @@ async fn zombie_connection_is_evicted() {
 }
 
 /// Verifies that `TCP_KEEPIDLE` on the client's outbound socket equals
-/// `keepalive_timeout_ms * TCP_IDLE_TIMEOUT_FACTOR`, confirming the socket is armed to probe after
+/// `keepalive_timeout_ms * TCP_KEEPALIVE_FACTOR`, confirming the socket is armed to probe after
 /// exactly the expected idle period.
 ///
 /// Internally, hyper's `HttpConnector::set_keepalive` calls `SockRef::set_tcp_keepalive` via
@@ -705,11 +705,11 @@ async fn tcp_keepalive_idle_time_matches_config() {
     // configured duration must be a whole number of seconds or the comparison fails.
     const IDLE_TIMEOUT_MS: u64 = 2000;
     let expected_keepalive_idle =
-        Duration::from_millis(IDLE_TIMEOUT_MS).mul_f64(TCP_IDLE_TIMEOUT_FACTOR);
+        Duration::from_millis(IDLE_TIMEOUT_MS).mul_f64(TCP_KEEPALIVE_FACTOR);
     assert_eq!(
         expected_keepalive_idle.subsec_nanos(),
         0,
-        "IDLE_TIMEOUT_MS * TCP_IDLE_TIMEOUT_FACTOR must be a whole number of seconds"
+        "IDLE_TIMEOUT_MS * TCP_KEEPALIVE_FACTOR must be a whole number of seconds"
     );
 
     let mut ports = available_ports_factory(unique_u16!());
@@ -732,6 +732,6 @@ async fn tcp_keepalive_idle_time_matches_config() {
         .expect("SO_KEEPALIVE should be set and TCP_KEEPIDLE should be readable");
     assert_eq!(
         actual_keepalive_idle, expected_keepalive_idle,
-        "TCP_KEEPIDLE should equal keepalive_timeout_ms * TCP_IDLE_TIMEOUT_FACTOR"
+        "TCP_KEEPIDLE should equal keepalive_timeout_ms * TCP_KEEPALIVE_FACTOR"
     );
 }

--- a/crates/apollo_infra/src/tests/test_utils.rs
+++ b/crates/apollo_infra/src/tests/test_utils.rs
@@ -17,9 +17,11 @@ use serde::{Deserialize, Serialize};
 use socket2::SockRef;
 use starknet_types_core::felt::Felt;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio::sync::Semaphore;
 
-use crate::component_client::ClientResult;
+use crate::component_client::{ClientResult, RemoteComponentClient};
 use crate::component_definitions::{ComponentRequestHandler, ComponentStarter, PrioritizedRequest};
 use crate::component_server::RemoteServerConfig;
 use crate::metrics::{
@@ -35,8 +37,11 @@ pub(crate) type ValueA = Felt;
 pub(crate) type ValueB = Felt;
 pub(crate) type ResultA = ClientResult<ValueA>;
 pub(crate) type ResultB = ClientResult<ValueB>;
+pub(crate) type ComponentAClient = RemoteComponentClient<ComponentARequest, ComponentAResponse>;
+pub(crate) type ComponentBClient = RemoteComponentClient<ComponentBRequest, ComponentBResponse>;
 
 pub(crate) const VALID_VALUE_A: ValueA = Felt::ONE;
+pub(crate) const MAX_CONCURRENCY: usize = 10;
 
 #[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
 #[strum_discriminants(
@@ -361,4 +366,53 @@ pub(crate) fn client_socket_keepalive_time(server_addr: SocketAddr) -> Option<Du
         }
     }
     None
+}
+
+/// Connects a raw TCP stream to `addr`, performs the HTTP/2 connection preface and SETTINGS
+/// exchange, then returns the stream without ever responding to PING frames — simulating a
+/// zombie connection.
+pub(crate) async fn connect_zombie(addr: SocketAddr) -> TcpStream {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+
+    // HTTP/2 client connection preface.
+    stream.write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").await.unwrap();
+    // Empty SETTINGS frame: length=0, type=0x4 (SETTINGS), flags=0x0, stream_id=0.
+    stream.write_all(&[0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]).await.unwrap();
+
+    // Read server frames, accumulating bytes to handle fragmentation. Once we see the
+    // server's SETTINGS frame, respond with SETTINGS_ACK and stop — becoming a zombie that
+    // ignores all subsequent frames (including PING).
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 4096];
+    'done: loop {
+        let n = stream.read(&mut tmp).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+
+        let mut pos = 0;
+        while pos + 9 <= buf.len() {
+            let length = (usize::from(buf[pos]) << 16)
+                | (usize::from(buf[pos + 1]) << 8)
+                | usize::from(buf[pos + 2]);
+            if pos + 9 + length > buf.len() {
+                break; // incomplete frame, read more
+            }
+            let frame_type = buf[pos + 3];
+            let flags = buf[pos + 4];
+            if frame_type == 0x04 /* SETTINGS */ && flags & 0x01 == 0
+            // not ACK
+            {
+                // Send SETTINGS_ACK and stop responding to anything.
+                stream
+                    .write_all(&[0x00, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00])
+                    .await
+                    .unwrap();
+                break 'done;
+            }
+            pos += 9 + length;
+        }
+    }
+    stream
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor that renames and centralizes a TCP keepalive scaling constant; behavior should remain the same aside from potential compilation/import fallout.
> 
> **Overview**
> **Centralizes TCP keepalive tuning logic.** The TCP keepalive multiplier previously defined in `remote_component_client.rs` (`TCP_IDLE_TIMEOUT_FACTOR`) is renamed to `TCP_KEEPALIVE_FACTOR` and moved into `component_definitions.rs`, with the compile-time `> 1.0` assertion relocated accordingly.
> 
> All usages (client socket keepalive configuration, keepalive-vs-HTTP validation, and end-to-end socket option tests) are updated to reference the new shared constant and updated wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33840b3f064c5cad7cd04947ceb4f3b8c6681ce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->