### PR TITLE
deployment: add component ports and urls to hybrid environment overlays

### DIFF
--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/committer.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/committer.yaml
@@ -3,3 +3,7 @@ config:
   sequencerConfig:
     committer_config.storage_config.cache_size: 50000000
     committer_config.verify_state_diff_hash: true
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.committer.port: 55013
+    components.committer.url: sequencer-committer-service

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/core.yaml
@@ -29,6 +29,26 @@ config:
     consensus_manager_config.staking_manager_config.dynamic_config.default_committee: 0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true;0x67,1,0x1,true;0x68,1,0x1,true
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee: ''
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee.#is_none: true
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.committer.port: 55013
+    components.committer.url: sequencer-committer-service
+    components.l1_events_provider.port: 55004
+    components.l1_events_provider.url: sequencer-l1-service
+    components.l1_gas_price_provider.port: 55003
+    components.l1_gas_price_provider.url: sequencer-l1-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
+    components.sierra_compiler.port: 55007
+    components.sierra_compiler.url: sequencer-sierracompiler-service
+    components.signature_manager.port: 55008
+    components.signature_manager.url: sequencer-core-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service
     state_sync_config.static_config.central_sync_client_config.#is_none: false
     state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold: 103129
     state_sync_config.static_config.p2p_sync_client_config.#is_none: true

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/gateway.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/gateway.yaml
@@ -5,4 +5,14 @@ config:
     gateway_config.static_config.authorized_declarer_accounts.#is_none: true
     gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap: 200
     gateway_config.static_config.stateless_tx_validator_config.max_contract_bytecode_size: 81920
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.gateway.port: 55002
+    components.gateway.url: sequencer-gateway-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service
     gateway_config.static_config.stateless_tx_validator_config.min_gas_price: 8000000000

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/l1.yaml
@@ -5,3 +5,11 @@ config:
     base_layer_config.bpo2_start_block_number: 24168146
     base_layer_config.fusaka_no_bpo_start_block_number: 23934586
     base_layer_config.starknet_contract_address: '0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4'
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.l1_events_provider.port: 55004
+    components.l1_events_provider.url: sequencer-l1-service
+    components.l1_gas_price_provider.port: 55003
+    components.l1_gas_price_provider.url: sequencer-l1-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/mempool.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/mempool.yaml
@@ -1,4 +1,12 @@
 config:
   configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_mempool.json
   sequencerConfig:
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.gateway.port: 55002
+    components.gateway.url: sequencer-gateway-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
     mempool_config.dynamic_config.transaction_ttl: 300

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/sierra-compiler.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/sierra-compiler.yaml
@@ -2,4 +2,6 @@ config:
   configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_sierra_compiler.json
   sequencerConfig:
     sierra_compiler_config.audited_libfuncs_only: true
+    components.sierra_compiler.port: 55007
+    components.sierra_compiler.url: sequencer-sierracompiler-service
     sierra_compiler_config.max_bytecode_size: 81920

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/committer.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/committer.yaml
@@ -3,3 +3,7 @@ config:
   sequencerConfig:
     committer_config.storage_config.cache_size: 10000000
     committer_config.verify_state_diff_hash: true
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.committer.port: 55013
+    components.committer.url: sequencer-committer-service

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/core.yaml
@@ -29,6 +29,26 @@ config:
     consensus_manager_config.staking_manager_config.dynamic_config.default_committee: 0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true;0x67,1,0x1,true;0x68,1,0x1,true
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee: ''
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee.#is_none: true
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.committer.port: 55013
+    components.committer.url: sequencer-committer-service
+    components.l1_events_provider.port: 55004
+    components.l1_events_provider.url: sequencer-l1-service
+    components.l1_gas_price_provider.port: 55003
+    components.l1_gas_price_provider.url: sequencer-l1-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
+    components.sierra_compiler.port: 55007
+    components.sierra_compiler.url: sequencer-sierracompiler-service
+    components.signature_manager.port: 55008
+    components.signature_manager.url: sequencer-core-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service
     state_sync_config.static_config.central_sync_client_config.#is_none: false
     state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold: 0
     state_sync_config.static_config.p2p_sync_client_config.#is_none: true

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/gateway.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/gateway.yaml
@@ -5,4 +5,14 @@ config:
     gateway_config.static_config.authorized_declarer_accounts.#is_none: true
     gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap: 200
     gateway_config.static_config.stateless_tx_validator_config.max_contract_bytecode_size: 81920
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.gateway.port: 55002
+    components.gateway.url: sequencer-gateway-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service
     gateway_config.static_config.stateless_tx_validator_config.min_gas_price: 8000000000

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/l1.yaml
@@ -5,3 +5,11 @@ config:
     base_layer_config.bpo2_start_block_number: 9504747
     base_layer_config.fusaka_no_bpo_start_block_number: 9408577
     base_layer_config.starknet_contract_address: '0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057'
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.l1_events_provider.port: 55004
+    components.l1_events_provider.url: sequencer-l1-service
+    components.l1_gas_price_provider.port: 55003
+    components.l1_gas_price_provider.url: sequencer-l1-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/mempool.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/mempool.yaml
@@ -1,4 +1,12 @@
 config:
   configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_mempool.json
   sequencerConfig:
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.gateway.port: 55002
+    components.gateway.url: sequencer-gateway-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
     mempool_config.dynamic_config.transaction_ttl: 300

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/sierra-compiler.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/sierra-compiler.yaml
@@ -2,4 +2,6 @@ config:
   configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_sierra_compiler.json
   sequencerConfig:
     sierra_compiler_config.audited_libfuncs_only: true
