### PR TITLE
apollo_batcher: fix flaky write_error_is_ignored test

### DIFF
--- a/crates/apollo_batcher/src/pre_confirmed_block_writer_test.rs
+++ b/crates/apollo_batcher/src/pre_confirmed_block_writer_test.rs
@@ -192,17 +192,32 @@ async fn final_write_includes_pending_changes() {
 /// Uses a sequence of Ok -> Err -> Ok to verify the writer continues after a mid-stream failure.
 #[tokio::test]
 async fn write_error_is_ignored() {
+    // Synchronization primitives to coordinate test phases with mock calls.
+    let first_write_done = Arc::new(Notify::new());
+    let first_write_done_clone = first_write_done.clone();
+    let second_write_done = Arc::new(Notify::new());
+    let second_write_done_clone = second_write_done.clone();
+    let third_write_done = Arc::new(Notify::new());
+    let third_write_done_clone = third_write_done.clone();
+
     let mut seq = mockall::Sequence::new();
     let mut mock_client = MockPreconfirmedCendeClientTrait::new();
-    mock_client
-        .expect_write_pre_confirmed_block()
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(|_| Ok(()));
-    mock_client.expect_write_pre_confirmed_block().times(1).in_sequence(&mut seq).returning(|_| {
-        Err(PreconfirmedCendeClientError::RequestFailed(StatusCode::INTERNAL_SERVER_ERROR))
+    mock_client.expect_write_pre_confirmed_block().times(1).in_sequence(&mut seq).returning(
+        move |_| {
+            first_write_done_clone.notify_one();
+            Ok(())
+        },
+    );
+    mock_client.expect_write_pre_confirmed_block().times(1).in_sequence(&mut seq).returning(
+        move |_| {
+            second_write_done_clone.notify_one();
+            Err(PreconfirmedCendeClientError::RequestFailed(StatusCode::INTERNAL_SERVER_ERROR))
+        },
+    );
+    mock_client.expect_write_pre_confirmed_block().times(1..).returning(move |_| {
+        third_write_done_clone.notify_one();
+        Ok(())
     });
-    mock_client.expect_write_pre_confirmed_block().times(1..).returning(|_| Ok(()));
 
     let (mut writer, pre_confirmed_tx_sender) = create_writer(mock_client, WRITE_INTERVAL_MS);
 
@@ -216,8 +231,8 @@ async fn write_error_is_ignored() {
 
     let writer_handle = tokio::spawn(async move { writer.run().await });
 
-    // Let the initial write (Ok) complete.
-    tokio::time::sleep(Duration::from_millis(WRITE_INTERVAL_MS)).await;
+    // Wait for the initial write (Ok) to complete.
+    first_write_done.notified().await;
 
     // Trigger a second write (Err).
     for tx in test_txs(3..4) {
@@ -226,7 +241,7 @@ async fn write_error_is_ignored() {
             .await
             .unwrap();
     }
-    tokio::time::sleep(Duration::from_millis(WRITE_INTERVAL_MS)).await;
+    second_write_done.notified().await;
 
     // Trigger a third write (Ok) to confirm the writer recovered.
     for tx in test_txs(4..5) {
@@ -235,7 +250,7 @@ async fn write_error_is_ignored() {
             .await
             .unwrap();
     }
-    tokio::time::sleep(Duration::from_millis(WRITE_INTERVAL_MS)).await;
+    third_write_done.notified().await;
 
     drop(pre_confirmed_tx_sender);
 


### PR DESCRIPTION
Replace timing-based synchronization (tokio::time::sleep) with deterministic Notify primitives to coordinate mock calls with test phases. This eliminates race conditions where the test could complete before expected mock calls fired.

https://claude.ai/code/session_01Q7jZVGeduewBZ8ZjZiR3Fm