### PR TITLE
starknet_patricia_storage: use async_storage derive macro

### DIFF
--- a/crates/starknet_patricia_storage/src/aerospike_storage.rs
+++ b/crates/starknet_patricia_storage/src/aerospike_storage.rs
@@ -24,6 +24,7 @@ use aerospike::{
     Value,
     WritePolicy,
 };
+use async_trait::async_trait;
 
 use crate::storage_trait::{
     AsyncStorage,
@@ -130,6 +131,7 @@ impl AerospikeStorage {
     }
 }
 
+#[async_trait]
 impl ImmutableReadOnlyStorage for AerospikeStorage {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         let record = self
@@ -164,6 +166,7 @@ impl ImmutableReadOnlyStorage for AerospikeStorage {
     }
 }
 
+#[async_trait]
 impl ReadOnlyStorage for AerospikeStorage {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         ImmutableReadOnlyStorage::get(self, key).await
@@ -174,6 +177,7 @@ impl ReadOnlyStorage for AerospikeStorage {
     }
 }
 
+#[async_trait]
 impl Storage for AerospikeStorage {
     type Stats = NoStats;
     type Config = EmptyStorageConfig;

--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use apollo_config::dumping::{prepend_sub_config_name, ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use async_trait::async_trait;
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationErrors};
@@ -40,6 +41,7 @@ pub struct BorrowedStorage<'a, S: Storage> {
     pub storage: &'a mut S,
 }
 
+#[async_trait]
 impl ImmutableReadOnlyStorage for MapStorage {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(self.0.get(key).cloned())
@@ -50,6 +52,7 @@ impl ImmutableReadOnlyStorage for MapStorage {
     }
 }
 
+#[async_trait]
 impl ReadOnlyStorage for MapStorage {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         ImmutableReadOnlyStorage::get(self, key).await
@@ -60,6 +63,7 @@ impl ReadOnlyStorage for MapStorage {
     }
 }
 
