### PR TITLE
blockifier,apollo_batcher: add From CommitmentStateDiff for ThinStateDiff

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -156,9 +156,10 @@ impl BlockExecutionArtifacts {
         let l1_da_mode = L1DataAvailabilityMode::from_use_kzg_da(block_info.use_kzg_da);
         let transactions_data =
             prepare_txs_hashing_data(&execution_data.execution_infos_and_signatures);
+        // TODO(Ayelet): Remove the clones.
         let (header_commitments, measurements) = calculate_block_commitments(
             &transactions_data,
-            commitment_state_diff_as_thin_state_diff(&commitment_state_diff),
+            ThinStateDiff::from(commitment_state_diff.clone()),
             l1_da_mode,
             &block_info.starknet_version,
         )
@@ -195,7 +196,8 @@ impl BlockExecutionArtifacts {
     }
 
     pub fn thin_state_diff(&self) -> ThinStateDiff {
-        commitment_state_diff_as_thin_state_diff(&self.commitment_state_diff)
+        // TODO(Ayelet): Remove the clones.
+        ThinStateDiff::from(self.commitment_state_diff.clone())
     }
 
     pub fn commitment(&self) -> ProposalCommitment {
@@ -210,22 +212,6 @@ impl BlockExecutionArtifacts {
     /// Returns the [PartialBlockHashComponents] based on the execution artifacts.
     pub fn partial_block_hash_components(&self) -> PartialBlockHashComponents {
         self.partial_block_hash_components.clone()
-    }
-}
-
-fn commitment_state_diff_as_thin_state_diff(
-    commitment_state_diff: &CommitmentStateDiff,
-) -> ThinStateDiff {
-    // TODO(Ayelet): Remove the clones.
-    ThinStateDiff {
-        deployed_contracts: commitment_state_diff.address_to_class_hash.clone(),
-        storage_diffs: commitment_state_diff.storage_updates.clone(),
-        class_hash_to_compiled_class_hash: commitment_state_diff
-            .class_hash_to_compiled_class_hash
-            .clone(),
-        nonces: commitment_state_diff.address_to_nonce.clone(),
-        // TODO(AlonH): Remove this when the structure of storage diffs changes.
-        deprecated_declared_classes: Vec::new(),
     }
 }
 

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use indexmap::IndexMap;
 use starknet_api::abi::abi_utils::get_fee_token_var_address;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
-use starknet_api::state::StorageKey;
+use starknet_api::state::{StorageKey, ThinStateDiff};
 use starknet_types_core::felt::Felt;
 
 use crate::context::TransactionContext;
@@ -683,6 +683,20 @@ impl From<StateMaps> for CommitmentStateDiff {
             storage_updates: StorageDiff::from(StorageView(diff.storage)),
             class_hash_to_compiled_class_hash: IndexMap::from_iter(diff.compiled_class_hashes),
             address_to_nonce: IndexMap::from_iter(diff.nonces),
+        }
+    }
+}
+
+impl From<CommitmentStateDiff> for ThinStateDiff {
+    fn from(commitment_state_diff: CommitmentStateDiff) -> Self {
+        Self {
+            deployed_contracts: commitment_state_diff.address_to_class_hash,
+            storage_diffs: commitment_state_diff.storage_updates,
+            class_hash_to_compiled_class_hash: commitment_state_diff
+                .class_hash_to_compiled_class_hash,
+            nonces: commitment_state_diff.address_to_nonce,
+            // TODO(AlonH): Remove this when the structure of storage diffs changes.
+            deprecated_declared_classes: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `impl From<CommitmentStateDiff> for ThinStateDiff` in `blockifier` (consuming conversion; `deprecated_declared_classes` stays empty with existing AlonH TODO).
- `apollo_batcher`: call `ThinStateDiff::from(commitment_state_diff.clone())` at previous helper sites; keep Ayelet's TODO next to explicit clones; remove private `commitment_state_diff_as_thin_state_diff`.

## Test plan
- [x] `cargo check -p blockifier -p apollo_batcher`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a straightforward type conversion and switches call sites to use it; behavior should remain equivalent aside from potential clone/move semantics.
> 
> **Overview**
> Introduces `impl From<CommitmentStateDiff> for ThinStateDiff` in `blockifier`, centralizing the conversion logic (with `deprecated_declared_classes` still emitted as an empty vec).
> 
> Updates `apollo_batcher`’s block commitment/hash calculation to use `ThinStateDiff::from(commitment_state_diff.clone())` and removes the local helper that previously performed this mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1534e65e474013d5988a0b7368b57f49672bad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->