### PR TITLE
apollo_integration_tests: parallelize running services

### DIFF
--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -361,15 +361,6 @@ impl RunningNode {
         handle.abort();
     }
 
-    pub fn run_service(&mut self, service: NodeService) {
-        assert!(
-            !self.executable_handles.contains_key(&service),
-            "Service {service:?} is already running."
-        );
-        let handle = self.node_setup.run_service(service);
-        self.executable_handles.insert(service, handle);
-    }
-
     pub fn get_node_index(&self) -> usize {
         self.node_setup.get_node_index().unwrap()
     }
@@ -492,18 +483,46 @@ impl IntegrationTestManager {
     ) {
         get_node_executable_path();
         info!("Rerunning shut-down services for specified nodes: {nodes_services_to_run:?}.");
-        // TODO(Tsabary): run these in parallel.
-        nodes_services_to_run.into_iter().for_each(|(node_index, services)| {
+
+        // Assert no service is already running before spawning anything. Checking up-front avoids
+        // silently overwriting an existing AbortOnDropHandle (which would abort the running
+        // service) and avoids spawning any processes when the call is invalid.
+        for (&node_index, services) in &nodes_services_to_run {
             let running_node = self
                 .running_nodes
-                .get_mut(&node_index)
+                .get(&node_index)
                 .unwrap_or_else(|| panic!("Node {node_index} is not in the running map."));
-
-            // TODO(Tsabary): run these in parallel.
-            for service in services {
-                running_node.run_service(service);
+            for &service in services {
+                assert!(
+                    !running_node.executable_handles.contains_key(&service),
+                    "Service {service:?} is already running for node {node_index}."
+                );
             }
-        });
+        }
+
+        // Spawn all services up-front. NodeSetup::run_service only needs &self, so all
+        // spawns can be issued before any handle is inserted into the map.
+        let new_handles: Vec<(usize, NodeService, AbortOnDropHandle<()>)> = nodes_services_to_run
+            .iter()
+            .flat_map(|(&node_index, services)| {
+                let node_setup = &self
+                    .running_nodes
+                    .get(&node_index)
+                    .unwrap_or_else(|| panic!("Node {node_index} is not in the running map."))
+                    .node_setup;
+                services
+                    .iter()
+                    .map(move |&service| (node_index, service, node_setup.run_service(service)))
+            })
+            .collect();
+
+        for (node_index, service, handle) in new_handles {
+            self.running_nodes
+                .get_mut(&node_index)
+                .unwrap_or_else(|| panic!("Node {node_index} is not in the running map."))
+                .executable_handles
+                .insert(service, handle);
+        }
 
         // Wait for the rerun executables to start
         self.await_alive(AWAIT_ALIVE_INTERVAL_MS, AWAIT_ALIVE_ATTEMPTS).await;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk test-harness change that only affects how integration tests restart node services; main risk is subtle ordering/handle-management issues that could cause flaky test startup.
> 
> **Overview**
> `IntegrationTestManager::run_node_services` now restarts services across multiple nodes by spawning *all* service processes up-front (collecting handles) and only then inserting those handles into each node’s `executable_handles` map.
> 
> This removes the previous nested iteration that restarted services node-by-node, improving restart concurrency while keeping the same post-startup `await_alive` verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9aa32583f561f9a12f2f18aa327ff5fd8281f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->