### PR TITLE
deployment: shrink Grafana dashboard JSON to stay under 1MB import limit

### DIFF
--- a/deployments/monitoring/src/builders/dashboard_builder.py
+++ b/deployments/monitoring/src/builders/dashboard_builder.py
@@ -31,22 +31,16 @@ def create_grafana_panel(panel: dict, panel_id: int, y_position: int, x_position
     log_comment = extra.get("log_comment", "")
     thresholds = extra.get("thresholds", {})
     legend_values = extra.get("legend_values", [])
-    query_parts = [
-        f"resource.labels.namespace_name=~%22^%28${{namespace:pipe}}%29$%22",
-        quote(log_query),
-    ]
+    extra_parts = []
+    if log_query:
+        extra_parts.append(quote(log_query))
     if log_comment:
-        query_parts.append(quote(log_comment))
-    query_value = "%0A".join(query_parts)
-    # TODO(Ron): Turn link into variable to save space in the json file
-    link = "\n".join(
-        [
-            "https://console.cloud.google.com/logs/query;",
-            f"query={query_value};",
-            "summaryFields=resource%252Flabels%252Fnamespace_name,resource%252Flabels%252Fcontainer_name;",
-            "timeRange=${__from:date:iso}%2F${__to:date:iso}",
-            "?project=${gcp_project}",
-        ]
+        extra_parts.append(quote(log_comment))
+    query_extras = ("%0A" + "%0A".join(extra_parts)) if extra_parts else ""
+    link = (
+        "${gcp_logs_prefix:raw}${namespace:pipe}%29$%22"
+        + query_extras
+        + "${gcp_logs_mid:raw}${__from:date:iso}%2F${__to:date:iso}\n?project=${gcp_project}"
     )
     legends = extra.get("legends", [])
     display_name_override_value = (
@@ -125,7 +119,7 @@ def create_grafana_panel(panel: dict, panel_id: int, y_position: int, x_position
 def remove_cluster_and_namespace_from_display_name():
     # One label-set segment that can include quoted values (with escaped chars),
     # so braces inside matcher regex strings do not terminate the segment early.
-    label_set_chunk = r'(?:[^{}"]|"(?:\\.|[^"\\])*")*'
+    label_set_chunk = r'(?:"[^"]*"|[^}])*'
 
     return {
         "id": "renameByRegex",

--- a/deployments/monitoring/src/common/grafana10_objects.py
+++ b/deployments/monitoring/src/common/grafana10_objects.py
@@ -128,6 +128,23 @@ templating_object = {
             + POD_SUFFIX_OPTIONAL_RE
             + r"$",
         },
+        {
+            "type": "constant",
+            "name": "gcp_logs_prefix",
+            "query": (
+                "https://console.cloud.google.com/logs/query;\n"
+                "query=resource.labels.namespace_name=~%22^%28"
+            ),
+        },
+        {
+            "type": "constant",
+            "name": "gcp_logs_mid",
+            "query": (
+                ";\nsummaryFields=resource%252Flabels%252Fnamespace_name,"
+                "resource%252Flabels%252Fcontainer_name;\n"
+                "timeRange="
+            ),
+        },
     ]
 }
 


### PR DESCRIPTION
Hoist the static fragments of the per-panel GCP Logs URL into two new constant template variables (`gcp_logs_prefix`, `gcp_logs_mid`) and compact the cluster/namespace `renameByRegex` chunk from the verbose quoted/escaped form to `(?:"[^"]*"|[^}])*` while preserving correct handling of regex quantifiers (`{8,}`, `{5}`) inside the `$pod` value.

Measured on the current dev_grafana.json (383 data panels), comparing the build against main vs this branch:

  Before: 814,524 B (795.4 KB) — 228.6 KB headroom under 1MB
  After : 714,692 B (697.9 KB) — 326.1 KB headroom under 1MB
  Saved :  99,832 B  (97.5 KB, 12.3% reduction)

Breakdown of the saved bytes (sum across all data panels):
  links           : 136,589 -> 75,516  (-61,073 B)
  transformations : 206,054 -> 166,988 (-39,066 B)