### PR TITLE
deployment: prewarm Cairo 1 compile cache in node_setup image

### DIFF
--- a/deployments/images/sequencer/node_setup.Dockerfile
+++ b/deployments/images/sequencer/node_setup.Dockerfile
@@ -20,12 +20,30 @@ RUN cargo chef cook --recipe-path recipe.json --bin sequencer_node_setup
 COPY . .
 RUN cargo build --bin sequencer_node_setup
 
+# Pre-warm the Cairo 1 compilation cache: sequencer_node_setup compiles its
+# feature contracts on demand, so run it here (full source tree + toolchain
+# present) to populate target/blockifier_test_artifacts, which the final stage
+# copies so the slim runtime image needs no compiler. The args mirror the
+# runtime invocation so the same cache keys are produced; the db/config output
+# is discarded.
+# PATH includes /app so the bootstrap step finds the anvil binary fetched above.
+RUN PATH="/app:$PATH" ./target/debug/sequencer_node_setup \
+    --output-base-dir /tmp/cache_warmup_output \
+    --data-prefix-path /tmp/cache_warmup_data \
+    --n-distributed 0 --n-hybrid 0 --n-consolidated 1 \
+    && rm -rf /tmp/cache_warmup_output /tmp/cache_warmup_data
+
 FROM ubuntu:24.04 AS final_stage
 
 ENV ID=1001
 WORKDIR /app
 # Required crate for sequencer_node_setup to work
 COPY --from=builder /app/crates/blockifier_test_utils/resources ./crates/blockifier_test_utils/resources
+# Libfuncs allow-list read during Cairo 1 cache lookups; lives outside
+# blockifier_test_utils/resources, so copy it explicitly.
+COPY --from=builder /app/crates/apollo_compile_to_casm/src/allowed_libfuncs.json ./crates/apollo_compile_to_casm/src/allowed_libfuncs.json
+# Pre-warmed Cairo 1 compilation cache (see builder stage).
+COPY --from=builder /app/target/blockifier_test_artifacts ./target/blockifier_test_artifacts
 COPY --from=builder /app/target/debug/sequencer_node_setup ./target/debug/sequencer_node_setup
 COPY --from=builder /usr/bin/tini /usr/bin/tini
 COPY --from=builder /app/anvil /usr/bin/anvil


### PR DESCRIPTION
## Problem

Deploying the local monitoring stack (`deployments/monitoring/README.md`) fails: `sequencer_node_setup` panics during DB bootstrap with a missing `crates/apollo_compile_to_casm/src/allowed_libfuncs.json`, which blocks every dependent service (`config_injector`, `sequencer_node`, `sequencer_simulator`).

## Root cause

`blockifier_test_utils` switched from *committed* Cairo 1 artifacts to *on-demand compilation* (#13105 + #13106), deleting the checked-in `*.casm.json`/`*.sierra.json`. `node_setup` used to read those committed files (already copied via `blockifier_test_utils/resources`); now the same bootstrap path compiles them at runtime. The slim `ubuntu:24.04` final stage has neither the compile inputs nor a compiler, so it panics. So this has been broken since those PRs landed.

## Fix

Pre-warm the Cairo 1 compilation cache in the **builder** stage (full source tree + toolchain present, `anvil` put on `PATH` so bootstrap completes), then copy `target/blockifier_test_artifacts` + `allowed_libfuncs.json` into the final image. At runtime the cache is fresh, so no compiler is invoked — keeps the lightweight fresh-ubuntu image (no LLVM, no cairo-package download, no source tree). Adds ~2 MB to the image.

> Note: the build now needs network access during the warmup step to download the Cairo 1 compiler.

## Verification

Rebuilt and redeployed the local monitoring stack:
- `sequencer_node_setup` → exits 0 ("Node setup completed")
- `sequencer_node` → up, `/monitoring/alive` returns 200, actively producing blocks
- prometheus / grafana / dummy_recorder / dummy_exchange_rate_oracle → up

Two pre-existing issues remain, unrelated to this fix: a `sequencer_simulator` startup race (no retry before the node's gateway is up) and an `alert_builder.py` `KeyError: 'observer_applicable'` in Grafana provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)