### PR TITLE
apollo_mempool: handle zero cost transaction replacment for small fee values

### DIFF
--- a/crates/apollo_mempool/src/fee_mempool_test.rs
+++ b/crates/apollo_mempool/src/fee_mempool_test.rs
@@ -852,6 +852,38 @@ fn test_fee_escalation_valid_replacement_minimum_values() {
 }
 
 #[rstest]
+fn test_fee_escalation_small_values_require_minimum_increase() {
+    // When existing_value * percentage / 100 == 0 (integer truncation), the required increase
+    // should still be at least 1 — not zero, which would allow same-value replacement.
+    let existing_tip = 5_u64;
+    let existing_gas = 5_u128;
+    let tx = tx!(tx_hash: 0, tip: existing_tip, max_l2_gas_price: existing_gas);
+    let mempool = MempoolTestContentBuilder::new()
+        .with_pool([tx.clone()])
+        .with_fee_escalation_percentage(10) // 5 * 10 / 100 == 0 without max(1).
+        .build_full_mempool();
+
+    // Same values: should be rejected.
+    let invalid_replacement =
+        add_tx_input!(tx_hash: 1, tip: existing_tip, max_l2_gas_price: existing_gas);
+    validate_and_add_txs_and_verify_no_replacement_in_pool(
+        mempool,
+        tx.clone(),
+        [invalid_replacement],
+    );
+
+    let mempool = MempoolTestContentBuilder::new()
+        .with_pool([tx.clone()])
+        .with_fee_escalation_percentage(10)
+        .build_full_mempool();
+
+    // Increased by 1: should be accepted.
+    let valid_replacement =
+        add_tx_input!(tx_hash: 2, tip: existing_tip + 1, max_l2_gas_price: existing_gas + 1);
+    validate_and_add_tx_and_verify_replacement_in_pool(mempool, valid_replacement);
+}
+
+#[rstest]
 fn test_fee_escalation_valid_replacement_maximum_values() {
     // Setup.
     let tx = tx!(tx_hash: 0, tip: u64::MAX / 100, max_l2_gas_price: u128::MAX / 100 );

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -790,12 +790,17 @@ impl Mempool {
     fn increased_enough(&self, existing_value: u128, incoming_value: u128) -> bool {
         let percentage = u128::from(self.config.static_config.fee_escalation_percentage);
 
+        if percentage == 0 {
+            // Zero percentage means the incoming value must be at least the existing value.
+            return existing_value <= incoming_value;
+        }
+
         // Note: To reduce precision loss, we first multiply by the percentage and then divide by
         // 100. This could cause an overflow and an automatic rejection of the transaction, but the
         // values aren't expected to be large enough for this to be an issue.
         let Some(escalation_qualified_value) = existing_value
             .checked_mul(percentage)
-            .map(|v| v / 100)
+            .map(|v| (v / 100).max(1))
             .and_then(|increase| existing_value.checked_add(increase))
         else {
             // Overflow occurred during calculation; reject the transaction.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core fee-escalation replacement criteria; could alter which transactions are accepted/replaced in edge cases (small fees or 0% config).
> 
> **Overview**
> Fixes fee-escalation replacement math to prevent *zero-cost* replacements when small fee values and integer truncation would otherwise require a 0 bump. `Mempool::increased_enough` now enforces a minimum increase of 1 for nonzero escalation percentages, and explicitly treats a 0% escalation setting as always allowing replacement.
> 
> Adds a regression test (`test_fee_escalation_small_values_require_minimum_increase`) covering rejection of same-fee replacements and acceptance when both tip and max gas price increase by 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c716da30a31df2334e9d3c95e6e4f8dbd2d2f9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->