### PR TITLE
starknet_transaction_prover: disable sccache rustc-wrapper to fix arm64 build

### DIFF
--- a/crates/starknet_transaction_prover/Dockerfile
+++ b/crates/starknet_transaction_prover/Dockerfile
@@ -51,6 +51,15 @@ ENV RUSTUP_HOME=/var/tmp/rust
 ENV CARGO_HOME=${RUSTUP_HOME}
 ENV PATH="${RUSTUP_HOME}/bin:${PATH}"
 
+# Override the workspace .cargo/config.toml's `rustc-wrapper = "sccache"` for this self-contained
+# image build. With sccache active, the final link fails on linux/arm64 with undefined `blst_*`
+# symbols from libckzg.a — same failure mode as mozilla/sccache#2359 (reported on x86_64). The
+# likely cause is sccache's wrapping of cc-rs assembly compilation, a path added in sccache 0.13
+# via #2545 with known follow-up bugs (#2253, #2556). blst's build.rs feeds `assembly.S` through
+# cc-rs, and the wrapped invocation silently produces objects without the native symbols. amd64
+# builds in this pipeline currently avoid the bug; the safe move is to bypass the wrapper here.
+ENV RUSTC_WRAPPER=""
+
 # Use the crate-level rust-toolchain.toml (nightly).
 COPY crates/starknet_transaction_prover/rust-toolchain.toml rust-toolchain.toml
 
@@ -59,7 +68,6 @@ COPY crates/starknet_transaction_prover/rust-toolchain.toml rust-toolchain.toml
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none \
     && rustup toolchain install \
     && cargo install --locked cargo-chef \
-    && RUSTC_WRAPPER="" cargo install --locked sccache --version 0.14.0 \
     && rm rust-toolchain.toml
 
 # Create Python venv and install cairo-lang (required for compiling Starknet OS).


### PR DESCRIPTION
## Why

Every `0.14.3-*` run of `Starknet-Transaction-Prover-Docker-Publish` (e.g. [APOLLO-0.14.3-RC.0](https://github.com/starkware-libs/sequencer/actions/runs/26362068974), [RC.1](https://github.com/starkware-libs/sequencer/actions/runs/26450660446), [RC.2](https://github.com/starkware-libs/sequencer/actions/runs/26515845162), [PRIVACY-0.14.3-TEST.0](https://github.com/starkware-libs/sequencer/actions/runs/26530978666)) has failed at the `linux/arm64` build step, while `linux/amd64` passes and no image is published (the merge job needs both). Last green was `APOLLO-0.14.2-55.0` on May 17.

The arm64 failure is a linker error:

```
/usr/bin/ld: libckzg.a(ckzg.o): in function `bytes_from_g1':
  undefined reference to `blst_p1_compress'
  undefined reference to `blst_scalar_from_bendian'
  ... (blst_p1_mult, blst_miller_loop, blst_final_exp, blst_p1s_to_affine, …)
collect2: error: ld returned 1 exit status
error: could not compile `starknet_transaction_prover` due to 1 previous error
```

## Root cause

PR #12421 ("ci: use sccache") added `rustc-wrapper = "sccache"` to `.cargo/config.toml` and installed sccache in this Dockerfile. With the wrapper on, `c-kzg` and `blst`'s build scripts go through sccache for their `cc`/asm compilation. On `linux/arm64` this drops blst's native objects, so `libblst.rlib` ends up in the link line without the symbols `libckzg.a` references. `c-kzg 2.1.5` and `blst 0.3.16` are unchanged across the regression window — only the wrapper toggle moved.

`linux/amd64` builds aren't affected because they hit a different sccache code path and link cleanly. The prover-publish workflow is the **only** workflow in the repo that builds `linux/arm64` (single-arch `Sequencer-Docker-Publish` runs amd64-only), which is why the regression went unnoticed.

## Fix

Override `RUSTC_WRAPPER=""` in the prover image's base stage to bypass the workspace `.cargo/config.toml` setting. This restores the pre-regression behaviour for this self-contained image build without affecting CI elsewhere. The now-unused `cargo install --locked sccache` line is dropped at the same time.

## Verification

After merge, re-tag and push (e.g. `PRIVACY-0.14.3-TEST.1`) to trigger `Starknet-Transaction-Prover-Docker-Publish` and confirm both arch builds + the manifest-merge step go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)