### PR TITLE
apollo_gateway: remove StatelessTransactionValidatorTrait

### DIFF
--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -67,10 +67,7 @@ use crate::stateful_transaction_validator::{
     StatefulTransactionValidatorFactoryTrait,
     StatefulTransactionValidatorTrait,
 };
-use crate::stateless_transaction_validator::{
-    StatelessTransactionValidator,
-    StatelessTransactionValidatorTrait,
-};
+use crate::stateless_transaction_validator::StatelessTransactionValidator;
 use crate::sync_state_reader::SyncStateReaderFactory;
 
 #[cfg(test)]
@@ -85,7 +82,6 @@ type ProofArchiveHandle =
 #[derive(Clone)]
 pub struct Gateway(
     GenericGateway<
-        StatelessTransactionValidator,
         TransactionConverter,
         StatefulTransactionValidatorFactory<SyncStateReaderFactory>,
     >,
@@ -97,7 +93,6 @@ impl Gateway {
         state_reader_factory: Arc<SyncStateReaderFactory>,
         mempool_client: SharedMempoolClient,
         transaction_converter: Arc<TransactionConverter>,
-        stateless_tx_validator: Arc<StatelessTransactionValidator>,
         proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
     ) -> Self {
         Self(GenericGateway::new(
@@ -105,7 +100,6 @@ impl Gateway {
             state_reader_factory,
             mempool_client,
             transaction_converter,
-            stateless_tx_validator,
             proof_archive_writer,
         ))
     }
@@ -121,37 +115,30 @@ impl Gateway {
 
 #[derive(Clone)]
 pub struct GenericGateway<
-    TStatelessValidator: StatelessTransactionValidatorTrait,
     TTransactionConverter: TransactionConverterTrait,
     TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
 > {
     config: Arc<GatewayConfig>,
-    stateless_tx_validator: Arc<TStatelessValidator>,
+    stateless_tx_validator: Arc<StatelessTransactionValidator>,
     stateful_tx_validator_factory: Arc<TStatefulValidatorFactory>,
     mempool_client: SharedMempoolClient,
     transaction_converter: Arc<TTransactionConverter>,
     proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
 }
 
-impl<
-    TStatelessValidator: StatelessTransactionValidatorTrait,
-    TTransactionConverter: TransactionConverterTrait,
-    TStateReaderFactory: StateReaderFactory,
->
-    GenericGateway<
-        TStatelessValidator,
-        TTransactionConverter,
-        StatefulTransactionValidatorFactory<TStateReaderFactory>,
-    >
+impl<TTransactionConverter: TransactionConverterTrait, TStateReaderFactory: StateReaderFactory>
+    GenericGateway<TTransactionConverter, StatefulTransactionValidatorFactory<TStateReaderFactory>>
 {
     pub(crate) fn new(
         config: GatewayConfig,
         state_reader_factory: Arc<TStateReaderFactory>,
         mempool_client: SharedMempoolClient,
         transaction_converter: Arc<TTransactionConverter>,
-        stateless_tx_validator: Arc<TStatelessValidator>,
         proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
     ) -> Self {
+        let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
+            config: config.static_config.stateless_tx_validator_config.clone(),
+        });
         Self {
             config: Arc::new(config.clone()),
             stateless_tx_validator,
@@ -170,10 +157,9 @@ impl<
     }
 }
 impl<
-    TStatelessValidator: StatelessTransactionValidatorTrait,
     TTransactionConverter: TransactionConverterTrait,
     TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
-> GenericGateway<TStatelessValidator, TTransactionConverter, TStatefulValidatorFactory>
+> GenericGateway<TTransactionConverter, TStatefulValidatorFactory>
 {
     pub async fn start(&self) {
         register_metrics();
@@ -444,9 +430,6 @@ pub fn create_gateway(
         proof_manager_client,
         config.static_config.chain_info.chain_id.clone(),
     ));
-    let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
-        config: config.static_config.stateless_tx_validator_config.clone(),
-    });
 
     // Create proof archive writer: use NoOp if bucket name is empty, otherwise use real GCS.
     let proof_archive_writer: Arc<dyn ProofArchiveWriterTrait> =
@@ -463,7 +446,6 @@ pub fn create_gateway(
         state_reader_factory,
         mempool_client,
         transaction_converter,
-        stateless_tx_validator,
         proof_archive_writer,
     )
 }

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -89,7 +89,7 @@ use starknet_types_core::felt::Felt;
 use strum::VariantNames;
 use tempfile::TempDir;
 
