### PR TITLE
apollo_integration_tests: run in parallel

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,7 +7,7 @@ max-threads = 1
 # serialized tests (mostly integration tests)
 [[profile.default.overrides]]
 # TODO(victork): evaluate whether these are indeed required to run sequentially
-filter = '(package(apollo_integration_tests) & kind(test)) | package(apollo_network) | (package(apollo_l1_events) & kind(test))'
+filter = 'package(apollo_network) | (package(apollo_l1_events) & kind(test))'
 test-group = 'serialized'
 
 # slow test exception whitelist

--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -141,7 +141,7 @@ impl FlowTestSetup {
             shared_ports.get_next_ports(num_nodes),
         );
 
-        let anvil_base_layer = AnvilBaseLayer::new(None, None).await;
+        let anvil_base_layer = AnvilBaseLayer::new(None, Some(shared_ports.get_next_port())).await;
         let base_layer_url = anvil_base_layer.get_url().await.unwrap();
         let base_layer_config = anvil_base_layer.ethereum_base_layer.config.clone();
 


### PR DESCRIPTION
This is not for running the separate test binaries in parallel, it's for running the  `#[test]` annotated functions defined in the crate's library in parallel (things like `validation_only_node_flow_test`, `declare_tx_flow_test` etc...)  
It runs said tests about x7 faster in parallel than running them serially (~30s vs ~3.5m).