### PR TITLE
workspace: pass --locked to cargo install invocations

### DIFF
--- a/crates/starknet_transaction_prover/Dockerfile
+++ b/crates/starknet_transaction_prover/Dockerfile
@@ -58,8 +58,8 @@ COPY crates/starknet_transaction_prover/rust-toolchain.toml rust-toolchain.toml
 # the nightly defined in rust-toolchain.toml.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none \
     && rustup toolchain install \
-    && cargo install cargo-chef \
-    && RUSTC_WRAPPER="" cargo install sccache --version 0.14.0 \
+    && cargo install --locked cargo-chef \
+    && RUSTC_WRAPPER="" cargo install --locked sccache --version 0.14.0 \
     && rm rust-toolchain.toml
 
 # Create Python venv and install cairo-lang (required for compiling Starknet OS).

--- a/deployments/images/base/Dockerfile
+++ b/deployments/images/base/Dockerfile
@@ -26,7 +26,7 @@ ENV PATH=$PATH:${RUSTUP_HOME}/bin
 
 RUN scripts/install_build_tools.sh
 RUN rustup toolchain install
-RUN cargo install cargo-chef
+RUN cargo install --locked cargo-chef
 
 ENV LLVM_SYS_191_PREFIX="/usr/lib/llvm-19/"
 ENV MLIR_SYS_190_PREFIX="/usr/lib/llvm-19/"


### PR DESCRIPTION
apollo_propeller: rename validate_shard to validate_unit in UnitValidator (#13503)

workspace: pass --locked to cargo install invocations (#13794)

Without --locked, cargo install resolves transitive deps to the latest
semver-compatible versions and ignores the Cargo.lock published with the
installed crate. When a transitive dep bumps its MSRV above the active
toolchain, the install breaks — independent of any local toolchain
change.

Two recent failures illustrate:
  cargo-chef v0.1.77 -> cargo-platform@0.3.3 requires rustc 1.91
      (nightly-2025-07-14 is 1.90.0-nightly, in the prover Dockerfile)
  sccache v0.14.0  -> constant_time_eq@0.4.3 requires rustc 1.95.0
      (stable toolchain is 1.92, in the sequencer Dockerfile)

Adding --locked reuses each crate's published Cargo.lock, which pins
transitive deps to versions that build on the crate's original MSRV.
It does not constrain the rustc used to compile — Rust's backward
compatibility still lets us bump the toolchain freely.

Covered sites:
  - crates/starknet_transaction_prover/Dockerfile (cargo-chef)
  - crates/blockifier_reexecution/replay/Dockerfile (cargo-chef)
  - deployments/images/base/Dockerfile (cargo-chef)
  - scripts/install_cargo_tools.sh (sccache, cargo-machete,
    cargo-nextest, taplo-cli, cargo-deny)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>