### PR TITLE
starknet_transaction_prover: /health endpoint, JSON log mode, startup banner

### DIFF
--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -14,7 +14,12 @@ async fn main() -> anyhow::Result<()> {
 
     use anyhow::Context;
     use clap::Parser;
-    use starknet_transaction_prover::server::config::{CliArgs, ServiceConfig, TransportMode};
+    use starknet_transaction_prover::server::config::{
+        CliArgs,
+        LogFormat,
+        ServiceConfig,
+        TransportMode,
+    };
     use starknet_transaction_prover::server::cors::{build_cors_layer, cors_mode};
     use starknet_transaction_prover::server::log_redact::redact_url_host;
     use starknet_transaction_prover::server::rpc_api::ProvingRpcServer;
@@ -29,23 +34,22 @@ async fn main() -> anyhow::Result<()> {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{fmt, EnvFilter};
 
-    // Parse CLI args before initializing tracing so the `--json-logs` flag can
-    // pick the formatter. Config loading still happens after to keep the
-    // existing CLI-override logs visible.
+    // Parse CLI args before initializing tracing so `--log-format` can pick
+    // the formatter. Config loading still happens after to keep the existing
+    // CLI-override logs visible.
     let args = CliArgs::parse();
 
     // TODO(Avi): Revisit the starknet_transaction_prover=debug default once the service stabilizes.
     // By default, keep service logs and lower third-party logs to warn. The
-    // formatter is JSON when `--json-logs`/`JSON_LOGS=true` is set, so log
-    // aggregators (e.g. Datadog) can parse fields directly without regex.
+    // formatter is JSON when `--log-format json` / `LOG_FORMAT=json` is set,
+    // so log aggregators (e.g. Datadog) can parse fields directly without regex.
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("warn,starknet_transaction_prover=debug,privacy_prove=info")
     });
     let registry = tracing_subscriber::registry().with(filter);
-    if args.json_logs {
-        registry.with(fmt::layer().json()).init();
-    } else {
-        registry.with(fmt::layer()).init();
+    match args.log_format {
+        LogFormat::Json => registry.with(fmt::layer().json()).init(),
+        LogFormat::Text => registry.with(fmt::layer()).init(),
     }
 
     let config = ServiceConfig::from_args(args)?;

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -28,17 +28,42 @@ async fn main() -> anyhow::Result<()> {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{fmt, EnvFilter};
 
+    // Parse CLI args before initializing tracing so the `--json-logs` flag can
+    // pick the formatter. Config loading still happens after to keep the
+    // existing CLI-override logs visible.
+    let args = CliArgs::parse();
+
     // TODO(Avi): Revisit the starknet_transaction_prover=debug default once the service stabilizes.
-    // Initialize tracing with RUST_LOG. By default, keep service logs and lower third-party
-    // logs to warn.
+    // By default, keep service logs and lower third-party logs to warn. The
+    // formatter is JSON when `--json-logs`/`JSON_LOGS=true` is set, so log
+    // aggregators (e.g. Datadog) can parse fields directly without regex.
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("warn,starknet_transaction_prover=debug,privacy_prove=info")
     });
-    tracing_subscriber::registry().with(fmt::layer()).with(filter).init();
+    let registry = tracing_subscriber::registry().with(filter);
+    if args.json_logs {
+        registry.with(fmt::layer().json()).init();
+    } else {
+        registry.with(fmt::layer()).init();
+    }
 
-    // Parse CLI args and load config.
-    let args = CliArgs::parse();
     let config = ServiceConfig::from_args(args)?;
