### PR TITLE
apollo_integration_tests: fix non-interpolating .expect() messages and log typos

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1428,7 +1428,9 @@ impl Batcher {
                     .storage_reader
                     .global_root(new_latest_height)
                     .expect("Failed to get global root from storage.")
-                    .expect("Global root is not set for height {new_latest_height}.");
+                    .unwrap_or_else(|| {
+                        panic!("Global root is not set for height {new_latest_height}.")
+                    });
                 assert_eq!(
                     global_root, stored_global_root,
                     "The given global root does not match the stored global root for height \

--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -1048,7 +1048,9 @@ impl<ContextT: ConsensusContext> MultiHeightManager<ContextT> {
                     .lock()
                     .await
                     .set_prev_voted_height(height)
-                    .expect("Failed to write voted height {self.height} to storage");
+                    .unwrap_or_else(|err| {
+                        panic!("Failed to write voted height {height} to storage: {err:?}")
+                    });
                 context.broadcast(vote.clone()).await?;
                 // Schedule a rebroadcast after the appropriate timeout.
                 let duration = match vote.vote_type {

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -350,10 +350,9 @@ impl ConsensusManager {
 
         // This function will panic if the revert fails.
         let revert_blocks_fn = move |height| async move {
-            self.batcher_client
-                .revert_block(RevertBlockInput { height })
-                .await
-                .expect("Failed to revert block at height {height} in the batcher");
+            self.batcher_client.revert_block(RevertBlockInput { height }).await.unwrap_or_else(
+                |err| panic!("Failed to revert block at height {height} in the batcher: {err:?}"),
+            );
         };
 
         const BATCHER_REVERT_COMPONENT_DATA: RevertComponentData = RevertComponentData {

--- a/crates/apollo_infra_utils/src/path_test.rs
+++ b/crates/apollo_infra_utils/src/path_test.rs
@@ -7,7 +7,7 @@ fn resolve_project_relative_path_on_non_existent_path() {
     assert!(!expected_path.exists());
     let result = resolve_project_relative_path(relative_path);
 
-    assert!(result.is_err(), "Expected an non-existent path error, got {result:?}");
+    assert!(result.is_err(), "Expected a non-existent path error, got {result:?}");
 }
 
 #[test]

--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -482,7 +482,7 @@ impl TxCollector {
             "Expected the first message in the stream to have id 0, got {incoming_message_id}"
         );
         let StreamMessageBody::Content(ProposalPart::Init(incoming_init)) = init_message else {
-            panic!("Expected a init message. Got: {init_message:?}")
+            panic!("Expected an init message. Got: {init_message:?}")
         };
 
         self.accumulated_txs.lock().await.start_round(incoming_init.height, incoming_init.round);

--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -363,10 +363,9 @@ impl RunningNode {
     }
 
     pub fn shutdown_service(&mut self, service: NodeService) {
-        let handle = self
-            .executable_handles
-            .remove(&service)
-            .expect("Service {service:?} does not exist in the running executables map.");
+        let handle = self.executable_handles.remove(&service).unwrap_or_else(|| {
+            panic!("Service {service:?} does not exist in the running executables map.")
+        });
         assert!(!handle.is_finished(), "Handle should still be running.");
         handle.abort();
     }
@@ -448,7 +447,7 @@ impl IntegrationTestManager {
             .idle_nodes
             .get(&node_idx)
             .or_else(|| self.running_nodes.get(&node_idx).map(|node| &node.node_setup))
-            .expect("Node {node_idx} does not exist in idle or running nodes.");
+            .unwrap_or_else(|| panic!("Node {node_idx} does not exist in idle or running nodes."));
         node_setup.node_type
     }
 
@@ -631,7 +630,7 @@ impl IntegrationTestManager {
             .expect("Running Nodes should be reverted.");
 
         info!(
-            "All running nodes have been reverted succesfully to block number \
+            "All running nodes have been reverted successfully to block number \
              {expected_block_number}."
         );
     }

--- a/crates/apollo_monitoring_endpoint/src/monitoring_endpoint.rs
+++ b/crates/apollo_monitoring_endpoint/src/monitoring_endpoint.rs
@@ -143,7 +143,7 @@ pub fn create_monitoring_endpoint(
 impl ComponentStarter for MonitoringEndpoint {
     async fn start(&mut self) {
         info!("Starting component {}.", short_type_name::<Self>());
-        self.run().await.unwrap_or_else(|e| panic!("Failed to start MointoringEndpoint: {e:?}"));
+        self.run().await.unwrap_or_else(|e| panic!("Failed to start MonitoringEndpoint: {e:?}"));
     }
 }
 

--- a/crates/apollo_storage/src/header.rs
+++ b/crates/apollo_storage/src/header.rs
@@ -390,7 +390,7 @@ impl HeaderStorageWriter for StorageTxn<'_, RW> {
 
         let reverted_header = headers_table
             .get(&self.txn, &block_number)?
-            .expect("Missing header for block {block_number}.");
+            .unwrap_or_else(|| panic!("Missing header for block {block_number}."));
         markers_table.upsert(&self.txn, &MarkerKind::Header, &block_number)?;
         headers_table.delete(&self.txn, &block_number)?;
         block_hash_to_number_table.delete(&self.txn, &reverted_header.block_hash)?;

--- a/crates/apollo_storage/src/serialization/serializers_test.rs
+++ b/crates/apollo_storage/src/serialization/serializers_test.rs
@@ -155,14 +155,15 @@ fn casm_serialization_regression() {
         let mut serialized: Vec<u8> = Vec::new();
         json_casm
             .serialize_into(&mut serialized)
-            .expect("Failed to serialize casm file: {json_file_name}");
+            .unwrap_or_else(|_| panic!("Failed to serialize casm file: {json_file_name}"));
         let bin_path = path_in_resources(Path::new("casm").join(bin_file_name));
-        let mut bin_file = File::open(bin_path)
-            .expect("Failed to open bin file: {bin_file_name}\n{FIX_SUGGESTION}");
+        let mut bin_file = File::open(bin_path).unwrap_or_else(|_| {
+            panic!("Failed to open bin file: {bin_file_name}\n{FIX_SUGGESTION}")
+        });
         let mut regression_casm_bytes = Vec::new();
-        bin_file
-            .read_to_end(&mut regression_casm_bytes)
-            .expect("Failed to read bin file: {bin_file_name}\n{FIX_SUGGESTION}");
+        bin_file.read_to_end(&mut regression_casm_bytes).unwrap_or_else(|_| {
+            panic!("Failed to read bin file: {bin_file_name}\n{FIX_SUGGESTION}")
+        });
         assert_eq!(
             regression_casm_bytes, serialized,
             "Serializing the casm gave a result different from the hardcoded \
@@ -179,16 +180,17 @@ fn casm_deserialization_regression() {
     }
 
     for (json_file_name, bin_file_name) in CASM_SERIALIZATION_REGRESSION_FILES {
-        let mut regression_casm_file =
-            File::open(path_in_resources(Path::new("casm").join(bin_file_name)))
-                .expect("Failed to open bin file: {bin_file_name}\n{FIX_SUGGESTION}");
+        let mut regression_casm_file = File::open(path_in_resources(
+            Path::new("casm").join(bin_file_name),
+        ))
+        .unwrap_or_else(|_| panic!("Failed to open bin file: {bin_file_name}\n{FIX_SUGGESTION}"));
         let mut regression_casm_bytes = Vec::new();
-        regression_casm_file
-            .read_to_end(&mut regression_casm_bytes)
-            .expect("Failed to read bin file: {bin_file_name}\n{FIX_SUGGESTION}");
+        regression_casm_file.read_to_end(&mut regression_casm_bytes).unwrap_or_else(|_| {
+            panic!("Failed to read bin file: {bin_file_name}\n{FIX_SUGGESTION}")
+        });
         let regression_casm =
             CasmContractClass::deserialize_from(&mut regression_casm_bytes.as_slice())
-                .expect("Failed to deserialize casm file: {casm_file}.");
+                .unwrap_or_else(|| panic!("Failed to deserialize casm file: {bin_file_name}."));
         let json_path = format!("casm/{json_file_name}");
         let json_casm: CasmContractClass = read_json_file(&json_path);
         assert_eq!(
@@ -208,7 +210,7 @@ fn fix_casm_regression_files() {
         let casm_bytes = serialized.into_boxed_slice();
         let mut hardcoded_file =
             File::create(path_in_resources(Path::new("casm").join(bin_file_name)))
-                .expect("Failed to create bin file {bin_file_name}\n");
+                .unwrap_or_else(|_| panic!("Failed to create bin file {bin_file_name}\n"));
         hardcoded_file.write_all(&casm_bytes).unwrap();
     }
 }

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -394,7 +394,7 @@ impl EntryPointExecutionContext {
         }
         .try_into()
         .unwrap_or_else(|error| {
-            log::warn!("Failed to convert global step limit to to usize: {error}.");
+            log::warn!("Failed to convert global step limit to usize: {error}.");
             usize::MAX
         });
 

--- a/crates/starknet_os/src/hints/hint_implementation/state_diff_encryption/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/state_diff_encryption/utils.rs
@@ -56,9 +56,12 @@ pub fn encrypt_symmetric_key(
         .iter()
         .zip(public_keys)
         .map(|(&sn_private_key, &public_key)| {
-            let public_key_point = AffinePoint::new_from_x(&public_key, true).expect(
-                "{public_key} does not represent the x coordinate of a point on the curve.",
-            );
+            let public_key_point =
+                AffinePoint::new_from_x(&public_key, true).unwrap_or_else(|| {
+                    panic!(
+                        "{public_key} does not represent the x coordinate of a point on the curve."
+                    )
+                });
             let shared_secret = (&public_key_point * sn_private_key).x();
             // Encrypt the symmetric key using the shared secret.
             // TODO(Avi, 10/09/2025): Use the naive felt encoding once available.
@@ -81,8 +84,9 @@ pub fn decrypt_symmetric_key(
     encrypted_symmetric_key: Felt,
 ) -> Felt {
     // Compute the shared secret using Diffie-Hellman key exchange.
-    let sn_public_key_point = AffinePoint::new_from_x(&sn_public_key, true)
-        .expect("{sn_public_key} does not represent the x coordinate of a point on the curve.");
+    let sn_public_key_point = AffinePoint::new_from_x(&sn_public_key, true).unwrap_or_else(|| {
+        panic!("{sn_public_key} does not represent the x coordinate of a point on the curve.")
+    });
     let shared_secret_point = &sn_public_key_point * private_key;
     let shared_secret = shared_secret_point.x();
 

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -282,7 +282,7 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
     ) -> Result<Self, FilledTreeError> {
         let root_node = updated_skeleton.get_node(NodeIndex::ROOT)?;
         let UpdatedSkeletonNode::UnmodifiedSubTree(root_hash) = root_node else {
-            panic!("A root of tree without modifications is expected to be a unmodified subtree.")
+            panic!("A root of tree without modifications is expected to be an unmodified subtree.")
         };
         Ok(Self { tree_map: HashMap::new(), root_hash: *root_hash })
     }


### PR DESCRIPTION
`.expect()` is an ordinary method on Option/Result that takes a `&str` and prints it verbatim on panic — it does not invoke `format_args!`. So named arguments inside the braces never get substituted:

    Before: thread '...' panicked at 'Service {service:?} does not exist in the running executables map.'
    After:  thread '...' panicked at 'Service Batcher does not exist in the running executables map.'

The panic still fires at the right moment for the right reason; only the diagnostic value is lost, which defeats the whole point of embedding the variable. The fix is to wrap the call as `.unwrap_or_else(|| panic!(...))` (or `|err| panic!("...: {err}")` on a Result), since `panic!` IS a format macro and the placeholders interpolate normally.

.expect() placeholder fixes (panic message would have been useless before):
  - apollo_storage/src/header.rs                                 ({block_number})
  - apollo_consensus_manager/src/consensus_manager.rs            ({height})
  - apollo_consensus/src/manager.rs                              (was {self.height} -- field access also invalid in fmt; corrected to local {height})
  - apollo_storage/src/serialization/serializers_test.rs         (7 sites; one referenced an out-of-scope {casm_file}, corrected to {bin_file_name})
  - starknet_os/.../state_diff_encryption/utils.rs               ({public_key}, {sn_public_key})
  - apollo_integration_tests/src/integration_test_manager.rs     ({service:?}, {node_idx})
  - apollo_batcher/src/batcher.rs                                ({new_latest_height})

No behavior change beyond what panic messages display; cargo check --tests passes on all touched crates.