### PR TITLE
apollo_rpc: delete dead code

### DIFF
--- a/crates/apollo_rpc/src/v0_8/error.rs
+++ b/crates/apollo_rpc/src/v0_8/error.rs
@@ -8,21 +8,11 @@ pub struct JsonRpcError<T: Serialize> {
     pub data: Option<T>,
 }
 
-// TODO(yair): Remove allow(dead_code) once all errors are used.
-#[allow(dead_code)]
-pub const FAILED_TO_RECEIVE_TRANSACTION: JsonRpcError<String> =
-    JsonRpcError { code: 1, message: "Failed to write transaction", data: None };
-
 pub const CONTRACT_NOT_FOUND: JsonRpcError<String> =
     JsonRpcError { code: 20, message: "Contract not found", data: None };
 
 pub const INVALID_TRANSACTION_HASH: JsonRpcError<String> =
     JsonRpcError { code: 25, message: "Invalid transaction hash", data: None };
-
-// TODO(shahak): Remove allow(dead_code) once all errors are used.
-#[allow(dead_code)]
-pub const INVALID_BLOCK_HASH: JsonRpcError<String> =
-    JsonRpcError { code: 26, message: "Invalid block hash", data: None };
 
 pub const BLOCK_NOT_FOUND: JsonRpcError<String> =
     JsonRpcError { code: 24, message: "Block not found", data: None };


### PR DESCRIPTION
## Description

Remove two error constants in `crates/apollo_rpc/src/v0_8/error.rs` that have been annotated with `#[allow(dead_code)]` since they were introduced and have never been given callers:

- `FAILED_TO_RECEIVE_TRANSACTION` (code 1) — TODO comment by `yair` said to remove `allow(dead_code)` once used; it never was.
- `INVALID_BLOCK_HASH` (code 26) — TODO comment by `shahak` said the same; also never used.

Both constants are confirmed to have zero callers across the entire codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G59fSPfUm7ZD91gXqN4GJW)_