+#[async_trait]
 impl Storage for MapStorage {
     type Stats = NoStats;
     type Config = EmptyStorageConfig;
@@ -244,6 +248,7 @@ impl<S: Storage> CachedStorage<S> {
 /// Uses [LruCache::peek] to fetch the value from the immutable cache, this doesn't update the cache
 /// internal state.
 /// Stats are being updated using atomic counters.
+#[async_trait]
 impl<S: Storage + ImmutableReadOnlyStorage> ImmutableReadOnlyStorage for CachedStorage<S> {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         self.reads.fetch_add(1, Ordering::Relaxed);
@@ -296,6 +301,7 @@ impl<S: Storage + ImmutableReadOnlyStorage> ImmutableReadOnlyStorage for CachedS
 }
 
 // TODO(Nimrod): Find a way to share the implementation with `ImmutableReadOnlyStorage`.
+#[async_trait]
 impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         self.reads.fetch_add(1, Ordering::Relaxed);
@@ -341,6 +347,7 @@ impl<S: Storage> ReadOnlyStorage for CachedStorage<S> {
     }
 }
 
+#[async_trait]
 impl<S: Storage + ImmutableReadOnlyStorage + 'static> Storage for CachedStorage<S> {
     type Stats = CachedStorageStats<S::Stats>;
     type Config = CachedStorageConfig<S::Config>;

--- a/crates/starknet_patricia_storage/src/mdbx_storage.rs
+++ b/crates/starknet_patricia_storage/src/mdbx_storage.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::path::Path;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use libmdbx::{
     Database as MdbxDb,
     DatabaseOptions,
@@ -105,6 +106,7 @@ impl MdbxStorage {
     }
 }
 
+#[async_trait]
 impl ImmutableReadOnlyStorage for MdbxStorage {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         let txn = self.db.begin_ro_txn()?;
@@ -123,6 +125,7 @@ impl ImmutableReadOnlyStorage for MdbxStorage {
     }
 }
 
+#[async_trait]
 impl ReadOnlyStorage for MdbxStorage {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         ImmutableReadOnlyStorage::get(self, key).await
@@ -133,6 +136,7 @@ impl ReadOnlyStorage for MdbxStorage {
     }
 }
 
+#[async_trait]
 impl Storage for MdbxStorage {
     type Stats = MdbxStorageStats;
     type Config = EmptyStorageConfig;

--- a/crates/starknet_patricia_storage/src/reads_collector_storage.rs
+++ b/crates/starknet_patricia_storage/src/reads_collector_storage.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::storage_trait::{
     DbHashMap,
     DbKey,
@@ -25,6 +27,7 @@ impl<'a, S: ImmutableReadOnlyStorage> ReadsCollectorStorage<'a, S> {
     }
 }
 
+#[async_trait]
 impl<'a, S: ImmutableReadOnlyStorage> ReadOnlyStorage for ReadsCollectorStorage<'a, S> {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         let value = self.storage.get(key).await?;

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use apollo_config::dumping::{ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use async_trait::async_trait;
 use rust_rocksdb::statistics::StatsLevel;
 use rust_rocksdb::{
     BlockBasedIndexType,
@@ -299,6 +300,7 @@ impl StorageStats for RocksDbStats {
     }
 }
 
+#[async_trait]
 impl ImmutableReadOnlyStorage for RocksDbStorage {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         if self.config.spawn_blocking_reads {
@@ -322,6 +324,7 @@ impl ImmutableReadOnlyStorage for RocksDbStorage {
     }
 }
 
+#[async_trait]
 impl ReadOnlyStorage for RocksDbStorage {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         ImmutableReadOnlyStorage::get(self, key).await
@@ -332,6 +335,7 @@ impl ReadOnlyStorage for RocksDbStorage {
     }
 }
 
+#[async_trait]
 impl Storage for RocksDbStorage {
     type Stats = RocksDbStats;
     type Config = RocksDbStorageConfig;

--- a/crates/starknet_patricia_storage/src/short_key_storage.rs
+++ b/crates/starknet_patricia_storage/src/short_key_storage.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use async_trait::async_trait;
 use blake2::Blake2s;
 use digest::Digest;
 
@@ -50,6 +51,7 @@ macro_rules! define_short_key_storage {
             }
         }
 
+        #[async_trait]
         impl<S: Storage + ImmutableReadOnlyStorage> ImmutableReadOnlyStorage for $name<S> {
             async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
                 self.storage.get(&Self::small_key(key)).await
@@ -64,6 +66,7 @@ macro_rules! define_short_key_storage {
             }
         }
 
+        #[async_trait]
         impl<S: Storage> ReadOnlyStorage for $name<S> {
             async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
                 self.storage.get_mut(&Self::small_key(key)).await
@@ -83,6 +86,7 @@ macro_rules! define_short_key_storage {
             }
         }
 
+        #[async_trait]
         impl<S: Storage> Storage for $name<S> {
             type Stats = S::Stats;
             type Config = EmptyStorageConfig;

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Display};
-use std::future::Future;
 
 use apollo_config::dumping::SerializeConfig;
 use apollo_config::{ParamPath, SerializedParam};
@@ -108,31 +107,21 @@ pub trait StorageConfigTrait:
 
 /// A read-only view of a storage that does not require mutable access.
 /// Allows concurrent reads from multiple threads.
+#[async_trait]
 pub trait ImmutableReadOnlyStorage: Send + Sync + 'static {
-    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
-    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
-    // for details.
-    fn get(
-        &self,
-        key: &DbKey,
-    ) -> impl Future<Output = PatriciaStorageResult<Option<DbValue>>> + Send;
+    async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>>;
 
-    fn mget(
-        &self,
-        keys: &[&DbKey],
-    ) -> impl Future<Output = PatriciaStorageResult<Vec<Option<DbValue>>>> + Send;
+    async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>>;
 
     /// Runs the given tasks concurrently, each with its own [ReadsCollectorStorage] snapshot.
     /// By default, discards collected reads.
-    fn gather<T>(&mut self, tasks: Vec<T>) -> impl Future<Output = Vec<T::Output>> + Send
+    async fn gather<T>(&mut self, tasks: Vec<T>) -> Vec<T::Output>
     where
         T: for<'s> StorageTask<'s, Self> + Send,
         Self: Sized,
     {
-        async move {
-            let (_reads, outputs) = run_tasks_and_collect_reads(self, tasks).await;
-            outputs
-        }
+        let (_reads, outputs) = run_tasks_and_collect_reads(self, tasks).await;
+        outputs
     }
 }
 
@@ -173,67 +162,38 @@ where
 }
 
 /// A read-only view of a storage. Does not assume concurrent access is possible.
+#[async_trait]
 pub trait ReadOnlyStorage: Send + Sync {
     /// Returns value from storage, if it exists.
     /// Uses a mutable `&self` to allow changes in the internal state of the storage (e.g.,
     /// for caching).
-    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
-    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
-    // for details.
-    fn get_mut(
-        &mut self,
-        key: &DbKey,
-    ) -> impl Future<Output = PatriciaStorageResult<Option<DbValue>>> + Send;
+    async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>>;
 
     /// Returns values from storage in same order of given keys. Value is None for keys that do not
     /// exist.
-    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
-    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
-    // for details.
-    fn mget_mut(
-        &mut self,
-        keys: &[&DbKey],
-    ) -> impl Future<Output = PatriciaStorageResult<Vec<Option<DbValue>>>> + Send;
+    async fn mget_mut(&mut self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>>;
 }
 
 /// A trait for the storage. Extends [ReadOnlyStorage] with write operations.
+#[async_trait]
 pub trait Storage: ReadOnlyStorage {
     type Stats: StorageStats;
     type Config: StorageConfigTrait;
 
     /// Sets value in storage. If key already exists, its value is overwritten.
-    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
-    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
-    // for details.
-    fn set(
-        &mut self,
-        key: DbKey,
-        value: DbValue,
-    ) -> impl Future<Output = PatriciaStorageResult<()>> + Send;
+    async fn set(&mut self, key: DbKey, value: DbValue) -> PatriciaStorageResult<()>;
 
     /// Sets values in storage.
-    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
-    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
-    // for details.
-    fn mset(
-        &mut self,
-        key_to_value: DbHashMap,
-    ) -> impl Future<Output = PatriciaStorageResult<()>> + Send;
+    async fn mset(&mut self, key_to_value: DbHashMap) -> PatriciaStorageResult<()>;
 
     /// Deletes a value from storage.
-    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
-    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
-    // for details.
-    fn delete(&mut self, key: &DbKey) -> impl Future<Output = PatriciaStorageResult<()>> + Send;
+    async fn delete(&mut self, key: &DbKey) -> PatriciaStorageResult<()>;
 
     /// Sets values in storage and deletes keys from storage in a single operation.
-    // Use explicit desugaring of `async fn` to allow adding trait bounds to the return type, see
-    // https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#async-fn-in-public-traits
-    // for details.
-    fn multi_set_and_delete(
+    async fn multi_set_and_delete(
         &mut self,
         key_to_operation: DbOperationMap,
-    ) -> impl Future<Output = PatriciaStorageResult<()>> + Send;
+    ) -> PatriciaStorageResult<()>;
 
     /// If implemented, returns the statistics of the storage.
     fn get_stats(&self) -> PatriciaStorageResult<Self::Stats>;
@@ -278,6 +238,7 @@ impl StorageConfigTrait for EmptyStorageConfig {}
 #[derive(Clone)]
 pub struct NullStorage;
 
+#[async_trait]
 impl ImmutableReadOnlyStorage for NullStorage {
     async fn get(&self, _key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(None)
@@ -288,6 +249,7 @@ impl ImmutableReadOnlyStorage for NullStorage {
     }
 }
 
+#[async_trait]
 impl ReadOnlyStorage for NullStorage {
     async fn get_mut(&mut self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         ImmutableReadOnlyStorage::get(self, key).await
@@ -298,6 +260,7 @@ impl ReadOnlyStorage for NullStorage {
     }
 }
 
+#[async_trait]
 impl Storage for NullStorage {
     type Stats = NoStats;
     type Config = EmptyStorageConfig;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This changes the core `Storage`/`ReadOnlyStorage`/`ImmutableReadOnlyStorage` trait signatures, so it can break downstream implementers/callers and subtly affect async behavior via `async_trait` boxing.
> 
> **Overview**
> Refactors the `starknet_patricia_storage` storage API to use `#[async_trait]` with `async fn` methods on `ImmutableReadOnlyStorage`, `ReadOnlyStorage`, and `Storage`, replacing the previous explicit `Future` return types (including `gather`).
> 
> Updates all in-crate storage backends (`aerospike`, `map`/`cached`, `mdbx`, `rocksdb`, `reads_collector`, and `short_key_storage`) to import `async_trait` and annotate their trait impls accordingly, without changing their functional read/write logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148b15b95e24739038352d3deb5223e3fd5fac07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->