### PR TITLE
apollo_dashboard: fix spot-eviction false positives in success-count alerts

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -902,7 +902,7 @@
       "name": "eth_to_strk_success_count",
       "title": "Eth to Strk success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1396,7 +1396,7 @@
       "name": "l1_gas_price_scraper_success_count",
       "title": "L1 gas price scraper success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -15,15 +15,21 @@ use crate::alerts::{
     ObserverApplicability,
     PENDING_DURATION_DEFAULT,
 };
+use crate::query_builder::sum_increase;
 
 /// Alert if we have no successful eth to strk rates data from the last hour.
+///
+/// Uses `sum_increase` instead of bare `increase` to avoid false positives on spot eviction: when
+/// a pod is evicted and rescheduled, the new pod's counter resets to 0, so a bare `increase([1h])`
+/// would return 0 until the first success. `sum` aggregates across all pod series, and the
+/// evicted pod's data points remain in the TSDB for the full 1h window, keeping the sum ≥ 1.
 pub(crate) fn get_eth_to_strk_success_count_alert() -> Alert {
     const ALERT_NAME: &str = "eth_to_strk_success_count";
     Alert::new(
         ALERT_NAME,
         "Eth to Strk success count",
         EvaluationRate::Default,
-        format!("increase({}[1h])", ETH_TO_STRK_SUCCESS_COUNT.get_name_with_filter()),
+        sum_increase(&ETH_TO_STRK_SUCCESS_COUNT, "1h"),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
@@ -32,13 +38,15 @@ pub(crate) fn get_eth_to_strk_success_count_alert() -> Alert {
 }
 
 /// Alert if had no successful l1 gas price scrape in the last hour.
+///
+/// Uses `sum_increase` for the same spot-eviction reason as `get_eth_to_strk_success_count_alert`.
 pub(crate) fn get_l1_gas_price_scraper_success_count_alert() -> Alert {
     const ALERT_NAME: &str = "l1_gas_price_scraper_success_count";
     Alert::new(
         ALERT_NAME,
         "L1 gas price scraper success count",
         EvaluationRate::Default,
-        format!("increase({}[1h])", L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
+        sum_increase(&L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT, "1h"),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),

--- a/crates/apollo_dashboard/src/query_builder.rs
+++ b/crates/apollo_dashboard/src/query_builder.rs
@@ -32,6 +32,13 @@ pub(crate) fn seconds_since_last_timestamp(metric: &dyn MetricQueryName) -> Stri
     format!("time() - max(last_over_time({}[12h]))", metric.get_name_with_filter())
 }
 
+/// Builds `sum(increase(<metric>[<duration>]))` for aggregating a counter across all instances.
+///
+/// Example: `sum_increase(&m, "1h")` → `sum(increase(my_counter{...}[1h]))`
+pub(crate) fn sum_increase(metric: &dyn MetricQueryName, duration: &str) -> String {
+    format!("sum({})", increase(metric, duration))
+}
+
 /// Returns `sum by (namespace, pod) (<inner>)` where `<inner>` is either
 /// the raw metric query or `increase(<metric>[<duration>])`.
 ///

--- a/crates/apollo_dashboard/src/query_builder_test.rs
+++ b/crates/apollo_dashboard/src/query_builder_test.rs
@@ -2,7 +2,15 @@ use apollo_metrics::metric_definitions::METRIC_LABEL_FILTER;
 use apollo_metrics::metrics::{MetricGauge, MetricScope};
 use rstest::rstest;
 
-use crate::query_builder::{increase, sum_by_label, sum_by_pod, DisplayMethod};
+use crate::query_builder::{increase, sum_by_label, sum_by_pod, sum_increase, DisplayMethod};
+
+#[test]
+fn sum_increase_formats_correctly() {
+    let m = MetricGauge::new(MetricScope::Batcher, "testing", "Fake description");
+    let q = sum_increase(&m, "1h");
+    let expected = format!("sum(increase(testing{METRIC_LABEL_FILTER}[1h]))");
+    assert_eq!(q, expected);
+}
 
 #[test]
 fn increase_formats_correctly() {


### PR DESCRIPTION
## Summary
- `eth_to_strk_success_count` and `l1_gas_price_scraper_success_count` alerts used bare `increase(metric[1h])` without `sum()`. After a spot eviction, the new pod starts with counter=0, so `increase([1h])` returns 0 and satisfies the `< 1` condition — firing a false alert.
- Fix: wrap with `sum()` so the query aggregates across all pod series. The evicted pod's data points remain in the Prometheus TSDB for the full 1h window, keeping the sum ≥ 1 while the new pod is starting up.
- Adds `sum_increase()` helper to `query_builder` for reuse.

## Test plan
- [ ] `cargo test -p apollo_dashboard` passes (16/16)
- [ ] Dashboard JSON regenerated via `sequencer_dashboard_generator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)