### PR TITLE
starknet_transaction_prover: Prometheus /metrics endpoint with build_info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12826,6 +12826,8 @@ dependencies = [
  "indexmap 2.12.0",
  "jsonrpsee",
  "jsonschema",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mockito",
  "privacy-circuit-verify",
  "privacy-prove",

--- a/crates/starknet_transaction_prover/Cargo.toml
+++ b/crates/starknet_transaction_prover/Cargo.toml
@@ -28,6 +28,8 @@ http.workspace = true
 http-body-util.workspace = true
 indexmap.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 privacy-prove = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -22,11 +22,13 @@ async fn main() -> anyhow::Result<()> {
     };
     use starknet_transaction_prover::server::cors::{build_cors_layer, cors_mode};
     use starknet_transaction_prover::server::log_redact::redact_url_host;
+    use starknet_transaction_prover::server::metrics::install_exporter;
     use starknet_transaction_prover::server::panic::install_panic_hook;
     use starknet_transaction_prover::server::rpc_api::ProvingRpcServer;
     use starknet_transaction_prover::server::rpc_impl::ProvingRpcServerImpl;
     use starknet_transaction_prover::server::{
         start_server,
+        MetricsLayer,
         OhttpJsonrpseeLayer,
         OHTTP_JSONRPSEE_BODY_BUILDER,
     };
@@ -60,6 +62,14 @@ async fn main() -> anyhow::Result<()> {
     install_panic_hook();
 
     let config = ServiceConfig::from_args(args)?;
+
+    // Install the global Prometheus exporter and emit `prover_build_info`.
+    // Done before the server binds so a scrape during a slow startup still
+    // returns the build identity.
+    let prometheus_handle =
+        install_exporter(env!("CARGO_PKG_VERSION"), option_env!("GIT_SHA").unwrap_or("unknown"))
+            .context("Failed to install Prometheus exporter")?;
+    let metrics_layer = Some(MetricsLayer::new(prometheus_handle));
 
     // Startup banner — emitted before binding so a failed bind still leaves a
     // breadcrumb identifying the build. Fields are deliberately conservative:
@@ -109,6 +119,7 @@ async fn main() -> anyhow::Result<()> {
         config.max_request_body_size,
         cors_layer,
         ohttp_layer,
+        metrics_layer,
     )
     .await?;
 

--- a/crates/starknet_transaction_prover/src/server.rs
+++ b/crates/starknet_transaction_prover/src/server.rs
@@ -31,6 +31,7 @@ pub mod cors;
 pub mod errors;
 pub mod health;
 pub mod log_redact;
+pub mod metrics;
 #[cfg(test)]
 pub mod mock_rpc;
 pub mod panic;
@@ -39,6 +40,7 @@ pub mod rpc_impl;
 pub mod tls;
 
 pub use health::{HealthLayer, HEALTH_PATH};
+pub use metrics::{MetricsLayer, METRICS_PATH};
 
 #[cfg(test)]
 mod rpc_spec_test;
@@ -48,6 +50,7 @@ mod rpc_spec_test;
 mod ohttp_integration_test;
 
 /// Starts the JSON-RPC server in either HTTP or HTTPS mode depending on the transport.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_server(
     addr: SocketAddr,
     transport: &TransportMode,
@@ -56,6 +59,7 @@ pub async fn start_server(
     max_request_body_size: u32,
     cors_layer: Option<CorsLayer>,
     ohttp_layer: Option<OhttpJsonrpseeLayer>,
+    metrics_layer: Option<MetricsLayer>,
 ) -> anyhow::Result<(SocketAddr, ServerHandle)> {
     match transport {
         TransportMode::Http => {
@@ -80,10 +84,12 @@ pub async fn start_server(
                 // type it expects. `HttpBody::new` is a zero-cost wrapper, so
                 // non-OHTTP requests still stream through unbuffered.
                 .set_http_middleware(
-                    // `HealthLayer` sits outermost so `GET /health` is answered before
-                    // any other middleware runs (no compression, no CORS, no OHTTP).
+                    // `HealthLayer` and `MetricsLayer` sit outermost so the
+                    // monitoring endpoints answer before any other middleware
+                    // runs (no compression, no CORS, no OHTTP).
                     ServiceBuilder::new()
                         .layer(HealthLayer)
+                        .option_layer(metrics_layer)
                         .option_layer(cors_layer)
                         .layer(MapRequestBodyLayer::new(HttpBody::new))
                         .option_layer(ohttp_layer)
@@ -107,6 +113,7 @@ pub async fn start_server(
                 max_request_body_size,
                 cors_layer,
                 ohttp_layer,
+                metrics_layer,
             )
             .await
         }

--- a/crates/starknet_transaction_prover/src/server/metrics.rs
+++ b/crates/starknet_transaction_prover/src/server/metrics.rs
@@ -1,0 +1,112 @@
+//! Prometheus metrics surface for the prover.
+//!
+//! Mirrors the proof-interceptor design: a `/metrics` endpoint exposed on the
+//! same TCP listener as JSON-RPC so a single Datadog agent scrape job picks up
+//! both. Implemented as a tower middleware layer that short-circuits
+//! `GET /metrics` ahead of jsonrpsee, the same way `HealthLayer` handles
+//! `/health`.
+//!
+//! Metric names follow the existing sequencer pattern (snake_case, service
+//! prefix). No labels carry user-controlled or unbounded values; cardinality
+//! is bounded by the small enumerations declared below.
+
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures::future::{ready, Either, Ready};
+use http::{header, Method, Request, Response, StatusCode};
+use http_body_util::Full;
+use jsonrpsee::server::HttpBody;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use tower::{Layer, Service};
+
+#[cfg(test)]
+#[path = "metrics_test.rs"]
+mod metrics_test;
+
+/// Path served by [`MetricsLayer`].
+pub const METRICS_PATH: &str = "/metrics";
+
+/// Metric name constants. Kept here so `metrics!` invocations elsewhere link
+/// to a single definition instead of bare string literals.
+pub mod names {
+    /// Build identity. Value is always 1; labels carry version + git_sha.
+    pub const BUILD_INFO: &str = "prover_build_info";
+    /// Requests rejected because the concurrency semaphore was full.
+    pub const CONCURRENCY_REJECTED_TOTAL: &str = "prover_concurrency_rejected_total";
+}
+
+/// Initializes the global Prometheus exporter and emits the `build_info`
+/// gauge. Returns the handle used by [`MetricsLayer`] to render the scrape
+/// response.
+///
+/// Should be called exactly once at startup. The handle is cheap to clone
+/// (it wraps an `Arc`).
+pub fn install_exporter(version: &str, git_sha: &str) -> anyhow::Result<PrometheusHandle> {
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .map_err(|err| anyhow::anyhow!("failed to install prometheus recorder: {err}"))?;
+    metrics::gauge!(
+        names::BUILD_INFO,
+        "version" => version.to_string(),
+        "git_sha" => git_sha.to_string(),
+    )
+    .set(1.0);
+    // Pre-register the counter at 0 so it shows up in scrapes before the
+    // first rejection — dashboards relying on `rate(...) > 0` need the
+    // series to exist.
+    metrics::counter!(names::CONCURRENCY_REJECTED_TOTAL).increment(0);
+    Ok(handle)
+}
+
+/// tower [`Layer`] that intercepts `GET /metrics`.
+#[derive(Clone)]
+pub struct MetricsLayer {
+    handle: PrometheusHandle,
+}
+
+impl MetricsLayer {
+    pub fn new(handle: PrometheusHandle) -> Self {
+        Self { handle }
+    }
+}
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MetricsService { inner, handle: self.handle.clone() }
+    }
+}
+
+#[derive(Clone)]
+pub struct MetricsService<S> {
+    inner: S,
+    handle: PrometheusHandle,
+}
+
+impl<S, ReqB> Service<Request<ReqB>> for MetricsService<S>
+where
+    S: Service<Request<ReqB>, Response = Response<HttpBody>>,
+{
+    type Response = Response<HttpBody>;
+    type Error = S::Error;
+    type Future = Either<Ready<Result<Self::Response, Self::Error>>, S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqB>) -> Self::Future {
+        if request.method() == Method::GET && request.uri().path() == METRICS_PATH {
+            let body = Bytes::from(self.handle.render());
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "text/plain; version=0.0.4")
+                .body(HttpBody::new(Full::new(body)))
+                .expect("response build with a string body is infallible");
+            return Either::Left(ready(Ok(response)));
+        }
+        Either::Right(self.inner.call(request))
+    }
+}

--- a/crates/starknet_transaction_prover/src/server/metrics.rs
+++ b/crates/starknet_transaction_prover/src/server/metrics.rs
@@ -1,14 +1,8 @@
-//! Prometheus metrics surface for the prover.
+//! Prometheus `/metrics` endpoint as a tower middleware layer.
 //!
-//! Mirrors the proof-interceptor design: a `/metrics` endpoint exposed on the
-//! same TCP listener as JSON-RPC so a single Datadog agent scrape job picks up
-//! both. Implemented as a tower middleware layer that short-circuits
-//! `GET /metrics` ahead of jsonrpsee, the same way `HealthLayer` handles
-//! `/health`.
-//!
-//! Metric names follow the existing sequencer pattern (snake_case, service
-//! prefix). No labels carry user-controlled or unbounded values; cardinality
-//! is bounded by the small enumerations declared below.
+//! Short-circuits `GET /metrics` ahead of jsonrpsee so scrapes never run
+//! through the JSON-RPC parser. Label cardinality is bounded by the
+//! enumerations in [`names`] — no user-controlled values become labels.
 
 use std::task::{Context, Poll};
 

--- a/crates/starknet_transaction_prover/src/server/metrics_test.rs
+++ b/crates/starknet_transaction_prover/src/server/metrics_test.rs
@@ -1,0 +1,59 @@
+//! Unit tests for [`MetricsLayer`] and [`install_exporter`].
+
+use bytes::Bytes;
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::{BodyExt, Full};
+use jsonrpsee::server::HttpBody;
+use tower::{Layer, ServiceExt};
+
+use super::{install_exporter, MetricsLayer, METRICS_PATH};
+
+fn fallthrough_service() -> impl tower::Service<
+    Request<HttpBody>,
+    Response = Response<HttpBody>,
+    Error = std::convert::Infallible,
+    Future = futures::future::Ready<Result<Response<HttpBody>, std::convert::Infallible>>,
+> + Clone {
+    tower::service_fn(|_req: Request<HttpBody>| {
+        let response = Response::builder()
+            .status(StatusCode::IM_A_TEAPOT)
+            .body(HttpBody::new(Full::new(Bytes::from_static(b"fallthrough"))))
+            .expect("static body is infallible");
+        futures::future::ready(Ok::<_, std::convert::Infallible>(response))
+    })
+}
+
+fn empty_request(method: Method, path: &str) -> Request<HttpBody> {
+    Request::builder()
+        .method(method)
+        .uri(path)
+        .body(HttpBody::new(Full::new(Bytes::new())))
+        .expect("static body is infallible")
+}
+
+async fn read_body(response: Response<HttpBody>) -> (StatusCode, Vec<u8>) {
+    let (parts, body) = response.into_parts();
+    let bytes = body.collect().await.expect("body collect").to_bytes().to_vec();
+    (parts.status, bytes)
+}
+
+#[tokio::test]
+async fn get_metrics_renders_prometheus_text() {
+    // Note: install_exporter installs the global recorder, so this test must
+    // be the only one in the crate that calls it. Other metric tests should
+    // share this fixture or call install_exporter via `try_install`.
+    let handle = install_exporter("0.0.1-test", "deadbeef").expect("install");
+    let svc = MetricsLayer::new(handle).layer(fallthrough_service());
+
+    let response = svc.oneshot(empty_request(Method::GET, METRICS_PATH)).await.unwrap();
+
+    let (status, body) = read_body(response).await;
+    assert_eq!(status, StatusCode::OK);
+    let body_text = String::from_utf8(body).unwrap();
+    assert!(
+        body_text.contains("prover_build_info"),
+        "scrape should include build_info, got:\n{body_text}"
+    );
+    assert!(body_text.contains("version=\"0.0.1-test\""));
+    assert!(body_text.contains("git_sha=\"deadbeef\""));
+}

--- a/crates/starknet_transaction_prover/src/server/rpc_impl.rs
+++ b/crates/starknet_transaction_prover/src/server/rpc_impl.rs
@@ -13,6 +13,7 @@ use tracing::warn;
 use crate::proving::virtual_snos_prover::{ProveTransactionResult, RpcVirtualSnosProver};
 use crate::server::config::ServiceConfig;
 use crate::server::errors::service_busy;
+use crate::server::metrics::names::CONCURRENCY_REJECTED_TOTAL;
 use crate::server::rpc_api::ProvingRpcServer;
 
 /// Starknet RPC specification version.
@@ -57,6 +58,7 @@ impl ProvingRpcServer for ProvingRpcServerImpl {
         transaction: RpcTransaction,
     ) -> RpcResult<ProveTransactionResult> {
         let _permit = self.concurrency_semaphore.try_acquire().map_err(|_| {
+            metrics::counter!(CONCURRENCY_REJECTED_TOTAL).increment(1);
             warn!(
                 max_concurrent_requests = self.max_concurrent_requests,
                 "Rejected proving request: service is at capacity"

--- a/crates/starknet_transaction_prover/src/server/tls.rs
+++ b/crates/starknet_transaction_prover/src/server/tls.rs
@@ -27,7 +27,7 @@ use tower_http::map_request_body::MapRequestBodyLayer;
 use tower_http::map_response_body::MapResponseBodyLayer;
 use tracing::warn;
 
-use super::{HealthLayer, OhttpJsonrpseeLayer};
+use super::{HealthLayer, MetricsLayer, OhttpJsonrpseeLayer};
 
 /// Maximum time allowed for a TLS handshake before the connection is dropped.
 const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -45,6 +45,7 @@ pub async fn start_tls_server(
     max_request_body_size: u32,
     cors_layer: Option<CorsLayer>,
     ohttp_layer: Option<OhttpJsonrpseeLayer>,
+    metrics_layer: Option<MetricsLayer>,
 ) -> anyhow::Result<(SocketAddr, ServerHandle)> {
     let tls_acceptor = load_tls_acceptor(cert_path, key_path)?;
 
@@ -59,10 +60,11 @@ pub async fn start_tls_server(
     let svc_builder = ServerBuilder::default()
         .set_config(server_config)
         .set_http_middleware(
-            // `HealthLayer` sits outermost so `GET /health` is answered before
-            // any other middleware runs.
+            // `HealthLayer` and `MetricsLayer` sit outermost so the monitoring
+            // endpoints answer before any other middleware runs.
             ServiceBuilder::new()
                 .layer(HealthLayer)
+                .option_layer(metrics_layer)
                 .option_layer(cors_layer)
                 .layer(MapRequestBodyLayer::new(HttpBody::new))
                 .option_layer(ohttp_layer)


### PR DESCRIPTION
## Summary
New \`MetricsLayer\` tower middleware serves \`GET /metrics\` ahead of jsonrpsee — same outermost position as \`HealthLayer\` so scrapes bypass compression / CORS / OHTTP.

Two metrics in this PR; per-request histograms/counters are deferred to a follow-up that adds the per-call tower middleware:
- \`prover_build_info{version, git_sha}\` gauge — dashboards group metric changes by deploy. Version from \`CARGO_PKG_VERSION\`; \`git_sha\` from the build-time \`GIT_SHA\` env var (default \"unknown\").
- \`prover_concurrency_rejected_total\` counter — bumps when a request fails to acquire the concurrency semaphore. Pre-registered at 0 so dashboards relying on \`rate(...)\` see the series before the first rejection.

No labels carry user-controlled or unbounded values; cardinality is bounded by the small enumerations declared in \`metrics::names\`.

**Stacked on** #14045 (panic/shutdown).

## Test plan
- [x] \`MetricsLayer\` test asserts \`build_info\` appears in \`/metrics\` with the right \`version\` and \`git_sha\` labels
- [x] \`SEED=0 cargo test -p starknet_transaction_prover\` — 66 pass
- [x] \`cargo clippy -p starknet_transaction_prover --all-targets -- -D warnings\` — clean
- [x] \`scripts/rust_fmt.sh\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)