### PR TITLE
apollo_node,apollo_config_manager: add config manager reader client to node

### DIFF
--- a/crates/apollo_config_manager/src/config_manager_runner.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use notify::{Config as NotifyConfig, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::Value;
 use tokio::sync::mpsc;
-use tokio::sync::watch::{Receiver, Sender};
+use tokio::sync::watch::Sender;
 use tokio::time::{interval, Duration as TokioDuration, Interval};
 use tracing::{debug, error, info};
 
@@ -31,10 +31,6 @@ pub struct ConfigManagerRunner {
     config_manager_config: ConfigManagerConfig,
     config_manager_client: SharedConfigManagerClient,
     dynamic_config_tx: Sender<NodeDynamicConfig>,
-    // Keeps the receiver alive so the sender never observes a dead channel.
-    // TODO(Arni): Remove once LocalConfigManagerReaderClient is held long-term (done in
-    // arni/apollo_node/add_config_manager_reader_client_to_node).
-    _dynamic_config_rx: Receiver<NodeDynamicConfig>,
     cli_args: Vec<String>,
 }
 
@@ -65,16 +61,9 @@ impl ConfigManagerRunner {
         config_manager_config: ConfigManagerConfig,
         config_manager_client: SharedConfigManagerClient,
         dynamic_config_tx: Sender<NodeDynamicConfig>,
-        dynamic_config_rx: Receiver<NodeDynamicConfig>,
         cli_args: Vec<String>,
     ) -> Self {
-        Self {
-            config_manager_config,
-            config_manager_client,
-            dynamic_config_tx,
-            _dynamic_config_rx: dynamic_config_rx,
-            cli_args,
-        }
+        Self { config_manager_config, config_manager_client, dynamic_config_tx, cli_args }
     }
 
     /// Monitors config files for changes via file system events and periodic polling.

--- a/crates/apollo_config_manager/src/config_manager_runner_tests.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner_tests.rs
@@ -104,7 +104,6 @@ async fn config_manager_runner_update_config_with_changed_values() {
         config_manager_config,
         config_manager_client,
         dynamic_config_tx,
-        dynamic_config_rx.clone(),
         cli_args,
     );
 
@@ -171,7 +170,6 @@ async fn watcher_triggers_update_on_file_change() {
         ConfigManagerConfig::default(),
         client,
         dynamic_config_tx,
-        dynamic_config_rx,
         cli_args,
     );
 

--- a/crates/apollo_config_manager_types/src/communication.rs
+++ b/crates/apollo_config_manager_types/src/communication.rs
@@ -41,8 +41,8 @@ pub type RemoteConfigManagerClient =
     RemoteComponentClient<ConfigManagerRequest, ConfigManagerResponse>;
 pub type ConfigManagerClientResult<T> = Result<T, ConfigManagerClientError>;
 pub type ConfigManagerRequestWrapper = RequestWrapper<ConfigManagerRequest, ConfigManagerResponse>;
-pub type SharedConfigManagerClient = Arc<dyn ConfigManagerClient>;
 pub type LocalConfigManagerReaderClient = LocalComponentReaderClient<NodeDynamicConfig>;
+pub type SharedConfigManagerClient = Arc<dyn ConfigManagerClient>;
 
 // Generates a `ConfigManagerReaderClient` method that reads a field from `NodeDynamicConfig`.
 // The method name is derived by prepending `get_` to the field name.

--- a/crates/apollo_node/src/clients.rs
+++ b/crates/apollo_node/src/clients.rs
@@ -37,6 +37,7 @@ use apollo_config_manager_types::communication::{
     ConfigManagerRequest,
     ConfigManagerResponse,
     LocalConfigManagerClient,
+    LocalConfigManagerReaderClient,
     RemoteConfigManagerClient,
     SharedConfigManagerClient,
 };
@@ -48,7 +49,7 @@ use apollo_gateway_types::communication::{
     RemoteGatewayClient,
     SharedGatewayClient,
 };
-use apollo_infra::component_client::{Client, LocalComponentClient, RpcClient};
+use apollo_infra::component_client::{Client, LocalComponentClient, ReaderClient, RpcClient};
 use apollo_l1_events::communication::{LocalL1EventsProviderClient, RemoteL1EventsProviderClient};
 use apollo_l1_events::metrics::L1_EVENTS_INFRA_METRICS;
 use apollo_l1_events_types::{
@@ -76,7 +77,7 @@ use apollo_mempool_types::communication::{
     SharedMempoolClient,
 };
 use apollo_node_config::component_execution_config::ReactiveComponentExecutionMode;
-use apollo_node_config::node_config::SequencerNodeConfig;
+use apollo_node_config::node_config::{NodeDynamicConfig, SequencerNodeConfig};
 use apollo_proof_manager::metrics::PROOF_MANAGER_INFRA_METRICS;
 use apollo_proof_manager_types::{
     LocalProofManagerClient,
@@ -103,13 +104,15 @@ use apollo_state_sync_types::communication::{
 };
 use tracing::info;
 
-use crate::communication::SequencerNodeCommunication;
+use crate::communication::{NodeDynamicConfigChannels, SequencerNodeCommunication};
 
 pub struct SequencerNodeClients {
     batcher_client: RpcClient<BatcherRequest, BatcherResponse>,
     class_manager_client: RpcClient<ClassManagerRequest, ClassManagerResponse>,
     committer_client: RpcClient<CommitterRequest, CommitterResponse>,
+    // TODO(Arni): Remove once all consumers use reader_config_manager_client.
     config_manager_client: RpcClient<ConfigManagerRequest, ConfigManagerResponse>,
+    reader_config_manager_client: ReaderClient<NodeDynamicConfig>,
     gateway_client: RpcClient<GatewayRequest, GatewayResponse>,
     l1_events_provider_client: RpcClient<L1EventsProviderRequest, L1EventsProviderResponse>,
     l1_gas_price_client: RpcClient<L1GasPriceRequest, L1GasPriceResponse>,
@@ -198,6 +201,16 @@ impl SequencerNodeClients {
 
     pub fn get_config_manager_shared_client(&self) -> Option<SharedConfigManagerClient> {
         get_shared_client!(self, config_manager_client)
+    }
+
+    pub fn get_config_manager_reader_client(&self) -> Option<LocalConfigManagerReaderClient> {
+        match &self.reader_config_manager_client {
+            Client::LocalReadOnlyClient(client) => Some(client.clone()),
+            Client::Disabled => None,
+            Client::Local(_) | Client::Remote(_) => {
+                panic!("config_manager reader client must be LocalReadOnlyClient or Disabled")
+            }
+        }
     }
 
     pub fn get_gateway_local_client(
@@ -370,6 +383,7 @@ macro_rules! create_client {
 pub fn create_node_clients(
     config: &SequencerNodeConfig,
     channels: &mut SequencerNodeCommunication,
+    dynamic_config_channels: &mut NodeDynamicConfigChannels,
 ) -> SequencerNodeClients {
     info!("Creating node clients.");
 
@@ -420,6 +434,15 @@ pub fn create_node_clients(
         &CONFIG_MANAGER_INFRA_METRICS.get_local_client_metrics(),
         &CONFIG_MANAGER_INFRA_METRICS.get_remote_client_metrics()
     );
+
+    let reader_config_manager_client = match config.components.config_manager.execution_mode {
+        ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled => {
+            Client::LocalReadOnlyClient(LocalConfigManagerReaderClient::new(
+                dynamic_config_channels.take_rx(),
+            ))
+        }
+        _ => Client::Disabled,
+    };
 
     let gateway_client = create_client!(
         &config.components.gateway.execution_mode,
@@ -533,6 +556,7 @@ pub fn create_node_clients(
         class_manager_client,
         committer_client,
         config_manager_client,
+        reader_config_manager_client,
         gateway_client,
         l1_events_provider_client,
         l1_gas_price_client,

--- a/crates/apollo_node/src/communication.rs
+++ b/crates/apollo_node/src/communication.rs
@@ -9,13 +9,32 @@ use apollo_l1_events::communication::L1EventsProviderRequestWrapper;
 use apollo_l1_gas_price::communication::L1GasPriceRequestWrapper;
 use apollo_mempool_p2p_types::communication::MempoolP2pPropagatorRequestWrapper;
 use apollo_mempool_types::communication::MempoolRequestWrapper;
-use apollo_node_config::component_execution_config::ExpectedComponentConfig;
-use apollo_node_config::node_config::SequencerNodeConfig;
+use apollo_node_config::component_execution_config::{
+    ExpectedComponentConfig,
+    ReactiveComponentExecutionMode,
+};
+use apollo_node_config::node_config::{NodeDynamicConfig, SequencerNodeConfig};
 use apollo_proof_manager_types::ProofManagerRequestWrapper;
 use apollo_signature_manager_types::SignatureManagerRequestWrapper;
 use apollo_state_sync_types::communication::StateSyncRequestWrapper;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::watch;
 use tracing::info;
+
+pub struct NodeDynamicConfigChannels {
+    tx: Option<watch::Sender<NodeDynamicConfig>>,
+    rx: Option<watch::Receiver<NodeDynamicConfig>>,
+}
+
+impl NodeDynamicConfigChannels {
+    pub fn take_tx(&mut self) -> watch::Sender<NodeDynamicConfig> {
+        self.tx.take().expect("dynamic_config_tx should be available")
+    }
+
+    pub fn take_rx(&mut self) -> watch::Receiver<NodeDynamicConfig> {
+        self.rx.take().expect("dynamic_config_rx should be available")
+    }
+}
 
 pub struct SequencerNodeCommunication {
     batcher_channel: ComponentCommunication<BatcherRequestWrapper>,
@@ -139,8 +158,11 @@ impl SequencerNodeCommunication {
     }
 }
 
-pub fn create_node_channels(config: &SequencerNodeConfig) -> SequencerNodeCommunication {
+pub fn create_channels(
+    config: &SequencerNodeConfig,
+) -> (SequencerNodeCommunication, NodeDynamicConfigChannels) {
     info!("Creating node channels.");
+
     let (tx_batcher, rx_batcher) =
         match config.components.batcher.execution_mode.is_running_locally() {
             true => {
@@ -366,7 +388,7 @@ pub fn create_node_channels(config: &SequencerNodeConfig) -> SequencerNodeCommun
             false => (None, None),
         };
 
-    SequencerNodeCommunication {
+    let node_communication = SequencerNodeCommunication {
         batcher_channel: ComponentCommunication::new(tx_batcher, rx_batcher),
         class_manager_channel: ComponentCommunication::new(tx_class_manager, rx_class_manager),
         committer_channel: ComponentCommunication::new(tx_committer, rx_committer),
@@ -392,5 +414,15 @@ pub fn create_node_channels(config: &SequencerNodeConfig) -> SequencerNodeCommun
             rx_signature_manager,
         ),
         state_sync_channel: ComponentCommunication::new(tx_state_sync, rx_state_sync),
-    }
+    };
+
+    let dynamic_config_channels = match config.components.config_manager.execution_mode {
+        ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled => {
+            let (tx, rx) = watch::channel(NodeDynamicConfig::from(config));
+            NodeDynamicConfigChannels { tx: Some(tx), rx: Some(rx) }
+        }
+        _ => NodeDynamicConfigChannels { tx: None, rx: None },
+    };
+
+    (node_communication, dynamic_config_channels)
 }

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -41,10 +41,10 @@ use apollo_state_sync::{create_state_sync_and_runner, StateSync};
 use metrics_exporter_prometheus::PrometheusHandle;
 use papyrus_base_layer::cyclic_base_layer_wrapper::CyclicBaseLayerWrapper;
 use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerContract;
-use tokio::sync::watch;
 use tracing::info;
 
 use crate::clients::SequencerNodeClients;
+use crate::communication::NodeDynamicConfigChannels;
 
 pub struct SequencerNodeComponents {
     pub batcher: Option<Batcher>,
@@ -75,6 +75,7 @@ pub struct SequencerNodeComponents {
 pub async fn create_node_components(
     config: &SequencerNodeConfig,
     clients: &SequencerNodeClients,
+    dynamic_config_channels: &mut NodeDynamicConfigChannels,
     prometheus_handle: Option<PrometheusHandle>,
     cli_args: Vec<String>,
 ) -> SequencerNodeComponents {
@@ -170,8 +171,7 @@ pub async fn create_node_components(
                 // TODO(Arni): remove the config_manager.
                 let config_manager =
                     ConfigManager::new(config_manager_config.clone(), node_dynamic_config.clone());
-                let (dynamic_config_tx, dynamic_config_rx) =
-                    watch::channel(node_dynamic_config.clone());
+                let dynamic_config_tx = dynamic_config_channels.take_tx();
                 let config_manager_client = clients
                     .get_config_manager_shared_client()
                     .expect("Config Manager client should be available");
@@ -179,7 +179,6 @@ pub async fn create_node_components(
                     config_manager_config.clone(),
                     config_manager_client,
                     dynamic_config_tx,
-                    dynamic_config_rx,
                     cli_args,
                 );
                 (Some(config_manager), Some(config_manager_runner))

--- a/crates/apollo_node/src/utils.rs
+++ b/crates/apollo_node/src/utils.rs
@@ -3,7 +3,7 @@ use metrics_exporter_prometheus::PrometheusHandle;
 use tracing::info;
 
 use crate::clients::{create_node_clients, SequencerNodeClients};
-use crate::communication::create_node_channels;
+use crate::communication::create_channels;
 use crate::components::create_node_components;
 use crate::servers::{create_node_servers, SequencerNodeServers};
 
@@ -14,9 +14,16 @@ pub async fn create_node_modules(
 ) -> (SequencerNodeClients, SequencerNodeServers) {
     info!("Creating node modules.");
 
-    let mut channels = create_node_channels(config);
-    let clients = create_node_clients(config, &mut channels);
-    let components = create_node_components(config, &clients, prometheus_handle, cli_args).await;
+    let (mut channels, mut dynamic_config_channels) = create_channels(config);
+    let clients = create_node_clients(config, &mut channels, &mut dynamic_config_channels);
+    let components = create_node_components(
+        config,
+        &clients,
+        &mut dynamic_config_channels,
+        prometheus_handle,
+        cli_args,
+    )
+    .await;
     let servers = create_node_servers(config, &mut channels, components, &clients);
 
     (clients, servers)


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new dynamic-config watch-channel plumbing and a new `ConfigManager` reader client, which affects node initialization paths and can trigger runtime panics if misconfigured/execution modes don’t match expectations.
> 
> **Overview**
> Adds a **local read-only ConfigManager “reader” client** backed by a `tokio::sync::watch` channel carrying `NodeDynamicConfig`, enabling components to read the latest dynamic config without RPC.
> 
> Node startup now creates and threads `NodeDynamicConfigChannels` alongside existing component channels (`create_channels`), wires a `LocalConfigManagerReaderClient` into `SequencerNodeClients`, and updates `ConfigManagerRunner` to only take a watch `Sender` (no longer retaining a receiver to keep the channel alive).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e538fcf215354059d07d658f68b9f2a50da2dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->