### PR TITLE
starknet_transaction_prover: global panic hook + graceful SIGTERM shutdown

### DIFF
--- a/crates/starknet_transaction_prover/Cargo.toml
+++ b/crates/starknet_transaction_prover/Cargo.toml
@@ -55,7 +55,7 @@ tower-http = { workspace = true, features = [
 ] }
 tower_ohttp.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/starknet_transaction_prover/Cargo.toml
+++ b/crates/starknet_transaction_prover/Cargo.toml
@@ -44,7 +44,7 @@ starknet_patricia_storage.workspace = true
 starknet_proof_verifier.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "signal", "time"] }
 tokio-rustls.workspace = true
 tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true, features = [

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -41,8 +41,6 @@ async fn main() -> anyhow::Result<()> {
     // CLI-override logs visible.
     let args = CliArgs::parse();
 
-    install_panic_hook();
-
     // TODO(Avi): Revisit the starknet_transaction_prover=debug default once the service stabilizes.
     // By default, keep service logs and lower third-party logs to warn. The
     // formatter is JSON when `--log-format json` / `LOG_FORMAT=json` is set,
@@ -55,6 +53,11 @@ async fn main() -> anyhow::Result<()> {
         LogFormat::Json => registry.with(fmt::layer().json()).init(),
         LogFormat::Text => registry.with(fmt::layer()).init(),
     }
+
+    // Install after tracing init so the hook's `error!` macro reaches the
+    // subscriber. A panic before this line still hits the default stderr
+    // handler.
+    install_panic_hook();
 
     let config = ServiceConfig::from_args(args)?;
 

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> anyhow::Result<()> {
     };
     use starknet_transaction_prover::server::cors::{build_cors_layer, cors_mode};
     use starknet_transaction_prover::server::log_redact::redact_url_host;
+    use starknet_transaction_prover::server::panic::install_panic_hook;
     use starknet_transaction_prover::server::rpc_api::ProvingRpcServer;
     use starknet_transaction_prover::server::rpc_impl::ProvingRpcServerImpl;
     use starknet_transaction_prover::server::{
@@ -29,8 +30,9 @@ async fn main() -> anyhow::Result<()> {
         OhttpJsonrpseeLayer,
         OHTTP_JSONRPSEE_BODY_BUILDER,
     };
+    use tokio::signal::unix::{signal, SignalKind};
     use tower_ohttp::OhttpGateway;
-    use tracing::info;
+    use tracing::{info, warn};
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{fmt, EnvFilter};
 
@@ -38,6 +40,8 @@ async fn main() -> anyhow::Result<()> {
     // the formatter. Config loading still happens after to keep the existing
     // CLI-override logs visible.
     let args = CliArgs::parse();
+
+    install_panic_hook();
 
     // TODO(Avi): Revisit the starknet_transaction_prover=debug default once the service stabilizes.
     // By default, keep service logs and lower third-party logs to warn. The
@@ -116,6 +120,37 @@ async fn main() -> anyhow::Result<()> {
         "JSON-RPC proving server is running."
     );
 
+    // Bridge SIGTERM/SIGINT into jsonrpsee's `ServerHandle::stop`. Without
+    // this, container teardown sends SIGTERM and the prover's only response
+    // is to be killed with no log — operators can't tell graceful drains
+    // from crashes.
+    let shutdown_handle = server_handle.clone();
+    tokio::spawn(async move {
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(stream) => stream,
+            Err(err) => {
+                warn!(error = %err, "Failed to install SIGTERM handler");
+                return;
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(stream) => stream,
+            Err(err) => {
+                warn!(error = %err, "Failed to install SIGINT handler");
+                return;
+            }
+        };
+        let signal_name = tokio::select! {
+            _ = sigterm.recv() => "SIGTERM",
+            _ = sigint.recv() => "SIGINT",
+        };
+        info!(event = "shutdown_started", signal = signal_name, "Shutting down JSON-RPC server.");
+        if let Err(err) = shutdown_handle.stop() {
+            warn!(error = %err, "Failed to stop JSON-RPC server cleanly");
+        }
+    });
+
     server_handle.stopped().await;
+    info!(event = "shutdown_complete", "JSON-RPC server stopped.");
     Ok(())
 }

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -135,16 +135,17 @@ async fn main() -> anyhow::Result<()> {
         .ok();
     let shutdown_handle = server_handle.clone();
     tokio::spawn(async move {
-        let signal_name = match (sigterm, sigint) {
-            (Some(mut t), Some(mut i)) => tokio::select! {
+        let (mut sigterm, mut sigint) = (sigterm, sigint);
+        let signal_name = match (&mut sigterm, &mut sigint) {
+            (Some(t), Some(i)) => tokio::select! {
                 _ = t.recv() => "SIGTERM",
                 _ = i.recv() => "SIGINT",
             },
-            (Some(mut t), None) => {
+            (Some(t), None) => {
                 t.recv().await;
                 "SIGTERM"
             }
-            (None, Some(mut i)) => {
+            (None, Some(i)) => {
                 i.recv().await;
                 "SIGINT"
             }
@@ -154,6 +155,31 @@ async fn main() -> anyhow::Result<()> {
         if let Err(err) = shutdown_handle.stop() {
             warn!(error = %err, "Failed to stop JSON-RPC server cleanly");
         }
+
+        // Stay live for a second signal and force-exit. Tokio's OS-level
+        // signal handler keeps intercepting SIGTERM/SIGINT even after the
+        // first one fires (tokio-rs/tokio#7905); if we let our Signal
+        // instances drop, a second Ctrl+C would be silently swallowed and
+        // a stuck graceful-shutdown could only be killed with SIGKILL.
+        // Re-await the already-registered handlers and exit non-zero on
+        // the second hit so an operator can always reclaim the process.
+        match (&mut sigterm, &mut sigint) {
+            (Some(t), Some(i)) => {
+                tokio::select! {
+                    _ = t.recv() => {},
+                    _ = i.recv() => {},
+                }
+            }
+            (Some(t), None) => {
+                t.recv().await;
+            }
+            (None, Some(i)) => {
+                i.recv().await;
+            }
+            (None, None) => return,
+        }
+        warn!(event = "force_exit", "Received second termination signal; forcing exit.");
+        std::process::exit(1);
     });
 
     server_handle.stopped().await;

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -120,29 +120,32 @@ async fn main() -> anyhow::Result<()> {
         "JSON-RPC proving server is running."
     );
 
-    // Bridge SIGTERM/SIGINT into jsonrpsee's `ServerHandle::stop`. Without
-    // this, container teardown sends SIGTERM and the prover's only response
-    // is to be killed with no log — operators can't tell graceful drains
-    // from crashes.
+    // Bridge SIGTERM/SIGINT into jsonrpsee's `ServerHandle::stop` so
+    // container teardown becomes visible in logs. Both handlers are
+    // installed eagerly: if one fails, we still want the other to drive
+    // a graceful shutdown rather than silently dropping it.
+    let sigterm = signal(SignalKind::terminate())
+        .inspect_err(|err| warn!(error = %err, "Failed to install SIGTERM handler"))
+        .ok();
+    let sigint = signal(SignalKind::interrupt())
+        .inspect_err(|err| warn!(error = %err, "Failed to install SIGINT handler"))
+        .ok();
     let shutdown_handle = server_handle.clone();
     tokio::spawn(async move {
-        let mut sigterm = match signal(SignalKind::terminate()) {
-            Ok(stream) => stream,
-            Err(err) => {
-                warn!(error = %err, "Failed to install SIGTERM handler");
-                return;
+        let signal_name = match (sigterm, sigint) {
+            (Some(mut t), Some(mut i)) => tokio::select! {
+                _ = t.recv() => "SIGTERM",
+                _ = i.recv() => "SIGINT",
+            },
+            (Some(mut t), None) => {
+                t.recv().await;
+                "SIGTERM"
             }
-        };
-        let mut sigint = match signal(SignalKind::interrupt()) {
-            Ok(stream) => stream,
-            Err(err) => {
-                warn!(error = %err, "Failed to install SIGINT handler");
-                return;
+            (None, Some(mut i)) => {
+                i.recv().await;
+                "SIGINT"
             }
-        };
-        let signal_name = tokio::select! {
-            _ = sigterm.recv() => "SIGTERM",
-            _ = sigint.recv() => "SIGINT",
+            (None, None) => return,
         };
         info!(event = "shutdown_started", signal = signal_name, "Shutting down JSON-RPC server.");
         if let Err(err) = shutdown_handle.stop() {

--- a/crates/starknet_transaction_prover/src/server.rs
+++ b/crates/starknet_transaction_prover/src/server.rs
@@ -33,6 +33,7 @@ pub mod health;
 pub mod log_redact;
 #[cfg(test)]
 pub mod mock_rpc;
+pub mod panic;
 pub mod rpc_api;
 pub mod rpc_impl;
 pub mod tls;

--- a/crates/starknet_transaction_prover/src/server/panic.rs
+++ b/crates/starknet_transaction_prover/src/server/panic.rs
@@ -19,7 +19,7 @@ pub fn install_panic_hook() {
 }
 
 fn panic_hook(info: &PanicHookInfo<'_>) {
-    let message = extract_payload(info);
+    let message = info.payload_as_str().unwrap_or("<non-string panic payload>");
     let location = info
         .location()
         .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
@@ -33,47 +33,4 @@ fn panic_hook(info: &PanicHookInfo<'_>) {
         backtrace = %backtrace,
         "Service panicked",
     );
-}
-
-/// Best-effort extraction of the panic payload — supports the common
-/// `panic!("string literal")` and `panic!("{fmt}", ...)` cases. Returns
-/// `"<non-string panic payload>"` for arbitrary types.
-fn extract_payload(info: &PanicHookInfo<'_>) -> String {
-    let payload = info.payload();
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        return (*s).to_string();
-    }
-    if let Some(s) = payload.downcast_ref::<String>() {
-        return s.clone();
-    }
-    "<non-string panic payload>".to_string()
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use super::extract_payload;
-
-    fn capture_payload<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {
-        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-        let prev_hook = std::panic::take_hook();
-        let writer = Arc::clone(&captured);
-        std::panic::set_hook(Box::new(move |info| {
-            *writer.lock().unwrap() = Some(extract_payload(info));
-        }));
-        let _ = std::panic::catch_unwind(f);
-        std::panic::set_hook(prev_hook);
-        let value = captured.lock().unwrap().clone().unwrap_or_default();
-        value
-    }
-
-    // Panic-capturing tests share global state (the panic hook), so they must
-    // run serially. Using a shared mutex would force the same — keep these as
-    // a single `#[test]` to make ordering explicit.
-    #[test]
-    fn extracts_static_str_and_formatted_payloads() {
-        assert_eq!(capture_payload(|| panic!("static literal")), "static literal");
-        assert_eq!(capture_payload(|| panic!("formatted {}", 42)), "formatted 42");
-    }
 }

--- a/crates/starknet_transaction_prover/src/server/panic.rs
+++ b/crates/starknet_transaction_prover/src/server/panic.rs
@@ -19,7 +19,7 @@ pub fn install_panic_hook() {
 }
 
 fn panic_hook(info: &PanicHookInfo<'_>) {
-    let message = info.payload_as_str().unwrap_or("<non-string panic payload>");
+    let message = extract_payload(info);
     let location = info
         .location()
         .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
@@ -33,4 +33,50 @@ fn panic_hook(info: &PanicHookInfo<'_>) {
         backtrace = %backtrace,
         "Service panicked",
     );
+}
+
+/// Best-effort extraction of the panic payload — supports the common
+/// `panic!("string literal")` and `panic!("{fmt}", ...)` cases. Returns
+/// `"<non-string panic payload>"` for arbitrary types.
+///
+/// Could be replaced by `PanicHookInfo::payload_as_str()` once the prover's
+/// pinned toolchain (`nightly-2025-07-14`) ships it as stable — gated behind
+/// `panic_payload_as_str` today.
+fn extract_payload(info: &PanicHookInfo<'_>) -> String {
+    let payload = info.payload();
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "<non-string panic payload>".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::extract_payload;
+
+    fn capture_payload<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let prev_hook = std::panic::take_hook();
+        let writer = Arc::clone(&captured);
+        std::panic::set_hook(Box::new(move |info| {
+            *writer.lock().unwrap() = Some(extract_payload(info));
+        }));
+        let _ = std::panic::catch_unwind(f);
+        std::panic::set_hook(prev_hook);
+        let value = captured.lock().unwrap().clone().unwrap_or_default();
+        value
+    }
+
+    // Panic-capturing tests share global state (the panic hook), so they must
+    // run serially. Keep these as a single `#[test]` so ordering is explicit.
+    #[test]
+    fn extracts_static_str_and_formatted_payloads() {
+        assert_eq!(capture_payload(|| panic!("static literal")), "static literal");
+        assert_eq!(capture_payload(|| panic!("formatted {}", 42)), "formatted 42");
+    }
 }

--- a/crates/starknet_transaction_prover/src/server/panic.rs
+++ b/crates/starknet_transaction_prover/src/server/panic.rs
@@ -14,8 +14,6 @@ use std::panic::PanicHookInfo;
 
 use tracing::error;
 
-/// Installs the global panic hook. Idempotent — calling twice replaces the
-/// hook with itself.
 pub fn install_panic_hook() {
     std::panic::set_hook(Box::new(panic_hook));
 }

--- a/crates/starknet_transaction_prover/src/server/panic.rs
+++ b/crates/starknet_transaction_prover/src/server/panic.rs
@@ -1,0 +1,81 @@
+//! Process-wide panic hook for the prover.
+//!
+//! Without an explicit hook, panics in `tokio::spawn`ed work hit the runtime's
+//! default handler which prints to stderr in an ad-hoc format. We want one
+//! structured `tracing` event with location + backtrace so log aggregators
+//! (Datadog) can index it and on-call can be paged.
+//!
+//! The hook only emits a log line. It does *not* call `process::abort()` —
+//! the existing runtime behavior (which aborts on unhandled task panic by
+//! default for `#[tokio::main]`) is preserved.
+
+use std::backtrace::Backtrace;
+use std::panic::PanicHookInfo;
+
+use tracing::error;
+
+/// Installs the global panic hook. Idempotent — calling twice replaces the
+/// hook with itself.
+pub fn install_panic_hook() {
+    std::panic::set_hook(Box::new(panic_hook));
+}
+
+fn panic_hook(info: &PanicHookInfo<'_>) {
+    let message = extract_payload(info);
+    let location = info
+        .location()
+        .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+        .unwrap_or_else(|| "<unknown>".to_string());
+    // `force_capture` to get a backtrace regardless of RUST_BACKTRACE.
+    let backtrace = Backtrace::force_capture();
+    error!(
+        event = "panic",
+        location = %location,
+        message = %message,
+        backtrace = %backtrace,
+        "Service panicked",
+    );
+}
+
+/// Best-effort extraction of the panic payload — supports the common
+/// `panic!("string literal")` and `panic!("{fmt}", ...)` cases. Returns
+/// `"<non-string panic payload>"` for arbitrary types.
+fn extract_payload(info: &PanicHookInfo<'_>) -> String {
+    let payload = info.payload();
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "<non-string panic payload>".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::extract_payload;
+
+    fn capture_payload<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let prev_hook = std::panic::take_hook();
+        let writer = Arc::clone(&captured);
+        std::panic::set_hook(Box::new(move |info| {
+            *writer.lock().unwrap() = Some(extract_payload(info));
+        }));
+        let _ = std::panic::catch_unwind(f);
+        std::panic::set_hook(prev_hook);
+        let value = captured.lock().unwrap().clone().unwrap_or_default();
+        value
+    }
+
+    // Panic-capturing tests share global state (the panic hook), so they must
+    // run serially. Using a shared mutex would force the same — keep these as
+    // a single `#[test]` to make ordering explicit.
+    #[test]
+    fn extracts_static_str_and_formatted_payloads() {
+        assert_eq!(capture_payload(|| panic!("static literal")), "static literal");
+        assert_eq!(capture_payload(|| panic!("formatted {}", 42)), "formatted 42");
+    }
+}


### PR DESCRIPTION
## Summary
- New \`install_panic_hook\` registers \`std::panic::set_hook\` that emits one structured \`tracing::error\` event with location and a forced backtrace before the runtime tears down. Without it, panics in tokio tasks hit the default handler and print an ad-hoc line to stderr that Datadog can't parse.
- SIGTERM/SIGINT drive a graceful jsonrpsee shutdown. A side task selects on both signals, logs \`shutdown_started\` with the signal name, calls \`ServerHandle::stop\`, and main logs \`shutdown_complete\` once the server has drained. Container teardown used to be invisible in logs.

Counter increments are deferred until /metrics lands (follow-up PR) — for now the panic hook only logs.

**Stacked on** #14044 (uses the redacted-URL helper). Once that merges, this branch rebases to main with no change.

## Test plan
- [x] Unit tests for \`extract_payload\` (static \`&str\` and formatted \`String\` panic payloads)
- [x] \`SEED=0 cargo test -p starknet_transaction_prover\` — 65 pass
- [x] \`cargo clippy -p starknet_transaction_prover --all-targets -- -D warnings\` — clean
- [x] \`scripts/rust_fmt.sh\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)