### PR TITLE
starknet_transaction_prover: /health returns 503 when service is saturated

### DIFF
--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -11,6 +11,7 @@ fn main() {
 async fn main() -> anyhow::Result<()> {
     use std::net::SocketAddr;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use anyhow::Context;
     use clap::Parser;
@@ -21,11 +22,13 @@ async fn main() -> anyhow::Result<()> {
         TransportMode,
     };
     use starknet_transaction_prover::server::cors::{build_cors_layer, cors_mode};
+    use starknet_transaction_prover::server::health::HealthLayer;
     use starknet_transaction_prover::server::log_redact::redact_url_host;
     use starknet_transaction_prover::server::metrics::install_exporter;
     use starknet_transaction_prover::server::panic::install_panic_hook;
     use starknet_transaction_prover::server::rpc_api::ProvingRpcServer;
     use starknet_transaction_prover::server::rpc_impl::ProvingRpcServerImpl;
+    use starknet_transaction_prover::server::saturation::SaturationMonitor;
     use starknet_transaction_prover::server::{
         start_server,
         MetricsLayer,
@@ -87,8 +90,16 @@ async fn main() -> anyhow::Result<()> {
         "Starting Starknet transaction prover."
     );
 
+    // Shared saturation tracker — writer is `ProvingRpcServerImpl` on every
+    // permit acquire/reject; reader is `HealthLayer`. See `saturation.rs`.
+    let saturation_monitor = SaturationMonitor::default();
+    let health_layer = HealthLayer::with_saturation(
+        saturation_monitor.clone(),
+        Duration::from_millis(config.health_max_saturated_ms),
+    );
+
     // Build and start the JSON-RPC server.
-    let rpc_impl = ProvingRpcServerImpl::from_config(&config);
+    let rpc_impl = ProvingRpcServerImpl::from_config(&config, saturation_monitor);
     let addr = SocketAddr::new(config.ip, config.port);
     let cors_layer = build_cors_layer(&config.cors_allow_origin)?;
 
@@ -120,6 +131,7 @@ async fn main() -> anyhow::Result<()> {
         cors_layer,
         ohttp_layer,
         metrics_layer,
+        health_layer,
     )
     .await?;
 

--- a/crates/starknet_transaction_prover/src/server.rs
+++ b/crates/starknet_transaction_prover/src/server.rs
@@ -38,6 +38,7 @@ pub mod mock_rpc;
 pub mod panic;
 pub mod rpc_api;
 pub mod rpc_impl;
+pub mod saturation;
 #[cfg(test)]
 pub mod test_recorder;
 pub mod tls;
@@ -45,6 +46,7 @@ pub mod tls;
 pub use health::{HealthLayer, HEALTH_PATH};
 pub use http_metrics::HttpMetricsLayer;
 pub use metrics::{MetricsLayer, METRICS_PATH};
+pub use saturation::SaturationMonitor;
 
 #[cfg(test)]
 mod rpc_spec_test;
@@ -64,6 +66,7 @@ pub async fn start_server(
     cors_layer: Option<CorsLayer>,
     ohttp_layer: Option<OhttpJsonrpseeLayer>,
     metrics_layer: Option<MetricsLayer>,
+    health_layer: HealthLayer,
 ) -> anyhow::Result<(SocketAddr, ServerHandle)> {
     match transport {
         TransportMode::Http => {
@@ -98,7 +101,7 @@ pub async fn start_server(
                     // - The rest of the stack: CORS, body mapping for
                     //   OHTTP, OHTTP, body mapping back, compression.
                     ServiceBuilder::new()
-                        .layer(HealthLayer)
+                        .layer(health_layer)
                         .option_layer(metrics_layer)
                         .layer(HttpMetricsLayer)
                         .option_layer(cors_layer)
@@ -125,6 +128,7 @@ pub async fn start_server(
                 cors_layer,
                 ohttp_layer,
                 metrics_layer,
+                health_layer,
             )
             .await
         }

--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -31,6 +31,10 @@ const DEFAULT_COMPILED_CLASS_CACHE_SIZE: usize = 600;
 /// 5 MiB — matches the convention used elsewhere in the sequencer.
 const DEFAULT_MAX_REQUEST_BODY_SIZE: u32 = 5 * 1024 * 1024;
 const DEFAULT_OHTTP_KEY_CACHE_MAX_AGE_SECS: u64 = 3600;
+/// Default saturation window before `/health` returns 503. 10 seconds
+/// matches "service is rejecting requests for a sustained period" without
+/// flipping on a single in-flight burst.
+const DEFAULT_HEALTH_MAX_SATURATED_MS: u64 = 10_000;
 
 /// Transport mode for the JSON-RPC server.
 #[derive(Clone, Debug)]
@@ -98,6 +102,7 @@ struct RawServiceConfig {
     max_request_body_size: u32,
     ohttp_enabled: bool,
     ohttp_key_cache_max_age_secs: u64,
+    health_max_saturated_ms: u64,
 }
 
 impl Default for RawServiceConfig {
@@ -123,6 +128,7 @@ impl Default for RawServiceConfig {
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             ohttp_enabled: false,
             ohttp_key_cache_max_age_secs: DEFAULT_OHTTP_KEY_CACHE_MAX_AGE_SECS,
+            health_max_saturated_ms: DEFAULT_HEALTH_MAX_SATURATED_MS,
         }
     }
 }
@@ -154,6 +160,11 @@ pub struct ServiceConfig {
     pub ohttp_enabled: bool,
     /// Cache-Control max-age for the `GET /ohttp-keys` response (seconds).
     pub ohttp_key_cache_max_age_secs: u64,
+    /// Saturation window (milliseconds) before `/health` flips to 503. The
+    /// service is "saturated" when it has been continuously rejecting
+    /// proving requests due to the concurrency limit; once that has held
+    /// for this many milliseconds, load balancers should drain the pod.
+    pub health_max_saturated_ms: u64,
 }
 
 impl ServiceConfig {
@@ -384,6 +395,15 @@ impl ServiceConfig {
                 config.ohttp_key_cache_max_age_secs = secs;
             }
         }
+        if let Some(ms) = args.health_max_saturated_ms {
+            if ms != config.health_max_saturated_ms {
+                info!(
+                    "CLI override: health_max_saturated_ms: {} -> {}",
+                    config.health_max_saturated_ms, ms
+                );
+                config.health_max_saturated_ms = ms;
+            }
+        }
 
         // Validate required fields.
         if config.rpc_node_url.is_empty() {
@@ -468,6 +488,7 @@ impl ServiceConfig {
             max_request_body_size: config.max_request_body_size,
             ohttp_enabled: config.ohttp_enabled,
             ohttp_key_cache_max_age_secs: config.ohttp_key_cache_max_age_secs,
+            health_max_saturated_ms: config.health_max_saturated_ms,
         })
     }
 }
@@ -584,6 +605,14 @@ pub struct CliArgs {
         default_value_t = LogFormat::Text,
     )]
     pub log_format: LogFormat,
+
+    /// Saturation window (milliseconds) before `/health` returns 503
+    /// (default: 10000). The service is "saturated" when it has been
+    /// continuously rejecting proving requests due to the concurrency
+    /// limit; once that has held for this many milliseconds, load
+    /// balancers should drain the pod.
+    #[arg(long, value_name = "MILLIS", env = "HEALTH_MAX_SATURATED_MS")]
+    pub health_max_saturated_ms: Option<u64>,
 
     /// Hidden escape hatch: override the embedded bouncer config (block capacity limits) with a
     /// custom JSON file. Not advertised because the embedded defaults are tuned for this prover

--- a/crates/starknet_transaction_prover/src/server/config_test.rs
+++ b/crates/starknet_transaction_prover/src/server/config_test.rs
@@ -60,6 +60,7 @@ fn base_args() -> CliArgs {
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
         log_format: LogFormat::Text,
+        health_max_saturated_ms: None,
     }
 }
 
@@ -149,6 +150,7 @@ fn cors_allow_origin_rejects_non_array_in_config_file() {
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
         log_format: LogFormat::Text,
+        health_max_saturated_ms: None,
     };
 
     let error = ServiceConfig::from_args(args).unwrap_err();

--- a/crates/starknet_transaction_prover/src/server/health.rs
+++ b/crates/starknet_transaction_prover/src/server/health.rs
@@ -9,11 +9,14 @@
 //! (CORS, OHTTP, compression, body-mapping) already produce so the layer can be
 //! placed outermost in the existing `set_http_middleware` chain.
 //!
-//! Body intentionally contains no service state: it must remain safe to expose
-//! without authentication (no transaction data, no config, no version yet —
-//! version is logged at startup instead, see `main.rs`).
+//! When a `SaturationMonitor` is supplied, `/health` returns `503` with a
+//! short opaque body once the service has been continuously rejecting
+//! requests for the configured threshold — load balancers then drain the
+//! pod. Body intentionally contains no service state: no timestamps, no
+//! counters, no upstream URLs.
 
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use bytes::Bytes;
 use futures::future::{ready, Either, Ready};
@@ -22,6 +25,8 @@ use http_body_util::Full;
 use jsonrpsee::server::HttpBody;
 use tower::{Layer, Service};
 
+use super::saturation::SaturationMonitor;
+
 #[cfg(test)]
 #[path = "health_test.rs"]
 mod health_test;
@@ -29,23 +34,66 @@ mod health_test;
 /// Path served by [`HealthLayer`].
 pub const HEALTH_PATH: &str = "/health";
 
-/// Body returned by `GET /health`. Static and stateless — see module docs.
+/// Body returned by `GET /health` when healthy.
 const HEALTHY_BODY: &[u8] = br#"{"status":"ok"}"#;
+/// Body returned by `GET /health` when saturated. Reason is an opaque code,
+/// no internal state included.
+const SATURATED_BODY: &[u8] = br#"{"status":"unhealthy","reason":"saturated"}"#;
 
-#[derive(Clone, Copy, Default)]
-pub struct HealthLayer;
+/// `saturation: None` keeps the original always-200 behaviour;
+/// `Some(monitor)` flips to `503` once `monitor.saturated_for_at_least`
+/// crosses `saturation_threshold`.
+#[derive(Clone, Default)]
+pub struct HealthLayer {
+    saturation: Option<SaturationMonitor>,
+    saturation_threshold: Duration,
+}
+
+impl HealthLayer {
+    pub fn with_saturation(monitor: SaturationMonitor, threshold: Duration) -> Self {
+        Self { saturation: Some(monitor), saturation_threshold: threshold }
+    }
+}
 
 impl<S> Layer<S> for HealthLayer {
     type Service = HealthService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        HealthService { inner }
+        HealthService {
+            inner,
+            saturation: self.saturation.clone(),
+            saturation_threshold: self.saturation_threshold,
+        }
     }
 }
 
 #[derive(Clone)]
 pub struct HealthService<S> {
     inner: S,
+    saturation: Option<SaturationMonitor>,
+    saturation_threshold: Duration,
+}
+
+impl<S> HealthService<S> {
+    fn health_response(&self) -> Response<HttpBody> {
+        let saturated = self
+            .saturation
+            .as_ref()
+            .is_some_and(|monitor| monitor.saturated_for_at_least(self.saturation_threshold));
+        if saturated {
+            Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(HttpBody::new(Full::new(Bytes::from_static(SATURATED_BODY))))
+                .expect("response build with a static body is infallible")
+        } else {
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(HttpBody::new(Full::new(Bytes::from_static(HEALTHY_BODY))))
+                .expect("response build with a static body is infallible")
+        }
+    }
 }
 
 impl<S, ReqB> Service<Request<ReqB>> for HealthService<S>
