### PR TITLE
starknet_transaction_prover: add --log-format text|json CLI flag

### DIFF
--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -14,7 +14,12 @@ async fn main() -> anyhow::Result<()> {
 
     use anyhow::Context;
     use clap::Parser;
-    use starknet_transaction_prover::server::config::{CliArgs, ServiceConfig, TransportMode};
+    use starknet_transaction_prover::server::config::{
+        CliArgs,
+        LogFormat,
+        ServiceConfig,
+        TransportMode,
+    };
     use starknet_transaction_prover::server::cors::{build_cors_layer, cors_mode};
     use starknet_transaction_prover::server::rpc_api::ProvingRpcServer;
     use starknet_transaction_prover::server::rpc_impl::ProvingRpcServerImpl;
@@ -28,16 +33,18 @@ async fn main() -> anyhow::Result<()> {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{fmt, EnvFilter};
 
+    let args = CliArgs::parse();
+
     // TODO(Avi): Revisit the starknet_transaction_prover=debug default once the service stabilizes.
-    // Initialize tracing with RUST_LOG. By default, keep service logs and lower third-party
-    // logs to warn.
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("warn,starknet_transaction_prover=debug,privacy_prove=info")
     });
-    tracing_subscriber::registry().with(fmt::layer()).with(filter).init();
+    let registry = tracing_subscriber::registry().with(filter);
+    match args.log_format {
+        LogFormat::Json => registry.with(fmt::layer().json()).init(),
+        LogFormat::Text => registry.with(fmt::layer()).init(),
+    }
 
-    // Parse CLI args and load config.
-    let args = CliArgs::parse();
     let config = ServiceConfig::from_args(args)?;
 
     // Build and start the JSON-RPC server.

--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use blockifier::blockifier::config::ContractClassManagerConfig;
 use blockifier::bouncer::BouncerConfig;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ChainId, ContractAddress};
 use tracing::info;
@@ -36,6 +36,15 @@ const DEFAULT_OHTTP_KEY_CACHE_MAX_AGE_SECS: u64 = 3600;
 pub enum TransportMode {
     Http,
     Https { tls_cert_file: PathBuf, tls_key_file: PathBuf },
+}
+
+/// Output format for tracing log records.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum LogFormat {
+    #[default]
+    Text,
+    Json,
 }
 
 impl TransportMode {
@@ -546,6 +555,10 @@ pub struct CliArgs {
     /// Cache-Control max-age (seconds) for the `GET /ohttp-keys` response (default: 3600).
     #[arg(long, value_name = "SECS", env = "OHTTP_KEY_CACHE_MAX_AGE_SECS")]
     pub ohttp_key_cache_max_age_secs: Option<u64>,
+
+    /// Log output format. Use `json` in production so log aggregators parse fields directly.
+    #[arg(long, value_enum, value_name = "FORMAT", env = "LOG_FORMAT", default_value_t = LogFormat::Text)]
+    pub log_format: LogFormat,
 
     /// Hidden escape hatch: override the embedded bouncer config (block capacity limits) with a
     /// custom JSON file. Not advertised because the embedded defaults are tuned for this prover

--- a/crates/starknet_transaction_prover/src/server/config_test.rs
+++ b/crates/starknet_transaction_prover/src/server/config_test.rs
@@ -7,7 +7,7 @@ use rstest::rstest;
 use tempfile::NamedTempFile;
 
 use crate::errors::ConfigError;
-use crate::server::config::{CliArgs, ServiceConfig, TransportMode};
+use crate::server::config::{CliArgs, LogFormat, ServiceConfig, TransportMode};
 
 /// Mutex that serializes tests which modify environment variables.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -59,6 +59,7 @@ fn base_args() -> CliArgs {
         max_request_body_size: None,
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
+        log_format: LogFormat::Text,
     }
 }
 
@@ -147,6 +148,7 @@ fn cors_allow_origin_rejects_non_array_in_config_file() {
         max_request_body_size: None,
         ohttp_enabled: false,
         ohttp_key_cache_max_age_secs: None,
+        log_format: LogFormat::Text,
     };
 
     let error = ServiceConfig::from_args(args).unwrap_err();


### PR DESCRIPTION
starknet_transaction_prover: add --log-format text|json CLI flag

Adds a LogFormat enum and `--log-format` / `LOG_FORMAT=text|json`
selector that switches the tracing subscriber between the text and JSON
formatters. Default is text. Matches the discovery-service convention.

Co-Authored-By: Claude Opus 4.7 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)