### PR TITLE
apollo_infra_utils: tighten is_port_in_use to match real bind semantics

### DIFF
--- a/crates/apollo_infra_utils/src/test_utils.rs
+++ b/crates/apollo_infra_utils/src/test_utils.rs
@@ -110,13 +110,14 @@ impl AvailablePorts {
     }
 }
 
-// Checks if a port is occupied, without side effects.
+// Checks if a port is occupied, without side effects. Mirrors the real bind semantics used by
+// node components (wildcard address, no SO_REUSEADDR) so that the probe rejects ports a real
+// bind would also reject — including TIME_WAIT sockets and wildcard listeners on other
+// interfaces, which a `127.0.0.1` + SO_REUSEADDR probe would miss.
 fn is_port_in_use(port: u16) -> bool {
-    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
+    let addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), port);
     let socket =
         Socket::new(Domain::IPV4, Type::STREAM, None).expect("Should be able to create a socket.");
-    // Enable SO_REUSEADDR, which enables later binding to the address
-    socket.set_reuse_address(true).expect("Should be able to set socket properties.");
     socket.bind(&addr.into()).is_err()
 }
 


### PR DESCRIPTION
The port-availability probe in AvailablePorts::get_next_port bound to
127.0.0.1:port with SO_REUSEADDR=true, while node components (e.g.
MonitoringEndpoint) bind to 0.0.0.0:port without SO_REUSEADDR. Two
mismatches let a port slip past the probe but fail the real bind:

1. SO_REUSEADDR allows binding over TIME_WAIT sockets - the probe
   succeeds, the real bind 30s later does not.
2. A wildcard listener on another interface collides with the real
   0.0.0.0 bind but not with the 127.0.0.1 probe.

Match the probe to the real bind: 0.0.0.0:port, no SO_REUSEADDR.

Observed as a flaky integration_test_revert_flow: node 2's
MonitoringEndpoint panicked with AddrInUse on 0.0.0.0:36440, and the
harness then waited the full 2500x100ms aliveness window before failing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>