### PR TITLE
blockifier: add compute_accessed_keys and AccessedKeys

### DIFF
--- a/crates/blockifier/src/state.rs
+++ b/crates/blockifier/src/state.rs
@@ -1,3 +1,4 @@
+pub mod accessed_keys;
 pub mod cached_state;
 pub mod compiled_class_hash_migration;
 pub mod contract_class_manager;

--- a/crates/blockifier/src/state/accessed_keys.rs
+++ b/crates/blockifier/src/state/accessed_keys.rs
@@ -1,0 +1,98 @@
+use std::collections::BTreeSet;
+#[cfg(any(feature = "testing", test))]
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use starknet_api::block::BlockNumber;
+use starknet_api::core::{ClassHash, ContractAddress, BLOCK_HASH_TABLE_ADDRESS};
+use starknet_api::state::StorageKey;
+
+#[cfg(any(feature = "testing", test))]
+use super::cached_state::StateChangesKeys;
+use super::cached_state::{StateMaps, StorageEntry};
+use super::stateful_compression::predicted_alias_storage_entries;
+use crate::blockifier_versioned_constants::VersionedConstants;
+use crate::transaction::objects::TransactionExecutionInfo;
+
+#[cfg(test)]
+#[path = "accessed_keys_test.rs"]
+pub mod accessed_keys_test;
+
+/// The trie-leaf input that the OS needs to read at the execution of a block.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AccessedKeys {
+    /// Storage-trie leaves: `(contract_address, storage_key)` visited during execution, written in
+    /// the state diff, the `(BLOCK_HASH_TABLE_ADDRESS, block_number)` entries for SNOS ProofFacts,
+    /// and (when enabled) the alias-contract entries that `allocate_aliases_in_storage` will
+    /// touch.
+    pub storage_keys: BTreeSet<StorageEntry>,
+    /// Contracts-trie leaves: every contract address whose leaf the OS reads (call targets,
+    /// delegate-call targets, replaced classes, contracts written in the state diff).
+    pub accessed_contracts: BTreeSet<ContractAddress>,
+    /// Contract-class-trie leaves: every class hash whose compiled-class-hash leaf the OS reads
+    /// (class hashes dispatched to, newly deployed class hashes, declarations).
+    pub accessed_class_hashes: BTreeSet<ClassHash>,
+}
+
+#[cfg(any(feature = "testing", test))]
+impl From<AccessedKeys> for StateChangesKeys {
+    fn from(accessed_keys: AccessedKeys) -> Self {
+        Self {
+            nonce_keys: HashSet::new(),
+            class_hash_keys: HashSet::new(),
+            storage_keys: accessed_keys.storage_keys.into_iter().collect(),
+            compiled_class_hash_keys: accessed_keys.accessed_class_hashes.into_iter().collect(),
+            modified_contracts: accessed_keys.accessed_contracts.into_iter().collect(),
+        }
+    }
+}
+
+impl AccessedKeys {
+    /// Builds the [`AccessedKeys`] the OS needs to read at the execution of a block.
+    pub fn new<'a>(
+        execution_infos: impl IntoIterator<Item = &'a TransactionExecutionInfo>,
+        proof_facts_block_numbers: impl IntoIterator<Item = &'a BlockNumber>,
+        state_diff: &StateMaps,
+        versioned_constants: &VersionedConstants,
+    ) -> Self {
+        let mut storage_keys: BTreeSet<StorageEntry> = BTreeSet::new();
+        let mut accessed_contracts: BTreeSet<ContractAddress> = BTreeSet::new();
+        let mut accessed_class_hashes: BTreeSet<ClassHash> = BTreeSet::new();
+
+        // Scan the call infos.
+        for execution_info in execution_infos {
+            for call_info in execution_info.non_optional_call_infos().flat_map(|ci| ci.iter()) {
+                storage_keys.extend(call_info.get_visited_storage_entries());
+                storage_keys.extend(call_info.storage_access_tracker.accessed_blocks.iter().map(
+                    |block_number| (BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(block_number.0)),
+                ));
+                accessed_contracts.extend(call_info.get_visited_contract_addresses());
+                if let Some(class_hash) = call_info.call.class_hash {
+                    accessed_class_hashes.insert(class_hash);
+                }
+            }
+        }
+
+        storage_keys.extend(state_diff.storage.keys().copied());
+        // Add the block hash table entries for the proof facts.
+        for block_number in proof_facts_block_numbers {
+            storage_keys.insert((BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(block_number.0)));
+        }
+        // Add the alias contract entries when stateful compression is enabled (matching the
+        // condition under which `allocate_aliases_in_storage` runs in finalization).
+        if versioned_constants.enable_stateful_compression {
+            let alias_contract_address =
+                versioned_constants.os_constants.os_contract_addresses.alias_contract_address();
+            storage_keys
+                .extend(predicted_alias_storage_entries(state_diff, alias_contract_address));
+        }
+
+        accessed_contracts.extend(storage_keys.iter().map(|(address, _)| *address));
+        accessed_contracts.extend(state_diff.get_contract_addresses());
+
+        accessed_class_hashes.extend(state_diff.class_hashes.values().copied());
+        accessed_class_hashes.extend(state_diff.compiled_class_hashes.keys().copied());
+
+        Self { storage_keys, accessed_contracts, accessed_class_hashes }
+    }
+}

