### PR TITLE
blockifier: add CallInfo::get_visited_contract_addresses

### DIFF
--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -585,6 +585,17 @@ impl CallInfo {
             .map(move |key| (storage_address, *key))
     }
 
+    /// Contract addresses whose contracts-trie leaf the OS needs to replay this call: the call's
+    /// own `storage_address` (always read at dispatch), the `code_address` of delegate-style calls
+    /// when set (covers the deprecated `delegate_call` target), and any address queried via
+    /// `get_class_hash_at` (mirrored by `storage_access_tracker.accessed_contract_addresses`).
+    /// Inner calls are not traversed — use `CallInfo::iter` to walk the tree.
+    pub fn get_visited_contract_addresses(&self) -> impl Iterator<Item = ContractAddress> + '_ {
+        std::iter::once(self.call.storage_address)
+            .chain(self.call.code_address)
+            .chain(self.storage_access_tracker.accessed_contract_addresses.iter().copied())
+    }
+
     /// Returns a vector of Starknet Event objects collected during the execution, sorted by the
     /// order in which they were emitted.
     pub fn get_sorted_events(&self) -> Vec<Event> {


### PR DESCRIPTION
Mirrors the Python state-selector walk that drives the OS contracts-trie
input set. Yields the call's own storage_address, its code_address when set
(delegate-style calls), and the contents of
storage_access_tracker.accessed_contract_addresses. No new field is added —
the data is derived from existing CallEntryPoint and StorageAccessTracker
fields. Inner calls are not traversed by this method — use CallInfo::iter
to walk the tree.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>