### PR TITLE
scripts: serialize PyPy/Rust install and verify toolchain is usable

### DIFF
--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -101,17 +101,29 @@ log_step "install_build_tools" "Starting build tools installation..."
 
 install_common_packages
 
-log_step "install_build_tools" "Starting parallel installations (PyPy, Rust)..."
-pids=()
-install_pypy & pids+=($!)
-install_rust & pids+=($!)
-# Wait for all processes, fail if at least one failed.
-failed=0
-for pid in "${pids[@]}"; do
-    wait "$pid" || failed=1
-done
-(( $failed )) && exit 1
-log_step "install_build_tools" "Parallel installations completed"
+log_step "install_build_tools" "Installing PyPy and Rust..."
+# Intentionally serial: rustup-init's multi-threaded component downloader has a
+# known race (`thread 'CloseHandle' panicked at src/diskio/mod.rs: RecvError`)
+# that's triggered or aggravated by concurrent I/O from parallel installers.
+# When the race fires, rustup leaves a partial toolchain stub behind and later
+# `cargo install` calls fail with "'cargo' is not installed for the toolchain".
+install_pypy
+install_rust
+log_step "install_build_tools" "PyPy and Rust installed"
+
+# Belt-and-suspenders: rustup can still leave the pinned toolchain partially
+# installed (the `rust-toolchain.toml`-pinned channel as a stub without its
+# components). Probe with `cargo --version` against the active toolchain; if it
+# fails, force a reinstall to get the full component set.
+log_step "install_build_tools" "Verifying project Rust toolchain is usable..."
+pushd "${SCRIPT_DIR}/.." > /dev/null
+if ! cargo --version > /dev/null 2>&1; then
+    log_step "install_build_tools" "Project toolchain stub is missing components; forcing reinstall..."
+    rustup toolchain install --force
+fi
+popd > /dev/null
+log_step "install_build_tools" "Project Rust toolchain ready: $(rustc --version)"
+
 log_step "install_build_tools" "Running install_cargo_tools.sh..."
 ${SCRIPT_DIR}/install_cargo_tools.sh
 log_step "install_build_tools" "install_cargo_tools.sh completed"

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -102,21 +102,24 @@ log_step "install_build_tools" "Starting build tools installation..."
 install_common_packages
 
 log_step "install_build_tools" "Installing PyPy..."
-# Intentionally serial: rustup-init's multi-threaded component downloader has a
-# known race (`thread 'CloseHandle' panicked at src/diskio/mod.rs: RecvError`,
-# rust-lang/rustup#2926) that's triggered or aggravated by concurrent I/O from
-# parallel installers. When the race fires, rustup leaves a partial toolchain
-# stub behind and later `cargo install` calls fail with "'cargo' is not
-# installed for the toolchain".
+# Run PyPy and Rust installers serially. Concurrent disk I/O from a sibling
+# installer is a known trigger for rustup-init's multi-threaded downloader to
+# hit a `CloseHandle`/`RecvError` panic (see rust-lang/rustup#2926), and more
+# generally any mid-install failure can leave rustup with a partial toolchain
+# (the rust-toolchain.toml channel registered as a stub but its components
+# never fully downloaded). Serial execution removes one cheap trigger; the
+# verification step below handles any partial-install state regardless of
+# cause.
 install_pypy
 log_step "install_build_tools" "PyPy installed. Installing Rust..."
 install_rust
 log_step "install_build_tools" "Rust installed."
 
-# Belt-and-suspenders: rustup can still leave the pinned toolchain partially
-# installed (the `rust-toolchain.toml`-pinned channel as a stub without its
-# components). Probe with `cargo --version` against the active toolchain; if it
-# fails, force a reinstall to get the full component set.
+# Verify the pinned toolchain is actually usable. `cargo --version` in the
+# project dir resolves through rustup's proxy to the toml-pinned channel; on a
+# healthy install this is a ~10ms no-op. If it fails, the toolchain was left
+# in a partial state (stub registered without the cargo/rustc components) and
+# we force a reinstall.
 log_step "install_build_tools" "Verifying project Rust toolchain is usable..."
 pushd "${SCRIPT_DIR}/.." > /dev/null
 if ! cargo --version > /dev/null 2>&1; then

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -101,15 +101,17 @@ log_step "install_build_tools" "Starting build tools installation..."
 
 install_common_packages
 