--- a/crates/blockifier/src/state/accessed_keys_test.rs
+++ b/crates/blockifier/src/state/accessed_keys_test.rs
@@ -1,0 +1,190 @@
+use std::collections::BTreeSet;
+
+use starknet_api::block::BlockNumber;
+use starknet_api::core::{ContractAddress, Nonce, BLOCK_HASH_TABLE_ADDRESS};
+use starknet_api::state::StorageKey;
+use starknet_types_core::felt::Felt;
+
+use super::AccessedKeys;
+use crate::blockifier_versioned_constants::VersionedConstants;
+use crate::execution::call_info::{CallInfo, StorageAccessTracker};
+use crate::execution::entry_point::CallEntryPoint;
+use crate::state::cached_state::StateMaps;
+use crate::state::stateful_compression::ALIAS_COUNTER_STORAGE_KEY;
+use crate::transaction::objects::TransactionExecutionInfo;
+
+/// Builds a `VersionedConstants` with `enable_stateful_compression` set to the given value.
+/// Other fields (including `alias_contract_address`) come from the test defaults.
+fn versioned_constants_with_compression(enable_stateful_compression: bool) -> VersionedConstants {
+    let mut versioned_constants = VersionedConstants::create_for_testing();
+    versioned_constants.enable_stateful_compression = enable_stateful_compression;
+    versioned_constants
+}
+
+fn get_alias_contract_address(versioned_constants: &VersionedConstants) -> ContractAddress {
+    versioned_constants.os_constants.os_contract_addresses.alias_contract_address()
+}
+
+fn call_info_with_storage_accesses(
+    storage_address: ContractAddress,
+    accessed_storage_keys: impl IntoIterator<Item = StorageKey>,
+) -> CallInfo {
+    CallInfo {
+        call: CallEntryPoint { storage_address, ..Default::default() },
+        storage_access_tracker: StorageAccessTracker {
+            accessed_storage_keys: accessed_storage_keys.into_iter().collect(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn no_inputs_no_alias_prediction_yields_empty_storage_keys() {
+    let accessed = AccessedKeys::new(
+        std::iter::empty::<&TransactionExecutionInfo>(),
+        std::iter::empty::<&BlockNumber>(),
+        &StateMaps::default(),
+        &versioned_constants_with_compression(false),
+    );
+    assert!(accessed.storage_keys.is_empty());
+    assert!(accessed.accessed_contracts.is_empty());
+    assert!(accessed.accessed_class_hashes.is_empty());
+}
+
+#[test]
+fn empty_inputs_with_alias_prediction_contains_counter_only() {
+    let versioned_constants = versioned_constants_with_compression(true);
+    let alias_contract_address = get_alias_contract_address(&versioned_constants);
+    let accessed = AccessedKeys::new(
+        std::iter::empty::<&TransactionExecutionInfo>(),
+        std::iter::empty::<&BlockNumber>(),
+        &StateMaps::default(),
+        &versioned_constants,
+    );
+    assert_eq!(
+        accessed.storage_keys,
+        BTreeSet::from([(alias_contract_address, ALIAS_COUNTER_STORAGE_KEY)])
+    );
+    assert_eq!(accessed.accessed_contracts, BTreeSet::from([alias_contract_address]));
+}
+
+#[test]
+fn state_diff_storage_keys_are_included() {
+    let address = ContractAddress::from(0x100_u16);
+    let storage_key = StorageKey::from(0x200_u16);
+    let mut state_diff = StateMaps::default();
+    state_diff.storage.insert((address, storage_key), Felt::ONE);
+
+    let accessed = AccessedKeys::new(
+        std::iter::empty::<&TransactionExecutionInfo>(),
+        std::iter::empty::<&BlockNumber>(),
+        &state_diff,
+        &versioned_constants_with_compression(false),
+    );
+    assert!(accessed.storage_keys.contains(&(address, storage_key)));
+    assert!(accessed.accessed_contracts.contains(&address));
+}
+
+#[test]
+fn proof_facts_block_numbers_map_to_block_hash_table_entries() {
+    let block_number_x = BlockNumber(42);
+    let block_number_y = BlockNumber(99);
+    let accessed = AccessedKeys::new(
+        std::iter::empty::<&TransactionExecutionInfo>(),
+        [&block_number_x, &block_number_y],
+        &StateMaps::default(),
+        &versioned_constants_with_compression(false),
+    );
+    assert!(
+        accessed
+            .storage_keys
+            .contains(&(BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(block_number_x.0)))
+    );
+    assert!(
+        accessed
+            .storage_keys
+            .contains(&(BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(block_number_y.0)))
+    );
+    assert!(accessed.accessed_contracts.contains(&BLOCK_HASH_TABLE_ADDRESS));
+}
+
+#[test]
+fn alias_predictions_toggle_controls_alias_contract_entries() {
+    let modified_address = ContractAddress::from(0x100_u16);
+    let mut state_diff = StateMaps::default();
+    state_diff.nonces.insert(modified_address, Nonce(Felt::ONE));
+    let versioned_constants_with = versioned_constants_with_compression(true);
+    let versioned_constants_without = versioned_constants_with_compression(false);
+    let alias_contract_address = get_alias_contract_address(&versioned_constants_with);
+
+    let with_predictions = AccessedKeys::new(
+        std::iter::empty::<&TransactionExecutionInfo>(),
+        std::iter::empty::<&BlockNumber>(),
+        &state_diff,
+        &versioned_constants_with,
+    );
+    let without_predictions = AccessedKeys::new(
+        std::iter::empty::<&TransactionExecutionInfo>(),
+        std::iter::empty::<&BlockNumber>(),
+        &state_diff,
+        &versioned_constants_without,
+    );
+    assert!(
+        with_predictions
+            .storage_keys
+            .contains(&(alias_contract_address, ALIAS_COUNTER_STORAGE_KEY))
+    );
+    assert!(
+        without_predictions
+            .storage_keys
+            .iter()
+            .all(|(address, _)| address != &alias_contract_address)
+    );
+}
+
+#[test]
+fn visited_storage_entries_from_execution_info_are_included() {
+    let storage_address = ContractAddress::from(0x300_u16);
+    let key_a = StorageKey::from(0x400_u16);
+    let key_b = StorageKey::from(0x401_u16);
+    let execution_info = TransactionExecutionInfo {
+        execute_call_info: Some(call_info_with_storage_accesses(storage_address, [key_a, key_b])),
+        ..Default::default()
+    };
+
+    let accessed = AccessedKeys::new(
+        [&execution_info],
+        std::iter::empty::<&BlockNumber>(),
+        &StateMaps::default(),
+        &versioned_constants_with_compression(false),
+    );
+    assert!(accessed.storage_keys.contains(&(storage_address, key_a)));
+    assert!(accessed.storage_keys.contains(&(storage_address, key_b)));
+    assert!(accessed.accessed_contracts.contains(&storage_address));
+}
+
+/// For a reverted invoke, `execute_call_info` is `None`; the validate and fee_transfer call infos
+/// still exist and their accessed storage keys must be collected.
+#[test]
+fn reverted_invoke_collects_validate_and_fee_transfer_entries() {
+    let validate_address = ContractAddress::from(0x500_u16);
+    let validate_key = StorageKey::from(0x501_u16);
+    let fee_address = ContractAddress::from(0x600_u16);
+    let fee_key = StorageKey::from(0x601_u16);
+    let execution_info = TransactionExecutionInfo {
+        validate_call_info: Some(call_info_with_storage_accesses(validate_address, [validate_key])),
+        execute_call_info: None,
+        fee_transfer_call_info: Some(call_info_with_storage_accesses(fee_address, [fee_key])),
+        ..Default::default()
+    };
+
+    let accessed = AccessedKeys::new(
+        [&execution_info],
+        std::iter::empty::<&BlockNumber>(),
+        &StateMaps::default(),
+        &versioned_constants_with_compression(false),
+    );
+    assert!(accessed.storage_keys.contains(&(validate_address, validate_key)));
+    assert!(accessed.storage_keys.contains(&(fee_address, fee_key)));
+}


### PR DESCRIPTION
Define the AccessedKeys aggregate (storage_keys + modified_contracts +
compiled_class_hash_keys) the OS needs to replay a block, plus
compute_accessed_keys to produce it. A single walk of the call-info tree
gathers storage entries, contracts-trie leaves, and class hashes; the
block's state diff, ProofFacts block numbers, and (optionally) predicted
alias-contract entries are folded in. From<AccessedKeys> for StateChangesKeys
adapts it to the OS commitment-keys consumer.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>