### PR TITLE
blockifier_reexecution: add prefetch_initial_reads to ConsecutiveRpcStateReaders

### DIFF
--- a/crates/blockifier_reexecution/src/state_reader/prefetched_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/prefetched_state_reader.rs
@@ -8,14 +8,17 @@ use blockifier::state::state_api::{StateReader, StateResult};
 use blockifier::state::state_reader_and_contract_manager::FetchCompiledClasses;
 use serde::Deserialize;
 use serde_json::json;
+use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::rpc_transaction::{RpcInvokeTransaction, RpcInvokeTransactionV3, RpcTransaction};
 use starknet_api::state::StorageKey;
-use starknet_api::transaction::{InvokeTransaction, TransactionHash};
+use starknet_api::transaction::{InvokeTransaction, Transaction, TransactionHash};
+use starknet_core::types::ContractClass as StarknetContractClass;
 use starknet_types_core::felt::Felt;
 use tracing::warn;
 
 use crate::errors::{ReexecutionError, ReexecutionResult};
+use crate::state_reader::reexecution_state_reader::ReexecutionStateReader;
 use crate::state_reader::rpc_objects::BlockId;
 use crate::state_reader::rpc_state_reader::RpcStateReader;
 
@@ -228,4 +231,47 @@ impl From<RpcInitialReads> for StateMaps {
 /// `StateMaps`.
 pub fn deserialize_rpc_initial_reads(value: serde_json::Value) -> Result<StateMaps, String> {
     serde_json::from_value::<RpcInitialReads>(value).map(Into::into).map_err(|e| e.to_string())
+}
+
+impl SimulatedStateReader {
+    /// Creates a `SimulatedStateReader` by simulating the invoke V3 transactions in `txs`
+    /// to prefetch their initial state reads. Non-V3 transactions are ignored (their state
+    /// reads will fall back to individual RPC calls).
+    pub fn from_rpc_state_reader(
+        rpc_state_reader: RpcStateReader,
+        txs: &[(Transaction, TransactionHash)],
+    ) -> ReexecutionResult<Self> {
+        let invoke_v3_txs: Vec<_> = txs
+            .iter()
+            .filter_map(|(tx, hash)| match tx {
+                Transaction::Invoke(invoke @ InvokeTransaction::V3(_)) => {
+                    Some((invoke.clone(), *hash))
+                }
+                _ => None,
+            })
+            .collect();
+        let state_maps = if invoke_v3_txs.is_empty() {
+            StateMaps::default()
+        } else {
+            // Skip validation in simulate — this is only for prefetching state reads.
+            let validate_txs = false;
+            simulate_and_get_initial_reads(
+                &rpc_state_reader,
+                rpc_state_reader.block_id,
+                &invoke_v3_txs,
+                validate_txs,
+            )?
+        };
+        Ok(Self { state_maps, rpc_state_reader })
+    }
+}
+
+impl ReexecutionStateReader for SimulatedStateReader {
+    fn get_contract_class(&self, class_hash: &ClassHash) -> StateResult<StarknetContractClass> {
+        self.rpc_state_reader.get_contract_class(class_hash)
+    }
+
+    fn get_old_block_hash(&self, old_block_number: BlockNumber) -> ReexecutionResult<BlockHash> {
+        self.rpc_state_reader.get_old_block_hash(old_block_number)
+    }
 }

--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -56,6 +56,7 @@ use crate::state_reader::offline_state_reader::{
     SerializableDataPrevBlock,
     SerializableOfflineReexecutionData,
 };
+use crate::state_reader::prefetched_state_reader::SimulatedStateReader;
 use crate::state_reader::reexecution_state_reader::{
     ConsecutiveReexecutionStateReaders,
     ReexecutionStateReader,
@@ -329,32 +330,6 @@ impl RpcStateReader {
         ))
     }
 
