### PR TITLE
apollo_signature_manager: refactor SignatureManager to be config-driven

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,7 @@ dependencies = [
  "apollo_protobuf",
  "apollo_rpc",
  "apollo_sierra_compilation_config",
+ "apollo_signature_manager_types",
  "apollo_staking_config",
  "apollo_state_sync_config",
  "apollo_state_sync_metrics",

--- a/crates/apollo_integration_tests/Cargo.toml
+++ b/crates/apollo_integration_tests/Cargo.toml
@@ -51,6 +51,7 @@ apollo_proof_manager_config.workspace = true
 apollo_protobuf.workspace = true
 apollo_rpc.workspace = true
 apollo_sierra_compilation_config.workspace = true
+apollo_signature_manager_types.workspace = true
 apollo_staking_config.workspace = true
 apollo_state_sync_config.workspace = true
 apollo_state_sync_metrics.workspace = true

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -71,6 +71,7 @@ use apollo_node_config::node_config::{SequencerNodeConfig, CONFIG_POINTERS};
 use apollo_protobuf::consensus::DEFAULT_VALIDATOR_ID;
 use apollo_rpc::RpcConfig;
 use apollo_sierra_compilation_config::config::SierraCompilationConfig;
+use apollo_signature_manager_types::SignatureManagerConfig;
 use apollo_staking_config::config::{
     CommitteeConfig,
     ConfiguredStaker,
@@ -288,6 +289,7 @@ pub fn create_node_config(
 
     let l1_gas_price_scraper_config = L1GasPriceScraperConfig::default();
     let sierra_compiler_config = SierraCompilationConfig::default();
+    let signature_manager_config = SignatureManagerConfig::default();
 
     // Update config pointer values.
     let mut config_pointers_map = ConfigPointersMap::new(CONFIG_POINTERS.clone());
@@ -360,6 +362,8 @@ pub fn create_node_config(
         wrap_if_component_config_expected!(proof_manager, proof_manager_config);
     let sierra_compiler_config =
         wrap_if_component_config_expected!(sierra_compiler, sierra_compiler_config);
+    let signature_manager_config =
+        wrap_if_component_config_expected!(signature_manager, signature_manager_config);
     let state_sync_config = wrap_if_component_config_expected!(state_sync, state_sync_config);
 
     let sequencer_node_config = SequencerNodeConfig {
@@ -384,6 +388,7 @@ pub fn create_node_config(
         monitoring_config,
         proof_manager_config,
         sierra_compiler_config,
+        signature_manager_config,
         state_sync_config,
     };
 

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -528,7 +528,12 @@ pub async fn create_node_components(
     let signature_manager = match config.components.signature_manager.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-            Some(create_signature_manager())
+            let signature_manager_config = config
+                .signature_manager_config
+                .as_ref()
+                .expect("Signature Manager config should be set")
+                .clone();
+            Some(create_signature_manager(signature_manager_config))
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
     };

--- a/crates/apollo_signature_manager/src/lib.rs
+++ b/crates/apollo_signature_manager/src/lib.rs
@@ -4,8 +4,10 @@ pub mod communication;
 pub mod metrics;
 pub mod signature_manager;
 
-pub use crate::signature_manager::{LocalKeyStore, SignatureManager};
+use apollo_signature_manager_types::SignatureManagerConfig;
 
-pub fn create_signature_manager() -> SignatureManager {
-    SignatureManager::new(LocalKeyStore::new_for_testing())
+pub use crate::signature_manager::SignatureManager;
+
+pub fn create_signature_manager(config: SignatureManagerConfig) -> SignatureManager {
+    SignatureManager::new(config).expect("Failed to create SignatureManager")
 }

--- a/crates/apollo_signature_manager/src/signature_manager.rs
+++ b/crates/apollo_signature_manager/src/signature_manager.rs
@@ -3,8 +3,9 @@ use std::ops::Deref;
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_network_types::network_types::PeerId;
 use apollo_signature_manager_types::{
-    KeyStore,
-    KeyStoreResult,
+    KeySourceConfig,
+    KeyStoreError,
+    SignatureManagerConfig,
     SignatureManagerError,
     SignatureManagerResult,
 };
@@ -19,7 +20,6 @@ use starknet_api::crypto::utils::{
 };
 use starknet_core::crypto::{ecdsa_sign, ecdsa_verify, EcdsaVerifyError};
 use starknet_core::types::Felt;
-use starknet_crypto::get_public_key;
 use thiserror::Error;
 
 use crate::blake_utils::blake2s_to_felt;
@@ -48,12 +48,22 @@ impl Deref for MessageDigest {
 /// Provides signing and signature verification functionality.
 #[derive(Clone, Debug)]
 pub struct SignatureManager {
-    pub keystore: LocalKeyStore,
+    #[allow(dead_code)]
+    config: SignatureManagerConfig,
+    private_key: PrivateKey,
 }
 
 impl SignatureManager {
-    pub fn new(keystore: LocalKeyStore) -> Self {
-        Self { keystore }
+    pub fn new(config: SignatureManagerConfig) -> Result<Self, SignatureManagerError> {
+        let private_key = match &config.key_source {
+            KeySourceConfig::Local { private_key } => *private_key,
+            KeySourceConfig::GoogleSecretManager { .. } => {
+                return Err(SignatureManagerError::KeyStore(KeyStoreError::Custom(
+                    "GSM not yet supported".into(),
+                )));
+            }
+        };
+        Ok(Self { config, private_key })
     }
 
     pub async fn sign_identification(
@@ -74,8 +84,7 @@ impl SignatureManager {
     }
 
     async fn sign(&self, message_digest: MessageDigest) -> SignatureManagerResult<RawSignature> {
-        let private_key = self.keystore.get_key().await?;
-        let signature = ecdsa_sign(&private_key, &message_digest)
+        let signature = ecdsa_sign(&self.private_key, &message_digest)
             .map_err(|e| SignatureManagerError::Sign(e.to_string()))?;
 
         Ok(signature.into())
@@ -84,39 +93,6 @@ impl SignatureManager {
 
 #[async_trait]
 impl ComponentStarter for SignatureManager {}
-
-/// A simple in-memory key store.
-#[derive(Clone, Copy, Debug)]
-pub struct LocalKeyStore {
-    pub public_key: PublicKey,
-    private_key: PrivateKey,
-}
-
-impl LocalKeyStore {
-    fn _new(private_key: PrivateKey) -> Self {
-        let public_key = PublicKey(get_public_key(&private_key));
-        Self { private_key, public_key }
-    }
-
-    pub(crate) const fn new_for_testing() -> Self {
-        // Created using `cairo-lang`.
-        const PRIVATE_KEY: PrivateKey = PrivateKey(Felt::from_hex_unchecked(
-            "0x608bf2cdb1ad4138e72d2f82b8c5db9fa182d1883868ae582ed373429b7a133",
-        ));
-        const PUBLIC_KEY: PublicKey = PublicKey(Felt::from_hex_unchecked(
-            "0x125d56b1fbba593f1dd215b7c55e384acd838cad549c4a2b9c6d32d264f4e2a",
-        ));
-
-        Self { private_key: PRIVATE_KEY, public_key: PUBLIC_KEY }
-    }
-}
-
-#[async_trait]
-impl KeyStore for LocalKeyStore {
-    async fn get_key(&self) -> KeyStoreResult<PrivateKey> {
-        Ok(self.private_key)
-    }
-}
 
 // Utils.
 // TODO(noam.s): Consider wrapping each field in fixed delimiters (e.g. parentheses or tags) to

--- a/crates/apollo_signature_manager/src/signature_manager_test.rs
+++ b/crates/apollo_signature_manager/src/signature_manager_test.rs
@@ -1,17 +1,31 @@
 use apollo_network_types::network_types::PeerId;
+use apollo_signature_manager_types::{KeySourceConfig, SignatureManagerConfig};
 use expect_test::expect_file;
 use hex::FromHex;
 use starknet_api::block::BlockHash;
-use starknet_api::crypto::utils::Challenge;
+use starknet_api::crypto::utils::{Challenge, PrivateKey, PublicKey};
 use starknet_api::felt;
 use starknet_core::crypto::Signature;
+use starknet_core::types::Felt;
+use starknet_crypto::get_public_key;
 
 use crate::signature_manager::{
     verify_identity,
     verify_precommit_vote_signature,
-    LocalKeyStore,
     SignatureManager,
 };
+
+const TEST_PRIVATE_KEY: PrivateKey = PrivateKey(Felt::from_hex_unchecked(
+    "0x608bf2cdb1ad4138e72d2f82b8c5db9fa182d1883868ae582ed373429b7a133",
+));
+
+fn test_config() -> SignatureManagerConfig {
+    SignatureManagerConfig { key_source: KeySourceConfig::Local { private_key: TEST_PRIVATE_KEY } }
+}
+
+fn test_public_key() -> PublicKey {
+    PublicKey(get_public_key(&TEST_PRIVATE_KEY))
+}
 
 #[derive(Clone, Debug)]
 struct PeerIdentity {
@@ -33,27 +47,27 @@ impl PeerIdentity {
 #[test]
 fn test_verify_identity_invalid_signature() {
     let PeerIdentity { peer_id, challenge } = PeerIdentity::new();
-    let public_key = LocalKeyStore::new_for_testing().public_key;
     let invalid_signature = Signature { r: felt!("0x1"), s: felt!("0x2") };
 
-    assert!(!verify_identity(peer_id, challenge, invalid_signature.into(), public_key).unwrap());
+    assert!(
+        !verify_identity(peer_id, challenge, invalid_signature.into(), test_public_key()).unwrap()
+    );
 }
 
 #[test]
 fn test_verify_precommit_vote_signature_invalid() {
     let block_hash = BlockHash(felt!("0x1234"));
-    let public_key = LocalKeyStore::new_for_testing().public_key;
     let invalid_signature = Signature { r: felt!("0x1"), s: felt!("0x2") };
 
     assert!(
-        !verify_precommit_vote_signature(block_hash, invalid_signature.into(), public_key).unwrap()
+        !verify_precommit_vote_signature(block_hash, invalid_signature.into(), test_public_key())
+            .unwrap()
     );
 }
 
 #[tokio::test]
 async fn test_sign_identification() {
-    let key_store = LocalKeyStore::new_for_testing();
-    let signature_manager = SignatureManager::new(key_store);
+    let signature_manager = SignatureManager::new(test_config()).unwrap();
 
     let PeerIdentity { peer_id, challenge } = PeerIdentity::new();
     let signature = signature_manager.sign_identification(peer_id, challenge).await.unwrap();
@@ -61,14 +75,12 @@ async fn test_sign_identification() {
     // Auto-updates the file when you run: UPDATE_EXPECT=1 cargo test
     expect_file!["test_data/alice_identity_signature.txt"].assert_debug_eq(&signature);
 
-    // Test alignment with verification function.
-    assert!(verify_identity(peer_id, challenge, signature, key_store.public_key).unwrap());
+    assert!(verify_identity(peer_id, challenge, signature, test_public_key()).unwrap());
 }
 
 #[tokio::test]
 async fn test_sign_precommit_vote() {
-    let key_store = LocalKeyStore::new_for_testing();
-    let signature_manager = SignatureManager::new(key_store);
+    let signature_manager = SignatureManager::new(test_config()).unwrap();
 
     let block_hash = BlockHash(felt!("0x1234"));
     let signature = signature_manager.sign_precommit_vote(block_hash).await.unwrap();
@@ -76,6 +88,5 @@ async fn test_sign_precommit_vote() {
     // Auto-updates the file when you run: UPDATE_EXPECT=1 cargo test
     expect_file!["test_data/alice_precommit_signature.txt"].assert_debug_eq(&signature);
 
-    // Test alignment with verification function.
-    assert!(verify_precommit_vote_signature(block_hash, signature, key_store.public_key).unwrap());
+    assert!(verify_precommit_vote_signature(block_hash, signature, test_public_key()).unwrap());
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches signature creation and key-loading paths by switching `SignatureManager` to be constructed from `SignatureManagerConfig` (including new key-source handling), which could impact signing behavior if configs are missing/mis-set. No new external integrations are enabled yet (GSM explicitly errors), limiting blast radius.
> 
> **Overview**
> **`SignatureManager` is refactored to be config-driven.** `create_signature_manager` and `SignatureManager::new` now take a `SignatureManagerConfig`, extract the signing key from `key_source`, and remove the in-memory `LocalKeyStore`/testing-only construction; unsupported sources like *Google Secret Manager* currently return an explicit error.
> 
> **Node startup and tests are updated to pass signature-manager config.** `apollo_node` now requires `signature_manager_config` when the component runs locally, and integration tests add `apollo_signature_manager_types` plus default `SignatureManagerConfig` wiring so generated `SequencerNodeConfig` remains valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24814d8fb1708533ac7714d503e9da1e1d49a63f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->