### PR TITLE
apollo_batcher: record ProofFacts block_number per tx

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -51,8 +51,9 @@ use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
+use starknet_api::rpc_transaction::InternalRpcTransactionWithoutTxHash;
 use starknet_api::state::ThinStateDiff;
-use starknet_api::transaction::fields::TransactionSignature;
+use starknet_api::transaction::fields::{ProofFactsVariant, TransactionSignature};
 use starknet_api::transaction::{TransactionHash, TransactionOffsetInBlock};
 use thiserror::Error;
 use tokio::sync::mpsc::error::TrySendError;
@@ -644,6 +645,10 @@ async fn collect_execution_results_and_stream_txs(
                     );
                 assert_eq!(duplicate_tx_hash, None, "Duplicate transaction: {tx_hash}.");
 
+                if let Some(block_number) = proof_facts_block_number(input_tx) {
+                    execution_data.proof_facts_block_numbers.insert(tx_hash, block_number);
+                }
+
                 // Skip sending the pre confirmed executed transactions, receipts and state diffs
                 // during validation flow or if the channel was closed. In validate flow
                 // pre_confirmed_tx_sender is None.
@@ -828,6 +833,10 @@ pub struct BlockTransactionExecutionData {
         IndexMap<TransactionHash, (TransactionExecutionInfo, Option<TransactionSignature>)>,
     pub rejected_tx_hashes: IndexSet<TransactionHash>,
     pub consumed_l1_handler_tx_hashes: IndexSet<TransactionHash>,
+    /// For each successfully executed proof-carrying transaction (SNIP36), maps the block hash
+    /// that the proof was verified against to its block number. Used by the batcher to derive
+    /// accessed-key entries on `BLOCK_HASH_TABLE_ADDRESS`.
+    pub proof_facts_block_numbers: IndexMap<TransactionHash, BlockNumber>,
 }
 
 impl BlockTransactionExecutionData {
@@ -837,6 +846,7 @@ impl BlockTransactionExecutionData {
             remove_last_map(&mut self.execution_infos_and_signatures, tx_hash);
             remove_last_set(&mut self.rejected_tx_hashes, tx_hash);
             remove_last_set(&mut self.consumed_l1_handler_tx_hashes, tx_hash);
+            remove_last_map(&mut self.proof_facts_block_numbers, tx_hash);
         }
     }
 
