### PR TITLE
starknet_transaction_prover: delete dead code

### DIFF
--- a/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
+++ b/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
@@ -136,13 +136,6 @@ impl<R: VirtualSnosRunner + 'static> VirtualSnosProver<R> {
         }
     }
 
-    /// Disables fee-field validation (resource bounds, tip).
-    #[allow(dead_code)]
-    pub(crate) fn disable_fee_validation(mut self) -> Self {
-        self.validate_zero_fee_fields = false;
-        self
-    }
-
     /// Proves a transaction on top of the specified block.
     ///
     /// This method:


### PR DESCRIPTION
## Description

Remove the `disable_fee_validation()` builder method from `VirtualSnosProver` in `crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs`.

The method was annotated with `#[allow(dead_code)]` and has zero callers anywhere in the codebase. The same effect (disabling fee-field validation) is achievable through the existing `validate_zero_fee_fields` config field, which is already wired through the config system and CLI flags.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G59fSPfUm7ZD91gXqN4GJW)_