### PR TITLE
apollo_infra: move server connection eviction test to designated module

### DIFF
--- a/crates/apollo_infra/src/tests/mod.rs
+++ b/crates/apollo_infra/src/tests/mod.rs
@@ -5,4 +5,5 @@ mod local_component_client_server_test;
 mod local_request_prioritization_test;
 mod remote_client_connection_eviction_test;
 mod remote_component_client_server_test;
+mod remote_server_connection_eviction_test;
 mod server_metrics_test;

--- a/crates/apollo_infra/src/tests/mod.rs
+++ b/crates/apollo_infra/src/tests/mod.rs
@@ -3,5 +3,6 @@ pub(crate) mod test_utils;
 mod concurrent_servers_test;
 mod local_component_client_server_test;
 mod local_request_prioritization_test;
+mod remote_client_connection_eviction_test;
 mod remote_component_client_server_test;
 mod server_metrics_test;

--- a/crates/apollo_infra/src/tests/remote_client_connection_eviction_test.rs
+++ b/crates/apollo_infra/src/tests/remote_client_connection_eviction_test.rs
@@ -1,0 +1,105 @@
+use std::convert::Infallible;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use apollo_proc_macros::unique_u16;
+use bytes::Bytes;
+use http::header::CONTENT_TYPE;
+use http::StatusCode;
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto::Builder as Http2ServerBuilder;
+use tokio::net::TcpListener;
+use tokio::task;
+use tokio::time::sleep;
+
+use crate::component_client::RemoteClientConfig;
+use crate::component_definitions::APPLICATION_OCTET_STREAM;
+use crate::serde_utils::SerdeWrapper;
+use crate::tests::test_utils::{
+    available_ports_factory,
+    ComponentAClient,
+    ComponentAClientTrait,
+    ComponentAResponse,
+    TEST_REMOTE_CLIENT_METRICS,
+    VALID_VALUE_A,
+};
+
+/// Verifies that Hyper evicts an idle connection from its pool after the keepalive timeout
+/// and opens a new connection for the next request, which is detected by counting server-side
+/// accepts.
+#[tokio::test]
+async fn idle_connection_is_evicted_after_pool_timeout() {
+    const SUFFICIENTLY_LONG_KEEPALIVE_TIMEOUT_MS: u64 = 1000;
+    const MARGIN_MS: u64 = 300;
+
+    let socket = available_ports_factory(unique_u16!()).get_next_local_host_socket();
+    let accept_count = Arc::new(AtomicUsize::new(0));
+
+    // A server that accepts connections and keeps track of the number of connections it has
+    // accepted via `accept_count`.
+    {
+        let accept_count = accept_count.clone();
+        task::spawn(async move {
+            let listener = TcpListener::bind(socket).await.unwrap();
+            loop {
+                let Ok((stream, _)) = listener.accept().await else { continue };
+                accept_count.fetch_add(1, Ordering::SeqCst);
+                let io = TokioIo::new(stream);
+                let service = service_fn(|_req: Request<Incoming>| async {
+                    let body = ComponentAResponse::AGetValue(VALID_VALUE_A);
+                    Ok::<_, Infallible>(
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM)
+                            .body(Full::new(Bytes::from(
+                                SerdeWrapper::new(body).wrapper_serialize().unwrap(),
+                            )))
+                            .unwrap(),
+                    )
+                });
+                tokio::spawn(async move {
+                    let _ = Http2ServerBuilder::new(TokioExecutor::new())
+                        .http2()
+                        .serve_connection(io, service)
+                        .await;
+                });
+            }
+        });
+    }
+    task::yield_now().await;
+
+    let client = ComponentAClient::new(
+        RemoteClientConfig {
+            keepalive_timeout_ms: SUFFICIENTLY_LONG_KEEPALIVE_TIMEOUT_MS,
+            ..Default::default()
+        },
+        &socket.ip().to_string(),
+        socket.port(),
+        &TEST_REMOTE_CLIENT_METRICS,
+    );
+
+    // Establish connection C1.
+    client.a_get_value().await.expect("First request should succeed");
+    client.a_get_value().await.expect("Second request should succeed");
+    assert_eq!(
+        accept_count.load(Ordering::SeqCst),
+        1,
+        "There should have been a single connection."
+    );
+
+    // Let the idle timeout expire.
+    sleep(Duration::from_millis(SUFFICIENTLY_LONG_KEEPALIVE_TIMEOUT_MS + MARGIN_MS)).await;
+
+    // The next checkout detects C1 is expired, drops it, and opens a new connection C2.
+    client.a_get_value().await.expect("Third request should succeed");
+    assert_eq!(
+        accept_count.load(Ordering::SeqCst),
+        2,
+        "There should have been a new connection opened."
+    );
+}

