### PR TITLE
apollo_dashboard: aggregate l1_gas_price_scraper_success_count alert to fix pod-restart firing

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1396,7 +1396,7 @@
       "name": "l1_gas_price_scraper_success_count",
       "title": "L1 gas price scraper success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(l1_gas_price_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -41,7 +41,10 @@ pub(crate) fn get_l1_gas_price_scraper_success_count_alert() -> Alert {
         ALERT_NAME,
         "L1 gas price scraper success count",
         EvaluationRate::Default,
-        format!("increase({}[1h])", L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
+        format!(
+            "sum(increase({}[1h])) or vector(0)",
+            L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()
+        ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),


### PR DESCRIPTION
Same restart-firing issue as the parent PR but for the
l1_gas_price_scraper_success_count alert: a Deployment-style restart spawns
a new pod with a new name, and Prometheus sees a fresh per-pod series whose
counter sits at 0 until the gas-price scraper completes its startup and lands
its first successful scrape. During that gap, increase(metric[1h]) on the new
series returns 0 < 1.0 and the alert fires.

Apply the same `sum(...) or vector(0)` wrapping introduced in the parent PR
for the L1 message and ETH->STRK alerts, so the old pod's pre-restart
successes are aggregated with the new pod's eventual successes into a single
scalar.

- `crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs`: wrap
  `l1_gas_price_scraper_success_count` expression in `sum(...) or vector(0)`.
- `crates/apollo_dashboard/resources/dev_grafana_alerts.json`: fixture
  updated by hand to match — re-run
  `cargo run --bin sequencer_dashboard_generator -q` locally before pushing.

- Flagged for follow-up in the parent PR's commit message. Bringing it onto
  the same stack so reviewers see all three success-count alerts treated
  consistently.
- Same alternatives (last_over_time on the gauge, larger pending_duration)
  considered and rejected for the same reasons as the parent PR.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>