### PR TITLE
apollo_dashboard: aggregate l1/eth-to-strk success-count alerts to fix pod-restart firing

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -902,7 +902,7 @@
       "name": "eth_to_strk_success_count",
       "title": "Eth to Strk success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1422,7 +1422,7 @@
       "name": "l1_message_no_successes",
       "title": "L1 message no successes",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -23,7 +23,10 @@ pub(crate) fn get_eth_to_strk_success_count_alert() -> Alert {
         ALERT_NAME,
         "Eth to Strk success count",
         EvaluationRate::Default,
-        format!("increase({}[1h])", ETH_TO_STRK_SUCCESS_COUNT.get_name_with_filter()),
+        format!(
+            "sum(increase({}[1h])) or vector(0)",
+            ETH_TO_STRK_SUCCESS_COUNT.get_name_with_filter()
+        ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
@@ -18,7 +18,10 @@ pub(crate) fn get_l1_message_scraper_no_successes_alert() -> Alert {
         ALERT_NAME,
         "L1 message no successes",
         EvaluationRate::Default,
-        format!("increase({}[5m])", L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
+        format!(
+            "sum(increase({}[5m])) or vector(0)",
+            L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()
+        ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),


### PR DESCRIPTION
The `l1_message_no_successes` and `eth_to_strk_success_count` alerts fire on
every L1 pod restart, producing noise that hides real failures. Stop the
false-positive firing without weakening the underlying invariant.

- `crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs`: wrap
  `l1_message_no_successes` expression in `sum(...) or vector(0)`.
- `crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs`: same for
  `eth_to_strk_success_count`.
- `crates/apollo_dashboard/resources/dev_grafana_alerts.json`: regenerated
  fixture to match (edited by hand — `cargo run --bin
  sequencer_dashboard_generator -q` should be re-run locally to confirm
  byte-equality).

- **Why the alerts fire on restart.** The user's initial theory was that
  `increase()` counts the counter's drop to zero as a negative that cancels
  the prior increases. That's wrong on the mechanism: Prometheus' `increase()`
  does compensate for counter resets within a single series. The real cause
  is that the L1 service is a Deployment with `replicas: 1` and
  `statefulSet.enabled: false`, so a restart creates a new pod name → a new
  Prometheus series whose counter sits at 0 until the scraper finishes
  `fetch_start_block` → `get_last_historic_l2_height` → `initialize` → first
  `polling_interval_seconds` (30s default) → first `SUCCESS_COUNT.increment`.
  During that gap, the new per-pod series has `increase[5m] = 0 < 1.0` and
  alerts fire for that series.

- **Fix chosen: `sum(...) or vector(0)`.** Aggregating across series folds the
  old pod's pre-restart successes and the new pod's eventual successes into
  the same scalar, so the gap disappears as long as `initialize()` finishes
  inside the window. Matches the pattern already used by
  `l1_message_scraper_baselayer_error_count` and other non-observer-applicable
  alerts in this crate.

- **Alternatives considered.**
  (a) Switch to `time() - max(last_over_time(<LAST_SUCCESS_TIMESTAMP>[12h]))
      > threshold` — semantically the cleanest fit ("no success in N
      seconds") and reuses the gauge the dashboard panel already plots.
      Rejected for this PR to keep the diff small and the alert shape
      consistent with the rest of the file; worth a follow-up.
  (b) Increase `pending_duration` past the expected startup time. Rejected
      because we don't have a reliable upper bound on `initialize()`
      duration, and it just delays — doesn't eliminate — the false fire.

- **`and (is_observer == 0)` label-mismatch concern.** While investigating, I
  noted that the observer-filter clause introduced in #13938 wraps with
  `and (...)`, which requires exact label-set match — and `is_observer` is
  only emitted by the Core pod, not the L1 pod. That would have silently
  prevented these alerts from ever firing in the first place. Matan Lior
  already fixed this in #14114 by switching to `and on()`, so the change in
  this PR is safe to land on top.

- **`l1_gas_price_scraper_success_count` left untouched.** It has the same
  raw `increase(...[1h])` shape as the two fixed here and the same exposure,
  but it was outside the scope the user asked for. Flagged for a follow-up.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>