### PR TITLE
apollo_dashboard: add log queries to L1 gas price scraper error panels

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -1482,7 +1482,9 @@
           "exprs": [
             "increase(l1_gas_price_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m])"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "log_query": "\"Base layer error\" OR \"Scraper startup failure\""
+          }
         },
         {
           "title": "L1 Gas Price Scraper Reorg Detected",
@@ -1491,7 +1493,9 @@
           "exprs": [
             "increase(l1_gas_price_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m])"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "log_query": "\"L1 reorg detected\""
+          }
         },
         {
           "title": "L1 Gas Price Scraper Latest Scraped Block",

--- a/crates/apollo_dashboard/src/panels/l1_gas_price.rs
+++ b/crates/apollo_dashboard/src/panels/l1_gas_price.rs
@@ -99,6 +99,7 @@ fn get_panel_l1_gas_price_scraper_baselayer_error_count() -> Panel {
         increase(&L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT, DEFAULT_DURATION),
         PanelType::TimeSeries,
     )
+    .with_log_query("\"Base layer error\" OR \"Scraper startup failure\"")
 }
 
 fn get_panel_l1_gas_price_scraper_reorg_detected() -> Panel {
@@ -111,6 +112,7 @@ fn get_panel_l1_gas_price_scraper_reorg_detected() -> Panel {
         increase(&L1_GAS_PRICE_SCRAPER_REORG_DETECTED, DEFAULT_DURATION),
         PanelType::TimeSeries,
     )
+    .with_log_query("L1 reorg detected")
 }
 
 fn get_panel_l1_gas_price_scraper_seconds_since_last_successful_scrape() -> Panel {


### PR DESCRIPTION
## Summary
- Add log query `"Base layer error" OR "Scraper startup failure"` to the L1 Gas Price Scraper Base Layer Error Count panel
- Add log query `"L1 reorg detected"` to the L1 Gas Price Scraper Reorg Detected panel

## Test plan
- [ ] Dashboard regenerated via `cargo run --bin sequencer_dashboard_generator`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)