+
+    // Startup banner — emitted before binding so a failed bind still leaves a
+    // breadcrumb identifying the build. Fields are deliberately conservative:
+    // version + chain_id + redacted RPC host. No URLs with userinfo, no fee
+    // token address, no TLS paths, no transaction-scoped data.
+    info!(
+        version = env!("CARGO_PKG_VERSION"),
+        git_sha = option_env!("GIT_SHA").unwrap_or("unknown"),
+        chain_id = %config.prover_config.chain_id,
+        rpc_node_host = %redact_url_host(&config.prover_config.rpc_node_url),
+        validate_zero_fee_fields = config.prover_config.validate_zero_fee_fields,
+        blocking_check_enabled = config.prover_config.blocking_check_url.is_some(),
+        blocking_check_fail_open = config.prover_config.blocking_check_fail_open,
+        ohttp_enabled = config.ohttp_enabled,
+        "Starting Starknet transaction prover."
+    );
 
     // Build and start the JSON-RPC server.
     let rpc_impl = ProvingRpcServerImpl::from_config(&config);
@@ -88,4 +113,45 @@ async fn main() -> anyhow::Result<()> {
 
     server_handle.stopped().await;
     Ok(())
+}
+
+/// Returns `scheme://host[:port]` for a URL, dropping any userinfo, path,
+/// query, and fragment. Used to log the upstream RPC location without leaking
+/// credentials embedded in `rpc_node_url`. Falls back to `"<invalid url>"` if
+/// parsing fails — the actual URL is never echoed.
+#[cfg(feature = "stwo_proving")]
+fn redact_url_host(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(parsed) => {
+            let host = parsed.host_str().unwrap_or("");
+            match parsed.port() {
+                Some(port) => format!("{}://{}:{}", parsed.scheme(), host, port),
+                None => format!("{}://{}", parsed.scheme(), host),
+            }
+        }
+        Err(_) => "<invalid url>".to_string(),
+    }
+}
+
+#[cfg(all(test, feature = "stwo_proving"))]
+mod tests {
+    use super::redact_url_host;
+
+    #[test]
+    fn strips_userinfo_path_query() {
+        assert_eq!(
+            redact_url_host("https://user:pass@rpc.example.com:8443/v1?token=abc"),
+            "https://rpc.example.com:8443"
+        );
+    }
+
+    #[test]
+    fn keeps_default_port_implicit() {
+        assert_eq!(redact_url_host("https://rpc.example.com/"), "https://rpc.example.com");
+    }
+
+    #[test]
+    fn handles_invalid_url() {
+        assert_eq!(redact_url_host("not a url"), "<invalid url>");
+    }
 }

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -16,6 +16,7 @@ async fn main() -> anyhow::Result<()> {
     use clap::Parser;
     use starknet_transaction_prover::server::config::{CliArgs, ServiceConfig, TransportMode};
     use starknet_transaction_prover::server::cors::{build_cors_layer, cors_mode};
+    use starknet_transaction_prover::server::log_redact::redact_url_host;
     use starknet_transaction_prover::server::rpc_api::ProvingRpcServer;
     use starknet_transaction_prover::server::rpc_impl::ProvingRpcServerImpl;
     use starknet_transaction_prover::server::{
@@ -113,45 +114,4 @@ async fn main() -> anyhow::Result<()> {
 
     server_handle.stopped().await;
     Ok(())
-}
-
-/// Returns `scheme://host[:port]` for a URL, dropping any userinfo, path,
-/// query, and fragment. Used to log the upstream RPC location without leaking
-/// credentials embedded in `rpc_node_url`. Falls back to `"<invalid url>"` if
-/// parsing fails — the actual URL is never echoed.
-#[cfg(feature = "stwo_proving")]
-fn redact_url_host(url: &str) -> String {
-    match url::Url::parse(url) {
-        Ok(parsed) => {
-            let host = parsed.host_str().unwrap_or("");
-            match parsed.port() {
-                Some(port) => format!("{}://{}:{}", parsed.scheme(), host, port),
-                None => format!("{}://{}", parsed.scheme(), host),
-            }
-        }
-        Err(_) => "<invalid url>".to_string(),
-    }
-}
-
-#[cfg(all(test, feature = "stwo_proving"))]
-mod tests {
-    use super::redact_url_host;
-
-    #[test]
-    fn strips_userinfo_path_query() {
-        assert_eq!(
-            redact_url_host("https://user:pass@rpc.example.com:8443/v1?token=abc"),
-            "https://rpc.example.com:8443"
-        );
-    }
-
-    #[test]
-    fn keeps_default_port_implicit() {
-        assert_eq!(redact_url_host("https://rpc.example.com/"), "https://rpc.example.com");
-    }
-
-    #[test]
-    fn handles_invalid_url() {
-        assert_eq!(redact_url_host("not a url"), "<invalid url>");
-    }
 }

--- a/crates/starknet_transaction_prover/src/server.rs
+++ b/crates/starknet_transaction_prover/src/server.rs
@@ -29,11 +29,14 @@ pub const OHTTP_JSONRPSEE_BODY_BUILDER: fn(Full<Bytes>) -> HttpBody = HttpBody::
 pub mod config;
 pub mod cors;
 pub mod errors;
+pub mod health;
 #[cfg(test)]
 pub mod mock_rpc;
 pub mod rpc_api;
 pub mod rpc_impl;
 pub mod tls;
+
+pub use health::{HealthLayer, HEALTH_PATH};
 
 #[cfg(test)]
 mod rpc_spec_test;
@@ -75,7 +78,10 @@ pub async fn start_server(
                 // type it expects. `HttpBody::new` is a zero-cost wrapper, so
                 // non-OHTTP requests still stream through unbuffered.
                 .set_http_middleware(
+                    // `HealthLayer` sits outermost so `GET /health` is answered before
+                    // any other middleware runs (no compression, no CORS, no OHTTP).
                     ServiceBuilder::new()
+                        .layer(HealthLayer)
                         .option_layer(cors_layer)
                         .layer(MapRequestBodyLayer::new(HttpBody::new))
                         .option_layer(ohttp_layer)

--- a/crates/starknet_transaction_prover/src/server.rs
+++ b/crates/starknet_transaction_prover/src/server.rs
@@ -30,6 +30,7 @@ pub mod config;
 pub mod cors;
 pub mod errors;
 pub mod health;
+pub mod log_redact;
 #[cfg(test)]
 pub mod mock_rpc;
 pub mod rpc_api;

--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use blockifier::blockifier::config::ContractClassManagerConfig;
 use blockifier::bouncer::BouncerConfig;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ChainId, ContractAddress};
 use tracing::info;
@@ -37,6 +37,17 @@ const DEFAULT_OHTTP_KEY_CACHE_MAX_AGE_SECS: u64 = 3600;
 pub enum TransportMode {
     Http,
     Https { tls_cert_file: PathBuf, tls_key_file: PathBuf },
+}
+
+/// Output format for tracing log records.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum LogFormat {
+    /// Human-readable text formatter (default).
+    #[default]
+    Text,
+    /// One JSON object per line; recommended for production log aggregators.
+    Json,
 }
 
 impl TransportMode {
@@ -562,10 +573,17 @@ pub struct CliArgs {
     #[arg(long, value_name = "SECS", env = "OHTTP_KEY_CACHE_MAX_AGE_SECS")]
     pub ohttp_key_cache_max_age_secs: Option<u64>,
 
-    /// Emit logs as JSON instead of the human-readable default. Recommended for
-    /// production so log aggregators (e.g. Datadog) parse fields directly.
-    #[arg(long, env = "JSON_LOGS")]
-    pub json_logs: bool,
+    /// Log output format. Use `json` in production so log aggregators
+    /// (e.g. Datadog) parse fields directly. Matches the discovery-service
+    /// `LOG_FORMAT` env var for cross-service consistency.
+    #[arg(
+        long,
+        value_enum,
+        value_name = "FORMAT",
+        env = "LOG_FORMAT",
+        default_value_t = LogFormat::Text,
+    )]
+    pub log_format: LogFormat,
 
     /// Hidden escape hatch: override the embedded bouncer config (block capacity limits) with a
     /// custom JSON file. Not advertised because the embedded defaults are tuned for this prover

--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -547,6 +547,11 @@ pub struct CliArgs {
     #[arg(long, value_name = "SECS", env = "OHTTP_KEY_CACHE_MAX_AGE_SECS")]
     pub ohttp_key_cache_max_age_secs: Option<u64>,
 
+    /// Emit logs as JSON instead of the human-readable default. Recommended for
+    /// production so log aggregators (e.g. Datadog) parse fields directly.
+    #[arg(long, env = "JSON_LOGS")]
+    pub json_logs: bool,
+
     /// Hidden escape hatch: override the embedded bouncer config (block capacity limits) with a
     /// custom JSON file. Not advertised because the embedded defaults are tuned for this prover
     /// (including high `l1_gas` / `message_segment_length`: virtual OS output is not L1-bound; it

--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -17,6 +17,7 @@ use crate::running::runner::RunnerConfig;
 use crate::running::storage_proofs::StorageProofConfig;
 use crate::running::virtual_block_executor::RpcVirtualBlockExecutorConfig;
 use crate::server::cors::normalize_cors_allow_origins;
+use crate::server::log_redact::redact_url_host;
 
 #[cfg(test)]
 #[path = "config_test.rs"]
@@ -169,7 +170,14 @@ impl ServiceConfig {
         // Override with CLI arguments if provided.
         if let Some(rpc_url) = args.rpc_url {
             if rpc_url != config.rpc_node_url {
-                info!("CLI override: rpc_node_url: {} -> {}", config.rpc_node_url, rpc_url);
+                // `rpc_node_url` can contain credentials in the userinfo
+                // component (`https://user:secret@rpc...`). Log only the
+                // host so the secret never reaches a log aggregator.
+                info!(
+                    "CLI override: rpc_node_url: {} -> {}",
+                    redact_url_host(&config.rpc_node_url),
+                    redact_url_host(&rpc_url),
+                );
                 config.rpc_node_url = rpc_url;
             }
         }
@@ -302,9 +310,16 @@ impl ServiceConfig {
         }
         if let Some(url) = args.blocking_check_url {
             if Some(&url) != config.blocking_check_url.as_ref() {
+                // `blocking_check_url` is a JSON-RPC URL that may carry an
+                // auth token in userinfo; redact for the same reason as
+                // `rpc_node_url` above.
                 info!(
-                    "CLI override: blocking_check_url: {:?} -> {:?}",
-                    config.blocking_check_url, url
+                    "CLI override: blocking_check_url: {} -> {}",
+                    config
+                        .blocking_check_url
+                        .as_deref()
+                        .map_or("<unset>".to_string(), redact_url_host),
+                    redact_url_host(&url),
                 );
                 config.blocking_check_url = Some(url);
             }

--- a/crates/starknet_transaction_prover/src/server/config_test.rs
+++ b/crates/starknet_transaction_prover/src/server/config_test.rs
@@ -7,7 +7,7 @@ use rstest::rstest;
 use tempfile::NamedTempFile;
 
 use crate::errors::ConfigError;
-use crate::server::config::{CliArgs, ServiceConfig, TransportMode};
+use crate::server::config::{CliArgs, LogFormat, ServiceConfig, TransportMode};
 
 /// Mutex that serializes tests which modify environment variables.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -59,7 +59,7 @@ fn base_args() -> CliArgs {
         max_request_body_size: None,
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
-        json_logs: false,
+        log_format: LogFormat::Text,
     }
 }
 
@@ -148,7 +148,7 @@ fn cors_allow_origin_rejects_non_array_in_config_file() {
         max_request_body_size: None,
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
-        json_logs: false,
+        log_format: LogFormat::Text,
     };
 
     let error = ServiceConfig::from_args(args).unwrap_err();

--- a/crates/starknet_transaction_prover/src/server/config_test.rs
+++ b/crates/starknet_transaction_prover/src/server/config_test.rs
@@ -59,6 +59,7 @@ fn base_args() -> CliArgs {
         max_request_body_size: None,
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
+        json_logs: false,
     }
 }
 
@@ -147,6 +148,7 @@ fn cors_allow_origin_rejects_non_array_in_config_file() {
         max_request_body_size: None,
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
+        json_logs: false,
     };
 
     let error = ServiceConfig::from_args(args).unwrap_err();

--- a/crates/starknet_transaction_prover/src/server/health.rs
+++ b/crates/starknet_transaction_prover/src/server/health.rs
@@ -1,0 +1,76 @@
+//! HTTP `/health` endpoint as a tower middleware layer.
+//!
+//! Short-circuits `GET /health` with a `200 OK` JSON response *before* the
+//! jsonrpsee service sees the request, so health checks don't run through the
+//! JSON-RPC parser (which would reject GETs with 405). Any other request is
+//! passed through to the inner service unchanged.
+//!
+//! Returns the same `Response<HttpBody>` shape that the existing tower layers
+//! (CORS, OHTTP, compression, body-mapping) already produce so the layer can be
+//! placed outermost in the existing `set_http_middleware` chain.
+//!
+//! Body intentionally contains no service state: it must remain safe to expose
+//! without authentication (no transaction data, no config, no version yet —
+//! version is logged at startup instead, see `main.rs`).
+
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures::future::{ready, Either, Ready};
+use http::{header, Method, Request, Response, StatusCode};
+use http_body_util::Full;
+use jsonrpsee::server::HttpBody;
+use tower::{Layer, Service};
+
+#[cfg(test)]
+#[path = "health_test.rs"]
+mod health_test;
+
+/// Path served by [`HealthLayer`].
+pub const HEALTH_PATH: &str = "/health";
+
+/// Body returned by `GET /health`. Static and stateless — see module docs.
+const HEALTHY_BODY: &[u8] = br#"{"status":"ok"}"#;
+
+/// tower [`Layer`] that intercepts `GET /health`.
+#[derive(Clone, Copy, Default)]
+pub struct HealthLayer;
+
+impl<S> Layer<S> for HealthLayer {
+    type Service = HealthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HealthService { inner }
+    }
+}
+
+/// Service produced by [`HealthLayer`].
+#[derive(Clone)]
+pub struct HealthService<S> {
+    inner: S,
+}
+
+impl<S, ReqB> Service<Request<ReqB>> for HealthService<S>
+where
+    S: Service<Request<ReqB>, Response = Response<HttpBody>>,
+{
+    type Response = Response<HttpBody>;
+    type Error = S::Error;
+    type Future = Either<Ready<Result<Self::Response, Self::Error>>, S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqB>) -> Self::Future {
+        if request.method() == Method::GET && request.uri().path() == HEALTH_PATH {
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(HttpBody::new(Full::new(Bytes::from_static(HEALTHY_BODY))))
+                .expect("response build with a static body is infallible");
+            return Either::Left(ready(Ok(response)));
+        }
+        Either::Right(self.inner.call(request))
+    }
+}

