### PR TITLE
scripts: only run integration test cairo_native pass when blockifier is touched

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -92,9 +92,7 @@ class BaseCommand(Enum):
             print(f"Composing sequencer integration test commands.")
 
             def build_cmds(with_feature: bool) -> List[List[str]]:
-                feature_flag = (
-                    ["--features", "cairo_native"] if (with_feature and is_nightly) else []
-                )
+                feature_flag = ["--features", "cairo_native"] if with_feature else []
                 # Commands to build the node and all the test binaries.
                 build_cmds = [
                     ["cargo", "build", "--bin", binary_name] + feature_flag
@@ -120,8 +118,10 @@ class BaseCommand(Enum):
 
             cmds_no_feat = build_cmds(with_feature=False) + run_cmds
 
-            # Only run cairo_native feature if the blockifier crate is modified, and in nightly.
-            if CAIRO_NATIVE_CRATE_TRIGGERS.isdisjoint(crates) and not is_nightly:
+            # Only run the cairo_native pass when blockifier is being tested. An empty `crates`
+            # set means "all crates" (e.g. the nightly workflow runs without --changes_only),
+            # which implicitly includes blockifier.
+            if crates and CAIRO_NATIVE_CRATE_TRIGGERS.isdisjoint(crates):
                 return cmds_no_feat
 
             print("Composing sequencer integration test commands with cairo_native feature.")


### PR DESCRIPTION
## Summary

The two gates around the cairo_native integration test pass disagreed:

- **Outer guard** (whether to run a second pass): skipped only when *neither* blockifier was in `crates` *nor* nightly — i.e. ran on either.
- **Inner `feature_flag`** (whether to actually add `--features cairo_native`): added only when *both* `with_feature` *and* `is_nightly`.

Net effect:

- Non-nightly PR touching `blockifier`: second pass ran **without** the feature flag — pure duplicate of the first, no extra coverage, double exposure to flakes like `integration_test_revert_flow`.
- Nightly with `crates` not containing `blockifier`: also ran a useless duplicate.

Align both gates to one rule: **run the cairo_native pass iff `blockifier` is being tested**. An empty `crates` set ("all crates", e.g. the nightly workflow runs without `--changes_only`) implicitly includes blockifier.

| Run                                        | `crates`            | Behavior                                    |
|--------------------------------------------|---------------------|---------------------------------------------|
| PR touching `blockifier`                   | `{blockifier, ...}` | no-features + cairo_native passes           |
| PR not touching `blockifier`               | `{...}`             | single no-features pass                     |
| Nightly all-crates                         | `∅`                 | no-features + cairo_native passes           |
| Nightly `--changes_only` + `blockifier`    | `{blockifier, ...}` | no-features + cairo_native passes           |
| Nightly `--changes_only`, no `blockifier`  | `{gateway}`         | single no-features pass                     |

## Test plan

- [ ] CI on this PR (doesn't touch blockifier): single no-features pass, no duplicates.
- [ ] Open a follow-up PR that touches `blockifier` (without `apollo_integration_tests`); confirm cairo_native pass runs.
- [ ] Nightly workflow next run: cairo_native pass still runs (against empty `crates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)