### PR TITLE
apollo_integration_tests,apollo_deployments: prime strk_to_usd_oracle overlays

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -3479,6 +3479,32 @@
           "extra_params": {}
         },
         {
+          "title": "get_strk_to_usd_rate (client-side)",
+          "description": "client-side infra metrics for request type get_strk_to_usd_rate",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_strk_to_usd_rate (server-side)",
+          "description": "server-side infra metrics for request type get_strk_to_usd_rate",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(l1_gas_price_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.50 l1_gas_price_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(l1_gas_price_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_strk_to_usd_rate\"}[5m])), \"label_name\", \"0.95 l1_gas_price_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "initialize (client-side)",
           "description": "client-side infra metrics for request type initialize",
           "type": "timeseries",

--- a/crates/apollo_integration_tests/src/flow_test_setup.rs
+++ b/crates/apollo_integration_tests/src/flow_test_setup.rs
@@ -278,6 +278,11 @@ impl FlowSequencerSetup {
         let (eth_to_strk_oracle_url_headers, _join_handle) =
             spawn_local_eth_to_strk_oracle(available_ports.get_next_port());
         let eth_to_strk_oracle_config = ExchangeRateOracleConfig {
+            url_header_list: Some(vec![eth_to_strk_oracle_url_headers.clone().into()]),
+            ..Default::default()
+        };
+        // Reuse the same dummy oracle endpoint for STRK/USD; the handler returns a constant.
+        let strk_to_usd_oracle_config = ExchangeRateOracleConfig {
             url_header_list: Some(vec![eth_to_strk_oracle_url_headers.into()]),
             ..Default::default()
         };
@@ -309,6 +314,7 @@ impl FlowSequencerSetup {
             state_sync_config,
             consensus_manager_config,
             eth_to_strk_oracle_config,
+            strk_to_usd_oracle_config,
             mempool_p2p_config,
             monitoring_endpoint_config,
             component_config,

--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -1367,6 +1367,11 @@ async fn get_sequencer_setup_configs(
             url_header_list: Some(vec![eth_to_strk_oracle_url.clone().into()]),
             ..Default::default()
         };
+        // Reuse the same dummy oracle endpoint for STRK/USD; the handler returns a constant.
+        let strk_to_usd_oracle_config = ExchangeRateOracleConfig {
+            url_header_list: Some(vec![eth_to_strk_oracle_url.clone().into()]),
+            ..Default::default()
+        };
 
         let validator_id = set_validator_id(&mut consensus_manager_config, node_index);
         let chain_info = chain_info.clone();
@@ -1397,6 +1402,7 @@ async fn get_sequencer_setup_configs(
                 state_sync_config.clone(),
                 consensus_manager_config.clone(),
                 eth_to_strk_oracle_config.clone(),
+                strk_to_usd_oracle_config.clone(),
                 mempool_p2p_config.clone(),
                 monitoring_endpoint_config,
                 executable_component_config.clone(),

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -267,6 +267,7 @@ pub fn create_node_config(
     mut state_sync_config: StateSyncConfig,
     mut consensus_manager_config: ConsensusManagerConfig,
     eth_to_strk_oracle_config: ExchangeRateOracleConfig,
+    strk_to_usd_oracle_config: ExchangeRateOracleConfig,
     mempool_p2p_config: MempoolP2pConfig,
     monitoring_endpoint_config: MonitoringEndpointConfig,
     components: ComponentConfig,
@@ -313,6 +314,7 @@ pub fn create_node_config(
         // Use newly minted blocks on Anvil to be used for gas price calculations.
         lag_margin_seconds: Duration::from_secs(0),
         eth_to_strk_oracle_config,
+        strk_to_usd_oracle_config,
         ..Default::default()
     };
     let http_server_config =

--- a/crates/apollo_l1_gas_price/src/communication.rs
+++ b/crates/apollo_l1_gas_price/src/communication.rs
@@ -32,6 +32,9 @@ impl ComponentRequestHandler<L1GasPriceRequest, L1GasPriceResponse> for L1GasPri
             L1GasPriceRequest::GetEthToFriRate(timestamp) => {
                 L1GasPriceResponse::GetEthToFriRate(self.eth_to_fri_rate(timestamp).await)
             }
+            L1GasPriceRequest::GetStrkToUsdRate(timestamp) => {
+                L1GasPriceResponse::GetStrkToUsdRate(self.strk_to_usd_rate(timestamp).await)
+            }
         }
     }
 }

--- a/crates/apollo_l1_gas_price_types/src/lib.rs
+++ b/crates/apollo_l1_gas_price_types/src/lib.rs
@@ -71,6 +71,7 @@ pub enum L1GasPriceRequest {
     GetGasPrice(BlockTimestamp),
     AddGasPrice(GasPriceData),
     GetEthToFriRate(u64),
+    GetStrkToUsdRate(u64),
 }
 impl_debug_for_infra_requests_and_responses!(L1GasPriceRequest);
 impl_labeled_request!(L1GasPriceRequest, L1GasPriceRequestLabelValue);
@@ -82,6 +83,7 @@ pub enum L1GasPriceResponse {
     GetGasPrice(L1GasPriceProviderResult<PriceInfo>),
     AddGasPrice(L1GasPriceProviderResult<()>),
     GetEthToFriRate(L1GasPriceProviderResult<u128>),
+    GetStrkToUsdRate(L1GasPriceProviderResult<u128>),
 }
 impl_debug_for_infra_requests_and_responses!(L1GasPriceResponse);
 
@@ -99,7 +101,11 @@ pub trait L1GasPriceProviderClient: Send + Sync {
         timestamp: BlockTimestamp,
     ) -> L1GasPriceProviderClientResult<PriceInfo>;
 
+    /// ETH/FRI rate as 18-decimal fixed-point integer (e.g. 5000 STRK per ETH → `5000 * 10^18`).
     async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
+
+    /// STRK/USD rate as 18-decimal fixed-point integer (e.g. 24.5 STRK per USD → `24.5 * 10^18`).
+    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
 }
 
 #[cfg_attr(any(feature = "testing", test), automock)]
@@ -166,6 +172,19 @@ where
             request,
             L1GasPriceResponse,
             GetEthToFriRate,
+            L1GasPriceClientError,
+            L1GasPriceProviderError,
+            Direct
+        )
+    }
+    #[instrument(skip(self))]
+    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128> {
+        let request = L1GasPriceRequest::GetStrkToUsdRate(timestamp);
+        handle_all_response_variants!(
+            self,
+            request,
+            L1GasPriceResponse,
+            GetStrkToUsdRate,
             L1GasPriceClientError,
             L1GasPriceProviderError,
             Direct


### PR DESCRIPTION
Goal: PR 4 of 6 in the stack moving the STRK/USD oracle into
L1GasPriceProvider. Lands BEFORE the orchestrator behavior flip
(PR 5) so that every test and deployment overlay already points
the new `strk_to_usd_oracle_config.url_header_list` at a working
endpoint. When PR 5 lands, integration runs immediately exercise
the new path with realistic data instead of silently freezing
fee_proposal at fee_actual.

Change summary:
- `create_node_config` takes a new `strk_to_usd_oracle_config:
  ExchangeRateOracleConfig` argument and plumbs it into
  `L1GasPriceProviderConfig`.
- Callers in `flow_test_setup.rs` and `integration_test_manager.rs`
  reuse the same dummy `spawn_local_eth_to_strk_oracle` URL for both
  oracles (the handler returns a constant rate, so semantically
  equivalent).
- `SecretsConfigOverride` in `apollo_deployments::test_utils` gains
  a `strk_to_usd_oracle_config.url_header_list` field so the
  generated secrets file covers the new private parameter.
- Deployment app-config presets
  (`l1_gas_price_provider_config.json`,
  `replacer_l1_gas_price_provider_config.json`) gain the same three
  per-oracle overrides (`lag_interval_seconds=900`, `max_cache_size=100`,
  `query_timeout_sec=10`) for STRK/USD, mirroring eth_to_strk.

Decision points:
- One dummy oracle process serving both feeds instead of spawning two.
  The fake handler is rate-agnostic — same response shape, single port
  allocation, same join handle. If we ever need rate-specific dummy
  values, splitting into two processes is a localized change.

Action required after merge (cannot run from this sandbox):
- `cargo run --bin update_apollo_node_config_schema` to regenerate
  `config_secrets_schema.json` (it gains a new private parameter
  from PR 1's earlier addition).
- `cargo run --bin deployment_generator` to regenerate
  `testing_secrets.json` with the new strk_to_usd entry from
  `SecretsConfigOverride`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>