--- a/crates/starknet_transaction_prover/src/server/health.rs
+++ b/crates/starknet_transaction_prover/src/server/health.rs
@@ -32,7 +32,6 @@ pub const HEALTH_PATH: &str = "/health";
 /// Body returned by `GET /health`. Static and stateless — see module docs.
 const HEALTHY_BODY: &[u8] = br#"{"status":"ok"}"#;
 
-/// tower [`Layer`] that intercepts `GET /health`.
 #[derive(Clone, Copy, Default)]
 pub struct HealthLayer;
 
@@ -44,7 +43,6 @@ impl<S> Layer<S> for HealthLayer {
     }
 }
 
-/// Service produced by [`HealthLayer`].
 #[derive(Clone)]
 pub struct HealthService<S> {
     inner: S,

--- a/crates/starknet_transaction_prover/src/server/health.rs
+++ b/crates/starknet_transaction_prover/src/server/health.rs
@@ -56,8 +56,14 @@ where
     type Error = S::Error;
     type Future = Either<Ready<Result<Self::Response, Self::Error>>, S::Future>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Always ready: the health-check fast path doesn't need the inner
+        // service, so we don't want inner backpressure to block readiness
+        // probes — that would cause load balancers to pull healthy-but-busy
+        // instances precisely when they're under load. The inner service's
+        // own `poll_ready` is driven on demand by `inner.call` inside the
+        // non-health branch below.
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, request: Request<ReqB>) -> Self::Future {

--- a/crates/starknet_transaction_prover/src/server/health_test.rs
+++ b/crates/starknet_transaction_prover/src/server/health_test.rs
@@ -1,0 +1,72 @@
+//! Unit tests for [`HealthLayer`].
+
+use bytes::Bytes;
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::{BodyExt, Full};
+use jsonrpsee::server::HttpBody;
+use tower::{Layer, ServiceExt};
+
+use super::{HealthLayer, HEALTH_PATH};
+
+/// Inner stub: returns 418 for any request so we can tell whether [`HealthLayer`]
+/// short-circuited vs. passed through.
+fn fallthrough_service() -> impl tower::Service<
+    Request<HttpBody>,
+    Response = Response<HttpBody>,
+    Error = std::convert::Infallible,
+    Future = futures::future::Ready<Result<Response<HttpBody>, std::convert::Infallible>>,
+> + Clone {
+    tower::service_fn(|_req: Request<HttpBody>| {
+        let response = Response::builder()
+            .status(StatusCode::IM_A_TEAPOT)
+            .body(HttpBody::new(Full::new(Bytes::from_static(b"fallthrough"))))
+            .expect("static body is infallible");
+        futures::future::ready(Ok::<_, std::convert::Infallible>(response))
+    })
+}
+
+fn empty_request(method: Method, path: &str) -> Request<HttpBody> {
+    Request::builder()
+        .method(method)
+        .uri(path)
+        .body(HttpBody::new(Full::new(Bytes::new())))
+        .expect("static body is infallible")
+}
+
+async fn read_body(response: Response<HttpBody>) -> (StatusCode, Vec<u8>, http::HeaderMap) {
+    let (parts, body) = response.into_parts();
+    let bytes = body.collect().await.expect("body collect").to_bytes().to_vec();
+    (parts.status, bytes, parts.headers)
+}
+
+#[tokio::test]
+async fn get_health_returns_200_with_json_body() {
+    let svc = HealthLayer.layer(fallthrough_service());
+
+    let response = svc.oneshot(empty_request(Method::GET, HEALTH_PATH)).await.unwrap();
+
+    let (status, body, headers) = read_body(response).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, br#"{"status":"ok"}"#);
+    assert_eq!(headers.get(http::header::CONTENT_TYPE).unwrap(), "application/json");
+}
+
+#[tokio::test]
+async fn non_get_health_falls_through() {
+    let svc = HealthLayer.layer(fallthrough_service());
+
+    let response = svc.oneshot(empty_request(Method::POST, HEALTH_PATH)).await.unwrap();
+
+    let (status, _body, _) = read_body(response).await;
+    assert_eq!(status, StatusCode::IM_A_TEAPOT);
+}
+
+#[tokio::test]
+async fn get_other_path_falls_through() {
+    let svc = HealthLayer.layer(fallthrough_service());
+
+    let response = svc.oneshot(empty_request(Method::GET, "/")).await.unwrap();
+
+    let (status, _body, _) = read_body(response).await;
+    assert_eq!(status, StatusCode::IM_A_TEAPOT);
+}

--- a/crates/starknet_transaction_prover/src/server/log_redact.rs
+++ b/crates/starknet_transaction_prover/src/server/log_redact.rs
@@ -1,0 +1,26 @@
+//! Helpers for sanitizing values that appear in log lines.
+//!
+//! Currently exposes [`redact_url_host`], which collapses a URL down to
+//! `scheme://host[:port]`. Used to log upstream endpoints (`rpc_node_url`,
+//! `blocking_check_url`) without echoing userinfo or query strings — both of
+//! which routinely carry credentials in production configurations.
+
+#[cfg(test)]
+#[path = "log_redact_test.rs"]
+mod log_redact_test;
+
+/// Returns `scheme://host[:port]` for a URL, dropping any userinfo, path,
+/// query, and fragment. Falls back to `"<invalid url>"` when the input cannot
+/// be parsed — the raw URL is never echoed even on the error path.
+pub fn redact_url_host(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(parsed) => {
+            let host = parsed.host_str().unwrap_or("");
+            match parsed.port() {
+                Some(port) => format!("{}://{}:{}", parsed.scheme(), host, port),
+                None => format!("{}://{}", parsed.scheme(), host),
+            }
+        }
+        Err(_) => "<invalid url>".to_string(),
+    }
+}

