### PR TITLE
apollo_signature_manager: add signature manager config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
  "apollo_proof_manager_config",
  "apollo_reverts",
  "apollo_sierra_compilation_config",
+ "apollo_signature_manager_types",
  "apollo_staking_config",
  "apollo_state_sync_config",
  "blockifier",
@@ -2542,6 +2543,7 @@ dependencies = [
 name = "apollo_signature_manager_types"
 version = "0.0.0"
 dependencies = [
+ "apollo_config",
  "apollo_infra",
  "apollo_metrics",
  "apollo_network_types",
@@ -2551,6 +2553,7 @@ dependencies = [
  "starknet_api",
  "strum",
  "thiserror 1.0.69",
+ "validator",
 ]
 
 [[package]]

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3599,6 +3599,20 @@
     "privacy": "Public",
     "value": 5368709120
   },
+  "signature_manager_config.#is_none": {
+    "description": "Flag for an optional field.",
+    "privacy": "TemporaryValue",
+    "value": false
+  },
+  "signature_manager_config.key_source": {
+    "description": "The source of the signing key.",
+    "privacy": "Private",
+    "value": {
+      "Local": {
+        "private_key": "0x0"
+      }
+    }
+  },
   "starknet_url": {
     "description": "URL for communicating with Starknet.",
     "privacy": "TemporaryValue",

--- a/crates/apollo_node/resources/config_secrets_schema.json
+++ b/crates/apollo_node/resources/config_secrets_schema.json
@@ -3,6 +3,7 @@
   "consensus_manager_config.network_config.secret_key",
   "l1_gas_price_provider_config.eth_to_strk_oracle_config.url_header_list",
   "mempool_p2p_config.network_config.secret_key",
+  "signature_manager_config.key_source",
   "state_sync_config.static_config.central_sync_client_config.central_source_config.http_headers",
   "state_sync_config.static_config.network_config.secret_key"
 ]

--- a/crates/apollo_node_config/Cargo.toml
+++ b/crates/apollo_node_config/Cargo.toml
@@ -33,6 +33,7 @@ apollo_monitoring_endpoint_config.workspace = true
 apollo_proof_manager_config.workspace = true
 apollo_reverts.workspace = true
 apollo_sierra_compilation_config.workspace = true
+apollo_signature_manager_types.workspace = true
 apollo_staking_config.workspace = true
 apollo_state_sync_config.workspace = true
 blockifier.workspace = true

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -37,6 +37,7 @@ use apollo_monitoring_endpoint_config::config::MonitoringEndpointConfig;
 use apollo_proof_manager_config::config::ProofManagerConfig;
 use apollo_reverts::RevertConfig;
 use apollo_sierra_compilation_config::config::SierraCompilationConfig;
+use apollo_signature_manager_types::SignatureManagerConfig;
 use apollo_staking_config::config::StakingManagerDynamicConfig;
 use apollo_state_sync_config::config::{StateSyncConfig, StateSyncDynamicConfig};
 use blockifier::blockifier::config::NativeClassesWhitelist;
@@ -277,6 +278,8 @@ pub struct SequencerNodeConfig {
     #[validate(nested)]
     pub sierra_compiler_config: Option<SierraCompilationConfig>,
     #[validate(nested)]
+    pub signature_manager_config: Option<SignatureManagerConfig>,
+    #[validate(nested)]
     pub state_sync_config: Option<StateSyncConfig>,
 }
 
@@ -317,6 +320,7 @@ impl SerializeConfig for SequencerNodeConfig {
             ser_optional_sub_config(&self.l1_events_scraper_config, "l1_events_scraper_config"),
             ser_optional_sub_config(&self.proof_manager_config, "proof_manager_config"),
             ser_optional_sub_config(&self.sierra_compiler_config, "sierra_compiler_config"),
+            ser_optional_sub_config(&self.signature_manager_config, "signature_manager_config"),
             ser_optional_sub_config(&self.state_sync_config, "state_sync_config"),
         ];
 
@@ -350,6 +354,7 @@ impl Default for SequencerNodeConfig {
             monitoring_endpoint_config: Some(MonitoringEndpointConfig::default()),
             proof_manager_config: Some(ProofManagerConfig::default()),
             sierra_compiler_config: Some(SierraCompilationConfig::default()),
+            signature_manager_config: Some(SignatureManagerConfig::default()),
             state_sync_config: Some(StateSyncConfig::default()),
         }
     }
