### PR TITLE
apollo_node_config,apollo_deployments: unify cairo_native_mode via config pointer

### DIFF
--- a/crates/apollo_deployments/src/service.rs
+++ b/crates/apollo_deployments/src/service.rs
@@ -35,8 +35,6 @@ const SERVICES_DIR_NAME: &str = "services/";
 const REMOTE_SERVICE_URL_PLACEHOLDER: &str = "remote_service";
 
 // TODO(Tsabary): remove ports and mempool ttl from this list.
-// TODO(Shahak): unify the batcher and gateway `cairo_native_run_config.cairo_native_mode` values
-// using the config pointer mechanism so both components always receive the same value.
 pub static KEYS_TO_BE_REPLACED: phf::Set<&'static str> = phf_set! {
     "base_layer_config.bpo1_start_block_number",
     "base_layer_config.bpo2_start_block_number",
@@ -49,11 +47,11 @@ pub static KEYS_TO_BE_REPLACED: phf::Set<&'static str> = phf_set! {
     "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.receipt_l2_gas",
     "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.state_diff_size",
     "batcher_config.static_config.block_builder_config.execute_config.n_workers",
-    "batcher_config.static_config.contract_class_manager_config.cairo_native_run_config.cairo_native_mode",
     "batcher_config.static_config.first_block_with_partial_block_hash.#is_none",
     "batcher_config.static_config.first_block_with_partial_block_hash.block_hash",
     "batcher_config.static_config.first_block_with_partial_block_hash.block_number",
     "batcher_config.static_config.first_block_with_partial_block_hash.parent_block_hash",
+    "cairo_native_mode",
     "chain_id",
     "class_manager_config.static_config.class_manager_config.max_compiled_contract_class_object_size",
     "committer_config.storage_config.cache_size",
@@ -83,7 +81,6 @@ pub static KEYS_TO_BE_REPLACED: phf::Set<&'static str> = phf_set! {
     "eth_fee_token_address",
     "gateway_config.static_config.authorized_declarer_accounts.#is_none",
     "gateway_config.static_config.authorized_declarer_accounts",
-    "gateway_config.static_config.contract_class_manager_config.cairo_native_run_config.cairo_native_mode",
     "gateway_config.static_config.proof_archive_writer_config.bucket_name",
     "gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap",
     "gateway_config.static_config.stateless_tx_validator_config.allow_client_side_proving",

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -40,7 +40,7 @@ use apollo_sierra_compilation_config::config::SierraCompilationConfig;
 use apollo_staking_config::config::StakingManagerDynamicConfig;
 use apollo_state_sync_config::config::{StateSyncConfig, StateSyncDynamicConfig};
 use apollo_storage::StorageScope;
-use blockifier::blockifier::config::NativeClassesWhitelist;
+use blockifier::blockifier::config::{CairoNativeMode, NativeClassesWhitelist};
 use blockifier::blockifier_versioned_constants::VersionedConstantsOverrides;
 use clap::Command;
 use papyrus_base_layer::ethereum_base_layer_contract::EthereumBaseLayerConfig;
@@ -180,6 +180,21 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
                  max_cpu_time",
                 "gateway_config.static_config.contract_class_manager_config.native_compiler_config.\
                  max_cpu_time",
+            ]),
+        ),
+        (
+            ser_pointer_target_param(
+                "cairo_native_mode",
+                &CairoNativeMode::LazyCompilation,
+                "Cairo native execution mode. 'off' disables native execution, \
+                 'wait_on_compilation' compiles synchronously, and 'lazy_compilation' compiles \
+                 asynchronously.",
+            ),
+            set_pointing_param_paths(&[
+                "batcher_config.static_config.contract_class_manager_config.\
+                 cairo_native_run_config.cairo_native_mode",
+                "gateway_config.static_config.contract_class_manager_config.\
+                 cairo_native_run_config.cairo_native_mode",
             ]),
         ),
     ];


### PR DESCRIPTION
Replace the per-component placeholders for batcher and gateway
cairo_native_mode with a single top-level config pointer, so both
components are guaranteed to receive the same value.

Note: fixtures (config_schema.json, app_configs/*.json) must be
regenerated locally:
  cargo run --bin update_apollo_node_config_schema
  cargo run --bin deployment_generator

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>