### PR TITLE
apollo_l1_gas_price_types,apollo_l1_gas_price: expose get_strk_to_usd_rate

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -3479,6 +3479,32 @@
           "extra_params": {}
         },
         {
+          "title": "get_strk_to_usd_rate (client-side)",
+          "description": "client-side infra metrics for request type get_strk_to_usd_rate",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_strk_to_usd_rate (server-side)",
+          "description": "server-side infra metrics for request type get_strk_to_usd_rate",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "initialize (client-side)",
           "description": "client-side infra metrics for request type initialize",
           "type": "timeseries",

--- a/crates/apollo_l1_gas_price/src/communication.rs
+++ b/crates/apollo_l1_gas_price/src/communication.rs
@@ -32,6 +32,9 @@ impl ComponentRequestHandler<L1GasPriceRequest, L1GasPriceResponse> for L1GasPri
             L1GasPriceRequest::GetEthToFriRate(timestamp) => {
                 L1GasPriceResponse::GetEthToFriRate(self.eth_to_fri_rate(timestamp).await)
             }
+            L1GasPriceRequest::GetStrkToUsdRate(timestamp) => {
+                L1GasPriceResponse::GetStrkToUsdRate(self.strk_to_usd_rate(timestamp).await)
+            }
         }
     }
 }

--- a/crates/apollo_l1_gas_price_types/src/lib.rs
+++ b/crates/apollo_l1_gas_price_types/src/lib.rs
@@ -71,6 +71,7 @@ pub enum L1GasPriceRequest {
     GetGasPrice(BlockTimestamp),
     AddGasPrice(GasPriceData),
     GetEthToFriRate(u64),
+    GetStrkToUsdRate(u64),
 }
 impl_debug_for_infra_requests_and_responses!(L1GasPriceRequest);
 impl_labeled_request!(L1GasPriceRequest, L1GasPriceRequestLabelValue);
@@ -82,6 +83,7 @@ pub enum L1GasPriceResponse {
     GetGasPrice(L1GasPriceProviderResult<PriceInfo>),
     AddGasPrice(L1GasPriceProviderResult<()>),
     GetEthToFriRate(L1GasPriceProviderResult<u128>),
+    GetStrkToUsdRate(L1GasPriceProviderResult<u128>),
 }
 impl_debug_for_infra_requests_and_responses!(L1GasPriceResponse);
 
@@ -99,7 +101,11 @@ pub trait L1GasPriceProviderClient: Send + Sync {
         timestamp: BlockTimestamp,
     ) -> L1GasPriceProviderClientResult<PriceInfo>;
 
+    /// ETH/FRI rate as 18-decimal fixed-point integer (e.g. 5000 STRK per ETH → `5000 * 10^18`).
     async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
+
+    /// STRK/USD rate as 18-decimal fixed-point integer (e.g. 24.5 STRK per USD → `24.5 * 10^18`).
+    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
 }
 
 #[cfg_attr(any(feature = "testing", test), automock)]
@@ -166,6 +172,19 @@ where
             request,
             L1GasPriceResponse,
             GetEthToFriRate,
+            L1GasPriceClientError,
+            L1GasPriceProviderError,
+            Direct
+        )
+    }
+    #[instrument(skip(self))]
+    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128> {
+        let request = L1GasPriceRequest::GetStrkToUsdRate(timestamp);
+        handle_all_response_variants!(
+            self,
+            request,
+            L1GasPriceResponse,
+            GetStrkToUsdRate,
             L1GasPriceClientError,
             L1GasPriceProviderError,
             Direct


### PR DESCRIPTION
Goal: PR 3 of 6 in the stack moving the STRK/USD oracle into
L1GasPriceProvider. Surfaces the inherent method added in PR 2 on
the client trait so cross-process callers (notably the consensus
orchestrator in PR 5) can request a STRK/USD rate without holding
their own oracle.

Change summary:
- New `L1GasPriceRequest::GetStrkToUsdRate(u64)` variant.
- New `L1GasPriceResponse::GetStrkToUsdRate(L1GasPriceProviderResult<u128>)`
  variant.
- New `L1GasPriceProviderClient::get_strk_to_usd_rate` trait method,
  implemented on the blanket impl mirroring `get_rate`.
- Server-side dispatch arm in `apollo_l1_gas_price::communication`
  routes to `L1GasPriceProvider::strk_to_usd_rate`.

Decision points:
- Did not rename the existing `get_rate` (which dispatches to
  `GetEthToFriRate`) for symmetry; out of scope per the stack plan
  and would churn unrelated call sites in consensus orchestrator.
  The trait now has slightly asymmetric naming: `get_rate` (ETH/FRI)
  vs `get_strk_to_usd_rate`. Renaming is a separate cleanup if
  desired.
- `MockL1GasPriceProviderClient` is automock-generated and picks up
  the new method automatically.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>