### PR TITLE
ci: split Sierra compiler install out of install_cargo_tools.sh

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -19,3 +19,7 @@ runs:
       uses: ./.github/actions/install_rust
       with:
         github_token: ${{ inputs.github_token }}
+
+    - name: Install Sierra compilers.
+      shell: bash
+      run: ./scripts/install_compiler_binaries.sh

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -136,4 +136,8 @@ log_step "install_build_tools" "Running install_cargo_tools.sh..."
 ${SCRIPT_DIR}/install_cargo_tools.sh
 log_step "install_build_tools" "install_cargo_tools.sh completed"
 
+log_step "install_build_tools" "Running install_compiler_binaries.sh..."
+${SCRIPT_DIR}/install_compiler_binaries.sh
+log_step "install_build_tools" "install_compiler_binaries.sh completed"
+
 log_step "install_build_tools" "All build tools installed successfully!"

--- a/scripts/install_cargo_tools.sh
+++ b/scripts/install_cargo_tools.sh
@@ -49,9 +49,6 @@ function install_cargo_tools() {
     install_cargo_tool_if_needed "cargo nextest --version" "cargo-nextest" "0.9.113"
     install_cargo_tool_if_needed "taplo --version" "taplo-cli" "0.9.3"
     install_cargo_tool_if_needed "cargo deny --version" "cargo-deny" "0.16.2"
-
-    # Install Sierra compiler binaries (starknet-sierra-compile, starknet-native-compile).
-    "${SCRIPT_DIR}/install_compiler_binaries.sh"
 }
 
 install_cargo_tools


### PR DESCRIPTION
## Summary
- `install_cargo_tools.sh` was invoking `install_compiler_binaries.sh` at the end, coupling two unrelated concerns: cargo helper tools (`nextest`, `taplo`, `deny`, `sccache`, …) and the Sierra/native compiler binaries.
- External workflows that only want cargo tools end up forced to install `starknet-native-compile`, which builds `melior`/MLIR and requires LLVM 19. For callers that don't set up LLVM 19, the install fails — see the apollo nightly OS fuzz failure (https://github.com/starkware-industries/apollo/actions/runs/26133805533/job/76864440033), whose test only uses `RunnableCairo1::Casm` and never constructs any Sierra compiler.
- Move the compiler install out of `install_cargo_tools.sh`. To preserve identical behavior for every existing caller in this repo:
  - The `bootstrap` composite action gains an explicit `install_compiler_binaries.sh` step right after `install_rust`.
  - `install_build_tools.sh` (used by `deployments/images/base/Dockerfile`) gains an explicit `install_compiler_binaries.sh` call right after `install_cargo_tools.sh`, so the base image still ships with the Sierra compilers installed.
- Extend CI path filters so changes to *any* script in the install chain (`install_build_tools.sh`, `install_cargo_tools.sh`, `install_compiler_binaries.sh`, `install_llvm19.sh`, `compiler_versions.sh`) re-trigger the workflows that depend on that chain (blockifier_ci, blockifier_reexecution_ci, upload_artifacts_workflow, starknet_transaction_prover_ci, papyrus_ci, apollo_storage_os_input_ci). Previously only `install_build_tools.sh` was listed.
- External callers (apollo nightly, anything else outside this repo's `bootstrap` action / `install_build_tools.sh`) can now call `install_cargo_tools.sh` to get only cargo tools without dragging in compilers + the LLVM 19 dependency, or call `install_compiler_binaries.sh` explicitly when they need the binaries.

## Test plan
- [ ] Sequencer CI on this PR is fully green — bootstrap callers still install the compilers, base Dockerfile still installs the compilers, behavior unchanged.
- [ ] After merge, update the apollo nightly fuzz workflow to stop hitting the LLVM 19 dependency it doesn't need (no change required in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)