-use crate::errors::{GatewayResult, StatelessTransactionValidatorError};
+use crate::errors::GatewayResult;
 use crate::gateway::GenericGateway;
 use crate::metrics::{
     register_metrics,
@@ -109,7 +109,7 @@ use crate::stateful_transaction_validator::{
     MockStatefulTransactionValidatorTrait,
     StatefulTransactionValidatorFactory,
 };
-use crate::stateless_transaction_validator::MockStatelessTransactionValidatorTrait;
+use crate::stateless_transaction_validator::StatelessTransactionValidator;
 
 #[fixture]
 fn mock_stateful_transaction_validator() -> MockStatefulTransactionValidatorTrait {
@@ -119,13 +119,6 @@ fn mock_stateful_transaction_validator() -> MockStatefulTransactionValidatorTrai
 #[fixture]
 fn mock_stateful_transaction_validator_factory() -> MockStatefulTransactionValidatorFactoryTrait {
     MockStatefulTransactionValidatorFactoryTrait::new()
-}
-
-#[fixture]
-fn mock_stateless_transaction_validator() -> MockStatelessTransactionValidatorTrait {
-    let mut mock_stateless_transaction_validator = MockStatelessTransactionValidatorTrait::new();
-    mock_stateless_transaction_validator.expect_validate().return_once(|_| Ok(()));
-    mock_stateless_transaction_validator
 }
 
 #[fixture]
@@ -146,14 +139,12 @@ fn mock_dependencies() -> MockDependencies {
         local_test_state_reader_factory(CairoVersion::Cairo1(RunnableCairo1::Casm), true);
     let mock_mempool_client = MockMempoolClient::new();
     let mock_transaction_converter = MockTransactionConverterTrait::new();
-    let mock_stateless_transaction_validator = mock_stateless_transaction_validator();
     let mock_proof_archive_writer = MockProofArchiveWriterTrait::new();
     MockDependencies {
         config,
         state_reader_factory,
         mock_mempool_client,
         mock_transaction_converter,
-        mock_stateless_transaction_validator,
         mock_proof_archive_writer,
     }
 }
@@ -163,7 +154,6 @@ struct MockDependencies {
     state_reader_factory: TestStateReaderFactory,
     mock_mempool_client: MockMempoolClient,
     mock_transaction_converter: MockTransactionConverterTrait,
-    mock_stateless_transaction_validator: MockStatelessTransactionValidatorTrait,
     mock_proof_archive_writer: MockProofArchiveWriterTrait,
 }
 
@@ -171,7 +161,6 @@ impl MockDependencies {
     fn gateway(
         self,
     ) -> GenericGateway<
-        MockStatelessTransactionValidatorTrait,
         MockTransactionConverterTrait,
         StatefulTransactionValidatorFactory<TestStateReaderFactory>,
     > {
@@ -181,7 +170,6 @@ impl MockDependencies {
             Arc::new(self.state_reader_factory),
             Arc::new(self.mock_mempool_client),
             Arc::new(self.mock_transaction_converter),
-            Arc::new(self.mock_stateless_transaction_validator),
             Arc::new(self.mock_proof_archive_writer),
         )
     }
@@ -735,12 +723,13 @@ async fn add_tx_returns_error_when_extract_state_nonce_and_run_validations_fails
     let tx_args = invoke_args();
     setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
     let gateway = GenericGateway::<
-        MockStatelessTransactionValidatorTrait,
         MockTransactionConverterTrait,
         MockStatefulTransactionValidatorFactoryTrait,
     > {
-        config: Arc::new(mock_dependencies.config),
-        stateless_tx_validator: Arc::new(mock_dependencies.mock_stateless_transaction_validator),
+        config: Arc::new(mock_dependencies.config.clone()),
+        stateless_tx_validator: Arc::new(StatelessTransactionValidator {
+            config: mock_dependencies.config.static_config.stateless_tx_validator_config.clone(),
+        }),
         stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
         mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
         transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
@@ -756,19 +745,15 @@ async fn add_tx_returns_error_when_extract_state_nonce_and_run_validations_fails
 #[rstest]
 #[tokio::test]
 async fn stateless_transaction_validator_error(mut mock_dependencies: MockDependencies) {
-    let arbitrary_validation_error = Err(StatelessTransactionValidatorError::SignatureTooLong {
-        signature_length: 5001,
-        max_signature_length: 4000,
-    });
     let error_code =
         StarknetErrorCode::UnknownErrorCode("StarknetErrorCode.SIGNATURE_TOO_LONG".into());
-    let mut mock_stateless_transaction_validator = MockStatelessTransactionValidatorTrait::new();
-    mock_stateless_transaction_validator
-        .expect_validate()
-        .return_once(|_| arbitrary_validation_error);
-    mock_dependencies.mock_stateless_transaction_validator = mock_stateless_transaction_validator;
+    mock_dependencies.config.static_config.stateless_tx_validator_config.max_signature_length = 0;
+
+    let mut tx_args = invoke_args();
+    tx_args.signature = TransactionSignature(vec![Felt::ZERO].into());
+
     let gateway = mock_dependencies.gateway();
-    let result = gateway.add_tx(invoke_args().get_rpc_tx(), None).await;
+    let result = gateway.add_tx(tx_args.get_rpc_tx(), None).await;
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code, error_code);
@@ -792,12 +777,13 @@ async fn add_tx_returns_error_when_instantiating_validator_fails(
     let tx_args = invoke_args();
     setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
     let gateway = GenericGateway::<
-        MockStatelessTransactionValidatorTrait,
         MockTransactionConverterTrait,
         MockStatefulTransactionValidatorFactoryTrait,
     > {
-        config: Arc::new(mock_dependencies.config),
-        stateless_tx_validator: Arc::new(mock_dependencies.mock_stateless_transaction_validator),
+        config: Arc::new(mock_dependencies.config.clone()),
+        stateless_tx_validator: Arc::new(StatelessTransactionValidator {
+            config: mock_dependencies.config.static_config.stateless_tx_validator_config.clone(),
+        }),
         stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
         mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
         transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),

--- a/crates/apollo_gateway/src/stateless_transaction_validator.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator.rs
@@ -18,11 +18,6 @@ use crate::errors::{StatelessTransactionValidatorError, StatelessTransactionVali
 #[path = "stateless_transaction_validator_test.rs"]
 mod stateless_transaction_validator_test;
 
-#[cfg_attr(test, mockall::automock)]
-pub trait StatelessTransactionValidatorTrait: Send + Sync {
-    fn validate(&self, tx: &RpcTransaction) -> StatelessTransactionValidatorResult<()>;
-}
-
 #[derive(Clone)]
 pub struct StatelessTransactionValidator {
     pub config: StatelessTransactionValidatorConfig,
@@ -352,11 +347,5 @@ impl StatelessTransactionValidator {
         }
 
         Err(StatelessTransactionValidatorError::EntryPointsNotUniquelySorted)
-    }
-}
-
-impl StatelessTransactionValidatorTrait for StatelessTransactionValidator {
-    fn validate(&self, tx: &RpcTransaction) -> StatelessTransactionValidatorResult<()> {
-        Self::validate(self, tx)
     }
 }

--- a/crates/apollo_gateway/src/test_utils.rs
+++ b/crates/apollo_gateway/src/test_utils.rs
@@ -34,7 +34,6 @@ use crate::gateway::GenericGateway;
 use crate::proof_archive_writer::MockProofArchiveWriterTrait;
 use crate::state_reader_test_utils::{local_test_state_reader_factory, TestStateReaderFactory};
 use crate::stateful_transaction_validator::StatefulTransactionValidatorFactory;
-use crate::stateless_transaction_validator::StatelessTransactionValidator;
 
 pub const NON_EMPTY_RESOURCE_BOUNDS: ResourceBounds =
     ResourceBounds { max_amount: GasAmount(1), max_price_per_unit: GasPrice(1) };
@@ -161,7 +160,6 @@ pub fn rpc_tx_for_testing(
 }
 
 pub type GatewayForBenchmark = GenericGateway<
-    StatelessTransactionValidator,
     TransactionConverter,
     StatefulTransactionValidatorFactory<TestStateReaderFactory>,
 >;
@@ -179,9 +177,6 @@ pub fn gateway_for_benchmark(gateway_config: GatewayConfig) -> GatewayForBenchma
         proof_manager_client.clone(),
         gateway_config.static_config.chain_info.chain_id.clone(),
     );
-    let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
-        config: gateway_config.static_config.stateless_tx_validator_config.clone(),
-    });
     mempool_client.expect_add_tx().returning(|_| Ok(()));
     mempool_client.expect_validate_tx().returning(|_| Ok(()));
     mempool_client.expect_account_tx_in_pool_or_recent_block().returning(|_| Ok(false));
@@ -191,7 +186,6 @@ pub fn gateway_for_benchmark(gateway_config: GatewayConfig) -> GatewayForBenchma
         Arc::new(state_reader_factory),
         Arc::new(mempool_client),
         Arc::new(transaction_converter),
-        stateless_tx_validator,
         proof_archive_writer,
     )
 }

--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -170,7 +170,7 @@ impl Default for StatelessTransactionValidatorConfig {
             max_contract_class_object_size: 4089446,
             min_sierra_version: VersionId::new(1, 1, 0),
             max_sierra_version: VersionId::new(1, 8, usize::MAX),
-            allow_client_side_proving: false,
+            allow_client_side_proving: true,
             max_proof_size: 480000,
         }
     }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3097,7 +3097,7 @@
   "gateway_config.static_config.stateless_tx_validator_config.allow_client_side_proving": {
     "description": "If true, allows transactions with non-empty proof_facts or proof fields.",
     "privacy": "Public",
-    "value": false
+    "value": true
   },
   "gateway_config.static_config.stateless_tx_validator_config.max_calldata_length": {
     "description": "Limitation of calldata length.",


### PR DESCRIPTION
The trait existed only to allow mocking in gateway tests. The validator
is pure (no I/O, no async); tests can use the real
StatelessTransactionValidator configured to trigger the desired error
path. Removes one generic from GenericGateway and ~30 lines of
boilerplate.