-    pub fn get_transaction_executor(
-        self,
-        block_context_next_block: BlockContext,
-        transaction_executor_config: Option<TransactionExecutorConfig>,
-        contract_class_manager: &ContractClassManager,
-    ) -> ReexecutionResult<TransactionExecutor<StateReaderAndContractManager<RpcStateReader>>> {
-        let old_block_number = BlockNumber(
-            block_context_next_block.block_info().block_number.0
-                - constants::STORED_BLOCK_HASH_BUFFER,
-        );
-        let old_block_hash = self.get_old_block_hash(old_block_number)?;
-        // We don't collect class cache metrics for the reexecution.
-        let class_cache_metrics = None;
-        let state_reader_and_contract_manager = StateReaderAndContractManager::new(
-            self,
-            contract_class_manager.clone(),
-            class_cache_metrics,
-        );
-        Ok(TransactionExecutor::<StateReaderAndContractManager<RpcStateReader>>::pre_process_and_create(
-            state_reader_and_contract_manager,
-            block_context_next_block,
-            Some(BlockHashAndNumber { number: old_block_number, hash: old_block_hash }),
-            transaction_executor_config.unwrap_or_default(),
-        )?)
-    }
-
     /// Get the commitment state diff of the current block.
     /// Note: the commitment state diff does not include migrated_compiled_classes.
     pub fn get_state_diff(&self) -> ReexecutionResult<CommitmentStateDiff> {
@@ -554,6 +529,10 @@ pub struct ConsecutiveRpcStateReaders {
     /// If set, overrides `min_sierra_version_for_sierra_gas` in the block context so that all
     /// contracts with sierra version >= this value use sierra gas.
     pub min_sierra_version_override: Option<SierraVersion>,
+    /// When true, prefetch initial state reads via `starknet_simulateTransactions` before
+    /// execution. Uses `SimulatedStateReader` which serves prefetched reads from memory and
+    /// falls back to individual RPC calls on cache misses.
+    pub prefetch_initial_reads: bool,
     /// Contract class mapping collected during RPC reads, used for offline reexecution dumps.
     contract_class_mapping_dumper: Arc<Mutex<Option<StarknetContractClassMapping>>>,
 }
@@ -585,6 +564,7 @@ impl ConsecutiveRpcStateReaders {
             ),
             contract_class_manager,
             min_sierra_version_override: None,
+            prefetch_initial_reads: false,
             contract_class_mapping_dumper,
         }
     }
@@ -725,18 +705,42 @@ impl ConsecutiveRpcStateReaders {
     }
 }
 
-impl ConsecutiveReexecutionStateReaders<StateReaderAndContractManager<RpcStateReader>>
+type BoxedFetchCompiledClasses = Box<dyn FetchCompiledClasses + Send + Sync>;
+
+impl ConsecutiveReexecutionStateReaders<StateReaderAndContractManager<BoxedFetchCompiledClasses>>
     for ConsecutiveRpcStateReaders
 {
     fn pre_process_and_create_executor(
         self,
         transaction_executor_config: Option<TransactionExecutorConfig>,
-    ) -> ReexecutionResult<TransactionExecutor<StateReaderAndContractManager<RpcStateReader>>> {
-        self.last_block_state_reader.get_transaction_executor(
-            self.next_block_state_reader.get_block_context(self.min_sierra_version_override)?,
-            transaction_executor_config,
-            &self.contract_class_manager,
-        )
+    ) -> ReexecutionResult<
+        TransactionExecutor<StateReaderAndContractManager<BoxedFetchCompiledClasses>>,
+    > {
+        let block_context =
+            self.next_block_state_reader.get_block_context(self.min_sierra_version_override)?;
+        let old_block_number = BlockNumber(
+            block_context.block_info().block_number.0 - constants::STORED_BLOCK_HASH_BUFFER,
+        );
+        let old_block_hash = self.last_block_state_reader.get_old_block_hash(old_block_number)?;
+
+        let reader: BoxedFetchCompiledClasses = if self.prefetch_initial_reads {
+            // TODO(Aviv): this duplicates the get_all_txs_in_block call in reexecute_block;
+            // consider caching or passing txs through the trait to avoid the extra RPC round trip.
+            let txs = self.next_block_state_reader.get_all_txs_in_block()?;
+            Box::new(SimulatedStateReader::from_rpc_state_reader(
+                self.last_block_state_reader,
+                &txs,
+            )?)
+        } else {
+            Box::new(self.last_block_state_reader)
+        };
+
+        Ok(TransactionExecutor::pre_process_and_create(
+            StateReaderAndContractManager::new(reader, self.contract_class_manager.clone(), None),
+            block_context,
+            Some(BlockHashAndNumber { number: old_block_number, hash: old_block_hash }),
+            transaction_executor_config.unwrap_or_default(),
+        )?)
     }
 
     fn get_next_block_txs(&self) -> ReexecutionResult<Vec<BlockifierTransaction>> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the reexecution executor setup to optionally call `starknet_simulateTransactions` and swap in a boxed state reader, which can affect execution correctness/performance if simulation flags or V3 filtering diverge from actual reads. Also adjusts how contract-class dump data is retrieved after boxing, which could impact offline dump output if the Arc handling is wrong.
> 
> **Overview**
> Adds an opt-in `prefetch_initial_reads` mode for `ConsecutiveRpcStateReaders` that runs `starknet_simulateTransactions` with `RETURN_INITIAL_READS` and executes against a `SimulatedStateReader` serving prefetched `StateMaps` with RPC fallback on cache misses.
> 
> Refactors executor creation to accept a boxed `FetchCompiledClasses` reader (either `RpcStateReader` or `SimulatedStateReader`), and updates offline reexecution dumping to pull the contract-class mapping from a stored `Arc<Mutex<...>>` since the reader is now boxed/consumed during execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943528a5f1be032ca6f3b0e69eba6b7b0e059c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->