--- a/crates/starknet_transaction_prover/src/server/log_redact_test.rs
+++ b/crates/starknet_transaction_prover/src/server/log_redact_test.rs
@@ -1,0 +1,26 @@
+//! Unit tests for [`redact_url_host`].
+
+use super::redact_url_host;
+
+#[test]
+fn strips_userinfo_path_and_query() {
+    assert_eq!(
+        redact_url_host("https://user:pass@rpc.example.com:8443/v1?token=abc"),
+        "https://rpc.example.com:8443"
+    );
+}
+
+#[test]
+fn keeps_default_port_implicit() {
+    assert_eq!(redact_url_host("https://rpc.example.com/"), "https://rpc.example.com");
+}
+
+#[test]
+fn returns_placeholder_for_invalid_url() {
+    assert_eq!(redact_url_host("not a url"), "<invalid url>");
+}
+
+#[test]
+fn drops_fragment() {
+    assert_eq!(redact_url_host("https://rpc.example.com/#secret"), "https://rpc.example.com");
+}

--- a/crates/starknet_transaction_prover/src/server/tls.rs
+++ b/crates/starknet_transaction_prover/src/server/tls.rs
@@ -27,7 +27,7 @@ use tower_http::map_request_body::MapRequestBodyLayer;
 use tower_http::map_response_body::MapResponseBodyLayer;
 use tracing::warn;
 
