### PR TITLE
blockifier_reexecution: move compare_block_hash to utils

### DIFF
--- a/crates/blockifier_reexecution/src/rpc_replay.rs
+++ b/crates/blockifier_reexecution/src/rpc_replay.rs
@@ -9,26 +9,18 @@ use blockifier::blockifier::config::{
     ContractClassManagerConfig,
 };
 use blockifier::context::ChainInfo;
-use blockifier::state::cached_state::CommitmentStateDiff;
 use blockifier::state::contract_class_manager::ContractClassManager;
-use starknet_api::block::{BlockInfo, BlockNumber, StarknetVersion};
-use starknet_api::block_hash::block_hash_calculator::{
-    calculate_block_commitments,
-    calculate_block_hash,
-    PartialBlockHashComponents,
-    TransactionHashingData,
-};
+use starknet_api::block::BlockNumber;
+#[cfg(feature = "cairo_native")]
+use starknet_api::block_hash::block_hash_calculator::TransactionHashingData;
 #[cfg(feature = "cairo_native")]
 use starknet_api::contract_class::SierraVersion;
 
 use crate::errors::{RPCStateReaderError, ReexecutionError, ReexecutionResult};
 use crate::state_reader::config::RpcStateReaderConfig;
 use crate::state_reader::reexecution_state_reader::{BlockReexecutor, ReexecuteBlockOutcome};
-use crate::state_reader::rpc_objects::BlockHeader;
 use crate::state_reader::rpc_state_reader::RpcBlockReexecutor;
-use crate::utils::{compare_state_diffs, get_chain_info};
-// Block hash comparison is only valid for Starknet v0.14.0 and later.
-const MIN_VERSION_FOR_BLOCK_HASH_COMPARISON: &str = "0.14.0";
+use crate::utils::{compare_block_hash, compare_state_diffs, get_chain_info};
 
 struct ReplayCounters {
     matched: AtomicU64,
@@ -349,62 +341,6 @@ fn compare_tx_hashing_data(
         );
     }
     false
