### PR TITLE
blockifier: drop flaky execution_index assertion in scheduler flow test

### DIFF
--- a/crates/blockifier/src/concurrency/flow_test.rs
+++ b/crates/blockifier/src/concurrency/flow_test.rs
@@ -93,12 +93,10 @@ fn scheduler_flow_test(
         handle.join().unwrap();
     }
 
-    // The execution index can be strictly greater than chunk_size. This is a side effect of using
-    // atomic variables instead of locks, which can encapsulate both the check (whether to increment
-    // the variable or not) and the incrementation in a scope where no other threads can access the
-    // variable.
-    assert!(scheduler.execution_index.load(Ordering::Acquire) >= DEFAULT_CHUNK_SIZE);
-    // There is no guarantee about the validation index because of the use of the commit index.
+    // No assertion on execution_index: it is a dispatch cursor that both `finish_abort` and
+    // `next_version_to_execute` (on a `Missing` status) decrease via `fetch_min`, so its value at
+    // join time is not a high-water mark. The actually load-bearing invariants are checked below
+    // (commit_index, n_committed_txs, done_marker, per-tx final state).
     assert!(*scheduler.commit_index.lock().unwrap() == DEFAULT_CHUNK_SIZE);
     assert!(scheduler.get_n_committed_txs() == DEFAULT_CHUNK_SIZE);
     assert!(scheduler.done_marker.load(Ordering::Acquire));


### PR DESCRIPTION
## Summary
- Removes the line-100 assertion `scheduler.execution_index >= DEFAULT_CHUNK_SIZE` from `scheduler_flow_test`.
- `execution_index` is a dispatch cursor, not a high-water mark — both `finish_abort` (`scheduler.rs:150`) and `next_version_to_execute` on a `Missing` status (`scheduler.rs:231`) decrease it via `fetch_min`. So at join time, after `halt()` makes workers exit, the cursor can sit below `DEFAULT_CHUNK_SIZE` even though every tx ran and committed.
- Manifests as flakiness on the `num_threads = 4` case, especially on `--features cairo_native` builds where the larger binary + altered allocator/TLS layout widens the race window. Failing job for reference: https://github.com/starkware-libs/sequencer/actions/runs/26081999337/job/76685679267
- The remaining assertions (`commit_index`, `get_n_committed_txs`, `done_marker`, and the per-tx storage check) already prove every tx executed and committed with the right final state. The dropped line was checking an invariant the scheduler does not provide.

## Test plan
- [ ] CI green, including `test-with-cairo-native-feature`.
- [ ] Re-run a few times to confirm the `num_threads_3_4` flake is gone (the new build doesn't even reference `execution_index` at this point, so it cannot fail for that reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)