### PR TITLE
echonet: squash timestamp + block metadata changes for editing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,6 @@ dependencies = [
  "serde_json",
  "starknet-types-core",
  "starknet_api",
- "starknet_committer",
  "strum",
  "thiserror 1.0.69",
  "tokio",
@@ -1095,13 +1094,16 @@ dependencies = [
  "apollo_metrics",
  "assert_matches",
  "async-trait",
+ "base64 0.13.1",
  "indexmap 2.14.0",
+ "serde_json",
  "starknet_api",
  "starknet_committer",
  "starknet_patricia",
  "starknet_patricia_storage",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -1454,7 +1456,6 @@ dependencies = [
  "shared_execution_objects",
  "starknet-types-core",
  "starknet_api",
- "starknet_committer",
  "strum",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "pretty_assertions",
+ "reqwest 0.12.24",
  "rstest",
  "serde_json",
  "starknet-types-core",
@@ -1591,6 +1592,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
+ "url",
  "validator",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,6 +2887,7 @@ name = "apollo_transaction_converter"
 version = "0.0.0"
 dependencies = [
  "apollo_class_manager_types",
+ "apollo_config",
  "apollo_metrics",
  "apollo_proof_manager_types",
  "assert_matches",

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -724,11 +724,30 @@ impl Batcher {
     }
 
     #[instrument(skip(self), err)]
-    pub async fn get_block_metadata(&self) -> BatcherResult<ReplayMetadata> {
+    pub async fn get_block_metadata(&mut self) -> BatcherResult<ReplayMetadata> {
+        // Abort any stale active proposal BEFORE mutating the mempool below. The proposer
+        // side of consensus has no other path that calls `abort_proposal` on round
+        // transitions (unlike the validator side in validate_proposal.rs), so the previous
+        // round's block builder is otherwise still alive and polling the mempool. The
+        // `commit_block(default)` below would then feed it the rewound staged txs, it would
+        // re-execute them, and (in FIFO mode) a second pop of the same txs trips the
+        // duplicate-rejection assert in block_builder.rs:695. The abort signal causes that
+        // block builder to exit at its next loop iteration, bounding any further polling to
+        // a single iteration — not enough for the duplicate to materialize.
+        self.abort_active_proposal().await;
+
         let mempool_client = self.mempool_client.as_ref().expect(
             "Mempool client must be present in non-validation-only mode. Unreachable code when \
              validation-only mode is enabled.",
         );
+        // Round-start signal: rewinds any staged txs left behind by an aborted prior round so
+        // resolve_block_metadata below reflects the block we're actually about to build. In
+        // normal flow staged_txs is empty here and this is a no-op. propose_block will issue
+        // the same call again; with the FIFO queue's state-realignment invariant it's idempotent.
+        mempool_client.commit_block(CommitBlockArgs::default()).await.map_err(|err| {
+            error!("Mempool not ready for round start in get_block_metadata: {err}");
+            BatcherError::NotReady
+        })?;
         mempool_client.resolve_block_metadata().await.map_err(|err| {
             error!("Failed to get block metadata from mempool: {err}");
             BatcherError::InternalError

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -115,7 +115,7 @@ use starknet_api::block::{
     GasPriceVector,
     GasPrices,
     NonzeroGasPrice,
-    UnixTimestamp,
+    ReplayMetadata,
 };
 use starknet_api::block_hash::block_hash_calculator::{
     PartialBlockHash,
@@ -724,13 +724,13 @@ impl Batcher {
     }
 
     #[instrument(skip(self), err)]
-    pub async fn get_batch_timestamp(&self) -> BatcherResult<UnixTimestamp> {
+    pub async fn get_block_metadata(&self) -> BatcherResult<ReplayMetadata> {
         let mempool_client = self.mempool_client.as_ref().expect(
             "Mempool client must be present in non-validation-only mode. Unreachable code when \
              validation-only mode is enabled.",
         );
-        mempool_client.resolve_batch_timestamp().await.map_err(|err| {
-            error!("Failed to get timestamp from mempool: {err}");
+        mempool_client.resolve_block_metadata().await.map_err(|err| {
+            error!("Failed to get block metadata from mempool: {err}");
             BatcherError::InternalError
         })
     }

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -66,10 +66,8 @@ use apollo_storage::partial_block_hash::{
 };
 use apollo_storage::state::{StateStorageReader, StateStorageWriter};
 #[cfg(feature = "os_input")]
-use apollo_storage::state_commitment_infos::StateCommitmentInfosStorageReader;
-#[cfg(feature = "os_input")]
 use apollo_storage::state_commitment_infos::{
-    StateCommitmentInfos,
+    StateCommitmentInfosStorageReader,
     StateCommitmentInfosStorageWriter,
 };
 use apollo_storage::storage_reader_server::{
@@ -1545,10 +1543,7 @@ impl Batcher {
     }
 
     #[cfg(feature = "os_input")]
-    pub fn get_state_commitment_infos(
-        &self,
-        block_number: BlockNumber,
-    ) -> BatcherResult<StateCommitmentInfos> {
+    pub fn get_state_commitment_infos(&self, block_number: BlockNumber) -> BatcherResult<String> {
         self.storage_reader
             .get_state_commitment_infos(block_number)
             .map_err(|err| {
@@ -1758,10 +1753,7 @@ pub trait BatcherStorageReader: Send + Sync {
     fn get_block_hash(&self, height: BlockNumber) -> StorageResult<Option<BlockHash>>;
 
     #[cfg(feature = "os_input")]
-    fn get_state_commitment_infos(
-        &self,
-        height: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>>;
+    fn get_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<Option<String>>;
 
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
@@ -1858,10 +1850,7 @@ impl BatcherStorageReader for StorageReader {
     }
 
     #[cfg(feature = "os_input")]
-    fn get_state_commitment_infos(
-        &self,
-        height: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>> {
+    fn get_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<Option<String>> {
         self.begin_ro_txn()?.get_state_commitment_infos(height)
     }
 
@@ -1927,7 +1916,7 @@ pub trait BatcherStorageWriter: Send + Sync {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
-        state_commitment_infos: Option<StateCommitmentInfos>,
+        state_commitment_infos: Option<String>,
     ) -> StorageResult<()>;
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()>;
@@ -1973,7 +1962,7 @@ impl BatcherStorageWriter for StorageWriter {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
-        #[cfg(feature = "os_input")] state_commitment_infos: Option<StateCommitmentInfos>,
+        #[cfg(feature = "os_input")] state_commitment_infos: Option<String>,
     ) -> StorageResult<()> {
         #[cfg(not(feature = "os_input"))]
         info!(
@@ -1983,10 +1972,10 @@ impl BatcherStorageWriter for StorageWriter {
         #[cfg(feature = "os_input")]
         info!(
             "Setting global root and block hash for height {height}. Root: {global_root:?}, Block \
-             hash: {block_hash:?}, number of storage-trie commitment infos: {:?}.",
-            state_commitment_infos.as_ref().map(|state_commitment_infos| state_commitment_infos
-                .storage_tries_commitment_infos
-                .len())
+             hash: {block_hash:?}, compressed commitment infos byte length: {:?}.",
+            state_commitment_infos
+                .as_ref()
+                .map(|state_commitment_infos| state_commitment_infos.len())
         );
         let mut txn = self
             .begin_rw_txn()?

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1949,7 +1949,7 @@ async fn validation_only_propose_block_returns_not_supported() {
 #[should_panic(expected = "Mempool client must be present in non-validation-only mode.")]
 async fn validation_only_get_batch_timestamp_panics() {
     let batcher = create_batcher(validation_only_mock_dependencies()).await;
-    batcher.get_batch_timestamp().await.unwrap();
+    batcher.get_block_metadata().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1948,7 +1948,7 @@ async fn validation_only_propose_block_returns_not_supported() {
 #[tokio::test]
 #[should_panic(expected = "Mempool client must be present in non-validation-only mode.")]
 async fn validation_only_get_batch_timestamp_panics() {
-    let batcher = create_batcher(validation_only_mock_dependencies()).await;
+    let mut batcher = create_batcher(validation_only_mock_dependencies()).await;
     batcher.get_block_metadata().await.unwrap();
 }
 

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
@@ -20,8 +20,6 @@ use rstest::{fixture, rstest};
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::block_hash::block_hash_calculator::PartialBlockHashComponents;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::batcher::{MockBatcherStorageReader, MockBatcherStorageWriter};
@@ -70,7 +68,7 @@ fn mock_dependencies() -> MockDependencies {
         Box::pin(async {
             Ok(ReadPathsAndCommitBlockResponse {
                 global_root: GlobalRoot::default(),
-                state_commitment_infos: StateCommitmentInfos::default(),
+                state_commitment_infos: String::new(),
             })
         })
     });

--- a/crates/apollo_batcher/src/commitment_manager/types.rs
+++ b/crates/apollo_batcher/src/commitment_manager/types.rs
@@ -13,8 +13,6 @@ use apollo_committer_types::committer_types::{
     RevertBlockResponse,
 };
 use apollo_committer_types::communication::CommitterRequestLabelValue;
-#[cfg(feature = "os_input")]
-use apollo_storage::state_commitment_infos::StateCommitmentInfos;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::GlobalRoot;
 use tracing::warn;
@@ -76,10 +74,10 @@ impl Display for CommitterTaskInput {
 pub(crate) struct CommitmentTaskOutput {
     pub(crate) response: CommitBlockResponse,
     pub(crate) height: BlockNumber,
-    // The commitment infos derived from the committer output. `None` when the block was committed
-    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    // Compressed commitment infos from the committer. `None` when the block was committed via
+    // `CommitBlock` (no accessed keys to request the Patricia witnesses).
     #[cfg(feature = "os_input")]
-    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
+    pub(crate) state_commitment_infos: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -131,10 +129,10 @@ pub(crate) struct FinalBlockCommitment {
     // cannot be finalized.
     pub(crate) block_hash: Option<BlockHash>,
     pub(crate) global_root: GlobalRoot,
-    // The commitment infos derived from the committer output. `None` when the block was committed
-    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    // Compressed commitment infos from the committer. `None` when the block was committed via
+    // `CommitBlock` (no accessed keys to request the Patricia witnesses).
     #[cfg(feature = "os_input")]
-    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
+    pub(crate) state_commitment_infos: Option<String>,
 }
 
 pub(crate) struct TaskTimer {

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -61,8 +61,8 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
             BatcherRequest::RevertBlock(input) => {
                 BatcherResponse::RevertBlock(self.revert_block(input).await)
             }
-            BatcherRequest::GetBatchTimestamp => {
-                BatcherResponse::GetBatchTimestamp(self.get_batch_timestamp().await)
+            BatcherRequest::GetBlockMetadata => {
+                BatcherResponse::GetBlockMetadata(self.get_block_metadata().await)
             }
             BatcherRequest::CallContract(input) => {
                 BatcherResponse::CallContract(self.call_contract(input).await)

--- a/crates/apollo_batcher/src/test_utils.rs
+++ b/crates/apollo_batcher/src/test_utils.rs
@@ -45,8 +45,6 @@ use starknet_api::test_utils::l1_handler::{executable_l1_handler_tx, L1HandlerTx
 use starknet_api::transaction::fields::{Fee, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{class_hash, contract_address, nonce, tx_hash};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::{Receiver, Sender, UnboundedSender};
 use tokio::time::sleep;
@@ -309,7 +307,7 @@ impl Default for MockClients {
             Box::pin(async {
                 Ok(ReadPathsAndCommitBlockResponse {
                     global_root: GlobalRoot::default(),
-                    state_commitment_infos: StateCommitmentInfos::default(),
+                    state_commitment_infos: String::new(),
                 })
             })
         });

--- a/crates/apollo_batcher_types/Cargo.toml
+++ b/crates/apollo_batcher_types/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Type definitions and interfaces for the Apollo batcher component."
 
 [features]
-os_input = ["dep:starknet_committer"]
+os_input = []
 testing = ["mockall"]
 
 [lints]
@@ -26,7 +26,6 @@ mockall = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 starknet-types-core.workspace = true
 starknet_api.workspace = true
-starknet_committer = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -15,8 +15,6 @@ use async_trait::async_trait;
 use mockall::automock;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockNumber, ReplayMetadata};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use thiserror::Error;
 
@@ -56,11 +54,12 @@ pub trait BatcherClient: Send + Sync {
     async fn propose_block(&self, input: ProposeBlockInput) -> BatcherClientResult<()>;
     /// Gets the block hash for a given block number.
     async fn get_block_hash(&self, block_number: BlockNumber) -> BatcherClientResult<BlockHash>;
+    /// Gets the compressed (`base64(zstd(serde_json(..)))`) state commitment infos for a block.
     #[cfg(feature = "os_input")]
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<StateCommitmentInfos>;
+    ) -> BatcherClientResult<String>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -146,7 +145,7 @@ pub enum BatcherResponse {
     ProposeBlock(BatcherResult<()>),
     GetBlockHash(BatcherResult<BlockHash>),
     #[cfg(feature = "os_input")]
-    GetStateCommitmentInfos(BatcherResult<StateCommitmentInfos>),
+    GetStateCommitmentInfos(BatcherResult<String>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -205,7 +204,7 @@ where
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<StateCommitmentInfos> {
+    ) -> BatcherClientResult<String> {
         let request = BatcherRequest::GetStateCommitmentInfos(block_number);
         handle_all_response_variants!(
             self,

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
 use mockall::automock;
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{BlockHash, BlockNumber, UnixTimestamp};
+use starknet_api::block::{BlockHash, BlockNumber, ReplayMetadata};
 #[cfg(feature = "os_input")]
 use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
@@ -98,7 +98,7 @@ pub trait BatcherClient: Send + Sync {
     ) -> BatcherClientResult<SendTxsForProposalStatus>;
     /// Reverts the block with the given block number, only if it is the last in the storage.
     async fn revert_block(&self, input: RevertBlockInput) -> BatcherClientResult<()>;
-    async fn get_batch_timestamp(&self) -> BatcherClientResult<UnixTimestamp>;
+    async fn get_block_metadata(&self) -> BatcherClientResult<ReplayMetadata>;
     /// Executes a view (read-only) entry point on a contract against the latest committed batcher
     /// state and returns the retdata.
     async fn call_contract(
@@ -129,7 +129,7 @@ pub enum BatcherRequest {
     DecisionReached(DecisionReachedInput),
     AddSyncBlock(SyncBlock),
     RevertBlock(RevertBlockInput),
-    GetBatchTimestamp,
+    GetBlockMetadata,
     CallContract(CallContractInput),
 }
 impl_debug_for_infra_requests_and_responses!(BatcherRequest);
@@ -157,7 +157,7 @@ pub enum BatcherResponse {
     DecisionReached(BatcherResult<Box<DecisionReachedResponse>>),
     AddSyncBlock(BatcherResult<()>),
     RevertBlock(BatcherResult<()>),
-    GetBatchTimestamp(BatcherResult<u64>),
+    GetBlockMetadata(BatcherResult<ReplayMetadata>),
     CallContract(BatcherResult<CallContractOutput>),
 }
 impl_debug_for_infra_requests_and_responses!(BatcherResponse);
@@ -360,13 +360,13 @@ where
         )
     }
 
-    async fn get_batch_timestamp(&self) -> BatcherClientResult<UnixTimestamp> {
-        let request = BatcherRequest::GetBatchTimestamp;
+    async fn get_block_metadata(&self) -> BatcherClientResult<ReplayMetadata> {
+        let request = BatcherRequest::GetBlockMetadata;
         handle_all_response_variants!(
             self,
             request,
             BatcherResponse,
-            GetBatchTimestamp,
+            GetBlockMetadata,
             BatcherClientError,
             BatcherError,
             Direct

--- a/crates/apollo_committer/Cargo.toml
+++ b/crates/apollo_committer/Cargo.toml
@@ -7,7 +7,12 @@ license.workspace = true
 description = "State root commitment computation component for the Starknet sequencer."
 
 [features]
-os_input = ["apollo_committer_types/os_input", "starknet_committer/os_input"]
+os_input = [
+  "apollo_committer_types/os_input",
+  "dep:base64",
+  "dep:zstd",
+  "starknet_committer/os_input",
+]
 testing = []
 
 [dependencies]
@@ -16,10 +21,13 @@ apollo_committer_types.workspace = true
 apollo_infra.workspace = true
 apollo_metrics.workspace = true
 async-trait.workspace = true
+base64 = { workspace = true, optional = true }
+serde_json.workspace = true
 starknet_api.workspace = true
 starknet_committer.workspace = true
 starknet_patricia_storage = { workspace = true, features = ["rocksdb_storage"] }
 tracing.workspace = true
+zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -61,6 +61,8 @@ use starknet_committer::forest::filled_forest::FilledForest;
 #[cfg(feature = "os_input")]
 use starknet_committer::patricia_merkle_tree::tree::LeavesRequest;
 #[cfg(feature = "os_input")]
+use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+#[cfg(feature = "os_input")]
 use starknet_patricia_storage::errors::SerializationError;
 use starknet_patricia_storage::map_storage::CachedStorage;
 use starknet_patricia_storage::rocksdb_storage::RocksDbStorage;
@@ -147,6 +149,21 @@ fn commit_tip_metadata_bundle(
         next_offset,
     )
 }
+
+/// Compresses the state commitment infos to `base64(zstd(serde_json(..)))`, once at the source, so
+/// the witness stays compact across the committer->batcher RPC (which has an 8 MB response cap),
+/// batcher storage, and the cende blob.
+#[cfg(feature = "os_input")]
+fn compress_state_commitment_infos(infos: &StateCommitmentInfos) -> CommitterResult<String> {
+    let json = serde_json::to_vec(infos)
+        .map_err(|err| CommitterError::StateCommitmentInfosSerialization(err.to_string()))?;
+    let compressed = zstd::encode_all(json.as_slice(), STATE_COMMITMENT_INFOS_ZSTD_LEVEL)
+        .map_err(|err| CommitterError::StateCommitmentInfosCompression(err.to_string()))?;
+    Ok(base64::encode(compressed))
+}
+
+#[cfg(feature = "os_input")]
+const STATE_COMMITMENT_INFOS_ZSTD_LEVEL: i32 = 3;
 
 /// Apollo committer. Maintains the Starknet state tries in persistent storage.
 pub struct Committer<S: Storage, ForestDB>
@@ -540,7 +557,12 @@ where
                     .await
                     .map_err(|error| self.map_internal_error_at_height(height, error))?
                     .ok_or(CommitterError::MissingPatriciaPaths { height })?;
-                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
+                Ok(ReadPathsAndCommitBlockResponse {
+                    global_root,
+                    state_commitment_infos: compress_state_commitment_infos(
+                        &state_commitment_infos,
+                    )?,
+                })
             }
             // Flow overview:
             // 1. Fetch patricia paths for the accessed keys.
@@ -603,7 +625,12 @@ where
                 block_measurements.attempt_to_stop_measurement(Action::EndToEnd, 0).ok();
                 update_metrics(height, &block_measurements.block_measurement);
                 self.update_offset(next_offset);
-                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
+                Ok(ReadPathsAndCommitBlockResponse {
+                    global_root,
+                    state_commitment_infos: compress_state_commitment_infos(
+                        &state_commitment_infos,
+                    )?,
+                })
             }
         }
     }

--- a/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
+++ b/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
@@ -162,6 +162,17 @@ static BLOCK_1_REVERSED_STATE_DIFF: LazyLock<ThinStateDiff> = LazyLock::new(|| T
     ..Default::default()
 });
 
+/// Decompresses the response witness (`base64(zstd(serde_json(..)))`) so the assertions below can
+/// inspect the trie commitment infos.
+fn decompress_response_commitment_infos(
+    response: &ReadPathsAndCommitBlockResponse,
+) -> StateCommitmentInfos {
+    let compressed =
+        base64::decode(&response.state_commitment_infos).expect("response witness is valid base64");
+    let json = zstd::decode_all(compressed.as_slice()).expect("response witness is valid zstd");
+    serde_json::from_slice(&json).expect("response witness deserializes into StateCommitmentInfos")
+}
+
 fn read_paths_and_commit_block_request(
     state_diff: ThinStateDiff,
     state_diff_commitment: Option<StateDiffCommitment>,
@@ -330,11 +341,11 @@ async fn read_paths_and_commit_block_happy_flow() {
 
     let response = committer.read_paths_and_commit_block(request.clone()).await.unwrap();
     assert_eq!(committer.offset, BlockNumber(height + 1));
+    let commitment_infos = decompress_response_commitment_infos(&response);
     // The commitment infos don't retain the contract-trie leaves, so reconstruct the expected
     // contract states for the accessed contracts: storage root from the commitment infos, class
     // hash from the block-0 deployment, and the default (zero) nonce.
-    let contract_leaves: HashMap<ContractAddress, ContractState> = response
-        .state_commitment_infos
+    let contract_leaves: HashMap<ContractAddress, ContractState> = commitment_infos
         .storage_tries_commitment_infos
         .iter()
         .map(|(address, storage_info)| {
@@ -349,7 +360,7 @@ async fn read_paths_and_commit_block_happy_flow() {
         })
         .collect();
     verify_witness_patricia_paths(
-        &response.state_commitment_infos,
+        &commitment_infos,
         &accessed_keys,
         &ACCESSED_CLASS_LEAVES,
         &contract_leaves,
@@ -362,13 +373,12 @@ async fn read_paths_and_commit_block_happy_flow() {
 
     let replay_response = committer.read_paths_and_commit_block(request).await.unwrap();
     assert_eq!(response.global_root, replay_response.global_root);
-    assert_eq!(response.state_commitment_infos, replay_response.state_commitment_infos);
-    assert_witnesses_and_digest_present(
-        &mut committer,
-        BlockNumber(height),
-        &response.state_commitment_infos,
-    )
-    .await;
+    // Compare the decompressed witnesses, not the compressed strings: `StateCommitmentInfos`
+    // contains `HashMap`s whose JSON serialization order is not stable, so two equal witnesses can
+    // compress to different byte strings.
+    assert_eq!(commitment_infos, decompress_response_commitment_infos(&replay_response));
+    assert_witnesses_and_digest_present(&mut committer, BlockNumber(height), &commitment_infos)
+        .await;
 }
 
 /// Flow overview:
@@ -397,7 +407,7 @@ async fn revert_removes_witnesses_and_digest() {
     assert_witnesses_and_digest_present(
         &mut committer,
         BlockNumber(height_1),
-        &block_1_response.state_commitment_infos,
+        &decompress_response_commitment_infos(&block_1_response),
     )
     .await;
 
@@ -485,8 +495,7 @@ async fn test_bottom_of_new_edge_to_an_unmoidifed_subtree_is_present() {
     // This in turn also proves that G is not an edge node, as it's the bottom of an old
     // edge node, without explicitly requesting an opening of E.
     assert!(
-        response
-            .state_commitment_infos
+        decompress_response_commitment_infos(&response)
             .classes_trie_commitment_info
             .commitment_facts
             .contains_key(&node_g_hash),
@@ -558,8 +567,7 @@ async fn test_bottom_of_new_edge_which_was_not_bottom_of_an_old_edge_is_present(
     }));
 
     assert!(
-        response
-            .state_commitment_infos
+        decompress_response_commitment_infos(&response)
             .classes_trie_commitment_info
             .commitment_facts
             .contains_key(&node_e_hash),

--- a/crates/apollo_committer_types/src/committer_types.rs
+++ b/crates/apollo_committer_types/src/committer_types.rs
@@ -4,8 +4,6 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
 use starknet_api::state::ThinStateDiff;
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommitBlockRequest {
@@ -50,5 +48,7 @@ pub struct ReadPathsAndCommitBlockRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReadPathsAndCommitBlockResponse {
     pub global_root: GlobalRoot,
-    pub state_commitment_infos: StateCommitmentInfos,
+    /// The OS-input commitment infos, compressed by the committer into a
+    /// `base64(zstd(serde_json(StateCommitmentInfos)))` string (kept compact across this RPC).
+    pub state_commitment_infos: String,
 }

--- a/crates/apollo_committer_types/src/errors.rs
+++ b/crates/apollo_committer_types/src/errors.rs
@@ -62,6 +62,16 @@ pub enum CommitterError {
     #[cfg(feature = "os_input")]
     #[error("Missing Patricia paths for block {height}")]
     MissingPatriciaPaths { height: BlockNumber },
+    // Holds the error message rather than `#[from] serde_json::Error` because `CommitterError`
+    // crosses the RPC boundary and must stay `Clone`/`Serialize`/`Deserialize`.
+    #[cfg(feature = "os_input")]
+    #[error("Failed to serialize state commitment infos: {0}")]
+    StateCommitmentInfosSerialization(String),
+    // Holds the error message rather than `#[from] std::io::Error` for the same reason as
+    // `StateCommitmentInfosSerialization`.
+    #[cfg(feature = "os_input")]
+    #[error("Failed to compress state commitment infos: {0}")]
+    StateCommitmentInfosCompression(String),
 }
 
 pub type CommitterResult<T> = Result<T, CommitterError>;

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -292,10 +292,11 @@ impl ConsensusManager {
         SequencerConsensusContext::new(
             self.config.context_config.clone(),
             SequencerConsensusContextDeps {
-                transaction_converter: Arc::new(TransactionConverter::new(
+                transaction_converter: Arc::new(TransactionConverter::new_with_behavior_mode(
                     Arc::clone(&self.class_manager_client),
                     Arc::clone(&self.proof_manager_client),
                     self.config.context_config.static_config.chain_id.clone(),
+                    self.config.context_config.static_config.behavior_mode.clone(),
                 )),
                 state_sync_client: Arc::clone(&self.state_sync_client),
                 batcher: Arc::clone(&self.batcher_client),

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -42,7 +42,6 @@ serde_json = { workspace = true, features = ["arbitrary_precision"] }
 shared_execution_objects.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
-starknet_committer = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
@@ -83,11 +82,10 @@ rand_chacha.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 shared_execution_objects = { workspace = true, features = ["deserialize", "testing"] }
-starknet_committer = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true
 
 [features]
-os_input = ["apollo_batcher/os_input", "dep:starknet_committer"]
+os_input = ["apollo_batcher/os_input"]
 testing = ["shared_execution_objects/deserialize", "shared_execution_objects/testing"]

--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -28,11 +28,12 @@ use apollo_protobuf::consensus::{
 };
 use apollo_time::time::{Clock, DateTime};
 use apollo_transaction_converter::TransactionConverterError;
-use starknet_api::block::GasPrice;
+use starknet_api::block::{GasPrice, ReplayMetadata};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::transaction::TransactionHash;
+use starknet_api::versioned_constants_logic::effective_starknet_version;
 use starknet_api::StarknetApiError;
 use strum::{EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use tokio_util::sync::CancellationToken;
@@ -73,8 +74,8 @@ pub(crate) struct ProposalBuildArguments {
     pub proposal_round: Round,
     pub retrospective_block_hash_deadline: DateTime,
     pub retrospective_block_hash_retry_interval_millis: Duration,
-    // If true, for echonet mode, use the timestamp from the original block.
-    pub override_timestamp: bool,
+    // If true, for echonet mode, use the metadata of the original block.
+    pub override_block_metadata: bool,
     pub override_l2_gas_price_fri: Option<u128>,
     pub min_l2_gas_price_per_height: Vec<PricePerHeight>,
     pub compare_retrospective_block_hash: bool,
@@ -136,36 +137,83 @@ pub(crate) async fn build_proposal(
     Ok(proposal_commitment)
 }
 
-async fn get_proposal_timestamp(
-    override_timestamp: bool,
+async fn get_proposal_metadata(
+    override_block_metadata: bool,
     batcher: &dyn BatcherClient,
     clock: &dyn Clock,
-) -> u64 {
-    if override_timestamp {
-        match batcher.get_batch_timestamp().await {
-            Ok(timestamp) => return timestamp,
+) -> ReplayMetadata {
+    if override_block_metadata {
+        match batcher.get_block_metadata().await {
+            Ok(block_metadata) => {
+                info!(
+                    "Received block metadata from echonet: timestamp={}, block_number={:?}",
+                    block_metadata.timestamp, block_metadata.block_number,
+                );
+                return block_metadata;
+            }
             Err(err) => {
-                warn!("Failed to get timestamp from batcher, falling back to clock time: {err:?}");
+                warn!(
+                    "Failed to get block metadata from batcher, falling back to defaults: {err:?}"
+                );
             }
         }
     }
-    clock.unix_now()
+    ReplayMetadata {
+        timestamp: clock.unix_now(),
+        block_number: None,
+        l1_gas_price_wei: GasPrice::default(),
+        l1_data_gas_price_wei: GasPrice::default(),
+        l1_gas_price_fri: GasPrice::default(),
+        l1_data_gas_price_fri: GasPrice::default(),
+        l2_gas_price_fri: GasPrice::default(),
+    }
 }
 
 async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResult<ProposalInit> {
-    let timestamp = get_proposal_timestamp(
-        args.override_timestamp,
+    let proposal_metadata = get_proposal_metadata(
+        args.override_block_metadata,
         args.deps.batcher.as_ref(),
         args.deps.clock.as_ref(),
     )
     .await;
-    let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
-        args.deps.l1_gas_price_provider.clone(),
-        timestamp,
-        args.previous_proposal_init.as_ref(),
-        &args.gas_price_params,
-    )
-    .await;
+    let starknet_version = effective_starknet_version();
+    info!(
+        "Proposal metadata for height {}: starknet_version={}, timestamp={}, \
+         override_block_metadata={}",
+        args.build_param.height,
+        starknet_version,
+        proposal_metadata.timestamp,
+        args.override_block_metadata,
+    );
+    let timestamp = proposal_metadata.timestamp;
+    let (l1_gas_price_wei, l1_data_gas_price_wei, l1_gas_price_fri, l1_data_gas_price_fri) =
+        if args.override_block_metadata {
+            (
+                proposal_metadata.l1_gas_price_wei,
+                proposal_metadata.l1_data_gas_price_wei,
+                proposal_metadata.l1_gas_price_fri,
+                proposal_metadata.l1_data_gas_price_fri,
+            )
+        } else {
+            let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
+                args.deps.l1_gas_price_provider.clone(),
+                timestamp,
+                args.previous_proposal_init.as_ref(),
+                &args.gas_price_params,
+            )
+            .await;
+            (
+                l1_prices_wei.l1_gas_price,
+                l1_prices_wei.l1_data_gas_price,
+                l1_prices_fri.l1_gas_price,
+                l1_prices_fri.l1_data_gas_price,
+            )
+        };
+    let l2_gas_price_fri = if args.override_block_metadata {
+        proposal_metadata.l2_gas_price_fri
+    } else {
+        args.l2_gas_price
+    };
     let init = ProposalInit {
         height: args.build_param.height,
         round: args.build_param.round,
@@ -174,12 +222,12 @@ async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResul
         builder: args.builder_address,
         timestamp,
         l1_da_mode: args.l1_da_mode,
-        l2_gas_price_fri: args.l2_gas_price,
-        l1_gas_price_wei: l1_prices_wei.l1_gas_price,
-        l1_data_gas_price_wei: l1_prices_wei.l1_data_gas_price,
-        l1_gas_price_fri: l1_prices_fri.l1_gas_price,
-        l1_data_gas_price_fri: l1_prices_fri.l1_data_gas_price,
-        starknet_version: starknet_api::block::StarknetVersion::LATEST,
+        l2_gas_price_fri,
+        l1_gas_price_wei,
+        l1_data_gas_price_wei,
+        l1_gas_price_fri,
+        l1_data_gas_price_fri,
+        starknet_version,
         // TODO(Asmaa): Put the real value once we have it.
         // Sentinel until then; see `expected_version_constant_commitment` for why this is the
         // single source of truth shared with the validator.

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -133,8 +133,6 @@ use starknet_api::transaction::{
     TransactionVersion,
 };
 use starknet_api::{contract_address, felt, nonce, storage_key};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 use starknet_types_core::felt::Felt;
 
 use super::{
@@ -744,11 +742,7 @@ fn recent_state_commitment_infos() -> Vec<StateCommitmentInfosAndNumber> {
     [BlockNumber(1), BlockNumber(2)]
         .into_iter()
         .map(|block_number| StateCommitmentInfosAndNumber {
-            state_commitment_infos: StateCommitmentInfos {
-                contracts_trie_commitment_info: CommitmentInfo::default(),
-                classes_trie_commitment_info: CommitmentInfo::default(),
-                storage_tries_commitment_infos: HashMap::new(),
-            },
+            state_commitment_infos: format!("compressed-state-commitment-infos-{block_number}"),
             block_number,
         })
         .collect()

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -768,6 +768,7 @@ fn central_blob() -> AerospikeBlob {
 
     let blob_parameters = BlobParameters {
         block_info: block_info(),
+        starknet_version: StarknetVersion::LATEST,
         state_diff: thin_state_diff(),
         compressed_state_diff: Some(commitment_state_diff()),
         transactions_with_execution_infos,
@@ -806,6 +807,7 @@ fn central_blob_with_empty_or_none_fields() -> AerospikeBlob {
     let mock_class_manager = MockClassManagerClient::new();
     let blob_parameters = BlobParameters {
         block_info: block_info(),
+        starknet_version: StarknetVersion::LATEST,
         state_diff: thin_state_diff(),
         compressed_state_diff: None,
         transactions_with_execution_infos: vec![],

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -391,6 +391,7 @@ pub struct InternalTransactionWithReceipt {
 #[derive(Debug, Default)]
 pub struct BlobParameters {
     pub block_info: BlockInfo,
+    pub starknet_version: StarknetVersion,
     pub state_diff: ThinStateDiff,
     pub compressed_state_diff: Option<CommitmentStateDiff>,
     pub bouncer_weights: BouncerWeights,
@@ -422,7 +423,7 @@ impl AerospikeBlob {
         let block_timestamp = blob_parameters.block_info.block_timestamp.0;
 
         let block_info =
-            CentralBlockInfo::from((blob_parameters.block_info, StarknetVersion::LATEST));
+            CentralBlockInfo::from((blob_parameters.block_info, blob_parameters.starknet_version));
         let state_diff = CentralStateDiff::from((blob_parameters.state_diff, block_info.clone()));
         let compressed_state_diff =
             blob_parameters.compressed_state_diff.map(|compressed_state_diff| {

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -128,6 +128,12 @@ pub trait CendeContext: Send + Sync {
         &self,
         blob_parameters: BlobParameters,
     ) -> CendeAmbassadorResult<()>;
+
+    /// Returns the highest block whose state commitment info the recorder has contiguously stored,
+    /// or `None` if the recorder has none stored or the query failed. Used to bound the
+    /// `recent_state_commitment_infos` window to only the delta the recorder is still missing.
+    #[cfg(feature = "os_input")]
+    async fn query_last_stored_commitment_height(&self) -> Option<BlockNumber>;
 }
 
 #[derive(Clone)]
@@ -138,6 +144,8 @@ pub struct CendeAmbassador {
     prev_height_blob: Arc<Mutex<Option<Arc<AerospikeBlob>>>>,
     write_blob_url: Url,
     get_latest_received_block_url: Url,
+    #[cfg(feature = "os_input")]
+    get_last_stored_commitment_height_url: Url,
     client: ClientWithMiddleware,
     class_manager: SharedClassManagerClient,
 }
@@ -148,9 +156,20 @@ pub const RECORDER_WRITE_BLOB_PATH: &str = "/cende_recorder/write_blob";
 /// to DB. returns null when no blocks exist).
 pub const RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH: &str =
     "/cende_recorder/get_latest_received_block";
+/// The path to get the highest block whose state commitment info the Recorder has contiguously
+/// stored (returns null when none are stored).
+#[cfg(feature = "os_input")]
+pub const RECORDER_GET_LAST_STORED_COMMITMENT_HEIGHT_PATH: &str =
+    "/cende_recorder/get_last_stored_commitment_height";
 
 #[derive(Debug, Deserialize)]
 struct GetLatestReceivedBlockResponse {
+    block_number: Option<u64>,
+}
+
+#[cfg(feature = "os_input")]
+#[derive(Debug, Deserialize)]
+struct GetLastStoredCommitmentHeightResponse {
     block_number: Option<u64>,
 }
 
@@ -171,6 +190,11 @@ impl CendeAmbassador {
                 .recorder_url
                 .join(RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH)
                 .expect("Failed to construct get latest received block URL"),
+            #[cfg(feature = "os_input")]
+            get_last_stored_commitment_height_url: cende_config
+                .recorder_url
+                .join(RECORDER_GET_LAST_STORED_COMMITMENT_HEIGHT_PATH)
+                .expect("Failed to construct get last stored commitment height URL"),
             // Bound each attempt by the max retry interval. Without a per-attempt timeout
             // `RetryTransientMiddleware` only retries attempts that *return* a transient error, so
             // a request that hangs against a slow recorder would block until the build deadline
@@ -265,6 +289,38 @@ async fn fetch_latest_received_block(
     }
 }
 
+#[cfg(feature = "os_input")]
+async fn fetch_last_stored_commitment_height(
+    client: &ClientWithMiddleware,
+    url: &Url,
+) -> Option<BlockNumber> {
+    match client.get(url.as_str()).send().await {
+        Ok(response) if response.status().is_success() => {
+            match response.json::<GetLastStoredCommitmentHeightResponse>().await {
+                Ok(resp) => resp.block_number.map(BlockNumber),
+                Err(e) => {
+                    warn!(
+                        "Failed to parse recorder get_last_stored_commitment_height response: {e}"
+                    );
+                    None
+                }
+            }
+        }
+        Ok(response) => {
+            warn!(
+                "Recorder get_last_stored_commitment_height returned error status {}: {}",
+                response.status(),
+                response.text().await.unwrap_or_else(|_| "unparseable".to_string())
+            );
+            None
+        }
+        Err(e) => {
+            warn!("Failed to request recorder get_last_stored_commitment_height: {e}");
+            None
+        }
+    }
+}
+
 #[async_trait]
 impl CendeContext for CendeAmbassador {
     fn write_prev_height_blob(&self, current_height: BlockNumber) -> JoinHandle<bool> {
@@ -334,6 +390,15 @@ impl CendeContext for CendeAmbassador {
         info!("Blob for block number {block_number} is ready.");
         CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER.set_lossy(block_number.0);
         Ok(())
+    }
+
+    #[cfg(feature = "os_input")]
+    async fn query_last_stored_commitment_height(&self) -> Option<BlockNumber> {
+        fetch_last_stored_commitment_height(
+            &self.client,
+            &self.get_last_stored_commitment_height_url,
+        )
+        .await
     }
 }
 

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -44,8 +44,6 @@ use starknet_api::block::{BlockHashAndNumber, BlockInfo, BlockNumber, StarknetVe
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ClassHash;
 use starknet_api::state::ThinStateDiff;
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use tokio::sync::Mutex;
 use tokio::task::{self, JoinHandle};
 use tracing::{info, warn, Instrument};
@@ -80,7 +78,9 @@ pub type CendeAmbassadorResult<T> = Result<T, CendeAmbassadorError>;
 #[cfg(feature = "os_input")]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StateCommitmentInfosAndNumber {
-    pub state_commitment_infos: StateCommitmentInfos,
+    /// Compressed (`base64(zstd(serde_json(..)))`) commitment infos from the committer, forwarded
+    /// as-is into the cende blob.
+    pub state_commitment_infos: String,
     pub block_number: BlockNumber,
 }
 

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -592,6 +592,7 @@ impl SequencerConsensusContext {
             .cende_ambassador
             .prepare_blob_for_next_height(BlobParameters {
                 block_info: cende_block_info,
+                starknet_version: init.starknet_version,
                 state_diff,
                 compressed_state_diff: central_objects.compressed_state_diff,
                 transactions_with_execution_infos,
@@ -775,7 +776,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 self.config.static_config.build_proposal_time_ratio_for_retrospective_block_hash,
             );
 
-        let override_timestamp = match self.config.static_config.behavior_mode {
+        let override_block_metadata = match self.config.static_config.behavior_mode {
             BehaviorMode::Echonet => true,
             BehaviorMode::Starknet => false,
         };
@@ -813,7 +814,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 .config
                 .static_config
                 .retrospective_block_hash_retry_interval_millis,
-            override_timestamp,
+            override_block_metadata,
             override_l2_gas_price_fri: self.config.dynamic_config.override_l2_gas_price_fri,
             min_l2_gas_price_per_height: self
                 .config

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -703,7 +703,18 @@ impl SequencerConsensusContext {
                 .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
                 + 1,
         );
-        let lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
+        // The recorder only needs the commitment infos it has not stored yet, so query how far it
+        // is caught up and send only the delta from there. The fixed window remains an upper bound
+        // (cap how much we ever send), and a failed/empty query falls back to the full window so
+        // correctness never depends on the optimization succeeding.
+        let fixed_window_lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
+        let lowest_height =
+            match self.deps.cende_ambassador.query_last_stored_commitment_height().await {
+                Some(last_stored_height) => {
+                    fixed_window_lowest_height.max(last_stored_height.0.saturating_add(1))
+                }
+                None => fixed_window_lowest_height,
+            };
         for height in lowest_height..=height.0 {
             let block_number = BlockNumber(height);
             match self.deps.batcher.get_state_commitment_infos(block_number).await {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeMap;
-#[cfg(feature = "os_input")]
-use std::collections::HashMap;
 use std::future::ready;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
@@ -63,8 +61,6 @@ use starknet_api::execution_resources::GasAmount;
 use starknet_api::hash::StarkHash;
 use starknet_api::state::ThinStateDiff;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 
 #[cfg(feature = "os_input")]
 use crate::cende::StateCommitmentInfosAndNumber;
@@ -920,11 +916,8 @@ async fn blob_parent_proposal_commitment_binds_parent_fee_proposal() {
 async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let (mut deps, _network) = create_test_and_network_deps();
 
-    let state_commitment_infos = StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    };
+    // The batcher serves the compressed witness string; the orchestrator forwards it verbatim.
+    let state_commitment_infos = "compressed-state-commitment-infos".to_string();
 
     let returned_infos = state_commitment_infos.clone();
     deps.batcher
@@ -960,12 +953,8 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
 }
 
 #[cfg(feature = "os_input")]
-fn default_state_commitment_infos() -> StateCommitmentInfos {
-    StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    }
+fn default_state_commitment_infos() -> String {
+    "compressed-state-commitment-infos".to_string()
 }
 
 /// Builds a context whose batcher serves a commitment info for any height and whose recorder

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -932,6 +932,8 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
         .times(1)
         .return_once(move |_| Ok(returned_infos));
 
+    // setup_deps_for_build's default cende ambassador reports nothing stored, so the full window
+    // (just block 0 at this height) is sent.
     deps.setup_deps_for_build(SetupDepsArgs::default());
     deps.batcher
         .expect_decision_reached()
@@ -955,6 +957,88 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let mut context = deps.build_context();
     let _fin = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap().await;
     context.decision_reached(HEIGHT_0, ROUND_0, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
+}
+
+#[cfg(feature = "os_input")]
+fn default_state_commitment_infos() -> StateCommitmentInfos {
+    StateCommitmentInfos {
+        contracts_trie_commitment_info: CommitmentInfo::default(),
+        classes_trie_commitment_info: CommitmentInfo::default(),
+        storage_tries_commitment_infos: HashMap::new(),
+    }
+}
+
+/// Builds a context whose batcher serves a commitment info for any height and whose recorder
+/// reports `last_stored_height`, then returns the block numbers
+/// `collect_recent_state_commitment_infos` chose to send for `height`.
+#[cfg(feature = "os_input")]
+async fn collected_heights_for(
+    height: BlockNumber,
+    last_stored_height: Option<BlockNumber>,
+) -> Vec<u64> {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.batcher
+        .expect_get_state_commitment_infos()
+        .returning(|_| Ok(default_state_commitment_infos()));
+    deps.cende_ambassador
+        .expect_query_last_stored_commitment_height()
+        .times(1)
+        .return_once(move || last_stored_height);
+
+    let context = deps.build_context();
+    context
+        .collect_recent_state_commitment_infos(height)
+        .await
+        .iter()
+        .map(|info| info.block_number.0)
+        .collect()
+}
+
+/// When the recorder is behind, only the missing delta `(last_stored, height]` is sent.
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_sends_only_delta_above_recorder() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(97))).await;
+    assert_eq!(heights, vec![98, 99, 100]);
+}
+
+/// When the recorder is caught up to the previous block, only the current block is sent.
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_sends_single_block_when_recorder_caught_up() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(99))).await;
+    assert_eq!(heights, vec![100]);
+}
+
+/// The fixed window caps the delta: a recorder further behind than the window only gets the window.
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_caps_delta_at_fixed_window() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(50))).await;
+    let expected: Vec<u64> = (100 - N_BLOCK_HASHES_BACK_IN_BLOB..=100).collect();
+    assert_eq!(heights, expected);
+}
+
+/// A failed/empty query falls back to the full fixed window (safe degradation).
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_falls_back_to_full_window_on_query_failure() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, None).await;
+    let expected: Vec<u64> = (100 - N_BLOCK_HASHES_BACK_IN_BLOB..=100).collect();
+    assert_eq!(heights, expected);
+}
+
+/// If the recorder is at or ahead of the proposed height, nothing is sent (empty delta).
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_sends_nothing_when_recorder_at_height() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(100))).await;
+    assert!(heights.is_empty(), "expected empty delta, got {heights:?}");
 }
 
 /// Verify that when `stop_at_height` is set and decision is reached at that height:

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -318,6 +318,10 @@ impl TestDeps {
         self.cende_ambassador
             .expect_write_prev_height_blob()
             .return_once(|_height| tokio::spawn(ready(true)));
+        // Default: recorder reports nothing stored, so blob building sends the full commitment-info
+        // window. Tests exercising the delta bounding set their own expectation instead.
+        #[cfg(feature = "os_input")]
+        self.cende_ambassador.expect_query_last_stored_commitment_height().returning(|| None);
     }
 
     pub(crate) fn setup_default_gas_price_provider(&mut self) {

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -493,7 +493,7 @@ pub(crate) struct TestProposalBuildArguments {
     pub proposal_round: Round,
     pub retrospective_block_hash_deadline: DateTime,
     pub retrospective_block_hash_retry_interval_millis: Duration,
-    pub override_timestamp: bool,
+    pub override_block_metadata: bool,
     pub override_l2_gas_price_fri: Option<u128>,
     pub min_l2_gas_price_per_height: Vec<PricePerHeight>,
     pub compare_retrospective_block_hash: bool,
@@ -519,7 +519,7 @@ impl From<TestProposalBuildArguments> for ProposalBuildArguments {
             retrospective_block_hash_deadline: args.retrospective_block_hash_deadline,
             retrospective_block_hash_retry_interval_millis: args
                 .retrospective_block_hash_retry_interval_millis,
-            override_timestamp: args.override_timestamp,
+            override_block_metadata: args.override_block_metadata,
             override_l2_gas_price_fri: args.override_l2_gas_price_fri,
             min_l2_gas_price_per_height: args.min_l2_gas_price_per_height,
             compare_retrospective_block_hash: args.compare_retrospective_block_hash,
@@ -552,7 +552,7 @@ pub(crate) fn create_proposal_build_arguments()
     let cancel_token = CancellationToken::new();
     let previous_proposal_init = None;
     let proposal_round = 0;
-    let override_timestamp = false;
+    let override_block_metadata = false;
 
     (
         TestProposalBuildArguments {
@@ -572,7 +572,7 @@ pub(crate) fn create_proposal_build_arguments()
             proposal_round,
             retrospective_block_hash_deadline,
             retrospective_block_hash_retry_interval_millis,
-            override_timestamp,
+            override_block_metadata,
             override_l2_gas_price_fri: None,
             min_l2_gas_price_per_height: vec![],
             compare_retrospective_block_hash: true,

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -2507,32 +2507,6 @@
           "extra_params": {}
         },
         {
-          "title": "get_batch_timestamp (client-side)",
-          "description": "client-side infra metrics for request type get_batch_timestamp",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
-          "title": "get_batch_timestamp (server-side)",
-          "description": "server-side infra metrics for request type get_batch_timestamp",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
           "title": "get_block_hash (client-side)",
           "description": "client-side infra metrics for request type get_block_hash",
           "type": "timeseries",
@@ -2555,6 +2529,32 @@
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_metadata (client-side)",
+          "description": "client-side infra metrics for request type get_block_metadata",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_metadata (server-side)",
+          "description": "server-side infra metrics for request type get_block_metadata",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_metadata\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },
@@ -3971,28 +3971,28 @@
           "extra_params": {}
         },
         {
-          "title": "resolve_batch_timestamp (client-side)",
-          "description": "client-side infra metrics for request type resolve_batch_timestamp",
+          "title": "resolve_block_metadata (client-side)",
+          "description": "client-side infra metrics for request type resolve_block_metadata",
           "type": "timeseries",
           "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },
         {
-          "title": "resolve_batch_timestamp (server-side)",
-          "description": "server-side infra metrics for request type resolve_batch_timestamp",
+          "title": "resolve_block_metadata (server-side)",
+          "description": "server-side infra metrics for request type resolve_block_metadata",
           "type": "timeseries",
           "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.50 mempool_queueing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_batch_timestamp\"}[5m])), \"label_name\", \"0.95 mempool_queueing_times_secs\", \"le\", \".*\"))"
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.50 mempool_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(mempool_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"resolve_block_metadata\"}[5m])), \"label_name\", \"0.95 mempool_queueing_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },

--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -42,6 +42,7 @@ google-cloud-storage.workspace = true
 mempool_test_utils.workspace = true
 mockall.workspace = true
 num-rational.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -539,13 +539,15 @@ pub fn create_gateway(
         class_manager_client: class_manager_client.clone(),
         runtime,
     });
-    let transaction_converter = Arc::new(TransactionConverter::new(
+    let transaction_converter = Arc::new(TransactionConverter::new_with_behavior_mode(
         class_manager_client,
         proof_manager_client,
         config.static_config.chain_info.chain_id.clone(),
+        config.static_config.behavior_mode.clone(),
     ));
     let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
         config: config.static_config.stateless_tx_validator_config.clone(),
+        behavior_mode: config.static_config.behavior_mode.clone(),
     });
 
     // Create proof archive writer: use NoOp if bucket name is empty, otherwise use real GCS.

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::SharedClassManagerClient;
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::config::GatewayConfig;
 use apollo_gateway_types::deprecated_gateway_error::{
     KnownStarknetErrorCode,
@@ -29,6 +30,7 @@ use apollo_transaction_converter::{
 };
 use async_trait::async_trait;
 use blockifier::state::contract_class_manager::ContractClassManager;
+use starknet_api::block::StarknetVersion;
 use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
@@ -39,6 +41,7 @@ use starknet_api::rpc_transaction::{
 };
 use starknet_api::transaction::fields::{Proof, ProofFacts, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
+use starknet_api::versioned_constants_logic::set_effective_latest_version;
 use starknet_types_core::felt::Felt;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -186,6 +189,40 @@ impl<
     pub async fn start(&self) {
         register_metrics();
         self.proof_archive_writer.connect().await;
+        if self.config.static_config.behavior_mode == BehaviorMode::Echonet {
+            self.set_effective_starknet_version_from_echonet().await;
+        }
+    }
+
+    async fn set_effective_starknet_version_from_echonet(&self) {
+        let url: reqwest::Url = self
+            .config
+            .static_config
+            .recorder_url
+            .join("echonet/get_starknet_version")
+            .expect("recorder_url is validated at config load; joining a static path cannot fail")
+            .as_str()
+            .parse()
+            .expect("valid URL");
+
+        match reqwest::get(url).await {
+            Ok(response) if response.status().is_success() => match response.text().await {
+                Ok(version_str) => match StarknetVersion::try_from(version_str.trim()) {
+                    Ok(version) => {
+                        info!("Setting effective Starknet version from echonet: {version}");
+                        set_effective_latest_version(version);
+                    }
+                    Err(e) => {
+                        warn!("Failed to parse starknet version '{version_str}' from echonet: {e}")
+                    }
+                },
+                Err(e) => warn!("Failed to read echonet starknet version response: {e}"),
+            },
+            Ok(response) => {
+                warn!("Echonet get_starknet_version returned HTTP {}", response.status())
+            }
+            Err(e) => warn!("Failed to fetch starknet version from echonet: {e}"),
+        }
     }
 
     #[sequencer_latency_histogram(GATEWAY_ADD_TX_LATENCY, true)]

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::sync::{Arc, LazyLock};
 
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::dumping::SerializeConfig;
 use apollo_config::loading::load_and_process_config;
 use apollo_gateway_config::config::{
@@ -142,6 +143,8 @@ fn mock_dependencies() -> MockDependencies {
             authorized_declarer_accounts: None,
             max_concurrent_declare_compilations: 5,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
+            behavior_mode: BehaviorMode::Starknet,
+            recorder_url: "https://recorder_url".parse().unwrap(),
         },
         ..Default::default()
     };

--- a/crates/apollo_gateway/src/stateless_transaction_validator.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator.rs
@@ -1,3 +1,4 @@
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::compiler_version::VersionId;
 use apollo_gateway_config::config::StatelessTransactionValidatorConfig;
 use starknet_api::data_availability::DataAvailabilityMode;
@@ -26,6 +27,10 @@ pub trait StatelessTransactionValidatorTrait: Send + Sync {
 #[derive(Clone)]
 pub struct StatelessTransactionValidator {
     pub config: StatelessTransactionValidatorConfig,
+    // When set to `Echonet`, the consistency check accepts proof_facts without a proof
+    // (mainnet's feeder gateway strips the proof field, so a replayed private tx is
+    // sent here with proof_facts only). See `validate_proof_facts_and_proof_consistency`.
+    pub behavior_mode: BehaviorMode,
 }
 
 impl StatelessTransactionValidator {
@@ -253,6 +258,14 @@ impl StatelessTransactionValidator {
         let RpcInvokeTransaction::V3(tx) = tx;
         let has_proof_facts = !tx.proof_facts.is_empty();
         let has_proof = !tx.proof.is_empty();
+        // Echonet replays mainnet txs but mainnet's feeder gateway strips the `proof` field
+        // before serving — only `proof_facts` survives the round-trip. The proof is just
+        // verification metadata (not part of the tx hash, not read during execution); skipping
+        // its verification on replay produces the same tx hash, state diff, and block hash.
+        // So treat "facts present, proof absent" as valid in Echonet mode.
+        if self.behavior_mode == BehaviorMode::Echonet && has_proof_facts && !has_proof {
+            return Ok(());
+        }
         if has_proof_facts != has_proof {
             return Err(StatelessTransactionValidatorError::ProofFactsAndProofConsistency {
                 has_proof_facts,

--- a/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
@@ -235,11 +235,10 @@ fn test_invalid_resource_bounds(
     #[values(TransactionType::Declare, TransactionType::DeployAccount, TransactionType::Invoke)]
     tx_type: TransactionType,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator {
-            config: DEFAULT_VALIDATOR_CONFIG.to_owned(),
-            behavior_mode: BehaviorMode::default(),
-        };
+    let tx_validator = StatelessTransactionValidator {
+        config: DEFAULT_VALIDATOR_CONFIG.to_owned(),
+        behavior_mode: BehaviorMode::default(),
+    };
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -268,11 +267,10 @@ fn test_invalid_max_l2_gas_amount(
     #[case] expected_error: StatelessTransactionValidatorError,
     #[values(TransactionType::DeployAccount, TransactionType::Invoke)] tx_type: TransactionType,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator {
-            config: DEFAULT_VALIDATOR_CONFIG.to_owned(),
-            behavior_mode: BehaviorMode::default(),
-        };
+    let tx_validator = StatelessTransactionValidator {
+        config: DEFAULT_VALIDATOR_CONFIG.to_owned(),
+        behavior_mode: BehaviorMode::default(),
+    };
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -483,11 +481,10 @@ fn test_declare_sierra_version_failure(
     #[case] sierra_program: Vec<Felt>,
     #[case] expected_error: StatelessTransactionValidatorError,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator {
-            config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
-            behavior_mode: BehaviorMode::default(),
-        };
+    let tx_validator = StatelessTransactionValidator {
+        config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
+        behavior_mode: BehaviorMode::default(),
+    };
 
     let contract_class = SierraContractClass { sierra_program, ..Default::default() };
     let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
@@ -506,11 +503,10 @@ fn test_declare_sierra_version_failure(
 ))]
 #[case::max_sierra_version(create_sierra_program(&MAX_SIERRA_VERSION))]
 fn test_declare_sierra_version_sucsses(#[case] sierra_program: Vec<Felt>) {
-    let tx_validator =
-        StatelessTransactionValidator {
-            config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
-            behavior_mode: BehaviorMode::default(),
-        };
+    let tx_validator = StatelessTransactionValidator {
+        config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
+        behavior_mode: BehaviorMode::default(),
+    };
 
     let contract_class = SierraContractClass { sierra_program, ..Default::default() };
     let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
@@ -612,11 +608,10 @@ fn test_declare_entry_points_not_sorted_by_selector(
     #[case] entry_points: Vec<EntryPoint>,
     #[case] expected: StatelessTransactionValidatorResult<()>,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator {
-            config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
-            behavior_mode: BehaviorMode::default(),
-        };
+    let tx_validator = StatelessTransactionValidator {
+        config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
+        behavior_mode: BehaviorMode::default(),
+    };
 
     let contract_class = SierraContractClass {
         sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),

--- a/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 use std::vec;
 
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::compiler_version::{VersionId, VersionIdError};
 use apollo_gateway_config::config::StatelessTransactionValidatorConfig;
 use assert_matches::assert_matches;
@@ -163,7 +164,8 @@ fn test_positive_flow(
     #[values(TransactionType::Declare, TransactionType::DeployAccount, TransactionType::Invoke)]
     tx_type: TransactionType,
 ) {
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator =
+        StatelessTransactionValidator { config, behavior_mode: BehaviorMode::default() };
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -193,7 +195,8 @@ fn valid_l2_gas_amount_on_declare(
     #[case] rpc_tx_args: RpcTransactionArgs,
 ) {
     let tx_type = TransactionType::Declare;
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator =
+        StatelessTransactionValidator { config, behavior_mode: BehaviorMode::default() };
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -233,7 +236,10 @@ fn test_invalid_resource_bounds(
     tx_type: TransactionType,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG.to_owned() };
+        StatelessTransactionValidator {
+            config: DEFAULT_VALIDATOR_CONFIG.to_owned(),
+            behavior_mode: BehaviorMode::default(),
+        };
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -263,7 +269,10 @@ fn test_invalid_max_l2_gas_amount(
     #[values(TransactionType::DeployAccount, TransactionType::Invoke)] tx_type: TransactionType,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG.to_owned() };
+        StatelessTransactionValidator {
+            config: DEFAULT_VALIDATOR_CONFIG.to_owned(),
+            behavior_mode: BehaviorMode::default(),
+        };
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -391,7 +400,8 @@ fn test_invalid_tx(
     #[case] expected_error: StatelessTransactionValidatorError,
     #[case] tx_types: Vec<TransactionType>,
 ) {
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator =
+        StatelessTransactionValidator { config, behavior_mode: BehaviorMode::default() };
     for tx_type in tx_types {
         let tx = rpc_tx_for_testing(tx_type, rpc_tx_args.clone());
 
@@ -474,7 +484,10 @@ fn test_declare_sierra_version_failure(
     #[case] expected_error: StatelessTransactionValidatorError,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
+        StatelessTransactionValidator {
+            config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
+            behavior_mode: BehaviorMode::default(),
+        };
 
     let contract_class = SierraContractClass { sierra_program, ..Default::default() };
     let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
@@ -494,7 +507,10 @@ fn test_declare_sierra_version_failure(
 #[case::max_sierra_version(create_sierra_program(&MAX_SIERRA_VERSION))]
 fn test_declare_sierra_version_sucsses(#[case] sierra_program: Vec<Felt>) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
+        StatelessTransactionValidator {
+            config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
+            behavior_mode: BehaviorMode::default(),
+        };
 
     let contract_class = SierraContractClass { sierra_program, ..Default::default() };
     let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
@@ -510,6 +526,7 @@ fn test_declare_contract_class_size_too_long() {
             max_contract_class_object_size: config_max_contract_class_object_size,
             ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
         },
+        behavior_mode: BehaviorMode::default(),
     };
     let contract_class = SierraContractClass {
         sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
@@ -537,6 +554,7 @@ fn test_declare_contract_bytecode_size_too_long() {
             max_contract_bytecode_size: sierra_program.len() - 1,
             ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
         },
+        behavior_mode: BehaviorMode::default(),
     };
 
     let tx = rpc_declare_tx(
@@ -595,7 +613,10 @@ fn test_declare_entry_points_not_sorted_by_selector(
     #[case] expected: StatelessTransactionValidatorResult<()>,
 ) {
     let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
+        StatelessTransactionValidator {
+            config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone(),
+            behavior_mode: BehaviorMode::default(),
+        };
 
     let contract_class = SierraContractClass {
         sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
@@ -660,7 +681,8 @@ fn test_client_side_proving_flag(
         allow_client_side_proving,
         ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
     };
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator =
+        StatelessTransactionValidator { config, behavior_mode: BehaviorMode::default() };
 
     // Check for proof data before moving values.
     let has_proof_data = proof_facts.is_some() || proof.is_some();
@@ -702,7 +724,8 @@ fn test_proof_facts_and_proof_consistency(
         allow_client_side_proving: true,
         ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
     };
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator =
+        StatelessTransactionValidator { config, behavior_mode: BehaviorMode::default() };
 
     let rpc_tx_args = RpcTransactionArgs { proof_facts, proof, ..Default::default() };
 
@@ -717,6 +740,40 @@ fn test_proof_facts_and_proof_consistency(
                 has_proof_facts,
                 has_proof,
             }) if has_proof_facts == expected_has_proof_facts && has_proof == expected_has_proof
+        );
+    }
+}
+
+// In Echonet (replay) mode, mainnet's feeder gateway strips the `proof` field, so we receive
+// txs with proof_facts but no proof. The consistency check must let that through. (Replay-mode
+// txs in the other inconsistent direction — proof without facts — are still rejected, since
+// that case can't arise from a stripped-feeder response.)
+#[rstest]
+#[case::both_empty(ProofFacts::default(), Proof::default(), true)]
+#[case::both_non_empty(create_valid_proof_facts_for_testing(), Proof::proof_for_testing(), true)]
+#[case::proof_facts_only(create_valid_proof_facts_for_testing(), Proof::default(), true)]
+#[case::proof_only(ProofFacts::default(), Proof::proof_for_testing(), false)]
+fn test_proof_facts_and_proof_consistency_in_echonet_mode(
+    #[case] proof_facts: ProofFacts,
+    #[case] proof: Proof,
+    #[case] should_pass: bool,
+) {
+    let config = StatelessTransactionValidatorConfig {
+        allow_client_side_proving: true,
+        ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+    };
+    let tx_validator =
+        StatelessTransactionValidator { config, behavior_mode: BehaviorMode::Echonet };
+
+    let rpc_tx_args = RpcTransactionArgs { proof_facts, proof, ..Default::default() };
+    let tx = rpc_tx_for_testing(TransactionType::Invoke, rpc_tx_args);
+
+    if should_pass {
+        assert_matches!(tx_validator.validate(&tx), Ok(()));
+    } else {
+        assert_matches!(
+            tx_validator.validate(&tx),
+            Err(StatelessTransactionValidatorError::ProofFactsAndProofConsistency { .. })
         );
     }
 }

--- a/crates/apollo_gateway/src/test_utils.rs
+++ b/crates/apollo_gateway/src/test_utils.rs
@@ -174,13 +174,15 @@ pub fn gateway_for_benchmark(gateway_config: GatewayConfig) -> GatewayForBenchma
     let class_manager_client = Arc::new(MockClassManagerClient::new());
     let proof_manager_client = Arc::new(MockProofManagerClient::new());
     let proof_archive_writer = Arc::new(MockProofArchiveWriterTrait::new());
-    let transaction_converter = TransactionConverter::new(
+    let transaction_converter = TransactionConverter::new_with_behavior_mode(
         class_manager_client.clone(),
         proof_manager_client.clone(),
         gateway_config.static_config.chain_info.chain_id.clone(),
+        gateway_config.static_config.behavior_mode.clone(),
     );
     let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
         config: gateway_config.static_config.stateless_tx_validator_config.clone(),
+        behavior_mode: gateway_config.static_config.behavior_mode.clone(),
     });
     mempool_client.expect_add_tx().returning(|_| Ok(()));
     mempool_client.expect_validate_tx().returning(|_| Ok(()));

--- a/crates/apollo_gateway_config/Cargo.toml
+++ b/crates/apollo_gateway_config/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true, features = ["derive"] }
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
+url.workspace = true
 validator.workspace = true
 
 [features]

--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::converters::{
     deserialize_comma_separated_str,
     serialize_optional_comma_separated,
@@ -18,6 +19,7 @@ use blockifier::context::ChainInfo;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_types_core::felt::Felt;
+use url::Url;
 use validator::Validate;
 
 use crate::compiler_version::VersionId;
@@ -55,6 +57,8 @@ pub struct GatewayStaticConfig {
     #[validate(range(min = 1))]
     pub max_concurrent_declare_compilations: usize,
     pub proof_archive_writer_config: ProofArchiveWriterConfig,
+    pub behavior_mode: BehaviorMode,
+    pub recorder_url: Url,
 }
 
 impl Default for GatewayStaticConfig {
@@ -71,6 +75,10 @@ impl Default for GatewayStaticConfig {
             authorized_declarer_accounts: None,
             max_concurrent_declare_compilations: DEFAULT_MAX_CONCURRENT_DECLARE_COMPILATIONS,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
+            behavior_mode: BehaviorMode::Starknet,
+            recorder_url: "https://recorder_url"
+                .parse::<Url>()
+                .expect("recorder_url must be a valid URL"),
         }
     }
 }
@@ -116,6 +124,21 @@ impl SerializeConfig for GatewayStaticConfig {
             self.proof_archive_writer_config.dump(),
             "proof_archive_writer_config",
         ));
+        dump.extend(BTreeMap::from_iter([
+            ser_param(
+                "behavior_mode",
+                &self.behavior_mode,
+                "Behavior mode: 'starknet' for production, 'echonet' for test/replay mode.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "recorder_url",
+                &self.recorder_url,
+                "The URL of the recorder service (used in Echonet mode to fetch the initial \
+                 Starknet version).",
+                ParamPrivacyInput::Public,
+            ),
+        ]));
         dump
     }
 }

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -24,6 +24,7 @@ use apollo_class_manager_config::config::{
 };
 use apollo_committer::committer::StorageConstructor;
 use apollo_committer_config::config::{ApolloCommitterConfig, ApolloStorage};
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::converters::UrlAndHeaders;
 use apollo_config_manager_config::config::ConfigManagerConfig;
 use apollo_consensus_config::config::{
@@ -851,6 +852,8 @@ pub fn create_gateway_config(
             authorized_declarer_accounts: None,
             max_concurrent_declare_compilations: 5,
             proof_archive_writer_config,
+            behavior_mode: BehaviorMode::Starknet,
+            recorder_url: "https://recorder_url".parse().unwrap(),
         },
         ..Default::default()
     }

--- a/crates/apollo_mempool/Cargo.toml
+++ b/crates/apollo_mempool/Cargo.toml
@@ -39,6 +39,7 @@ rand.workspace = true
 reqwest.workspace = true
 reqwest-middleware.workspace = true
 reqwest-retry.workspace = true
+serde.workspace = true
 starknet_api.workspace = true
 strum = { workspace = true, features = ["derive"] }
 tokio.workspace = true

--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -26,7 +26,9 @@ use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{Jitter, RetryTransientMiddleware};
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use starknet_api::block::{GasPrice, ReplayMetadata, UnixTimestamp};
 use starknet_api::core::ContractAddress;
 use starknet_api::rpc_transaction::InternalRpcTransaction;
 use starknet_api::transaction::TransactionHash;
@@ -34,6 +36,17 @@ use tracing::warn;
 
 use crate::mempool::Mempool;
 use crate::metrics::register_metrics;
+
+/// The fields returned by `echonet/get_block_metadata`.
+#[derive(Clone, Deserialize, Serialize)]
+pub(crate) struct BlockProposalParams {
+    pub timestamp: UnixTimestamp,
+    pub l1_gas_price_wei: GasPrice,
+    pub l1_data_gas_price_wei: GasPrice,
+    pub l1_gas_price_fri: GasPrice,
+    pub l1_data_gas_price_fri: GasPrice,
+    pub l2_gas_price_fri: GasPrice,
+}
 
 pub type LocalMempoolServer =
     LocalComponentServer<MempoolCommunicationWrapper, MempoolRequest, MempoolResponse>;
@@ -171,8 +184,48 @@ impl MempoolCommunicationWrapper {
         self.mempool.mempool_snapshot()
     }
 
-    fn resolve_batch_timestamp(&mut self) -> MempoolResult<UnixTimestamp> {
-        Ok(self.mempool.resolve_batch_timestamp())
+    pub(crate) async fn resolve_block_metadata(&mut self) -> MempoolResult<ReplayMetadata> {
+        let block_metadata = self.mempool.resolve_block_metadata();
+        let default_metadata = ReplayMetadata {
+            timestamp: block_metadata.timestamp,
+            block_number: block_metadata.block_number,
+            l1_gas_price_wei: GasPrice::default(),
+            l1_data_gas_price_wei: GasPrice::default(),
+            l1_gas_price_fri: GasPrice::default(),
+            l1_data_gas_price_fri: GasPrice::default(),
+            l2_gas_price_fri: GasPrice::default(),
+        };
+
+        if !self.mempool.is_fifo() {
+            return Ok(default_metadata);
+        }
+
+        let Some(block_number) = block_metadata.block_number else {
+            return Ok(default_metadata);
+        };
+        let url = self
+            .mempool
+            .config
+            .static_config
+            .recorder_url
+            .join(&format!("echonet/get_block_metadata?block_number={}", block_number.0))
+            .expect("recorder_url is validated at config load; joining a static path cannot fail");
+
+        match self.try_fetch_json::<BlockProposalParams>(&url).await {
+            Ok(echonet_metadata) => Ok(ReplayMetadata {
+                timestamp: echonet_metadata.timestamp,
+                l1_gas_price_wei: echonet_metadata.l1_gas_price_wei,
+                l1_data_gas_price_wei: echonet_metadata.l1_data_gas_price_wei,
+                l1_gas_price_fri: echonet_metadata.l1_gas_price_fri,
+                l1_data_gas_price_fri: echonet_metadata.l1_data_gas_price_fri,
+                l2_gas_price_fri: echonet_metadata.l2_gas_price_fri,
+                ..default_metadata
+            }),
+            Err(e) => {
+                warn!("Failed to fetch block metadata for block {}: {}", block_number, e);
+                Ok(default_metadata)
+            }
+        }
     }
 
     // Fetches tx block metadata from recorder and updates mempool.
@@ -194,7 +247,7 @@ impl MempoolCommunicationWrapper {
             }
         };
 
-        match self.try_fetch_tx_block_metadata(&url).await {
+        match self.try_fetch_json::<TxBlockMetadata>(&url).await {
             Ok(tx_block_metadata) => {
                 self.mempool.update_tx_block_metadata(tx_hash, tx_block_metadata);
                 true
@@ -206,15 +259,12 @@ impl MempoolCommunicationWrapper {
         }
     }
 
-    async fn try_fetch_tx_block_metadata(
-        &self,
-        url: &reqwest::Url,
-    ) -> Result<TxBlockMetadata, String> {
+    async fn try_fetch_json<T: DeserializeOwned>(&self, url: &reqwest::Url) -> Result<T, String> {
         const REQUEST_TIMEOUT_SECS: u64 = 2;
         let response = self
             .echonet_client
             .get(url.as_str())
-            .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .send()
             .await
             .map_err(|e| format!("request failed: {}", e))?;
@@ -223,7 +273,7 @@ impl MempoolCommunicationWrapper {
             return Err(format!("HTTP {}", response.status()));
         }
 
-        response.json::<TxBlockMetadata>().await.map_err(|e| format!("invalid response: {}", e))
+        response.json::<T>().await.map_err(|e| format!("invalid response: {}", e))
     }
 }
 
@@ -256,8 +306,8 @@ impl ComponentRequestHandler<MempoolRequest, MempoolResponse> for MempoolCommuni
             MempoolRequest::GetMempoolSnapshot() => {
                 MempoolResponse::GetMempoolSnapshot(self.mempool_snapshot())
             }
-            MempoolRequest::ResolveBatchTimestamp => {
-                MempoolResponse::ResolveBatchTimestamp(self.resolve_batch_timestamp())
+            MempoolRequest::ResolveBlockMetadata => {
+                MempoolResponse::ResolveBlockMetadata(self.resolve_block_metadata().await)
             }
         }
     }

--- a/crates/apollo_mempool/src/fifo_mempool_test.rs
+++ b/crates/apollo_mempool/src/fifo_mempool_test.rs
@@ -469,6 +469,42 @@ fn test_realign_to_earlier_block_after_rewind(mut mempool: Mempool) {
 }
 
 #[rstest]
+fn test_rewind_realigns_state_so_pop_succeeds_without_resolve_metadata(mut mempool: Mempool) {
+    // Regression: when a proposer round drains a block's txs and then aborts (e.g., cende
+    // write failure), the next round-start signal (commit_block with default args) rewinds the
+    // staged txs back to the queue head. pop_ready_chunk MUST then return those txs WITHOUT
+    // requiring an intervening resolve_block_metadata call — observed in production at echonet
+    // block 6502414, where this gap caused an empty block and a transaction_commitment
+    // mismatch with mainnet.
+    //
+    // Note: this test deliberately calls `mempool.get_txs(...)` directly instead of
+    // `get_txs_and_assert_expected`, because the latter implicitly calls
+    // `resolve_block_metadata` first in FIFO mode, which would mask the bug by realigning
+    // state via that path.
+    let block_1_tx = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let block_2_tx = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
+
+    mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(1000, 1));
+    mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(2000, 2));
+
+    add_tx(&mut mempool, &block_1_tx);
+    add_tx(&mut mempool, &block_2_tx);
+
+    // Round 0 of block 1: resolve metadata, drain block-1 tx. After the drain,
+    // expected_block_number advances to 2 (block-2 tx is the new queue head).
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![block_1_tx.tx.clone()]);
+
+    // Round 0 aborts before commit. Round 1 starts: only the round-start commit_block(default)
+    // is issued — no resolve_block_metadata call between the rewind and the pop below.
+    commit_block(&mut mempool, [], []);
+
+    // pop_ready_chunk must succeed: rewind put block-1 tx back at the queue head and the
+    // realignment in rewind_txs must have reset expected_block_number back to 1.
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![block_1_tx.tx]);
+}
+
+#[rstest]
 fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
     let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
     let input2 = add_tx_input!(tx_hash: 2, address: "0x1", tx_nonce: 1, account_nonce: 0);

--- a/crates/apollo_mempool/src/fifo_mempool_test.rs
+++ b/crates/apollo_mempool/src/fifo_mempool_test.rs
@@ -6,6 +6,7 @@ use apollo_mempool_config::config::{MempoolConfig, MempoolDynamicConfig, Mempool
 use apollo_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
 use apollo_time::test_utils::FakeClock;
 use rstest::{fixture, rstest};
+use starknet_api::block::BlockNumber;
 use starknet_api::test_utils::invoke::internal_invoke_tx;
 use starknet_api::test_utils::valid_resource_bounds_for_testing;
 use starknet_api::transaction::fields::TransactionSignature;
@@ -241,13 +242,13 @@ fn test_resolve_batch_timestamp_persists_after_queue_emptied(mut mempool: Mempoo
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 
     // Consume all txs, emptying the queue.
     get_txs_and_assert_expected(&mut mempool, 2, &[input1.tx, input2.tx]);
 
     // Timestamp should persist after queue is emptied.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 }
 
 #[rstest]
@@ -267,7 +268,7 @@ fn test_get_txs_does_not_return_txs_with_different_timestamp(mut mempool: Mempoo
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 
     // Request one transaction from the first timestamp batch.
     get_txs_and_assert_expected(&mut mempool, 1, &[input1.tx]);
@@ -275,11 +276,11 @@ fn test_get_txs_does_not_return_txs_with_different_timestamp(mut mempool: Mempoo
     // get_txs pauses at the timestamp boundary; only returns remaining txs with timestamp 1000.
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx]);
 
-    // Without resolving batch timestamp, get_txs returns empty (next txs have timestamp 1001).
+    // Without resolving block metadata, get_txs returns empty (next txs have timestamp 1001).
     assert_eq!(mempool.get_txs(10).unwrap(), vec![]);
 
     // Resolve to advance to timestamp 1001.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx]);
 }
 
@@ -293,7 +294,7 @@ fn test_get_txs_same_block_spans_multiple_chunks(mut mempool: Mempool) {
         add_tx(&mut mempool, &input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     // First chunk: block builder fetches 100 txs.
     let chunk1 = mempool.get_txs(100).unwrap();
     assert_eq!(chunk1.len(), 100);
@@ -322,19 +323,47 @@ fn test_get_txs_pauses_once_on_block_number_gap(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx, input2.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input3.tx]);
 
     // Block 4 is missing.
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
 
     // Block 5 is present.
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input4.tx, input5.tx]);
+}
+
+#[rstest]
+fn test_empty_block_metadata_has_correct_block_number(mut mempool: Mempool) {
+    let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let input2 = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
+
+    // Block 10 has a tx, block 11 is empty, block 12 has a tx.
+    mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(1000, 10));
+    mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(1200, 12));
+
+    add_tx(&mut mempool, &input1);
+    add_tx(&mut mempool, &input2);
+
+    // Build block 10.
+    let meta = mempool.resolve_block_metadata();
+    assert_eq!(meta.block_number, Some(BlockNumber(10)));
+    mempool.get_txs(10).unwrap();
+
+    // Build block 11 (empty). block_number must be 11, not 12.
+    let meta = mempool.resolve_block_metadata();
+    assert_eq!(meta.block_number, Some(BlockNumber(11)));
+    assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
+
+    // Build block 12 (non-empty). block_number must be 12.
+    let meta = mempool.resolve_block_metadata();
+    assert_eq!(meta.block_number, Some(BlockNumber(12)));
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 }
 
 #[rstest]
@@ -352,17 +381,17 @@ fn test_get_txs_returns_empty_result_with_gaps(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 
     for _ in 0..19 {
-        assert_eq!(mempool.resolve_batch_timestamp(), 300);
+        assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
         assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input3.tx]);
 }
 
@@ -372,16 +401,16 @@ fn test_get_txs_after_queue_emptied_still_resolves_new_tx(mut mempool: Mempool) 
     mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(100, 1));
     add_tx(&mut mempool, &input1);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
 
     let input2 = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
     mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(200, 2));
     add_tx(&mut mempool, &input2);
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 }
 
@@ -400,15 +429,15 @@ fn test_rewind_partial_block_then_continue_to_next_block(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 3, &[input1.tx, input2.tx, input3.tx.clone()]);
 
     // Only tx 1 and 2 are committed; tx3 rewinds.
     commit_block(&mut mempool, [("0x1", 2)], []);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx]);
-    assert_eq!(mempool.resolve_batch_timestamp(), 2000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 2000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input5.tx]);
 }
 
@@ -424,18 +453,18 @@ fn test_realign_to_earlier_block_after_rewind(mut mempool: Mempool) {
     add_tx(&mut mempool, &input2);
 
     // Drain block 1. Expected_block_number = 2.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, std::slice::from_ref(&input1.tx));
 
     // Rewind tx of block 1. Expected_block_number is still 2.
     commit_block(&mut mempool, [], []);
 
     // Realign to block 1.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input1.tx]);
 
     // Now expected_block_number has advanced to 2 again; block-2 tx is next.
-    assert_eq!(mempool.resolve_batch_timestamp(), 2000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 2000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx]);
 }
 
@@ -456,7 +485,7 @@ fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     // Fetch tx1 and tx2; leave tx3 in queue.
     get_txs_and_assert_expected(&mut mempool, 2, &[input1.tx, input2.tx.clone()]);
 
@@ -467,16 +496,16 @@ fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
     add_tx(&mut mempool, &input4);
 
     // Rewound tx2 is at the front → timestamp must still be 1000, not 1001.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx, input3.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 1, &[input4.tx]);
 }
 
 #[rstest]
 fn test_resolve_batch_timestamp_returns_zero_when_never_had_transactions(mut mempool: Mempool) {
-    assert_eq!(mempool.resolve_batch_timestamp(), 0);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 0);
 }
 
 #[rstest]
@@ -494,7 +523,7 @@ fn test_rewind_many_transactions_from_same_address(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(
         &mut mempool,
         10,
@@ -504,12 +533,12 @@ fn test_rewind_many_transactions_from_same_address(mut mempool: Mempool) {
     // Commit only nonces 0 and 1; nonces 2, 3, 4 are rewound.
     commit_block(&mut mempool, [("0x1", 2)], []);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx, input5.tx]);
 
     commit_block(&mut mempool, [("0x1", 5)], []);
     // Queue should now be empty
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[]);
 }
 
@@ -541,7 +570,7 @@ fn test_expired_popped_txs_are_not_rewound() {
     fake_clock.advance(Duration::from_secs(65));
 
     // Both txs are popped then pruned as expired, so no tx should be returned.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![]);
 
     // Commit should not rewind expired popped txs back into queue.
@@ -565,14 +594,14 @@ fn test_rejected_tx_removes_same_address_from_fifo_queue(mut mempool: Mempool) {
     }
 
     // Stage only the first tx (timestamp 1000).
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[rejected_tx.tx]);
 
     // Reject tx. In FIFO, this removes same-address queued txs.
     commit_block(&mut mempool, [], [tx_hash!(1)]);
 
     // Next timestamp batch should include only the other address tx.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 10, &[other_address_tx.tx]);
 }
 

--- a/crates/apollo_mempool/src/fifo_mempool_test.rs
+++ b/crates/apollo_mempool/src/fifo_mempool_test.rs
@@ -366,6 +366,37 @@ fn test_empty_block_metadata_has_correct_block_number(mut mempool: Mempool) {
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 }
 
+// Regression: when two consecutive mainnet blocks share a wall-clock timestamp
+// (production occurrence: blocks 9188909 and 9188910 both at 1777228096), a single
+// `get_txs` call must not drain across the block boundary. The bug was that
+// `advance_block_if_drained` updated `expected_block_number` to N+1 but left the
+// timestamp at T_N — since T_{N+1} == T_N, `matches_tx` on the new front_tx returned
+// true and the outer `Mempool::get_txs` loop kept popping, pulling block N+1's tx
+// into the proposer's block-N proposal.
+#[rstest]
+fn test_get_txs_stops_at_block_boundary_even_with_shared_timestamp(mut mempool: Mempool) {
+    let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let input2 = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
+
+    // Block N and block N+1 share the same wall-clock timestamp.
+    mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(1777228096, 9188909));
+    mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(1777228096, 9188910));
+
+    add_tx(&mut mempool, &input1);
+    add_tx(&mut mempool, &input2);
+
+    // Round 1 builds block 9188909 — must contain ONLY input1, not input2 (which belongs
+    // to the next block on mainnet, even though they share the timestamp).
+    let meta = mempool.resolve_block_metadata();
+    assert_eq!(meta.block_number, Some(BlockNumber(9188909)));
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
+
+    // Round 2 builds block 9188910 with input2.
+    let meta = mempool.resolve_block_metadata();
+    assert_eq!(meta.block_number, Some(BlockNumber(9188910)));
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
+}
+
 #[rstest]
 fn test_get_txs_returns_empty_result_with_gaps(mut mempool: Mempool) {
     let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);

--- a/crates/apollo_mempool/src/fifo_transaction_queue.rs
+++ b/crates/apollo_mempool/src/fifo_transaction_queue.rs
@@ -8,7 +8,7 @@ use starknet_api::transaction::TransactionHash;
 use tracing::debug;
 
 use crate::mempool::TransactionReference;
-use crate::transaction_queue_trait::{RewindData, TransactionQueueTrait};
+use crate::transaction_queue_trait::{BlockMetadata, RewindData, TransactionQueueTrait};
 
 /// A FIFO (First-In-First-Out) transaction queue that orders transactions by arrival time.
 /// Used in Echonet mode to preserve the original transaction order from the source chain.
@@ -73,9 +73,7 @@ pub struct FifoTransactionQueue {
     // Temporary map from transaction hash to metadata before the transaction is inserted to
     // queue.
     pending_metadata: HashMap<TransactionHash, TxBlockMetadata>,
-    // Tracks current proposal metadata in FIFO mode:
-    // - timestamp returned by resolve_timestamp()
-    // - expected block number for get_txs()
+    // Proposal state set by resolve_metadata(); gates which txs pop_ready_chunk() may return.
     current_proposal_state: Option<CurrentProposalState>,
 }
 
@@ -157,20 +155,25 @@ impl FifoTransactionQueue {
             .collect()
     }
 
-    /// Returns that head transaction's timestamp.
-    fn sync_proposal_state_from_queue_front_tx(&mut self) -> UnixTimestamp {
+    /// Syncs current_proposal_state from the head of the queue and returns
+    /// the resulting (timestamp, block_number).
+    fn sync_proposal_state_from_queue_front_tx(&mut self) -> BlockMetadata {
         let &front_tx = self
             .queue
             .front()
             .expect("FIFO sync_proposal_state_from_queue_front: queue must be non-empty");
 
         let Some(prev_state) = self.current_proposal_state else {
-            self.current_proposal_state = Some(CurrentProposalState {
+            let state = CurrentProposalState {
                 timestamp: front_tx.timestamp,
                 expected_block_number: front_tx.block_number,
                 emit_empty_block: false,
-            });
-            return front_tx.timestamp;
+            };
+            self.current_proposal_state = Some(state);
+            return BlockMetadata {
+                timestamp: state.timestamp,
+                block_number: Some(state.expected_block_number),
+            };
         };
 
         let (expected_block_number, emit_empty_block) =
@@ -191,12 +194,21 @@ impl FifoTransactionQueue {
                 (prev_state.expected_block_number, false)
             };
 
-        self.current_proposal_state = Some(CurrentProposalState {
+        let state = CurrentProposalState {
             timestamp: front_tx.timestamp,
             expected_block_number,
             emit_empty_block,
-        });
-        front_tx.timestamp
+        };
+        self.current_proposal_state = Some(state);
+        // When emitting an empty block, `expected_block_number` has already been advanced to the
+        // next position (so subsequent calls don't re-detect the gap), but the block being built
+        // RIGHT NOW is `prev_state.expected_block_number` — one less.
+        let current_block_number = if emit_empty_block {
+            prev_state.expected_block_number
+        } else {
+            state.expected_block_number
+        };
+        BlockMetadata { timestamp: state.timestamp, block_number: Some(current_block_number) }
     }
 }
 
@@ -226,7 +238,7 @@ impl TransactionQueueTrait for FifoTransactionQueue {
 
         let Some(current_state) = self.current_proposal_state.as_mut() else {
             panic!(
-                "FIFO pop_ready_chunk: missing proposal state; resolve_timestamp must run before \
+                "FIFO pop_ready_chunk: missing proposal state; resolve_metadata must run before \
                  get_txs for this queue"
             );
         };
@@ -365,23 +377,26 @@ impl TransactionQueueTrait for FifoTransactionQueue {
         0
     }
 
-    fn resolve_timestamp(&mut self) -> UnixTimestamp {
+    fn resolve_metadata(&mut self) -> BlockMetadata {
         if self.queue.front().is_some() {
             return self.sync_proposal_state_from_queue_front_tx();
         }
-        // Queue is empty: reuse previous timestamp if it exists, otherwise return 0.
+        // Queue is empty: reuse previous timestamp and block number if they exist.
         match self.current_proposal_state {
             Some(state) => {
                 debug!(
-                    "FIFO resolve_timestamp: queue empty, reusing last_timestamp={:?}, \
+                    "FIFO resolve_metadata: queue empty, reusing last_timestamp={:?}, \
                      expected_block={:?}",
                     state.timestamp, state.expected_block_number
                 );
-                state.timestamp
+                BlockMetadata {
+                    timestamp: state.timestamp,
+                    block_number: Some(state.expected_block_number),
+                }
             }
             None => {
-                debug!("FIFO resolve_timestamp: queue empty, no previous proposal state");
-                0
+                debug!("FIFO resolve_metadata: queue empty, no previous proposal state");
+                BlockMetadata { timestamp: 0, block_number: None }
             }
         }
     }

--- a/crates/apollo_mempool/src/fifo_transaction_queue.rs
+++ b/crates/apollo_mempool/src/fifo_transaction_queue.rs
@@ -366,6 +366,15 @@ impl TransactionQueueTrait for FifoTransactionQueue {
 
         self.staged_txs.clear();
 
+        // If any txs were rewound, the queue head may now reference an earlier block than
+        // current_proposal_state expects (the previous proposal's pop drained the current block
+        // and advance_block_if_drained bumped expected_block_number forward). Realign so the
+        // next pop_ready_chunk() sees a matching head — otherwise a retried proposer round can
+        // see an empty mempool and commit an empty block.
+        if !rewound_hashes.is_empty() {
+            let _ = self.sync_proposal_state_from_queue_front_tx();
+        }
+
         rewound_hashes
     }
 

--- a/crates/apollo_mempool/src/fifo_transaction_queue.rs
+++ b/crates/apollo_mempool/src/fifo_transaction_queue.rs
@@ -46,7 +46,15 @@ impl CurrentProposalState {
             .expected_block_number
             .next()
             .expect("Block number overflow while advancing expected block after pop.");
-        self.emit_empty_block = false;
+        // Gate further pops within the current proposer round. Without this, the outer loop
+        // in `Mempool::get_txs` would keep calling `pop_ready_chunk` and — when the next
+        // mainnet block shares this block's wall-clock timestamp (which has happened in
+        // production: blocks 9188909 and 9188910 both at 1777228096) — `matches_tx` would
+        // pass on the new front and the proposer would silently drain the next block's tx
+        // into this block. The flag is cleared on the next round's `resolve_metadata` via
+        // `sync_proposal_state_from_queue_front_tx`'s "head matches the expected block"
+        // branch (or the "skip" branch if there's a real gap).
+        self.emit_empty_block = true;
     }
 }
 

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -17,7 +17,7 @@ use apollo_mempool_types::mempool_types::{
 use apollo_time::time::{Clock, DateTime};
 use indexmap::IndexSet;
 use rand::{rng, RngExt};
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::GasPrice;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
@@ -47,7 +47,7 @@ use crate::metrics::{
     MEMPOOL_TRANSACTIONS_RECEIVED,
 };
 use crate::transaction_pool::TransactionPool;
-use crate::transaction_queue_trait::{RewindData, TransactionQueueTrait};
+use crate::transaction_queue_trait::{BlockMetadata, RewindData, TransactionQueueTrait};
 use crate::utils::try_increment_nonce;
 
 #[cfg(test)]
@@ -288,14 +288,18 @@ impl Mempool {
         matches!(self.config.static_config.behavior_mode, BehaviorMode::Echonet)
     }
 
-    pub fn resolve_batch_timestamp(&mut self) -> UnixTimestamp {
+    pub(crate) fn resolve_block_metadata(&mut self) -> BlockMetadata {
         if !self.is_fifo() {
             let timestamp = self.clock.unix_now();
-            debug!("Mempool resolve_batch_timestamp (Fee): timestamp={}", timestamp);
-            return timestamp;
+            debug!(
+                "Mempool resolve_block_metadata (Fee): timestamp={}. Block number is not tracked \
+                 in fee-priority mode.",
+                timestamp
+            );
+            return BlockMetadata { timestamp, block_number: None };
         }
 
-        self.tx_queue.resolve_timestamp()
+        self.tx_queue.resolve_metadata()
     }
 
     pub(crate) fn update_tx_block_metadata(

--- a/crates/apollo_mempool/src/recorder_integration_test.rs
+++ b/crates/apollo_mempool/src/recorder_integration_test.rs
@@ -13,26 +13,47 @@ use axum::routing::get;
 use axum::Router;
 use reqwest::Url;
 use rstest::rstest;
-use starknet_api::block::BlockNumber;
+use starknet_api::block::{BlockNumber, GasPrice};
 use starknet_api::transaction::TransactionHash;
 use tokio::net::TcpListener;
 
 use crate::add_tx_input;
-use crate::communication::MempoolCommunicationWrapper;
+use crate::communication::{BlockProposalParams, MempoolCommunicationWrapper};
 use crate::mempool::Mempool;
 
-// Starts a mock HTTP server that simulates the recorder's get_tx_block_metadata endpoint.
+// Starts a mock HTTP server simulating the recorder's get_tx_block_metadata endpoint.
 // Returns the base URL (e.g., "http://127.0.0.1:12345").
-async fn start_mock_recorder(response: Result<TxBlockMetadata, StatusCode>) -> String {
-    let app = Router::new().route(
-        "/echonet/get_tx_block_metadata",
-        get(move || async move {
-            match response {
-                Ok(metadata) => (StatusCode::OK, Json(metadata)).into_response(),
-                Err(status) => status.into_response(),
-            }
-        }),
-    );
+async fn mock_tx_metadata_recorder(
+    tx_metadata_response: Result<TxBlockMetadata, StatusCode>,
+) -> String {
+    mock_recorder(tx_metadata_response, Err(StatusCode::NOT_FOUND)).await
+}
+
+// Starts a mock HTTP server simulating both recorder endpoints.
+// Returns the base URL (e.g., "http://127.0.0.1:12345").
+async fn mock_recorder(
+    tx_metadata_response: Result<TxBlockMetadata, StatusCode>,
+    block_metadata_response: Result<BlockProposalParams, StatusCode>,
+) -> String {
+    let app = Router::new()
+        .route(
+            "/echonet/get_tx_block_metadata",
+            get(move || async move {
+                match tx_metadata_response {
+                    Ok(metadata) => (StatusCode::OK, Json(metadata)).into_response(),
+                    Err(status) => status.into_response(),
+                }
+            }),
+        )
+        .route(
+            "/echonet/get_block_metadata",
+            get(move || async move {
+                match block_metadata_response {
+                    Ok(metadata) => (StatusCode::OK, Json(metadata)).into_response(),
+                    Err(status) => status.into_response(),
+                }
+            }),
+        );
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -65,8 +86,8 @@ fn create_mempool_communication_wrapper(recorder_url: String) -> MempoolCommunic
 #[rstest]
 #[tokio::test]
 async fn test_fetch_tx_block_metadata_success() {
-    let recorder_url = start_mock_recorder(Ok(TxBlockMetadata {
-        timestamp: 1000u64,
+    let recorder_url = mock_tx_metadata_recorder(Ok(TxBlockMetadata {
+        timestamp: 1000,
         block_number: BlockNumber(1234),
     }))
     .await;
@@ -81,7 +102,7 @@ async fn test_fetch_tx_block_metadata_success() {
 #[rstest]
 #[tokio::test]
 async fn test_fetch_tx_block_metadata_fails_on_http_error() {
-    let recorder_url = start_mock_recorder(Err(StatusCode::INTERNAL_SERVER_ERROR)).await;
+    let recorder_url = mock_tx_metadata_recorder(Err(StatusCode::INTERNAL_SERVER_ERROR)).await;
     let mut wrapper = create_mempool_communication_wrapper(recorder_url);
 
     let tx_hash = TransactionHash::default();
@@ -94,8 +115,8 @@ async fn test_fetch_tx_block_metadata_fails_on_http_error() {
 #[rstest]
 #[tokio::test]
 async fn test_add_tx_with_recorder_integration() {
-    let recorder_url = start_mock_recorder(Ok(TxBlockMetadata {
-        timestamp: 1000u64,
+    let recorder_url = mock_tx_metadata_recorder(Ok(TxBlockMetadata {
+        timestamp: 1000,
         block_number: BlockNumber(1234),
     }))
     .await;
@@ -105,4 +126,68 @@ async fn test_add_tx_with_recorder_integration() {
     let args_wrapper = AddTransactionArgsWrapper { args: tx_args, p2p_message_metadata: None };
 
     wrapper.add_tx(args_wrapper).await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_resolve_block_metadata_echonet_success() {
+    let tx_timestamp = 1000;
+    let echonet_timestamp = 2000;
+    let block_number = BlockNumber(1234);
+    let tx_metadata = TxBlockMetadata { timestamp: tx_timestamp, block_number };
+
+    // Echonet provides both the canonical timestamp and gas prices.
+    let l1_gas_price_wei = GasPrice(100);
+    let l1_data_gas_price_wei = GasPrice(200);
+    let l1_gas_price_fri = GasPrice(300);
+    let l1_data_gas_price_fri = GasPrice(400);
+    let l2_gas_price_fri = GasPrice(500);
+    let block_metadata = BlockProposalParams {
+        timestamp: echonet_timestamp,
+        l1_gas_price_wei,
+        l1_data_gas_price_wei,
+        l1_gas_price_fri,
+        l1_data_gas_price_fri,
+        l2_gas_price_fri,
+    };
+
+    let recorder_url = mock_recorder(Ok(tx_metadata), Ok(block_metadata)).await;
+    let mut wrapper = create_mempool_communication_wrapper(recorder_url);
+
+    let tx_args = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let args_wrapper = AddTransactionArgsWrapper { args: tx_args, p2p_message_metadata: None };
+    wrapper.add_tx(args_wrapper).await.unwrap();
+
+    let result = wrapper.resolve_block_metadata().await.unwrap();
+
+    // timestamp comes from echonet (canonical mainnet timestamp for the block).
+    assert_eq!(result.timestamp, echonet_timestamp);
+    // block_number comes from mempool tx metadata.
+    assert_eq!(result.block_number, Some(block_number));
+    // Gas prices come from echonet.
+    assert_eq!(result.l1_gas_price_wei, l1_gas_price_wei);
+    assert_eq!(result.l1_data_gas_price_wei, l1_data_gas_price_wei);
+    assert_eq!(result.l1_gas_price_fri, l1_gas_price_fri);
+    assert_eq!(result.l1_data_gas_price_fri, l1_data_gas_price_fri);
+    assert_eq!(result.l2_gas_price_fri, l2_gas_price_fri);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_resolve_block_metadata_echonet_falls_back_on_http_error() {
+    let tx_metadata = TxBlockMetadata { timestamp: 1000, block_number: BlockNumber(1234) };
+
+    let recorder_url = mock_recorder(Ok(tx_metadata), Err(StatusCode::INTERNAL_SERVER_ERROR)).await;
+    let mut wrapper = create_mempool_communication_wrapper(recorder_url);
+
+    let tx_args = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let args_wrapper = AddTransactionArgsWrapper { args: tx_args, p2p_message_metadata: None };
+    wrapper.add_tx(args_wrapper).await.unwrap();
+
+    let result = wrapper.resolve_block_metadata().await.unwrap();
+
+    assert_eq!(result.l1_gas_price_wei, GasPrice::default());
+    assert_eq!(result.l1_data_gas_price_wei, GasPrice::default());
+    assert_eq!(result.l1_gas_price_fri, GasPrice::default());
+    assert_eq!(result.l1_data_gas_price_fri, GasPrice::default());
 }

--- a/crates/apollo_mempool/src/test_utils.rs
+++ b/crates/apollo_mempool/src/test_utils.rs
@@ -310,9 +310,10 @@ pub fn get_txs_and_assert_expected(
     n_txs: usize,
     expected_txs: &[InternalRpcTransaction],
 ) {
-    // In FIFO mode, we need to resolve batch timestamp first to set the timestamp threshold.
+    // In FIFO mode, resolve_block_metadata must run before get_txs to set the current proposal
+    // state used to gate which transactions are eligible.
     if mempool.is_fifo() {
-        let _ = mempool.resolve_batch_timestamp();
+        let _ = mempool.resolve_block_metadata();
     }
     let txs = mempool.get_txs(n_txs).unwrap();
     assert_eq!(txs, expected_txs);

--- a/crates/apollo_mempool/src/transaction_queue_trait.rs
+++ b/crates/apollo_mempool/src/transaction_queue_trait.rs
@@ -2,11 +2,16 @@ use std::collections::HashMap;
 
 use apollo_mempool_types::mempool_types::{TransactionQueueSnapshot, TxBlockMetadata};
 use indexmap::IndexSet;
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::{BlockNumber, GasPrice, UnixTimestamp};
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::transaction::TransactionHash;
 
 use crate::mempool::TransactionReference;
+
+pub(crate) struct BlockMetadata {
+    pub timestamp: UnixTimestamp,
+    pub block_number: Option<BlockNumber>,
+}
 
 // Data needed for rewinding transactions back into the queue after a block commit.
 // Different queue types require different data.
@@ -67,10 +72,11 @@ pub trait TransactionQueueTrait: Send + Sync {
     // Default implementation is a no-op (for queues that don't support metadata updates).
     fn update_tx_block_metadata(&mut self, _tx_hash: TransactionHash, _metadata: TxBlockMetadata) {}
 
-    // Returns the sequencing timestamp and may update queue-internal state.
-    // Default implementation returns 0 for queues that don't use timestamp gating.
-    fn resolve_timestamp(&mut self) -> UnixTimestamp {
-        0
+    // Returns the block metadata and may update queue-internal state.
+    // Default implementation returns timestamp=0, block_number=None for queues that don't use
+    // timestamp gating.
+    fn resolve_metadata(&mut self) -> BlockMetadata {
+        BlockMetadata { timestamp: 0, block_number: None }
     }
 
     // Default implementation returns empty vec.

--- a/crates/apollo_mempool_types/src/communication.rs
+++ b/crates/apollo_mempool_types/src/communication.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
 use mockall::automock;
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::{GasPrice, ReplayMetadata};
 use starknet_api::core::ContractAddress;
 use starknet_api::rpc_transaction::InternalRpcTransaction;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
@@ -61,7 +61,7 @@ pub trait MempoolClient: Send + Sync {
     ) -> MempoolClientResult<bool>;
     async fn update_gas_price(&self, gas_price: GasPrice) -> MempoolClientResult<()>;
     async fn get_mempool_snapshot(&self) -> MempoolClientResult<MempoolSnapshot>;
-    async fn resolve_batch_timestamp(&self) -> MempoolClientResult<UnixTimestamp>;
+    async fn resolve_block_metadata(&self) -> MempoolClientResult<ReplayMetadata>;
 }
 
 #[derive(Serialize, Deserialize, Clone, AsRefStr, EnumDiscriminants)]
@@ -79,7 +79,7 @@ pub enum MempoolRequest {
     // TODO(yair): Rename to `StartBlock` and add cleanup of staged txs.
     UpdateGasPrice(GasPrice),
     GetMempoolSnapshot(),
-    ResolveBatchTimestamp,
+    ResolveBlockMetadata,
 }
 impl_debug_for_infra_requests_and_responses!(MempoolRequest);
 impl_labeled_request!(MempoolRequest, MempoolRequestLabelValue);
@@ -94,7 +94,7 @@ impl PrioritizedRequest for MempoolRequest {
             | MempoolRequest::AccountTxInPoolOrRecentBlock(_)
             | MempoolRequest::UpdateGasPrice(_)
             | MempoolRequest::GetMempoolSnapshot()
-            | MempoolRequest::ResolveBatchTimestamp => RequestPriority::Normal,
+            | MempoolRequest::ResolveBlockMetadata => RequestPriority::Normal,
         }
     }
 }
@@ -108,7 +108,7 @@ pub enum MempoolResponse {
     AccountTxInPoolOrRecentBlock(MempoolResult<bool>),
     UpdateGasPrice(MempoolResult<()>),
     GetMempoolSnapshot(MempoolResult<MempoolSnapshot>),
-    ResolveBatchTimestamp(MempoolResult<UnixTimestamp>),
+    ResolveBlockMetadata(MempoolResult<ReplayMetadata>),
 }
 impl_debug_for_infra_requests_and_responses!(MempoolResponse);
 
@@ -219,13 +219,13 @@ where
         )
     }
 
-    async fn resolve_batch_timestamp(&self) -> MempoolClientResult<UnixTimestamp> {
-        let request = MempoolRequest::ResolveBatchTimestamp;
+    async fn resolve_block_metadata(&self) -> MempoolClientResult<ReplayMetadata> {
+        let request = MempoolRequest::ResolveBlockMetadata;
         handle_all_response_variants!(
             self,
             request,
             MempoolResponse,
-            ResolveBatchTimestamp,
+            ResolveBlockMetadata,
             MempoolClientError,
             MempoolError,
             Direct

--- a/crates/apollo_node/Cargo.toml
+++ b/crates/apollo_node/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Main Starknet sequencer node orchestrating all components."
 
 [features]
+default = ["os_input"]
 cairo_native = ["apollo_batcher/cairo_native", "apollo_gateway/cairo_native"]
 os_input = [
   "apollo_batcher/os_input",

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3014,6 +3014,11 @@
     "privacy": "TemporaryValue",
     "value": true
   },
+  "gateway_config.static_config.behavior_mode": {
+    "description": "Behavior mode: 'starknet' for production, 'echonet' for test/replay mode.",
+    "pointer_target": "behavior_mode",
+    "privacy": "Public"
+  },
   "gateway_config.static_config.block_declare": {
     "description": "If true, the gateway will block declare transactions.",
     "privacy": "Public",
@@ -3098,6 +3103,11 @@
     "description": "The name of the bucket to write proofs to. An empty string indicates a test environment that does not connect to GCS.",
     "privacy": "Public",
     "value": "proof-archive"
+  },
+  "gateway_config.static_config.recorder_url": {
+    "description": "The URL of the recorder service (used in Echonet mode to fetch the initial Starknet version).",
+    "pointer_target": "recorder_url",
+    "privacy": "Public"
   },
   "gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap": {
     "description": "The maximum allowed gap between the account nonce and the transaction nonce.",

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -151,6 +151,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
             set_pointing_param_paths(&[
                 "consensus_manager_config.cende_config.recorder_url",
                 "batcher_config.static_config.pre_confirmed_cende_config.recorder_url",
+                "gateway_config.static_config.recorder_url",
                 "mempool_config.static_config.recorder_url",
             ]),
         ),
@@ -211,6 +212,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
         ),
         set_pointing_param_paths(&[
             "consensus_manager_config.context_config.static_config.behavior_mode",
+            "gateway_config.static_config.behavior_mode",
             "mempool_config.static_config.behavior_mode",
         ]),
     ));

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -188,8 +188,6 @@ use crate::header::StorageBlockHeader;
 use crate::metrics::{register_metrics, STORAGE_COMMIT_LATENCY};
 use crate::mmap_file::MMapFileStats;
 use crate::state::data::IndexedDeprecatedContractClass;
-#[cfg(feature = "os_input")]
-use crate::state_commitment_infos::StateCommitmentInfos;
 use crate::storage_reader_server::{
     create_storage_reader_server,
     ServerConfig,
@@ -1173,7 +1171,7 @@ struct FileHandlers<Mode: TransactionKind> {
     #[cfg(feature = "os_input")]
     accessed_keys: FileHandler<VersionZeroWrapper<AccessedKeys>, Mode>,
     #[cfg(feature = "os_input")]
-    state_commitment_infos: FileHandler<VersionZeroWrapper<StateCommitmentInfos>, Mode>,
+    state_commitment_infos: FileHandler<VersionZeroWrapper<String>, Mode>,
 }
 
 impl FileHandlers<RW> {
@@ -1216,11 +1214,11 @@ impl FileHandlers<RW> {
         self.clone().accessed_keys.append(accessed_keys)
     }
 
+    // Takes `&String` (not `&str`) because the mmap file handler appends `&V::Value`, i.e.
+    // `&String`.
     #[cfg(feature = "os_input")]
-    fn append_state_commitment_infos(
-        &self,
-        state_commitment_infos: &StateCommitmentInfos,
-    ) -> LocationInFile {
+    #[allow(clippy::ptr_arg)]
+    fn append_state_commitment_infos(&self, state_commitment_infos: &String) -> LocationInFile {
         self.clone().state_commitment_infos.append(state_commitment_infos)
     }
 
@@ -1326,11 +1324,11 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
     }
 
     #[cfg(feature = "os_input")]
-    // Returns the commitment infos at the given location or an error in case they don't exist.
+    // Returns the compressed commitment infos at the given location.
     pub(crate) fn get_state_commitment_infos_unchecked(
         &self,
         location: LocationInFile,
-    ) -> StorageResult<StateCommitmentInfos> {
+    ) -> StorageResult<String> {
         self.state_commitment_infos.get(location)?.ok_or(StorageError::DBInconsistency {
             msg: format!("StateCommitmentInfos at location {location:?} not found."),
         })

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -1,49 +1,25 @@
 //! Storage for the per-block OS-input commitment infos (state-trie commitment data for the OS).
+//!
+//! Stored as the already-compressed string (`base64(zstd(serde_json(..)))`) the committer produces,
+//! so this path persists the witness verbatim without (de)serializing `StateCommitmentInfos`.
 
 use starknet_api::block::BlockNumber;
-pub use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfosCodecError;
 
 #[cfg(test)]
 #[path = "state_commitment_infos_test.rs"]
 mod state_commitment_infos_test;
 
-use crate::db::serialization::{StorageSerde, StorageSerdeError};
 use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
 use crate::{OffsetKind, StorageResult, StorageTransaction};
 
-// Encoded with bincode (not serde_json): this is hash/`Felt`-heavy data, where bincode's fixed
-// binary encoding is markedly more compact than JSON's hex-string encoding. The trade-off is that
-// bincode is positional and not schema-evolution tolerant, which is acceptable here.
-impl StorageSerde for StateCommitmentInfos {
-    fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
-        let compressed = self.compress()?;
-        compressed.serialize_into(res)
-    }
-
-    fn deserialize_from(bytes: &mut impl std::io::Read) -> Option<Self> {
-        let compressed = Vec::<u8>::deserialize_from(bytes)?;
-        Self::decompress(&compressed).ok()
-    }
-}
-
-impl From<StateCommitmentInfosCodecError> for StorageSerdeError {
-    fn from(error: StateCommitmentInfosCodecError) -> Self {
-        match error {
-            StateCommitmentInfosCodecError::Bincode(error) => StorageSerdeError::Bincode(error),
-            StateCommitmentInfosCodecError::Io(error) => StorageSerdeError::Io(error),
-        }
-    }
-}
-
 /// Interface for reading the OS-input commitment infos from storage.
 pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
-    /// Returns the commitment infos for the given block, or `None` if not stored.
+    /// Returns the compressed commitment infos for the given block, or `None` if not stored.
     fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>>;
+    ) -> StorageResult<Option<String>>;
 }
 
 /// Interface for writing the OS-input commitment infos to storage.
@@ -51,11 +27,14 @@ pub trait StateCommitmentInfosStorageWriter
 where
     Self: Sized,
 {
-    /// Appends the commitment infos for the given block to storage.
+    /// Appends the compressed commitment infos for the given block to storage.
+    // Takes `&String` (not `&str`) because the mmap file handler appends `&V::Value`; `&str` would
+    // force an extra copy of the (potentially multi-MB) compressed witness.
+    #[allow(clippy::ptr_arg)]
     fn append_state_commitment_infos(
         self,
         block_number: BlockNumber,
-        state_commitment_infos: &StateCommitmentInfos,
+        state_commitment_infos: &String,
     ) -> StorageResult<Self>;
 
     /// Removes the commitment infos for the given block from storage.
@@ -69,7 +48,7 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
     fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>> {
+    ) -> StorageResult<Option<String>> {
         let table = self.open_table(&self.tables().state_commitment_infos)?;
         let Some(location) = table.get(self.txn(), &block_number)? else {
             return Ok(None);
@@ -79,10 +58,11 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
 }
 
 impl<T: StorageTransaction<Mode = RW>> StateCommitmentInfosStorageWriter for T {
+    #[allow(clippy::ptr_arg)]
     fn append_state_commitment_infos(
         self,
         block_number: BlockNumber,
-        state_commitment_infos: &StateCommitmentInfos,
+        state_commitment_infos: &String,
     ) -> StorageResult<Self> {
         let file_offset_table = self.open_table(&self.tables().file_offsets)?;
         let state_commitment_infos_table =

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-
 use starknet_api::block::BlockNumber;
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 
 use crate::state_commitment_infos::{
     StateCommitmentInfosStorageReader,
@@ -9,12 +6,9 @@ use crate::state_commitment_infos::{
 };
 use crate::test_utils::get_test_storage;
 
-fn sample_state_commitment_infos() -> StateCommitmentInfos {
-    StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    }
+// Storage persists the witness verbatim, so a plain string stands in for the real payload.
+fn sample_state_commitment_infos() -> String {
+    "compressed-state-commitment-infos".to_string()
 }
 
 #[test]

--- a/crates/apollo_transaction_converter/Cargo.toml
+++ b/crates/apollo_transaction_converter/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 apollo_class_manager_types.workspace = true
+apollo_config.workspace = true
 apollo_metrics.workspace = true
 apollo_proof_manager_types.workspace = true
 async-trait.workspace = true

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -232,13 +232,12 @@ impl TransactionConverterTrait for TransactionConverter {
                 // doesn't serve it on replay), so proof_manager has no entry. The downstream
                 // consumer treats this tx the same way (also echonet, also relaxed consistency
                 // check) — give back a default proof and let proof_facts flow through.
-                let proof = if tx.proof_facts.is_empty() {
-                    Proof::default()
-                } else if self.behavior_mode == BehaviorMode::Echonet {
-                    Proof::default()
-                } else {
-                    self.get_proof(&tx.proof_facts).await?
-                };
+                let proof =
+                    if tx.proof_facts.is_empty() || self.behavior_mode == BehaviorMode::Echonet {
+                        Proof::default()
+                    } else {
+                        self.get_proof(&tx.proof_facts).await?
+                    };
 
                 Ok(RpcTransaction::Invoke(RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
                     resource_bounds: tx.resource_bounds,
@@ -366,8 +365,8 @@ impl TransactionConverter {
                 // proof_facts without a proof. Treat as "no proof data" (skip verification +
                 // archive). `proof_facts` stays on the canonical tx; tx hash and execution are
                 // unaffected.
-                let skip_proof_for_replay = self.behavior_mode == BehaviorMode::Echonet
-                    && tx.proof.is_empty();
+                let skip_proof_for_replay =
+                    self.behavior_mode == BehaviorMode::Echonet && tx.proof.is_empty();
                 let proof_data = if tx.proof_facts.is_empty() || skip_proof_for_replay {
                     None
                 } else {

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::{ClassHashes, ClassManagerClientError, SharedClassManagerClient};
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_proof_manager_types::{ProofManagerClientError, SharedProofManagerClient};
 use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
@@ -116,6 +117,10 @@ pub struct TransactionConverter {
     class_manager_client: SharedClassManagerClient,
     proof_manager_client: SharedProofManagerClient,
     chain_id: ChainId,
+    // When set to `Echonet`, `convert_rpc_tx_to_internal` skips proof verification/archiving
+    // for replayed private txs that have `proof_facts` but no `proof` (mainnet's feeder
+    // strips `proof` before serving). See that method for details.
+    behavior_mode: BehaviorMode,
 }
 
 impl TransactionConverter {
@@ -124,7 +129,21 @@ impl TransactionConverter {
         proof_manager_client: SharedProofManagerClient,
         chain_id: ChainId,
     ) -> Self {
-        Self { class_manager_client, proof_manager_client, chain_id }
+        Self::new_with_behavior_mode(
+            class_manager_client,
+            proof_manager_client,
+            chain_id,
+            BehaviorMode::default(),
+        )
+    }
+
+    pub fn new_with_behavior_mode(
+        class_manager_client: SharedClassManagerClient,
+        proof_manager_client: SharedProofManagerClient,
+        chain_id: ChainId,
+        behavior_mode: BehaviorMode,
+    ) -> Self {
+        Self { class_manager_client, proof_manager_client, chain_id, behavior_mode }
     }
 
     async fn get_sierra(
@@ -209,7 +228,13 @@ impl TransactionConverterTrait for TransactionConverter {
             InternalRpcTransactionWithoutTxHash::Invoke(tx) => {
                 // We expect the proof to be available here because it has already been verified
                 // and stored by the proof manager in the gateway.
+                // Echonet exception: the gateway skipped storing the proof (mainnet's feeder
+                // doesn't serve it on replay), so proof_manager has no entry. The downstream
+                // consumer treats this tx the same way (also echonet, also relaxed consistency
+                // check) — give back a default proof and let proof_facts flow through.
                 let proof = if tx.proof_facts.is_empty() {
+                    Proof::default()
+                } else if self.behavior_mode == BehaviorMode::Echonet {
                     Proof::default()
                 } else {
                     self.get_proof(&tx.proof_facts).await?
@@ -337,7 +362,13 @@ impl TransactionConverter {
     ) -> TransactionConverterResult<(InternalRpcTransaction, Option<(ProofFacts, Proof)>)> {
         let (tx_without_hash, proof_data) = match tx {
             RpcTransaction::Invoke(RpcInvokeTransaction::V3(tx)) => {
-                let proof_data = if tx.proof_facts.is_empty() {
+                // Echonet replay: mainnet's feeder strips `proof` before serving, so we receive
+                // proof_facts without a proof. Treat as "no proof data" (skip verification +
+                // archive). `proof_facts` stays on the canonical tx; tx hash and execution are
+                // unaffected.
+                let skip_proof_for_replay = self.behavior_mode == BehaviorMode::Echonet
+                    && tx.proof.is_empty();
+                let proof_data = if tx.proof_facts.is_empty() || skip_proof_for_replay {
                     None
                 } else {
                     Some((tx.proof_facts.clone(), tx.proof.clone()))

--- a/crates/apollo_transaction_converter/src/transaction_converter_test.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use apollo_class_manager_types::{ClassHashes, MockClassManagerClient};
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_proof_manager_types::MockProofManagerClient;
 use assert_matches::assert_matches;
 use blockifier::context::ChainInfo;
@@ -230,4 +231,55 @@ async fn test_convert_internal_rpc_tx_to_rpc_tx_with_proof(proof_facts: ProofFac
         transaction_converter.convert_internal_rpc_tx_to_rpc_tx(internal_tx).await.unwrap();
 
     assert_eq!(rpc_tx, rpc_tx_from_internal);
+}
+
+// In Echonet mode, gateway flow skips storing the proof in proof_manager (mainnet's feeder
+// doesn't expose it on replay). When the proposer later converts the internal tx back to RPC
+// to stream the proposal to peers, it must NOT call get_proof — there's nothing to get and
+// `ProofNotFound` would abort the proposal. The converter should hand back `Proof::default()`
+// and let proof_facts flow through unchanged.
+// In Echonet mode, gateway flow receives a replayed tx with `proof_facts` populated but no
+// `proof` (mainnet's feeder strips it). Gateway skips storing the proof in proof_manager.
+// When the proposer later converts the internal tx back to RPC to stream the proposal to
+// peers, the converter must NOT call get_proof — there's nothing to get and `ProofNotFound`
+// would abort the proposal. The converter should hand back `Proof::default()` and let
+// proof_facts flow through unchanged.
+#[rstest]
+#[tokio::test]
+async fn test_internal_rpc_to_rpc_in_echonet_mode_skips_proof_manager_lookup(
+    proof_facts: ProofFacts,
+) {
+    // Simulate the echonet replay path: proof_facts present, proof absent.
+    let rpc_tx = invoke_tx_client_side_proving(
+        CairoVersion::default(),
+        proof_facts.clone(),
+        Proof::default(),
+    );
+
+    // No expectations on the mock — neither contains_proof nor get_proof should be called in
+    // Echonet mode. The mock asserts no unexpected calls.
+    let mock_proof_manager_client = MockProofManagerClient::new();
+
+    let transaction_converter = TransactionConverter::new_with_behavior_mode(
+        Arc::new(MockClassManagerClient::new()),
+        Arc::new(mock_proof_manager_client),
+        ChainInfo::create_for_testing().chain_id,
+        BehaviorMode::Echonet,
+    );
+
+    let (internal_tx, verification_handle) =
+        transaction_converter.convert_rpc_tx_to_internal_rpc_tx(rpc_tx.clone()).await.unwrap();
+    assert!(verification_handle.is_none(), "echonet must not spawn proof verification");
+
+    let rpc_tx_from_internal =
+        transaction_converter.convert_internal_rpc_tx_to_rpc_tx(internal_tx).await.unwrap();
+
+    // proof_facts are preserved; proof remains the default we put in.
+    let RpcTransaction::Invoke(starknet_api::rpc_transaction::RpcInvokeTransaction::V3(out_tx)) =
+        rpc_tx_from_internal
+    else {
+        panic!("expected V3 invoke");
+    };
+    assert_eq!(out_tx.proof_facts, proof_facts);
+    assert!(out_tx.proof.is_empty(), "proof must be default in echonet round-trip");
 }

--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -495,6 +495,7 @@ impl VersionedConstants {
     // TODO(Arni): Consider replacing each call to this function with `latest_with_overrides`, and
     // squashing the functions together.
     /// Returns the latest versioned constants, applying the given overrides.
+    /// In Echonet mode, "latest" is the version set via `set_effective_latest_version`.
     pub fn get_versioned_constants(
         versioned_constants_overrides: Option<VersionedConstantsOverrides>,
     ) -> Self {

--- a/crates/central_systest_blobs/src/cende_blob_regression_test.rs
+++ b/crates/central_systest_blobs/src/cende_blob_regression_test.rs
@@ -231,6 +231,7 @@ impl From<BlockData> for BlobParameters {
         };
 
         Self {
+            starknet_version: block_info.starknet_version,
             block_info,
             state_diff,
             compressed_state_diff: Some(commitment_state_diff),

--- a/crates/starknet_api/src/block.rs
+++ b/crates/starknet_api/src/block.rs
@@ -711,6 +711,19 @@ pub struct BlockInfo {
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct BlockSignature(pub Signature);
 
+/// Metadata for a block proposal, for Echonet mode.
+/// `block_number` is `None` in fee-priority mode where block numbers are not tracked.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReplayMetadata {
+    pub timestamp: UnixTimestamp,
+    pub block_number: Option<BlockNumber>,
+    pub l1_gas_price_wei: GasPrice,
+    pub l1_data_gas_price_wei: GasPrice,
+    pub l1_gas_price_fri: GasPrice,
+    pub l1_data_gas_price_fri: GasPrice,
+    pub l2_gas_price_fri: GasPrice,
+}
+
 /// The error type returned from the block verification functions.
 #[derive(thiserror::Error, Clone, Debug)]
 pub enum BlockVerificationError {

--- a/crates/starknet_api/src/versioned_constants_logic.rs
+++ b/crates/starknet_api/src/versioned_constants_logic.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 #[cfg(any(test, feature = "testing"))]
 use std::path::Path;
+use std::sync::OnceLock;
 
 #[cfg(any(test, feature = "testing"))]
 use expect_test::expect_file;
@@ -19,6 +20,25 @@ use strum::IntoEnumIterator;
 
 use crate::block::StarknetVersion;
 
+/// Process-wide override for the "latest" Starknet version.
+/// Set once at startup in Echonet mode so all versioned-constants lookups use the replayed
+/// network's version instead of the compile-time LATEST.
+static EFFECTIVE_LATEST_VERSION: OnceLock<StarknetVersion> = OnceLock::new();
+
+/// Sets the effective latest Starknet version for this process.
+/// In Echonet replay mode the gateway calls this once at startup so all versioned-constants
+/// lookups use the replayed network's version rather than the compile-time LATEST.
+pub fn set_effective_latest_version(version: StarknetVersion) {
+    // Ignore if already set — this is a write-once value.
+    EFFECTIVE_LATEST_VERSION.set(version).ok();
+}
+
+/// Returns the effective latest Starknet version: the value set via
+/// `set_effective_latest_version` if in Echonet mode, otherwise the compile-time LATEST.
+pub fn effective_starknet_version() -> StarknetVersion {
+    EFFECTIVE_LATEST_VERSION.get().copied().unwrap_or(StarknetVersion::LATEST)
+}
+
 pub trait VersionedConstantsTrait: Debug {
     type Error: Debug;
 
@@ -33,7 +53,12 @@ pub trait VersionedConstantsTrait: Debug {
 
     /// Gets the constants that shipped with the current version of the Starknet.
     /// To use custom constants, initialize the struct from a file using `from_path`.
-    fn latest_constants() -> &'static Self;
+    fn latest_constants() -> &'static Self {
+        let version = effective_starknet_version();
+        Self::get(&version).unwrap_or_else(|_| {
+            Self::get(&StarknetVersion::LATEST).expect("Latest version should support VC.")
+        })
+    }
 
     /// Gets the constants for the specified Starknet version.
     fn get(version: &StarknetVersion) -> Result<&'static Self, Self::Error>;
@@ -184,11 +209,6 @@ macro_rules! define_versioned_constants_inner {
                     },)*
                     _ => Err(Self::Error::InvalidStarknetVersion(*version)),
                 }
-            }
-
-            fn latest_constants() -> &'static Self {
-                Self::get(&starknet_api::block::StarknetVersion::LATEST)
-                    .expect("Latest version should support VC.")
             }
 
             fn get(

--- a/deployments/images/sequencer/Dockerfile
+++ b/deployments/images/sequencer/Dockerfile
@@ -35,7 +35,7 @@ RUN BUILD_FLAGS=""; \
     elif [ "$BUILD_MODE" = "profiling" ]; then \
         BUILD_FLAGS="--profile profiling"; \
     fi; \
-    cargo build $BUILD_FLAGS --bin apollo_node --features cairo_native
+    cargo build $BUILD_FLAGS --bin apollo_node --features cairo_native,os_input
 
 # Install compiler binaries used for Sierra compilation at runtime.
 # Binaries land under $CARGO_TOOLS_ROOT/<binary>-<version>/bin/<binary>; the


### PR DESCRIPTION
Squashes the rebased ron/add-timestamp-to-block stack into a single commit on top of main for ad-hoc editing. Combines:
  - echonet: rename replay functions before getting block metadata
  - echonet: share json parse func
  - echonet: fetch block metadata from echonet
  - echonet: Add timestamp to block metadata