### PR TITLE
blockifier: add predicted_alias_storage_entries

### DIFF
--- a/crates/blockifier/src/state/stateful_compression.rs
+++ b/crates/blockifier/src/state/stateful_compression.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use starknet_api::core::{ContractAddress, PatriciaKey};
 use starknet_api::state::StorageKey;
@@ -6,7 +6,7 @@ use starknet_api::StarknetApiError;
 use starknet_types_core::felt::Felt;
 use thiserror::Error;
 
-use super::cached_state::{CachedState, StateMaps};
+use super::cached_state::{CachedState, StateMaps, StorageEntry};
 use super::errors::StateError;
 use super::state_api::{State, StateReader, StateResult};
 
@@ -77,6 +77,29 @@ pub fn allocate_aliases_in_storage<S: StateReader>(
     }
 
     alias_updater.finalize_updates()
+}
+
+/// Predicts the storage entries on the alias contract that `allocate_aliases_in_storage` will
+/// read (and may write) for the given `state_diff`, without running the allocation. Mirrors the
+/// access pattern of `AliasUpdater::new` (counter read) plus each `AliasUpdater::insert_alias`
+/// call (one read per qualifying key).
+pub fn predicted_alias_storage_entries(
+    state_diff: &StateMaps,
+    alias_contract_address: ContractAddress,
+) -> HashSet<StorageEntry> {
+    let mut entries = HashSet::new();
+    entries.insert((alias_contract_address, ALIAS_COUNTER_STORAGE_KEY));
+    for address in state_diff.get_contract_addresses() {
+        if should_compress_address(&address) {
+            entries.insert((alias_contract_address, StorageKey(address.0)));
+        }
+    }
+    for (address, storage_key) in state_diff.storage.keys() {
+        if should_compress_storage_key(storage_key, address) {
+            entries.insert((alias_contract_address, *storage_key));
+        }
+    }
+    entries
 }
 
 /// Updates the alias contract with the new keys.
@@ -182,7 +205,7 @@ impl<S: StateReader> AliasCompressor<'_, S> {
         &self,
         contract_address: &ContractAddress,
     ) -> CompressionResult<ContractAddress> {
-        if contract_address.0 >= MIN_VALUE_FOR_ALIAS_ALLOC {
+        if should_compress_address(contract_address) {
             Ok(self.get_alias(StorageKey(contract_address.0))?.try_into()?)
         } else {
             Ok(*contract_address)
@@ -194,9 +217,7 @@ impl<S: StateReader> AliasCompressor<'_, S> {
         storage_key: &StorageKey,
         contract_address: &ContractAddress,
     ) -> CompressionResult<StorageKey> {
-        if storage_key.0 >= MIN_VALUE_FOR_ALIAS_ALLOC
-            && contract_address > &MAX_NON_COMPRESSED_CONTRACT_ADDRESS
-        {
+        if should_compress_storage_key(storage_key, contract_address) {
             Ok(self.get_alias(*storage_key)?.try_into()?)
         } else {
             Ok(*storage_key)
@@ -207,4 +228,16 @@ impl<S: StateReader> AliasCompressor<'_, S> {
         let alias = self.state.get_storage_at(self.alias_contract_address, alias_key)?;
         if alias == Felt::ZERO { Err(CompressionError::MissedAlias(alias_key)) } else { Ok(alias) }
     }
+}
+
+fn should_compress_address(contract_address: &ContractAddress) -> bool {
+    contract_address.0 >= MIN_VALUE_FOR_ALIAS_ALLOC
+}
+
+fn should_compress_storage_key(
+    storage_key: &StorageKey,
+    contract_address: &ContractAddress,
+) -> bool {
+    storage_key.0 >= MIN_VALUE_FOR_ALIAS_ALLOC
+        && contract_address > &MAX_NON_COMPRESSED_CONTRACT_ADDRESS
 }

--- a/crates/blockifier/src/state/stateful_compression_test.rs
+++ b/crates/blockifier/src/state/stateful_compression_test.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use assert_matches::assert_matches;
 use rstest::rstest;
@@ -17,7 +17,11 @@ use super::{
 };
 use crate::state::cached_state::{CachedState, StateMaps, StorageEntry};
 use crate::state::state_api::{State, StateReader};
-use crate::state::stateful_compression::{AliasCompressor, CompressionError};
+use crate::state::stateful_compression::{
+    predicted_alias_storage_entries,
+    AliasCompressor,
+    CompressionError,
+};
 use crate::state::stateful_compression_test_utils::decompress;
 use crate::test_utils::dict_state_reader::DictStateReader;
 use crate::test_utils::ALIAS_CONTRACT_ADDRESS;
@@ -166,6 +170,46 @@ fn test_iterate_aliases() {
         .into_iter()
         .collect()
     );
+}
+
+/// Locks `predicted_alias_storage_entries` to the actual access pattern of
+/// `allocate_aliases_in_storage`. With no pre-existing aliases, every predicted read becomes a
+/// write to the alias contract, so the predicted set must equal the alias-contract write set.
+#[test]
+fn test_predicted_alias_storage_entries_parity() {
+    let mut state = initial_state(0);
+    state
+        .set_storage_at(ContractAddress::from(0x201_u16), StorageKey::from(0x307_u16), Felt::ONE)
+        .unwrap();
+    state
+        .set_storage_at(ContractAddress::from(0x201_u16), StorageKey::from(0x309_u16), Felt::TWO)
+        .unwrap();
+    state
+        .set_storage_at(ContractAddress::from(0x201_u16), StorageKey::from(0x304_u16), Felt::THREE)
+        .unwrap();
+    state
+        .set_storage_at(MAX_NON_COMPRESSED_CONTRACT_ADDRESS, StorageKey::from(0x301_u16), Felt::ONE)
+        .unwrap();
+    state.get_class_hash_at(ContractAddress::from(0x202_u16)).unwrap();
+    state.set_class_hash_at(ContractAddress::from(0x202_u16), ClassHash(Felt::ONE)).unwrap();
+    state.increment_nonce(ContractAddress::from(0x200_u16)).unwrap();
+
+    let state_diff_before_alloc = state.to_state_diff().unwrap().state_maps;
+    let predicted =
+        predicted_alias_storage_entries(&state_diff_before_alloc, *ALIAS_CONTRACT_ADDRESS);
+
+    allocate_aliases_in_storage(&mut state, *ALIAS_CONTRACT_ADDRESS).unwrap();
+    let actual_alias_writes: HashSet<StorageEntry> = state
+        .to_state_diff()
+        .unwrap()
+        .state_maps
+        .storage
+        .keys()
+        .filter(|(address, _)| address == &*ALIAS_CONTRACT_ADDRESS)
+        .copied()
+        .collect();
+
+    assert_eq!(predicted, actual_alias_writes);
 }
 
 #[rstest]


### PR DESCRIPTION
Predicts the alias-contract storage entries that allocate_aliases_in_storage
would touch for a given state_diff, without running the allocation. Used by
the batcher to assemble the accessed-keys set written for OS replay.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>