### PR TITLE
apollo_integration_tests: add shared proof-flow infrastructure (#13760)

### DIFF
--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -517,12 +517,7 @@ impl CallInfo {
             executed_class_hashes.insert(class_hash);
 
             // Storage entries.
-            let call_storage_entries = call_info
-                .storage_access_tracker
-                .accessed_storage_keys
-                .iter()
-                .map(|storage_key| (call_info.call.storage_address, *storage_key));
-            visited_storage_entries.extend(call_storage_entries);
+            visited_storage_entries.extend(call_info.get_visited_storage_entries());
 
             // Messages.
             l2_to_l1_payload_lengths.extend(
@@ -580,6 +575,14 @@ impl CallInfo {
             acc += &inner_call.resources;
             acc
         })
+    }
+
+    pub fn get_visited_storage_entries(&self) -> impl Iterator<Item = StorageEntry> + '_ {
+        let storage_address = self.call.storage_address;
+        self.storage_access_tracker
+            .accessed_storage_keys
+            .iter()
+            .map(move |key| (storage_address, *key))
     }
 
     /// Returns a vector of Starknet Event objects collected during the execution, sorted by the


### PR DESCRIPTION
apollo_integration_tests: add shared proof-flow infrastructure (#13760)

starknet_proof_verifier: bump stwo crates (#13932)

apollo_consensus_orchestrator: add SNIP-35 module (#13854)

chore: merge branch main-v0.14.2 into main (with conflicts)

ci: add 60-minute timeout to all PR-triggered jobs (#14010)

apollo_consensus_orchestrator: add SNIP-35 module tests (#13815)

fix_conflicts

starknet_api,starknet_proof_verifier: rename PROOF_VERSION to PROOF_VERSION_V0 (#14011)

Merge pull request #14018 from starkware-libs/aviv/merge-main-v0.14.2-into-main-1778481175

Merge main-v0.14.2 into main

apollo_gateway: block mempool send until proof archive write completes (#13984)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

apollo_consensus_orchestrator: add SNIP-35 metrics (#13816)

blockifier: activate CASM hash migration (#14025)

Signed-off-by: Dori Medini <dori@starkware.co>

deployment: fix mainnet max_n_events (#14009)

apollo_dashboard: add SNIP-35 row (#13954)

apollo_l1_gas_price_types,apollo_l1_gas_price: rename trait method eth_to_fri_rate to fetch_rate (#13987)

* apollo_dashboard: add SNIP-35 row

* apollo_l1_gas_price_types,apollo_l1_gas_price: rename trait method eth_to_fri_rate to fetch_rate

apollo_gateway: add private transactions received metric (#14023)

Adds GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED counter that increments for
every invoke_v3 transaction with non-empty proof_facts received by the
gateway, enabling comparison with total received transactions in dashboards.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

apollo_dashboard: add transactions received by proof type panel (#14024)

Adds a Stat panel to the Gateway row showing private (invoke_v3 with
non-empty proof_facts) vs public transactions received, using the
GATEWAY_PRIVATE_TRANSACTIONS_RECEIVED counter from the previous PR.
Both series use sum() to aggregate across multiple gateway pods.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

apollo_batcher: remove candidate tx stream (#13989)

deployment: add profiling build mode with heaptrack support for memory leak investigation (#12823)

Add a `profiling` Cargo profile (release + debug symbols) and update the
Dockerfile and CI workflow to support it. This enables on-demand memory
profiling with heaptrack by attaching to a running node via `--pid`.

apollo_consensus_orchestrator: cover L1 FRI gas-price margin rejection in tests (#14027)

The existing invalid_proposal_init test only exercises the l2_gas_price_fri
exact-equality rejection path. The L1 FRI margin rejection at
is_proposal_init_valid had no characterization coverage.

Add a parametrized rstest over the two L1 FRI gas-price fields that calls
is_proposal_init_valid directly so the margin path is exercised whenever
the gating fixture or the validator logic changes. The scaffold
(enum + parametrized case) is shaped to grow when we add WEI cases in
the follow-up commit.

apollo_consensus_orchestrator: validate L1 WEI gas prices in ProposalInit (#14028)

is_proposal_init_valid only checked the FRI L1 gas prices; the WEI prices
flowed unchecked into BlockInfo.eth_gas_prices, the eth_to_fri_rate
derivation, the partial_block_hash, and the Cende-persisted block payload.

Mirror the existing within_margin check on l1_gas_price_wei and
l1_data_gas_price_wei using the validator's own L1 gas price provider
snapshot (already fetched by get_l1_prices_in_fri_and_wei) and the same
l1_gas_price_margin_percent versioned constant.

Extend the parametrized rejects_proposal_init_l1_gas_price_out_of_margin
test added in the previous commit with WEI cases.

Also fix change_gas_price_overrides: a stale duplicate line was re-setting
l1_data_gas_price_fri after the override instead of l1_data_gas_price_wei,
which the new WEI margin check now correctly catches. Recompute the
expected WEI from the FRI override via fri_to_wei(ETH_TO_FRI_RATE).

apollo_batcher: fix race in the final_write_includes_pending_changes test (#14036)

apollo_gateway: skip archiving proof if transaction is P2P (#14022)

apollo_infra_utils,apollo_compile_to_native: add compiler version text files (#13671)

Create plain text files containing compiler binary versions as the single
source of truth. Rust constants now use include_str!().trim_ascii_end()
to read from these files. Shell scripts and Dockerfiles will read them
with cat in a follow-up.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

apollo_dashboard: observer applicability affects expression (#13938)

apollo_consensus_orchestrator,apollo_consensus_manager: add strk_exchange_rate_oracle field to deps (#13823)

scripts: add install_compiler_binaries.sh (#13672)

New script to install Sierra compiler binaries (starknet-sierra-compile,
starknet-native-compile). Reads versions from .txt files, handles LLVM
env vars for native compile, and skips gracefully when LLVM 19 is missing.

Includes compiler_versions.sh helper that reads version .txt files.

Not yet called from install_cargo_tools.sh — wired up in a follow-up.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

starknet_os: extract cairo blake run to function (#14030)

apollo_compilation_utils: add verify_compiler_binary (#13673)

New function that checks a compiler binary's version at runtime and
panics with installation instructions if missing or wrong version.
Added alongside the existing install_compiler_binary — no callers yet.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

starknet_os: move blake constants to struct scope (#14031)

* starknet_os: extract cairo blake run to function

* starknet_os: move blake constants to struct scope

blockifier: fix blake estimation offset by fixing constants (#14034)

apollo_consensus_orchestrator: add SNIP-35 fee_proposals sliding window (#13817)

apollo_consensus: get voting weight from committee (#13224)

starknet_api: add PROOF_VERSION_V1 and accept either marker in ProofFactsVariant (#14012)

apollo_mempool_p2p: fix Duration::MAX in tests (prevent overflow on addition) (#14062)

Signed-off-by: Dori Medini <dori@starkware.co>

apollo_starknet_os_program: update cairo-lang to 0.14.3a1 (#14020)

* apollo_starknet_os_program: update cairo-lang to 0.14.3a1

Signed-off-by: Dori Medini <dori@starkware.co>

* blockifier,starknet_os: make blake step estimation exact via per-msg discount

Adopts the off-by-one fix from #14034 and goes further: the cairo blake
implementation amortizes 2 steps per full 16-u32 message processed, so
the estimator's base cost must scale with `n_full_msgs`. Verified by
running `encode_felt252_data_and_calc_blake_hash` against inputs from
0 to 2000 large felts (1000 full messages) — the new formula matches
actual cairo steps exactly for every probe.

Final constants:
- STEPS_EMPTY_INPUT: 168 -> 167
- BASE_STEPS_FULL_MSG: 117 -> 216 (pre-discount baseline)
- BASE_STEPS_PARTIAL_MSG: 193 -> 192 (pre-discount baseline)
- STEPS_DISCOUNT_PER_FULL_MSG: new, 2

Removes the `resources.n_steps -= 1;` hack in blake2s_test that was
compensating for the off-by-one. Bumps the compiled_class_test margin
267 -> 400 to absorb residual under-estimates from non-blake constants
(entry-point / segment overheads) in casm_hash_estimation; with the
exact blake formula, the worst observed margin drops from 4471 to 325.

UPDATE_EXPECT on bouncer_test updates the post-migration sierra/proving
gas to reflect the new formula.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---------

Signed-off-by: Dori Medini <dori@starkware.co>
Co-authored-by: Yonatan Iluz <yonatan@starkware.co>
Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

starknet_proof_verifier: accept either PROOF_VERSION_V0 or PROOF_VERSION_V1 in verify_proof (#14013)

* starknet_api: add PROOF_VERSION_V1 and accept either marker in ProofFactsVariant

* starknet_proof_verifier: accept either PROOF_VERSION_V0 or PROOF_VERSION_V1 in verify_proof

apollo_consensus_orchestrator: add fee_actual floor to EIP-1559 gas price calculation (#13824)

apollo_starknet_os_program,starknet_os: support PROOF_VERSION_V1 in check_proof_facts (#14014)

apollo_l1_gas_price: rate oracle query checks status code (#13417)

apollo_dashboard: add log queries to L1 gas price scraper error panels (#14065)

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

apollo_dashboard: cleanup, naming, framework, and row reorg (#14037)

Improvements to the dashboard generator that don't change the visualization
semantics of any single panel:

- Bug fixes: drop the duplicate Pod Disk Limit Utilization panel (same query
  as Pod Disk Utilization); fix the "Occurances" typo and clarify the
  consensus_round_above_zero description ("round > 0", not "round == 1");
  scale L1 gas price latest mean values to Gwei; add a unit to the mempool
  P2P broadcasted batch size; replace raw-metric-name titles in two
  mempool_p2p panels.
- Framework: add Unit::Short (Grafana k/M/G abbreviation) and use it for
  count-typed panels (mempool sizes, Tokio counters, sync diff, nonce-gap
  stats, batch sizes); document traffic_light_thresholds (kept allow(dead_code)
  for the follow-up PR that uses it).
- Naming: standardize row names (HTTP Server, Mempool P2P, Consensus P2P);
  Title Case in the Mempool P2P / Tokio panels; consistent "by Resource"
  casing; drop redundant suffixes like "(Num TXs)" once the unit conveys it.
- Reorg: group the ~30 rows into logical sections in the dashboard
  (overview → block production → tx lifecycle → execution → sync →
  operational → networking → infra) with section comments.

dev_grafana.json regenerated from these changes.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>

deployment: shrink Grafana dashboard JSON to stay under 1MB import limit (#14063)

Hoist the static fragments of the per-panel GCP Logs URL into two new
constant template variables (`gcp_logs_prefix`, `gcp_logs_mid`) and
compact the cluster/namespace `renameByRegex` chunk from the verbose
quoted/escaped form to `(?:"[^"]*"|[^}])*` while preserving correct
handling of regex quantifiers (`{8,}`, `{5}`) inside the `$pod` value.

Measured on the current dev_grafana.json (383 data panels), comparing
the build against main vs this branch:

  Before: 814,524 B (795.4 KB) — 228.6 KB headroom under 1MB
  After : 714,692 B (697.9 KB) — 326.1 KB headroom under 1MB
  Saved :  99,832 B  (97.5 KB, 12.3% reduction)

Breakdown of the saved bytes (sum across all data panels):
  links           : 136,589 -> 75,516  (-61,073 B)
  transformations : 206,054 -> 166,988 (-39,066 B)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

starknet_api,starknet_proof_verifier: write PROOF_VERSION_V1 in try_into_proof_facts (#14015)

apollo_dashboard: add traffic-light thresholds to health panels (#14039)

Surface "is this metric in a worrying range?" at a glance by attaching
green/yellow/red threshold steps to eight high-signal panels:
- Consensus Round (yellow ≥1, red ≥3) — non-zero rounds indicate trouble.
  Description also expanded to explain what the colors mean.
- Sync Diff From Feeder Gateway (yellow ≥6, red ≥10).
- Mempool Accounts With Nonce Gap (yellow ≥3, red ≥10) and Stuck
  Transactions (yellow ≥20, red ≥100).
- "Seconds since last …" panels: HTTP Server received tx (10/60),
  L1 message scrape (30/120), L1 gas price scrape (120/300),
  ETH→STRK rate update (1200/1800; expected cadence ~15 min).

Drops the allow(dead_code) on traffic_light_thresholds now that it has
callers. dev_grafana.json regenerated.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>

ci,scripts: install LLVM before cargo tools (#13674) (#14060)

Reorder bootstrap and install_build_tools.sh so LLVM 19 is installed
before cargo tools. This is needed because install_cargo_tools.sh will
install starknet-native-compile which requires LLVM to build.

Safe change: LLVM installation does not depend on Rust.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

apollo_node: drop test file handle on first write failure (#14067)

Signed-off-by: Dori Medini <dori@starkware.co>

apollo_node: spawn a blocking thread when writing to stdout in tests (#14068)

Signed-off-by: Dori Medini <dori@starkware.co>

scripts: remove unused --feeder-url from take_nodes_out_of_observer_mode (#14008)

The fetched block number was only used as a soft filter on the post-restart
logs URL. Drop the flag and the related dead plumbing, and refresh the script
title/help text to describe what the script actually does.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

apollo_integration_tests: fix non-interpolating .expect() messages and log typos (#14069)

The original motivating bug lives in apollo_integration_tests:

    // crates/apollo_integration_tests/src/integration_test_manager.rs
    .expect("Service {service:?} does not exist in the running executables map.");
    .expect("Node {node_idx} does not exist in idle or running nodes.");

`.expect()` is an ordinary method on Option/Result that takes a `&str` and
prints it verbatim on panic — it does not invoke `format_args!`. So named
arguments inside the braces never get substituted:

    Before: thread '...' panicked at 'Service {service:?} does not exist in the running executables map.'
    After:  thread '...' panicked at 'Service Batcher does not exist in the running executables map.'

The panic still fires at the right moment for the right reason; only the
diagnostic value is lost, which defeats the whole point of embedding the
variable. The fix is to wrap the call as `.unwrap_or_else(|| panic!(...))`
(or `|err| panic!("...: {err}")` on a Result), since `panic!` IS a format
macro and the placeholders interpolate normally.

A workspace grep revealed the same anti-pattern in nine more places, plus a
small batch of unrelated typos in user-facing log/panic/assert strings.
Bundling them all here because the common audit "are all log strings in the
sequencer correct?" is what surfaced them.

.expect() placeholder fixes (panic message would have been useless before):
  - apollo_storage/src/header.rs                                 ({block_number})
  - apollo_consensus_manager/src/consensus_manager.rs            ({height})
  - apollo_consensus/src/manager.rs                              (was {self.height} -- field access also invalid in fmt; corrected to local {height})
  - apollo_storage/src/serialization/serializers_test.rs         (7 sites; one referenced an out-of-scope {casm_file}, corrected to {bin_file_name})
  - starknet_os/.../state_diff_encryption/utils.rs               ({public_key}, {sn_public_key})
  - apollo_integration_tests/src/integration_test_manager.rs     ({service:?}, {node_idx})
  - apollo_batcher/src/batcher.rs                                ({new_latest_height})

Plain typo fixes in log/panic/assert messages:
  - apollo_integration_tests/src/integration_test_manager.rs     "succesfully" -> "successfully" (info!)
  - blockifier/src/execution/entry_point.rs                      "to to usize" -> "to usize" (log::warn!, duplicate word)
  - apollo_monitoring_endpoint/src/monitoring_endpoint.rs        "MointoringEndpoint" -> "MonitoringEndpoint" (panic!)
  - starknet_patricia/.../filled_tree/tree.rs                    "a unmodified" -> "an unmodified" (panic!)
  - apollo_integration_tests/src/flow_test_setup.rs              "a init message" -> "an init message" (panic!)
  - apollo_infra_utils/src/path_test.rs                          "an non-existent" -> "a non-existent" (assert!)

No behavior change beyond what panic messages display; cargo check --tests
passes on all touched crates.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

starknet_proof_verifier: add v0.14.3 regression case for PROOF_VERSION_V1 fixture (#14016)

apollo_compile_to_casm,apollo_compile_to_native: switch to script-based compiler installation (#13675)

Remove build.rs from both compiler crates — compiler binaries are now
installed by scripts/install_compiler_binaries.sh (called from
install_cargo_tools.sh) instead of as a cargo build side effect.

- Delete build.rs and [build-dependencies] from both crates
- Compiler constructors use verify_compiler_binary + PATH-based lookup
  (skip version check for custom paths in SierraToNativeCompiler)
- install_cargo_tools.sh calls install_compiler_binaries.sh
- Dockerfiles use cargo install with versions from .txt files
- Base Dockerfile copies new scripts and version files

Old install_compiler_binary() and legacy path functions are left for
removal in a follow-up cleanup.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

apollo_compilation_utils: remove dead install_compiler_binary and legacy paths (#13676)

Remove code that is no longer used after the switch to script-based
compiler installation:

- Remove install_compiler_binary() and legacy_binary_path()
- Remove shared_folder_dir(), target_dir() from paths.rs
- Remove tempfile build-dependency from apollo_compilation_utils
- Update workflow artifact path and BUILD file

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

starknet_os: recompute and assert the blake constants (#14032)

scripts: only run integration test cairo_native pass when blockifier is touched (#14040)

Two gates governed the cairo_native integration test pass and disagreed:

- The outer guard skipped the second pass only when neither blockifier was
  in `crates` nor the run was nightly (OR semantics — run on either).
- The inner `feature_flag` only added `--features cairo_native` when both
  with_feature and is_nightly were true (AND semantics).

Net effect on a non-nightly PR touching blockifier: the second pass ran but
without the feature flag — pure duplicate of the first pass, no extra
coverage, double exposure to the integration_test_revert_flow flake.
On nightly with no blockifier in `crates`, it also ran a useless duplicate.

Align both gates to one rule: run the cairo_native pass iff blockifier is
being tested. Empty `crates` ("all crates", e.g. nightly without
--changes_only) implicitly includes blockifier and triggers the pass.

Result by scenario:
- PR touching blockifier            -> no-features + cairo_native passes
- PR not touching blockifier        -> single no-features pass
- Nightly all-crates                -> no-features + cairo_native passes
- Nightly changes_only + blockifier -> no-features + cairo_native passes
- Nightly changes_only, no blockif. -> single no-features pass

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

blockifier,starknet_os: expect the blake constants in tests and check consistency (#14035)

blockifier: extract CallInfo::get_visited_storage_entries

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>