### PR TITLE
starknet_committer: delete dead code

### DIFF
--- a/crates/starknet_committer/src/db/facts_db/node_serde.rs
+++ b/crates/starknet_committer/src/db/facts_db/node_serde.rs
@@ -31,8 +31,6 @@ pub(crate) const BINARY_BYTES: usize = 2 * SERIALIZE_HASH_BYTES;
 pub(crate) const EDGE_LENGTH_BYTES: usize = 1;
 pub(crate) const EDGE_PATH_BYTES: usize = 32;
 pub(crate) const EDGE_BYTES: usize = SERIALIZE_HASH_BYTES + EDGE_PATH_BYTES + EDGE_LENGTH_BYTES;
-#[allow(dead_code)]
-pub(crate) const STORAGE_LEAF_SIZE: usize = SERIALIZE_HASH_BYTES;
 
 pub const FACT_LAYOUT_DB_KEY_SEPARATOR: &[u8] = DEFAULT_DB_KEY_SEPARATOR;
 


### PR DESCRIPTION
## Description

Remove the unused `STORAGE_LEAF_SIZE` constant from `crates/starknet_committer/src/db/facts_db/node_serde.rs`.

The constant has been annotated with `#[allow(dead_code)]` since it was introduced and has never had a caller anywhere in the codebase. It is simply `SERIALIZE_HASH_BYTES` (32) by another name, and nothing references it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G59fSPfUm7ZD91gXqN4GJW)_