### PR TITLE
blockifier: adopt cairo-native executors via cfg-resolved NativeContractExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.9.0-rc.7"
-source = "git+https://github.com/starkware-libs/cairo_native.git?rev=6184f7a635110bb84fae58ffa082fb9b2d286ada#6184f7a635110bb84fae58ffa082fb9b2d286ada"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=931a25d608b594138d332f7395fb98b391f1564b#931a25d608b594138d332f7395fb98b391f1564b"
 dependencies = [
  "aquamarine",
  "ark-ec 0.5.0",
@@ -4992,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "cairo-starknet-syscalls"
 version = "0.9.0-rc.7"
-source = "git+https://github.com/starkware-libs/cairo_native.git?rev=6184f7a635110bb84fae58ffa082fb9b2d286ada#6184f7a635110bb84fae58ffa082fb9b2d286ada"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=931a25d608b594138d332f7395fb98b391f1564b#931a25d608b594138d332f7395fb98b391f1564b"
 dependencies = [
  "serde",
  "starknet-types-core",
@@ -12349,7 +12349,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "sierra-emu"
 version = "0.9.0-rc.7"
-source = "git+https://github.com/starkware-libs/cairo_native.git?rev=6184f7a635110bb84fae58ffa082fb9b2d286ada#6184f7a635110bb84fae58ffa082fb9b2d286ada"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=931a25d608b594138d332f7395fb98b391f1564b#931a25d608b594138d332f7395fb98b391f1564b"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-filesystem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4852,6 +4852,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-test-plugin"
+version = "2.19.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bb3a904befddc475d7f4d70a6c58f42a0ce49497d71b04b8fa5aa766953c2b"
+dependencies = [
+ "anyhow",
+ "cairo-lang-compiler",
+ "cairo-lang-debug",
+ "cairo-lang-defs",
+ "cairo-lang-filesystem",
+ "cairo-lang-lowering",
+ "cairo-lang-parser",
+ "cairo-lang-semantic",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-generator",
+ "cairo-lang-starknet",
+ "cairo-lang-starknet-classes",
+ "cairo-lang-syntax",
+ "cairo-lang-utils",
+ "indoc 2.0.7",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-traits",
+ "salsa",
+ "serde",
+ "starknet-types-core",
+]
+
+[[package]]
 name = "cairo-lang-test-utils"
 version = "2.19.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4890,8 +4919,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.9.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaaf48d22c1c9a0bb5aedf0a66f5b1a37f41dc3df5ce18480ce2abbed9a88657"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=a21f3f57128d2a91067fa31bff92bd00bdc85ba5#a21f3f57128d2a91067fa31bff92bd00bdc85ba5"
 dependencies = [
  "aquamarine",
  "ark-ec 0.5.0",
@@ -4909,6 +4937,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
+ "cairo-starknet-syscalls",
  "educe 0.5.11",
  "itertools 0.14.0",
  "keccak 0.1.5",
@@ -4926,6 +4955,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sierra-emu",
  "starknet-curve 0.6.0",
  "starknet-types-core",
  "tempfile",
@@ -4958,6 +4988,15 @@ dependencies = [
  "thiserror 1.0.69",
  "thiserror-no-std",
  "tracing",
+]
+
+[[package]]
+name = "cairo-starknet-syscalls"
+version = "0.9.0-rc.7"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=a21f3f57128d2a91067fa31bff92bd00bdc85ba5#a21f3f57128d2a91067fa31bff92bd00bdc85ba5"
+dependencies = [
+ "serde",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -6219,6 +6258,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -8186,6 +8226,7 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2 0.10.9",
+ "signature",
 ]
 
 [[package]]
@@ -9958,6 +9999,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10455,6 +10508,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.110",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -12284,6 +12346,47 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sierra-emu"
+version = "0.9.0-rc.7"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=a21f3f57128d2a91067fa31bff92bd00bdc85ba5#a21f3f57128d2a91067fa31bff92bd00bdc85ba5"
+dependencies = [
+ "cairo-lang-compiler",
+ "cairo-lang-filesystem",
+ "cairo-lang-lowering",
+ "cairo-lang-runner",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-ap-change",
+ "cairo-lang-sierra-gas",
+ "cairo-lang-sierra-to-casm",
+ "cairo-lang-sierra-type-size",
+ "cairo-lang-starknet-classes",
+ "cairo-lang-test-plugin",
+ "cairo-lang-utils",
+ "cairo-starknet-syscalls",
+ "clap",
+ "generic-array",
+ "k256",
+ "keccak 0.1.5",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "p256",
+ "rand 0.9.2",
+ "rayon",
+ "sec1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "starknet-crypto 0.8.1",
+ "starknet-curve 0.6.0",
+ "starknet-types-core",
+ "thiserror 2.0.17",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4853,9 +4853,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.19.0-rc.0"
+version = "2.19.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bb3a904befddc475d7f4d70a6c58f42a0ce49497d71b04b8fa5aa766953c2b"
+checksum = "eaceca861261038c5162af5da78152dea4cc59a1197c32c742bee98e8d41b574"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.9.0-rc.7"
-source = "git+https://github.com/starkware-libs/cairo_native.git?rev=a21f3f57128d2a91067fa31bff92bd00bdc85ba5#a21f3f57128d2a91067fa31bff92bd00bdc85ba5"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=6184f7a635110bb84fae58ffa082fb9b2d286ada#6184f7a635110bb84fae58ffa082fb9b2d286ada"
 dependencies = [
  "aquamarine",
  "ark-ec 0.5.0",
@@ -4951,7 +4951,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.9.2",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4993,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "cairo-starknet-syscalls"
 version = "0.9.0-rc.7"
-source = "git+https://github.com/starkware-libs/cairo_native.git?rev=a21f3f57128d2a91067fa31bff92bd00bdc85ba5#a21f3f57128d2a91067fa31bff92bd00bdc85ba5"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=6184f7a635110bb84fae58ffa082fb9b2d286ada#6184f7a635110bb84fae58ffa082fb9b2d286ada"
 dependencies = [
  "serde",
  "starknet-types-core",
@@ -12350,7 +12349,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "sierra-emu"
 version = "0.9.0-rc.7"
-source = "git+https://github.com/starkware-libs/cairo_native.git?rev=a21f3f57128d2a91067fa31bff92bd00bdc85ba5#a21f3f57128d2a91067fa31bff92bd00bdc85ba5"
+source = "git+https://github.com/starkware-libs/cairo_native.git?rev=6184f7a635110bb84fae58ffa082fb9b2d286ada#6184f7a635110bb84fae58ffa082fb9b2d286ada"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-filesystem",
@@ -12373,7 +12372,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand 0.9.2",
  "rayon",
  "sec1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ cairo-lang-utils = "2.19.0-rc.3"
 # (starkware-libs/cairo_native#1610 → #1611 → #1612 → #1613) containing
 # `ContractExecutor`, `EmuContractInfo`, `AotWithProgram`, and `run_with_profile`.
 # Switch back to a crates.io version once those land in a published cairo-native release.
-cairo-native = { git = "https://github.com/starkware-libs/cairo_native.git", rev = "7107710f05801b63f3f40d863dd8ed38680cc6f6" }
+cairo-native = { git = "https://github.com/starkware-libs/cairo_native.git", rev = "7107710f05801b63f3f40d863dd8ed38680cc6f6", version = "0.9.0-rc.7" }
 cairo-program-runner-lib = "1.1.0"
 cairo-vm = "3.2.0"
 camelpaste = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,11 +260,11 @@ cairo-lang-sierra = "2.19.0-rc.3"
 cairo-lang-sierra-to-casm = "2.19.0-rc.3"
 cairo-lang-starknet-classes = "2.19.0-rc.3"
 cairo-lang-utils = "2.19.0-rc.3"
-# TEMP: git dep pinned to the tip of the unreleased PR stack
-# (starkware-libs/cairo_native#1610 → #1611 → #1612 → #1613) containing
-# `EmuContractExecutor`, `AotWithProgram`, and `run_with_libfunc_profile`.
-# Switch back to a crates.io version once those land in a published cairo-native release.
-cairo-native = { git = "https://github.com/starkware-libs/cairo_native.git", rev = "6184f7a635110bb84fae58ffa082fb9b2d286ada", version = "0.9.0-rc.7" }
+# TEMP: git dep pinned to cairo_native's main, past the now-merged #1610 → #1611 →
+# #1612 → #1613 stack that added `EmuContractExecutor`, `AotWithProgram`, and
+# `run_with_libfunc_profile`. Switch back to a crates.io version once a release
+# containing them is published (still 0.9.0-rc.7 as of this pin).
+cairo-native = { git = "https://github.com/starkware-libs/cairo_native.git", rev = "931a25d608b594138d332f7395fb98b391f1564b", version = "0.9.0-rc.7" }
 cairo-program-runner-lib = "1.1.0"
 cairo-vm = "3.2.0"
 camelpaste = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,7 +260,11 @@ cairo-lang-sierra = "2.19.0-rc.3"
 cairo-lang-sierra-to-casm = "2.19.0-rc.3"
 cairo-lang-starknet-classes = "2.19.0-rc.3"
 cairo-lang-utils = "2.19.0-rc.3"
-cairo-native = "0.9.0-rc.7"
+# TEMP: git dep pinned to the tip of the unreleased PR stack
+# (starkware-libs/cairo_native#1610 → #1611 → #1612 → #1613) containing
+# `ContractExecutor`, `EmuContractInfo`, `AotWithProgram`, and `run_with_profile`.
+# Switch back to a crates.io version once those land in a published cairo-native release.
+cairo-native = { git = "https://github.com/starkware-libs/cairo_native.git", rev = "7107710f05801b63f3f40d863dd8ed38680cc6f6" }
 cairo-program-runner-lib = "1.1.0"
 cairo-vm = "3.2.0"
 camelpaste = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,9 +262,9 @@ cairo-lang-starknet-classes = "2.19.0-rc.3"
 cairo-lang-utils = "2.19.0-rc.3"
 # TEMP: git dep pinned to the tip of the unreleased PR stack
 # (starkware-libs/cairo_native#1610 → #1611 → #1612 → #1613) containing
-# `ContractExecutor`, `EmuContractInfo`, `AotWithProgram`, and `run_with_profile`.
+# `EmuContractExecutor`, `AotWithProgram`, and `run_with_libfunc_profile`.
 # Switch back to a crates.io version once those land in a published cairo-native release.
-cairo-native = { git = "https://github.com/starkware-libs/cairo_native.git", rev = "7107710f05801b63f3f40d863dd8ed38680cc6f6", version = "0.9.0-rc.7" }
+cairo-native = { git = "https://github.com/starkware-libs/cairo_native.git", rev = "6184f7a635110bb84fae58ffa082fb9b2d286ada", version = "0.9.0-rc.7" }
 cairo-program-runner-lib = "1.1.0"
 cairo-vm = "3.2.0"
 camelpaste = "0.1.0"

--- a/crates/apollo_compile_to_native/Cargo.toml
+++ b/crates/apollo_compile_to_native/Cargo.toml
@@ -13,6 +13,13 @@ workspace = true
 # Enables `SierraToNativeCompiler::compile_with_program`, which returns the
 # AOT executor paired with the Sierra program required by cairo-native's
 # libfunc profiler.
+#
+# This only enables profiling in the linked cairo-native library. The profiler
+# symbol that `run_with_libfunc_profile` looks up is emitted by the compiler, so
+# the `starknet-native-compile` binary must itself be built with its
+# `with-libfunc-profiling` feature; a default-built binary yields `.so`s with no
+# profiler symbol and every profiled call then fails. Point
+# `SierraCompilationConfig.compiler_binary_path` at an instrumented binary.
 with-libfunc-profiling = ["cairo-native/with-libfunc-profiling"]
 
 [dependencies]

--- a/crates/apollo_compile_to_native/Cargo.toml
+++ b/crates/apollo_compile_to_native/Cargo.toml
@@ -9,6 +9,12 @@ description = "A utility crate for compiling Sierra code into Cairo native."
 [lints]
 workspace = true
 
+[features]
+# Enables `SierraToNativeCompiler::compile_with_program`, which returns the
+# AOT executor paired with the Sierra program required by cairo-native's
+# libfunc profiler.
+with-libfunc-profiling = ["cairo-native/with-libfunc-profiling"]
+
 [dependencies]
 apollo_compilation_utils.workspace = true
 apollo_compile_to_native_types.workspace = true

--- a/crates/apollo_compile_to_native/src/compiler.rs
+++ b/crates/apollo_compile_to_native/src/compiler.rs
@@ -1,4 +1,6 @@
 use std::path::PathBuf;
+#[cfg(feature = "with-libfunc-profiling")]
+use std::sync::Arc;
 
 use apollo_compilation_utils::build_utils::verify_compiler_binary;
 use apollo_compilation_utils::compiler_utils::compile_with_args;
@@ -8,6 +10,8 @@ use apollo_compilation_utils::resource_limits::ResourceLimits;
 use apollo_compile_to_native_types::SierraCompilationConfig;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use cairo_native::executor::AotContractExecutor;
+#[cfg(feature = "with-libfunc-profiling")]
+use cairo_native::executor::AotWithProgram;
 use tempfile::NamedTempFile;
 
 use crate::constants::{CAIRO_NATIVE_BINARY_NAME, REQUIRED_CAIRO_NATIVE_VERSION};
@@ -58,5 +62,26 @@ impl SierraToNativeCompiler {
         Ok(AotContractExecutor::from_path(output_file.path())
             .map_err(|e| CompilationUtilError::CompilationError(e.to_string()))?
             .unwrap())
+    }
+
+    /// Like [`Self::compile`], but also returns the Sierra program so cairo-native's
+    /// libfunc profiler can resolve runtime libfunc IDs back to declarations. The
+    /// program is extracted from `contract_class` before compilation so the two are
+    /// guaranteed to correspond.
+    #[cfg(feature = "with-libfunc-profiling")]
+    pub fn compile_with_program(
+        &self,
+        contract_class: ContractClass,
+    ) -> Result<AotWithProgram, CompilationUtilError> {
+        let program = contract_class
+            .extract_sierra_program(false)
+            .map(|extracted| Arc::new(extracted.program))
+            .map_err(|err| {
+                CompilationUtilError::UnexpectedError(format!(
+                    "Failed to extract Sierra program for profiling: {err}"
+                ))
+            })?;
+        let executor = self.compile(contract_class)?;
+        Ok(AotWithProgram { executor, program })
     }
 }

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -23,8 +23,9 @@ node_api = []
 only-native = ["cairo_native"]
 os_input = []
 reexecution = ["transaction_serde"]
-# Enables the sierra-emu execution path of `cairo_native::ContractExecutor`. Pulls in
-# cairo-native's `sierra-emu` feature which compiles `SierraEmuSyscallBridge`.
+# Backs native contract classes with the sierra-emu interpreter instead of the AOT
+# executor (testing / benchmarking builds only). Takes precedence over
+# `with-libfunc-profiling` in the `NativeContractExecutor` resolution.
 sierra-emu = ["cairo-native/sierra-emu", "cairo_native"]
 testing = [
   "blockifier_test_utils",
@@ -37,7 +38,7 @@ testing = [
 tracing = []
 transaction_serde = []
 # Enables libfunc-level profiling for native execution. Pulls in cairo-native's
-# `with-libfunc-profiling` so `ContractExecutor::run_with_profile` is available,
+# `with-libfunc-profiling` so `AotWithProgram::run_with_profile` is available,
 # and apollo_compile_to_native's matching feature so `SierraToNativeCompiler` can
 # pair the compiled executor with its Sierra program in one call.
 with-libfunc-profiling = [

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -23,6 +23,9 @@ node_api = []
 only-native = ["cairo_native"]
 os_input = []
 reexecution = ["transaction_serde"]
+# Enables the sierra-emu execution path of `cairo_native::ContractExecutor`. Pulls in
+# cairo-native's `sierra-emu` feature which compiles `SierraEmuSyscallBridge`.
+sierra-emu = ["cairo-native/sierra-emu", "cairo_native"]
 testing = [
   "blockifier_test_utils",
   "expect-test",
@@ -33,6 +36,15 @@ testing = [
 ]
 tracing = []
 transaction_serde = []
+# Enables libfunc-level profiling for native execution. Pulls in cairo-native's
+# `with-libfunc-profiling` so `ContractExecutor::run_with_profile` is available,
+# and apollo_compile_to_native's matching feature so `SierraToNativeCompiler` can
+# pair the compiled executor with its Sierra program in one call.
+with-libfunc-profiling = [
+  "apollo_compile_to_native/with-libfunc-profiling",
+  "cairo-native/with-libfunc-profiling",
+  "cairo_native",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/blockifier/src/execution/native.rs
+++ b/crates/blockifier/src/execution/native.rs
@@ -1,5 +1,8 @@
 pub mod contract_class;
 pub mod entry_point_execution;
+#[cfg(feature = "with-libfunc-profiling")]
+pub mod profiling;
+mod run_dispatch;
 pub mod syscall_handler;
 pub mod utils;
 

--- a/crates/blockifier/src/execution/native/contract_class.rs
+++ b/crates/blockifier/src/execution/native/contract_class.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 #[cfg(feature = "with-libfunc-profiling")]
 use cairo_native::executor::AotWithProgram;
+#[cfg(feature = "sierra-emu")]
+use cairo_native::executor::EmuContractInfo;
 use cairo_native::executor::{AotContractExecutor, ContractExecutor};
 use starknet_api::contract_class::compiled_class_hash::HashableCompiledClass;
 use starknet_api::core::EntryPointSelector;
@@ -33,6 +35,17 @@ impl NativeCompiledClassV1 {
     /// sierra_contract_class.
     pub fn new(executor: AotContractExecutor, casm: CompiledClassV1) -> NativeCompiledClassV1 {
         let contract = NativeCompiledClassV1Inner::new(executor.into(), casm);
+
+        Self(Arc::new(contract))
+    }
+
+    /// Initialize a compiled class backed by the sierra-emu interpreter instead of the AOT
+    /// executor. Intended for the out-of-tree benchmarking / replay feature branch — those
+    /// tools are not expected to merge into this repo and will consume this constructor
+    /// from a fork. `pub` so a fork can reach it without patching this file.
+    #[cfg(feature = "sierra-emu")]
+    pub fn new_from_emu(info: EmuContractInfo, casm: CompiledClassV1) -> NativeCompiledClassV1 {
+        let contract = NativeCompiledClassV1Inner::new(info.into(), casm);
 
         Self(Arc::new(contract))
     }

--- a/crates/blockifier/src/execution/native/contract_class.rs
+++ b/crates/blockifier/src/execution/native/contract_class.rs
@@ -4,8 +4,6 @@ use std::sync::Arc;
 
 #[cfg(feature = "with-libfunc-profiling")]
 use cairo_native::executor::AotWithProgram;
-#[cfg(feature = "sierra-emu")]
-use cairo_native::executor::EmuContractInfo;
 use cairo_native::executor::{AotContractExecutor, ContractExecutor};
 use starknet_api::contract_class::compiled_class_hash::HashableCompiledClass;
 use starknet_api::core::EntryPointSelector;
@@ -35,16 +33,6 @@ impl NativeCompiledClassV1 {
     /// sierra_contract_class.
     pub fn new(executor: AotContractExecutor, casm: CompiledClassV1) -> NativeCompiledClassV1 {
         let contract = NativeCompiledClassV1Inner::new(executor.into(), casm);
-
-        Self(Arc::new(contract))
-    }
-
-    /// Initialize a compiled class backed by the sierra-emu interpreter instead of the AOT
-    /// executor. Used by benchmarking / replay tooling that wants to execute through the emu
-    /// VM while reusing the rest of the blockifier pipeline.
-    #[cfg(feature = "sierra-emu")]
-    pub fn new_from_emu(info: EmuContractInfo, casm: CompiledClassV1) -> NativeCompiledClassV1 {
-        let contract = NativeCompiledClassV1Inner::new(info.into(), casm);
 
         Self(Arc::new(contract))
     }

--- a/crates/blockifier/src/execution/native/contract_class.rs
+++ b/crates/blockifier/src/execution/native/contract_class.rs
@@ -2,7 +2,11 @@ use std::borrow::Cow;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use cairo_native::executor::AotContractExecutor;
+#[cfg(feature = "with-libfunc-profiling")]
+use cairo_native::executor::AotWithProgram;
+#[cfg(feature = "sierra-emu")]
+use cairo_native::executor::EmuContractInfo;
+use cairo_native::executor::{AotContractExecutor, ContractExecutor};
 use starknet_api::contract_class::compiled_class_hash::HashableCompiledClass;
 use starknet_api::core::EntryPointSelector;
 use starknet_types_core::felt::Felt;
@@ -30,7 +34,28 @@ impl NativeCompiledClassV1 {
     /// executor must be derived from sierra_program which in turn must be derived from
     /// sierra_contract_class.
     pub fn new(executor: AotContractExecutor, casm: CompiledClassV1) -> NativeCompiledClassV1 {
-        let contract = NativeCompiledClassV1Inner::new(executor, casm);
+        let contract = NativeCompiledClassV1Inner::new(executor.into(), casm);
+
+        Self(Arc::new(contract))
+    }
+
+    /// Initialize a compiled class backed by the sierra-emu interpreter instead of the AOT
+    /// executor. Used by benchmarking / replay tooling that wants to execute through the emu
+    /// VM while reusing the rest of the blockifier pipeline.
+    #[cfg(feature = "sierra-emu")]
+    pub fn new_from_emu(info: EmuContractInfo, casm: CompiledClassV1) -> NativeCompiledClassV1 {
+        let contract = NativeCompiledClassV1Inner::new(info.into(), casm);
+
+        Self(Arc::new(contract))
+    }
+
+    /// Like [`Self::new`], but also stores the Sierra `Program` (via the cairo-native
+    /// [`AotWithProgram`] pairing) so [`cairo_native::ContractExecutor::run_with_profile`]
+    /// can resolve libfunc samples. Only callable when the `with-libfunc-profiling`
+    /// feature is enabled.
+    #[cfg(feature = "with-libfunc-profiling")]
+    pub fn new_with_program(info: AotWithProgram, casm: CompiledClassV1) -> NativeCompiledClassV1 {
+        let contract = NativeCompiledClassV1Inner::new(info.into(), casm);
 
         Self(Arc::new(contract))
     }
@@ -71,12 +96,12 @@ impl HashableCompiledClass<EntryPointV1, NestedFeltCounts> for NativeCompiledCla
 
 #[derive(Debug)]
 pub struct NativeCompiledClassV1Inner {
-    pub executor: AotContractExecutor,
+    pub executor: ContractExecutor,
     casm: CompiledClassV1,
 }
 
 impl NativeCompiledClassV1Inner {
-    fn new(executor: AotContractExecutor, casm: CompiledClassV1) -> Self {
+    fn new(executor: ContractExecutor, casm: CompiledClassV1) -> Self {
         NativeCompiledClassV1Inner { executor, casm }
     }
 }

--- a/crates/blockifier/src/execution/native/contract_class.rs
+++ b/crates/blockifier/src/execution/native/contract_class.rs
@@ -2,11 +2,12 @@ use std::borrow::Cow;
 use std::ops::Deref;
 use std::sync::Arc;
 
-#[cfg(feature = "with-libfunc-profiling")]
+#[cfg(not(any(feature = "sierra-emu", feature = "with-libfunc-profiling")))]
+use cairo_native::executor::AotContractExecutor;
+#[cfg(all(feature = "with-libfunc-profiling", not(feature = "sierra-emu")))]
 use cairo_native::executor::AotWithProgram;
 #[cfg(feature = "sierra-emu")]
-use cairo_native::executor::EmuContractInfo;
-use cairo_native::executor::{AotContractExecutor, ContractExecutor};
+use cairo_native::executor::EmuContractExecutor;
 use starknet_api::contract_class::compiled_class_hash::HashableCompiledClass;
 use starknet_api::core::EntryPointSelector;
 use starknet_types_core::felt::Felt;
@@ -14,6 +15,20 @@ use starknet_types_core::felt::Felt;
 use crate::execution::contract_class::{CompiledClassV1, EntryPointV1, NestedFeltCounts};
 use crate::execution::entry_point::EntryPointTypeAndSelector;
 use crate::execution::errors::PreExecutionError;
+
+/// The executor backing native contract classes, resolved per build. All three types
+/// expose the same `run` shape, so call sites are identical across builds.
+///
+/// Production builds use cairo-native's AOT executor. The `sierra-emu` feature
+/// (testing / benchmarking) swaps in the sierra-emu interpreter and takes precedence
+/// over `with-libfunc-profiling`, which pairs the AOT executor with its Sierra program
+/// so libfunc profiling samples can be resolved.
+#[cfg(feature = "sierra-emu")]
+pub type NativeContractExecutor = EmuContractExecutor;
+#[cfg(all(feature = "with-libfunc-profiling", not(feature = "sierra-emu")))]
+pub type NativeContractExecutor = AotWithProgram;
+#[cfg(not(any(feature = "sierra-emu", feature = "with-libfunc-profiling")))]
+pub type NativeContractExecutor = AotContractExecutor;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NativeCompiledClassV1(pub Arc<NativeCompiledClassV1Inner>);
 impl Deref for NativeCompiledClassV1 {
@@ -32,31 +47,10 @@ impl NativeCompiledClassV1 {
     /// Initialize a compiled class for native.
     ///
     /// executor must be derived from sierra_program which in turn must be derived from
-    /// sierra_contract_class.
-    pub fn new(executor: AotContractExecutor, casm: CompiledClassV1) -> NativeCompiledClassV1 {
-        let contract = NativeCompiledClassV1Inner::new(executor.into(), casm);
-
-        Self(Arc::new(contract))
-    }
-
-    /// Initialize a compiled class backed by the sierra-emu interpreter instead of the AOT
-    /// executor. Intended for the out-of-tree benchmarking / replay feature branch — those
-    /// tools are not expected to merge into this repo and will consume this constructor
-    /// from a fork. `pub` so a fork can reach it without patching this file.
-    #[cfg(feature = "sierra-emu")]
-    pub fn new_from_emu(info: EmuContractInfo, casm: CompiledClassV1) -> NativeCompiledClassV1 {
-        let contract = NativeCompiledClassV1Inner::new(info.into(), casm);
-
-        Self(Arc::new(contract))
-    }
-
-    /// Like [`Self::new`], but also stores the Sierra `Program` (via the cairo-native
-    /// [`AotWithProgram`] pairing) so [`cairo_native::ContractExecutor::run_with_profile`]
-    /// can resolve libfunc samples. Only callable when the `with-libfunc-profiling`
-    /// feature is enabled.
-    #[cfg(feature = "with-libfunc-profiling")]
-    pub fn new_with_program(info: AotWithProgram, casm: CompiledClassV1) -> NativeCompiledClassV1 {
-        let contract = NativeCompiledClassV1Inner::new(info.into(), casm);
+    /// sierra_contract_class. The executor's type -- and therefore this constructor's
+    /// signature -- follows the build's [`NativeContractExecutor`] resolution.
+    pub fn new(executor: NativeContractExecutor, casm: CompiledClassV1) -> NativeCompiledClassV1 {
+        let contract = NativeCompiledClassV1Inner::new(executor, casm);
 
         Self(Arc::new(contract))
     }
@@ -97,12 +91,12 @@ impl HashableCompiledClass<EntryPointV1, NestedFeltCounts> for NativeCompiledCla
 
 #[derive(Debug)]
 pub struct NativeCompiledClassV1Inner {
-    pub executor: ContractExecutor,
+    pub executor: NativeContractExecutor,
     casm: CompiledClassV1,
 }
 
 impl NativeCompiledClassV1Inner {
-    fn new(executor: ContractExecutor, casm: CompiledClassV1) -> Self {
+    fn new(executor: NativeContractExecutor, casm: CompiledClassV1) -> Self {
         NativeCompiledClassV1Inner { executor, casm }
     }
 }

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -14,6 +14,7 @@ use crate::execution::contract_class::TrackedResource;
 use crate::execution::entry_point::{EntryPointExecutionContext, ExecutableCallEntryPoint};
 use crate::execution::errors::{EntryPointExecutionError, PostExecutionError, PreExecutionError};
 use crate::execution::native::contract_class::NativeCompiledClassV1;
+use crate::execution::native::run_dispatch::run_native_executor;
 use crate::execution::native::syscall_handler::NativeSyscallHandler;
 use crate::state::state_api::State;
 use crate::transaction::objects::ExecutionResourcesTraits;
@@ -57,11 +58,12 @@ pub fn execute_entry_point_call(
         .checked_sub(initial_budget)
         .ok_or(PreExecutionError::InsufficientEntryPointGas)?;
 
-    let execution_result = compiled_class.executor.run(
+    let execution_result = run_native_executor(
+        &compiled_class.executor,
         entry_point.selector.0,
         &syscall_handler.base.call.calldata.0.clone(),
         call_initial_gas,
-        Some(builtin_costs),
+        builtin_costs,
         &mut syscall_handler,
     );
 

--- a/crates/blockifier/src/execution/native/profiling.rs
+++ b/crates/blockifier/src/execution/native/profiling.rs
@@ -1,0 +1,68 @@
+//! Blockifier-side storage for libfunc profiles collected by
+//! [`cairo_native::ContractExecutor::run_with_profile`].
+//!
+//! cairo-native owns the profiling primitive; this module only provides the keying
+//! (transaction hash / block number / class hash + selector) that's not visible from
+//! cairo-native's layer.
+//!
+//! Intended for single-tenant benchmarking. The map grows without bound — drain it
+//! externally between runs.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use cairo_native::executor::Program;
+use cairo_native::metadata::profiler::Profile;
+use starknet_types_core::felt::Felt;
+
+use crate::execution::native::syscall_handler::NativeSyscallHandler;
+
+pub struct EntrypointProfile {
+    pub class_hash: Felt,
+    pub selector: Felt,
+    pub profile: Profile,
+    pub program: Arc<Program>,
+}
+
+pub struct TransactionProfile {
+    pub block_number: u64,
+    pub tx_hash: String,
+    pub entrypoint_profiles: Vec<EntrypointProfile>,
+}
+
+type ProfilesByBlockTx = HashMap<String, TransactionProfile>;
+
+pub static LIBFUNC_PROFILES_MAP: LazyLock<Mutex<ProfilesByBlockTx>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Builds an `FnOnce(Profile, Arc<Program>)` that, when invoked, records the captured
+/// profile in `LIBFUNC_PROFILES_MAP` keyed by the syscall handler's current transaction
+/// hash. The program is supplied by cairo-native's
+/// [`cairo_native::ContractExecutor::run_with_profile`] callback alongside the profile.
+///
+/// All keying data is extracted up front so the closure doesn't re-borrow
+/// `syscall_handler` — required because the closure outlives the call to
+/// `ContractExecutor::run_with_profile`, which itself holds a `&mut` to the handler.
+pub fn record_profile_for(
+    syscall_handler: &NativeSyscallHandler<'_>,
+    selector: Felt,
+) -> impl FnOnce(Profile, Arc<Program>) + 'static {
+    let class_hash = *syscall_handler.base.call.class_hash;
+    let tx_hash =
+        syscall_handler.base.context.tx_context.tx_info.transaction_hash().to_hex_string();
+    let block_number =
+        syscall_handler.base.context.tx_context.block_context.block_info.block_number.0;
+
+    move |profile, program| {
+        let entry = EntrypointProfile { class_hash, selector, profile, program };
+        let mut map = LIBFUNC_PROFILES_MAP.lock().unwrap();
+        map.entry(tx_hash.clone())
+            .or_insert_with(|| TransactionProfile {
+                block_number,
+                tx_hash: tx_hash.clone(),
+                entrypoint_profiles: Vec::new(),
+            })
+            .entrypoint_profiles
+            .push(entry);
+    }
+}

--- a/crates/blockifier/src/execution/native/profiling.rs
+++ b/crates/blockifier/src/execution/native/profiling.rs
@@ -1,5 +1,5 @@
 //! Blockifier-side storage for libfunc profiles collected by
-//! [`cairo_native::ContractExecutor::run_with_profile`].
+//! `cairo_native::executor::AotWithProgram::run_with_profile`.
 //!
 //! cairo-native owns the profiling primitive; this module only provides the keying
 //! (transaction hash / block number / class hash + selector) that's not visible from
@@ -9,9 +9,9 @@
 //! externally between runs.
 
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex};
 
-use cairo_native::executor::Program;
+use cairo_native::executor::ArcProgram;
 use cairo_native::metadata::profiler::Profile;
 use starknet_types_core::felt::Felt;
 
@@ -21,7 +21,7 @@ pub struct EntrypointProfile {
     pub class_hash: Felt,
     pub selector: Felt,
     pub profile: Profile,
-    pub program: Arc<Program>,
+    pub program: ArcProgram,
 }
 
 pub struct TransactionProfile {
@@ -35,18 +35,18 @@ type ProfilesByBlockTx = HashMap<String, TransactionProfile>;
 pub static LIBFUNC_PROFILES_MAP: LazyLock<Mutex<ProfilesByBlockTx>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Builds an `FnOnce(Profile, Arc<Program>)` that, when invoked, records the captured
+/// Builds an `FnOnce(Profile, ArcProgram)` that, when invoked, records the captured
 /// profile in `LIBFUNC_PROFILES_MAP` keyed by the syscall handler's current transaction
 /// hash. The program is supplied by cairo-native's
-/// [`cairo_native::ContractExecutor::run_with_profile`] callback alongside the profile.
+/// `AotWithProgram::run_with_profile` callback alongside the profile.
 ///
 /// All keying data is extracted up front so the closure doesn't re-borrow
 /// `syscall_handler` — required because the closure outlives the call to
-/// `ContractExecutor::run_with_profile`, which itself holds a `&mut` to the handler.
+/// `AotWithProgram::run_with_profile`, which itself holds a `&mut` to the handler.
 pub fn record_profile_for(
     syscall_handler: &NativeSyscallHandler<'_>,
     selector: Felt,
-) -> impl FnOnce(Profile, Arc<Program>) + 'static {
+) -> impl FnOnce(Profile, ArcProgram) + 'static {
     let class_hash = *syscall_handler.base.call.class_hash;
     let tx_hash =
         syscall_handler.base.context.tx_context.tx_info.transaction_hash().to_hex_string();

--- a/crates/blockifier/src/execution/native/run_dispatch.rs
+++ b/crates/blockifier/src/execution/native/run_dispatch.rs
@@ -1,0 +1,45 @@
+//! Dispatches a [`ContractExecutor`] entry-point call, transparently routing through
+//! [`ContractExecutor::run_with_profile`] when libfunc profiling is enabled.
+//!
+//! Keeps the libfunc-profiling cfg-noise out of the main entry-point execution path.
+
+use cairo_native::error::Result;
+use cairo_native::execution_result::ContractExecutionResult;
+use cairo_native::executor::ContractExecutor;
+use cairo_native::utils::BuiltinCosts;
+use starknet_types_core::felt::Felt;
+
+use crate::execution::native::syscall_handler::NativeSyscallHandler;
+
+/// Runs an entry point on `executor`. Always available.
+///
+/// When `with-libfunc-profiling` is enabled the call is routed through
+/// [`ContractExecutor::run_with_profile`]; for the `AotWithProgram` variant cairo-native
+/// invokes our callback with the captured profile and the program it was built from, which
+/// we record into [`crate::execution::native::profiling::LIBFUNC_PROFILES_MAP`] keyed by
+/// the current transaction hash. For other variants cairo-native falls through to
+/// [`ContractExecutor::run`] and the callback is never invoked.
+pub fn run_native_executor(
+    executor: &ContractExecutor,
+    selector: Felt,
+    calldata: &[Felt],
+    call_initial_gas: u64,
+    builtin_costs: BuiltinCosts,
+    syscall_handler: &mut NativeSyscallHandler<'_>,
+) -> Result<ContractExecutionResult> {
+    #[cfg(feature = "with-libfunc-profiling")]
+    {
+        let on_profile =
+            crate::execution::native::profiling::record_profile_for(syscall_handler, selector);
+        executor.run_with_profile(
+            selector,
+            calldata,
+            call_initial_gas,
+            Some(builtin_costs),
+            syscall_handler,
+            on_profile,
+        )
+    }
+    #[cfg(not(feature = "with-libfunc-profiling"))]
+    executor.run(selector, calldata, call_initial_gas, Some(builtin_costs), syscall_handler)
+}

--- a/crates/blockifier/src/execution/native/run_dispatch.rs
+++ b/crates/blockifier/src/execution/native/run_dispatch.rs
@@ -1,33 +1,34 @@
-//! Dispatches a [`ContractExecutor`] entry-point call, transparently routing through
-//! [`ContractExecutor::run_with_profile`] when libfunc profiling is enabled.
+//! Dispatches a [`NativeContractExecutor`] entry-point call, transparently routing
+//! through `AotWithProgram::run_with_profile` when libfunc profiling is enabled.
 //!
 //! Keeps the libfunc-profiling cfg-noise out of the main entry-point execution path.
 
 use cairo_native::error::Result;
 use cairo_native::execution_result::ContractExecutionResult;
-use cairo_native::executor::ContractExecutor;
 use cairo_native::utils::BuiltinCosts;
 use starknet_types_core::felt::Felt;
 
+use crate::execution::native::contract_class::NativeContractExecutor;
 use crate::execution::native::syscall_handler::NativeSyscallHandler;
 
 /// Runs an entry point on `executor`. Always available.
 ///
-/// When `with-libfunc-profiling` is enabled the call is routed through
-/// [`ContractExecutor::run_with_profile`]; for the `AotWithProgram` variant cairo-native
-/// invokes our callback with the captured profile and the program it was built from, which
-/// we record into [`crate::execution::native::profiling::LIBFUNC_PROFILES_MAP`] keyed by
-/// the current transaction hash. For other variants cairo-native falls through to
-/// [`ContractExecutor::run`] and the callback is never invoked.
+/// All [`NativeContractExecutor`] candidates expose the same `run` shape, so the call
+/// site is identical across builds. When `with-libfunc-profiling` is enabled (and
+/// `sierra-emu` is not -- the interpreter takes precedence and collects no profiles),
+/// the call is routed through `AotWithProgram::run_with_profile`, which invokes our
+/// callback with the captured profile and the program the executor was built from; we
+/// record it into [`crate::execution::native::profiling::LIBFUNC_PROFILES_MAP`] keyed
+/// by the current transaction hash.
 pub fn run_native_executor(
-    executor: &ContractExecutor,
+    executor: &NativeContractExecutor,
     selector: Felt,
     calldata: &[Felt],
     call_initial_gas: u64,
     builtin_costs: BuiltinCosts,
     syscall_handler: &mut NativeSyscallHandler<'_>,
 ) -> Result<ContractExecutionResult> {
-    #[cfg(feature = "with-libfunc-profiling")]
+    #[cfg(all(feature = "with-libfunc-profiling", not(feature = "sierra-emu")))]
     {
         let on_profile =
             crate::execution::native::profiling::record_profile_for(syscall_handler, selector);
@@ -40,6 +41,6 @@ pub fn run_native_executor(
             on_profile,
         )
     }
-    #[cfg(not(feature = "with-libfunc-profiling"))]
+    #[cfg(any(not(feature = "with-libfunc-profiling"), feature = "sierra-emu"))]
     executor.run(selector, calldata, call_initial_gas, Some(builtin_costs), syscall_handler)
 }

--- a/crates/blockifier/src/state/native_class_manager.rs
+++ b/crates/blockifier/src/state/native_class_manager.rs
@@ -286,13 +286,9 @@ fn process_compilation_request(
 
     let start = Instant::now();
     #[cfg(feature = "with-libfunc-profiling")]
-    let compilation_result = compiler
-        .compile_with_program(sierra_for_compilation)
-        .map(|info| NativeCompiledClassV1::new_with_program(info, casm.clone()));
+    let compilation_result = compiler.compile_with_program(sierra_for_compilation);
     #[cfg(not(feature = "with-libfunc-profiling"))]
-    let compilation_result = compiler
-        .compile(sierra_for_compilation)
-        .map(|executor| NativeCompiledClassV1::new(executor, casm.clone()));
+    let compilation_result = compiler.compile(sierra_for_compilation);
     let duration = start.elapsed();
     log::info!(
         "Compiling to native contract with class hash: {:#066x}. Duration: {:.3} seconds",
@@ -300,7 +296,11 @@ fn process_compilation_request(
         duration.as_secs_f32()
     );
     match compilation_result {
-        Ok(native_compiled_class) => {
+        Ok(compiled) => {
+            #[cfg(feature = "with-libfunc-profiling")]
+            let native_compiled_class = NativeCompiledClassV1::new_with_program(compiled, casm);
+            #[cfg(not(feature = "with-libfunc-profiling"))]
+            let native_compiled_class = NativeCompiledClassV1::new(compiled, casm);
             class_cache.set(
                 class_hash,
                 CompiledClasses::V1Native(CachedCairoNative::Compiled(native_compiled_class)),

--- a/crates/blockifier/src/state/native_class_manager.rs
+++ b/crates/blockifier/src/state/native_class_manager.rs
@@ -283,8 +283,16 @@ fn process_compilation_request(
         return Ok(());
     }
     let sierra_for_compilation = into_contract_class_for_compilation(sierra.as_ref());
+
     let start = Instant::now();
-    let compilation_result = compiler.compile(sierra_for_compilation);
+    #[cfg(feature = "with-libfunc-profiling")]
+    let compilation_result = compiler
+        .compile_with_program(sierra_for_compilation)
+        .map(|info| NativeCompiledClassV1::new_with_program(info, casm.clone()));
+    #[cfg(not(feature = "with-libfunc-profiling"))]
+    let compilation_result = compiler
+        .compile(sierra_for_compilation)
+        .map(|executor| NativeCompiledClassV1::new(executor, casm.clone()));
     let duration = start.elapsed();
     log::info!(
         "Compiling to native contract with class hash: {:#066x}. Duration: {:.3} seconds",
@@ -292,8 +300,7 @@ fn process_compilation_request(
         duration.as_secs_f32()
     );
     match compilation_result {
-        Ok(executor) => {
-            let native_compiled_class = NativeCompiledClassV1::new(executor, casm);
+        Ok(native_compiled_class) => {
             class_cache.set(
                 class_hash,
                 CompiledClasses::V1Native(CachedCairoNative::Compiled(native_compiled_class)),

--- a/crates/blockifier/src/state/native_class_manager.rs
+++ b/crates/blockifier/src/state/native_class_manager.rs
@@ -7,6 +7,13 @@ use apollo_compilation_utils::errors::CompilationUtilError;
 use apollo_compile_to_native::compiler::SierraToNativeCompiler;
 #[cfg(any(feature = "testing", test))]
 use cached::Cached;
+#[cfg(feature = "sierra-emu")]
+use cairo_lang_starknet_classes::contract_class::{
+    version_id_from_serialized_sierra_program,
+    ContractClass as CairoLangContractClass,
+};
+#[cfg(feature = "sierra-emu")]
+use cairo_native::executor::EmuContractExecutor;
 use log;
 use starknet_api::class_cache::GlobalContractCache;
 use starknet_api::core::{ClassHash, CompiledClassHash};
@@ -273,7 +280,9 @@ fn run_compilation_worker(
 /// Processes a compilation request and caches the result.
 fn process_compilation_request(
     class_cache: RawClassCache,
-    compiler: Arc<SierraToNativeCompiler>,
+    #[cfg_attr(feature = "sierra-emu", allow(unused_variables))] compiler: Arc<
+        SierraToNativeCompiler,
+    >,
     compilation_request: CompilationRequest,
     panic_on_compilation_failure: bool,
 ) -> Result<(), CompilationUtilError> {
@@ -285,9 +294,14 @@ fn process_compilation_request(
     let sierra_for_compilation = into_contract_class_for_compilation(sierra.as_ref());
 
     let start = Instant::now();
-    #[cfg(feature = "with-libfunc-profiling")]
+    // The construction below matches the build's `NativeContractExecutor` resolution:
+    // sierra-emu (no native compilation; the interpreter consumes the Sierra program
+    // directly), AOT paired with its Sierra program (libfunc profiling), or plain AOT.
+    #[cfg(feature = "sierra-emu")]
+    let compilation_result = emu_contract_executor(sierra_for_compilation);
+    #[cfg(all(feature = "with-libfunc-profiling", not(feature = "sierra-emu")))]
     let compilation_result = compiler.compile_with_program(sierra_for_compilation);
-    #[cfg(not(feature = "with-libfunc-profiling"))]
+    #[cfg(not(any(feature = "with-libfunc-profiling", feature = "sierra-emu")))]
     let compilation_result = compiler.compile(sierra_for_compilation);
     let duration = start.elapsed();
     log::info!(
@@ -297,9 +311,6 @@ fn process_compilation_request(
     );
     match compilation_result {
         Ok(compiled) => {
-            #[cfg(feature = "with-libfunc-profiling")]
-            let native_compiled_class = NativeCompiledClassV1::new_with_program(compiled, casm);
-            #[cfg(not(feature = "with-libfunc-profiling"))]
             let native_compiled_class = NativeCompiledClassV1::new(compiled, casm);
             class_cache.set(
                 class_hash,
@@ -324,4 +335,33 @@ fn process_compilation_request(
             Err(err)
         }
     }
+}
+
+/// Builds a sierra-emu-backed executor from the Sierra class. Nothing is compiled --
+/// the interpreter consumes the Sierra program directly.
+#[cfg(feature = "sierra-emu")]
+fn emu_contract_executor(
+    contract_class: CairoLangContractClass,
+) -> Result<EmuContractExecutor, CompilationUtilError> {
+    let (sierra_version, _compiler_version) = version_id_from_serialized_sierra_program(
+        &contract_class.sierra_program,
+    )
+    .map_err(|err| {
+        CompilationUtilError::UnexpectedError(format!(
+            "Failed to extract Sierra version for sierra-emu execution: {err}"
+        ))
+    })?;
+    let program = contract_class
+        .extract_sierra_program(false)
+        .map(|extracted| Arc::new(extracted.program))
+        .map_err(|err| {
+            CompilationUtilError::UnexpectedError(format!(
+                "Failed to extract Sierra program for sierra-emu execution: {err}"
+            ))
+        })?;
+    Ok(EmuContractExecutor {
+        program,
+        entry_points: contract_class.entry_points_by_type,
+        sierra_version,
+    })
 }

--- a/crates/blockifier/src/test_utils/struct_impls.rs
+++ b/crates/blockifier/src/test_utils/struct_impls.rs
@@ -8,8 +8,12 @@ use blockifier_test_utils::contracts::get_raw_contract_class;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 #[cfg(feature = "cairo_native")]
 use cairo_lang_starknet_classes::contract_class::ContractClass as SierraContractClass;
-#[cfg(feature = "cairo_native")]
+#[cfg(all(feature = "cairo_native", not(feature = "sierra-emu")))]
 use cairo_native::executor::AotContractExecutor;
+#[cfg(all(feature = "with-libfunc-profiling", not(feature = "sierra-emu")))]
+use cairo_native::executor::AotWithProgram;
+#[cfg(feature = "sierra-emu")]
+use cairo_native::executor::EmuContractExecutor;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use starknet_api::block::{BlockInfo, BlockNumber};
 use starknet_api::contract_address;
@@ -297,7 +301,9 @@ impl NativeCompiledClassV1 {
         let sierra_version = SierraVersion::extract_from_program(&sierra_version_values)
             .expect("Cannot extract sierra version from sierra program");
 
-        let executor = AotContractExecutor::new(
+        // Executor construction matches the build's `NativeContractExecutor` resolution.
+        #[cfg(not(feature = "sierra-emu"))]
+        let aot_executor = AotContractExecutor::new(
             &extracted.program,
             &sierra_contract_class.entry_points_by_type,
             sierra_version.clone().into(),
@@ -307,6 +313,18 @@ impl NativeCompiledClassV1 {
             None,
         )
         .expect("Cannot compile sierra into native");
+
+        #[cfg(feature = "sierra-emu")]
+        let executor = EmuContractExecutor {
+            program: Arc::new(extracted.program.clone()),
+            entry_points: sierra_contract_class.entry_points_by_type.clone(),
+            sierra_version: sierra_version.clone().into(),
+        };
+        #[cfg(all(feature = "with-libfunc-profiling", not(feature = "sierra-emu")))]
+        let executor =
+            AotWithProgram { executor: aot_executor, program: Arc::new(extracted.program.clone()) };
+        #[cfg(not(any(feature = "sierra-emu", feature = "with-libfunc-profiling")))]
+        let executor = aot_executor;
 
         // Compile the sierra contract class into casm.
         let casm_contract_class = CasmContractClass::from_contract_class(


### PR DESCRIPTION
## Summary

Replaces the local `AotContractExecutor` field on `NativeCompiledClassV1Inner` with a **cfg-resolved `NativeContractExecutor` type alias** and adopts cairo-native's new libfunc-profiling APIs. There is no dispatch enum anywhere: the executor backend is always selected at compile time, so production builds store literally `AotContractExecutor`, and the special backends exist only inside their feature gates.

`NativeContractExecutor` resolution (all three types expose the same `run` shape, so call sites are identical across builds):

| build | executor type |
|---|---|
| production (`cairo_native`) | `AotContractExecutor` |
| `sierra-emu` (testing / benchmarking; takes precedence) | `EmuContractExecutor` — the class manager skips native compilation entirely and the sierra-emu interpreter consumes the Sierra program directly |
| `with-libfunc-profiling` | `AotWithProgram` — AOT executor paired with its Sierra program so libfunc samples can be resolved |

The conversion glue between cairo-native and sierra-emu syscall traits, and the libfunc profiling instrumentation — both previously maintained in blockifier — live in cairo-native.

> [!IMPORTANT]
> Depends on the cairo_native PR stack (in order), all now merged to `main`:
> - starkware-libs/cairo_native#1610 — align sierra-emu `StarknetSyscallHandler` trait/types with cairo-native (released in `0.9.0-rc.7`)
> - starkware-libs/cairo_native#1611 — extract shared `cairo-native-syscalls` crate (released in `0.9.0-rc.7`)
> - starkware-libs/cairo_native#1612 — `EmuContractExecutor` + `sierra_emu::VirtualMachine::run_contract` (merged)
> - starkware-libs/cairo_native#1613 — `run_with_libfunc_profile` + `AotWithProgram` with inherent `run`/`run_with_profile` (merged)
>
> No crates.io release includes #1612/#1613 yet, so the workspace `Cargo.toml` still uses a `git`/`rev` dep, now pinned to cairo_native's post-merge `main` tip (rev `931a25d6`, package version still `0.9.0-rc.7`). **Do not merge until a cairo-native release containing them is published**, then swap the `git`/`rev` dep back to a published `version = "..."`.

## Commits

1. `blockifier,apollo_compile_to_native: adopt cairo_native::ContractExecutor + libfunc profiling` — the original enum-based adoption; switches `executor: AotContractExecutor` → cairo-native's `ContractExecutor`; adds `sierra-emu` + `with-libfunc-profiling` features; adds `SierraToNativeCompiler::compile_with_program`; routes `entry_point_execution` through `run_dispatch::run_native_executor`.
2. `workspace: declare cairo-native version on git dep for version sync test`.
3. `blockifier: address review feedback on native compilation path` — `casm` moves into the constructor at zero cost.
4. `blockifier: re-add new_from_emu for out-of-tree benchmarking branch`.
5. `apollo_compile_to_native: document instrumented-binary requirement for libfunc profiling`.
6. **`blockifier: replace ContractExecutor enum with cfg-resolved NativeContractExecutor`** — removes the enum from production code (revert this commit to restore the enum-based design). Collapses `new`/`new_from_emu`/`new_with_program` into a single `new(executor: NativeContractExecutor, _)`; the class manager and test utils construct the matching backend per build; `sierra-emu` now actually executes in-tree instead of gating a dead constructor.
7. `workspace: bump cairo-native git pin past merged #1612/#1613` — moves the git rev from the old (now squashed-away) PR-stack tip to cairo_native's post-merge `main` HEAD.

Branch is rebased over main (cairo-lang `2.19.0-rc.3`), per review.

## Replaces

The (still-open) #13542 / #13543 / #13755 stack. The sierra-emu syscall conversions and the libfunc profiling primitive moved to cairo-native (per @Yoni-Starkware's review on #13543); the executor-backend selection is now a compile-time type resolution rather than an enum in production code (per @orizi's review on the cairo-native stack).

## Test plan

- [x] `cargo check -p blockifier --features cairo_native,testing`
- [x] `cargo check -p blockifier --features cairo_native,sierra-emu,testing`
- [x] `cargo check -p blockifier --features cairo_native,with-libfunc-profiling,testing`
- [x] `cargo check -p blockifier --features cairo_native,sierra-emu,with-libfunc-profiling,testing`
- [ ] CI green
- [ ] Once cairo-native is released, swap the `git`/`rev` dep back to a crates.io `version = "..."` and re-run CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