+    components.sierra_compiler.port: 55007
+    components.sierra_compiler.url: sequencer-sierracompiler-service
     sierra_compiler_config.max_bytecode_size: 81920

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/committer.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/committer.yaml
@@ -3,3 +3,7 @@ config:
   sequencerConfig:
     committer_config.storage_config.cache_size: 10000000
     committer_config.verify_state_diff_hash: true
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.committer.port: 55013
+    components.committer.url: sequencer-committer-service

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/core.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/core.yaml
@@ -29,6 +29,26 @@ config:
     consensus_manager_config.staking_manager_config.dynamic_config.default_committee: 0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee: ''
     consensus_manager_config.staking_manager_config.dynamic_config.override_committee.#is_none: true
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.committer.port: 55013
+    components.committer.url: sequencer-committer-service
+    components.l1_events_provider.port: 55004
+    components.l1_events_provider.url: sequencer-l1-service
+    components.l1_gas_price_provider.port: 55003
+    components.l1_gas_price_provider.url: sequencer-l1-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
+    components.sierra_compiler.port: 55007
+    components.sierra_compiler.url: sequencer-sierracompiler-service
+    components.signature_manager.port: 55008
+    components.signature_manager.url: sequencer-core-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service
     state_sync_config.static_config.central_sync_client_config.#is_none: false
     state_sync_config.static_config.central_sync_client_config.sync_config.store_sierras_and_casms_block_threshold: 0
     state_sync_config.static_config.p2p_sync_client_config.#is_none: true

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/gateway.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/gateway.yaml
@@ -5,4 +5,14 @@ config:
     gateway_config.static_config.authorized_declarer_accounts.#is_none: true
     gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap: 200
     gateway_config.static_config.stateless_tx_validator_config.max_contract_bytecode_size: 81920
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.gateway.port: 55002
+    components.gateway.url: sequencer-gateway-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service
     gateway_config.static_config.stateless_tx_validator_config.min_gas_price: 8000000000

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/l1.yaml
@@ -5,3 +5,11 @@ config:
     base_layer_config.bpo2_start_block_number: 9504747
     base_layer_config.fusaka_no_bpo_start_block_number: 9408577
     base_layer_config.starknet_contract_address: '0x4737c0c1B4D5b1A687B42610DdabEE781152359c'
+    components.batcher.port: 55000
+    components.batcher.url: sequencer-core-service
+    components.l1_events_provider.port: 55004
+    components.l1_events_provider.url: sequencer-l1-service
+    components.l1_gas_price_provider.port: 55003
+    components.l1_gas_price_provider.url: sequencer-l1-service
+    components.state_sync.port: 55009
+    components.state_sync.url: sequencer-core-service

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/mempool.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/mempool.yaml
@@ -1,4 +1,12 @@
 config:
   configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_mempool.json
   sequencerConfig:
+    components.class_manager.port: 55001
+    components.class_manager.url: sequencer-core-service
+    components.gateway.port: 55002
+    components.gateway.url: sequencer-gateway-service
+    components.mempool.port: 55006
+    components.mempool.url: sequencer-mempool-service
+    components.proof_manager.port: 55012
+    components.proof_manager.url: sequencer-core-service
     mempool_config.dynamic_config.transaction_ttl: 300

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/sierra-compiler.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/sierra-compiler.yaml
@@ -2,4 +2,6 @@ config:
   configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_sierra_compiler.json
   sequencerConfig:
     sierra_compiler_config.audited_libfuncs_only: false
+    components.sierra_compiler.port: 55007
+    components.sierra_compiler.url: sequencer-sierracompiler-service
     sierra_compiler_config.max_bytecode_size: 81920


### PR DESCRIPTION
Add `components.*` port and URL entries to each production environment's service overlays (core, l1, gateway, mempool, committer, sierra-compiler) for mainnet, sepolia-alpha, and sepolia-integration.

Values are identical across all three environments.

**Corresponding devops PR (removes the same keys from the devops overlays):** starkware-industries/sequencer-devops#703