### PR TITLE
blockifier: add with-libfunc-profiling feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,6 +3761,7 @@ dependencies = [
  "cached",
  "cairo-lang-casm",
  "cairo-lang-runner",
+ "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "cairo-native",

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -18,6 +18,11 @@ cairo_native = [
 ]
 benchmarking = []
 only-native = ["cairo_native"]
+with-libfunc-profiling = [
+  "cairo-native/with-libfunc-profiling",
+  "cairo_native",
+  "dep:cairo-lang-sierra",
+]
 mocks = []
 native_blockifier = []
 node_api = []
@@ -44,6 +49,7 @@ blockifier_test_utils = { workspace = true, optional = true }
 cached.workspace = true
 cairo-lang-casm = { workspace = true, features = ["parity-scale-codec"] }
 cairo-lang-runner.workspace = true
+cairo-lang-sierra = { workspace = true, optional = true }
 cairo-lang-starknet-classes.workspace = true
 cairo-lang-utils.workspace = true
 cairo-native = { workspace = true, optional = true }

--- a/crates/blockifier/src/execution/native.rs
+++ b/crates/blockifier/src/execution/native.rs
@@ -1,5 +1,7 @@
 pub mod contract_class;
 pub mod entry_point_execution;
+#[cfg(feature = "with-libfunc-profiling")]
+pub mod profiling;
 pub mod syscall_handler;
 pub mod utils;
 

--- a/crates/blockifier/src/execution/native/contract_class.rs
+++ b/crates/blockifier/src/execution/native/contract_class.rs
@@ -35,6 +35,19 @@ impl NativeCompiledClassV1 {
         Self(Arc::new(contract))
     }
 
+    /// Like [`Self::new`], but additionally stores the Sierra `program` so libfunc profiling
+    /// can resolve libfunc IDs for the running entrypoint.
+    #[cfg(feature = "with-libfunc-profiling")]
+    pub fn new_with_program(
+        executor: AotContractExecutor,
+        casm: CompiledClassV1,
+        program: cairo_lang_sierra::program::Program,
+    ) -> NativeCompiledClassV1 {
+        let contract = NativeCompiledClassV1Inner::new_with_program(executor, casm, program);
+
+        Self(Arc::new(contract))
+    }
+
     pub fn get_entry_point(
         &self,
         entry_point: &EntryPointTypeAndSelector,
@@ -72,12 +85,29 @@ impl HashableCompiledClass<EntryPointV1, NestedFeltCounts> for NativeCompiledCla
 #[derive(Debug)]
 pub struct NativeCompiledClassV1Inner {
     pub executor: AotContractExecutor,
+    #[cfg(feature = "with-libfunc-profiling")]
+    pub program: Option<cairo_lang_sierra::program::Program>,
     casm: CompiledClassV1,
 }
 
 impl NativeCompiledClassV1Inner {
     fn new(executor: AotContractExecutor, casm: CompiledClassV1) -> Self {
-        NativeCompiledClassV1Inner { executor, casm }
+        NativeCompiledClassV1Inner {
+            executor,
+            #[cfg(feature = "with-libfunc-profiling")]
+            program: None,
+            casm,
+        }
+    }
+
+    #[cfg(feature = "with-libfunc-profiling")]
+    fn new_with_program(
+        executor: AotContractExecutor,
+        casm: CompiledClassV1,
+        program: cairo_lang_sierra::program::Program,
+    ) -> Self {
+        let executor = executor.into();
+        NativeCompiledClassV1Inner { executor, program: Some(program), casm }
     }
 }
 

--- a/crates/blockifier/src/execution/native/contract_class.rs
+++ b/crates/blockifier/src/execution/native/contract_class.rs
@@ -36,12 +36,13 @@ impl NativeCompiledClassV1 {
     }
 
     /// Like [`Self::new`], but additionally stores the Sierra `program` so libfunc profiling
-    /// can resolve libfunc IDs for the running entrypoint.
+    /// can resolve libfunc IDs for the running entrypoint. The program is shared via `Arc`
+    /// across every profile entry, avoiding per-call deep clones.
     #[cfg(feature = "with-libfunc-profiling")]
     pub fn new_with_program(
         executor: AotContractExecutor,
         casm: CompiledClassV1,
-        program: cairo_lang_sierra::program::Program,
+        program: Arc<cairo_lang_sierra::program::Program>,
     ) -> NativeCompiledClassV1 {
         let contract = NativeCompiledClassV1Inner::new_with_program(executor, casm, program);
 
@@ -86,7 +87,7 @@ impl HashableCompiledClass<EntryPointV1, NestedFeltCounts> for NativeCompiledCla
 pub struct NativeCompiledClassV1Inner {
     pub executor: AotContractExecutor,
     #[cfg(feature = "with-libfunc-profiling")]
-    pub program: Option<cairo_lang_sierra::program::Program>,
+    pub program: Option<Arc<cairo_lang_sierra::program::Program>>,
     casm: CompiledClassV1,
 }
 
@@ -104,8 +105,12 @@ impl NativeCompiledClassV1Inner {
     fn new_with_program(
         executor: AotContractExecutor,
         casm: CompiledClassV1,
-        program: cairo_lang_sierra::program::Program,
+        program: Arc<cairo_lang_sierra::program::Program>,
     ) -> Self {
+        // Forward-compat: `executor` becomes the `ContractExecutor` enum in #13542 with
+        // `From<AotContractExecutor>`. Going through `.into()` keeps this constructor
+        // compiling unchanged once that lands. On this branch alone it's the blanket
+        // identity conversion.
         let executor = executor.into();
         NativeCompiledClassV1Inner { executor, program: Some(program), casm }
     }

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -59,6 +59,26 @@ pub fn execute_entry_point_call(
         .checked_sub(initial_budget)
         .ok_or(PreExecutionError::InsufficientEntryPointGas)?;
 
+    #[cfg(feature = "with-libfunc-profiling")]
+    let execution_result = match &compiled_class.program {
+        Some(program) => crate::execution::native::profiling::run_profiled(
+            &compiled_class.executor,
+            program,
+            entry_point.selector.0,
+            &syscall_handler.base.call.calldata.0.clone(),
+            call_initial_gas,
+            Some(builtin_costs),
+            &mut syscall_handler,
+        ),
+        None => compiled_class.executor.run(
+            entry_point.selector.0,
+            &syscall_handler.base.call.calldata.0.clone(),
+            call_initial_gas,
+            Some(builtin_costs),
+            &mut syscall_handler,
+        ),
+    };
+    #[cfg(not(feature = "with-libfunc-profiling"))]
     let execution_result = compiled_class.executor.run(
         entry_point.selector.0,
         &syscall_handler.base.call.calldata.0.clone(),

--- a/crates/blockifier/src/execution/native/profiling.rs
+++ b/crates/blockifier/src/execution/native/profiling.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::{LazyLock, Mutex};
+
+use cairo_lang_sierra::ids::ConcreteLibfuncId;
+use cairo_native::execution_result::ContractExecutionResult;
+use cairo_native::executor::AotContractExecutor;
+use cairo_native::metadata::profiler::{
+    LibfuncProfileData,
+    ProfilerBinding,
+    ProfilerImpl,
+    LIBFUNC_PROFILE,
+};
+use cairo_native::utils::BuiltinCosts;
+use starknet_types_core::felt::Felt;
+
+use crate::execution::native::syscall_handler::NativeSyscallHandler;
+
+pub struct EntrypointProfile {
+    pub class_hash: Felt,
+    pub selector: Felt,
+    pub profile: HashMap<ConcreteLibfuncId, LibfuncProfileData>,
+    pub program: cairo_lang_sierra::program::Program,
+}
+
+pub struct TransactionProfile {
+    pub block_number: u64,
+    pub tx_hash: String,
+    pub entrypoint_profiles: Vec<EntrypointProfile>,
+}
+
+type ProfilesByBlockTx = HashMap<String, TransactionProfile>;
+
+pub static LIBFUNC_PROFILES_MAP: LazyLock<Mutex<ProfilesByBlockTx>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Wraps `AotContractExecutor::run` with libfunc profiling instrumentation.
+///
+/// Collects per-entrypoint profiling data into `LIBFUNC_PROFILES_MAP`, keyed by transaction hash.
+pub fn run_profiled(
+    executor: &AotContractExecutor,
+    program: &cairo_lang_sierra::program::Program,
+    selector: Felt,
+    args: &[Felt],
+    gas: u64,
+    builtin_costs: Option<BuiltinCosts>,
+    syscall_handler: &mut NativeSyscallHandler<'_>,
+) -> cairo_native::error::Result<ContractExecutionResult> {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let class_hash = *syscall_handler.base.call.class_hash;
+    let tx_hash =
+        syscall_handler.base.context.tx_context.tx_info.transaction_hash().to_hex_string();
+    let block_number =
+        syscall_handler.base.context.tx_context.block_context.block_info.block_number.0;
+
+    let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    LIBFUNC_PROFILE.lock().unwrap().insert(counter, ProfilerImpl::new());
+
+    let trace_id = unsafe {
+        let trace_id_ptr = executor.find_symbol_ptr(ProfilerBinding::ProfileId.symbol()).unwrap();
+        trace_id_ptr.cast::<u64>().as_mut().unwrap()
+    };
+
+    let old_trace_id = *trace_id;
+    *trace_id = counter;
+
+    let result = executor.run(selector, args, gas, builtin_costs, syscall_handler);
+
+    let profiler = LIBFUNC_PROFILE.lock().unwrap().remove(&counter).unwrap();
+    let raw_profile = profiler.get_profile(program);
+
+    let mut profiles_map = LIBFUNC_PROFILES_MAP.lock().unwrap();
+
+    let profile =
+        EntrypointProfile { class_hash, selector, profile: raw_profile, program: program.clone() };
+
+    match profiles_map.get_mut(&tx_hash) {
+        Some(tx_profile) => {
+            tx_profile.entrypoint_profiles.push(profile);
+        }
+        None => {
+            let tx_profile = TransactionProfile {
+                block_number,
+                tx_hash: tx_hash.clone(),
+                entrypoint_profiles: vec![profile],
+            };
+            profiles_map.insert(tx_hash, tx_profile);
+        }
+    };
+
+    *trace_id = old_trace_id;
+
+    result
+}

--- a/crates/blockifier/src/execution/native/profiling.rs
+++ b/crates/blockifier/src/execution/native/profiling.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use cairo_lang_sierra::ids::ConcreteLibfuncId;
+use cairo_lang_sierra::program::Program;
 use cairo_native::execution_result::ContractExecutionResult;
 use cairo_native::executor::AotContractExecutor;
 use cairo_native::metadata::profiler::{
@@ -20,7 +21,7 @@ pub struct EntrypointProfile {
     pub class_hash: Felt,
     pub selector: Felt,
     pub profile: HashMap<ConcreteLibfuncId, LibfuncProfileData>,
-    pub program: cairo_lang_sierra::program::Program,
+    pub program: Arc<Program>,
 }
 
 pub struct TransactionProfile {
@@ -39,7 +40,7 @@ pub static LIBFUNC_PROFILES_MAP: LazyLock<Mutex<ProfilesByBlockTx>> =
 /// Collects per-entrypoint profiling data into `LIBFUNC_PROFILES_MAP`, keyed by transaction hash.
 pub fn run_profiled(
     executor: &AotContractExecutor,
-    program: &cairo_lang_sierra::program::Program,
+    program: &Arc<Program>,
     selector: Felt,
     args: &[Felt],
     gas: u64,
@@ -58,13 +59,21 @@ pub fn run_profiled(
 
     LIBFUNC_PROFILE.lock().unwrap().insert(counter, ProfilerImpl::new());
 
-    let trace_id = unsafe {
-        let trace_id_ptr = executor.find_symbol_ptr(ProfilerBinding::ProfileId.symbol()).unwrap();
-        trace_id_ptr.cast::<u64>().as_mut().unwrap()
-    };
+    // `trace_id_ptr` targets a global symbol in the executor's shared library; the pointer
+    // is valid for the executor's lifetime. Profiling is intended for single-threaded
+    // benchmarking — concurrent calls would race on this symbol (tracked separately).
+    let trace_id_ptr =
+        executor.find_symbol_ptr(ProfilerBinding::ProfileId.symbol()).unwrap().cast::<u64>();
+    // SAFETY: see above. Read/write to a non-null, properly-aligned `*mut u64`.
+    let old_trace_id = unsafe { *trace_id_ptr };
+    unsafe {
+        *trace_id_ptr = counter;
+    }
 
-    let old_trace_id = *trace_id;
-    *trace_id = counter;
+    // Restores `trace_id` and drops the `LIBFUNC_PROFILE` slot if `executor.run` (or any
+    // step before the success-path drain) panics; without this the profiler symbol stays
+    // pinned at `counter` and the slot leaks forever.
+    let _guard = ProfilerGuard { trace_id_ptr, old_trace_id, counter };
 
     let result = executor.run(selector, args, gas, builtin_costs, syscall_handler);
 
@@ -73,8 +82,12 @@ pub fn run_profiled(
 
     let mut profiles_map = LIBFUNC_PROFILES_MAP.lock().unwrap();
 
-    let profile =
-        EntrypointProfile { class_hash, selector, profile: raw_profile, program: program.clone() };
+    let profile = EntrypointProfile {
+        class_hash,
+        selector,
+        profile: raw_profile,
+        program: Arc::clone(program),
+    };
 
     match profiles_map.get_mut(&tx_hash) {
         Some(tx_profile) => {
@@ -90,7 +103,28 @@ pub fn run_profiled(
         }
     };
 
-    *trace_id = old_trace_id;
-
     result
+}
+
+/// RAII cleanup for the profiler globals. On drop, restores `*trace_id_ptr` to `old_trace_id`
+/// and removes the `LIBFUNC_PROFILE` entry at `counter`. Removing on the success path is a
+/// no-op because the caller has already taken the slot out.
+struct ProfilerGuard {
+    trace_id_ptr: *mut u64,
+    old_trace_id: u64,
+    counter: u64,
+}
+
+impl Drop for ProfilerGuard {
+    fn drop(&mut self) {
+        // SAFETY: the pointer targets a global in the executor's shared library and outlives
+        // this guard. Single-threaded profiling means no concurrent writer aliases it here.
+        unsafe {
+            *self.trace_id_ptr = self.old_trace_id;
+        }
+        // Tolerate a poisoned mutex silently — Drop must not panic.
+        if let Ok(mut profile) = LIBFUNC_PROFILE.lock() {
+            profile.remove(&self.counter);
+        }
+    }
 }

--- a/crates/blockifier/src/state/native_class_manager.rs
+++ b/crates/blockifier/src/state/native_class_manager.rs
@@ -285,11 +285,12 @@ fn process_compilation_request(
     let sierra_for_compilation = into_contract_class_for_compilation(sierra.as_ref());
 
     // The Sierra program is needed by libfunc profiling to map runtime libfunc IDs back to
-    // declarations. Extract it before `compile` consumes `sierra_for_compilation`.
+    // declarations. Extract it before `compile` consumes `sierra_for_compilation`. Wrap in
+    // `Arc` so the cached compiled class and every per-call profile share a single allocation.
     #[cfg(feature = "with-libfunc-profiling")]
     let program_for_profiling = sierra_for_compilation
         .extract_sierra_program(false)
-        .map(|extracted| extracted.program)
+        .map(|extracted| Arc::new(extracted.program))
         .map_err(|err| {
             log::warn!(
                 "Failed to extract Sierra program for profiling (class hash: {:#066x}): {err}",

--- a/crates/blockifier/src/state/native_class_manager.rs
+++ b/crates/blockifier/src/state/native_class_manager.rs
@@ -283,6 +283,21 @@ fn process_compilation_request(
         return Ok(());
     }
     let sierra_for_compilation = into_contract_class_for_compilation(sierra.as_ref());
+
+    // The Sierra program is needed by libfunc profiling to map runtime libfunc IDs back to
+    // declarations. Extract it before `compile` consumes `sierra_for_compilation`.
+    #[cfg(feature = "with-libfunc-profiling")]
+    let program_for_profiling = sierra_for_compilation
+        .extract_sierra_program(false)
+        .map(|extracted| extracted.program)
+        .map_err(|err| {
+            log::warn!(
+                "Failed to extract Sierra program for profiling (class hash: {:#066x}): {err}",
+                class_hash.0
+            );
+        })
+        .ok();
+
     let start = Instant::now();
     let compilation_result = compiler.compile(sierra_for_compilation);
     let duration = start.elapsed();
@@ -293,6 +308,14 @@ fn process_compilation_request(
     );
     match compilation_result {
         Ok(executor) => {
+            #[cfg(feature = "with-libfunc-profiling")]
+            let native_compiled_class = match program_for_profiling {
+                Some(program) => {
+                    NativeCompiledClassV1::new_with_program(executor, casm, program)
+                }
+                None => NativeCompiledClassV1::new(executor, casm),
+            };
+            #[cfg(not(feature = "with-libfunc-profiling"))]
             let native_compiled_class = NativeCompiledClassV1::new(executor, casm);
             class_cache.set(
                 class_hash,


### PR DESCRIPTION
Adds the `with-libfunc-profiling` feature flag for execution profiling
support. When enabled, introduces an `AotWithProgram` variant on
`ContractExecutor` that collects per-entrypoint libfunc profiling data
into a global map keyed by transaction hash.

Zero behavior change without the flag enabled.