@@ -68,12 +116,7 @@ where
 
     fn call(&mut self, request: Request<ReqB>) -> Self::Future {
         if request.method() == Method::GET && request.uri().path() == HEALTH_PATH {
-            let response = Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(HttpBody::new(Full::new(Bytes::from_static(HEALTHY_BODY))))
-                .expect("response build with a static body is infallible");
-            return Either::Left(ready(Ok(response)));
+            return Either::Left(ready(Ok(self.health_response())));
         }
         Either::Right(self.inner.call(request))
     }

--- a/crates/starknet_transaction_prover/src/server/health_test.rs
+++ b/crates/starknet_transaction_prover/src/server/health_test.rs
@@ -6,6 +6,7 @@ use http_body_util::{BodyExt, Full};
 use jsonrpsee::server::HttpBody;
 use tower::{Layer, ServiceExt};
 
+use super::super::saturation::SaturationMonitor;
 use super::{HealthLayer, HEALTH_PATH};
 
 /// Inner stub: returns 418 for any request so we can tell whether [`HealthLayer`]
@@ -41,7 +42,7 @@ async fn read_body(response: Response<HttpBody>) -> (StatusCode, Vec<u8>, http::
 
 #[tokio::test]
 async fn get_health_returns_200_with_json_body() {
-    let svc = HealthLayer.layer(fallthrough_service());
+    let svc = HealthLayer::default().layer(fallthrough_service());
 
     let response = svc.oneshot(empty_request(Method::GET, HEALTH_PATH)).await.unwrap();
 
@@ -53,7 +54,7 @@ async fn get_health_returns_200_with_json_body() {
 
 #[tokio::test]
 async fn non_get_health_falls_through() {
-    let svc = HealthLayer.layer(fallthrough_service());
+    let svc = HealthLayer::default().layer(fallthrough_service());
 
     let response = svc.oneshot(empty_request(Method::POST, HEALTH_PATH)).await.unwrap();
 
@@ -63,10 +64,57 @@ async fn non_get_health_falls_through() {
 
 #[tokio::test]
 async fn get_other_path_falls_through() {
-    let svc = HealthLayer.layer(fallthrough_service());
+    let svc = HealthLayer::default().layer(fallthrough_service());
 
     let response = svc.oneshot(empty_request(Method::GET, "/")).await.unwrap();
 
     let (status, _body, _) = read_body(response).await;
     assert_eq!(status, StatusCode::IM_A_TEAPOT);
+}
+
+#[tokio::test]
+async fn unsaturated_health_returns_200_when_monitor_is_supplied() {
+    let monitor = SaturationMonitor::default();
+    let svc = HealthLayer::with_saturation(monitor, std::time::Duration::from_millis(0))
+        .layer(fallthrough_service());
+
+    let response = svc.oneshot(empty_request(Method::GET, HEALTH_PATH)).await.unwrap();
+
+    let (status, body, _) = read_body(response).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, br#"{"status":"ok"}"#);
+}
+
+#[tokio::test]
+async fn saturated_for_at_least_threshold_returns_503_with_opaque_body() {
+    let monitor = SaturationMonitor::default();
+    monitor.mark_rejected();
+    // Zero threshold so the saturation is immediately past it. Avoids
+    // sleeping in the test.
+    let svc = HealthLayer::with_saturation(monitor, std::time::Duration::from_millis(0))
+        .layer(fallthrough_service());
+
+    let response = svc.oneshot(empty_request(Method::GET, HEALTH_PATH)).await.unwrap();
+
+    let (status, body, _) = read_body(response).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    let body_text = std::str::from_utf8(&body).unwrap();
+    assert!(body_text.contains("saturated"));
+    // No internal state — no timestamps, no permits, no upstream URLs.
+    assert!(!body_text.contains("Instant"));
+    assert!(!body_text.chars().any(|c| c.is_ascii_digit()), "body had digits: {body_text}");
+}
+
+#[tokio::test]
+async fn recovery_clears_saturation_and_health_returns_to_200() {
+    let monitor = SaturationMonitor::default();
+    monitor.mark_rejected();
+    monitor.mark_accepted();
+    let svc = HealthLayer::with_saturation(monitor, std::time::Duration::from_millis(0))
+        .layer(fallthrough_service());
+
+    let response = svc.oneshot(empty_request(Method::GET, HEALTH_PATH)).await.unwrap();
+    let (status, body, _) = read_body(response).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, br#"{"status":"ok"}"#);
 }

--- a/crates/starknet_transaction_prover/src/server/rpc_impl.rs
+++ b/crates/starknet_transaction_prover/src/server/rpc_impl.rs
@@ -15,6 +15,7 @@ use crate::server::config::ServiceConfig;
 use crate::server::errors::service_busy;
 use crate::server::metrics::names::CONCURRENCY_REJECTED_TOTAL;
 use crate::server::rpc_api::ProvingRpcServer;
+use crate::server::saturation::SaturationMonitor;
 
 /// Starknet RPC specification version.
 pub(crate) const SPEC_VERSION: &str = "0.10.1";
@@ -27,22 +28,30 @@ pub struct ProvingRpcServerImpl {
     concurrency_semaphore: Arc<Semaphore>,
     /// Configured max concurrent requests (used in error messages).
     max_concurrent_requests: usize,
+    /// Tracks how long the service has been rejecting requests so
+    /// `/health` can flip to 503. Cloned cheaply (Arc internally).
+    saturation_monitor: SaturationMonitor,
 }
 
 impl ProvingRpcServerImpl {
     /// Creates a new ProvingRpcServerImpl from a prover.
-    pub(crate) fn new(prover: RpcVirtualSnosProver, max_concurrent_requests: usize) -> Self {
+    pub(crate) fn new(
+        prover: RpcVirtualSnosProver,
+        max_concurrent_requests: usize,
+        saturation_monitor: SaturationMonitor,
+    ) -> Self {
         Self {
             prover,
             concurrency_semaphore: Arc::new(Semaphore::new(max_concurrent_requests)),
             max_concurrent_requests,
+            saturation_monitor,
         }
     }
 
     /// Creates a new ProvingRpcServerImpl from configuration.
-    pub fn from_config(config: &ServiceConfig) -> Self {
+    pub fn from_config(config: &ServiceConfig, saturation_monitor: SaturationMonitor) -> Self {
         let prover = RpcVirtualSnosProver::new(&config.prover_config);
-        Self::new(prover, config.max_concurrent_requests)
+        Self::new(prover, config.max_concurrent_requests, saturation_monitor)
     }
 }
 
@@ -59,12 +68,16 @@ impl ProvingRpcServer for ProvingRpcServerImpl {
     ) -> RpcResult<ProveTransactionResult> {
         let _permit = self.concurrency_semaphore.try_acquire().map_err(|_| {
             metrics::counter!(CONCURRENCY_REJECTED_TOTAL).increment(1);
+            self.saturation_monitor.mark_rejected();
             warn!(
                 max_concurrent_requests = self.max_concurrent_requests,
                 "Rejected proving request: service is at capacity"
             );
             service_busy(self.max_concurrent_requests)
         })?;
+        // We hold the permit. The service successfully accepted this
+        // request — clear any saturation window so /health can recover.
+        self.saturation_monitor.mark_accepted();
 
         self.prover.prove_transaction(block_id, transaction).await.map_err(|err| {
             warn!("prove_transaction failed: {:?}", err);

--- a/crates/starknet_transaction_prover/src/server/rpc_spec_test.rs
+++ b/crates/starknet_transaction_prover/src/server/rpc_spec_test.rs
@@ -41,8 +41,11 @@ static SPEC: LazyLock<Value> = LazyLock::new(|| read_json_file("proving_api_open
 fn rpc_module() -> RpcModule<ProvingRpcServerImpl> {
     let config =
         ProverConfig { rpc_node_url: DUMMY_RPC_NODE_URL.to_string(), ..Default::default() };
-    let rpc_impl =
-        ProvingRpcServerImpl::new(RpcVirtualSnosProver::new(&config), TEST_MAX_CONCURRENT_REQUESTS);
+    let rpc_impl = ProvingRpcServerImpl::new(
+        RpcVirtualSnosProver::new(&config),
+        TEST_MAX_CONCURRENT_REQUESTS,
+        crate::server::SaturationMonitor::default(),
+    );
     rpc_impl.into_rpc()
 }
 

--- a/crates/starknet_transaction_prover/src/server/saturation.rs
+++ b/crates/starknet_transaction_prover/src/server/saturation.rs
@@ -1,0 +1,63 @@
+//! Saturation tracking for the prover's concurrency-limited request path.
+//!
+//! Used by both `ProvingRpcServerImpl` (writer) and `HealthLayer` (reader)
+//! so `/health` can flip to 503 once the service has been rejecting
+//! requests for a sustained period.
+//!
+//! Mechanism:
+//! - On every rejection from the concurrency semaphore: if the monitor is currently "clear", set a
+//!   timestamp marking when saturation started.
+//! - On every successful acquire: clear the timestamp.
+//! - `/health` consults [`SaturationMonitor::saturated_for_at_least`] with the configured threshold
+//!   and returns 503 if it passed.
+//!
+//! Saturation is therefore measured by *traffic that the service has tried
+//! to serve*. With no traffic at all, the monitor reports healthy — there
+//! is no saturation event to time. This matches the proof-interceptor's
+//! upstream-reachability tracking ([[health-reachability]]) so the two
+//! services behave the same way from a load-balancer's perspective.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+#[path = "saturation_test.rs"]
+mod saturation_test;
+
+/// Cheap-to-clone handle to the shared saturation state. The interior
+/// `Arc<Mutex<...>>` makes both `mark_rejected`/`mark_accepted` and the
+/// read path lock-free at the API surface.
+#[derive(Clone, Default)]
+pub struct SaturationMonitor {
+    state: Arc<Mutex<Option<Instant>>>,
+}
+
+impl SaturationMonitor {
+    /// Record a rejection. Starts the saturation window if this is the
+    /// first rejection since the last `mark_accepted` (or since startup).
+    pub fn mark_rejected(&self) {
+        let mut state = self.state.lock().expect("saturation lock poisoned");
+        if state.is_none() {
+            *state = Some(Instant::now());
+        }
+    }
+
+    /// Record a successful acquire. Clears the saturation window so a
+    /// transient burst of rejections doesn't keep `/health` red forever
+    /// once the service recovers.
+    pub fn mark_accepted(&self) {
+        let mut state = self.state.lock().expect("saturation lock poisoned");
+        *state = None;
+    }
+
+    /// Returns true when the service has been continuously rejecting
+    /// requests for at least `threshold`. Returns false when the service
+    /// has handled at least one request successfully within the window or
+    /// has not seen any traffic at all.
+    pub fn saturated_for_at_least(&self, threshold: Duration) -> bool {
+        match *self.state.lock().expect("saturation lock poisoned") {
+            Some(started_at) => started_at.elapsed() >= threshold,
+            None => false,
+        }
+    }
+}

--- a/crates/starknet_transaction_prover/src/server/saturation_test.rs
+++ b/crates/starknet_transaction_prover/src/server/saturation_test.rs
@@ -1,0 +1,47 @@
+//! Unit tests for [`SaturationMonitor`].
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use super::SaturationMonitor;
+
+#[test]
+fn starts_healthy_before_any_traffic() {
+    let monitor = SaturationMonitor::default();
+    assert!(!monitor.saturated_for_at_least(Duration::from_millis(0)));
+    assert!(!monitor.saturated_for_at_least(Duration::from_secs(10)));
+}
+
+#[test]
+fn rejection_starts_window_and_threshold_eventually_passes() {
+    let monitor = SaturationMonitor::default();
+    monitor.mark_rejected();
+    // Window has just opened — zero-elapsed comparison must still be true
+    // (we are at or past the 0ms threshold).
+    assert!(monitor.saturated_for_at_least(Duration::from_millis(0)));
+    // Not yet at the 50ms threshold — the rejection happened just now.
+    assert!(!monitor.saturated_for_at_least(Duration::from_millis(50)));
+    sleep(Duration::from_millis(60));
+    assert!(monitor.saturated_for_at_least(Duration::from_millis(50)));
+}
+
+#[test]
+fn repeated_rejections_do_not_reset_the_window() {
+    let monitor = SaturationMonitor::default();
+    monitor.mark_rejected();
+    sleep(Duration::from_millis(30));
+    // A second rejection should extend, not restart, the saturation
+    // window — operators care about "how long has this been bad", which
+    // is the time since the first rejection.
+    monitor.mark_rejected();
+    assert!(monitor.saturated_for_at_least(Duration::from_millis(25)));
+}
+
+#[test]
+fn one_successful_acquire_clears_the_window() {
+    let monitor = SaturationMonitor::default();
+    monitor.mark_rejected();
+    sleep(Duration::from_millis(10));
+    monitor.mark_accepted();
+    assert!(!monitor.saturated_for_at_least(Duration::from_millis(0)));
+}

--- a/crates/starknet_transaction_prover/src/server/tls.rs
+++ b/crates/starknet_transaction_prover/src/server/tls.rs
@@ -46,6 +46,7 @@ pub async fn start_tls_server(
     cors_layer: Option<CorsLayer>,
     ohttp_layer: Option<OhttpJsonrpseeLayer>,
     metrics_layer: Option<MetricsLayer>,
+    health_layer: HealthLayer,
 ) -> anyhow::Result<(SocketAddr, ServerHandle)> {
     let tls_acceptor = load_tls_acceptor(cert_path, key_path)?;
 
@@ -64,7 +65,7 @@ pub async fn start_tls_server(
             // sits inside the monitoring endpoints so probes don't distort
             // request-latency distributions.
             ServiceBuilder::new()
-                .layer(HealthLayer)
+                .layer(health_layer)
                 .option_layer(metrics_layer)
                 .layer(HttpMetricsLayer)
                 .option_layer(cors_layer)


### PR DESCRIPTION
## Summary
Closes the saturation follow-up from #14044: \`/health\` flips to 503 once the service has been continuously rejecting proving requests for the configured threshold, so AWS ALB / ECS can drain a sick pod instead of keeping it in rotation.

- New \`SaturationMonitor\` (\`Arc<Mutex<Option<Instant>>>\`, cheap-to-clone). Writer is \`ProvingRpcServerImpl\` (\`mark_rejected()\` on permit-acquire failure, \`mark_accepted()\` on success). Reader is \`HealthLayer::with_saturation\`.
- \`HealthLayer\` returns 503 with body \`{\"status\":\"unhealthy\",\"reason\":\"saturated\"}\` once \`saturated_for_at_least(threshold)\` is true. Otherwise 200 OK as before.
- Saturation is measured by *traffic the service has tried to serve*. With no traffic at all, the monitor reports healthy.
- One successful request clears the saturation window so a transient burst doesn't keep /health red forever once the service recovers.
- New config: \`health_max_saturated_ms\` (default 10000ms), overridable via \`--health-max-saturated-ms\` / \`HEALTH_MAX_SATURATED_MS\`.

Response body intentionally contains no internal state — no timestamps, no permit counts, no upstream URLs.

**Stacked on** #14057.

## Test plan
- [x] 4 \`SaturationMonitor\` unit tests: starts healthy, rejection starts window, repeat rejections don't reset, recovery clears
- [x] 3 \`HealthLayer\` tests: unsaturated → 200, saturated → 503 with opaque body that contains no digits, recovery → 200
- [x] \`SEED=0 cargo test -p starknet_transaction_prover\` — 75 pass
- [x] \`cargo clippy -p starknet_transaction_prover --all-targets -- -D warnings\` — clean
- [x] \`scripts/rust_fmt.sh\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)