### PR TITLE
starknet_committer: derive skeleton updates from actual updates

### DIFF
--- a/crates/starknet_committer/src/block_committer/commit.rs
+++ b/crates/starknet_committer/src/block_committer/commit.rs
@@ -9,6 +9,8 @@ use tracing::{debug, warn};
 use crate::block_committer::errors::BlockCommitmentError;
 use crate::block_committer::input::{
     contract_address_into_node_index,
+    skeleton_storage_updates,
+    skeleton_trie_updates,
     Input,
     StarknetStorageValue,
     StateDiff,
@@ -73,7 +75,8 @@ pub async fn commit_block<Reader: ForestReader + Send, M: MeasurementsTrait + Se
         original_contracts_trie_leaves,
         actual_storage_updates,
         actual_classes_updates,
-        &input.state_diff,
+        &input.state_diff.address_to_class_hash,
+        &input.state_diff.address_to_nonce,
         measurements,
     )
     .await
@@ -123,7 +126,8 @@ async fn compute_updated_forest<M: MeasurementsTrait + Send>(
     original_contracts_trie_leaves: HashMap<NodeIndex, ContractState>,
     actual_storage_updates: HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
     actual_classes_updates: LeafModifications<CompiledClassHash>,
-    state_diff: &StateDiff,
+    address_to_class_hash: &HashMap<ContractAddress, ClassHash>,
+    address_to_nonce: &HashMap<ContractAddress, Nonce>,
     measurements: &mut M,
 ) -> BlockCommitmentResult<(FilledForest, DeletedNodes)> {
     measurements.start_measurement(Action::Compute);
@@ -131,11 +135,11 @@ async fn compute_updated_forest<M: MeasurementsTrait + Send>(
     // Compute the new topology.
     let updated_forest = UpdatedSkeletonForest::create(
         &original_forest,
-        &state_diff.skeleton_classes_updates(),
-        &state_diff.skeleton_storage_updates(),
+        &skeleton_trie_updates(&actual_classes_updates),
+        &skeleton_storage_updates(&actual_storage_updates),
         &original_contracts_trie_leaves,
-        &state_diff.address_to_class_hash,
-        &state_diff.address_to_nonce,
+        address_to_class_hash,
+        address_to_nonce,
     )?;
     debug!("Updated skeleton forest created successfully.");
 
@@ -154,8 +158,8 @@ async fn compute_updated_forest<M: MeasurementsTrait + Send>(
         actual_storage_updates,
         actual_classes_updates,
         &original_contracts_trie_leaves,
-        &state_diff.address_to_class_hash,
-        &state_diff.address_to_nonce,
+        address_to_class_hash,
+        address_to_nonce,
     )
     .await?;
     measurements.attempt_to_stop_measurement(Action::Compute, 0).ok();

--- a/crates/starknet_committer/src/block_committer/input.rs
+++ b/crates/starknet_committer/src/block_committer/input.rs
@@ -74,6 +74,12 @@ impl From<u128> for StarknetStorageKey {
 #[derive(Clone, Copy, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StarknetStorageValue(pub Felt);
 
+impl From<StarknetStorageValue> for SkeletonLeaf {
+    fn from(value: StarknetStorageValue) -> Self {
+        SkeletonLeaf::from(value.0)
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StateDiff {
     pub address_to_class_hash: HashMap<ContractAddress, ClassHash>,
@@ -264,33 +270,6 @@ impl StateDiff {
     }
 
     /// For each modified contract calculates it's actual storage updates.
-    pub(crate) fn skeleton_storage_updates(
-        &self,
-    ) -> HashMap<ContractAddress, LeafModifications<SkeletonLeaf>> {
-        self.accessed_addresses()
-            .iter()
-            .map(|address| {
-                let updates = match self.storage_updates.get(address) {
-                    Some(inner_updates) => inner_updates
-                        .iter()
-                        .map(|(key, value)| (key.into(), SkeletonLeaf::from(value.0)))
-                        .collect(),
-                    None => HashMap::new(),
-                };
-                (**address, updates)
-            })
-            .collect()
-    }
-
-    pub(crate) fn skeleton_classes_updates(&self) -> LeafModifications<SkeletonLeaf> {
-        self.class_hash_to_compiled_class_hash
-            .iter()
-            .map(|(class_hash, compiled_class_hash)| {
-                (class_hash_into_node_index(class_hash), SkeletonLeaf::from(compiled_class_hash.0))
-            })
-            .collect()
-    }
-
     pub(crate) fn actual_storage_updates(
         &self,
     ) -> HashMap<ContractAddress, LeafModifications<StarknetStorageValue>> {
@@ -316,4 +295,22 @@ impl StateDiff {
             })
             .collect()
     }
+}
+
+/// Reduces a single trie's actual leaf updates to skeleton updates (whether each leaf is zero or
+/// non-zero).
+pub(crate) fn skeleton_trie_updates<L: Copy + Into<SkeletonLeaf>>(
+    actual_updates: &LeafModifications<L>,
+) -> LeafModifications<SkeletonLeaf> {
+    actual_updates.iter().map(|(&index, &value)| (index, value.into())).collect()
+}
+
+/// Reduces the actual storage updates to skeleton updates.
+pub(crate) fn skeleton_storage_updates(
+    actual_storage_updates: &HashMap<ContractAddress, LeafModifications<StarknetStorageValue>>,
+) -> HashMap<ContractAddress, LeafModifications<SkeletonLeaf>> {
+    actual_storage_updates
+        .iter()
+        .map(|(address, updates)| (*address, skeleton_trie_updates(updates)))
+        .collect()
 }

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -6,6 +6,7 @@ use starknet_api::hash::HashOutput;
 use starknet_patricia::impl_from_hex_for_felt_wrapper;
 use starknet_patricia::patricia_merkle_tree::filled_tree::tree::FilledTreeImpl;
 use starknet_patricia::patricia_merkle_tree::node_data::inner_node::PreimageMap;
+use starknet_patricia::patricia_merkle_tree::node_data::leaf::SkeletonLeaf;
 use starknet_patricia::patricia_merkle_tree::types::NodeIndex;
 use starknet_types_core::felt::{Felt, FromStrError};
 
@@ -22,6 +23,12 @@ pub fn class_hash_into_node_index(class_hash: &ClassHash) -> NodeIndex {
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CompiledClassHash(pub Felt);
+
+impl From<CompiledClassHash> for SkeletonLeaf {
+    fn from(compiled_class_hash: CompiledClassHash) -> Self {
+        SkeletonLeaf::from(compiled_class_hash.0)
+    }
+}
 
 impl AsRef<CompiledClassHash> for CompiledClassHash {
     fn as_ref(&self) -> &CompiledClassHash {


### PR DESCRIPTION
read_original_forest now takes &Input. The skeleton updates fed to
UpdatedSkeletonForest are derived from the already-computed actual
updates via a generic skeleton_trie_updates (pure value mapping),
instead of re-walking the state diff. Adds From<_> for SkeletonLeaf
impls for the leaf value types to back the generic bound.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>