### PR TITLE
deployment: add recorder_url to hybrid environment overlays

### DIFF
--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/common.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/common.yaml
@@ -8,6 +8,7 @@ config:
     chain_id: SN_MAIN
     eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
     native_classes_whitelist: '["0x054c5afe61ed27be53b1e4dec5707209a9fcabdb14712fb800fbc60439090115"]'
+    recorder_url: http://starknet-mainnet.cende-recorder-proxy.starknet.io/
     starknet_url: https://feeder.alpha-mainnet.starknet.io/
     strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d'
     versioned_constants_overrides.max_n_events: 1000

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/common.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/common.yaml
@@ -8,6 +8,7 @@ config:
     chain_id: SN_SEPOLIA
     eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
     native_classes_whitelist: All
+    recorder_url: http://starknet-sepolia-alpha.cende-recorder-proxy.starknet.io/
     starknet_url: https://feeder.alpha-sepolia.starknet.io/
     strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d'
     versioned_constants_overrides.max_n_events: 1000

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/common.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/common.yaml
@@ -8,6 +8,7 @@ config:
     chain_id: SN_INTEGRATION_SEPOLIA
     eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
     native_classes_whitelist: All
+    recorder_url: http://starknet-sepolia-integration.cende-recorder-proxy.starknet.io/
     starknet_url: https://feeder.integration-sepolia.starknet.io/
     strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d'
     versioned_constants_overrides.max_n_events: 1000


### PR DESCRIPTION
Add `recorder_url` to `config.sequencerConfig` in each production hybrid environment overlay:

- `mainnet/common.yaml`: `http://starknet-mainnet.cende-recorder-proxy.starknet.io/`
- `sepolia-alpha/common.yaml`: `http://starknet-sepolia-alpha.cende-recorder-proxy.starknet.io/`
- `sepolia-integration/common.yaml`: `http://starknet-sepolia-integration.cende-recorder-proxy.starknet.io/`

**Corresponding devops PR (removes the same key from the devops overlays):** starkware-industries/sequencer-devops#702