### PR TITLE
deployment: add sepolia-alpha overlay configs

### DIFF
--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/common.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/common.yaml
@@ -1,0 +1,20 @@
+image:
+  repository: ghcr.io/starkware-libs/sequencer/sequencer
+  tag: APOLLO-0.14.2-RC.5
+  imagePullPolicy: IfNotPresent
+
+config:
+  sequencerConfig:
+    chain_id: SN_SEPOLIA
+    eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
+    native_classes_whitelist: All
+    strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d'
+    versioned_constants_overrides.max_n_events: 1000
+
+env:
+- name: RUST_LOG
+  value: debug
+- name: RUST_BACKTRACE
+  value: full
+- name: NO_COLOR
+  value: '1'

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/committer.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/committer.yaml
@@ -1,0 +1,5 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_committer.json
+  sequencerConfig:
+    committer_config.storage_config.cache_size: 10000000
+    committer_config.verify_state_diff_hash: true

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/core.yaml
@@ -1,0 +1,33 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_core.json
+  sequencerConfig:
+    batcher_config.dynamic_config.n_concurrent_txs: 8
+    batcher_config.dynamic_config.proposer_idle_detection_delay_millis: 2000
+    batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.n_events: 5000
+    batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.state_diff_size: 5000
+    batcher_config.static_config.block_builder_config.execute_config.n_workers: 5
+    batcher_config.static_config.first_block_with_partial_block_hash.#is_none: false
+    batcher_config.static_config.first_block_with_partial_block_hash.block_hash: '0x578b4e2f34e4da24e7482de643b4e3435fa7e34770cdb8d71002bb19e415ffa'
+    batcher_config.static_config.first_block_with_partial_block_hash.block_number: 86311
+    batcher_config.static_config.first_block_with_partial_block_hash.parent_block_hash: '0x5c980ea7747167d2ae98fa7ef7d62f52243e924c453b4934045443d977458d3'
+    class_manager_config.static_config.class_manager_config.max_compiled_contract_class_object_size: 4089446
+    consensus_manager_config.consensus_manager_config.dynamic_config.require_virtual_proposer_vote: false
+    consensus_manager_config.consensus_manager_config.dynamic_config.timeouts.proposal.base: 9.1
+    consensus_manager_config.consensus_manager_config.dynamic_config.timeouts.proposal.max: 9.1
+    consensus_manager_config.context_config.dynamic_config.build_proposal_margin_millis: 1000
+    consensus_manager_config.context_config.dynamic_config.compare_retrospective_block_hash: true
+    consensus_manager_config.context_config.dynamic_config.min_l2_gas_price_per_height: ''
+    consensus_manager_config.context_config.dynamic_config.override_eth_to_fri_rate: 0
+    consensus_manager_config.context_config.dynamic_config.override_eth_to_fri_rate.#is_none: true
+    consensus_manager_config.context_config.dynamic_config.override_l1_data_gas_price_fri: 0
+    consensus_manager_config.context_config.dynamic_config.override_l1_data_gas_price_fri.#is_none: true
+    consensus_manager_config.context_config.dynamic_config.override_l1_gas_price_fri: 0
+    consensus_manager_config.context_config.dynamic_config.override_l1_gas_price_fri.#is_none: true
+    consensus_manager_config.context_config.dynamic_config.override_l2_gas_price_fri: 0
+    consensus_manager_config.context_config.dynamic_config.override_l2_gas_price_fri.#is_none: true
+    consensus_manager_config.staking_manager_config.dynamic_config.default_committee: 0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true;0x67,1,0x1,true;0x68,1,0x1,true
+    consensus_manager_config.staking_manager_config.dynamic_config.override_committee: ''
+    consensus_manager_config.staking_manager_config.dynamic_config.override_committee.#is_none: true
+    state_sync_config.static_config.central_sync_client_config.#is_none: false
+    state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold: 0
+    state_sync_config.static_config.p2p_sync_client_config.#is_none: true

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/gateway.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/gateway.yaml
@@ -1,0 +1,7 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_gateway.json
+  sequencerConfig:
+    gateway_config.static_config.authorized_declarer_accounts: ''
+    gateway_config.static_config.authorized_declarer_accounts.#is_none: true
+    gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap: 200
+    gateway_config.static_config.stateless_tx_validator_config.min_gas_price: 8000000000

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/l1.yaml
@@ -1,0 +1,7 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_l1.json
+  sequencerConfig:
+    base_layer_config.bpo1_start_block_number: 9456501
+    base_layer_config.bpo2_start_block_number: 9504747
+    base_layer_config.fusaka_no_bpo_start_block_number: 9408577
+    base_layer_config.starknet_contract_address: '0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057'

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/mempool.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/mempool.yaml
@@ -1,0 +1,4 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_mempool.json
+  sequencerConfig:
+    mempool_config.dynamic_config.transaction_ttl: 300

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/sierra-compiler.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/sierra-compiler.yaml
@@ -1,0 +1,5 @@
+config:
+  configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_sierra_compiler.json
+  sequencerConfig:
+    sierra_compiler_config.audited_libfuncs_only: true
+    sierra_compiler_config.max_bytecode_size: 81920


### PR DESCRIPTION
## Summary
- Adds 7 new files under `deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/` containing only fields safe for public exposure
- Public fields: chain/protocol identity (chain_id=SN_SEPOLIA, fee tokens, native_classes_whitelist, L1 contract/block numbers), consensus params, application tuning, image metadata, env vars

## Companion PR
sequencer-devops: `nimrod/sepolia-alpha-public-overlay-configs`

## Test plan
- [ ] Verify no private fields (ports, URLs, k8s infra, secrets) exist in any file under `deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/`
- [ ] After merging both PRs, run CDK8s synthesis simulating the cp step and confirm no config drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)