### PR TITLE
apollo_node: assert unneeded configs are not set

### DIFF
--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -294,7 +294,10 @@ pub async fn create_node_components(
             Some(L1GasPriceProvider::new_with_oracle(l1_gas_price_provider_config.clone()))
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => {
-            // TODO(tsabary): assert config is not set.
+            assert!(
+                config.l1_gas_price_provider_config.is_none(),
+                "L1 Gas Price Provider config should not be set"
+            );
             None
         }
     };
@@ -320,7 +323,10 @@ pub async fn create_node_components(
             ))
         }
         ActiveComponentExecutionMode::Disabled => {
-            // TODO(tsabary): assert config is not set.
+            assert!(
+                config.l1_gas_price_scraper_config.is_none(),
+                "L1 Gas Price Scraper config should not be set"
+            );
             None
         }
     };
@@ -362,7 +368,10 @@ pub async fn create_node_components(
             }
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => {
-            // TODO(tsabary): assert config is not set.
+            assert!(
+                config.l1_events_provider_config.is_none(),
+                "L1 Events Provider config should not be set"
+            );
             None
         }
     };
@@ -395,7 +404,10 @@ pub async fn create_node_components(
             )
         }
         ActiveComponentExecutionMode::Disabled => {
-            // TODO(tsabary): assert config is not set.
+            assert!(
+                config.l1_events_scraper_config.is_none(),
+                "L1 Events Scraper config should not be set"
+            );
             None
         }
     };
@@ -419,7 +431,7 @@ pub async fn create_node_components(
             Some(mempool)
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => {
-            // TODO(tsabary): assert config is not set.
+            assert!(config.mempool_config.is_none(), "Mempool config should not be set");
             None
         }
     };
@@ -505,7 +517,10 @@ pub async fn create_node_components(
             Some(ProofManager::new(proof_manager_config.clone()))
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => {
-            // TODO(tsabary): assert config is not set.
+            assert!(
+                config.proof_manager_config.is_none(),
+                "Proof Manager config should not be set"
+            );
             None
         }
     };
@@ -520,7 +535,10 @@ pub async fn create_node_components(
             Some(create_sierra_compiler(sierra_compiler_config.clone()))
         }
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => {
-            // TODO(tsabary): assert config is not set.
+            assert!(
+                config.sierra_compiler_config.is_none(),
+                "Sierra Compiler config should not be set"
+            );
             None
         }
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new runtime assertions that will panic on startup if certain component configs are provided while the component is `Disabled`/`Remote`, which could break previously working but misconfigured deployments.
> 
> **Overview**
> Tightens node startup validation by adding `assert!(...is_none())` checks for several components when their execution mode is `Disabled` or `Remote`.
> 
> This enforces that `l1_gas_price_provider`, `l1_gas_price_scraper`, `l1_events_provider`, `l1_events_scraper`, `mempool`, `proof_manager`, and `sierra_compiler` do not receive unused configs, replacing prior TODOs and making misconfiguration fail fast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c34e339f127753ea0a27015ae686d0703610ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->