### PR TITLE
apollo_consensus_orchestrator: validate builder address in ProposalInit against config

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -641,6 +641,7 @@ impl ConsensusContext for SequencerConsensusContext {
             std::cmp::Ordering::Equal => {
                 let proposal_init_validation = ProposalInitValidation {
                     height: init.height,
+                    builder_address: self.config.static_config.builder_address,
                     block_timestamp_window_seconds: self
                         .config
                         .static_config
@@ -878,6 +879,7 @@ impl ConsensusContext for SequencerConsensusContext {
         };
         let proposal_init_validation = ProposalInitValidation {
             height: init.height,
+            builder_address: self.config.static_config.builder_address,
             block_timestamp_window_seconds: self
                 .config
                 .static_config

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -28,6 +28,7 @@ use futures::channel::mpsc;
 use futures::StreamExt;
 use starknet_api::block::{BlockNumber, GasPrice, StarknetVersion};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
+use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
@@ -72,6 +73,7 @@ pub(crate) struct ProposalValidateArguments {
 #[derive(Clone, Debug)]
 pub(crate) struct ProposalInitValidation {
     pub height: BlockNumber,
+    pub builder_address: ContractAddress,
     pub block_timestamp_window_seconds: u64,
     pub previous_proposal_init: Option<PreviousProposalInitInfo>,
     pub l1_da_mode: L1DataAvailabilityMode,
@@ -295,6 +297,16 @@ async fn is_proposal_init_valid(
             init_proposed.clone(),
             proposal_init_validation.clone(),
             "ProposalInit validation failed".to_string(),
+        ));
+    }
+    if init_proposed.builder != proposal_init_validation.builder_address {
+        return Err(ValidateProposalError::InvalidProposalInit(
+            init_proposed.clone(),
+            proposal_init_validation.clone(),
+            format!(
+                "Builder address mismatch: expected={}, proposed={}",
+                proposal_init_validation.builder_address, init_proposed.builder
+            ),
         ));
     }
     let (l1_gas_prices_fri, _l1_gas_prices_wei) = get_l1_prices_in_fri_and_wei(

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
@@ -26,6 +26,7 @@ use futures::SinkExt;
 use rstest::rstest;
 use starknet_api::block::{BlockNumber, GasPrice, StarknetVersion};
 use starknet_api::block_hash::block_hash_calculator::{BlockHeaderCommitments, PartialBlockHash};
+use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
@@ -90,6 +91,7 @@ fn create_proposal_validate_arguments()
     let init = proposal_init(BlockNumber(0), 0);
     let proposal_init_validation = ProposalInitValidation {
         height: BlockNumber(0),
+        builder_address: ContractAddress::default(),
         block_timestamp_window_seconds: 60,
         previous_proposal_init: None,
         l1_da_mode: L1DataAvailabilityMode::Blob,


### PR DESCRIPTION
## Summary
- Rebased from PR #13682 on top of `matanl/validate-starknet-version`
- Adds `builder_address: ContractAddress` to `ProposalInitValidation`
- Validates in `is_proposal_init_valid()` that `init.builder` matches `static_config.builder_address`, rejecting the proposal before block execution if it doesn't
- Plumbs `self.config.static_config.builder_address` into both `ProposalInitValidation` construction sites in `SequencerConsensusContext`

## Test plan
- Existing test fixture updated with `builder_address: ContractAddress::default()` to match the default proposer address used in tests
- All 16 existing `validate_proposal` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)