### PR TITLE
apollo_gateway: add private transactions received metric

### DIFF
--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -34,6 +34,7 @@ use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
     InternalRpcTransactionWithoutTxHash,
     RpcDeclareTransaction,
+    RpcInvokeTransaction,
     RpcTransaction,
 };
 use starknet_api::transaction::fields::{Proof, ProofFacts, TransactionSignature};
@@ -210,6 +211,11 @@ impl<
     ) -> GatewayResult<GatewayOutput> {
         let mut metric_counters = GatewayMetricHandle::new(&tx, &p2p_message_metadata);
         metric_counters.count_transaction_received();
+        if let RpcTransaction::Invoke(RpcInvokeTransaction::V3(ref inv)) = tx {
+            if !inv.proof_facts.is_empty() {
+                metric_counters.count_private_transaction_received();
+            }
+        }
 
         if let RpcTransaction::Declare(ref declare_tx) = tx {
             if let Err(e) = self.check_declare_permissions(declare_tx) {

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -96,6 +96,7 @@ use crate::metrics::{
     GatewayMetricHandle,
     SourceLabelValue,
     GATEWAY_ADD_TX_LATENCY,
+    GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED,
     GATEWAY_PROOF_ARCHIVE_WRITE_FAILURE,
     GATEWAY_TRANSACTIONS_FAILED,
     GATEWAY_TRANSACTIONS_RECEIVED,
@@ -550,6 +551,34 @@ async fn test_add_tx_fails_when_proof_archive_write_fails(mut mock_dependencies:
 
 #[rstest]
 #[tokio::test]
+async fn test_private_transaction_counter(mut mock_dependencies: MockDependencies) {
+    let private_tx_args = invoke_args_with_client_side_proving();
+    setup_mock_state(&mut mock_dependencies, &private_tx_args, Ok(()), Ok(())).await;
+    let AddTxResults { metrics, .. } =
+        run_add_tx_and_extract_metrics(mock_dependencies, &private_tx_args).await;
+    assert_eq!(
+        GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED.parse_numeric_metric::<u64>(&metrics),
+        Some(1)
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_public_transaction_does_not_increment_private_counter(
+    mut mock_dependencies: MockDependencies,
+) {
+    let public_tx_args = invoke_args();
+    setup_mock_state(&mut mock_dependencies, &public_tx_args, Ok(()), Ok(())).await;
+    let AddTxResults { metrics, .. } =
+        run_add_tx_and_extract_metrics(mock_dependencies, &public_tx_args).await;
+    assert_eq!(
+        GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED.parse_numeric_metric::<u64>(&metrics),
+        Some(0)
+    );
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_add_tx_fails_when_proof_verification_fails(mut mock_dependencies: MockDependencies) {
     let tx_args = invoke_args_with_client_side_proving();
 
@@ -677,6 +706,10 @@ fn test_register_metrics() {
             GATEWAY_ADD_TX_LATENCY.assert_eq(&metrics, &HistogramValue::default());
         }
     }
+    assert_eq!(
+        GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED.parse_numeric_metric::<u64>(&metrics),
+        Some(0)
+    );
 }
 
 #[rstest]

--- a/crates/apollo_gateway/src/metrics.rs
+++ b/crates/apollo_gateway/src/metrics.rs
@@ -46,6 +46,7 @@ define_metrics!(
         LabeledMetricCounter { GATEWAY_TRANSACTIONS_SENT_TO_MEMPOOL, "gateway_transactions_sent_to_mempool", "Counter of transactions sent to the mempool", init = 0 , labels = TRANSACTION_TYPE_AND_SOURCE_LABELS},
         LabeledMetricCounter { GATEWAY_ADD_TX_FAILURE, "gateway_add_tx_failure", "Counter of add_tx failures by reason", init = 0 , labels = ADD_TX_FAILURE_LABELS},
         MetricCounter { GATEWAY_PROOF_ARCHIVE_WRITE_FAILURE, "gateway_proof_archive_write_failure", "Counter of proof archive (GCS) write failures", init=0 },
+        MetricCounter { GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED, "gateway_private_transactions_received", "Counter of private transactions (invoke_v3 with non-empty proof_facts) received", init=0 },
         MetricHistogram { GATEWAY_ADD_TX_LATENCY, "gateway_add_tx_latency", "Latency of gateway add_tx function in secs" },
         MetricHistogram { GATEWAY_VALIDATE_TX_LATENCY, "gateway_validate_tx_latency", "Latency of gateway validate function in secs" },
         MetricHistogram { GATEWAY_VALIDATE_STATEFUL_TX_STORAGE_TIME, "gateway_validate_stateful_tx_storage_time", "Total time spent in storage operations in secs during stateful tx validation" },
@@ -132,6 +133,10 @@ impl GatewayMetricHandle {
 
     pub fn count_transaction_received(&self) {
         GATEWAY_TRANSACTIONS_RECEIVED.increment(1, &self.label());
+    }
+
+    pub fn count_private_transaction_received(&self) {
+        GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED.increment(1);
     }
 
     pub fn transaction_sent_to_mempool(&mut self) {
@@ -264,4 +269,5 @@ pub(crate) fn register_metrics() {
     GATEWAY_VALIDATE_STATEFUL_TX_STORAGE_TIME.register();
     GATEWAY_VALIDATE_STATEFUL_TX_STORAGE_OPERATIONS.register();
     GATEWAY_PROOF_MANAGER_STORE_LATENCY.register();
+    GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED.register();
 }


### PR DESCRIPTION
Adds GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED counter that increments for
every invoke_v3 transaction with non-empty proof_facts received by the
gateway, enabling comparison with total received transactions in dashboards.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>