--- a/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
+++ b/crates/apollo_infra/src/tests/remote_component_client_server_test.rs
@@ -24,12 +24,10 @@ use rstest::rstest;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use starknet_types_core::felt::Felt;
-use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc::channel;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task;
-use tokio::time::{sleep, timeout};
 
 use crate::component_client::{
     ClientError,
@@ -54,13 +52,11 @@ use crate::component_server::{
     LocalComponentServer,
     LocalServerConfig,
     RemoteComponentServer,
-    RemoteServerConfig,
 };
 use crate::serde_utils::SerdeWrapper;
 use crate::tests::test_utils::{
     available_ports_factory,
     client_socket_keepalive_time,
-    connect_zombie,
     dummy_remote_server_config,
     test_a_b_functionality,
     ComponentA,
@@ -637,54 +633,6 @@ async fn retry_request() {
     );
     let expected_error_contained_keywords = [StatusCode::IM_A_TEAPOT.as_str()];
     verify_error(a_client_no_retry.clone(), &expected_error_contained_keywords).await;
-}
-
-/// Verifies that the server closes a zombie connection after the keepalive interval and
-/// timeout elapse without receiving a PING response.
-#[tokio::test]
-async fn zombie_connection_is_evicted() {
-    const KEEPALIVE_INTERVAL_MS: u64 = 100;
-    const KEEPALIVE_TIMEOUT_MS: u64 = 100;
-    const MARGIN_MS: u64 = 500;
-
-    let socket = available_ports_factory(unique_u16!()).get_next_local_host_socket();
-
-    // Start a RemoteComponentServer with very short keepalive values.
-    // The local channel receiver is intentionally dropped — no requests will be sent.
-    let (tx, _rx) = channel::<RequestWrapper<ComponentARequest, ComponentAResponse>>(32);
-    let local_client = LocalComponentClient::<ComponentARequest, ComponentAResponse>::new(
-        tx,
-        &TEST_LOCAL_CLIENT_METRICS,
-    );
-    let config = RemoteServerConfig {
-        keepalive_interval_ms: KEEPALIVE_INTERVAL_MS,
-        keepalive_timeout_ms: KEEPALIVE_TIMEOUT_MS,
-        ..dummy_remote_server_config(socket.ip(), MAX_CONCURRENCY)
-    };
-    let mut server = RemoteComponentServer::new(
-        local_client,
-        config,
-        socket.port(),
-        &TEST_REMOTE_SERVER_METRICS,
-    );
-    task::spawn(async move { server.start().await });
-    task::yield_now().await;
-
-    let mut zombie = connect_zombie(socket).await;
-
-    // Wait for the keepalive cycle to fire and time out.
-    sleep(Duration::from_millis(KEEPALIVE_INTERVAL_MS + KEEPALIVE_TIMEOUT_MS + MARGIN_MS)).await;
-
-    // The server should have closed the connection; read_to_end should return quickly with
-    // whatever GOAWAY bytes were sent, and then EOF.
-    let mut remainder = Vec::new();
-    let read_result =
-        timeout(Duration::from_millis(MARGIN_MS), zombie.read_to_end(&mut remainder)).await;
-    assert!(
-        read_result.is_ok(),
-        "Server should have closed the zombie connection after keepalive timeout, but the \
-         connection is still open"
-    );
 }
 
 /// Verifies that `TCP_KEEPIDLE` on the client's outbound socket equals

--- a/crates/apollo_infra/src/tests/remote_server_connection_eviction_test.rs
+++ b/crates/apollo_infra/src/tests/remote_server_connection_eviction_test.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use apollo_proc_macros::unique_u16;
+use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc::channel;
+use tokio::task;
+use tokio::time::{sleep, timeout};
+
+use crate::component_client::LocalComponentClient;
+use crate::component_definitions::RequestWrapper;
+use crate::component_server::{ComponentServerStarter, RemoteComponentServer, RemoteServerConfig};
+use crate::tests::test_utils::{
+    available_ports_factory,
+    connect_zombie,
+    dummy_remote_server_config,
+    ComponentARequest,
+    ComponentAResponse,
+    MAX_CONCURRENCY,
+    TEST_LOCAL_CLIENT_METRICS,
+    TEST_REMOTE_SERVER_METRICS,
+};
+
+/// Verifies that the server closes a zombie connection after the HTTP keepalive interval and
+/// timeout elapse without receiving a PING response.
+#[tokio::test]
+async fn zombie_connection_is_evicted_via_http_keepalive() {
+    const KEEPALIVE_INTERVAL_MS: u64 = 100;
+    const KEEPALIVE_TIMEOUT_MS: u64 = 100;
+    const MARGIN_MS: u64 = 500;
+
+    let socket = available_ports_factory(unique_u16!()).get_next_local_host_socket();
+
+    // Start a RemoteComponentServer with very short keepalive values.
+    // The local channel receiver is intentionally dropped — no requests will be sent.
+    let (tx, _rx) = channel::<RequestWrapper<ComponentARequest, ComponentAResponse>>(32);
+    let local_client = LocalComponentClient::<ComponentARequest, ComponentAResponse>::new(
+        tx,
+        &TEST_LOCAL_CLIENT_METRICS,
+    );
+    let config = RemoteServerConfig {
+        keepalive_interval_ms: KEEPALIVE_INTERVAL_MS,
+        keepalive_timeout_ms: KEEPALIVE_TIMEOUT_MS,
+        ..dummy_remote_server_config(socket.ip(), MAX_CONCURRENCY)
+    };
+    let mut server = RemoteComponentServer::new(
+        local_client,
+        config,
+        socket.port(),
+        &TEST_REMOTE_SERVER_METRICS,
+    );
+    task::spawn(async move { server.start().await });
+    task::yield_now().await;
+
+    let mut zombie = connect_zombie(socket).await;
+
+    // Wait for the keepalive cycle to fire and time out.
+    sleep(Duration::from_millis(KEEPALIVE_INTERVAL_MS + KEEPALIVE_TIMEOUT_MS + MARGIN_MS)).await;
+
+    // The server should have closed the connection; read_to_end should return quickly with
+    // whatever GOAWAY bytes were sent, and then EOF.
+    let mut remainder = Vec::new();
+    let read_result =
+        timeout(Duration::from_millis(MARGIN_MS), zombie.read_to_end(&mut remainder)).await;
+    assert!(
+        read_result.is_ok(),
+        "Server should have closed the zombie connection after keepalive timeout, but the \
+         connection is still open"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only reorganizes test code by moving an existing keepalive/zombie-connection eviction test into its own module, with no production logic changes.
> 
> **Overview**
> Moves the server-side zombie connection eviction coverage out of `remote_component_client_server_test.rs` into a new `remote_server_connection_eviction_test.rs` module, and wires it into the test suite via `tests/mod.rs`.
> 
> The extracted test (`zombie_connection_is_evicted_via_http_keepalive`) still validates that `RemoteComponentServer` closes idle HTTP/2 connections after the configured keepalive interval/timeout; the original in-file version and now-unused imports are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a5069dba4176bc12890a8225c24d4ebe870700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->