### PR TITLE
apollo_gateway: collapse stateful validator factory into the validator and drop traits

### DIFF
--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -62,11 +62,7 @@ use crate::proof_archive_writer::{
     ProofArchiveWriterTrait,
 };
 use crate::state_reader::StateReaderFactory;
-use crate::stateful_transaction_validator::{
-    StatefulTransactionValidatorFactory,
-    StatefulTransactionValidatorFactoryTrait,
-    StatefulTransactionValidatorTrait,
-};
+use crate::stateful_transaction_validator::StatefulTransactionValidator;
 use crate::stateless_transaction_validator::StatelessTransactionValidator;
 use crate::sync_state_reader::SyncStateReaderFactory;
 
@@ -80,12 +76,7 @@ type ProofArchiveHandle =
     Option<(JoinHandle<(Felt, Result<(), ProofArchiveError>)>, TransactionHash)>;
 
 #[derive(Clone)]
-pub struct Gateway(
-    GenericGateway<
-        TransactionConverter,
-        StatefulTransactionValidatorFactory<SyncStateReaderFactory>,
-    >,
-);
+pub struct Gateway(GenericGateway<TransactionConverter, SyncStateReaderFactory>);
 
 impl Gateway {
     fn new(
@@ -116,18 +107,20 @@ impl Gateway {
 #[derive(Clone)]
 pub struct GenericGateway<
     TTransactionConverter: TransactionConverterTrait,
-    TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
+    TStateReaderFactory: StateReaderFactory,
 > {
     config: Arc<GatewayConfig>,
     stateless_tx_validator: Arc<StatelessTransactionValidator>,
-    stateful_tx_validator_factory: Arc<TStatefulValidatorFactory>,
+    stateful_tx_validator: Arc<StatefulTransactionValidator<TStateReaderFactory>>,
     mempool_client: SharedMempoolClient,
     transaction_converter: Arc<TTransactionConverter>,
     proof_archive_writer: Arc<dyn ProofArchiveWriterTrait>,
 }
 
-impl<TTransactionConverter: TransactionConverterTrait, TStateReaderFactory: StateReaderFactory>
-    GenericGateway<TTransactionConverter, StatefulTransactionValidatorFactory<TStateReaderFactory>>
+impl<
+    TTransactionConverter: TransactionConverterTrait,
+    TStateReaderFactory: StateReaderFactory + 'static,
+> GenericGateway<TTransactionConverter, TStateReaderFactory>
 {
     pub(crate) fn new(
         config: GatewayConfig,
@@ -139,28 +132,24 @@ impl<TTransactionConverter: TransactionConverterTrait, TStateReaderFactory: Stat
         let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
             config: config.static_config.stateless_tx_validator_config.clone(),
         });
+        let stateful_tx_validator = Arc::new(StatefulTransactionValidator {
+            config: config.static_config.stateful_tx_validator_config.clone(),
+            chain_info: config.static_config.chain_info.clone(),
+            state_reader_factory,
+            contract_class_manager: ContractClassManager::start(
+                config.static_config.contract_class_manager_config.clone(),
+            ),
+        });
         Self {
-            config: Arc::new(config.clone()),
+            config: Arc::new(config),
             stateless_tx_validator,
-            stateful_tx_validator_factory: Arc::new(StatefulTransactionValidatorFactory {
-                config: config.static_config.stateful_tx_validator_config.clone(),
-                chain_info: config.static_config.chain_info.clone(),
-                state_reader_factory,
-                contract_class_manager: ContractClassManager::start(
-                    config.static_config.contract_class_manager_config.clone(),
-                ),
-            }),
+            stateful_tx_validator,
             mempool_client,
             transaction_converter,
             proof_archive_writer,
         }
     }
-}
-impl<
-    TTransactionConverter: TransactionConverterTrait,
-    TStatefulValidatorFactory: StatefulTransactionValidatorFactoryTrait,
-> GenericGateway<TTransactionConverter, TStatefulValidatorFactory>
-{
+
     pub async fn start(&self) {
         register_metrics();
         self.proof_archive_writer.connect().await;
@@ -211,14 +200,13 @@ impl<
         let (internal_tx, executable_tx, proof_data) =
             self.convert_rpc_tx_to_internal_and_executable_txs(tx, &tx_signature).await?;
 
-        let mut stateful_transaction_validator = self
-            .stateful_tx_validator_factory
-            .instantiate_validator(self.config.dynamic_config.native_classes_whitelist.clone())
-            .await
-            .inspect_err(|e| metric_counters.record_add_tx_failure(e))?;
-
-        let nonce = stateful_transaction_validator
-            .extract_state_nonce_and_run_validations(&executable_tx, self.mempool_client.clone())
+        let nonce = self
+            .stateful_tx_validator
+            .validate_stateful_tx(
+                &executable_tx,
+                self.mempool_client.clone(),
+                self.config.dynamic_config.native_classes_whitelist.clone(),
+            )
             .await
             .inspect_err(|e| metric_counters.record_add_tx_failure(e))?;
 

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -11,11 +11,7 @@ use apollo_gateway_config::config::{
     StatefulTransactionValidatorConfig,
     StatelessTransactionValidatorConfig,
 };
-use apollo_gateway_types::deprecated_gateway_error::{
-    KnownStarknetErrorCode,
-    StarknetError,
-    StarknetErrorCode,
-};
+use apollo_gateway_types::deprecated_gateway_error::{KnownStarknetErrorCode, StarknetErrorCode};
 use apollo_gateway_types::gateway_types::{
     DeclareGatewayOutput,
     DeployAccountGatewayOutput,
@@ -104,23 +100,6 @@ use crate::metrics::{
 };
 use crate::proof_archive_writer::MockProofArchiveWriterTrait;
 use crate::state_reader_test_utils::{local_test_state_reader_factory, TestStateReaderFactory};
-use crate::stateful_transaction_validator::{
-    MockStatefulTransactionValidatorFactoryTrait,
-    MockStatefulTransactionValidatorTrait,
-    StatefulTransactionValidatorFactory,
-};
-use crate::stateless_transaction_validator::StatelessTransactionValidator;
-
-#[fixture]
-fn mock_stateful_transaction_validator() -> MockStatefulTransactionValidatorTrait {
-    MockStatefulTransactionValidatorTrait::new()
-}
-
-#[fixture]
-fn mock_stateful_transaction_validator_factory() -> MockStatefulTransactionValidatorFactoryTrait {
-    MockStatefulTransactionValidatorFactoryTrait::new()
-}
-
 #[fixture]
 fn mock_dependencies() -> MockDependencies {
     let config = GatewayConfig {
@@ -161,12 +140,7 @@ struct MockDependencies {
 }
 
 impl MockDependencies {
-    fn gateway(
-        self,
-    ) -> GenericGateway<
-        MockTransactionConverterTrait,
-        StatefulTransactionValidatorFactory<TestStateReaderFactory>,
-    > {
+    fn gateway(self) -> GenericGateway<MockTransactionConverterTrait, TestStateReaderFactory> {
         register_metrics();
         GenericGateway::new(
             self.config,
@@ -691,58 +665,26 @@ fn test_full_cycle_dump_deserialize_authorized_declarer_accounts(
 }
 
 #[rstest]
-#[case::validate_failure(StarknetErrorCode::KnownErrorCode(
-    KnownStarknetErrorCode::ValidateFailure
-))]
-#[case::invalid_nonce(StarknetErrorCode::KnownErrorCode(
-    KnownStarknetErrorCode::InvalidTransactionNonce
-))]
-#[case::gas_price_too_low(
-    StarknetErrorCode::UnknownErrorCode("StarknetErrorCode.GAS_PRICE_TOO_LOW".into())
-)]
-#[case::internal_error(
-    StarknetErrorCode::UnknownErrorCode("StarknetErrorCode.InternalError".into())
-)]
 #[tokio::test]
