### PR TITLE
apollo_batcher_config: reduce proposer_idle_detection_delay 2000 -> 1500ms (SNIP-40)

### DIFF
--- a/crates/apollo_batcher_config/src/config.rs
+++ b/crates/apollo_batcher_config/src/config.rs
@@ -340,7 +340,7 @@ impl Default for BatcherDynamicConfig {
             storage_reader_server_dynamic_config: StorageReaderServerDynamicConfig::default(),
             n_concurrent_txs: 100,
             tx_polling_interval_millis: 10,
-            proposer_idle_detection_delay_millis: Duration::from_millis(2000),
+            proposer_idle_detection_delay_millis: Duration::from_millis(1500),
         }
     }
 }

--- a/crates/apollo_deployments/resources/app_configs/batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/batcher_config.json
@@ -1,6 +1,6 @@
 {
   "batcher_config.dynamic_config.n_concurrent_txs": 100,
-  "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": 2000,
+  "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": 1500,
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": false,
   "batcher_config.dynamic_config.tx_polling_interval_millis": 200,
   "batcher_config.static_config.block_builder_config.bouncer_config.builtin_weights.gas_costs.blake": 3334,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -52,7 +52,7 @@
   "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": {
     "description": "Minimum time (in milliseconds) that must pass since block creation started before checking for idle state. If this delay has passed AND no transactions are currently being executed, the proposer will finish building the current block.",
     "privacy": "Public",
-    "value": 2000
+    "value": 1500
   },
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": {
     "description": "Whether to enable the storage reader HTTP server.",


### PR DESCRIPTION
Per SNIP-40 "More Frequent Blocks", reduce the batcher's mempool idle-detection
delay from 2.0s to 1.5s. Block cadence is driven by this delay, so this changes
the typical block execution slot from ~2s to ~1.5s.

Spec: https://community.starknet.io/t/snip-40-more-frequent-blocks/116203

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>