### PR TITLE
blockifier_reexecution,starknet_transaction_prover: graceful fallback on prefetch failure

### DIFF
--- a/crates/blockifier_reexecution/src/state_reader/prefetched_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/prefetched_state_reader.rs
@@ -237,7 +237,15 @@ impl SimulatedStateReader {
                 &invoke_v3_txs,
                 validate_txs,
                 skip_fee_charge,
-            )?
+            )
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "State prefetch via starknet_simulateTransactions failed, falling back to \
+                     individual RPC reads (slower). Ensure the node supports Starknet spec >= \
+                     v0.10.1. Error: {e}"
+                );
+                StateMaps::default()
+            })
         };
         Ok(Self { state_maps, rpc_state_reader })
     }

--- a/crates/starknet_transaction_prover/src/running/virtual_block_executor.rs
+++ b/crates/starknet_transaction_prover/src/running/virtual_block_executor.rs
@@ -427,7 +427,14 @@ impl VirtualBlockExecutor for RpcVirtualBlockExecutor {
                 self.validate_txs,
                 skip_fee_charge,
             )
-            .map_err(|e| VirtualBlockExecutorError::ReexecutionError(Box::new(e)))?;
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "State prefetch via starknet_simulateTransactions failed, falling back to \
+                     individual RPC reads (slower). Ensure the node supports Starknet spec >= \
+                     v0.10.1. Error: {e}"
+                );
+                StateMaps::default()
+            });
             Ok(Box::new(SimulatedStateReader::new(state_maps, rpc_state_reader)))
         } else {
             Ok(Box::new(rpc_state_reader))


### PR DESCRIPTION
If `starknet_simulateTransactions` fails (e.g. the node does not support
Starknet spec >= v0.10.1, or a transient network error), log a warning
and fall back to empty `StateMaps` instead of failing the block.

The `SimulatedStateReader` with empty maps routes all reads through
individual RPC calls — slower but correct.

Both call sites are updated:
- `SimulatedStateReader::from_rpc_state_reader` (reexecution flow)
- `RpcVirtualBlockExecutor::state_reader` (virtual block executor)