### PR TITLE
blockifier: fix flaky scheduler_flow_test with cairo_native

### DIFF
--- a/crates/blockifier/src/concurrency/flow_test.rs
+++ b/crates/blockifier/src/concurrency/flow_test.rs
@@ -23,6 +23,12 @@ fn validate(
     tx_index: TxIndex,
     commit_phase: bool,
 ) -> bool {
+    // Skip validation if the scheduler is done and we're not in commit phase. This avoids a race
+    // where finish_abort decreases execution_index after halt() is called, causing the final
+    // execution_index assertion to fail.
+    if !commit_phase && scheduler.done() {
+        return true;
+    }
     let state_proxy = versioned_state.pin_version(tx_index);
     let (reads, writes) = get_reads_writes_for(Task::ValidationTask(tx_index), versioned_state);
     let read_set_valid = state_proxy.validate_reads(&reads).unwrap();


### PR DESCRIPTION
## Summary
- Fix flaky `scheduler_flow_test` that fails with `cairo_native` feature
- Race condition: non-commit-phase validation could decrease `execution_index` after `halt()` was called, causing the final assertion to fail
- Fix: skip validation when scheduler is done and not in commit phase

## Test plan
- [x] `cargo test -p blockifier scheduler_flow_test` passes consistently (10+ runs)
- [x] Clippy passes

Slack thread: https://starkwareindustries.slack.com/archives/C07E54Y3W3H/p1779181157886819?thread_ts=1779178544.153829&cid=C07E54Y3W3H

https://claude.ai/code/session_019fGbjcK1SVXW9xjcpCxsFx
