### PR TITLE
ci,scripts: install LLVM before cargo tools

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -12,10 +12,10 @@ runs:
     - name: Setup Namespace Cache
       uses: ./.github/actions/namespace_cache
 
+    - name: Install cairo native.
+      uses: ./.github/actions/setup_native_deps
+
     - name: Install rust.
       uses: ./.github/actions/install_rust
       with:
         github_token: ${{ inputs.github_token }}
-
-    - name: Install cairo native.
-      uses: ./.github/actions/setup_native_deps

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -129,10 +129,11 @@ fi
 popd > /dev/null
 log_step "install_build_tools" "Project Rust toolchain ready: $(rustc --version)"
 
+log_step "install_build_tools" "Running dependencies.sh..."
+./dependencies.sh
+log_step "install_build_tools" "dependencies.sh completed"
 log_step "install_build_tools" "Running install_cargo_tools.sh..."
 ${SCRIPT_DIR}/install_cargo_tools.sh
 log_step "install_build_tools" "install_cargo_tools.sh completed"
-log_step "install_build_tools" "Running dependencies.sh..."
-./dependencies.sh
 
 log_step "install_build_tools" "All build tools installed successfully!"


### PR DESCRIPTION
Reorder bootstrap and install_build_tools.sh so LLVM 19 is installed
before cargo tools. This is needed because install_cargo_tools.sh will
install starknet-native-compile which requires LLVM to build.

Safe change: LLVM installation does not depend on Rust.

---

Re-do of #13674, which was accidentally merged into `avi/compiler-verify-fn`
instead of `main`. The change itself (squash commit `08764c4529`) is identical;
this PR cherry-picks that commit onto `main`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>