@@ -535,6 +540,10 @@ impl SequencerNodeConfig {
         validate_component_config_is_set_iff_running_locally!(
             sierra_compiler,
             sierra_compiler_config
+        );
+        validate_component_config_is_set_iff_running_locally!(
+            signature_manager,
+            signature_manager_config
         );
         validate_component_config_is_set_iff_running_locally!(state_sync, state_sync_config);
 

--- a/crates/apollo_signature_manager_types/Cargo.toml
+++ b/crates/apollo_signature_manager_types/Cargo.toml
@@ -10,6 +10,7 @@ description = "Type definitions for the Apollo signature manager."
 testing = []
 
 [dependencies]
+apollo_config.workspace = true
 apollo_infra.workspace = true
 apollo_metrics.workspace = true
 apollo_network_types.workspace = true
@@ -19,6 +20,7 @@ serde.workspace = true
 starknet_api.workspace = true
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
+validator.workspace = true
 
 [lints]
 workspace = true

--- a/crates/apollo_signature_manager_types/src/lib.rs
+++ b/crates/apollo_signature_manager_types/src/lib.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use apollo_config::dumping::{ser_param, SerializeConfig};
+use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use apollo_infra::component_client::{ClientError, LocalComponentClient, RemoteComponentClient};
 use apollo_infra::component_definitions::{ComponentClient, PrioritizedRequest, RequestWrapper};
 use apollo_infra::requests::LABEL_NAME_REQUEST_VARIANT;
@@ -18,6 +21,43 @@ use starknet_api::block::BlockHash;
 use starknet_api::crypto::utils::{Challenge, PrivateKey, RawSignature, SignatureConversionError};
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use thiserror::Error;
+use validator::Validate;
+
+/// Configuration for the signature manager component.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Validate)]
+pub struct SignatureManagerConfig {
+    pub key_source: KeySourceConfig,
+}
+
+impl SerializeConfig for SignatureManagerConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from([ser_param(
+            "key_source",
+            &self.key_source,
+            "The source of the signing key.",
+            ParamPrivacyInput::Private,
+        )])
+    }
+}
+
+/// Specifies where the signing key is sourced from.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum KeySourceConfig {
+    /// Use a locally provided private key.
+    Local { private_key: PrivateKey },
+    /// Fetch the key from Google Secret Manager on first use.
+    GoogleSecretManager {
+        /// Full GSM resource name, e.g.
+        /// "projects/my-project/secrets/validator-key/versions/latest"
+        secret_name: String,
+    },
+}
+
+impl Default for KeySourceConfig {
+    fn default() -> Self {
+        KeySourceConfig::Local { private_key: PrivateKey::default() }
+    }
+}
 
 pub type KeyStoreResult<T> = Result<T, KeyStoreError>;
 pub type SignatureManagerResult<T> = Result<T, SignatureManagerError>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new node-level config surface for key material, including a private-key/secret-manager source selector; misconfiguration could impact signing or leak secrets if handled incorrectly, though changes are mostly additive wiring.
> 
> **Overview**
> Adds a new `signature_manager_config` to `SequencerNodeConfig`, including defaulting, serialization dumping, and validation that the config is present when the `signature_manager` component runs locally.
> 
> Introduces `SignatureManagerConfig`/`KeySourceConfig` in `apollo_signature_manager_types` (local private key vs Google Secret Manager) and updates config schemas to expose `signature_manager_config.key_source` as **Private** and include it in `config_secrets_schema.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08f59f56c739d461cb47d2caf3077a8b12213db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->