-async fn add_tx_returns_error_when_extract_state_nonce_and_run_validations_fails(
-    #[case] error_code: StarknetErrorCode,
-    mut mock_stateful_transaction_validator: MockStatefulTransactionValidatorTrait,
-    mut mock_stateful_transaction_validator_factory: MockStatefulTransactionValidatorFactoryTrait,
+async fn add_tx_returns_error_when_stateful_validation_fails(
     mut mock_dependencies: MockDependencies,
 ) {
-    let expected_error = StarknetError {
-        code: error_code.clone(),
-        message: "placeholder".into(), // Message is not checked
-    };
+    // The state reader returns account_nonce=0 for any sender, and max_allowed_nonce_gap defaults
+    // to 200, so a tx with nonce 1000 is rejected by validate_nonce.
+    let mut tx_args = invoke_args();
+    tx_args.nonce = nonce!(1000);
+    let internal_tx = tx_args.get_internal_tx();
+    tx_args.tx_hash = internal_tx.tx.calculate_transaction_hash(&CHAIN_ID_FOR_TESTS).unwrap();
 
-    mock_stateful_transaction_validator
-        .expect_extract_state_nonce_and_run_validations()
-        .return_once(|_, _| Err(expected_error));
-
-    mock_stateful_transaction_validator_factory
-        .expect_instantiate_validator()
-        .return_once(|_| Ok(Box::new(mock_stateful_transaction_validator)));
-
-    let tx_args = invoke_args();
     setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
-    let gateway = GenericGateway::<
-        MockTransactionConverterTrait,
-        MockStatefulTransactionValidatorFactoryTrait,
-    > {
-        config: Arc::new(mock_dependencies.config.clone()),
-        stateless_tx_validator: Arc::new(StatelessTransactionValidator {
-            config: mock_dependencies.config.static_config.stateless_tx_validator_config.clone(),
-        }),
-        stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
-        mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
-        transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
-        proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
-    };
 
+    let gateway = mock_dependencies.gateway();
     let result = gateway.add_tx(tx_args.get_rpc_tx(), None).await;
 
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err().code, error_code);
+    assert_eq!(
+        result.unwrap_err().code,
+        StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidTransactionNonce),
+    );
 }
 
 #[rstest]
