### PR TITLE
blockifier: add disable_casm_hash_migration on VersionedConstants

### DIFF
--- a/crates/apollo_gateway/src/stateful_transaction_validator.rs
+++ b/crates/apollo_gateway/src/stateful_transaction_validator.rs
@@ -291,7 +291,7 @@ where
             self.config.versioned_constants_overrides.clone(),
         );
         // The validation of a transaction is not affected by the casm hash migration.
-        versioned_constants.enable_casm_hash_migration = false;
+        versioned_constants.disable_casm_hash_migration();
 
         let mut block_info = self.gateway_fixed_block_state_reader.get_block_info().await?;
         block_info.block_number = block_info.block_number.unchecked_next();

--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -421,6 +421,10 @@ impl VersionedConstants {
         self.os_constants.validate_rounding_consts.validate_timestamp_rounding
     }
 
+    pub fn disable_casm_hash_migration(&mut self) {
+        self.enable_casm_hash_migration = false;
+    }
+
     #[cfg(any(feature = "testing", test))]
     pub fn create_for_account_testing() -> Self {
         let step_cost = ResourceCost::from_integer(1);

--- a/crates/blockifier_reexecution/src/state_reader/offline_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/offline_state_reader.rs
@@ -110,9 +110,8 @@ impl From<SerializableOfflineReexecutionData> for OfflineReexecutionData {
                 .api_txs_to_blockifier_txs_next_block(transactions_next_block)
                 .expect("Failed to convert starknet-api transactions to blockifier transactions.");
 
-        // Disable casm hash migration for reexecution.
         let mut versioned_constants = VersionedConstants::get(&starknet_version).unwrap().clone();
-        versioned_constants.enable_casm_hash_migration = false;
+        versioned_constants.disable_casm_hash_migration();
 
         Self {
             offline_state_reader_prev_block,

--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -344,9 +344,7 @@ impl RpcStateReader {
 
     pub fn get_versioned_constants(&self) -> ReexecutionResult<VersionedConstants> {
         let mut vc = VersionedConstants::get(&self.get_starknet_version()?)?.clone();
-        // Casm hash migration is not supported. It requires compiled class hashes, and the
-        // reexecution state readers do not have them.
-        vc.enable_casm_hash_migration = false;
+        vc.disable_casm_hash_migration();
         Ok(vc)
     }
 

--- a/crates/native_blockifier/src/py_validator.rs
+++ b/crates/native_blockifier/src/py_validator.rs
@@ -47,7 +47,7 @@ impl PyValidator {
             py_versioned_constants_overrides.into(),
         ));
         // The validation of a transaction is not affected by the casm hash migration.
-        versioned_constants.enable_casm_hash_migration = false;
+        versioned_constants.disable_casm_hash_migration();
         let block_context = BlockContext::new(
             next_block_info.try_into().expect("Failed to convert block info."),
             os_config.into_chain_info(),

--- a/crates/starknet_transaction_prover/src/running/virtual_block_executor.rs
+++ b/crates/starknet_transaction_prover/src/running/virtual_block_executor.rs
@@ -127,7 +127,7 @@ impl BaseBlockInfo {
                 .clone()
         };
         // Disable casm hash migration for virtual block execution.
-        versioned_constants.enable_casm_hash_migration = false;
+        versioned_constants.disable_casm_hash_migration();
         // Enable Sierra gas for all Cairo 1 contracts.
         // Version (0, 0, 0) is reserved for Cairo 0, so set to (0, 0, 1) for Cairo 1.
         versioned_constants.min_sierra_version_for_sierra_gas = SierraVersion::new(0, 0, 1);


### PR DESCRIPTION
Shared helper to flip enable_casm_hash_migration = false, used by reexecution, offline replay, the virtual block executor, and the gateway/native validators.