### PR TITLE
starknet_committer,starknet_committer_and_os_cli: write CommitmentOffset metadata after snap sync

### DIFF
--- a/crates/starknet_committer/src/db/forest_trait.rs
+++ b/crates/starknet_committer/src/db/forest_trait.rs
@@ -25,7 +25,7 @@ use crate::db::serde_db_utils::DbBlockNumber;
 use crate::db::trie_traversal::{create_classes_trie, create_contracts_trie, create_storage_tries};
 use crate::forest::deleted_nodes::DeletedNodes;
 use crate::forest::filled_forest::FilledForest;
-use crate::forest::forest_errors::ForestResult;
+use crate::forest::forest_errors::{ForestError, ForestResult};
 use crate::forest::original_skeleton_forest::{ForestSortedIndices, OriginalSkeletonForest};
 use crate::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 use crate::patricia_merkle_tree::types::CompiledClassHash;
@@ -177,6 +177,27 @@ pub trait ForestWriter: Send {
 pub trait ForestWriterWithMetadata: ForestWriter + ForestMetadata {
     /// Serializes deleted nodes into a vector of database keys.
     fn serialize_deleted_nodes(deleted_nodes: DeletedNodes) -> Vec<DbKey>;
+
+    /// Writes only metadata entries to storage, without a filled forest.
+    /// Returns an error if any of the metadata keys are already set.
+    /// May overwrite existing metadata in case of a write race (existence check and writing are not
+    /// a single atomic operation).
+    async fn try_write_metadata(
+        &mut self,
+        metadata: HashMap<ForestMetadataType, DbValue>,
+    ) -> ForestResult<()> {
+        let mut updates = DbHashMap::new();
+        for (metadata_type, value) in metadata {
+            // Another thread may change this existence before the updates are written.
+            let existing = self.read_metadata(metadata_type.clone()).await?;
+            if existing.is_some() {
+                return Err(ForestError::MetadataKeyAlreadySet(metadata_type));
+            }
+            Self::insert_metadata(&mut updates, metadata_type, value);
+        }
+        self.write_updates(updates_to_set_operations(updates)).await;
+        Ok(())
+    }
 
     async fn write_with_metadata(
         &mut self,

--- a/crates/starknet_committer/src/forest/forest_errors.rs
+++ b/crates/starknet_committer/src/forest/forest_errors.rs
@@ -6,6 +6,8 @@ use starknet_patricia_storage::storage_trait::PatriciaStorageError;
 use thiserror::Error;
 use tokio::task::JoinError;
 
+use crate::db::forest_trait::ForestMetadataType;
+
 pub(crate) type ForestResult<T> = Result<T, ForestError>;
 
 #[derive(Debug, Error)]
@@ -41,4 +43,6 @@ pub enum ForestError {
     JoinError(#[from] JoinError),
     #[error("Couldn't create Storage Trie: {0}")]
     StorageTrie(#[source] FilledTreeError),
+    #[error("Metadata key {0:?} is already set")]
+    MetadataKeyAlreadySet(ForestMetadataType),
 }

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
@@ -30,12 +30,14 @@ use starknet_committer::block_committer::measurements_util::{
 };
 use starknet_committer::db::forest_trait::{
     EmptyInitialReadContext,
+    ForestMetadataType,
     ForestWriterWithMetadata,
     StorageInitializer,
 };
 use starknet_committer::db::index_db::{IndexDb, IndexDbReadContext};
+use starknet_committer::db::serde_db_utils::{serialize_felt_no_packing, DbBlockNumber};
 use starknet_committer::patricia_merkle_tree::types::CompiledClassHash as CommitterCompiledClassHash;
-use starknet_patricia_storage::storage_trait::Storage;
+use starknet_patricia_storage::storage_trait::{DbValue, Storage};
 use starknet_types_core::felt::{Felt, NonZeroFelt};
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -489,12 +491,30 @@ pub async fn run_snap_sync(
     .expect("process_request failed for classes tree");
 
     // All requests are done; unwrap the Arc to get owned CommitState.
-    let final_state = Arc::try_unwrap(commit_state)
+    let mut final_state = Arc::try_unwrap(commit_state)
         .unwrap_or_else(|_| panic!("No other Arc references should exist at this point"))
         .into_inner();
 
+    // Write the commitment offset so the committer knows where to resume.
+    let next_offset = block_target.next().expect("block_target is too high");
+    final_state
+        .committer_db
+        .try_write_metadata(HashMap::from([
+            (
+                ForestMetadataType::CommitmentOffset,
+                DbValue(DbBlockNumber(next_offset).serialize().to_vec()),
+            ),
+            (
+                ForestMetadataType::StateRoot(DbBlockNumber(block_target)),
+                serialize_felt_no_packing(final_state.state_roots.global_root().0),
+            ),
+        ]))
+        .await
+        .expect("Failed to write snap sync metadata");
+
     info!(
-        "Snap sync complete. Contracts tree root: {}, Classes tree root: {}",
+        "Snap sync complete. Next offset: {}, contracts tree root: {}, classes tree root: {}",
+        next_offset.0,
         final_state.state_roots.contracts_trie_root_hash.0.to_hex_string(),
         final_state.state_roots.classes_trie_root_hash.0.to_hex_string(),
     );


### PR DESCRIPTION
starknet_committer,starknet_committer_and_os_cli: write CommitmentOffset metadata after snap sync

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

starknet_committer_and_os_cli: use checked next() for commitment offset in snap sync

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

starknet_committer_and_os_cli: log next offset in snap sync completion message

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>