-}
-
-/// Computes the block hash from the reexecution output and compares it against the expected hash
-/// from the chain. Returns `true` if they match, or if the block predates v0.14.0 (skipped).
-///
-/// Uses the state root from the RPC block header (`new_root`) since the blockifier does not
-/// compute state roots. If the state diff already matched, the state root should also match.
-///
-/// Note: Blocks before v0.14.0 may include deprecated (Cairo 0) declared classes which are not
-/// represented in [`CommitmentStateDiff`]; those blocks skip hash comparison below.
-async fn compare_block_hash(
-    txs_hashing_data: Vec<TransactionHashingData>,
-    actual_state_diff: CommitmentStateDiff,
-    block_header: &BlockHeader,
-    block_number: BlockNumber,
-) -> ReexecutionResult<bool> {
-    let starknet_version: StarknetVersion = block_header.starknet_version.clone().try_into()?;
-
-    let min_version: StarknetVersion =
-        MIN_VERSION_FOR_BLOCK_HASH_COMPARISON.try_into().expect("Invalid min version constant.");
-    if starknet_version < min_version {
-        tracing::debug!(
-            "Block {block_number}: skipping block hash comparison (version {} < {}).",
-            block_header.starknet_version,
-            MIN_VERSION_FOR_BLOCK_HASH_COMPARISON
-        );
-        return Ok(true);
-    }
-
-    let (commitments, _measurements) = calculate_block_commitments(
-        &txs_hashing_data,
-        actual_state_diff.into(),
-        block_header.l1_da_mode,
-        &starknet_version,
-    )
-    .await;
-
-    let block_info: BlockInfo = block_header.clone().try_into()?;
-    let partial_block_hash_components = PartialBlockHashComponents::new(&block_info, commitments);
-
-    let computed_hash = calculate_block_hash(
-        &partial_block_hash_components,
-        block_header.new_root,
-        block_header.parent_hash,
-    )?;
-
-    if computed_hash == block_header.block_hash {
-        Ok(true)
-    } else {
-        tracing::warn!(
-            "Block hash mismatch for block {block_number}.\n  expected: {}\n  actual:   {}",
-            block_header.block_hash,
-            computed_hash,
-        );
-        Ok(false)
-    }
 }
 
 fn is_block_not_found(err: &ReexecutionError) -> bool {

--- a/crates/blockifier_reexecution/src/utils.rs
+++ b/crates/blockifier_reexecution/src/utils.rs
@@ -10,13 +10,21 @@ use blockifier::state::global_cache::CompiledClasses;
 use blockifier::state::state_api::StateResult;
 use indexmap::IndexMap;
 use pretty_assertions::assert_eq;
-use starknet_api::block::BlockNumber;
+use starknet_api::block::{BlockInfo, BlockNumber, StarknetVersion};
+use starknet_api::block_hash::block_hash_calculator::{
+    calculate_block_commitments,
+    calculate_block_hash,
+    PartialBlockHashComponents,
+    TransactionHashingData,
+};
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::state::{SierraContractClass, StorageKey};
 use starknet_types_core::felt::Felt;
 
+use crate::errors::ReexecutionResult;
 use crate::state_reader::config::RpcStateReaderConfig;
+use crate::state_reader::rpc_objects::BlockHeader;
 
 pub static RPC_NODE_URL: LazyLock<String> = LazyLock::new(|| {
     env::var("TEST_URL")
@@ -185,6 +193,65 @@ pub fn compare_state_diffs(
         tracing::warn!("State diff mismatch for block {block_number}.\n{diff}");
     }
     is_match
+}
+
+// Block hash comparison is only valid for Starknet v0.14.0 and later.
+const MIN_VERSION_FOR_BLOCK_HASH_COMPARISON: &str = "0.14.0";
+
+/// Computes the block hash from the reexecution output and compares it against the expected hash
+/// from the chain. Returns `true` if they match, or if the block predates v0.14.0 (skipped).
+///
+/// Uses the state root from the RPC block header (`new_root`) since the blockifier does not
+/// compute state roots. If the state diff already matched, the state root should also match.
+///
+/// Note: Blocks before v0.14.0 may include deprecated (Cairo 0) declared classes which are not
+/// represented in [`CommitmentStateDiff`]; those blocks skip hash comparison below.
+pub async fn compare_block_hash(
+    txs_hashing_data: Vec<TransactionHashingData>,
+    actual_state_diff: CommitmentStateDiff,
+    block_header: &BlockHeader,
+    block_number: BlockNumber,
+) -> ReexecutionResult<bool> {
+    let starknet_version: StarknetVersion = block_header.starknet_version.clone().try_into()?;
+
+    let min_version: StarknetVersion =
+        MIN_VERSION_FOR_BLOCK_HASH_COMPARISON.try_into().expect("Invalid min version constant.");
+    if starknet_version < min_version {
+        tracing::debug!(
+            "Block {block_number}: skipping block hash comparison (version {} < {}).",
+            block_header.starknet_version,
+            MIN_VERSION_FOR_BLOCK_HASH_COMPARISON
+        );
+        return Ok(true);
+    }
+
+    let (commitments, _measurements) = calculate_block_commitments(
+        &txs_hashing_data,
+        actual_state_diff.into(),
+        block_header.l1_da_mode,
+        &starknet_version,
+    )
+    .await;
+
+    let block_info: BlockInfo = block_header.clone().try_into()?;
+    let partial_block_hash_components = PartialBlockHashComponents::new(&block_info, commitments);
+
+    let computed_hash = calculate_block_hash(
+        &partial_block_hash_components,
+        block_header.new_root,
+        block_header.parent_hash,
+    )?;
+
+    if computed_hash == block_header.block_hash {
+        Ok(true)
+    } else {
+        tracing::warn!(
+            "Block hash mismatch for block {block_number}.\n  expected: {}\n  actual:   {}",
+            block_header.block_hash,
+            computed_hash,
+        );
+        Ok(false)
+    }
 }
 
 /// Asserts equality between two `CommitmentStateDiff` structs, ignoring insertion order.


### PR DESCRIPTION
## Summary
- Moves `compare_block_hash` and `MIN_VERSION_FOR_BLOCK_HASH_COMPARISON` from `rpc_replay.rs` to `utils.rs`, making the function `pub`
- Updates `rpc_replay.rs` to import it from `utils`

This is a preliminary refactor to make `compare_block_hash` available to other callers (follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)