### PR TITLE
apollo_consensus_orchestrator: validate L1 WEI gas prices in ProposalInit

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -1311,12 +1311,13 @@ async fn change_gas_price_overrides() {
     let proposal_commitment = fin_receiver.await.unwrap_err();
     assert!(matches!(proposal_commitment, Canceled));
 
-    // Add the new overrides so validation passes.
+    // Add the new overrides so validation passes. The override sets the FRI value; the
+    // validator recomputes WEI via fri_to_wei(ETH_TO_FRI_RATE), so the proposed init must
+    // mirror that conversion to stay within the WEI margin too.
     let mut modified_init = proposal_init(HEIGHT_1, ROUND_1);
     modified_init.l1_data_gas_price_fri = GasPrice(ODDLY_SPECIFIC_L1_DATA_GAS_PRICE);
-    // Note that the eth to fri conversion rate by default is 10^18 so we can just replace wei to
-    // fri 1:1.
-    modified_init.l1_data_gas_price_fri = GasPrice(ODDLY_SPECIFIC_L1_DATA_GAS_PRICE);
+    modified_init.l1_data_gas_price_wei =
+        GasPrice(ODDLY_SPECIFIC_L1_DATA_GAS_PRICE).fri_to_wei(ETH_TO_FRI_RATE).unwrap();
 
     let content_receiver = send_proposal_to_validator_context(&mut context).await;
     let fin_receiver = context.validate_proposal(modified_init, TIMEOUT, content_receiver).await;

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -297,7 +297,7 @@ async fn is_proposal_init_valid(
             "ProposalInit validation failed".to_string(),
         ));
     }
-    let (l1_gas_prices_fri, _l1_gas_prices_wei) = get_l1_prices_in_fri_and_wei(
+    let (l1_gas_prices_fri, l1_gas_prices_wei) = get_l1_prices_in_fri_and_wei(
         l1_gas_price_provider,
         init_proposed.timestamp,
         proposal_init_validation.previous_proposal_init.as_ref(),
@@ -306,17 +306,27 @@ async fn is_proposal_init_valid(
     .await;
     let l1_gas_price_margin_percent =
         VersionedConstants::latest_constants().l1_gas_price_margin_percent.into();
-    debug!("L1 price info: {l1_gas_prices_fri:?}");
+    debug!("L1 price info: fri={l1_gas_prices_fri:?}, wei={l1_gas_prices_wei:?}");
 
     let l1_gas_price_fri = l1_gas_prices_fri.l1_gas_price;
     let l1_data_gas_price_fri = l1_gas_prices_fri.l1_data_gas_price;
+    let l1_gas_price_wei = l1_gas_prices_wei.l1_gas_price;
+    let l1_data_gas_price_wei = l1_gas_prices_wei.l1_data_gas_price;
     let l1_gas_price_fri_proposed = init_proposed.l1_gas_price_fri;
     let l1_data_gas_price_fri_proposed = init_proposed.l1_data_gas_price_fri;
+    let l1_gas_price_wei_proposed = init_proposed.l1_gas_price_wei;
+    let l1_data_gas_price_wei_proposed = init_proposed.l1_data_gas_price_wei;
 
     if !(within_margin(l1_gas_price_fri_proposed, l1_gas_price_fri, l1_gas_price_margin_percent)
         && within_margin(
             l1_data_gas_price_fri_proposed,
             l1_data_gas_price_fri,
+            l1_gas_price_margin_percent,
+        )
+        && within_margin(l1_gas_price_wei_proposed, l1_gas_price_wei, l1_gas_price_margin_percent)
+        && within_margin(
+            l1_data_gas_price_wei_proposed,
+            l1_data_gas_price_wei,
             l1_gas_price_margin_percent,
         ))
     {
@@ -326,7 +336,10 @@ async fn is_proposal_init_valid(
             format!(
                 "L1 gas price mismatch: expected L1 gas price FRI={l1_gas_price_fri}, \
                  proposed={l1_gas_price_fri_proposed}, expected L1 data gas price \
-                 FRI={l1_data_gas_price_fri}, proposed={l1_data_gas_price_fri_proposed}, \
+                 FRI={l1_data_gas_price_fri}, proposed={l1_data_gas_price_fri_proposed}, expected \
+                 L1 gas price WEI={l1_gas_price_wei}, proposed={l1_gas_price_wei_proposed}, \
+                 expected L1 data gas price WEI={l1_data_gas_price_wei}, \
+                 proposed={l1_data_gas_price_wei_proposed}, \
                  l1_gas_price_margin_percent={l1_gas_price_margin_percent}"
             ),
         ));

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
@@ -246,11 +246,15 @@ async fn invalid_proposal_init() {
 enum L1GasPriceField {
     GasPriceFri,
     DataGasPriceFri,
+    GasPriceWei,
+    DataGasPriceWei,
 }
 
 #[rstest]
 #[case::l1_gas_price_fri(L1GasPriceField::GasPriceFri)]
 #[case::l1_data_gas_price_fri(L1GasPriceField::DataGasPriceFri)]
+#[case::l1_gas_price_wei(L1GasPriceField::GasPriceWei)]
+#[case::l1_data_gas_price_wei(L1GasPriceField::DataGasPriceWei)]
 #[tokio::test]
 async fn rejects_proposal_init_l1_gas_price_out_of_margin(#[case] field: L1GasPriceField) {
     let (proposal_args, _content_sender) = create_proposal_validate_arguments();
@@ -267,6 +271,8 @@ async fn rejects_proposal_init_l1_gas_price_out_of_margin(#[case] field: L1GasPr
     let target = match field {
         L1GasPriceField::GasPriceFri => &mut init.l1_gas_price_fri,
         L1GasPriceField::DataGasPriceFri => &mut init.l1_data_gas_price_fri,
+        L1GasPriceField::GasPriceWei => &mut init.l1_gas_price_wei,
+        L1GasPriceField::DataGasPriceWei => &mut init.l1_data_gas_price_wei,
     };
     *target = GasPrice(target.0.saturating_mul(10));
 


### PR DESCRIPTION
is_proposal_init_valid only checked the FRI L1 gas prices; the WEI prices
flowed unchecked into BlockInfo.eth_gas_prices, the eth_to_fri_rate
derivation, the partial_block_hash, and the Cende-persisted block payload.

Mirror the existing within_margin check on l1_gas_price_wei and
l1_data_gas_price_wei using the validator's own L1 gas price provider
snapshot (already fetched by get_l1_prices_in_fri_and_wei) and the same
l1_gas_price_margin_percent versioned constant.

Extend the parametrized rejects_proposal_init_l1_gas_price_out_of_margin
test added in the previous commit with WEI cases.

Also fix change_gas_price_overrides: a stale duplicate line was re-setting
l1_data_gas_price_fri after the override instead of l1_data_gas_price_wei,
which the new WEI margin check now correctly catches. Recompute the
expected WEI from the FRI override via fri_to_wei(ETH_TO_FRI_RATE).