### PR TITLE
starknet_os_flow_tests: drive commitment keys from compute_accessed_keys

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -53,7 +53,7 @@ use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::InternalRpcTransactionWithoutTxHash;
 use starknet_api::state::ThinStateDiff;
-use starknet_api::transaction::fields::{ProofFactsVariant, TransactionSignature};
+use starknet_api::transaction::fields::{snos_block_number_from_proof_facts, TransactionSignature};
 use starknet_api::transaction::{TransactionHash, TransactionOffsetInBlock};
 use thiserror::Error;
 use tokio::sync::mpsc::error::TrySendError;
@@ -882,10 +882,7 @@ fn remove_last_set(set: &mut IndexSet<TransactionHash>, tx_hash: &TransactionHas
 fn proof_facts_block_number(tx: &InternalConsensusTransaction) -> Option<BlockNumber> {
     let InternalConsensusTransaction::RpcTransaction(rpc) = tx else { return None };
     let InternalRpcTransactionWithoutTxHash::Invoke(invoke) = &rpc.tx else { return None };
-    match ProofFactsVariant::try_from(&invoke.proof_facts) {
-        Ok(ProofFactsVariant::Snos(snos)) => Some(snos.block_number),
-        Ok(ProofFactsVariant::Empty) | Err(_) => None,
-    }
+    snos_block_number_from_proof_facts(&invoke.proof_facts)
 }
 
 fn record_and_log_block_commitment_measurements(

--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -817,6 +817,15 @@ impl TryFrom<ProofFacts> for SnosProofFacts {
     }
 }
 
+/// If `proof facts` is parsed as valid SNOS data, returns the base block number used to verify the
+/// proof. Otherwise returns `None`.
+pub fn snos_block_number_from_proof_facts(proof_facts: &ProofFacts) -> Option<BlockNumber> {
+    match ProofFactsVariant::try_from(proof_facts) {
+        Ok(ProofFactsVariant::Snos(snos)) => Some(snos.block_number),
+        Ok(ProofFactsVariant::Empty) | Err(_) => None,
+    }
+}
+
 /// Client-provided proof used for client-side proving.
 /// Serialized as a base64 string of big-endian u32 bytes.
 #[derive(

--- a/crates/starknet_os_flow_tests/src/test_manager.rs
+++ b/crates/starknet_os_flow_tests/src/test_manager.rs
@@ -1,15 +1,21 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 use blockifier::blockifier_versioned_constants::VersionedConstants;
 use blockifier::bouncer::BouncerConfig;
 use blockifier::context::{BlockContext, ChainInfo, FeeTokenAddresses};
+use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::{CachedState, StateMaps};
 use blockifier::state::state_api::{StateReader, UpdatableState};
 use blockifier::state::stateful_compression_test_utils::decompress;
 use blockifier::test_utils::dict_state_reader::DictStateReader;
 use blockifier::test_utils::ALIAS_CONTRACT_ADDRESS;
-use blockifier::transaction::objects::TransactionExecutionInfo;
+use blockifier::transaction::objects::{
+    TransactionExecutionInfo,
+    TransactionInfo,
+    TransactionInfoCreator,
+};
 use blockifier::transaction::transaction_execution::Transaction as BlockifierTransaction;
 use blockifier_test_utils::calldata::create_calldata;
 use blockifier_test_utils::contracts::FeatureContract;
@@ -47,7 +53,7 @@ use starknet_api::state::{SierraContractClass, StorageKey};
 use starknet_api::test_utils::invoke::{invoke_tx, InvokeTxArgs};
 use starknet_api::test_utils::{NonceManager, CHAIN_ID_FOR_TESTS, TEST_SEQUENCER_ADDRESS};
 use starknet_api::transaction::constants::TRANSFER_EVENT_NAME;
-use starknet_api::transaction::fields::{Calldata, Fee, Tip};
+use starknet_api::transaction::fields::{snos_block_number_from_proof_facts, Calldata, Fee, Tip};
 use starknet_api::transaction::{Event, L1HandlerTransaction, L1ToL2Payload, MessageToL1};
 use starknet_committer::block_committer::input::{
     IsSubset,
@@ -72,6 +78,7 @@ use starknet_os::runner::{run_os_stateless, DEFAULT_OS_LAYOUT};
 use starknet_os::test_utils::coverage::expect_hint_coverage;
 use starknet_transaction_prover::running::committer_utils::{
     commit_state_diff,
+    commitment_state_diff_to_committer_state_diff,
     state_maps_to_committer_state_diff,
 };
 use starknet_types_core::felt::Felt;
@@ -858,7 +865,7 @@ impl<S: FlowTestState> TestBuilder<S> {
                 execute_transactions::<CachedState<S>>(
                     state,
                     &block_txs,
-                    block_context,
+                    block_context.clone(),
                     self.virtual_os,
                 );
             Self::verify_execution_outputs(
@@ -868,12 +875,35 @@ impl<S: FlowTestState> TestBuilder<S> {
                 &execution_outputs,
             );
             let initial_reads = get_extended_initial_reads(&final_state);
-            // Update the wrapped state.
             let state_diff = final_state.to_state_diff().unwrap().state_maps;
+            // Update the wrapped state.
             state = final_state.state;
             state.apply_writes(&state_diff, &final_state.class_hash_to_class.borrow());
+
+            // Derive the OS commitment-keys from the same accessed-keys the batcher produces —
+            // validating end-to-end that what the batcher persists is sufficient for the OS to
+            // replay the block.
+            // In virtual-OS mode, the executor skips allocating aliases, so we own a copy of the
+            // versioned constants with `enable_stateful_compression` forced off.
+            let accessed_keys_versioned_constants: Cow<'_, VersionedConstants> = if self.virtual_os
+            {
+                let mut vc = block_context.versioned_constants().clone();
+                vc.enable_stateful_compression = false;
+                Cow::Owned(vc)
+            } else {
+                Cow::Borrowed(block_context.versioned_constants())
+            };
+            let proof_facts_block_numbers = collect_proof_facts_block_numbers(&block_txs);
+            let commitment_state_diff = state_diff.into();
+            let accessed_keys = AccessedKeys::new(
+                execution_outputs.iter().map(|(info, _)| info),
+                &proof_facts_block_numbers,
+                &commitment_state_diff,
+                &accessed_keys_versioned_constants,
+            );
             // Commit the state diff.
-            let committer_state_diff = state_maps_to_committer_state_diff(state_diff);
+            let committer_state_diff =
+                commitment_state_diff_to_committer_state_diff(commitment_state_diff);
             let mut db = FactsDb::new(map_storage);
             let new_state_roots = commit_state_diff(
                 &mut db,
@@ -885,12 +915,11 @@ impl<S: FlowTestState> TestBuilder<S> {
             .expect("Failed to commit state diff.");
             map_storage = db.consume_storage();
 
-            // Prepare the OS input.
             let commitment_infos = StateCommitmentInfos::new(
                 &previous_state_roots,
                 &new_state_roots,
                 &mut map_storage,
-                &initial_reads.keys(),
+                &accessed_keys.into(),
             )
             .await
             .unwrap();
@@ -1001,6 +1030,21 @@ impl TestBuilder<DictStateReader> {
         );
         Self::new_with_initial_state_data(initial_state_data, config, true)
     }
+}
+
+/// Extracts the block numbers stored in each tx's SNOS proof facts. Empty / malformed proof facts
+/// and non-account transactions yield no entry. Mirrors the production extraction performed in the
+/// batcher's block_builder.
+fn collect_proof_facts_block_numbers(block_txs: &[BlockifierTransaction]) -> Vec<BlockNumber> {
+    block_txs
+        .iter()
+        .filter_map(|tx| match tx.create_tx_info() {
+            TransactionInfo::Current(current) => {
+                snos_block_number_from_proof_facts(&current.proof_facts)
+            }
+            TransactionInfo::Deprecated(_) => None,
+        })
+        .collect()
 }
 
 /// Returns a BlockContext of the given block number with the with the STRK fee token address that

--- a/crates/starknet_transaction_prover/src/running/committer_utils.rs
+++ b/crates/starknet_transaction_prover/src/running/committer_utils.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::hash::BuildHasher;
 
-use blockifier::state::cached_state::{StateMaps, StorageDiff, StorageView};
+use blockifier::state::cached_state::{CommitmentStateDiff, StateMaps, StorageDiff, StorageView};
 use indexmap::IndexMap;
 use starknet_api::core::{ClassHash, Nonce};
 use starknet_api::hash::{HashOutput, StateRoots};
@@ -46,6 +46,36 @@ pub fn state_maps_to_committer_state_diff(state_maps: StateMaps) -> StateDiff {
             })
             .collect(),
         storage_updates: StorageDiff::from(StorageView(state_maps.storage))
+            .into_iter()
+            .map(|(address, updates)| {
+                (
+                    address,
+                    updates
+                        .into_iter()
+                        .map(|(key, value)| (StarknetStorageKey(key), StarknetStorageValue(value)))
+                        .collect(),
+                )
+            })
+            .collect(),
+    }
+}
+
+/// Converts blockifier's CommitmentStateDiff to committer's StateDiff format.
+pub fn commitment_state_diff_to_committer_state_diff(
+    commitment_state_diff: CommitmentStateDiff,
+) -> StateDiff {
+    StateDiff {
+        address_to_class_hash: commitment_state_diff.address_to_class_hash.into_iter().collect(),
+        address_to_nonce: commitment_state_diff.address_to_nonce.into_iter().collect(),
+        class_hash_to_compiled_class_hash: commitment_state_diff
+            .class_hash_to_compiled_class_hash
+            .into_iter()
+            .map(|(class_hash, compiled_class_hash)| {
+                (class_hash, CompiledClassHash(compiled_class_hash.0))
+            })
+            .collect(),
+        storage_updates: commitment_state_diff
+            .storage_updates
             .into_iter()
             .map(|(address, updates)| {
                 (


### PR DESCRIPTION
Replace the legacy initial_reads.keys() input to StateCommitmentInfos::new
with the same accessed-keys aggregate the batcher writes — validating
end-to-end that what the batcher persists is sufficient for the OS to
replay the block. ProofFacts block numbers are extracted from the block's
BlockifierTransactions (via create_tx_info -> Current -> proof_facts ->
ProofFactsVariant::Snos) and passed through to compute_accessed_keys.
Virtual-OS mode skips the alias-contract entries since the executor doesn't
run allocate_aliases_in_storage there. The resulting StateChangesKeys is
built via From<AccessedKeys>.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>