### PR TITLE
apollo_integration_tests: validation_only test exercises state-sync catch-up

### DIFF
--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -199,6 +199,7 @@ impl FlowTestSetup {
                             block_max_capacity_gas,
                             allow_bootstrap_txs,
                             node_descriptors[node_index].validation_only,
+                            node_descriptors[node_index].consensus_startup_delay_override,
                         )
                     },
                 ),
@@ -266,6 +267,7 @@ impl FlowSequencerSetup {
         block_max_capacity_gas: GasAmount,
         allow_bootstrap_txs: bool,
         validation_only: bool,
+        consensus_startup_delay_override: Option<std::time::Duration>,
     ) -> Self {
         let path = None;
         let StorageTestSetup { storage_config, storage_handles } =
@@ -274,6 +276,9 @@ impl FlowSequencerSetup {
         let (recorder_url, _join_handle) =
             spawn_local_success_recorder(available_ports.get_next_port());
         consensus_manager_config.cende_config.recorder_url = recorder_url;
+        if let Some(delay) = consensus_startup_delay_override {
+            consensus_manager_config.consensus_manager_config.static_config.startup_delay = delay;
+        }
 
         let (eth_to_strk_oracle_url_headers, _join_handle) =
             spawn_local_eth_to_strk_oracle(available_ports.get_next_port());

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -145,25 +145,52 @@ use crate::state_reader::StorageTestConfig;
 pub struct NodeDescriptor {
     pub node_type: NodeType,
     pub validation_only: bool,
+    /// Overrides the consensus `startup_delay` for this node. `None` keeps the framework
+    /// default. Setting a larger delay lets the other nodes build blocks first so this node
+    /// has to catch up via state sync when it finally joins consensus.
+    pub consensus_startup_delay_override: Option<Duration>,
 }
 
 impl NodeDescriptor {
     pub fn consolidated() -> Self {
-        Self { node_type: NodeType::Consolidated, validation_only: false }
+        Self {
+            node_type: NodeType::Consolidated,
+            validation_only: false,
+            consensus_startup_delay_override: None,
+        }
     }
 
     pub fn hybrid() -> Self {
-        Self { node_type: NodeType::Hybrid, validation_only: false }
+        Self {
+            node_type: NodeType::Hybrid,
+            validation_only: false,
+            consensus_startup_delay_override: None,
+        }
     }
 
     pub fn distributed() -> Self {
-        Self { node_type: NodeType::Distributed, validation_only: false }
+        Self {
+            node_type: NodeType::Distributed,
+            validation_only: false,
+            consensus_startup_delay_override: None,
+        }
     }
 
     /// A validation-only node always runs as consolidated: it participates in consensus to
     /// validate proposals but does not produce blocks.
     pub fn validation_only() -> Self {
-        Self { node_type: NodeType::Consolidated, validation_only: true }
+        Self {
+            node_type: NodeType::Consolidated,
+            validation_only: true,
+            consensus_startup_delay_override: None,
+        }
+    }
+
+    /// Sets the consensus `startup_delay` override. Used to simulate a node joining the
+    /// network late.
+    pub fn with_consensus_startup_delay(mut self, delay: Duration) -> Self {
+        self.consensus_startup_delay_override = Some(delay);
+        self
     }
 }
 

--- a/crates/apollo_integration_tests/tests/validation_only_node_flow_test.rs
+++ b/crates/apollo_integration_tests/tests/validation_only_node_flow_test.rs
@@ -16,19 +16,41 @@ use starknet_api::rpc_transaction::RpcTransaction;
 
 const N_TXS: usize = 3;
 
-/// Verifies that validation-only nodes actively vote in consensus.
-/// With 1 proposer and 1 validation-only nodes (equal weight), the validation-only node
-/// must vote for every block.
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn validation_only_node_needed_for_quorum() {
+/// Verifies that a validation-only node can catch up via state sync after starting late.
+///
+/// Topology: 2 proposers + 1 validation-only node. With 3 stakers of weight 1 each and
+/// `assume_no_malicious_validators = true` (which selects `HONEST_QUORUM`, 1/2), the 2
+/// proposers reach quorum on their own and keep building blocks while the validation-only
+/// node sleeps in its consensus `startup_delay`. When the validation-only node finally
+/// joins consensus, it must catch up to the network's height via state sync —
+/// `SequencerConsensusContext::try_sync` calls `state_sync.get_block` at the start of every
+/// height to skip ahead when sync is already past the consensus height.
+///
+/// `state_sync.get_block` reads the `transaction_metadata` table, which is marked unused
+/// under `StorageScope::StateOnly`. Validation-only nodes open state sync with
+/// `StateOnly`, so `get_block` returns `ScopeError`, catch-up fails for every height the
+/// validator is behind by, and the validator never reaches the network's height — the test
+/// times out waiting for the validator's batcher height to match the proposers'.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn validation_only_node_catches_up_via_state_sync() {
+    // Give the proposers a head start so they commit several blocks before the
+    // validation-only node enters consensus and is forced to use state sync to catch up.
+    // Default proposer `startup_delay` is 15s, so the validator joins ~15s after the
+    // proposers begin building blocks.
+    const VALIDATOR_STARTUP_DELAY: Duration = Duration::from_secs(30);
     end_to_end_flow(
         EndToEndFlowArgs::new(
             TestIdentifier::ValidationOnlyNodeNeededForQuorumTest,
             create_test_scenario(),
             BouncerWeights::default().proving_gas,
         )
-        .node_descriptors(vec![NodeDescriptor::consolidated(), NodeDescriptor::validation_only()])
-        .scenario_timeout(Duration::from_secs(90)),
+        .node_descriptors(vec![
+            NodeDescriptor::consolidated(),
+            NodeDescriptor::consolidated(),
+            NodeDescriptor::validation_only()
+                .with_consensus_startup_delay(VALIDATOR_STARTUP_DELAY),
+        ])
+        .scenario_timeout(Duration::from_secs(120)),
     )
     .await
 }


### PR DESCRIPTION
Adds a `consensus_startup_delay_override` to `NodeDescriptor` and the corresponding
plumbing through `FlowSequencerSetup::new`, then rewrites
`validation_only_node_flow_test` to use 2 proposers and a delayed validation-only node.

With 3 stakers of weight 1 each and `assume_no_malicious_validators = true`
(`HONEST_QUORUM` = 1/2), the 2 proposers reach quorum without the validation-only node,
so they commit blocks while it sleeps in its consensus `startup_delay`. When the
validation-only node finally joins consensus, it must catch up via state sync — i.e.
`SequencerConsensusContext::try_sync` calls `state_sync.get_block` at the start of every
height.

`state_sync.get_block` reads the `transaction_metadata` table, which is marked unused
under `StorageScope::StateOnly`. Validation-only nodes open state sync with `StateOnly`,
so `get_block` returns `ScopeError`, catch-up fails, and the validator never reaches the
proposers' height. The test fails at `verify_block_hash_flow`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>