### PR TITLE
blockifier: take CommitmentStateDiff in AccessedKeys::new and predicted_alias_storage_entries

### DIFF
--- a/crates/blockifier/src/state/accessed_keys.rs
+++ b/crates/blockifier/src/state/accessed_keys.rs
@@ -9,7 +9,7 @@ use starknet_api::state::StorageKey;
 
 #[cfg(any(feature = "testing", test))]
 use super::cached_state::StateChangesKeys;
-use super::cached_state::{StateMaps, StorageEntry};
+use super::cached_state::{CommitmentStateDiff, StorageEntry};
 use super::stateful_compression::predicted_alias_storage_entries;
 use crate::blockifier_versioned_constants::VersionedConstants;
 use crate::transaction::objects::TransactionExecutionInfo;
@@ -52,7 +52,7 @@ impl AccessedKeys {
     pub fn new<'a>(
         execution_infos: impl IntoIterator<Item = &'a TransactionExecutionInfo>,
         proof_facts_block_numbers: impl IntoIterator<Item = &'a BlockNumber>,
-        state_diff: &StateMaps,
+        state_diff: &CommitmentStateDiff,
         versioned_constants: &VersionedConstants,
     ) -> Self {
         let mut storage_keys: BTreeSet<StorageEntry> = BTreeSet::new();
@@ -73,7 +73,10 @@ impl AccessedKeys {
             }
         }
 
-        storage_keys.extend(state_diff.storage.keys().copied());
+        // Storage entries written in the state diff.
+        for (address, inner) in &state_diff.storage_updates {
+            storage_keys.extend(inner.keys().map(|key| (*address, *key)));
+        }
         // Add the block hash table entries for the proof facts.
         for block_number in proof_facts_block_numbers {
             storage_keys.insert((BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(block_number.0)));
@@ -88,10 +91,10 @@ impl AccessedKeys {
         }
 
         accessed_contracts.extend(storage_keys.iter().map(|(address, _)| *address));
-        accessed_contracts.extend(state_diff.get_contract_addresses());
+        accessed_contracts.extend(state_diff.get_contract_addresses().into_iter().copied());
 
-        accessed_class_hashes.extend(state_diff.class_hashes.values().copied());
-        accessed_class_hashes.extend(state_diff.compiled_class_hashes.keys().copied());
+        accessed_class_hashes.extend(state_diff.address_to_class_hash.values().copied());
+        accessed_class_hashes.extend(state_diff.class_hash_to_compiled_class_hash.keys().copied());
 
         Self { storage_keys, accessed_contracts, accessed_class_hashes }
     }

--- a/crates/blockifier/src/state/accessed_keys_test.rs
+++ b/crates/blockifier/src/state/accessed_keys_test.rs
@@ -9,7 +9,7 @@ use super::AccessedKeys;
 use crate::blockifier_versioned_constants::VersionedConstants;
 use crate::execution::call_info::{CallInfo, StorageAccessTracker};
 use crate::execution::entry_point::CallEntryPoint;
-use crate::state::cached_state::StateMaps;
+use crate::state::cached_state::CommitmentStateDiff;
 use crate::state::stateful_compression::ALIAS_COUNTER_STORAGE_KEY;
 use crate::transaction::objects::TransactionExecutionInfo;
 
