### PR TITLE
starknet_transaction_prover: per-request structured log with request-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12829,6 +12829,7 @@ dependencies = [
  "mockito",
  "privacy-circuit-verify",
  "privacy-prove",
+ "rand 0.8.5",
  "reqwest 0.12.24",
  "rstest",
  "serde",

--- a/crates/starknet_transaction_prover/Cargo.toml
+++ b/crates/starknet_transaction_prover/Cargo.toml
@@ -29,6 +29,7 @@ http-body-util.workspace = true
 indexmap.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 privacy-prove = { workspace = true, optional = true }
+rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/starknet_transaction_prover/src/server.rs
+++ b/crates/starknet_transaction_prover/src/server.rs
@@ -33,11 +33,13 @@ pub mod health;
 pub mod log_redact;
 #[cfg(test)]
 pub mod mock_rpc;
+pub mod request_log;
 pub mod rpc_api;
 pub mod rpc_impl;
 pub mod tls;
 
 pub use health::{HealthLayer, HEALTH_PATH};
+pub use request_log::{RequestLogLayer, REQUEST_ID_HEADER};
 
 #[cfg(test)]
 mod rpc_spec_test;
@@ -79,9 +81,11 @@ pub async fn start_server(
                 // type it expects. `HttpBody::new` is a zero-cost wrapper, so
                 // non-OHTTP requests still stream through unbuffered.
                 .set_http_middleware(
-                    // `HealthLayer` sits outermost so `GET /health` is answered before
-                    // any other middleware runs (no compression, no CORS, no OHTTP).
+                    // `RequestLogLayer` is outermost so the latency it measures
+                    // includes the time spent in every other layer. `HealthLayer`
+                    // sits inside it so probes still complete before CORS/OHTTP.
                     ServiceBuilder::new()
+                        .layer(RequestLogLayer)
                         .layer(HealthLayer)
                         .option_layer(cors_layer)
                         .layer(MapRequestBodyLayer::new(HttpBody::new))

--- a/crates/starknet_transaction_prover/src/server/request_log.rs
+++ b/crates/starknet_transaction_prover/src/server/request_log.rs
@@ -29,7 +29,12 @@ mod request_log_test;
 /// HTTP header carrying the request id.
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
 
-/// Returns a new request id formatted as a 32-character lowercase hex string.
+/// Cap on accepted incoming request-id length. Anything longer is dropped
+/// in favour of a freshly generated id so the value never balloons into
+/// AsyncLocalStorage / tracing fields and so log aggregators don't have
+/// to parse megabyte-scale ids.
+const MAX_REQUEST_ID_LEN: usize = 128;
+
 fn new_request_id() -> String {
     let mut bytes = [0u8; 16];
     rand::thread_rng().fill_bytes(&mut bytes);
@@ -40,16 +45,25 @@ fn new_request_id() -> String {
     hex
 }
 
-/// Extracts an existing `x-request-id` header, falling back to a freshly
-/// generated id when the header is missing or non-ASCII (avoiding tracing
-/// fields that can't be safely emitted as strings).
+/// Accepts the incoming `x-request-id` only when it's a short printable
+/// ASCII token. CR/LF would let a client smuggle headers into the
+/// response; arbitrary bytes (including unicode) make the value unsafe
+/// to round-trip through `HeaderValue::from_str`. Any reject falls back
+/// to a freshly generated hex id.
 fn extract_or_generate_request_id<B>(request: &Request<B>) -> String {
     request
         .headers()
         .get(REQUEST_ID_HEADER)
         .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty() && value.len() <= MAX_REQUEST_ID_LEN)
+        .filter(|value| value.bytes().all(is_safe_request_id_byte))
         .map(|value| value.to_string())
         .unwrap_or_else(new_request_id)
+}
+
+fn is_safe_request_id_byte(b: u8) -> bool {
+    // Printable ASCII excluding whitespace. Rejects CR/LF/NUL/DEL etc.
+    b.is_ascii_graphic()
 }
 
 /// tower [`Layer`] producing [`RequestLogService`].

--- a/crates/starknet_transaction_prover/src/server/request_log.rs
+++ b/crates/starknet_transaction_prover/src/server/request_log.rs
@@ -1,0 +1,142 @@
+//! tower middleware that logs one structured line per HTTP request and
+//! propagates a request id.
+//!
+//! Sits ahead of jsonrpsee so every JSON-RPC POST (and any pass-through like
+//! OHTTP key fetches) gets a single log line with `event="http_request"`,
+//! `request_id`, `method`, `path`, `status`, and `latency_ms`. The id is
+//! either accepted from the incoming `x-request-id` header or generated as a
+//! 128-bit random hex string (no `uuid` dep — `rand::random` covers it).
+//! The id is also returned on the response so callers can quote it when
+//! reporting failures.
+//!
+//! Body bytes are never inspected — transaction calldata is private user data
+//! per the privacy-pool threat model.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use http::{HeaderValue, Request, Response};
+use jsonrpsee::server::HttpBody;
+use rand::RngCore;
+use tower::{Layer, Service};
+use tracing::info;
+
+#[cfg(test)]
+#[path = "request_log_test.rs"]
+mod request_log_test;
+
+/// HTTP header carrying the request id.
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+
+/// Returns a new request id formatted as a 32-character lowercase hex string.
+fn new_request_id() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    let mut hex = String::with_capacity(32);
+    for byte in bytes {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
+/// Extracts an existing `x-request-id` header, falling back to a freshly
+/// generated id when the header is missing or non-ASCII (avoiding tracing
+/// fields that can't be safely emitted as strings).
+fn extract_or_generate_request_id<B>(request: &Request<B>) -> String {
+    request
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_string())
+        .unwrap_or_else(new_request_id)
+}
+
+/// tower [`Layer`] producing [`RequestLogService`].
+#[derive(Clone, Copy, Default)]
+pub struct RequestLogLayer;
+
+impl<S> Layer<S> for RequestLogLayer {
+    type Service = RequestLogService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestLogService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct RequestLogService<S> {
+    inner: S,
+}
+
+impl<S, ReqB> Service<Request<ReqB>> for RequestLogService<S>
+where
+    S: Service<Request<ReqB>, Response = Response<HttpBody>>,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = Response<HttpBody>;
+    type Error = S::Error;
+    type Future =
+        Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: Request<ReqB>) -> Self::Future {
+        let request_id = extract_or_generate_request_id(&request);
+        // Ensure the header reflects the (possibly generated) id so inner
+        // services that re-read it see a consistent value.
+        if let Ok(header_value) = HeaderValue::from_str(&request_id) {
+            request.headers_mut().insert(REQUEST_ID_HEADER, header_value);
+        }
+        let method = request.method().clone();
+        let path = request.uri().path().to_string();
+        let start = Instant::now();
+
+        let future = self.inner.call(request);
+        let request_id_for_response = request_id.clone();
+
+        Box::pin(async move {
+            let result = future.await;
+            // `as_millis` returns `u128`; saturate to `u64` so the tracing
+            // field type stays simple. A request latency anywhere near 2^64
+            // ms (584 million years) is unreachable.
+            let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            match result {
+                Ok(mut response) => {
+                    let status = response.status().as_u16();
+                    if let Ok(header_value) = HeaderValue::from_str(&request_id_for_response) {
+                        response.headers_mut().insert(REQUEST_ID_HEADER, header_value);
+                    }
+                    info!(
+                        event = "http_request",
+                        request_id = %request_id_for_response,
+                        method = %method,
+                        path = %path,
+                        status = status,
+                        latency_ms = latency_ms,
+                        "HTTP request handled."
+                    );
+                    Ok(response)
+                }
+                Err(err) => {
+                    // The error path can't observe status, but still emit a
+                    // log line so request timing is visible even on inner
+                    // service failure.
+                    info!(
+                        event = "http_request",
+                        request_id = %request_id_for_response,
+                        method = %method,
+                        path = %path,
+                        latency_ms = latency_ms,
+                        outcome = "service_error",
+                        "HTTP request failed in tower stack."
+                    );
+                    Err(err)
+                }
+            }
+        })
+    }
+}

--- a/crates/starknet_transaction_prover/src/server/request_log_test.rs
+++ b/crates/starknet_transaction_prover/src/server/request_log_test.rs
@@ -76,7 +76,6 @@ async fn generates_request_id_when_absent_and_echoes_it() {
 
 #[tokio::test]
 async fn drops_non_ascii_incoming_id_and_generates_a_fresh_one() {
-    // \xff is not valid ASCII-visible — `to_str()` fails so we fall back.
     let mut request = request_with_header(None);
     request
         .headers_mut()
@@ -88,4 +87,41 @@ async fn drops_non_ascii_incoming_id_and_generates_a_fresh_one() {
     let (_body, headers) = read_body(response).await;
     let header_id = headers.get(REQUEST_ID_HEADER).unwrap().to_str().unwrap();
     assert_eq!(header_id.len(), 32, "should have generated a fresh hex id");
+}
+
+#[tokio::test]
+async fn drops_request_id_containing_whitespace() {
+    // CRLF in header values is rejected by the http crate itself at parse
+    // time, so the residual concern is whitespace and other ASCII bytes
+    // that would confuse log parsers if echoed verbatim into structured
+    // fields.
+    for hostile in ["with space", "tab\there", "leading space "] {
+        let mut request = request_with_header(None);
+        request
+            .headers_mut()
+            .insert(REQUEST_ID_HEADER, http::HeaderValue::from_bytes(hostile.as_bytes()).unwrap());
+        let svc = RequestLogLayer.layer(echo_request_id_service());
+        let response = svc.oneshot(request).await.unwrap();
+        let (_body, headers) = read_body(response).await;
+        let header_id = headers.get(REQUEST_ID_HEADER).unwrap().to_str().unwrap();
+        assert_eq!(
+            header_id.len(),
+            32,
+            "expected fresh hex id for hostile input {hostile:?}, got {header_id:?}",
+        );
+    }
+}
+
+#[tokio::test]
+async fn drops_oversize_request_id() {
+    let huge = "a".repeat(2048);
+    let mut request = request_with_header(None);
+    request
+        .headers_mut()
+        .insert(REQUEST_ID_HEADER, http::HeaderValue::from_bytes(huge.as_bytes()).unwrap());
+    let svc = RequestLogLayer.layer(echo_request_id_service());
+    let response = svc.oneshot(request).await.unwrap();
+    let (_body, headers) = read_body(response).await;
+    let header_id = headers.get(REQUEST_ID_HEADER).unwrap().to_str().unwrap();
+    assert_eq!(header_id.len(), 32);
 }

--- a/crates/starknet_transaction_prover/src/server/request_log_test.rs
+++ b/crates/starknet_transaction_prover/src/server/request_log_test.rs
@@ -1,0 +1,91 @@
+//! Unit tests for [`RequestLogLayer`].
+
+use bytes::Bytes;
+use http::{Method, Request, Response, StatusCode};
+use http_body_util::Full;
+use jsonrpsee::server::HttpBody;
+use tower::{Layer, ServiceExt};
+
+use super::{RequestLogLayer, REQUEST_ID_HEADER};
+
+fn echo_request_id_service() -> impl tower::Service<
+    Request<HttpBody>,
+    Response = Response<HttpBody>,
+    Error = std::convert::Infallible,
+    Future = futures::future::Ready<Result<Response<HttpBody>, std::convert::Infallible>>,
+> + Clone {
+    tower::service_fn(|req: Request<HttpBody>| {
+        // Echo the request id into the response body so tests can assert the
+        // layer rewrote the header on the request before the inner service
+        // ran.
+        let id = req
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .map(|value| value.to_str().unwrap().to_string())
+            .unwrap_or_default();
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body(HttpBody::new(Full::new(Bytes::from(id))))
+            .expect("static body is infallible");
+        futures::future::ready(Ok::<_, std::convert::Infallible>(response))
+    })
+}
+
+fn request_with_header(value: Option<&str>) -> Request<HttpBody> {
+    let mut builder = Request::builder().method(Method::POST).uri("/");
+    if let Some(value) = value {
+        builder = builder.header(REQUEST_ID_HEADER, value);
+    }
+    builder.body(HttpBody::new(Full::new(Bytes::new()))).expect("static body is infallible")
+}
+
+async fn read_body(response: Response<HttpBody>) -> (Vec<u8>, http::HeaderMap) {
+    use http_body_util::BodyExt;
+    let (parts, body) = response.into_parts();
+    let bytes = body.collect().await.expect("body collect").to_bytes().to_vec();
+    (bytes, parts.headers)
+}
+
+#[tokio::test]
+async fn echoes_supplied_request_id_on_response() {
+    let svc = RequestLogLayer.layer(echo_request_id_service());
+
+    let response = svc.oneshot(request_with_header(Some("client-supplied-id"))).await.unwrap();
+
+    let (body, headers) = read_body(response).await;
+    assert_eq!(headers.get(REQUEST_ID_HEADER).unwrap(), "client-supplied-id");
+    assert_eq!(String::from_utf8(body).unwrap(), "client-supplied-id");
+}
+
+#[tokio::test]
+async fn generates_request_id_when_absent_and_echoes_it() {
+    let svc = RequestLogLayer.layer(echo_request_id_service());
+
+    let response = svc.oneshot(request_with_header(None)).await.unwrap();
+
+    let (body, headers) = read_body(response).await;
+    let header_id = headers.get(REQUEST_ID_HEADER).unwrap().to_str().unwrap();
+    let body_id = String::from_utf8(body).unwrap();
+    // Body is what the inner service saw — they must match (the layer
+    // rewrote the request header before forwarding).
+    assert_eq!(header_id, body_id);
+    // 32-char hex (16 bytes).
+    assert_eq!(header_id.len(), 32);
+    assert!(header_id.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[tokio::test]
+async fn drops_non_ascii_incoming_id_and_generates_a_fresh_one() {
+    // \xff is not valid ASCII-visible — `to_str()` fails so we fall back.
+    let mut request = request_with_header(None);
+    request
+        .headers_mut()
+        .insert(REQUEST_ID_HEADER, http::HeaderValue::from_bytes(b"\xff\xfe").unwrap());
+
+    let svc = RequestLogLayer.layer(echo_request_id_service());
+    let response = svc.oneshot(request).await.unwrap();
+
+    let (_body, headers) = read_body(response).await;
+    let header_id = headers.get(REQUEST_ID_HEADER).unwrap().to_str().unwrap();
+    assert_eq!(header_id.len(), 32, "should have generated a fresh hex id");
+}

--- a/crates/starknet_transaction_prover/src/server/tls.rs
+++ b/crates/starknet_transaction_prover/src/server/tls.rs
@@ -27,7 +27,7 @@ use tower_http::map_request_body::MapRequestBodyLayer;
 use tower_http::map_response_body::MapResponseBodyLayer;
 use tracing::warn;
 
-use super::{HealthLayer, OhttpJsonrpseeLayer};
+use super::{HealthLayer, OhttpJsonrpseeLayer, RequestLogLayer};
 
 /// Maximum time allowed for a TLS handshake before the connection is dropped.
 const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -59,9 +59,11 @@ pub async fn start_tls_server(
     let svc_builder = ServerBuilder::default()
         .set_config(server_config)
         .set_http_middleware(
-            // `HealthLayer` sits outermost so `GET /health` is answered before
-            // any other middleware runs.
+            // `RequestLogLayer` is outermost so it sees status + latency for
+            // every request (including health probes). See `server.rs` for the
+            // layer-order rationale.
             ServiceBuilder::new()
+                .layer(RequestLogLayer)
                 .layer(HealthLayer)
                 .option_layer(cors_layer)
                 .layer(MapRequestBodyLayer::new(HttpBody::new))


### PR DESCRIPTION
## Summary
Adds a tower middleware that emits one \`event=\"http_request\"\` log line per HTTP request and propagates an \`x-request-id\` header end-to-end.

- \`RequestLogLayer\` sits outermost in the tower stack so the latency it measures includes every other layer (health, CORS, OHTTP, compression, jsonrpsee). Existing per-call \`#[instrument]\` spans in \`prove_transaction\` nest cleanly inside it.
- The id is accepted from the incoming \`x-request-id\` header or generated as a 32-character hex string using \`rand\` (already a workspace dep — avoids pulling in \`uuid\`). Non-ASCII incoming headers are dropped and a fresh id is generated.
- The id is echoed on the response so callers can quote it when reporting failures, and is also re-written onto the inbound request so inner services see a consistent value.
- Body bytes are never inspected; only method, path, status, and latency are logged. Transaction calldata is private user data per the privacy-pool threat model.

**Stacked on** #14044 (HealthLayer + redacted startup banner).

## Test plan
- [x] Unit tests: echoes supplied id, generates UUID-like hex when absent, drops non-ASCII incoming ids
- [x] \`SEED=0 cargo test -p starknet_transaction_prover\` — 67 pass
- [x] \`cargo clippy -p starknet_transaction_prover --all-targets -- -D warnings\` — clean
- [x] \`scripts/rust_fmt.sh\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)