### PR TITLE
deployment: add mainnet overlay config

### DIFF
--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/common.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/common.yaml
@@ -1,0 +1,20 @@
+image:
+  repository: ghcr.io/starkware-libs/sequencer/sequencer
+  tag: APOLLO-0.14.2-RC.6
+  imagePullPolicy: IfNotPresent
+
+config:
+  sequencerConfig:
+    chain_id: SN_MAIN
+    eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
+    native_classes_whitelist: '["0x054c5afe61ed27be53b1e4dec5707209a9fcabdb14712fb800fbc60439090115"]'
+    strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d'
+    versioned_constants_overrides.max_n_events: 5000
+
+env:
+- name: RUST_LOG
+  value: debug
+- name: RUST_BACKTRACE
+  value: full
+- name: NO_COLOR
+  value: '1'

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/committer.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/committer.yaml
@@ -1,0 +1,5 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_committer.json
+  sequencerConfig:
+    committer_config.storage_config.cache_size: 50000000
+    committer_config.verify_state_diff_hash: true

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/core.yaml
@@ -1,0 +1,33 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_core.json
+  sequencerConfig:
+    batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.n_events: 5000
+    batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.state_diff_size: 5000
+    batcher_config.static_config.block_builder_config.execute_config.n_workers: 12
+    batcher_config.dynamic_config.n_concurrent_txs: 100
+    batcher_config.dynamic_config.proposer_idle_detection_delay_millis: 2000
+    batcher_config.static_config.first_block_with_partial_block_hash.#is_none: false
+    batcher_config.static_config.first_block_with_partial_block_hash.block_hash: '0x12889b177c93baa28b5ee3afc80cb6f4836adac086af4bef25ae1ac762e8a62'
+    batcher_config.static_config.first_block_with_partial_block_hash.block_number: 671813
+    batcher_config.static_config.first_block_with_partial_block_hash.parent_block_hash: '0x1e68b0d22b14688dc97afa3006a53cf4e62ebcb02102e80f55e8b48f9a28b97'
+    class_manager_config.static_config.class_manager_config.max_compiled_contract_class_object_size: 4089446
+    consensus_manager_config.consensus_manager_config.dynamic_config.require_virtual_proposer_vote: false
+    consensus_manager_config.consensus_manager_config.dynamic_config.timeouts.proposal.base: 9.1
+    consensus_manager_config.consensus_manager_config.dynamic_config.timeouts.proposal.max: 9.1
+    consensus_manager_config.context_config.dynamic_config.build_proposal_margin_millis: 1000
+    consensus_manager_config.context_config.dynamic_config.compare_retrospective_block_hash: true
+    consensus_manager_config.context_config.dynamic_config.min_l2_gas_price_per_height: '8269292:27400000000,8742344:30100000000'
+    consensus_manager_config.context_config.dynamic_config.override_eth_to_fri_rate: 0
+    consensus_manager_config.context_config.dynamic_config.override_eth_to_fri_rate.#is_none: true
+    consensus_manager_config.context_config.dynamic_config.override_l1_data_gas_price_fri: 0
+    consensus_manager_config.context_config.dynamic_config.override_l1_data_gas_price_fri.#is_none: true
+    consensus_manager_config.context_config.dynamic_config.override_l1_gas_price_fri: 0
+    consensus_manager_config.context_config.dynamic_config.override_l1_gas_price_fri.#is_none: true
+    consensus_manager_config.context_config.dynamic_config.override_l2_gas_price_fri: 0
+    consensus_manager_config.context_config.dynamic_config.override_l2_gas_price_fri.#is_none: true
+    consensus_manager_config.staking_manager_config.dynamic_config.default_committee: 0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true;0x67,1,0x1,true;0x68,1,0x1,true
+    consensus_manager_config.staking_manager_config.dynamic_config.override_committee: ''
+    consensus_manager_config.staking_manager_config.dynamic_config.override_committee.#is_none: true
+    state_sync_config.static_config.central_sync_client_config.#is_none: false
+    state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold: 103129
+    state_sync_config.static_config.p2p_sync_client_config.#is_none: true

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/gateway.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/gateway.yaml
@@ -1,0 +1,7 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_gateway.json
+  sequencerConfig:
+    gateway_config.static_config.authorized_declarer_accounts: ''
+    gateway_config.static_config.authorized_declarer_accounts.#is_none: true
+    gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap: 200
+    gateway_config.static_config.stateless_tx_validator_config.min_gas_price: 8000000000

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/l1.yaml
@@ -1,0 +1,7 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_l1.json
+  sequencerConfig:
+    base_layer_config.bpo1_start_block_number: 23973546
+    base_layer_config.bpo2_start_block_number: 24168146
+    base_layer_config.fusaka_no_bpo_start_block_number: 23934586
+    base_layer_config.starknet_contract_address: '0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4'

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/mempool.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/mempool.yaml
@@ -1,0 +1,4 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_mempool.json
+  sequencerConfig:
+    mempool_config.dynamic_config.transaction_ttl: 300

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/sierra-compiler.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/sierra-compiler.yaml
@@ -1,0 +1,5 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_sierra_compiler.json
+  sequencerConfig:
+    sierra_compiler_config.audited_libfuncs_only: true
+    sierra_compiler_config.max_bytecode_size: 81920


### PR DESCRIPTION
## Summary
- Adds 7 new files under `deployments/sequencer/configs/overlays/hybrid/mainnet/` containing only fields safe for public exposure
- Public fields: chain/protocol identity (chain_id, fee tokens, native_classes_whitelist, L1 contract/block numbers), consensus params, application tuning (bouncer limits, n_workers, cache_size, etc.), image metadata, env vars
- Private fields stay in sequencer-devops: ports, component URLs, k8s infra, bootstrap peers, recorder/starknet URLs, secrets

## Context
The sequencer-devops repo holds `common_*.yaml` overlay files for mainnet. Each will be updated (in a companion PR) to `include:` the corresponding public file here, pulling in public config at CDK8s synthesis time. The deployment workflow already does `cp -rf devops/overlays → public/overlays` before synthesis, so public files at these paths survive the copy and are available via the include chain.

## Companion PR
sequencer-devops: `nimrod/mainnet-public-overlay-configs`

## Test plan
- [ ] Verify no private fields (ports, URLs, k8s infra, secrets) exist in any file under `deployments/sequencer/configs/overlays/hybrid/mainnet/`
- [ ] After merging both PRs, run CDK8s synthesis simulating the cp step and confirm no config drift vs. pre-migration output

🤖 Generated with [Claude Code](https://claude.com/claude-code)