### PR TITLE
apollo_http_server,apollo_dashboard: propagate tracing span into tokio::spawn in add_tx_inner

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -63,7 +63,9 @@
           "exprs": [
             "sum by (add_tx_failure_reason) (increase(gateway_add_tx_failure{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__range])) > 0"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "log_query": "\"Error while adding transaction\""
+          }
         }
       ],
       "collapsed": false
@@ -1081,7 +1083,9 @@
           "exprs": [
             "sum by (add_tx_failure_reason) (increase(gateway_add_tx_failure{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__range])) > 0"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "log_query": "\"Error while adding transaction\""
+          }
         },
         {
           "title": "Transactions Sent to Mempool by Type",

--- a/crates/apollo_dashboard/src/panels/gateway.rs
+++ b/crates/apollo_dashboard/src/panels/gateway.rs
@@ -91,6 +91,7 @@ pub(crate) fn get_panel_gateway_add_tx_failure_by_reason() -> Panel {
         ),
         PanelType::Stat,
     )
+    .with_log_query("Error while adding transaction")
 }
 
 fn get_panel_gateway_transactions_failure_rate() -> Panel {

--- a/crates/apollo_http_server/src/http_server.rs
+++ b/crates/apollo_http_server/src/http_server.rs
@@ -37,7 +37,7 @@ use tokio::sync::watch::{channel, Receiver, Sender};
 use tokio::time;
 use tower_http::decompression::RequestDecompressionLayer;
 use tower_http::limit::RequestBodyLimitLayer;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument, warn, Instrument};
 
 use crate::deprecated_gateway_transaction::DeprecatedGatewayTransactionV3;
 use crate::errors::{HttpServerError, HttpServerRunError};
@@ -299,14 +299,17 @@ async fn add_tx_inner(
         .and_then(|region| region.to_str().ok())
         .unwrap_or("N/A")
         .to_string();
-    let add_tx_result = tokio::spawn(async move {
-        let add_tx_result = app_state.gateway_client.add_tx(gateway_input).await.map_err(|e| {
-            debug!("Error while adding transaction: {}", e);
-            HttpServerError::from(Box::new(e))
-        });
-        record_added_transactions(&add_tx_result, &region);
-        add_tx_result
-    })
+    let add_tx_result = tokio::spawn(
+        async move {
+            let add_tx_result = app_state.gateway_client.add_tx(gateway_input).await.map_err(|e| {
+                debug!("Error while adding transaction: {}", e);
+                HttpServerError::from(Box::new(e))
+            });
+            record_added_transactions(&add_tx_result, &region);
+            add_tx_result
+        }
+        .instrument(tracing::Span::current()),
+    )
     .await
     .expect("Should be able to get add_tx result");
 


### PR DESCRIPTION
tokio::spawn does not inherit the caller's tracing span, so logs emitted
inside the spawned task were orphaned from the add_tx instrument span.
Fix by attaching the current span via .instrument(tracing::Span::current()).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>