### PR TITLE
apollo_dashboard: fix observer filter broken for aggregated alert expressions

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -18,7 +18,7 @@
       "name": "batched_transactions_stuck",
       "title": "Batched Transactions Stuck",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck-sampling_window_secs-expression$$$s])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck-sampling_window_secs-expression$$$s])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -44,7 +44,7 @@
       "name": "batched_transactions_stuck_long_time",
       "title": "Batched Transactions Stuck Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck_long_time-sampling_window_secs-expression$$$s])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck_long_time-sampling_window_secs-expression$$$s])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -70,7 +70,7 @@
       "name": "batcher_l1_events_provider_errors",
       "title": "Batcher L1 events provider errors",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(batcher_l1_events_provider_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(batcher_l1_events_provider_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -122,7 +122,7 @@
       "name": "batcher_storage_open_read_transactions",
       "title": "batcher - High number of open read transactions",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(max_over_time(batcher_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(max_over_time(batcher_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -148,7 +148,7 @@
       "name": "cende_write_blob_failure",
       "title": "Cende write blob failure",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -174,7 +174,7 @@
       "name": "cende_write_blob_failure_once",
       "title": "Cende write blob failure once",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(cende_write_blob_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -200,7 +200,7 @@
       "name": "cende_write_prev_height_blob_latency_too_high",
       "title": "Cende write prev height blob latency too high",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "((sum(rate(cende_write_prev_height_blob_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) / clamp_min(sum(rate(cende_write_prev_height_blob_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0), 0.0000001)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(rate(cende_write_prev_height_blob_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) / clamp_min(sum(rate(cende_write_prev_height_blob_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0), 0.0000001)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -252,7 +252,7 @@
       "name": "class_manager_storage_open_read_transactions",
       "title": "class_manager - High number of open read transactions",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(max_over_time(class_manager_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(max_over_time(class_manager_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -330,7 +330,7 @@
       "name": "config_manager_update_error_increase",
       "title": "Config manager update error increase",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(config_manager_update_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(config_manager_update_errors{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -382,7 +382,7 @@
       "name": "consensus_block_number_stuck",
       "title": "Consensus Block Number Stuck",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -408,7 +408,7 @@
       "name": "consensus_block_number_stuck_long_time",
       "title": "Consensus Block Number Stuck Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -434,7 +434,7 @@
       "name": "consensus_conflicting_votes",
       "title": "Consensus conflicting votes",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_conflicting_votes{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_conflicting_votes{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -460,7 +460,7 @@
       "name": "consensus_decisions_reached_by_consensus_ratio",
       "title": "Consensus decisions reached by consensus ratio",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "((sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) / clamp_min((sum(increase(consensus_decisions_reached_by_sync{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) + (sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)), 1)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) / clamp_min((sum(increase(consensus_decisions_reached_by_sync{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) + (sum(increase(consensus_decisions_reached_by_consensus{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)), 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -486,7 +486,7 @@
       "name": "consensus_inbound_peer_evicted",
       "title": "Consensus inbound peer evicted",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_inbound_peer_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_inbound_peer_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -512,7 +512,7 @@
       "name": "consensus_inbound_stream_buffer_full",
       "title": "Consensus inbound stream buffer full",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_inbound_stream_buffer_full{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_inbound_stream_buffer_full{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -538,7 +538,7 @@
       "name": "consensus_inbound_stream_evicted",
       "title": "Consensus inbound stream evicted",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_inbound_stream_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_inbound_stream_evicted{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -564,7 +564,7 @@
       "name": "consensus_l1_gas_price_provider_failure",
       "title": "Consensus L1 gas price provider failure",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -590,7 +590,7 @@
       "name": "consensus_l1_gas_price_provider_failure_once",
       "title": "Consensus L1 gas price provider failure once",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_l1_gas_price_provider_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -720,7 +720,7 @@
       "name": "consensus_proposal_fin_mismatch_once",
       "title": "Consensus proposal fin mismatch occurred",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_proposal_fin_mismatch{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_proposal_fin_mismatch{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -772,7 +772,7 @@
       "name": "consensus_round_above_zero",
       "title": "Consensus round above zero",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -798,7 +798,7 @@
       "name": "consensus_round_above_zero_multiple_times",
       "title": "Consensus round above zero multiple times",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_round_above_zero_multiple_times-sampling_window_secs-expression$$$s])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(consensus_round_above_zero{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_round_above_zero_multiple_times-sampling_window_secs-expression$$$s])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -824,7 +824,7 @@
       "name": "consensus_round_high",
       "title": "Consensus round high",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(max_over_time(consensus_round{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(max_over_time(consensus_round{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -850,7 +850,7 @@
       "name": "consensus_votes_num_sent_messages",
       "title": "Consensus votes num sent messages",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(apollo_consensus_votes_num_sent_messages{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(apollo_consensus_votes_num_sent_messages{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -876,7 +876,7 @@
       "name": "eth_to_strk_error_count",
       "title": "Eth to Strk error count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(eth_to_strk_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(eth_to_strk_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -902,7 +902,7 @@
       "name": "eth_to_strk_success_count",
       "title": "Eth to Strk success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -928,7 +928,7 @@
       "name": "gateway_add_tx_idle_p2p_rpc",
       "title": "Gateway add_tx idle (p2p+rpc)",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -954,7 +954,7 @@
       "name": "gateway_low_successful_transaction_rate",
       "title": "gateway low successful transaction rate",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(gateway_transactions_sent_to_mempool{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(gateway_transactions_sent_to_mempool{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -980,7 +980,7 @@
       "name": "gateway_proof_archive_write_failure",
       "title": "Gateway proof archive (GCS) write failure",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(gateway_proof_archive_write_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(gateway_proof_archive_write_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1032,7 +1032,7 @@
       "name": "high_empty_blocks_ratio",
       "title": "High ratio of empty blocks",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(batcher_num_transaction_in_block_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"0.001\"}[$$$high_empty_blocks_ratio-zero_bucket-sampling_window_secs-expression$$$s])) / clamp_min(sum(increase(batcher_num_transaction_in_block_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$high_empty_blocks_ratio-total_count-sampling_window_secs-expression$$$s])), 1)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(batcher_num_transaction_in_block_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"0.001\"}[$$$high_empty_blocks_ratio-zero_bucket-sampling_window_secs-expression$$$s])) / clamp_min(sum(increase(batcher_num_transaction_in_block_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$high_empty_blocks_ratio-total_count-sampling_window_secs-expression$$$s])), 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1058,7 +1058,7 @@
       "name": "http_server_avg_add_tx_latency",
       "title": "High HTTP server average add_tx latency",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(rate(http_server_add_tx_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]) / clamp_min(rate(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]), 1/300)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(rate(http_server_add_tx_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]) / clamp_min(rate(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m]), 1/300)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1084,7 +1084,7 @@
       "name": "http_server_high_deprecated_transaction_failure_ratio",
       "title": "http server high deprecated transaction failure ratio",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1110,7 +1110,7 @@
       "name": "http_server_high_transaction_failure_ratio",
       "title": "http server high transaction failure ratio",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "((increase(http_server_added_transactions_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) - increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((increase(http_server_added_transactions_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) - increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1136,7 +1136,7 @@
       "name": "http_server_internal_error_once",
       "title": "http server internal error once",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[20m]) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1162,7 +1162,7 @@
       "name": "http_server_internal_error_ratio",
       "title": "http server internal error ratio",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(http_server_added_transactions_internal_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1188,7 +1188,7 @@
       "name": "http_server_min_add_tx_latency",
       "title": "High HTTP server minimal add_tx latency",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "((sum(increase(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) > 0) * (sum(increase(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"1.0\"}[2m])) < 1)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(http_server_add_tx_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) > 0) * (sum(increase(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", le=\"1.0\"}[2m])) < 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1214,7 +1214,7 @@
       "name": "http_server_no_successful_transactions",
       "title": "http server no successful transactions",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1240,7 +1240,7 @@
       "name": "http_server_p95_add_tx_latency",
       "title": "High HTTP server P95 add_tx latency",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(histogram_quantile(0.95, sum(rate(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) by (le))) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(histogram_quantile(0.95, sum(rate(http_server_add_tx_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) by (le))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1292,7 +1292,7 @@
       "name": "l1_gas_price_provider_insufficient_history",
       "title": "L1 gas price provider insufficient history",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(l1_gas_price_provider_insufficient_history{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(l1_gas_price_provider_insufficient_history{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1344,7 +1344,7 @@
       "name": "l1_gas_price_scraper_baselayer_error_count",
       "title": "L1 gas price scraper baselayer error count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(l1_gas_price_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(l1_gas_price_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1370,7 +1370,7 @@
       "name": "l1_gas_price_scraper_reorg_detected",
       "title": "L1 gas price scraper reorg detected",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(l1_gas_price_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(l1_gas_price_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1396,7 +1396,7 @@
       "name": "l1_gas_price_scraper_success_count",
       "title": "L1 gas price scraper success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1422,7 +1422,7 @@
       "name": "l1_message_no_successes",
       "title": "L1 message no successes",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1448,7 +1448,7 @@
       "name": "l1_message_scraper_baselayer_error_count",
       "title": "L1 message scraper baselayer error count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(l1_message_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(l1_message_scraper_baselayer_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1474,7 +1474,7 @@
       "name": "l1_message_scraper_reorg_detected",
       "title": "L1 message scraper reorg detected",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(l1_message_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(l1_message_scraper_reorg_detected{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1500,7 +1500,7 @@
       "name": "mempool_add_tx_idle_p2p_rpc",
       "title": "Mempool add_tx idle (p2p+rpc)",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1526,7 +1526,7 @@
       "name": "mempool_evictions_count",
       "title": "Mempool evictions count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\", drop_reason=\"evicted\"}) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\", drop_reason=\"evicted\"}) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1552,7 +1552,7 @@
       "name": "mempool_p2p_disconnections",
       "title": "Mempool p2p disconnections",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "((sum(changes(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) / 2) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(changes(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) / 2) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1578,7 +1578,7 @@
       "name": "mempool_p2p_peer_down",
       "title": "Mempool p2p peer down",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(max_over_time(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(max_over_time(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1630,7 +1630,7 @@
       "name": "mempool_pool_size_increase",
       "title": "Mempool pool size increase",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(mempool_pool_size{cluster=~\"$cluster\", namespace=~\"$namespace\"}) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(mempool_pool_size{cluster=~\"$cluster\", namespace=~\"$namespace\"}) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1682,7 +1682,7 @@
       "name": "mempool_transaction_drop_ratio",
       "title": "Mempool transaction drop ratio",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]) / clamp_min(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]), 1)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(mempool_transactions_dropped{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]) / clamp_min(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[10m]), 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1708,7 +1708,7 @@
       "name": "native_compilation_error",
       "title": "Native compilation alert",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(native_compilation_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(native_compilation_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1864,7 +1864,7 @@
       "name": "preconfirmed_block_not_written",
       "title": "Preconfirmed block not written",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1942,7 +1942,7 @@
       "name": "staking_epoch_id_mismatch",
       "title": "Staking epoch ID mismatch between nodes",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(max(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"}) - min(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"})) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(max(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"}) - min(staking_current_epoch_id{cluster=~\"$cluster\", namespace=~\"$namespace\"})) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1968,7 +1968,7 @@
       "name": "state_sync_lag",
       "title": "State sync lag",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"} - apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(apollo_central_sync_central_block_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"} - apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -2072,7 +2072,7 @@
       "name": "sync_storage_open_read_transactions",
       "title": "sync - High number of open read transactions",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(max_over_time(sync_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(max_over_time(sync_storage_open_read_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -2098,7 +2098,7 @@
       "name": "pod_state_not_ready",
       "title": "Pod status Not Ready",
       "ruleGroup": "evaluation_rate_high",
-      "expr": "(sum by (service_name) (label_replace(kube_pod_container_status_ready{cluster=~\"$cluster\", namespace=~\"$namespace\"}, \"service_name\", \"$1\", \"pod\", \"^sequencer-(.+)-(?:deployment|statefulset)-[a-z0-9]+(?:-[a-z0-9]+)?$\"))) and (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum by (service_name) (label_replace(kube_pod_container_status_ready{cluster=~\"$cluster\", namespace=~\"$namespace\"}, \"service_name\", \"$1\", \"pod\", \"^sequencer-(.+)-(?:deployment|statefulset)-[a-z0-9]+(?:-[a-z0-9]+)?$\"))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alerts.rs
+++ b/crates/apollo_dashboard/src/alerts.rs
@@ -277,7 +277,9 @@ impl Alert {
             ObserverApplicability::Applicable => expr,
             ObserverApplicability::NotApplicable => {
                 ExpressionOrExpressionWithPlaceholder::ConcreteValue(format!(
-                    "({}) and ({} == 0)",
+                    // `and on()` ignores label sets so the unlabeled scalar produced by
+                    // aggregations like sum() still matches the pod-labeled is_observer series.
+                    "({}) and on() ({} == 0)",
                     expr.to_alert_promql(),
                     IS_OBSERVER.get_name_with_filter(),
                 ))

--- a/crates/apollo_dashboard/src/dashboard_test.rs
+++ b/crates/apollo_dashboard/src/dashboard_test.rs
@@ -60,7 +60,7 @@ fn serialize_alert_not_applicable_to_observer_appends_is_observer_filter() {
 
     let serialized = serde_json::to_value(&alert).unwrap();
     // Expr should be wrapped in parentheses for PromQL precedence (`and` binds tighter than `or`).
-    let expected_expr = "(foo or vector(0)) and (is_observer{cluster=~\"$cluster\", \
+    let expected_expr = "(foo or vector(0)) and on() (is_observer{cluster=~\"$cluster\", \
                          namespace=~\"$namespace\"} == 0)";
     assert_eq!(serialized["expr"], expected_expr);
 }


### PR DESCRIPTION
## Summary
- All alert expressions using `sum()` (or other aggregations that strip labels) produce an unlabeled result `{}`. The existing `and (is_observer{cluster, namespace} == 0)` clause uses PromQL's default `and` which requires matching label sets — `{}` never matches `{cluster, namespace, pod, ...}`, so these expressions always return empty and the alerts **never fire**.
- Verified with a production Prometheus query using `kube_pod_container_status_ready` as a stand-in (same label shape as `is_observer`): `sum(...) and (kube_pod_container_status_ready == 1)` returns No data while `sum(...) and on() (kube_pod_container_status_ready == 1)` returns the correct value.
- Fix: use `and on()` (empty `on` clause) which ignores label sets, effectively checking "there exists at least one non-observer pod" without requiring label alignment.
- Affects all ~20 `ObserverApplicability::NotApplicable` alerts.

## Test plan
- [ ] `cargo test -p apollo_dashboard` passes
- [ ] Dashboard JSON regenerated via `sequencer_dashboard_generator`
- [ ] Verify in Grafana Explore that `sum(...) and on() (is_observer{...} == 0)` returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)