@@ -756,43 +698,6 @@ async fn stateless_transaction_validator_error(mut mock_dependencies: MockDepend
     tx_args.signature = TransactionSignature(vec![Felt::ZERO].into());
 
     let gateway = mock_dependencies.gateway();
-    let result = gateway.add_tx(tx_args.get_rpc_tx(), None).await;
-
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err().code, error_code);
-}
-
-#[rstest]
-#[tokio::test]
-async fn add_tx_returns_error_when_instantiating_validator_fails(
-    mut mock_stateful_transaction_validator_factory: MockStatefulTransactionValidatorFactoryTrait,
-    mut mock_dependencies: MockDependencies,
-) {
-    let error_code = StarknetErrorCode::UnknownErrorCode("StarknetErrorCode.InternalError".into());
-    let expected_error = StarknetError {
-        code: error_code.clone(),
-        message: "placeholder".into(), // Message is not checked
-    };
-    mock_stateful_transaction_validator_factory
-        .expect_instantiate_validator()
-        .return_once(|_| Err(expected_error));
-
-    let tx_args = invoke_args();
-    setup_transaction_converter_mock(&mut mock_dependencies.mock_transaction_converter, &tx_args);
-    let gateway = GenericGateway::<
-        MockTransactionConverterTrait,
-        MockStatefulTransactionValidatorFactoryTrait,
-    > {
-        config: Arc::new(mock_dependencies.config.clone()),
-        stateless_tx_validator: Arc::new(StatelessTransactionValidator {
-            config: mock_dependencies.config.static_config.stateless_tx_validator_config.clone(),
-        }),
-        stateful_tx_validator_factory: Arc::new(mock_stateful_transaction_validator_factory),
-        mempool_client: Arc::new(mock_dependencies.mock_mempool_client),
-        transaction_converter: Arc::new(mock_dependencies.mock_transaction_converter),
-        proof_archive_writer: Arc::new(mock_dependencies.mock_proof_archive_writer),
-    };
-
     let result = gateway.add_tx(tx_args.get_rpc_tx(), None).await;
 
     assert!(result.is_err());

--- a/crates/apollo_gateway/src/stateful_transaction_validator.rs
+++ b/crates/apollo_gateway/src/stateful_transaction_validator.rs
@@ -10,7 +10,6 @@ use apollo_gateway_types::errors::GatewaySpecError;
 use apollo_mempool_types::communication::SharedMempoolClient;
 use apollo_mempool_types::mempool_types::ValidationArgs;
 use apollo_proc_macros::sequencer_latency_histogram;
-use async_trait::async_trait;
 use blockifier::blockifier::config::NativeClassesWhitelist;
 use blockifier::blockifier::stateful_validator::{StatefulValidator, StatefulValidatorTrait};
 use blockifier::blockifier_versioned_constants::VersionedConstants;
@@ -23,7 +22,7 @@ use blockifier::transaction::account_transaction::{AccountTransaction, Execution
 use blockifier::transaction::transactions::enforce_fee;
 use num_rational::Ratio;
 use starknet_api::block::NonzeroGasPrice;
-use starknet_api::core::{ContractAddress, Nonce};
+use starknet_api::core::Nonce;
 use starknet_api::executable_transaction::{
     AccountTransaction as ExecutableTransaction,
     InvokeTransaction as ExecutableInvokeTransaction,
@@ -35,58 +34,29 @@ use tracing::{debug, Span};
 use crate::errors::{mempool_client_err_to_deprecated_gw_err, StatefulTransactionValidatorResult};
 use crate::gateway_fixed_block_state_reader::GatewayFixedBlockStateReader;
 use crate::metrics::{GATEWAY_CLASS_CACHE_METRICS, GATEWAY_VALIDATE_TX_LATENCY};
-use crate::state_reader::{GatewayStateReaderWithCompiledClasses, StateReaderFactory};
+use crate::state_reader::StateReaderFactory;
 
 #[cfg(test)]
 #[path = "stateful_transaction_validator_test.rs"]
 mod stateful_transaction_validator_test;
 
-#[async_trait]
-pub trait StatefulTransactionValidatorFactoryTrait: Send + Sync {
-    type Validator: StatefulTransactionValidatorTrait;
-
-    async fn instantiate_validator(
-        &self,
-        native_classes_whitelist: NativeClassesWhitelist,
-    ) -> StatefulTransactionValidatorResult<Box<Self::Validator>>;
-}
-
-#[cfg(test)]
-mockall::mock! {
-    pub StatefulTransactionValidatorFactoryTrait {}
-
-    #[async_trait]
-    impl StatefulTransactionValidatorFactoryTrait for StatefulTransactionValidatorFactoryTrait {
-        type Validator = MockStatefulTransactionValidatorTrait;
-
-        async fn instantiate_validator(
-            &self,
-            native_classes_whitelist: NativeClassesWhitelist,
-        ) -> StatefulTransactionValidatorResult<Box<MockStatefulTransactionValidatorTrait>>;
-    }
-}
-
 #[derive(Clone)]
-pub struct StatefulTransactionValidatorFactory<TStateReaderFactory: StateReaderFactory> {
+pub struct StatefulTransactionValidator<TStateReaderFactory: StateReaderFactory> {
     pub config: StatefulTransactionValidatorConfig,
     pub chain_info: ChainInfo,
     pub state_reader_factory: Arc<TStateReaderFactory>,
     pub contract_class_manager: ContractClassManager,
 }
 
-#[async_trait]
-impl<TStateReaderFactory: StateReaderFactory> StatefulTransactionValidatorFactoryTrait
-    for StatefulTransactionValidatorFactory<TStateReaderFactory>
+impl<TStateReaderFactory: StateReaderFactory + 'static>
+    StatefulTransactionValidator<TStateReaderFactory>
 {
-    type Validator = StatefulTransactionValidator<
-        <TStateReaderFactory as StateReaderFactory>::TGatewayStateReaderWithCompiledClasses,
-        <TStateReaderFactory as StateReaderFactory>::TGatewayFixedBlockStateReader,
-    >;
-
-    async fn instantiate_validator(
+    pub async fn validate_stateful_tx(
         &self,
+        executable_tx: &ExecutableTransaction,
+        mempool_client: SharedMempoolClient,
         native_classes_whitelist: NativeClassesWhitelist,
-    ) -> StatefulTransactionValidatorResult<Box<Self::Validator>> {
+    ) -> StatefulTransactionValidatorResult<Nonce> {
         // TODO(yael 6/5/2024): consider storing the block_info as part of the
         // StatefulTransactionValidator and update it only once a new block is created.
         let (blockifier_state_reader, gateway_fixed_block_state_reader) = self
@@ -110,58 +80,10 @@ impl<TStateReaderFactory: StateReaderFactory> StatefulTransactionValidatorFactor
                 Some(GATEWAY_CLASS_CACHE_METRICS),
             );
 
-        Ok(Box::new(StatefulTransactionValidator::new(
-            self.config.clone(),
-            self.chain_info.clone(),
-            state_reader_and_contract_manager,
-            gateway_fixed_block_state_reader,
-        )))
-    }
-}
-
-#[cfg_attr(test, mockall::automock)]
-#[async_trait]
-pub trait StatefulTransactionValidatorTrait: Send {
-    async fn extract_state_nonce_and_run_validations(
-        &mut self,
-        executable_tx: &ExecutableTransaction,
-        mempool_client: SharedMempoolClient,
-    ) -> StatefulTransactionValidatorResult<Nonce>;
-}
-
-pub struct StatefulTransactionValidator<
-    TGatewayStateReaderWithCompiledClasses: GatewayStateReaderWithCompiledClasses,
-    TGatewayFixedBlockStateReader: GatewayFixedBlockStateReader,
-> {
-    config: StatefulTransactionValidatorConfig,
-    chain_info: ChainInfo,
-    // Consumed when running the CPU-heavy blockifier validation.
-    // TODO(Itamar): The whole `StatefulTransactionValidator` is never used after
-    // `state_reader_and_contract_manager` is taken. Make it non-optional and discard the
-    // instance after use.
-    state_reader_and_contract_manager:
-        Option<StateReaderAndContractManager<TGatewayStateReaderWithCompiledClasses>>,
-    gateway_fixed_block_state_reader: TGatewayFixedBlockStateReader,
-}
-
-#[async_trait]
-impl<TGatewayStateReaderWithCompiledClasses, TGatewayFixedBlockStateReader>
-    StatefulTransactionValidatorTrait
-    for StatefulTransactionValidator<
-        TGatewayStateReaderWithCompiledClasses,
-        TGatewayFixedBlockStateReader,
-    >
-where
-    TGatewayStateReaderWithCompiledClasses: GatewayStateReaderWithCompiledClasses + 'static,
-    TGatewayFixedBlockStateReader: GatewayFixedBlockStateReader,
-{
-    async fn extract_state_nonce_and_run_validations(
-        &mut self,
-        executable_tx: &ExecutableTransaction,
-        mempool_client: SharedMempoolClient,
-    ) -> StatefulTransactionValidatorResult<Nonce> {
-        let account_nonce =
-            self.get_nonce_from_state(executable_tx.contract_address()).await.map_err(|e| {
+        let account_nonce = gateway_fixed_block_state_reader
+            .get_nonce(executable_tx.contract_address())
+            .await
+            .map_err(|e| {
                 // TODO(noamsp): Fix this. Need to map the errors better.
                 StarknetError::internal_with_signature_logging(
                     format!(
@@ -172,63 +94,63 @@ where
                     e,
                 )
             })?;
-        let skip_validate =
-            self.run_pre_validation_checks(executable_tx, account_nonce, mempool_client).await?;
-        self.run_validate_entry_point(executable_tx, skip_validate).await?;
+        let skip_validate = self
+            .run_pre_validation_checks(
+                &gateway_fixed_block_state_reader,
+                executable_tx,
+                account_nonce,
+                mempool_client,
+            )
+            .await?;
+        self.run_validate_entry_point(
+            &gateway_fixed_block_state_reader,
+            executable_tx,
+            skip_validate,
+            state_reader_and_contract_manager,
+        )
+        .await?;
         Ok(account_nonce)
     }
-}
 
-impl<TGatewayStateReaderWithCompiledClasses, TGatewayFixedBlockStateReader>
-    StatefulTransactionValidator<
-        TGatewayStateReaderWithCompiledClasses,
-        TGatewayFixedBlockStateReader,
-    >
-where
-    TGatewayStateReaderWithCompiledClasses: GatewayStateReaderWithCompiledClasses + 'static,
-    TGatewayFixedBlockStateReader: GatewayFixedBlockStateReader,
-{
-    fn new(
-        config: StatefulTransactionValidatorConfig,
-        chain_info: ChainInfo,
-        state_reader_and_contract_manager: StateReaderAndContractManager<
-            TGatewayStateReaderWithCompiledClasses,
-        >,
-        gateway_fixed_block_state_reader: TGatewayFixedBlockStateReader,
-    ) -> Self {
-        Self {
-            config,
-            chain_info,
-            state_reader_and_contract_manager: Some(state_reader_and_contract_manager),
+    pub(crate) async fn run_pre_validation_checks(
+        &self,
+        gateway_fixed_block_state_reader: &impl GatewayFixedBlockStateReader,
+        executable_tx: &ExecutableTransaction,
+        account_nonce: Nonce,
+        mempool_client: SharedMempoolClient,
+    ) -> StatefulTransactionValidatorResult<bool> {
+        self.validate_state_preconditions(
             gateway_fixed_block_state_reader,
-        }
-    }
-
-    fn take_state_reader_and_contract_manager(
-        &mut self,
-    ) -> StateReaderAndContractManager<TGatewayStateReaderWithCompiledClasses> {
-        self.state_reader_and_contract_manager.take().expect("Validator was already consumed")
+            executable_tx,
+            account_nonce,
+        )
+        .await?;
+        validate_by_mempool(executable_tx, account_nonce, mempool_client.clone()).await?;
+        let skip_validate =
+            skip_stateful_validations(executable_tx, account_nonce, mempool_client.clone()).await?;
+        Ok(skip_validate)
     }
 
     async fn validate_state_preconditions(
         &self,
+        gateway_fixed_block_state_reader: &impl GatewayFixedBlockStateReader,
         executable_tx: &ExecutableTransaction,
         account_nonce: Nonce,
     ) -> StatefulTransactionValidatorResult<()> {
-        self.validate_resource_bounds(executable_tx).await?;
+        self.validate_resource_bounds(gateway_fixed_block_state_reader, executable_tx).await?;
         self.validate_nonce(executable_tx, account_nonce)?;
         Ok(())
     }
 
-    async fn validate_resource_bounds(
+    pub(crate) async fn validate_resource_bounds(
         &self,
+        gateway_fixed_block_state_reader: &impl GatewayFixedBlockStateReader,
         executable_tx: &ExecutableTransaction,
     ) -> StatefulTransactionValidatorResult<()> {
         // Skip this validation during the systems bootstrap phase.
         if self.config.validate_resource_bounds {
             // TODO(Arni): getnext_l2_gas_price from the block header.
-            let previous_block_l2_gas_price = self
-                .gateway_fixed_block_state_reader
+            let previous_block_l2_gas_price = gateway_fixed_block_state_reader
                 .get_block_info()
                 .await?
                 .gas_prices
@@ -242,7 +164,7 @@ where
         Ok(())
     }
 
-    fn validate_nonce(
+    pub(crate) fn validate_nonce(
         &self,
         executable_tx: &ExecutableTransaction,
         account_nonce: Nonce,
@@ -299,62 +221,6 @@ where
         Ok(())
     }
 
-    #[sequencer_latency_histogram(GATEWAY_VALIDATE_TX_LATENCY, true)]
-    async fn run_validate_entry_point(
-        &mut self,
-        executable_tx: &ExecutableTransaction,
-        skip_validate: bool,
-    ) -> StatefulTransactionValidatorResult<()> {
-        let only_query = false;
-        let charge_fee = enforce_fee(executable_tx, only_query);
-        let strict_nonce_check = false;
-        let execution_flags =
-            ExecutionFlags { only_query, charge_fee, validate: !skip_validate, strict_nonce_check };
-
-        let account_tx = AccountTransaction { tx: executable_tx.clone(), execution_flags };
-
-        // Build block context.
-        let mut versioned_constants = VersionedConstants::get_versioned_constants(
-            self.config.versioned_constants_overrides.clone(),
-        );
-        // The validation of a transaction is not affected by the casm hash migration.
-        versioned_constants.enable_casm_hash_migration = false;
-
-        let mut block_info = self.gateway_fixed_block_state_reader.get_block_info().await?;
-        block_info.block_number = block_info.block_number.unchecked_next();
-        let block_context = BlockContext::new(
-            block_info,
-            self.chain_info.clone(),
-            versioned_constants,
-            BouncerConfig::max(),
-        );
-
-        // Move state into the blocking task and run CPU-heavy validation.
-        let state_reader_and_contract_manager = self.take_state_reader_and_contract_manager();
-
-        let cur_span = Span::current();
-        #[allow(clippy::result_large_err)]
-        tokio::task::spawn_blocking(move || {
-            cur_span.in_scope(|| {
-                let state = CachedState::new(state_reader_and_contract_manager);
-                let mut blockifier_validator = StatefulValidator::create(state, block_context);
-                blockifier_validator.validate(account_tx)
-            })
-        })
-        .await
-        .map_err(|e| StarknetError {
-            code: StarknetErrorCode::UnknownErrorCode(
-                "StarknetErrorCode.InternalError".to_string(),
-            ),
-            message: format!("Blocking task join error when running the validate entry point: {e}"),
-        })?
-        .map_err(|e| StarknetError {
-            code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::ValidateFailure),
-            message: e.to_string(),
-        })?;
-        Ok(())
-    }
-
     // TODO(Arni): Consider running this validation for all gas prices.
     fn validate_tx_l2_gas_price_within_threshold(
         &self,
@@ -389,24 +255,62 @@ where
         Ok(())
     }
 
-    async fn get_nonce_from_state(
+    #[sequencer_latency_histogram(GATEWAY_VALIDATE_TX_LATENCY, true)]
+    async fn run_validate_entry_point(
         &self,
-        contract_address: ContractAddress,
-    ) -> StatefulTransactionValidatorResult<Nonce> {
-        self.gateway_fixed_block_state_reader.get_nonce(contract_address).await
-    }
-
-    async fn run_pre_validation_checks(
-        &self,
+        gateway_fixed_block_state_reader: &impl GatewayFixedBlockStateReader,
         executable_tx: &ExecutableTransaction,
-        account_nonce: Nonce,
-        mempool_client: SharedMempoolClient,
-    ) -> StatefulTransactionValidatorResult<bool> {
-        self.validate_state_preconditions(executable_tx, account_nonce).await?;
-        validate_by_mempool(executable_tx, account_nonce, mempool_client.clone()).await?;
-        let skip_validate =
-            skip_stateful_validations(executable_tx, account_nonce, mempool_client.clone()).await?;
-        Ok(skip_validate)
+        skip_validate: bool,
+        state_reader_and_contract_manager: StateReaderAndContractManager<
+            <TStateReaderFactory as StateReaderFactory>::TGatewayStateReaderWithCompiledClasses,
+        >,
+    ) -> StatefulTransactionValidatorResult<()> {
+        let only_query = false;
+        let charge_fee = enforce_fee(executable_tx, only_query);
+        let strict_nonce_check = false;
+        let execution_flags =
+            ExecutionFlags { only_query, charge_fee, validate: !skip_validate, strict_nonce_check };
+
+        let account_tx = AccountTransaction { tx: executable_tx.clone(), execution_flags };
+
+        // Build block context.
+        let mut versioned_constants = VersionedConstants::get_versioned_constants(
+            self.config.versioned_constants_overrides.clone(),
+        );
+        // The validation of a transaction is not affected by the casm hash migration.
+        versioned_constants.enable_casm_hash_migration = false;
+
+        let mut block_info = gateway_fixed_block_state_reader.get_block_info().await?;
+        block_info.block_number = block_info.block_number.unchecked_next();
+        let block_context = BlockContext::new(
+            block_info,
+            self.chain_info.clone(),
+            versioned_constants,
+            BouncerConfig::max(),
+        );
+
+        // Move state into the blocking task and run CPU-heavy validation.
+        let cur_span = Span::current();
+        #[allow(clippy::result_large_err)]
+        tokio::task::spawn_blocking(move || {
+            cur_span.in_scope(|| {
+                let state = CachedState::new(state_reader_and_contract_manager);
+                let mut blockifier_validator = StatefulValidator::create(state, block_context);
+                blockifier_validator.validate(account_tx)
+            })
+        })
+        .await
+        .map_err(|e| StarknetError {
+            code: StarknetErrorCode::UnknownErrorCode(
+                "StarknetErrorCode.InternalError".to_string(),
+            ),
+            message: format!("Blocking task join error when running the validate entry point: {e}"),
+        })?
+        .map_err(|e| StarknetError {
+            code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::ValidateFailure),
+            message: e.to_string(),
+        })?;
+        Ok(())
     }
 }
 

--- a/crates/apollo_gateway/src/stateful_transaction_validator_test.rs
+++ b/crates/apollo_gateway/src/stateful_transaction_validator_test.rs
@@ -7,14 +7,13 @@ use apollo_gateway_types::deprecated_gateway_error::{
     StarknetErrorCode,
 };
 use apollo_mempool_types::communication::MockMempoolClient;
-use blockifier::blockifier::config::{ContractClassManagerConfig, NativeClassesWhitelist};
+use blockifier::blockifier::config::ContractClassManagerConfig;
 use blockifier::context::ChainInfo;
 use blockifier::state::contract_class_manager::ContractClassManager;
 use blockifier::test_utils::contracts::FeatureContractTrait;
 use blockifier::transaction::test_utils::calculate_class_info_for_testing;
 use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
 use blockifier_test_utils::contracts::FeatureContract;
-use mockall::predicate::eq;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::block::{BlockInfo, GasPrice, GasPriceVector, GasPrices, NonzeroGasPrice};
@@ -27,51 +26,21 @@ use starknet_api::transaction::fields::{AllResourceBounds, ResourceBounds, Valid
 use starknet_api::{declare_tx_args, deploy_account_tx_args, invoke_tx_args, nonce};
 
 use crate::gateway_fixed_block_state_reader::MockGatewayFixedBlockStateReader;
-use crate::state_reader_test_utils::{local_test_state_reader_factory, TestStateReader};
-use crate::stateful_transaction_validator::{
-    StatefulTransactionValidator,
-    StatefulTransactionValidatorFactory,
-    StatefulTransactionValidatorFactoryTrait,
-    StatefulTransactionValidatorTrait,
-};
+use crate::state_reader_test_utils::{local_test_state_reader_factory, TestStateReaderFactory};
+use crate::stateful_transaction_validator::StatefulTransactionValidator;
 
-#[tokio::test]
-async fn test_get_nonce_fail_on_extract_state_nonce_and_run_validations() {
-    let executable_tx = executable_invoke_tx(invoke_tx_args!());
-    let mut mock_gateway_fixed_block = MockGatewayFixedBlockStateReader::new();
-    mock_gateway_fixed_block
-        .expect_get_nonce()
-        .with(eq(executable_tx.sender_address()))
-        .return_once(|_| {
-            Err(StarknetError {
-                code: StarknetErrorCode::UnknownErrorCode(
-                    "StarknetErrorCode.InternalError".to_string(),
-                ),
-                message: "Internal error".to_string(),
-            })
-        });
-
-    let mempool_client = Arc::new(MockMempoolClient::new());
-    let mut stateful_validator: StatefulTransactionValidator<TestStateReader, _> =
-        StatefulTransactionValidator {
-            config: StatefulTransactionValidatorConfig::default(),
-            chain_info: ChainInfo::create_for_testing(),
-            state_reader_and_contract_manager: None,
-            gateway_fixed_block_state_reader: mock_gateway_fixed_block,
-        };
-
-    let result = stateful_validator
-        .extract_state_nonce_and_run_validations(&executable_tx, mempool_client)
-        .await;
-    assert_eq!(
-        result,
-        Err(StarknetError {
-            code: StarknetErrorCode::UnknownErrorCode(
-                "StarknetErrorCode.InternalError".to_string()
-            ),
-            message: "Internal error".to_string(),
-        })
-    );
+fn validator_for_testing(
+    config: StatefulTransactionValidatorConfig,
+) -> StatefulTransactionValidator<TestStateReaderFactory> {
+    StatefulTransactionValidator {
+        config,
+        chain_info: ChainInfo::create_for_testing(),
+        state_reader_factory: Arc::new(local_test_state_reader_factory(
+            CairoVersion::Cairo1(RunnableCairo1::Casm),
+            true,
+        )),
+        contract_class_manager: ContractClassManager::start(ContractClassManagerConfig::default()),
+    }
 }
 
 // TODO(Arni): consider testing declare and deploy account.
@@ -104,14 +73,6 @@ async fn test_run_pre_validation_checks(
     let mut mock_gateway_fixed_block = MockGatewayFixedBlockStateReader::new();
     mock_gateway_fixed_block.expect_get_block_info().returning(|| Ok(BlockInfo::default()));
 
-    let stateful_validator: StatefulTransactionValidator<TestStateReader, _> =
-        StatefulTransactionValidator {
-            config: StatefulTransactionValidatorConfig::default(),
-            chain_info: ChainInfo::create_for_testing(),
-            state_reader_and_contract_manager: None,
-            gateway_fixed_block_state_reader: mock_gateway_fixed_block,
-        };
-
     let resource_bounds = if zero_gas_fee {
         ValidResourceBounds::AllResources(AllResourceBounds {
             l2_gas: ResourceBounds { max_price_per_unit: 0_u128.into(), ..Default::default() },
@@ -122,30 +83,16 @@ async fn test_run_pre_validation_checks(
     };
     let executable_tx: AccountTransaction = executable_invoke_tx(invoke_tx_args!(resource_bounds));
 
-    let result = stateful_validator
-        .run_pre_validation_checks(&executable_tx, account_nonce, mempool_client)
+    let validator = validator_for_testing(StatefulTransactionValidatorConfig::default());
+    let result = validator
+        .run_pre_validation_checks(
+            &mock_gateway_fixed_block,
+            &executable_tx,
+            account_nonce,
+            mempool_client,
+        )
         .await;
     assert_eq!(result, expected_result);
-}
-
-#[rstest]
-#[tokio::test]
-async fn test_instantiate_validator() {
-    let state_reader_factory =
-        local_test_state_reader_factory(CairoVersion::Cairo1(RunnableCairo1::Casm), false);
-
-    let stateful_validator_factory = StatefulTransactionValidatorFactory {
-        config: StatefulTransactionValidatorConfig::default(),
-        chain_info: ChainInfo::create_for_testing(),
-        state_reader_factory: Arc::new(state_reader_factory),
-        contract_class_manager: ContractClassManager::start(ContractClassManagerConfig::default()),
-    };
-    // The whitelist is irrelevant for the test.
-    let native_classes_whitelist = NativeClassesWhitelist::All;
-
-    let validator =
-        stateful_validator_factory.instantiate_validator(native_classes_whitelist).await;
-    assert!(validator.is_ok());
 }
 
 #[rstest]
@@ -202,25 +149,20 @@ async fn test_skip_validate(
     mock_mempool_client.expect_validate_tx().returning(|_| Ok(()));
     let mempool_client = Arc::new(mock_mempool_client);
 
-    // Configure gateway state reader to return the provided sender/account nonce.
-    let mut mock_gateway_fixed_block = MockGatewayFixedBlockStateReader::new();
-    mock_gateway_fixed_block
-        .expect_get_nonce()
-        .with(eq(executable_tx.sender_address()))
-        .return_once(move |_| Ok(sender_nonce));
-    let stateful_validator: StatefulTransactionValidator<TestStateReader, _> =
-        StatefulTransactionValidator {
-            config: StatefulTransactionValidatorConfig {
-                validate_resource_bounds: false,
-                ..Default::default()
-            },
-            chain_info: ChainInfo::create_for_testing(),
-            state_reader_and_contract_manager: None,
-            gateway_fixed_block_state_reader: mock_gateway_fixed_block,
-        };
+    // validate_resource_bounds is false, so the reader is never read.
+    let mock_gateway_fixed_block = MockGatewayFixedBlockStateReader::new();
 
-    let skip_validate = stateful_validator
-        .run_pre_validation_checks(&executable_tx, sender_nonce, mempool_client)
+    let validator = validator_for_testing(StatefulTransactionValidatorConfig {
+        validate_resource_bounds: false,
+        ..Default::default()
+    });
+    let skip_validate = validator
+        .run_pre_validation_checks(
+            &mock_gateway_fixed_block,
+            &executable_tx,
+            sender_nonce,
+            mempool_client,
+        )
         .await
         .unwrap();
     assert_eq!(skip_validate, !should_validate);
@@ -285,7 +227,7 @@ async fn test_skip_validate(
     })
 )]
 #[tokio::test]
-async fn validate_resource_bounds(
+async fn test_validate_resource_bounds(
     #[case] prev_l2_gas_price: NonzeroGasPrice,
     #[case] min_gas_price_percentage: u8,
     #[case] tx_gas_price_per_unit: GasPrice,
@@ -311,19 +253,13 @@ async fn validate_resource_bounds(
         })
     });
 
-    let stateful_validator: StatefulTransactionValidator<TestStateReader, _> =
-        StatefulTransactionValidator {
-            config: StatefulTransactionValidatorConfig {
-                validate_resource_bounds: true,
-                min_gas_price_percentage,
-                ..Default::default()
-            },
-            chain_info: ChainInfo::create_for_testing(),
-            state_reader_and_contract_manager: None,
-            gateway_fixed_block_state_reader: mock_gateway_fixed_block,
-        };
-
-    let result = stateful_validator.validate_resource_bounds(&executable_tx).await;
+    let validator = validator_for_testing(StatefulTransactionValidatorConfig {
+        validate_resource_bounds: true,
+        min_gas_price_percentage,
+        ..Default::default()
+    });
+    let result =
+        validator.validate_resource_bounds(&mock_gateway_fixed_block, &executable_tx).await;
     assert_eq!(result, expected_result);
 }
 
@@ -417,27 +353,24 @@ async fn run_pre_validation_checks_test(
     max_allowed_nonce_gap: u32,
     expected_result: Result<bool, StarknetErrorCode>,
 ) {
-    let mut mock_gateway_fixed_block = MockGatewayFixedBlockStateReader::new();
-    mock_gateway_fixed_block
-        .expect_get_nonce()
-        .with(eq(executable_tx.sender_address()))
-        .return_once(move |_| Ok(account_nonce));
-    let stateful_validator: StatefulTransactionValidator<TestStateReader, _> =
-        StatefulTransactionValidator {
-            config: StatefulTransactionValidatorConfig {
-                max_allowed_nonce_gap,
-                validate_resource_bounds: false,
-                ..Default::default()
-            },
-            chain_info: ChainInfo::create_for_testing(),
-            state_reader_and_contract_manager: None,
-            gateway_fixed_block_state_reader: mock_gateway_fixed_block,
-        };
+    // validate_resource_bounds is false, so the reader is never read.
+    let mock_gateway_fixed_block = MockGatewayFixedBlockStateReader::new();
 
     let mut mempool_client = MockMempoolClient::new();
     mempool_client.expect_validate_tx().returning(|_| Ok(()));
-    let result = stateful_validator
-        .run_pre_validation_checks(&executable_tx, account_nonce, Arc::new(mempool_client))
+
+    let validator = validator_for_testing(StatefulTransactionValidatorConfig {
+        max_allowed_nonce_gap,
+        validate_resource_bounds: false,
+        ..Default::default()
+    });
+    let result = validator
+        .run_pre_validation_checks(
+            &mock_gateway_fixed_block,
+            &executable_tx,
+            account_nonce,
+            Arc::new(mempool_client),
+        )
         .await
         .map_err(|err| err.code);
     assert_eq!(result, expected_result);

--- a/crates/apollo_gateway/src/test_utils.rs
+++ b/crates/apollo_gateway/src/test_utils.rs
@@ -33,7 +33,6 @@ use starknet_types_core::felt::Felt;
 use crate::gateway::GenericGateway;
 use crate::proof_archive_writer::MockProofArchiveWriterTrait;
 use crate::state_reader_test_utils::{local_test_state_reader_factory, TestStateReaderFactory};
-use crate::stateful_transaction_validator::StatefulTransactionValidatorFactory;
 
 pub const NON_EMPTY_RESOURCE_BOUNDS: ResourceBounds =
     ResourceBounds { max_amount: GasAmount(1), max_price_per_unit: GasPrice(1) };
@@ -159,10 +158,7 @@ pub fn rpc_tx_for_testing(
     }
 }
 
-pub type GatewayForBenchmark = GenericGateway<
-    TransactionConverter,
-    StatefulTransactionValidatorFactory<TestStateReaderFactory>,
->;
+pub type GatewayForBenchmark = GenericGateway<TransactionConverter, TestStateReaderFactory>;
 
 pub fn gateway_for_benchmark(gateway_config: GatewayConfig) -> GatewayForBenchmark {
     let cairo_version = CairoVersion::Cairo1(RunnableCairo1::Casm);


### PR DESCRIPTION
Merges StatefulTransactionValidatorFactory and StatefulTransactionValidator
into one struct holding (config, chain_info, state_reader_factory,
contract_class_manager). The two-step instantiate+extract API becomes
a single validate_stateful_tx method.

Drops StatefulTransactionValidatorFactoryTrait and StatefulTransactionValidatorTrait
(plus their mocks). Gateway tests use the real validator with TestStateReaderFactory
and trigger errors via real data (bad nonce). GenericGateway loses one trait
generic in favor of TStateReaderFactory: StateReaderFactory.

The Option<state_reader_and_contract_manager> workaround disappears since
the per-tx state is now local to validate_stateful_tx.

Net -273 lines.