### PR TITLE
apollo_dashboard: convert categorical Stat panels to PieCharts

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -614,24 +614,30 @@
         },
         {
           "title": "Transactions Received by Source",
-          "description": "The number of transactions received by source (over the selected time range)",
-          "type": "stat",
+          "description": "The distribution of transactions received by source (HTTP vs P2P), over the selected time range",
+          "type": "piechart",
           "exprs": [
             "sum by (source) (increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__range]))"
           ],
           "extra_params": {
-            "log_query": "\"Processing tx\" AND \"is_p2p=\""
+            "log_query": "\"Processing tx\" AND \"is_p2p=\"",
+            "legend_values": [
+              "percent"
+            ]
           }
         },
         {
           "title": "Transactions Received by Type",
-          "description": "The number of transactions received by type (over the selected time range)",
-          "type": "stat",
+          "description": "The distribution of transactions received by type, over the selected time range",
+          "type": "piechart",
           "exprs": [
             "sum by (tx_type) (increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__range]))"
           ],
           "extra_params": {
-            "log_query": "\"Processing tx\""
+            "log_query": "\"Processing tx\"",
+            "legend_values": [
+              "percent"
+            ]
           }
         },
         {
@@ -753,12 +759,16 @@
         },
         {
           "title": "Dropped Transactions by Reason",
-          "description": "Number of transactions dropped from the mempool by reason (over the selected time range)",
-          "type": "stat",
+          "description": "Distribution of mempool drop reasons over the selected time range",
+          "type": "piechart",
           "exprs": [
             "sum by (drop_reason) (increase(mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__range]))"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "legend_values": [
+              "percent"
+            ]
+          }
         },
         {
           "title": "Pool Size (Num TXs)",
@@ -950,13 +960,16 @@
         },
         {
           "title": "Block Close Reasons",
-          "description": "Number of blocks closed by reason (10m window)",
-          "type": "stat",
+          "description": "Distribution of reasons for closing a block (10m window). Common reasons: builder deadline reached, block full, no transactions to execute.",
+          "type": "piechart",
           "exprs": [
             "sum by (block_close_reason) (increase(batcher_block_close_reason{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m]))"
           ],
           "extra_params": {
-            "log_query": "\"Block builder deadline reached.\" OR \"Block is full.\" OR \"No transactions are being executed and\""
+            "log_query": "\"Block builder deadline reached.\" OR \"Block is full.\" OR \"No transactions are being executed and\"",
+            "legend_values": [
+              "percent"
+            ]
           }
         },
         {
@@ -1166,13 +1179,17 @@
           }
         },
         {
-          "title": "Blocks Full By Resource",
-          "description": "Number of blocks closed on each bouncer resource (10m window)",
-          "type": "stat",
+          "title": "Blocks Full by Resource",
+          "description": "Distribution of bouncer resources that filled a block (10m window)",
+          "type": "piechart",
           "exprs": [
             "sum by (resource) (increase(blockifier_blocks_full_by_resource{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m]))"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "legend_values": [
+              "percent"
+            ]
+          }
         },
         {
           "title": "Transactions Per Block",

--- a/crates/apollo_dashboard/src/panels/batcher.rs
+++ b/crates/apollo_dashboard/src/panels/batcher.rs
@@ -146,15 +146,19 @@ pub(crate) fn get_panel_batched_transactions_rate() -> Panel {
 fn get_panel_block_close_reasons() -> Panel {
     Panel::new(
         "Block Close Reasons",
-        format!("Number of blocks closed by reason ({} window)", DEFAULT_DURATION),
+        format!(
+            "Distribution of reasons for closing a block ({DEFAULT_DURATION} window). Common \
+             reasons: builder deadline reached, block full, no transactions to execute."
+        ),
         sum_by_label(
             &BLOCK_CLOSE_REASON,
             LABEL_NAME_BLOCK_CLOSE_REASON,
             DisplayMethod::Increase(DEFAULT_DURATION),
             false,
         ),
-        PanelType::Stat,
+        PanelType::PieChart,
     )
+    .with_legend_values(vec!["percent"])
     .with_log_query(
         "\"Block builder deadline reached.\" OR \"Block is full.\" OR \"No transactions are being \
          executed and\"",

--- a/crates/apollo_dashboard/src/panels/blockifier.rs
+++ b/crates/apollo_dashboard/src/panels/blockifier.rs
@@ -77,16 +77,19 @@ fn get_panel_native_execution_ratio() -> Panel {
 
 fn get_panel_blocks_full_by_resource() -> Panel {
     Panel::new(
-        "Blocks Full By Resource",
-        format!("Number of blocks closed on each bouncer resource ({} window)", DEFAULT_DURATION),
+        "Blocks Full by Resource",
+        format!(
+            "Distribution of bouncer resources that filled a block ({DEFAULT_DURATION} window)"
+        ),
         sum_by_label(
             &BLOCKS_FULL_BY_RESOURCE,
             LABEL_NAME_BLOCK_FULL_RESOURCE,
             DisplayMethod::Increase(DEFAULT_DURATION),
             false,
         ),
-        PanelType::Stat,
+        PanelType::PieChart,
     )
+    .with_legend_values(vec!["percent"])
 }
 
 fn get_panel_transactions_per_block() -> Panel {

--- a/crates/apollo_dashboard/src/panels/gateway.rs
+++ b/crates/apollo_dashboard/src/panels/gateway.rs
@@ -23,30 +23,33 @@ use crate::query_builder::{increase, sum_by_label, DisplayMethod, RANGE_DURATION
 fn get_panel_gateway_transactions_received_by_type() -> Panel {
     Panel::new(
         "Transactions Received by Type",
-        "The number of transactions received by type (over the selected time range)",
+        "The distribution of transactions received by type, over the selected time range",
         sum_by_label(
             &GATEWAY_TRANSACTIONS_RECEIVED,
             GATEWAY_LABEL_NAME_TX_TYPE,
             DisplayMethod::Increase(RANGE_DURATION),
             false,
         ),
-        PanelType::Stat,
+        PanelType::PieChart,
     )
+    .with_legend_values(vec!["percent"])
     .with_log_query("\"Processing tx\"")
 }
 
 fn get_panel_gateway_transactions_received_by_source() -> Panel {
     Panel::new(
         "Transactions Received by Source",
-        "The number of transactions received by source (over the selected time range)",
+        "The distribution of transactions received by source (HTTP vs P2P), over the selected \
+         time range",
         sum_by_label(
             &GATEWAY_TRANSACTIONS_RECEIVED,
             LABEL_NAME_SOURCE,
             DisplayMethod::Increase(RANGE_DURATION),
             false,
         ),
-        PanelType::Stat,
+        PanelType::PieChart,
     )
+    .with_legend_values(vec!["percent"])
     .with_log_query("\"Processing tx\" AND \"is_p2p=\"")
 }
 

--- a/crates/apollo_dashboard/src/panels/mempool.rs
+++ b/crates/apollo_dashboard/src/panels/mempool.rs
@@ -48,15 +48,16 @@ fn get_panel_mempool_transactions_committed() -> Panel {
 fn get_panel_mempool_transactions_dropped() -> Panel {
     Panel::new(
         "Dropped Transactions by Reason",
-        "Number of transactions dropped from the mempool by reason (over the selected time range)",
+        "Distribution of mempool drop reasons over the selected time range",
         sum_by_label(
             &MEMPOOL_TRANSACTIONS_DROPPED,
             LABEL_NAME_DROP_REASON,
             DisplayMethod::Increase(RANGE_DURATION),
             false,
         ),
-        PanelType::Stat,
+        PanelType::PieChart,
     )
+    .with_legend_values(vec!["percent"])
 }
 fn get_panel_mempool_pool_size() -> Panel {
     Panel::new(


### PR DESCRIPTION
Convert five "X by category" panels from Stat (a row of value cards) to
PieChart with a percent legend, so the relative distribution across
categories reads at a glance:
- Gateway: Transactions Received by Type, Transactions Received by Source
- Batcher: Block Close Reasons
- Blockifier: Blocks Full by Resource
- Mempool: Dropped Transactions by Reason

Descriptions updated to "Distribution of …" to match the new shape.
dev_grafana.json regenerated.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>