### PR TITLE
apollo_dashboard: fix stale log queries and add l1 event scraper error panel queries

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -905,7 +905,7 @@
             "batcher_building_height{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}"
           ],
           "extra_params": {
-            "log_query": "\"Building block at height\""
+            "log_query": "\"Starting to work on height\""
           }
         },
         {
@@ -1019,7 +1019,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1040,7 +1040,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1052,7 +1052,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1064,7 +1064,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1076,7 +1076,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1088,7 +1088,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1100,7 +1100,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1112,7 +1112,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {
@@ -1124,7 +1124,7 @@
           ],
           "extra_params": {
             "unit": "s",
-            "log_query": "\"Block\" AND \"commitment latencies\""
+            "log_query": "\"Block\" AND \"commitments latencies\""
           }
         },
         {

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -1555,7 +1555,9 @@
           "exprs": [
             "increase(l1_message_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m])"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "log_query": "\"BaseLayerError during scraping\""
+          }
         },
         {
           "title": "L1 Message Scraper Reorg Detected",
@@ -1564,7 +1566,9 @@
           "exprs": [
             "increase(l1_message_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h])"
           ],
-          "extra_params": {}
+          "extra_params": {
+            "log_query": "\"L1 reorg detected\""
+          }
         }
       ],
       "collapsed": true

--- a/crates/apollo_dashboard/src/panels/batcher.rs
+++ b/crates/apollo_dashboard/src/panels/batcher.rs
@@ -51,7 +51,7 @@ fn get_panel_commitment_manager_average_latency(
     let expr = format!("{numerator} / {divisor}");
     Panel::new(name, description, expr, PanelType::TimeSeries)
         .with_unit(Unit::Seconds)
-        .with_log_query("\"Block\" AND \"commitment latencies\"")
+        .with_log_query("\"Block\" AND \"commitments latencies\"")
 }
 
 pub(crate) fn get_panel_consensus_block_time_avg() -> Panel {
@@ -97,7 +97,7 @@ fn get_panel_building_height() -> Panel {
         BUILDING_HEIGHT.get_name_with_filter().to_string(),
         PanelType::Stat,
     )
-    .with_log_query("Building block at height")
+    .with_log_query("Starting to work on height")
 }
 
 fn get_panel_global_root_height() -> Panel {

--- a/crates/apollo_dashboard/src/panels/l1_events.rs
+++ b/crates/apollo_dashboard/src/panels/l1_events.rs
@@ -32,6 +32,7 @@ fn get_panel_l1_message_scraper_baselayer_error_count() -> Panel {
         increase(&L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT, DEFAULT_DURATION),
         PanelType::TimeSeries,
     )
+    .with_log_query("BaseLayerError during scraping")
 }
 fn get_panel_l1_message_scraper_reorg_detected() -> Panel {
     Panel::new(
@@ -40,6 +41,7 @@ fn get_panel_l1_message_scraper_reorg_detected() -> Panel {
         increase(&L1_MESSAGE_SCRAPER_REORG_DETECTED, "12h"),
         PanelType::TimeSeries,
     )
+    .with_log_query("L1 reorg detected")
 }
 fn get_panel_l1_message_scraper_latest_scraped_block() -> Panel {
     Panel::from_gauge(&L1_MESSAGE_SCRAPER_LATEST_SCRAPED_BLOCK, PanelType::TimeSeries)

--- a/crates/apollo_l1_events/src/l1_scraper.rs
+++ b/crates/apollo_l1_events/src/l1_scraper.rs
@@ -111,6 +111,10 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1EventsScraper<Bas
                     L1_MESSAGE_SCRAPER_SUCCESS_COUNT.increment(1);
                     set_unix_now_seconds(&L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS);
                 }
+                Err(e @ L1EventsScraperError::L1ReorgDetected { .. }) => {
+                    warn!("L1 reorg detected during scraping: {e}");
+                    return Err(e);
+                }
                 Err(e) => return Err(e),
             }
         }

--- a/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_scraper.rs
@@ -99,7 +99,7 @@ impl<B: BaseLayerContract + Send + Sync + Debug> L1GasPriceScraper<B> {
         loop {
             // If we get an Ok() we just keep going with the loop.
             if let Err(e) = self.update_prices(&mut block_number).await {
-                error!("Error while scraping gas prices: {e:?}");
+                error!("Error while scraping gas prices: {e}");
 
                 match e {
                     L1GasPriceScraperError::BaseLayerError(_) => {


### PR DESCRIPTION
## Summary
- Fix two stale log queries in batcher panels that no longer matched source log messages:
  - `"Building block at height"` → `"Starting to work on height"` (batcher.rs:310)
  - `"Block" AND "commitment latencies"` → `"Block" AND "commitments latencies"` (block_builder.rs:915 uses the plural form)
- Add log queries to L1 message scraper error panels (previously missing):
  - Base layer error count → `"BaseLayerError during scraping"`
  - Reorg detected → `"L1 reorg detected"`
- Fix `apollo_l1_gas_price` scraper log format: `{e:?}` → `{e}` (Display) so log output contains the readable error string `"Base layer error: ..."` / `"L1 reorg detected: ..."` that the dashboard queries match on
- Add explicit `warn!` in `apollo_l1_events` scraper for the `L1ReorgDetected` case (was previously only a silent `return Err(e)`, making the log query unreliable)

## Test plan
- [ ] Dashboard regenerated via `cargo run --bin sequencer_dashboard_generator`
- [ ] `cargo build -p apollo_l1_gas_price -p apollo_l1_events` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)