### PR TITLE
apollo_dashboard: use container_memory_rss for pod memory utilization alerts

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1320,7 +1320,7 @@
       "name": "pod_state_high_memory_utilization",
       "title": "Pod High Memory Utilization ( >70% )",
       "ruleGroup": "general",
-      "expr": "max(container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
+      "expr": "max(container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
       "conditions": [
         {
           "evaluator": {
@@ -1348,7 +1348,7 @@
       "name": "pod_state_critical_memory_utilization",
       "title": "Pod Critical Memory Utilization ( >85% )",
       "ruleGroup": "general",
-      "expr": "max(container_memory_working_set_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
+      "expr": "max(container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) / max(container_spec_memory_limit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (container, pod, namespace) * 100",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
@@ -16,7 +16,7 @@ use crate::alerts::{
 define_metrics!(
     Pod => {
         MetricCounter { CONTAINER_CPU_USAGE_SECONDS_TOTAL, "container_cpu_usage_seconds_total", "Cumulative CPU time consumed by the container in seconds. Use with irate() for CPU usage rate.", init=0 },
-        MetricGauge { CONTAINER_MEMORY_WORKING_SET_BYTES, "container_memory_working_set_bytes", "Estimated amount of memory that cannot be evicted (working set: recently accessed memory, dirty memory, kernel memory). Used by the OOM killer for eviction decisions." },
+        MetricGauge { CONTAINER_MEMORY_WORKING_SET_BYTES, "container_memory_working_set_bytes", "Memory usage minus inactive file-backed pages (memory.usage_in_bytes - inactive_file). Includes anonymous memory, active file cache, and kernel memory. Active file cache is reclaimable, so this metric overstates true memory pressure. Used by the Kubernetes kubelet for pod eviction decisions (not the Linux OOM killer, which uses RSS/anon)." },
         MetricGauge { CONTAINER_MEMORY_RSS, "container_memory_rss", "Resident set size: anonymous (non file-backed) memory used by the container. This is the cgroup memory.stat `anon` and corresponds to what the kernel OOM killer cannot reclaim." },
         MetricGauge { CONTAINER_SPEC_CPU_QUOTA, "container_spec_cpu_quota", "CPU quota in microseconds allocated to the container from the container spec (cgroups)." },
         MetricGauge { CONTAINER_SPEC_MEMORY_LIMIT_BYTES, "container_spec_memory_limit_bytes", "Memory limit for the container from the container spec, in bytes. Exceeding this limit can trigger OOM kill." },

--- a/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/infra_alerts.rs
@@ -17,6 +17,7 @@ define_metrics!(
     Pod => {
         MetricCounter { CONTAINER_CPU_USAGE_SECONDS_TOTAL, "container_cpu_usage_seconds_total", "Cumulative CPU time consumed by the container in seconds. Use with irate() for CPU usage rate.", init=0 },
         MetricGauge { CONTAINER_MEMORY_WORKING_SET_BYTES, "container_memory_working_set_bytes", "Estimated amount of memory that cannot be evicted (working set: recently accessed memory, dirty memory, kernel memory). Used by the OOM killer for eviction decisions." },
+        MetricGauge { CONTAINER_MEMORY_RSS, "container_memory_rss", "Resident set size: anonymous (non file-backed) memory used by the container. This is the cgroup memory.stat `anon` and corresponds to what the kernel OOM killer cannot reclaim." },
         MetricGauge { CONTAINER_SPEC_CPU_QUOTA, "container_spec_cpu_quota", "CPU quota in microseconds allocated to the container from the container spec (cgroups)." },
         MetricGauge { CONTAINER_SPEC_MEMORY_LIMIT_BYTES, "container_spec_memory_limit_bytes", "Memory limit for the container from the container spec, in bytes. Exceeding this limit can trigger OOM kill." },
         MetricGauge { KUBE_POD_CONTAINER_STATUS_READY, "kube_pod_container_status_ready", "Indicates whether a specific container within a pod has successfully passed its readiness check (Readiness Probe) and is currently ready to serve network traffic." },
@@ -87,11 +88,14 @@ fn get_general_pod_memory_utilization(
         AlertGroup::General,
         format!(
             // Calculates the memory usage percentage of each container in a pod, relative to its
-            // memory limit. This expression compares the actual memory usage
-            // (working_set_bytes) of containers against their defined memory limits
-            // (spec_memory_limit_bytes), and returns the result as a percentage.
+            // memory limit. This expression compares the container's resident set size
+            // (memory_rss, i.e. anonymous non-reclaimable memory) against its defined memory
+            // limit (spec_memory_limit_bytes), and returns the result as a percentage. RSS is
+            // used here instead of working_set_bytes so the alert tracks memory that the kernel
+            // cannot reclaim — which is what actually drives OOM kills — rather than including
+            // page cache that the kernel will free on demand.
             "max({}) by (container, pod, namespace) / max({}) by (container, pod, namespace) * 100",
-            CONTAINER_MEMORY_WORKING_SET_BYTES.get_name_with_filter(),
+            CONTAINER_MEMORY_RSS.get_name_with_filter(),
             CONTAINER_SPEC_MEMORY_LIMIT_BYTES.get_name_with_filter(),
         ),
         vec![AlertCondition::new(


### PR DESCRIPTION
## Summary

Switch `pod_state_high_memory_utilization` (>70%) and `pod_state_critical_memory_utilization` (>85%) to compare `container_memory_rss` against `container_spec_memory_limit_bytes` instead of `container_memory_working_set_bytes`.

## Why

`container_memory_working_set_bytes` is defined by cAdvisor / cgroup memory accounting as `memory.usage − inactive_file`, so it still includes the **active** file-backed page cache. That page cache is reclaimable on demand by the kernel and cannot trigger an OOM kill. `container_memory_rss` (cgroup `memory.stat anon`) is the non-reclaimable portion that the OOM killer actually targets.

In production on `apollo-mainnet-{0..5}` `sequencer-committer-statefulset-0`:

| Pod | working_set / limit (old metric) | rss / limit (new metric) |
|---|---|---|
| apollo-0 (cache=10m) | 96 % | 24 % |
| apollo-1 (cache=50m) | 96 % | 46 % |
| apollo-2 | 64–96 % (varies w/ LRU age) | 46 % |
| apollo-3 | 96 % | 38 % |
| apollo-4 | 84 % | 46 % |
| apollo-5 | 96 % | 38 % |

The old alert fired continuously while no pod was ever at risk of OOM (`memory.events oom_kill = 0` across 14 days, no `pgmajfault`, `MemAvailable ≥ 38 GiB` on every snapshot). The new alert keeps the same thresholds and stays universal across pods, but only fires when the *non-reclaimable* portion actually approaches the limit.

## References

- [Linux kernel — Control Group v2 (memory controller)](https://docs.kernel.org/admin-guide/cgroup-v2.html) — `anon` = "memory used in anonymous mappings"; `active_file` / `inactive_file` are on the page-reclaim LRU lists.
- [Sourcegraph — Beyond working set memory: understanding the cAdvisor memory metrics](https://sourcegraph.com/blog/beyond-working-set-memory-understanding-the-cadvisor-memory-metrics) — explicitly notes `container_memory_rss` is "often a close proxy for what the OOM killer looks at" and that working_set high values do not by themselves trigger OOM.
- [mihai-albert.com — OOM in Kubernetes, Part 3](https://mihai-albert.com/2022/02/13/out-of-memory-oom-in-kubernetes-part-3-memory-metrics-sources-and-tools-to-collect-them/) — `working_set_bytes = usage_in_bytes − inactive_file`.

## Test plan

- [x] `cargo run -q -p apollo_dashboard --bin sequencer_dashboard_generator` regenerated `crates/apollo_dashboard/resources/dev_grafana_alerts.json` — diff is exactly the two `expr` lines.
- [x] `cargo test -p apollo_dashboard` — 14/14 pass (including snapshot `default_dev_grafana_dashboard`).
- [ ] After merge & cluster sync: confirm in Grafana that the two rules in `apollo-mainnet-{0..5}-arg-*` now reference `container_memory_rss` and stop firing for the committer pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)