### PR TITLE
apollo_class_manager: delete dead code

### DIFF
--- a/crates/apollo_class_manager/src/class_storage.rs
+++ b/crates/apollo_class_manager/src/class_storage.rs
@@ -448,32 +448,6 @@ impl FsClassStorage {
             .set_executable_class_hash_v2(class_id, executable_class_hash_v2)?)
     }
 
-    #[allow(dead_code)]
-    fn write_class(
-        &self,
-        class_id: ClassId,
-        class: RawClass,
-        executable_class: RawExecutableClass,
-    ) -> FsClassStorageResult<()> {
-        let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
-        class.write_to_file(concat_sierra_filename(&persistent_dir))?;
-        executable_class.write_to_file(concat_executable_filename(&persistent_dir))?;
-
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    fn write_deprecated_class(
-        &self,
-        class_id: ClassId,
-        class: RawExecutableClass,
-    ) -> FsClassStorageResult<()> {
-        let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
-        class.write_to_file(concat_deprecated_executable_filename(&persistent_dir))?;
-
-        Ok(())
-    }
-
     fn write_class_atomically(
         &self,
         class_id: ClassId,


### PR DESCRIPTION
## Summary

Remove `write_class` and `write_deprecated_class` from `FsClassStorage` in `class_storage.rs`.

Both methods write class files directly to the persistent directory **without** atomicity guarantees. They were superseded by `write_class_atomically` and `write_deprecated_class_atomically`, which write to a temporary directory first and then atomically rename it into place. Neither of the non-atomic methods has any callers anywhere in the codebase — both carried `#[allow(dead_code)]`.

## Test plan
- `cargo test -p apollo_class_manager` — all 13 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01G59fSPfUm7ZD91gXqN4GJW)_