@@ -44,7 +44,7 @@ fn no_inputs_no_alias_prediction_yields_empty_storage_keys() {
     let accessed = AccessedKeys::new(
         std::iter::empty::<&TransactionExecutionInfo>(),
         std::iter::empty::<&BlockNumber>(),
-        &StateMaps::default(),
+        &CommitmentStateDiff::default(),
         &versioned_constants_with_compression(false),
     );
     assert!(accessed.storage_keys.is_empty());
@@ -59,7 +59,7 @@ fn empty_inputs_with_alias_prediction_contains_counter_only() {
     let accessed = AccessedKeys::new(
         std::iter::empty::<&TransactionExecutionInfo>(),
         std::iter::empty::<&BlockNumber>(),
-        &StateMaps::default(),
+        &CommitmentStateDiff::default(),
         &versioned_constants,
     );
     assert_eq!(
@@ -73,8 +73,8 @@ fn empty_inputs_with_alias_prediction_contains_counter_only() {
 fn state_diff_storage_keys_are_included() {
     let address = ContractAddress::from(0x100_u16);
     let storage_key = StorageKey::from(0x200_u16);
-    let mut state_diff = StateMaps::default();
-    state_diff.storage.insert((address, storage_key), Felt::ONE);
+    let mut state_diff = CommitmentStateDiff::default();
+    state_diff.storage_updates.entry(address).or_default().insert(storage_key, Felt::ONE);
 
     let accessed = AccessedKeys::new(
         std::iter::empty::<&TransactionExecutionInfo>(),
@@ -93,7 +93,7 @@ fn proof_facts_block_numbers_map_to_block_hash_table_entries() {
     let accessed = AccessedKeys::new(
         std::iter::empty::<&TransactionExecutionInfo>(),
         [&block_number_x, &block_number_y],
-        &StateMaps::default(),
+        &CommitmentStateDiff::default(),
         &versioned_constants_with_compression(false),
     );
     assert!(
@@ -112,8 +112,8 @@ fn proof_facts_block_numbers_map_to_block_hash_table_entries() {
 #[test]
 fn alias_predictions_toggle_controls_alias_contract_entries() {
     let modified_address = ContractAddress::from(0x100_u16);
-    let mut state_diff = StateMaps::default();
-    state_diff.nonces.insert(modified_address, Nonce(Felt::ONE));
+    let mut state_diff = CommitmentStateDiff::default();
+    state_diff.address_to_nonce.insert(modified_address, Nonce(Felt::ONE));
     let versioned_constants_with = versioned_constants_with_compression(true);
     let versioned_constants_without = versioned_constants_with_compression(false);
     let alias_contract_address = get_alias_contract_address(&versioned_constants_with);
@@ -156,7 +156,7 @@ fn visited_storage_entries_from_execution_info_are_included() {
     let accessed = AccessedKeys::new(
         [&execution_info],
         std::iter::empty::<&BlockNumber>(),
-        &StateMaps::default(),
+        &CommitmentStateDiff::default(),
         &versioned_constants_with_compression(false),
     );
     assert!(accessed.storage_keys.contains(&(storage_address, key_a)));
@@ -182,7 +182,7 @@ fn reverted_invoke_collects_validate_and_fee_transfer_entries() {
     let accessed = AccessedKeys::new(
         [&execution_info],
         std::iter::empty::<&BlockNumber>(),
-        &StateMaps::default(),
+        &CommitmentStateDiff::default(),
         &versioned_constants_with_compression(false),
     );
     assert!(accessed.storage_keys.contains(&(validate_address, validate_key)));

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -676,6 +676,17 @@ pub struct CommitmentStateDiff {
     pub class_hash_to_compiled_class_hash: IndexMap<ClassHash, CompiledClassHash>,
 }
 
+impl CommitmentStateDiff {
+    /// Union of addresses with storage updates, nonce changes, or class hash changes.
+    pub fn get_contract_addresses(&self) -> HashSet<&ContractAddress> {
+        self.storage_updates
+            .keys()
+            .chain(self.address_to_nonce.keys())
+            .chain(self.address_to_class_hash.keys())
+            .collect()
+    }
+}
+
 impl From<StateMaps> for CommitmentStateDiff {
     fn from(diff: StateMaps) -> Self {
         Self {

--- a/crates/blockifier/src/state/stateful_compression.rs
+++ b/crates/blockifier/src/state/stateful_compression.rs
@@ -6,7 +6,7 @@ use starknet_api::StarknetApiError;
 use starknet_types_core::felt::Felt;
 use thiserror::Error;
 
-use super::cached_state::{CachedState, StateMaps, StorageEntry};
+use super::cached_state::{CachedState, CommitmentStateDiff, StateMaps, StorageEntry};
 use super::errors::StateError;
 use super::state_api::{State, StateReader, StateResult};
 
@@ -84,19 +84,21 @@ pub fn allocate_aliases_in_storage<S: StateReader>(
 /// access pattern of `AliasUpdater::new` (counter read) plus each `AliasUpdater::insert_alias`
 /// call (one read per qualifying key).
 pub fn predicted_alias_storage_entries(
-    state_diff: &StateMaps,
+    state_diff: &CommitmentStateDiff,
     alias_contract_address: ContractAddress,
 ) -> HashSet<StorageEntry> {
     let mut entries = HashSet::new();
     entries.insert((alias_contract_address, ALIAS_COUNTER_STORAGE_KEY));
     for address in state_diff.get_contract_addresses() {
-        if should_compress_address(&address) {
+        if should_compress_address(address) {
             entries.insert((alias_contract_address, StorageKey(address.0)));
         }
     }
-    for (address, storage_key) in state_diff.storage.keys() {
-        if should_compress_storage_key(storage_key, address) {
-            entries.insert((alias_contract_address, *storage_key));
+    for (address, inner) in &state_diff.storage_updates {
+        for storage_key in inner.keys() {
+            if should_compress_storage_key(storage_key, address) {
+                entries.insert((alias_contract_address, *storage_key));
+            }
         }
     }
     entries

--- a/crates/blockifier/src/state/stateful_compression_test.rs
+++ b/crates/blockifier/src/state/stateful_compression_test.rs
@@ -15,7 +15,7 @@ use super::{
     INITIAL_AVAILABLE_ALIAS,
     MAX_NON_COMPRESSED_CONTRACT_ADDRESS,
 };
-use crate::state::cached_state::{CachedState, StateMaps, StorageEntry};
+use crate::state::cached_state::{CachedState, CommitmentStateDiff, StateMaps, StorageEntry};
 use crate::state::state_api::{State, StateReader};
 use crate::state::stateful_compression::{
     predicted_alias_storage_entries,
@@ -194,7 +194,8 @@ fn test_predicted_alias_storage_entries_parity() {
     state.set_class_hash_at(ContractAddress::from(0x202_u16), ClassHash(Felt::ONE)).unwrap();
     state.increment_nonce(ContractAddress::from(0x200_u16)).unwrap();
 
-    let state_diff_before_alloc = state.to_state_diff().unwrap().state_maps;
+    let state_diff_before_alloc =
+        CommitmentStateDiff::from(state.to_state_diff().unwrap().state_maps);
     let predicted =
         predicted_alias_storage_entries(&state_diff_before_alloc, *ALIAS_CONTRACT_ADDRESS);
 


### PR DESCRIPTION
CommitmentStateDiff is the natural per-block state-diff type at the OS-replay
boundary (the batcher's BlockExecutionArtifacts already carries one). Swap
both AccessedKeys::new and predicted_alias_storage_entries to consume it
directly:

- AccessedKeys::new derives storage entries from
  state_diff.storage_updates, the modified-contracts union from
  storage_updates / address_to_nonce / address_to_class_hash, and the
  class-hash keys from address_to_class_hash + class_hash_to_compiled_class_hash.
- predicted_alias_storage_entries now walks CommitmentStateDiff directly;
  the parity test converts its StateMaps fixture via CommitmentStateDiff::from.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>