-use super::OhttpJsonrpseeLayer;
+use super::{HealthLayer, OhttpJsonrpseeLayer};
 
 /// Maximum time allowed for a TLS handshake before the connection is dropped.
 const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -59,7 +59,10 @@ pub async fn start_tls_server(
     let svc_builder = ServerBuilder::default()
         .set_config(server_config)
         .set_http_middleware(
+            // `HealthLayer` sits outermost so `GET /health` is answered before
+            // any other middleware runs.
             ServiceBuilder::new()
+                .layer(HealthLayer)
                 .option_layer(cors_layer)
                 .layer(MapRequestBodyLayer::new(HttpBody::new))
                 .option_layer(ohttp_layer)


### PR DESCRIPTION
## Summary
- New `HealthLayer` short-circuits `GET /health` ahead of jsonrpsee so load balancers can probe without going through the JSON-RPC parser. Body is a static `{\"status\":\"ok\"}` — no service state exposed.
- `--json-logs` / `JSON_LOGS=true` switches `tracing_subscriber` to a JSON formatter so log aggregators (Datadog) can parse fields directly.
- Startup banner logs `version`, `git_sha` (build-time), `chain_id`, redacted RPC host (`scheme://host[:port]` only — userinfo and path stripped), and feature toggles. Transaction contents and URLs with credentials are never echoed.

First of several small PRs adding observability to the transaction prover (Slack [thread](https://starkwareindustries.slack.com/archives/CT6BYCJBV/p1777988622116229?thread_ts=1777988543.187689&cid=CT6BYCJBV)). Follow-ups will add per-request structured logging + request IDs, /metrics, proving-job histograms, and a global panic handler.

## Test plan
- [x] Unit tests for `HealthLayer` (200 on GET, fall-through on POST/other paths)
- [x] Unit tests for `redact_url_host` (strips userinfo/path/query)
- [x] `SEED=0 cargo test -p starknet_transaction_prover` — 60 pass
- [x] `cargo clippy -p starknet_transaction_prover --all-targets -- -D warnings` — clean
- [x] `scripts/rust_fmt.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)