### PR TITLE
tower_ohttp: new crate with tower layer for oblivious http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bhttp"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d305a54bcb99974213b4c78a486c34091e83c5d6d6572f7f4331c904ea9d127"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6981,6 +6990,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpke"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf",
+ "hmac 0.12.1",
+ "rand_core 0.9.3",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9522,6 +9551,28 @@ checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "ohttp"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a03aaaf57495c75ce66aee6a7c3b21abf046c9d4cca3d45b22cdbf0de1bfba"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "byteorder",
+ "chacha20poly1305",
+ "hex",
+ "hkdf",
+ "hpke",
+ "log",
+ "rand 0.9.2",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "toml 0.9.8",
 ]
 
 [[package]]
@@ -13646,6 +13697,24 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_ohttp"
+version = "0.18.0-rc.1"
+dependencies = [
+ "bhttp",
+ "bytes",
+ "hex",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "ohttp",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ members = [
   "crates/starknet_patricia_storage",
   "crates/starknet_proof_verifier",
   "crates/starknet_transaction_prover",
+  "crates/tower_ohttp",
   "toml_test_utils",
   "workspace_tests",
 ]
@@ -233,6 +234,7 @@ asynchronous-codec = "0.7.0"
 axum = "0.8"
 base64 = "0.13.0"
 bench_tools.path = "crates/bench_tools"
+bhttp = "0.7"
 bincode = "1.3.3"
 bitvec = "1.0.1"
 blake2 = "0.10.6"
@@ -280,6 +282,7 @@ glob = "0.3.1"
 google-cloud-storage = "0.22.1"
 hex = "0.4.3"
 http = "1.1"
+http-body = "1"
 http-body-util = "0.1"
 human_bytes = "0.4.3"
 hyper = "1.8"
@@ -313,6 +316,7 @@ num-integer = "0.1.45"
 num-rational = "0.4"
 num-traits = "0.2.15"
 num_enum = "0.7.3"
+ohttp = { version = "0.7", default-features = false }
 once_cell = "1.19.0"
 os_info = "3.6.0"
 page_size = "0.6.0"
@@ -397,6 +401,7 @@ toml = "0.8"
 toml_test_utils.path = "toml_test_utils"
 tower = "0.5.2"
 tower-http = "0.6"
+tower_ohttp.path = "crates/tower_ohttp"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 tracing-test = "0.2"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -118,6 +118,7 @@ const AllowedScopes = ['apollo_base_layer_tests',
     'starknet_patricia',
     'starknet_patricia_storage',
     'time',
+    'tower_ohttp',
     'workspace',
     'workspace_tests',
 ];

--- a/crates/tower_ohttp/Cargo.toml
+++ b/crates/tower_ohttp/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "tower_ohttp"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+description = "Framework-agnostic tower middleware for Oblivious HTTP (RFC 9458)."
+
+[features]
+# Exposes OHTTP client-side primitives (`test_gateway`,
+# `encapsulate_bhttp_request`, `decapsulate_bhttp_response`) for consumers
+# that want to write integration tests against the layer.
+testing = []
+
+[dependencies]
+bhttp.workspace = true
+bytes.workspace = true
+hex.workspace = true
+http.workspace = true
+http-body.workspace = true
+http-body-util.workspace = true
+ohttp = { workspace = true, features = ["client", "rust-hpke", "server"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tower = { workspace = true, features = ["util"] }
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/tower_ohttp/README.md
+++ b/crates/tower_ohttp/README.md
@@ -1,0 +1,100 @@
+# tower_ohttp
+
+Framework-agnostic tower middleware for Oblivious HTTP (RFC 9458). Wraps any
+`tower::Service<http::Request<B>, Response = http::Response<B>>` — where `B`
+is the framework's native body type — and transparently handles OHTTP
+envelope encryption:
+
+- `GET /ohttp-keys` → returns the HPKE key configuration.
+- `POST /` with `Content-Type: message/ohttp-req` → decapsulates the outer
+  envelope, rebuilds the inner HTTP request (method, path, headers, body all
+  preserved from the encrypted Binary HTTP payload), forwards it to the inner
+  service, and encapsulates the response as `message/ohttp-res`.
+- Everything else → forwarded to the inner service untouched, with the
+  original streaming body. The layer does not buffer or inspect non-OHTTP
+  request bodies, and the `body_limit` does not apply to them.
+
+The crate has no framework dependencies. For OHTTP requests the layer buffers
+the encrypted envelope into `Full<Bytes>`, decapsulates it, and rebuilds the
+inner request — converting its body to the inner service's body type `B` via
+a `body_builder` closure the consumer supplies at construction. The same
+closure converts any responses the layer constructs itself (OHTTP-encrypted
+responses, error responses, the `/ohttp-keys` response). Non-OHTTP requests
+bypass the closure entirely.
+
+## Usage
+
+Load the HPKE private key once at startup, then plug `OhttpLayer` into your
+framework's tower stack. The only framework-specific piece is the
+`body_builder` function — a `Fn(Full<Bytes>) -> B` where `B` is the
+framework's native body type. The same closure handles both request-body
+buffering and layer-owned responses (OHTTP-encrypted, error, `/ohttp-keys`).
+
+```rust
+use std::sync::Arc;
+use tower_ohttp::{OhttpGateway, OhttpLayer};
+
+// Load from `OHTTP_KEY` env var (64 hex chars = 32-byte X25519 private key).
+// Use `OhttpGateway::from_ikm(...)` if you load keys from a secrets manager.
+let gateway = Arc::new(OhttpGateway::from_env()?);
+```
+
+### axum
+
+`axum::body::Body` is the same type on both sides of `Service`, and axum's
+`Error = Infallible`, so the layer plugs in with zero glue:
+
+```rust
+use axum::body::Body;
+
+let ohttp_layer = OhttpLayer::new(
+    gateway,
+    5 * 1024 * 1024,  // body_limit (bytes)
+    3600,             // key_cache_max_age_secs
+    Body::new,        // body_builder
+);
+
+let app = api_router.layer(ohttp_layer);
+```
+
+No `HandleErrorLayer`, no `MapRequestBodyLayer`, no `map_err` — `Body::new`
+serves as the universal `Full<Bytes> → Body` adapter for both directions,
+and the layer's `Error = S::Error = Infallible` flows through unchanged.
+
+### jsonrpsee
+
+```rust
+use jsonrpsee::server::{HttpBody, ServerBuilder};
+use tower::ServiceBuilder;
+
+let ohttp_layer = OhttpLayer::new(
+    gateway,
+    5 * 1024 * 1024,
+    3600,
+    HttpBody::new,    // body_builder
+);
+
+// ServerBuilder::default()
+//     .set_http_middleware(ServiceBuilder::new().layer(ohttp_layer))
+//     .build(addr).await?;
+```
+
+Compression with OHTTP is correctness-sensitive: compressing ciphertext is
+wasted work, and compress-then-encrypt (compression between the layer and
+the inner service) requires a
+`tower_http::map_response_body::MapResponseBodyLayer::new(HttpBody::new)`
+between `CompressionLayer` and `OhttpLayer` to normalize `CompressionBody<HttpBody>`
+back to `HttpBody`. See `tower_ohttp`'s integration tests for a complete
+example.
+
+## Key types
+
+- [`OhttpGateway`](src/gateway.rs) — HPKE key state. Construct once at startup
+  from `OHTTP_KEY` env var, a hex string, or raw keying material.
+- [`OhttpLayer`](src/layer.rs) / [`OhttpService`](src/layer.rs) — the tower
+  `Layer`/`Service` that handles OHTTP traffic. Both are generic over a
+  body-builder closure `Fn(Full<Bytes>) -> ResBody`. For a stable sized type
+  that implements `Copy`, pass a `fn` pointer (e.g. `HttpBody::new`).
+- [`OhttpError`](src/errors.rs) — unified error type for both gateway
+  initialization and per-request processing. Has `into_response()` for
+  consumers that want to emit OHTTP error responses from their own handlers.

--- a/crates/tower_ohttp/src/bhttp_codec.rs
+++ b/crates/tower_ohttp/src/bhttp_codec.rs
@@ -1,0 +1,119 @@
+//! Conversion between Binary HTTP (RFC 9292) messages and standard `http::Request`/
+//! `http::Response` values. These are the pure-data helpers used by the layer;
+//! they have no tower or framework dependencies.
+
+use bytes::Bytes;
+use http::header;
+use http_body_util::{BodyExt, Full};
+use tower::BoxError;
+use tracing::debug;
+
+use crate::errors::OhttpError;
+use crate::OHTTP_RESPONSE_CONTENT_TYPE;
+
+/// Rebuild a standard `http::Request<Full<Bytes>>` from a parsed Binary HTTP
+/// message.
+///
+/// Method and path are required fields per RFC 9292 §3.2 — a BHTTP message
+/// missing either is rejected with `OhttpError::InvalidFormat` rather than
+/// silently defaulted. All BHTTP header fields are forwarded to the inner
+/// request — this includes `content-type`, `accept-encoding`, and anything
+/// else the client specified inside the encrypted envelope.
+pub fn rebuild_request(
+    bhttp_message: &bhttp::Message,
+) -> Result<http::Request<Full<Bytes>>, OhttpError> {
+    let body = bhttp_message.content().to_vec();
+
+    // Method and path are required fields of a BHTTP request per RFC 9292 §3.2.
+    // Missing either means the inner message is malformed.
+    let method_bytes = bhttp_message
+        .control()
+        .method()
+        .ok_or(OhttpError::InvalidFormat("missing method in BHTTP control"))?;
+    let method = http::Method::from_bytes(method_bytes)
+        .map_err(|_| OhttpError::InvalidFormat("invalid method in BHTTP control"))?;
+
+    let path_bytes = bhttp_message
+        .control()
+        .path()
+        .ok_or(OhttpError::InvalidFormat("missing path in BHTTP control"))?;
+    let path = std::str::from_utf8(path_bytes)
+        .map_err(|_| OhttpError::InvalidFormat("non-utf8 path in BHTTP control"))?;
+
+    let mut builder = http::Request::builder()
+        .method(method)
+        .uri(path)
+        .header(header::CONTENT_LENGTH, body.len());
+
+    // Forward all BHTTP headers to the inner request. Content-Type is essential
+    // for REST routers that dispatch on it; Accept-Encoding allows the inner
+    // CompressionLayer to compress the response before OHTTP encryption.
+    // Skip Content-Length — we set it from the body length above.
+    for field in bhttp_message.header().fields() {
+        if field.name().eq_ignore_ascii_case(b"content-length") {
+            continue;
+        }
+        builder = builder.header(field.name(), field.value());
+    }
+
+    builder.body(Full::new(Bytes::from(body))).map_err(|error| {
+        debug!("Failed to rebuild inner request: {error}");
+        OhttpError::InvalidFormat("failed to rebuild inner request")
+    })
+}
+
+/// Encode an `http::Response` as a Binary HTTP message, then encapsulate it
+/// using the supplied OHTTP `ServerResponse`.
+///
+/// The outer OHTTP envelope is always 200 per RFC 9458 — the inner response's
+/// real status code is preserved inside the encrypted BHTTP payload, along with
+/// all response headers.
+pub async fn encapsulate_response<B>(
+    response: http::Response<B>,
+    server_response: ohttp::ServerResponse,
+) -> Result<http::Response<Full<Bytes>>, OhttpError>
+where
+    B: http_body::Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    let status = response.status();
+    let response_headers = response.headers().clone();
+
+    let response_body = response
+        .into_body()
+        .collect()
+        .await
+        .map_err(|_| OhttpError::Internal("failed to read inner response body"))?
+        .to_bytes();
+
+    // `http::StatusCode` is 100–999; BHTTP accepts the same range per RFC 9292 §3.2,
+    // so this should never fail in practice. Propagate as an internal error rather
+    // than silently coercing to 500 — silent coercion would mask a real bug in the
+    // inner service (e.g. a non-standard status code) under a misleading response.
+    let bhttp_status = bhttp::StatusCode::try_from(u64::from(status.as_u16())).map_err(|_| {
+        debug!("Inner response status {} not representable in BHTTP", status.as_u16());
+        OhttpError::Internal("inner response status not representable in BHTTP")
+    })?;
+    let mut bhttp_response = bhttp::Message::response(bhttp_status);
+    for (name, value) in &response_headers {
+        bhttp_response.put_header(name.as_str(), value.as_bytes());
+    }
+    bhttp_response.write_content(&response_body);
+
+    let mut bhttp_bytes = Vec::new();
+    bhttp_response.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_bytes).map_err(|error| {
+        debug!("Failed to encode Binary HTTP response: {error}");
+        OhttpError::Internal("failed to encode BHTTP response")
+    })?;
+
+    let encrypted = server_response.encapsulate(&bhttp_bytes).map_err(|error| {
+        debug!("Failed to encapsulate OHTTP response: {error}");
+        OhttpError::Internal("failed to encapsulate OHTTP response")
+    })?;
+
+    Ok(http::Response::builder()
+        .status(http::StatusCode::OK)
+        .header(header::CONTENT_TYPE, OHTTP_RESPONSE_CONTENT_TYPE)
+        .body(Full::new(Bytes::from(encrypted)))
+        .expect("response builder should not fail"))
+}

--- a/crates/tower_ohttp/src/errors.rs
+++ b/crates/tower_ohttp/src/errors.rs
@@ -1,0 +1,104 @@
+//! `OhttpError` — unified error type for gateway initialization and
+//! per-request processing.
+
+use bytes::Bytes;
+use http::header;
+use http_body_util::Full;
+
+/// Errors produced by OHTTP gateway setup and request/response processing.
+#[derive(Debug, thiserror::Error)]
+pub enum OhttpError {
+    #[error("OHTTP_KEY environment variable not set")]
+    MissingKeyEnvVar,
+
+    /// Parsing or length validation of a raw key failed. String payload is a
+    /// diagnostic intended for logs, not for clients.
+    #[error("invalid OHTTP key: {0}")]
+    InvalidKey(String),
+
+    /// The underlying `ohttp` crate rejected the key config (e.g. unsupported
+    /// KEM / suite combination, or internal HPKE setup failure).
+    #[error("failed to build OHTTP key config: {0}")]
+    KeyConfig(#[source] ohttp::Error),
+
+    #[error("OHTTP decapsulation failed")]
+    DecapsulationFailed,
+
+    /// The decrypted payload was not a valid Binary HTTP message, or the
+    /// rebuilt inner HTTP request could not be constructed from it.
+    #[error("invalid Binary HTTP message: {0}")]
+    InvalidFormat(&'static str),
+
+    #[error("request body exceeds size limit")]
+    BodyTooLarge,
+
+    #[error("failed to read request body")]
+    BadRequestBody,
+
+    /// Catch-all for internal errors during response encapsulation — things
+    /// that indicate a bug in the layer itself rather than bad input.
+    #[error("internal error: {0}")]
+    Internal(&'static str),
+}
+
+impl OhttpError {
+    /// HTTP status code this error maps to.
+    pub fn status(&self) -> http::StatusCode {
+        match self {
+            Self::DecapsulationFailed | Self::InvalidFormat(_) => {
+                http::StatusCode::UNPROCESSABLE_ENTITY
+            }
+            Self::BodyTooLarge => http::StatusCode::PAYLOAD_TOO_LARGE,
+            Self::BadRequestBody => http::StatusCode::BAD_REQUEST,
+            // Initialization errors and internal errors become 500. In practice
+            // initialization errors never reach this path — they're handled at
+            // startup and propagated via `?`.
+            Self::MissingKeyEnvVar
+            | Self::InvalidKey(_)
+            | Self::KeyConfig(_)
+            | Self::Internal(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    /// Machine-readable error code included in the JSON error body.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::DecapsulationFailed => "OHTTP_DECAPSULATION_FAILED",
+            Self::InvalidFormat(_) => "OHTTP_INVALID_FORMAT",
+            Self::BodyTooLarge => "OHTTP_BODY_TOO_LARGE",
+            Self::BadRequestBody => "OHTTP_INVALID_FORMAT",
+            Self::MissingKeyEnvVar
+            | Self::InvalidKey(_)
+            | Self::KeyConfig(_)
+            | Self::Internal(_) => "INTERNAL_ERROR",
+        }
+    }
+
+    /// Human-readable error message for the JSON error body.
+    pub fn message(&self) -> &str {
+        match self {
+            Self::DecapsulationFailed => "Failed to decapsulate OHTTP request",
+            Self::InvalidFormat(detail) => detail,
+            Self::BodyTooLarge => "Request body exceeds the size limit",
+            Self::BadRequestBody => "Failed to read request body",
+            Self::MissingKeyEnvVar => "OHTTP gateway not initialized",
+            Self::InvalidKey(_) => "invalid OHTTP key",
+            Self::KeyConfig(_) => "failed to build OHTTP key config",
+            Self::Internal(detail) => detail,
+        }
+    }
+
+    /// Convert into a plaintext JSON HTTP response with `Full<Bytes>` body.
+    /// The body is always `application/json` of the shape
+    /// `{"error": {"code": "...", "message": "..."}}`.
+    pub fn into_response(self) -> http::Response<Full<Bytes>> {
+        let body = serde_json::json!({
+            "error": { "code": self.code(), "message": self.message() }
+        });
+        http::Response::builder()
+            .status(self.status())
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Full::new(Bytes::from(body.to_string())))
+            .expect("error response builder should not fail")
+    }
+}

--- a/crates/tower_ohttp/src/gateway.rs
+++ b/crates/tower_ohttp/src/gateway.rs
@@ -1,0 +1,145 @@
+//! OHTTP gateway: loads HPKE keys from the environment or from raw material
+//! and exposes the `ohttp::Server` for request decapsulation (RFC 9458).
+
+use ohttp::hpke::{Aead, Kdf, Kem};
+use ohttp::{KeyConfig, KeyId, Server, SymmetricSuite};
+use tracing::info;
+
+use crate::errors::OhttpError;
+
+/// Default KEM used by `from_env` / `from_hex_key`. Currently X25519 — the
+/// only variant `ohttp 0.7` supports. When newer versions add P-256 etc.,
+/// add sibling constructors (`from_pem_p256`, etc.) that call `from_ikm`
+/// with the appropriate `Kem` value.
+const DEFAULT_KEM: Kem = Kem::X25519Sha256;
+
+/// Default HPKE symmetric suite. Kept hardcoded because the combinations
+/// that make cryptographic sense are narrow and these are secure defaults.
+fn default_suite() -> SymmetricSuite {
+    SymmetricSuite::new(Kdf::HkdfSha256, Aead::Aes128Gcm)
+}
+
+/// Expected raw key length for a given KEM.
+fn kem_ikm_len(kem: Kem) -> usize {
+    match kem {
+        Kem::X25519Sha256 => 32,
+    }
+}
+
+/// OHTTP gateway that holds the server key configuration and
+/// decapsulates/encapsulates requests (RFC 9458).
+pub struct OhttpGateway {
+    server: Server,
+    encoded_key_config: Vec<u8>,
+}
+
+impl OhttpGateway {
+    /// Load a single X25519 OHTTP key from the `OHTTP_KEY` environment
+    /// variable. The value must be a hex-encoded 32-byte private key
+    /// (64 hex chars). Key ID is 0.
+    pub fn from_env() -> Result<Self, OhttpError> {
+        let hex_key = std::env::var("OHTTP_KEY").map_err(|_| OhttpError::MissingKeyEnvVar)?;
+        Self::from_hex_key(&hex_key)
+    }
+
+    /// Build from a hex-encoded X25519 private key string (64 hex chars).
+    /// Key ID is 0.
+    pub fn from_hex_key(hex_key: &str) -> Result<Self, OhttpError> {
+        let hex_key = hex_key.trim();
+        let ikm = hex::decode(hex_key)
+            .map_err(|_| OhttpError::InvalidKey(format!("invalid hex: {hex_key}")))?;
+        let expected = kem_ikm_len(DEFAULT_KEM);
+        if ikm.len() != expected {
+            return Err(OhttpError::InvalidKey(format!(
+                "expected {expected} bytes, got {}",
+                ikm.len()
+            )));
+        }
+        Self::from_ikm(0, DEFAULT_KEM, &ikm)
+    }
+
+    /// Low-level constructor: build a gateway from raw key material and an
+    /// explicit KEM. This is the path future constructors (e.g. PEM-loaded
+    /// P-256 keys) route through.
+    pub fn from_ikm(key_id: KeyId, kem: Kem, ikm: &[u8]) -> Result<Self, OhttpError> {
+        let key_config = KeyConfig::derive(key_id, kem, vec![default_suite()], ikm)
+            .map_err(OhttpError::KeyConfig)?;
+
+        let encoded_key_config =
+            KeyConfig::encode_list(&[&key_config]).map_err(OhttpError::KeyConfig)?;
+
+        let server = Server::new(key_config).map_err(OhttpError::KeyConfig)?;
+
+        info!(kem = ?kem, key_id, "OHTTP key loaded");
+
+        Ok(Self { server, encoded_key_config })
+    }
+
+    /// Returns the encoded key config bytes for the `GET /ohttp-keys` endpoint.
+    /// Format: `application/ohttp-keys` (concatenated key configs with length prefixes).
+    pub fn encoded_config(&self) -> &[u8] {
+        &self.encoded_key_config
+    }
+
+    /// Returns a reference to the underlying OHTTP server for decapsulation.
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_ikm() -> [u8; 32] {
+        let mut ikm = [0u8; 32];
+        ikm[0] = 1; // non-zero so key derivation produces a valid key
+        ikm
+    }
+
+    #[test]
+    fn from_ikm_produces_valid_config() {
+        let gateway = OhttpGateway::from_ikm(0, Kem::X25519Sha256, &test_ikm()).unwrap();
+        assert!(!gateway.encoded_config().is_empty());
+    }
+
+    #[test]
+    fn from_hex_key_roundtrip() {
+        let hex = hex::encode(test_ikm());
+        let gateway = OhttpGateway::from_hex_key(&hex).unwrap();
+        assert!(!gateway.encoded_config().is_empty());
+    }
+
+    #[test]
+    fn from_hex_key_rejects_short() {
+        let result = OhttpGateway::from_hex_key("aabb");
+        assert!(matches!(result, Err(OhttpError::InvalidKey(_))));
+    }
+
+    #[test]
+    fn from_hex_key_rejects_invalid_hex() {
+        let result = OhttpGateway::from_hex_key("zzzz");
+        assert!(matches!(result, Err(OhttpError::InvalidKey(_))));
+    }
+
+    #[test]
+    fn decapsulate_roundtrip() {
+        let gateway = OhttpGateway::from_ikm(0, Kem::X25519Sha256, &test_ikm()).unwrap();
+
+        let config_bytes = gateway.encoded_config();
+        let client_request = ohttp::ClientRequest::from_encoded_config_list(config_bytes).unwrap();
+
+        let plaintext_request = b"test request body";
+        let (encapsulated, client_response) =
+            client_request.encapsulate(plaintext_request).unwrap();
+
+        let (decapsulated, server_response) = gateway.server().decapsulate(&encapsulated).unwrap();
+        assert_eq!(decapsulated, plaintext_request);
+
+        let plaintext_response = b"test response body";
+        let encapsulated_response = server_response.encapsulate(plaintext_response).unwrap();
+
+        let decapsulated_response = client_response.decapsulate(&encapsulated_response).unwrap();
+        assert_eq!(decapsulated_response, plaintext_response);
+    }
+}

--- a/crates/tower_ohttp/src/layer.rs
+++ b/crates/tower_ohttp/src/layer.rs
@@ -1,0 +1,394 @@
+//! Tower `Layer` and `Service` that add OHTTP (RFC 9458) envelope encryption.
+//!
+//! Routing behavior:
+//! - `GET /ohttp-keys` → HPKE key configuration (bypasses inner service)
+//! - `Content-Type: message/ohttp-req` → decapsulate, forward, encapsulate
+//! - Everything else → forwarded to the inner service unchanged, with the original streaming body.
+//!   The layer does not buffer or inspect non-OHTTP request bodies, and `body_limit` does not apply
+//!   to them.
+//!
+//! The layer wraps any `Service<Request<B>, Response = Response<B>>` where
+//! `B` is the framework's native body type (same on both sides). For OHTTP
+//! requests it buffers the encrypted envelope into `Full<Bytes>`, decapsulates
+//! it, rebuilds the inner request, and converts its body to `B` via a
+//! `body_builder` closure (`Fn(Full<Bytes>) -> B`). The same closure converts
+//! the `Full<Bytes>` responses the layer constructs itself (OHTTP-encrypted,
+//! error, `/ohttp-keys`) into `B`, and `Self::Error = S::Error` so the inner
+//! service's error type flows through unchanged (e.g. `Infallible` for axum).
+//!
+//! Typical `body_builder` values: `HttpBody::new` for jsonrpsee,
+//! `axum::body::Body::new` for axum, `std::convert::identity` when
+//! `B = Full<Bytes>`.
+
+use std::io::Cursor;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use http::header;
+use http_body_util::{BodyExt, Full, LengthLimitError, Limited};
+use tower::{BoxError, Layer, Service, ServiceExt};
+use tracing::debug;
+
+use crate::bhttp_codec::{encapsulate_response, rebuild_request};
+use crate::errors::OhttpError;
+use crate::gateway::OhttpGateway;
+use crate::{OHTTP_KEYS_PATH, OHTTP_REQUEST_CONTENT_TYPE};
+
+/// Shared runtime state for the OHTTP gateway.
+struct OhttpState<F> {
+    gateway: Arc<OhttpGateway>,
+    body_limit: usize,
+    key_cache_max_age_secs: u64,
+    /// Converts `Full<Bytes>` into the inner service's body type. Used for
+    /// both directions: buffered request bodies on the way in, and the
+    /// layer's owned responses (OHTTP-encrypted, error, `/ohttp-keys`) on
+    /// the way out.
+    body_builder: F,
+}
+
+/// Tower [`Layer`] that adds OHTTP envelope encryption.
+pub struct OhttpLayer<F>(Arc<OhttpState<F>>);
+
+impl<F> Clone for OhttpLayer<F> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<F> OhttpLayer<F> {
+    /// Create a new OHTTP layer.
+    ///
+    /// # Parameters
+    /// - `gateway`: HPKE key state (shared via `Arc` with any other copies).
+    /// - `body_limit`: maximum size of an OHTTP request envelope, in bytes. Non-OHTTP requests
+    ///   bypass the layer's body pipeline entirely and are not subject to this limit — the inner
+    ///   service enforces its own.
+    /// - `key_cache_max_age_secs`: `Cache-Control: public, max-age=…` value on the `/ohttp-keys`
+    ///   response.
+    /// - `body_builder`: function that converts a `Full<Bytes>` into the inner service's body type
+    ///   `B`. Used when rebuilding the inner request from a decapsulated OHTTP envelope, and when
+    ///   emitting responses the layer owns itself (OHTTP-encrypted, error, `/ohttp-keys`).
+    ///   Non-OHTTP requests are forwarded to the inner service with their original body unchanged —
+    ///   the closure is not invoked on their path. Examples:
+    ///   - `std::convert::identity` when `B = Full<Bytes>`
+    ///   - `jsonrpsee::server::HttpBody::new` (jsonrpsee consumers)
+    ///   - `axum::body::Body::new` (axum consumers)
+    pub fn new(
+        gateway: Arc<OhttpGateway>,
+        body_limit: usize,
+        key_cache_max_age_secs: u64,
+        body_builder: F,
+    ) -> Self {
+        Self(Arc::new(OhttpState { gateway, body_limit, key_cache_max_age_secs, body_builder }))
+    }
+}
+
+impl<S, F> Layer<S> for OhttpLayer<F> {
+    type Service = OhttpService<S, F>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        OhttpService { inner, state: self.0.clone() }
+    }
+}
+
+/// Tower [`Service`] produced by [`OhttpLayer`].
+pub struct OhttpService<S, F> {
+    inner: S,
+    state: Arc<OhttpState<F>>,
+}
+
+impl<S: Clone, F> Clone for OhttpService<S, F> {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone(), state: self.state.clone() }
+    }
+}
+
+impl<S, F, B> Service<http::Request<B>> for OhttpService<S, F>
+where
+    B: http_body::Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+    S: Service<http::Request<B>, Response = http::Response<B>> + Clone + Send + 'static,
+    S::Error: std::fmt::Debug + Send + 'static,
+    S::Future: Send + 'static,
+    F: Fn(Full<Bytes>) -> B + Send + Sync + 'static,
+{
+    type Response = http::Response<B>;
+    type Error = S::Error;
+    type Future =
+        Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: http::Request<B>) -> Self::Future {
+        let inner = self.inner.clone();
+        let state = self.state.clone();
+
+        Box::pin(async move {
+            let build_body = |full| (state.body_builder)(full);
+
+            // Route 1: GET /ohttp-keys — return key config directly, no buffering.
+            if request.method() == http::Method::GET && request.uri().path() == OHTTP_KEYS_PATH {
+                let cache_control = format!("public, max-age={}", state.key_cache_max_age_secs);
+                let key_config = state.gateway.encoded_config().to_vec();
+                let response = http::Response::builder()
+                    .status(http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "application/ohttp-keys")
+                    .header(header::CACHE_CONTROL, cache_control)
+                    .body(Full::new(Bytes::from(key_config)))
+                    .expect("key config response builder should not fail");
+                return Ok(response.map(build_body));
+            }
+
+            // Route 2: non-OHTTP → forward untouched. The layer does not buffer
+            // the body, does not apply `body_limit`, and does not invoke
+            // `body_builder`; the inner service consumes the original body directly.
+            let is_ohttp = request
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|ct| ct.eq_ignore_ascii_case(OHTTP_REQUEST_CONTENT_TYPE));
+            if !is_ohttp {
+                return inner.oneshot(request).await;
+            }
+
+            // Route 3: OHTTP envelope → buffer into `Full<Bytes>` under `body_limit`,
+            // decapsulate, parse BHTTP, rebuild inner request, forward, encapsulate.
+            let body_bytes = match Limited::new(request.into_body(), state.body_limit)
+                .collect()
+                .await
+                .map(|collected| collected.to_bytes())
+            {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    let err = if error.downcast_ref::<LengthLimitError>().is_some() {
+                        OhttpError::BodyTooLarge
+                    } else {
+                        OhttpError::BadRequestBody
+                    };
+                    return Ok(err.into_response().map(build_body));
+                }
+            };
+
+            let (bhttp_bytes, server_response) =
+                match state.gateway.server().decapsulate(&body_bytes) {
+                    Ok(result) => result,
+                    Err(error) => {
+                        debug!("OHTTP decapsulation failed: {error}");
+                        return Ok(OhttpError::DecapsulationFailed.into_response().map(build_body));
+                    }
+                };
+
+            // RFC 9458 §5.2: errors detected after successful OHTTP decapsulation
+            // MUST be sent in an encapsulated response. Collapse all post-decap
+            // fallible work into a single Result so `server_response` is used
+            // exactly once — either for the encapsulated success response, or for
+            // the encapsulated error response.
+            let post_decap_result: Result<http::Response<B>, OhttpError> = async {
+                let bhttp_message = bhttp::Message::read_bhttp(&mut Cursor::new(&bhttp_bytes))
+                    .map_err(|error| {
+                        debug!("Invalid Binary HTTP message: {error}");
+                        OhttpError::InvalidFormat("Invalid Binary HTTP message")
+                    })?;
+
+                let inner_request = rebuild_request(&bhttp_message)?.map(build_body);
+
+                inner.oneshot(inner_request).await.map_err(|error| {
+                    debug!("Inner service error after successful OHTTP decapsulation: {error:?}");
+                    OhttpError::Internal("inner service error after OHTTP decapsulation")
+                })
+            }
+            .await;
+
+            let response_to_encapsulate: http::Response<B> = match post_decap_result {
+                Ok(response) => response,
+                Err(err) => err.into_response().map(build_body),
+            };
+
+            match encapsulate_response(response_to_encapsulate, server_response).await {
+                Ok(response) => Ok(response.map(build_body)),
+                Err(err) => {
+                    // `server_response` was consumed by the failing `encapsulate_response`
+                    // call above — no second chance to encapsulate. Fall back to plaintext.
+                    // This is the only branch that may legitimately leak a plaintext error
+                    // after successful decapsulation; it indicates an internal bug (BHTTP
+                    // encode / HPKE seal failure), not a routine error path.
+                    Ok(err.into_response().map(build_body))
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower::Layer;
+
+    use crate::layer::OhttpLayer;
+    use crate::test_utils::{
+        collect_body,
+        echo_service,
+        failing_service,
+        not_found_service,
+        test_gateway,
+        TestHarness,
+    };
+
+    const DEFAULT_BODY_LIMIT: usize = 102_400;
+    const KEY_CACHE_SECS: u64 = 3600;
+
+    /// A `fn` pointer alias for the identity body builder, so `OhttpLayer`'s
+    /// `F` parameter has a stable sized type instead of `impl Fn`.
+    type IdentityBody =
+        fn(http_body_util::Full<bytes::Bytes>) -> http_body_util::Full<bytes::Bytes>;
+    const IDENTITY_BODY_BUILDER: IdentityBody = std::convert::identity;
+
+    fn test_layer_with_limit(body_limit: usize) -> OhttpLayer<IdentityBody> {
+        OhttpLayer::new(test_gateway(), body_limit, KEY_CACHE_SECS, IDENTITY_BODY_BUILDER)
+    }
+
+    fn test_layer() -> OhttpLayer<IdentityBody> {
+        test_layer_with_limit(DEFAULT_BODY_LIMIT)
+    }
+
+    #[tokio::test]
+    async fn ohttp_request_round_trip() {
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(echo_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let body = br#"{"jsonrpc":"2.0","method":"starknet_specVersion","id":1}"#;
+        let response = harness.ohttp_round_trip("POST", "/", body, &[]).await;
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, body);
+    }
+
+    #[tokio::test]
+    async fn non_post_method_round_trip() {
+        // GET /health encapsulated in OHTTP must reach the inner service as GET.
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(echo_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let response = harness.ohttp_round_trip("GET", "/health", b"", &[]).await;
+
+        assert_eq!(response.status, 200);
+        let method = response.bhttp_message.header().get(b"x-echo-method").unwrap();
+        let path = response.bhttp_message.header().get(b"x-echo-path").unwrap();
+        assert_eq!(method, b"GET");
+        assert_eq!(path, b"/health");
+    }
+
+    #[tokio::test]
+    async fn non_200_status_round_trip() {
+        // A 404 from the inner service must be preserved inside the encrypted
+        // BHTTP envelope; the outer OHTTP response is still 200.
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(not_found_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let response = harness.ohttp_round_trip("GET", "/missing", b"", &[]).await;
+
+        assert_eq!(response.status, 404);
+        assert_eq!(response.body, br#"{"error":"not found"}"#);
+    }
+
+    #[tokio::test]
+    async fn content_type_routing() {
+        // content-type in the BHTTP request must be forwarded to the inner
+        // service (not hardcoded to application/json).
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(echo_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let response = harness
+            .ohttp_round_trip("POST", "/", b"plain text", &[("content-type", b"text/plain")])
+            .await;
+
+        assert_eq!(response.status, 200);
+        let echoed_content_type =
+            response.bhttp_message.header().get(b"x-echo-content-type").unwrap();
+        assert_eq!(echoed_content_type, b"text/plain");
+    }
+
+    #[tokio::test]
+    async fn malformed_ohttp_returns_422() {
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(echo_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let response = harness.send_raw_ohttp(b"not valid ohttp".to_vec()).await;
+        assert_eq!(response.status(), http::StatusCode::UNPROCESSABLE_ENTITY);
+
+        let body = collect_body(response).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], "OHTTP_DECAPSULATION_FAILED");
+    }
+
+    #[tokio::test]
+    async fn oversized_ohttp_body_returns_413() {
+        let body_limit = 64;
+        let layer = test_layer_with_limit(body_limit);
+        let svc = layer.layer(tower::service_fn(echo_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let response = harness.send_raw_ohttp(vec![0u8; body_limit + 1]).await;
+        assert_eq!(response.status(), http::StatusCode::PAYLOAD_TOO_LARGE);
+
+        let body = collect_body(response).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], "OHTTP_BODY_TOO_LARGE");
+    }
+
+    #[tokio::test]
+    async fn post_decap_bhttp_parse_error_is_encapsulated() {
+        // HPKE-seal bytes that are NOT a valid BHTTP message. Decapsulation
+        // succeeds, then BHTTP parsing fails. RFC 9458 §5.2: the resulting
+        // error MUST be returned encapsulated, not as plaintext JSON.
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(echo_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let response = harness.send_raw_inner_bhttp(b"NOT A VALID BHTTP MESSAGE").await;
+
+        // `send_raw_inner_bhttp` already asserted the outer envelope is
+        // `message/ohttp-res`. The inner (decapsulated) response is a 422 with
+        // the JSON error body.
+        assert_eq!(response.status, 422);
+        let json: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(json["error"]["code"], "OHTTP_INVALID_FORMAT");
+    }
+
+    #[tokio::test]
+    async fn post_decap_inner_service_error_is_encapsulated() {
+        // Inner service returns Err after decapsulation succeeds. RFC 9458
+        // §5.2: the error MUST be returned encapsulated as a 500.
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(failing_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let response = harness.ohttp_round_trip("POST", "/", b"{}", &[]).await;
+
+        assert_eq!(response.status, 500);
+        let json: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(json["error"]["code"], "INTERNAL_ERROR");
+    }
+
+    #[tokio::test]
+    async fn non_ohttp_request_passes_through() {
+        let layer = test_layer();
+        let svc = layer.layer(tower::service_fn(echo_service));
+        let mut harness = TestHarness { gateway: test_gateway(), svc };
+
+        let body = br#"{"jsonrpc":"2.0","method":"starknet_specVersion","id":1}"#;
+        let response = harness.send_plaintext(body).await;
+        assert_eq!(response.status(), http::StatusCode::OK);
+
+        let echoed_body = collect_body(response).await;
+        assert_eq!(echoed_body.as_ref(), body);
+    }
+}

--- a/crates/tower_ohttp/src/lib.rs
+++ b/crates/tower_ohttp/src/lib.rs
@@ -1,0 +1,39 @@
+//! Oblivious HTTP (RFC 9458) tower middleware.
+//!
+//! This crate provides a framework-agnostic `OhttpLayer`/`OhttpService` tower
+//! middleware that decapsulates incoming `message/ohttp-req` requests, forwards
+//! them to the inner service, and encapsulates the response as `message/ohttp-res`.
+//! Non-OHTTP requests are forwarded to the inner service with their original
+//! streaming body — the layer does not buffer, inspect, or otherwise touch them.
+//! A `GET /ohttp-keys` request returns the HPKE key configuration.
+//!
+//! The layer wraps any `Service<Request<B>, Response = Response<B>>` where `B` is
+//! the framework's native body type (same on both sides). For OHTTP requests it
+//! buffers the encrypted envelope into `Full<Bytes>`, decapsulates, and rebuilds
+//! the inner request — converting its body to `B` via a `body_builder` closure
+//! (`Fn(Full<Bytes>) -> B`). The same closure converts the `Full<Bytes>` responses
+//! the layer constructs itself (OHTTP-encrypted, error, `/ohttp-keys`) into `B`,
+//! and the layer's `Error` is `S::Error`, so the inner service's error type flows
+//! through unchanged.
+//!
+//! Consumers pass `HttpBody::new` for jsonrpsee, `axum::body::Body::new` for axum,
+//! or `std::convert::identity` when the inner service already uses `Full<Bytes>`.
+
+pub mod bhttp_codec;
+pub mod errors;
+pub mod gateway;
+pub mod layer;
+
+/// Client-side OHTTP primitives for tests. Enabled by the `testing` feature
+/// so consumers can depend on them from `[dev-dependencies]` without pulling
+/// the symbols into release builds.
+#[cfg(any(test, feature = "testing"))]
+pub mod test_utils;
+
+pub use errors::OhttpError;
+pub use gateway::OhttpGateway;
+pub use layer::{OhttpLayer, OhttpService};
+
+pub(crate) const OHTTP_REQUEST_CONTENT_TYPE: &str = "message/ohttp-req";
+pub(crate) const OHTTP_RESPONSE_CONTENT_TYPE: &str = "message/ohttp-res";
+pub(crate) const OHTTP_KEYS_PATH: &str = "/ohttp-keys";

--- a/crates/tower_ohttp/src/test_utils.rs
+++ b/crates/tower_ohttp/src/test_utils.rs
@@ -1,0 +1,267 @@
+//! OHTTP test helpers.
+//!
+//! Two layers live in this module:
+//!
+//! - **Public primitives** (`pub fn`) — usable by any downstream crate that enables the `testing`
+//!   feature. These cover the client-side BHTTP/HPKE round trip and a deterministic test gateway.
+//!   They deliberately don't touch tower `Service` types or the inner service's body
+//!   representation.
+//!
+//! - **Internal fixtures** (`pub(crate) ...`) — `TestHarness`, `echo_service`, `not_found_service`,
+//!   `collect_body`. Coupled to `Full<Bytes>` as the inner service body type because that's what
+//!   `tower_ohttp`'s own tests exercise. Consumers of the crate write their own echo services (with
+//!   their framework body type) and build requests with the public primitives.
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+#[cfg(test)]
+use bytes::Bytes;
+#[cfg(test)]
+use http::header;
+#[cfg(test)]
+use http_body_util::{BodyExt, Full};
+#[cfg(test)]
+use tower::{BoxError, Service};
+
+use crate::OhttpGateway;
+
+// ---------- public primitives (testing feature) ----------
+
+/// Deterministic test gateway with a fixed key (first byte = 1, rest = 0).
+/// Re-used across tests so they don't each have to repeat the key setup.
+pub fn test_gateway() -> Arc<OhttpGateway> {
+    let mut ikm = [0u8; 32];
+    ikm[0] = 1;
+    Arc::new(OhttpGateway::from_ikm(0, ohttp::hpke::Kem::X25519Sha256, &ikm).unwrap())
+}
+
+/// Client-side: build a BHTTP request for `(method, path, body, extra_headers)`
+/// and encrypt it with the gateway's published key config. Returns the outer
+/// encrypted envelope bytes plus the `ClientResponse` state that must be
+/// passed to `decapsulate_bhttp_response` to decrypt the matching response.
+pub fn encapsulate_bhttp_request(
+    gateway: &OhttpGateway,
+    method: &str,
+    path: &str,
+    body: &[u8],
+    extra_headers: &[(&str, &[u8])],
+) -> (Vec<u8>, ohttp::ClientResponse) {
+    let mut bhttp_request = bhttp::Message::request(
+        method.as_bytes().to_vec(),
+        b"https".to_vec(),
+        b"".to_vec(),
+        path.as_bytes().to_vec(),
+    );
+    for (name, value) in extra_headers {
+        bhttp_request.put_header(*name, *value);
+    }
+    bhttp_request.write_content(body);
+
+    let mut bhttp_bytes = Vec::new();
+    bhttp_request.write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_bytes).unwrap();
+
+    let client_request =
+        ohttp::ClientRequest::from_encoded_config_list(gateway.encoded_config()).unwrap();
+    client_request.encapsulate(&bhttp_bytes).unwrap()
+}
+
+/// Decapsulated OHTTP response: inner status code, inner body, and the full
+/// parsed BHTTP message (for assertions on preserved headers like
+/// `content-encoding`).
+pub struct DecapsulatedOhttpResponse {
+    pub status: u16,
+    pub body: Vec<u8>,
+    pub bhttp_message: bhttp::Message,
+}
+
+/// Client-side: decrypt an OHTTP response envelope using the matching
+/// `ClientResponse` context, parse the inner BHTTP message, and return the
+/// status + body + the full BHTTP message.
+pub fn decapsulate_bhttp_response(
+    client_response: ohttp::ClientResponse,
+    encrypted_response: &[u8],
+) -> DecapsulatedOhttpResponse {
+    let bhttp_bytes = client_response.decapsulate(encrypted_response).unwrap();
+    let bhttp_message = bhttp::Message::read_bhttp(&mut Cursor::new(&bhttp_bytes)).unwrap();
+    let status = bhttp_message.control().status().map(|s| s.code()).unwrap_or(0);
+    let body = bhttp_message.content().to_vec();
+    DecapsulatedOhttpResponse { status, body, bhttp_message }
+}
+
+// ---------- internal fixtures (tower_ohttp's own tests only) ----------
+
+#[cfg(test)]
+pub(crate) use internal::*;
+
+#[cfg(test)]
+mod internal {
+    use super::*;
+
+    /// Echo service: returns method, path, and content-type in response
+    /// headers (prefixed `x-echo-*`), with the request body echoed as the
+    /// response body.
+    pub(crate) async fn echo_service(
+        request: http::Request<Full<Bytes>>,
+    ) -> Result<http::Response<Full<Bytes>>, BoxError> {
+        let method = request.method().to_string();
+        let path = request.uri().path().to_string();
+        let content_type = request
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let body_bytes =
+            request.into_body().collect().await.map(|c| c.to_bytes()).unwrap_or_default();
+
+        Ok(http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/json")
+            .header("x-echo-method", method)
+            .header("x-echo-path", path)
+            .header("x-echo-content-type", content_type)
+            .body(Full::new(body_bytes))
+            .unwrap())
+    }
+
+    /// Service that always returns a 404 response with a JSON body.
+    pub(crate) async fn not_found_service(
+        _request: http::Request<Full<Bytes>>,
+    ) -> Result<http::Response<Full<Bytes>>, BoxError> {
+        Ok(http::Response::builder()
+            .status(http::StatusCode::NOT_FOUND)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Full::new(Bytes::from_static(br#"{"error":"not found"}"#)))
+            .unwrap())
+    }
+
+    /// Service that always returns `Err`. Used to exercise the layer's
+    /// inner-service-error branch after successful OHTTP decapsulation.
+    pub(crate) async fn failing_service(
+        _request: http::Request<Full<Bytes>>,
+    ) -> Result<http::Response<Full<Bytes>>, BoxError> {
+        Err("simulated inner service failure".into())
+    }
+
+    /// Test harness that runs OHTTP round trips against an `OhttpLayer`-wrapped
+    /// service. Uses the public primitives above for the client-side BHTTP/HPKE
+    /// work and wraps them in a convenience `ohttp_round_trip` method that also
+    /// handles outer-request construction and envelope assertions.
+    pub(crate) struct TestHarness<S> {
+        pub gateway: Arc<OhttpGateway>,
+        pub svc: S,
+    }
+
+    impl<S, ResBody> TestHarness<S>
+    where
+        ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        ResBody::Error: Into<BoxError>,
+        S: Service<
+                http::Request<Full<Bytes>>,
+                Response = http::Response<ResBody>,
+                Error = BoxError,
+            > + Send,
+    {
+        /// Encapsulate a BHTTP request and run it through the service. Asserts
+        /// the outer envelope is 200 with `message/ohttp-res` content type.
+        pub async fn ohttp_round_trip(
+            &mut self,
+            method: &str,
+            path: &str,
+            body: &[u8],
+            extra_headers: &[(&str, &[u8])],
+        ) -> DecapsulatedOhttpResponse {
+            let (encapsulated, client_response) =
+                encapsulate_bhttp_request(&self.gateway, method, path, body, extra_headers);
+
+            let request = http::Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::CONTENT_TYPE, "message/ohttp-req")
+                .body(Full::new(Bytes::from(encapsulated)))
+                .unwrap();
+
+            let response = self.svc.call(request).await.unwrap();
+            assert_eq!(response.status(), http::StatusCode::OK);
+            assert_eq!(response.headers().get(header::CONTENT_TYPE).unwrap(), "message/ohttp-res");
+
+            let encrypted_body = response
+                .into_body()
+                .collect()
+                .await
+                .map_err(|_| "failed to read layer response body")
+                .unwrap()
+                .to_bytes();
+            decapsulate_bhttp_response(client_response, &encrypted_body)
+        }
+
+        /// Send raw bytes as an OHTTP request (for error-path tests).
+        pub async fn send_raw_ohttp(&mut self, raw_body: Vec<u8>) -> http::Response<ResBody> {
+            let request = http::Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::CONTENT_TYPE, "message/ohttp-req")
+                .body(Full::new(Bytes::from(raw_body)))
+                .unwrap();
+            self.svc.call(request).await.unwrap()
+        }
+
+        /// HPKE-seal arbitrary (possibly invalid) inner bytes and run them
+        /// through the service. Unlike `ohttp_round_trip`, this bypasses the
+        /// valid-BHTTP construction path — use it to drive post-decapsulation
+        /// error branches where the decrypted body is not a valid BHTTP message.
+        /// Asserts the outer envelope is 200 `message/ohttp-res` and returns
+        /// the decapsulated inner response.
+        pub async fn send_raw_inner_bhttp(
+            &mut self,
+            raw_inner_bytes: &[u8],
+        ) -> DecapsulatedOhttpResponse {
+            let client_request =
+                ohttp::ClientRequest::from_encoded_config_list(self.gateway.encoded_config())
+                    .unwrap();
+            let (encapsulated, client_response) =
+                client_request.encapsulate(raw_inner_bytes).unwrap();
+
+            let request = http::Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::CONTENT_TYPE, "message/ohttp-req")
+                .body(Full::new(Bytes::from(encapsulated)))
+                .unwrap();
+
+            let response = self.svc.call(request).await.unwrap();
+            assert_eq!(response.status(), http::StatusCode::OK);
+            assert_eq!(response.headers().get(header::CONTENT_TYPE).unwrap(), "message/ohttp-res");
+
+            let encrypted_body = response
+                .into_body()
+                .collect()
+                .await
+                .map_err(|_| "failed to read layer response body")
+                .unwrap()
+                .to_bytes();
+            decapsulate_bhttp_response(client_response, &encrypted_body)
+        }
+
+        /// Send a plaintext (non-OHTTP) request.
+        pub async fn send_plaintext(&mut self, body: &[u8]) -> http::Response<ResBody> {
+            let request = http::Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::copy_from_slice(body)))
+                .unwrap();
+            self.svc.call(request).await.unwrap()
+        }
+    }
+
+    /// Collect a layer response body into bytes for assertions.
+    pub(crate) async fn collect_body<ResBody>(response: http::Response<ResBody>) -> Bytes
+    where
+        ResBody: http_body::Body<Data = Bytes> + Send + 'static,
+        ResBody::Error: Into<BoxError>,
+    {
+        response.into_body().collect().await.map_err(|_| "body err").unwrap().to_bytes()
+    }
+}


### PR DESCRIPTION
# tower_ohttp: new crate for OHTTP (RFC 9458) tower middleware

## Rationale

Multiple services in the Starkware stack need Oblivious HTTP (RFC 9458) envelope encryption. The transaction prover needs it so that requests containing Starknet transactions stay opaque to post-TLS-termination infrastructure (load balancers, reverse proxies, application-host logs). A sibling service in a separate repo needs the same capability. Rather than duplicate the ~700 LoC of middleware, BHTTP codec, and HPKE key handling per service, this PR introduces a shared workspace crate.

This PR adds the crate only. Wiring OHTTP into `starknet_transaction_prover` follows in a stacked PR.

## What's in the crate

| Module | Role |
|---|---|
| `gateway.rs` | `OhttpGateway` — loads an HPKE private key from `OHTTP_KEY` (hex), a literal hex string, or raw input keying material. Exposes the `ohttp::Server` for decapsulation and the encoded key config for the `/ohttp-keys` endpoint. |
| `layer.rs` | `OhttpLayer<F>` / `OhttpService<S, F>` — tower `Layer` and `Service` implementing the full OHTTP flow. Routes `GET /ohttp-keys` to the key config, `Content-Type: message/ohttp-req` through the decapsulate → forward → encapsulate pipeline, everything else straight to the inner service. |
| `bhttp_codec.rs` | `rebuild_request` / `encapsulate_response` — Binary HTTP (RFC 9292) ↔ `http::Request` / `http::Response` conversion. Preserves method, path, headers, body; preserves inner response status and headers inside the encrypted envelope (the outer response is always 200 per RFC 9458). |
| `errors.rs` | `OhttpError` — unified error type covering gateway initialization (`MissingKeyEnvVar`, `InvalidKey`, `KeyConfig`) and per-request processing (`DecapsulationFailed`, `InvalidFormat`, `BodyTooLarge`, `BadRequestBody`, `Internal`). Provides `into_response()` returning a plaintext JSON `http::Response<Full<Bytes>>` so consumers can emit OHTTP errors from their own handlers. |
| `test_utils.rs` | `TestHarness`, echo services, test gateway — shared fixtures for the layer unit tests. |

## Design highlights

### Framework-agnostic by construction

The crate has **zero framework dependencies** — no `jsonrpsee`, no `axum`, no feature flags. Consumers plug the layer into any tower middleware stack regardless of the outer framework.

This works because the layer is generic over a `body_builder` closure:

```rust
OhttpLayer::new(gateway, body_limit, cache_secs, body_builder)
```

where `body_builder: Fn(Full<Bytes>) -> ResBody`. For the handful of responses the layer constructs itself (error responses, the `/ohttp-keys` response, encrypted OHTTP responses), the closure converts `Full<Bytes>` to the inner service's body type. Typical values:

- `HttpBody::new` for jsonrpsee consumers
- `axum::body::Body::new` for axum consumers
- `std::convert::identity` when the inner service already uses `Full<Bytes>`

This avoids orphan-rule problems and keeps consumer code to three lines of glue.

### Preserved inner request/response semantics

Unlike simpler OHTTP gateways that hardcode POST + `application/json`, this implementation fully round-trips the inner message:

- **Method** comes from the BHTTP control data — GET requests (e.g. `/health`) reach the inner service as GET, not coerced to POST.
- **Path** comes from the BHTTP control data — path-routed inner services see the correct URI.
- **All BHTTP request headers** are forwarded to the inner request, including `content-type` and `accept-encoding`.
- **Inner response status code** is preserved inside the encrypted BHTTP payload — a 404 from the inner service reaches the client as 404 after decryption, even though the outer OHTTP response is always 200 per RFC 9458.
- **Inner response headers** (including `content-type` and `content-encoding`) are copied into the BHTTP response.

### Compress-then-encrypt

The layer forwards the client's `Accept-Encoding` BHTTP header to the rebuilt inner request, so a `tower_http::CompressionLayer` placed between `OhttpLayer` and the inner service will compress the response body **before** OHTTP encryption. This is standard cryptographic practice: compression on plaintext is effective; compression on ciphertext is not.

### Input body buffering

The layer buffers incoming request bodies into `Full<Bytes>` before dispatch, with a configurable size limit applied before decryption (prevents resource exhaustion on encrypted payloads). This trades a small allocation on the plaintext pass-through path for the ability to accept any outer body type — `hyper::body::Incoming`, `jsonrpsee::server::HttpBody`, `axum::body::Body`, or `Full<Bytes>` itself — without framework-specific plumbing.

### Error responses stay plaintext

Pre-decapsulation errors (413 body too large, 422 malformed envelope, 400 bad request body) are returned as plaintext JSON. There's no server-response context yet at that stage, and the client's HPKE state hasn't been established. Post-decapsulation errors from the inner service are wrapped in the encrypted OHTTP response envelope normally.

## Tests

12 tests covering the full gateway + layer behavior:

**Gateway (`gateway.rs`):**
- `from_ikm_produces_valid_config`
- `from_hex_key_roundtrip`
- `from_hex_key_rejects_short`
- `from_hex_key_rejects_invalid_hex`
- `decapsulate_roundtrip` (full HPKE encapsulate → decapsulate → encapsulate → decapsulate)

**Layer (`layer.rs`):**
- `ohttp_request_round_trip` — happy-path POST / round trip
- `non_post_method_round_trip` — `GET /health` reaches the inner service as GET (not hardcoded POST)
- `non_200_status_round_trip` — inner 404 is preserved inside the encrypted BHTTP, outer envelope is 200
- `content_type_routing` — `content-type: text/plain` in the BHTTP request reaches the inner service unchanged
- `malformed_ohttp_returns_422` — plaintext JSON error with code `OHTTP_DECAPSULATION_FAILED`
- `oversized_ohttp_body_returns_413` — plaintext JSON error with code `OHTTP_BODY_TOO_LARGE`
- `non_ohttp_request_passes_through` — plaintext JSON request bypasses OHTTP and reaches the inner service unchanged

## Dependencies

Runtime: `bhttp`, `ohttp = { features = ["client", "rust-hpke", "server"] }`, `http`, `http-body`, `http-body-util`, `tower`, `bytes`, `hex`, `serde_json`, `thiserror`, `tracing`.

Dev: `tokio` (macros, rt).

## Out of scope

- **Consumer integration** — wiring the layer into `starknet_transaction_prover` is a separate stacked PR.
- **Key rotation / multi-key support** — a single key per gateway instance today; rotation requires a restart. The `from_ikm` entry point accepts an arbitrary `KeyId` and `Kem`, so adding multi-key/rotation later doesn't need restructuring.
- **Non-X25519 KEMs** — `ohttp 0.7` only supports `X25519Sha256`. When newer versions add P-256 (or similar), add a sibling constructor that routes through `from_ikm` with the appropriate `Kem` value.

## Verification

```bash
cargo build -p tower_ohttp
SEED=0 cargo test -p tower_ohttp
cargo clippy -p tower_ohttp --lib --tests
```