-log_step "install_build_tools" "Installing PyPy and Rust..."
+log_step "install_build_tools" "Installing PyPy..."
 # Intentionally serial: rustup-init's multi-threaded component downloader has a
-# known race (`thread 'CloseHandle' panicked at src/diskio/mod.rs: RecvError`)
-# that's triggered or aggravated by concurrent I/O from parallel installers.
-# When the race fires, rustup leaves a partial toolchain stub behind and later
-# `cargo install` calls fail with "'cargo' is not installed for the toolchain".
+# known race (`thread 'CloseHandle' panicked at src/diskio/mod.rs: RecvError`,
+# rust-lang/rustup#2926) that's triggered or aggravated by concurrent I/O from
+# parallel installers. When the race fires, rustup leaves a partial toolchain
+# stub behind and later `cargo install` calls fail with "'cargo' is not
+# installed for the toolchain".
 install_pypy
+log_step "install_build_tools" "PyPy installed. Installing Rust..."
 install_rust
-log_step "install_build_tools" "PyPy and Rust installed"
+log_step "install_build_tools" "Rust installed."
 
 # Belt-and-suspenders: rustup can still leave the pinned toolchain partially
 # installed (the `rust-toolchain.toml`-pinned channel as a stub without its


### PR DESCRIPTION
## Summary

Fixes a flaky Docker build failure of the form:

```
#14 60.73 [install_build_tools] Installing sccache 0.14.0...
#14 60.92 error: 'cargo' is not installed for the toolchain '1.92-x86_64-unknown-linux-gnu'.
#14 ERROR: process "/bin/sh -c scripts/install_build_tools.sh" did not complete successfully: exit code: 1
```

### What we observed

- `'cargo' is not installed for the toolchain '1.9x-…'` on several runs (PR #13795's reproducer, `remove-mock-forest-storage`'s sequencer docker build, and the most recent report on `einat/proof-flow-1-state-reader-fixes`).
- rustup panicking mid-install with `thread 'CloseHandle' panicked at src/diskio/mod.rs:…: called Result::unwrap() on an Err value: RecvError` on two separate runs (one on this branch, one on main's `native-blockifier-artifacts-push`). In both cases, buildx then hung for ~50 minutes until its gRPC keepalive timed out.

Both observations share a root pattern: rustup is asked to install the `rust-toolchain.toml`-pinned channel, the install is interrupted mid-flight, and rustup is left with a **stub** entry for the channel (marked "installed" / "active") while its components (rustc, cargo, …) never finished downloading. On the next invocation, `cargo install …` fails with "cargo is not installed for the toolchain".

I don't have a single log that shows the panic directly causing a subsequent "cargo not installed" error — the buildx hang usually masks what would have surfaced — but the panic is at least one plausible mid-install failure mode, and any mid-install exit (panic, OOM, timeout, etc.) produces the same partial-install state.

### Fixes

1. **Serialize `install_pypy` and `install_rust`.** Concurrent disk I/O from a sibling installer is a known trigger for rustup's multi-threaded downloader panic ([rust-lang/rustup#2926](https://github.com/rust-lang/rustup/issues/2926)). Serial execution removes that trigger. The extra wall-time cost is ~10s per fresh base-image build (PyPy's runtime), and the step is Docker-cached most of the time.
2. **Probe the pinned toolchain after install; force-reinstall on failure.** This is the real correctness guarantee — it catches any partial-install state regardless of what caused it. `cargo --version` in the project dir (where `rust-toolchain.toml` is the active override) is a ~10ms no-op on a healthy install, so devs who already have the toolchain fully installed pay nothing. `--force` is only invoked when the check actually fails.

### Why not unconditional `rustup toolchain install --force`?

It works in Docker (layer cache absorbs the cost) but is disruptive on a developer machine: `--force` re-downloads ~200 MB even when the toolchain is perfectly fine. The conditional probe avoids that.

## Test plan

- [ ] CI (Docker builds in particular) passes on this branch
- [ ] On a dev machine with 1.92 already installed, the verification step short-circuits (no unnecessary reinstall in logs)