### PR TITLE
starknet_transaction_prover: bump prover_panics_total on panic hook fire

### DIFF
--- a/crates/starknet_transaction_prover/src/server/metrics.rs
+++ b/crates/starknet_transaction_prover/src/server/metrics.rs
@@ -27,6 +27,8 @@ pub const METRICS_PATH: &str = "/metrics";
 pub mod names {
     /// Build identity. Value is always 1; labels carry version + git_sha.
     pub const BUILD_INFO: &str = "prover_build_info";
+    /// Unhandled panics caught by the global panic hook.
+    pub const PANICS_TOTAL: &str = "prover_panics_total";
     /// Wall-clock duration of `prove_transaction` end-to-end. Bucketed.
     pub const PROVE_TRANSACTION_DURATION_SECONDS: &str =
         "prover_prove_transaction_duration_seconds";
@@ -71,6 +73,8 @@ pub fn install_exporter(version: &str, git_sha: &str) -> anyhow::Result<Promethe
         "git_sha" => git_sha.to_string(),
     )
     .set(1.0);
+    // Pre-register at zero so the series exists in scrapes before the first panic.
+    metrics::counter!(names::PANICS_TOTAL).increment(0);
     super::http_metrics::preregister_http_metrics();
     Ok(handle)
 }

--- a/crates/starknet_transaction_prover/src/server/panic.rs
+++ b/crates/starknet_transaction_prover/src/server/panic.rs
@@ -1,11 +1,15 @@
 //! Process-wide panic hook: one structured `tracing` event with location +
 //! backtrace (indexable by log aggregators) instead of the default ad-hoc
-//! stderr output. Only logs — abort-on-panic behavior is preserved.
+//! stderr output, plus a `prover_panics_total` bump so alerts can fire on
+//! panic rate rather than log search. Only logs and counts — runtime
+//! abort-on-panic behavior is preserved.
 
 use std::backtrace::Backtrace;
 use std::panic::PanicHookInfo;
 
 use tracing::error;
+
+use crate::server::metrics::names::PANICS_TOTAL;
 
 #[cfg(test)]
 #[path = "panic_test.rs"]
@@ -16,6 +20,9 @@ pub fn install_panic_hook() {
 }
 
 fn panic_hook(info: &PanicHookInfo<'_>) {
+    // Increment first — if `Backtrace::force_capture` or the `error!` macro
+    // panic recursively, the counter still reflects the original panic.
+    metrics::counter!(PANICS_TOTAL).increment(1);
     let payload = extract_payload(info);
     let location = info
         .location()

--- a/crates/starknet_transaction_prover/src/server/panic_test.rs
+++ b/crates/starknet_transaction_prover/src/server/panic_test.rs
@@ -1,11 +1,20 @@
+use std::sync::Mutex;
+
 use tracing_test::traced_test;
 
+use crate::server::metrics::names::PANICS_TOTAL;
 use crate::server::panic::install_panic_hook;
+use crate::server::test_recorder::{metric_value, shared_handle};
 
-// The panic hook is global state — a single #[test] keeps captures serial.
+/// Serializes tests that install the process-global panic hook. The hook
+/// also bumps a shared Prometheus counter, so a panic from a concurrently
+/// running test would skew another test's before/after delta on that counter.
+static PANIC_HOOK_TEST_LOCK: Mutex<()> = Mutex::new(());
+
 #[test]
 #[traced_test]
 fn logs_structured_event_with_location_payload_and_backtrace() {
+    let _guard = PANIC_HOOK_TEST_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     let prev_hook = std::panic::take_hook();
     install_panic_hook();
     let _ = std::panic::catch_unwind(|| panic!("static literal"));
@@ -39,4 +48,19 @@ fn logs_structured_event_with_location_payload_and_backtrace() {
         logs_contain("backtrace=") && logs_contain("panic_hook"),
         "must capture a real backtrace, not an empty one"
     );
+}
+
+#[test]
+fn panic_hook_bumps_panics_total_counter() {
+    let _guard = PANIC_HOOK_TEST_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let handle = shared_handle();
+    let before = metric_value(&handle.render(), PANICS_TOTAL);
+
+    let prev_hook = std::panic::take_hook();
+    install_panic_hook();
+    let _ = std::panic::catch_unwind(|| panic!("counter-test panic"));
+    std::panic::set_hook(prev_hook);
+
+    let after = metric_value(&handle.render(), PANICS_TOTAL);
+    assert_eq!(after - before, 1.0);
 }


### PR DESCRIPTION
Bumps the new `prover_panics_total` counter from the panic hook before
constructing the backtrace, so dashboards can alert on panic rate without
log search. The pre-registered zero observation in `install_exporter`
keeps the series visible at scrape time even before the first panic.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>