### PR TITLE
apollo_l1_gas_price: hold strk_to_usd oracle client + strk_to_usd_rate

### DIFF
--- a/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
@@ -23,6 +23,7 @@ use crate::metrics::{
     L1_DATA_GAS_PRICE_LATEST_MEAN_VALUE,
     L1_GAS_PRICE_LATEST_MEAN_VALUE,
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
+    STRK_TO_USD_ORACLE_METRICS,
 };
 
 #[cfg(test)]
@@ -60,14 +61,21 @@ pub struct L1GasPriceProvider {
     // If received data before initialization (is None), it means the scraper has restarted.
     price_samples_by_block: Option<RingBuffer<GasPriceData>>,
     eth_to_strk_oracle_client: Arc<dyn ExchangeRateOracleClientTrait>,
+    strk_to_usd_oracle_client: Arc<dyn ExchangeRateOracleClientTrait>,
 }
 
 impl L1GasPriceProvider {
     pub fn new(
         config: L1GasPriceProviderConfig,
         eth_to_strk_oracle_client: Arc<dyn ExchangeRateOracleClientTrait>,
+        strk_to_usd_oracle_client: Arc<dyn ExchangeRateOracleClientTrait>,
     ) -> Self {
-        Self { config, price_samples_by_block: None, eth_to_strk_oracle_client }
+        Self {
+            config,
+            price_samples_by_block: None,
+            eth_to_strk_oracle_client,
+            strk_to_usd_oracle_client,
+        }
     }
 
     pub fn new_with_oracle(config: L1GasPriceProviderConfig) -> Self {
@@ -75,7 +83,11 @@ impl L1GasPriceProvider {
             config.eth_to_strk_oracle_config.clone(),
             ETH_TO_STRK_ORACLE_METRICS,
         );
-        Self::new(config, Arc::new(eth_to_strk_oracle_client))
+        let strk_to_usd_oracle_client = ExchangeRateOracleClient::new(
+            config.strk_to_usd_oracle_config.clone(),
+            STRK_TO_USD_ORACLE_METRICS,
+        );
+        Self::new(config, Arc::new(eth_to_strk_oracle_client), Arc::new(strk_to_usd_oracle_client))
     }
 
     pub fn initialize(&mut self) -> L1GasPriceProviderResult<()> {
@@ -189,6 +201,13 @@ impl L1GasPriceProvider {
 
     pub async fn eth_to_fri_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<u128> {
         self.eth_to_strk_oracle_client
+            .fetch_rate(timestamp)
+            .await
+            .map_err(L1GasPriceProviderError::ExchangeRateOracleClientError)
+    }
+
+    pub async fn strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<u128> {
+        self.strk_to_usd_oracle_client
             .fetch_rate(timestamp)
             .await
             .map_err(L1GasPriceProviderError::ExchangeRateOracleClientError)

--- a/crates/apollo_l1_gas_price/src/l1_gas_price_provider_test.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_provider_test.rs
@@ -11,9 +11,11 @@ use crate::l1_gas_price_provider::{L1GasPriceProvider, L1GasPriceProviderError};
 // Returns the provider, a vector of block prices to compare with, and the timestamp of block[3].
 fn make_provider() -> (L1GasPriceProvider, Vec<PriceInfo>, u64) {
     let eth_to_strk_oracle_client = Arc::new(MockExchangeRateOracleClientTrait::new());
+    let strk_to_usd_oracle_client = Arc::new(MockExchangeRateOracleClientTrait::new());
     let mut provider = L1GasPriceProvider::new(
         L1GasPriceProviderConfig { number_of_blocks_for_mean: 3, ..Default::default() },
         eth_to_strk_oracle_client,
+        strk_to_usd_oracle_client,
     );
     provider.initialize().unwrap();
     let mut prices = Vec::new();
@@ -117,9 +119,11 @@ fn gas_price_provider_timestamp_changes_mean() {
 #[test]
 fn gas_price_provider_can_start_at_nonzero_height() {
     let eth_to_strk_oracle_client = Arc::new(MockExchangeRateOracleClientTrait::new());
+    let strk_to_usd_oracle_client = Arc::new(MockExchangeRateOracleClientTrait::new());
     let mut provider = L1GasPriceProvider::new(
         L1GasPriceProviderConfig { number_of_blocks_for_mean: 3, ..Default::default() },
         eth_to_strk_oracle_client,
+        strk_to_usd_oracle_client,
     );
     provider.initialize().unwrap();
     let price_info = PriceInfo { base_fee_per_gas: GasPrice(0), blob_fee: GasPrice(0) };
@@ -130,9 +134,11 @@ fn gas_price_provider_can_start_at_nonzero_height() {
 #[test]
 fn gas_price_provider_uninitialized_error() {
     let eth_to_strk_oracle_client = Arc::new(MockExchangeRateOracleClientTrait::new());
+    let strk_to_usd_oracle_client = Arc::new(MockExchangeRateOracleClientTrait::new());
     let mut provider = L1GasPriceProvider::new(
         L1GasPriceProviderConfig { number_of_blocks_for_mean: 3, ..Default::default() },
         eth_to_strk_oracle_client,
+        strk_to_usd_oracle_client,
     );
     let price_info = PriceInfo { base_fee_per_gas: GasPrice(0), blob_fee: GasPrice(0) };
     let timestamp = BlockTimestamp(0);


### PR DESCRIPTION
Goal: PR 2 of 6 in the stack moving the STRK/USD oracle from the
ad-hoc wiring in SequencerConsensusContext into L1GasPriceProvider.
This commit adds the field and inherent method on the provider but
nothing calls it yet — the seam is established without behavior
change.

Change summary:
- `L1GasPriceProvider` gains a second `Arc<dyn ExchangeRateOracleClientTrait>`
  field (`strk_to_usd_oracle_client`), positionally after the existing
  `eth_to_strk_oracle_client`.
- `new` takes a second oracle client parameter.
- `new_with_oracle` reads `config.strk_to_usd_oracle_config` (added in
  the previous commit on this stack) and constructs the client.
- New inherent method `strk_to_usd_rate(timestamp)` mirrors the
  existing `eth_to_fri_rate`.
- Unit tests in `l1_gas_price_provider_test.rs` updated to pass a
  second mock to the constructor.

Decision points:
- Positional constructor argument over a builder. The struct has two
  oracle clients now; if a third lands later, builder pattern is the
  right move. For two, positional is fine.
- Same `ExchangeRateOracleClientError` propagation via the existing
  `L1GasPriceProviderError::ExchangeRateOracleClientError` variant.
  No new error variant needed — the two oracles are semantically
  identical, only differ by URL.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>