@@ -864,6 +874,17 @@ fn remove_last_map<V>(map: &mut IndexMap<TransactionHash, V>, tx_hash: &Transact
 fn remove_last_set(set: &mut IndexSet<TransactionHash>, tx_hash: &TransactionHash) {
     if let Some((idx, _)) = set.swap_remove_full(tx_hash) {
         assert_eq!(idx, set.len(), "The removed txs must be the last ones.");
+    }
+}
+
+/// If the transaction includes an SNIP36 proof, returns the block number whose state will be used
+/// to verify the proof against. Otherwise returns `None`.
+fn proof_facts_block_number(tx: &InternalConsensusTransaction) -> Option<BlockNumber> {
+    let InternalConsensusTransaction::RpcTransaction(rpc) = tx else { return None };
+    let InternalRpcTransactionWithoutTxHash::Invoke(invoke) = &rpc.tx else { return None };
+    match ProofFactsVariant::try_from(&invoke.proof_facts) {
+        Ok(ProofFactsVariant::Snos(snos)) => Some(snos.block_number),
+        Ok(ProofFactsVariant::Empty) | Err(_) => None,
     }
 }
 

--- a/crates/apollo_batcher/src/block_builder_test.rs
+++ b/crates/apollo_batcher/src/block_builder_test.rs
@@ -32,13 +32,21 @@ use mockall::predicate::eq;
 use mockall::Sequence;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
-use starknet_api::block::BlockInfo;
+use starknet_api::block::{BlockInfo, BlockNumber};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::execution_resources::{GasAmount, GasVector};
+use starknet_api::test_utils::invoke::{internal_invoke_tx, InvokeTxArgs};
 use starknet_api::test_utils::CHAIN_ID_FOR_TESTS;
-use starknet_api::transaction::fields::{Fee, TransactionSignature};
+use starknet_api::transaction::fields::{
+    Fee,
+    TransactionSignature,
+    PROOF_VERSION_V0,
+    VIRTUAL_OS_OUTPUT_VERSION,
+    VIRTUAL_SNOS,
+};
 use starknet_api::transaction::TransactionHash;
-use starknet_api::tx_hash;
+use starknet_api::{proof_facts, tx_hash};
+use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::block_builder::{
@@ -102,6 +110,7 @@ async fn block_execution_artifacts(
         execution_infos_and_signatures,
         rejected_tx_hashes,
         consumed_l1_handler_tx_hashes,
+        proof_facts_block_numbers: IndexMap::default(),
     };
     // Each mock transaction uses 1 L2 gas so the total amount should be the number of txs.
     assert_eq!(
@@ -1219,4 +1228,59 @@ async fn partial_chunk_execution_validator(#[case] successful: bool) {
             Err(BlockBuilderError::FailOnError(FailOnErrorCause::DeadlineReached))
         ));
     }
+}
+
+/// Builds an invoke transaction carrying SNOS proof facts that reference `block_number`.
+fn invoke_tx_with_snos_proof_facts(
+    tx_hash: TransactionHash,
+    block_number: BlockNumber,
+) -> InternalConsensusTransaction {
+    let program_hash = Felt::from(0xAA_u32);
+    let block_hash = Felt::from(0xBB_u32);
+    let config_hash = Felt::from(0xCC_u32);
+    let proof_facts = proof_facts![
+        PROOF_VERSION_V0,
+        VIRTUAL_SNOS,
+        program_hash,
+        VIRTUAL_OS_OUTPUT_VERSION,
+        Felt::from(block_number.0),
+        block_hash,
+        config_hash
+    ];
+    InternalConsensusTransaction::RpcTransaction(internal_invoke_tx(InvokeTxArgs {
+        tx_hash,
+        proof_facts,
+        ..Default::default()
+    }))
+}
+
+/// Verifies the execution output of proof-carrying transactions (SNIP36).
+#[tokio::test]
+async fn proof_facts_block_numbers_collected_from_snos_invokes() {
+    // The first tx carries SNOS proof facts.
+    let proof_block_number = BlockNumber(42);
+    let mut input_txs = vec![invoke_tx_with_snos_proof_facts(tx_hash!(0), proof_block_number)];
+    input_txs.extend(test_txs(1..N_CONCURRENT_TXS));
+
+    let (mock_transaction_executor, _) =
+        one_chunk_mock_executor(&input_txs, input_txs.len(), false).await;
+    let mock_tx_provider = mock_tx_provider_limitless_calls(vec![input_txs]);
+    let (_abort_sender, abort_receiver) = tokio::sync::oneshot::channel();
+
+    let result_block_artifacts = run_build_block(
+        mock_transaction_executor,
+        mock_tx_provider,
+        None,
+        false,
+        abort_receiver,
+        BLOCK_GENERATION_DEADLINE_SECS,
+        DEFAULT_IDLE_TIMEOUT_MS,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result_block_artifacts.execution_data.proof_facts_block_numbers,
+        IndexMap::from([(tx_hash!(0), proof_block_number)]),
+    );
 }

--- a/crates/apollo_batcher/src/test_utils.rs
+++ b/crates/apollo_batcher/src/test_utils.rs
@@ -194,6 +194,7 @@ impl BlockExecutionArtifacts {
             execution_infos_and_signatures: indexed_execution_infos_and_signatures(),
             rejected_tx_hashes: test_txs(10..15).iter().map(|tx| tx.tx_hash()).collect(),
             consumed_l1_handler_tx_hashes: Default::default(),
+            proof_facts_block_numbers: Default::default(),
         };
         let block_execution_summary = BlockExecutionSummary {
             state_diff: CommitmentStateDiff {


### PR DESCRIPTION
For each successfully-executed tx carrying non-empty SNOS proof facts, store
the (tx_hash -> block_number) pair on BlockTransactionExecutionData. The
batcher will fold these into the BLOCK_HASH_TABLE_ADDRESS entries it writes
to the accessed-key set. Rollback flows alongside execution_infos via
remove_last_txs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>