### PR TITLE
apollo_infra,apollo_config_manager_types: add reader client variant for watch-channel-based clients

### DIFF
--- a/crates/apollo_config_manager/src/config_manager_runner.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner.rs
@@ -32,8 +32,8 @@ pub struct ConfigManagerRunner {
     config_manager_client: SharedConfigManagerClient,
     dynamic_config_tx: Sender<NodeDynamicConfig>,
     // Keeps the receiver alive so the sender never observes a dead channel.
-    // TODO(Arni): Remove once LocalComponentReaderClient is held long-term (done in
-    // arni/http_server/add_client_to_server).
+    // TODO(Arni): Remove once LocalConfigManagerReaderClient is held long-term (done in
+    // arni/apollo_node/add_config_manager_reader_client_to_node).
     _dynamic_config_rx: Receiver<NodeDynamicConfig>,
     cli_args: Vec<String>,
 }

--- a/crates/apollo_infra/src/component_client/definitions.rs
+++ b/crates/apollo_infra/src/component_client/definitions.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use super::{LocalComponentClient, RemoteComponentClient};
+use crate::component_client::LocalComponentReaderClient;
 use crate::component_definitions::ServerError;
 
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
@@ -22,26 +23,46 @@ pub enum ClientError {
 
 pub type ClientResult<T> = Result<T, ClientError>;
 
-pub enum Client<Request, Response>
+/// A client that communicates via request/response (local mpsc or remote HTTP). The standard
+/// client type for components that support both local and remote deployment.
+pub type RpcClient<Request, Response> = Client<Request, Response, ()>;
+
+/// A client that reads the latest value from a watch channel. Used for components that only
+/// support local read-only access with no remote deployment option.
+pub type ReaderClient<ReadValueType> = Client<(), (), ReadValueType>;
+
+pub enum Client<Request, Response, ReadValueType>
 where
     Request: Send + Serialize,
     Response: Send + DeserializeOwned,
+    ReadValueType: Send + Clone,
 {
     Local(LocalComponentClient<Request, Response>),
+    LocalReadOnlyClient(LocalComponentReaderClient<ReadValueType>),
     Remote(RemoteComponentClient<Request, Response>),
     Disabled,
 }
 
-impl<Request, Response> Client<Request, Response>
+impl<Request, Response, ReadValueType> Client<Request, Response, ReadValueType>
 where
     Request: Send + Serialize,
     Response: Send + DeserializeOwned,
+    ReadValueType: Send + Clone,
 {
     pub fn get_local_client(&self) -> LocalComponentClient<Request, Response> {
         match self {
             Client::Local(client) => client.clone(),
-            Client::Remote(_) | Client::Disabled => {
+            Client::LocalReadOnlyClient(_) | Client::Remote(_) | Client::Disabled => {
                 panic!("Local client should be set for inbound remote connections.");
+            }
+        }
+    }
+
+    pub fn get_local_read_only_client(&self) -> LocalComponentReaderClient<ReadValueType> {
+        match self {
+            Client::LocalReadOnlyClient(client) => client.clone(),
+            Client::Local(_) | Client::Remote(_) | Client::Disabled => {
+                panic!("Expected LocalReadOnlyClient, got a different client variant.");
             }
         }
     }

--- a/crates/apollo_node/src/clients.rs
+++ b/crates/apollo_node/src/clients.rs
@@ -48,7 +48,7 @@ use apollo_gateway_types::communication::{
     RemoteGatewayClient,
     SharedGatewayClient,
 };
-use apollo_infra::component_client::{Client, LocalComponentClient};
+use apollo_infra::component_client::{Client, LocalComponentClient, RpcClient};
 use apollo_l1_events::communication::{LocalL1EventsProviderClient, RemoteL1EventsProviderClient};
 use apollo_l1_events::metrics::L1_EVENTS_INFRA_METRICS;
 use apollo_l1_events_types::{
@@ -106,20 +106,20 @@ use tracing::info;
 use crate::communication::SequencerNodeCommunication;
 
 pub struct SequencerNodeClients {
-    batcher_client: Client<BatcherRequest, BatcherResponse>,
-    class_manager_client: Client<ClassManagerRequest, ClassManagerResponse>,
-    committer_client: Client<CommitterRequest, CommitterResponse>,
-    config_manager_client: Client<ConfigManagerRequest, ConfigManagerResponse>,
-    gateway_client: Client<GatewayRequest, GatewayResponse>,
-    l1_events_provider_client: Client<L1EventsProviderRequest, L1EventsProviderResponse>,
-    l1_gas_price_client: Client<L1GasPriceRequest, L1GasPriceResponse>,
-    mempool_client: Client<MempoolRequest, MempoolResponse>,
+    batcher_client: RpcClient<BatcherRequest, BatcherResponse>,
+    class_manager_client: RpcClient<ClassManagerRequest, ClassManagerResponse>,
+    committer_client: RpcClient<CommitterRequest, CommitterResponse>,
+    config_manager_client: RpcClient<ConfigManagerRequest, ConfigManagerResponse>,
+    gateway_client: RpcClient<GatewayRequest, GatewayResponse>,
+    l1_events_provider_client: RpcClient<L1EventsProviderRequest, L1EventsProviderResponse>,
+    l1_gas_price_client: RpcClient<L1GasPriceRequest, L1GasPriceResponse>,
+    mempool_client: RpcClient<MempoolRequest, MempoolResponse>,
     mempool_p2p_propagator_client:
-        Client<MempoolP2pPropagatorRequest, MempoolP2pPropagatorResponse>,
-    proof_manager_client: Client<ProofManagerRequest, ProofManagerResponse>,
-    sierra_compiler_client: Client<SierraCompilerRequest, SierraCompilerResponse>,
-    signature_manager_client: Client<SignatureManagerRequest, SignatureManagerResponse>,
-    state_sync_client: Client<StateSyncRequest, StateSyncResponse>,
+        RpcClient<MempoolP2pPropagatorRequest, MempoolP2pPropagatorResponse>,
+    proof_manager_client: RpcClient<ProofManagerRequest, ProofManagerResponse>,
+    sierra_compiler_client: RpcClient<SierraCompilerRequest, SierraCompilerResponse>,
+    signature_manager_client: RpcClient<SignatureManagerRequest, SignatureManagerResponse>,
+    state_sync_client: RpcClient<StateSyncRequest, StateSyncResponse>,
 }
 
 /// A macro to retrieve a shared client wrapped in an `Arc`. The returned client is either the local
@@ -155,6 +155,9 @@ macro_rules! get_shared_client {
     ($self:ident, $client_field:ident) => {{
         match &$self.$client_field {
             Client::Local(local_client) => Some(Arc::new(local_client.clone())),
+            Client::LocalReadOnlyClient(_) => {
+                panic!("LocalReadOnlyClient is not a shared client")
+            }
             Client::Remote(remote_client) => Some(Arc::new(remote_client.clone())),
             Client::Disabled => None,
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `Client` variant and turns `Client` into a 3-parameter generic, which can ripple through type usage and cause runtime panics if callers assume request/response semantics. Changes are infrastructure-level but largely additive and compile-time enforced via new `RpcClient`/`ReaderClient` aliases.
> 
> **Overview**
> Adds a new **local read-only** client variant (`LocalReadOnlyClient`) to the `apollo_infra` component `Client` abstraction, along with `RpcClient` and `ReaderClient` type aliases and a `get_local_read_only_client()` accessor.
> 
> Updates `apollo_node` to type its existing request/response component clients as `RpcClient` and makes `get_shared_client!` explicitly reject the new read-only variant (panic). Includes a small comment update in `ConfigManagerRunner` referencing the upcoming reader-client holder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f970280b834ba71d9c028b77f7b1978ec6543563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->