### PR TITLE
starknet_committer,starknet_committer_and_os_cli: log snap-sync progress per request

### DIFF
--- a/crates/starknet_committer/src/block_committer/input.rs
+++ b/crates/starknet_committer/src/block_committer/input.rs
@@ -83,6 +83,29 @@ pub struct StateDiff {
         HashMap<ContractAddress, HashMap<StarknetStorageKey, StarknetStorageValue>>,
 }
 
+impl StateDiff {
+    pub fn len(&self) -> usize {
+        let Self {
+            address_to_class_hash,
+            address_to_nonce,
+            class_hash_to_compiled_class_hash,
+            storage_updates,
+        } = self;
+        let mut result = 0usize;
+        result += address_to_class_hash.len();
+        result += address_to_nonce.len();
+        result += class_hash_to_compiled_class_hash.len();
+        for storage_map in storage_updates.values() {
+            result += storage_map.len();
+        }
+        result
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
 impl From<ThinStateDiff> for StateDiff {
     fn from(
         ThinStateDiff {

--- a/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/snap_sync.rs
@@ -331,6 +331,13 @@ fn process_request<K: TreeKey, S: Storage + Send + 'static>(
 ) -> Pin<Box<dyn Future<Output = Result<(), SnapSyncError>> + Send>> {
     Box::pin(async move {
         let (state_diff, actual_end) = K::scan(&reader, &request, block_target, size_limit)?;
+        info!(
+            "context={:?} range=[{}, {}] leaves={}",
+            request.context,
+            request.start.key().to_hex_string(),
+            actual_end.to_hex_string(),
+            state_diff.len()
+        );
         commit_state_diff(state_diff, &commit_state).await;
 
         let start_felt: Felt = *request.start.key();


### PR DESCRIPTION
Adds StateDiff::len/is_empty and logs context, range, and leaf count
for each processed request in process_request.