### PR TITLE
apollo_l1_events: count scraped-but-uncommitted txs in pending gauge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,8 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "itertools 0.12.1",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mockall",
  "papyrus_base_layer",
  "pretty_assertions",

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -1582,7 +1582,7 @@
         },
         {
           "title": "L1 Message Provider Num Pending Txs",
-          "description": "The number of pending L1 handler transactions in the transaction manager",
+          "description": "Number of L1 handler transactions that have been scraped (Full payload stored) but are not yet committed on L2",
           "type": "timeseries",
           "exprs": [
             "l1_message_provider_num_pending_txs{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}"

--- a/crates/apollo_l1_events/Cargo.toml
+++ b/crates/apollo_l1_events/Cargo.toml
@@ -42,10 +42,13 @@ alloy.workspace = true
 apollo_base_layer_tests.workspace = true
 apollo_infra_utils = { workspace = true, features = ["testing"] }
 apollo_l1_events_types = { workspace = true, features = ["testing"] }
+apollo_metrics = { workspace = true, features = ["testing"] }
 apollo_state_sync_types = { workspace = true, features = ["testing"] }
 apollo_time = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 itertools.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 mockall.workspace = true
 papyrus_base_layer = { workspace = true, features = ["testing"] }
 pretty_assertions.workspace = true

--- a/crates/apollo_l1_events/src/l1_events_provider_tests.rs
+++ b/crates/apollo_l1_events/src/l1_events_provider_tests.rs
@@ -24,6 +24,7 @@ use apollo_time::time::Clock;
 use assert_matches::assert_matches;
 use indexmap::IndexSet;
 use itertools::Itertools;
+use metrics_exporter_prometheus::PrometheusBuilder;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
@@ -33,6 +34,7 @@ use starknet_api::tx_hash;
 
 use crate::catchupper::{Catchupper, CommitBlockBacklog, SyncTaskHandle};
 use crate::l1_events_provider::L1EventsProvider;
+use crate::metrics::L1_MESSAGE_PROVIDER_NUM_PENDING_TXS;
 use crate::test_utils::{
     l1_handler,
     make_catchupper,
@@ -1920,4 +1922,41 @@ async fn tx_cancelled_during_initialization_never_reaches_proposable_index() {
     assert!(snapshot.cancellation_started_on_l2.contains(&tx_hash));
     let cancelled_tx = l1_events_provider.tx_manager.records.get(&tx_hash).unwrap();
     assert_eq!(cancelled_tx.state, TransactionState::CancellationStartedOnL2);
+}
+
+#[test]
+fn pending_txs_metric_tracks_scraped_uncommitted_txs() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+    let mut l1_events_provider = L1EventsProviderContentBuilder::new()
+        .with_state(ProviderState::Pending)
+        .build_into_l1_provider();
+
+    // Two txs share `scrape_timestamp = 7`, one uses `scrape_timestamp = 8`. With the previous
+    // `proposable_index.len()` implementation this would have read as 2 (two timestamp buckets);
+    // the correct count is 3.
+    let shared_timestamp = BlockTimestamp(7);
+    let unique_timestamp = BlockTimestamp(8);
+    l1_events_provider
+        .add_events(vec![
+            timed_l1_handler_event(tx_hash!(1), shared_timestamp),
+            timed_l1_handler_event(tx_hash!(2), shared_timestamp),
+            timed_l1_handler_event(tx_hash!(3), unique_timestamp),
+        ])
+        .unwrap();
+    let metrics_as_string = recorder.handle().render();
+    L1_MESSAGE_PROVIDER_NUM_PENDING_TXS.assert_eq::<u64>(&metrics_as_string, 3);
+
+    // Committing two of them leaves one scraped-but-uncommitted tx.
+    l1_events_provider
+        .commit_block([tx_hash!(1), tx_hash!(2)].into(), [].into(), BlockNumber(0))
+        .unwrap();
+    let metrics_as_string = recorder.handle().render();
+    L1_MESSAGE_PROVIDER_NUM_PENDING_TXS.assert_eq::<u64>(&metrics_as_string, 1);
+
+    // Committing the last one drops the gauge to zero.
+    l1_events_provider.commit_block([tx_hash!(3)].into(), [].into(), BlockNumber(1)).unwrap();
+    let metrics_as_string = recorder.handle().render();
+    L1_MESSAGE_PROVIDER_NUM_PENDING_TXS.assert_eq::<u64>(&metrics_as_string, 0);
 }

--- a/crates/apollo_l1_events/src/metrics.rs
+++ b/crates/apollo_l1_events/src/metrics.rs
@@ -17,7 +17,7 @@ define_metrics!(
         MetricCounter { L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT, "l1_message_scraper_baselayer_error_count", "Number of times the L1 message scraper encountered an error while scraping the base layer", init=0},
         MetricCounter { L1_MESSAGE_SCRAPER_REORG_DETECTED, "l1_message_scraper_reorg_detected", "Number of times the L1 message scraper detected a reorganization in the base layer", init=0},
         MetricGauge { L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS, "l1_message_scraper_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful L1 message scrape" },
-        MetricGauge { L1_MESSAGE_PROVIDER_NUM_PENDING_TXS, "l1_message_provider_num_pending_txs", "The number of pending L1 handler transactions in the transaction manager" },
+        MetricGauge { L1_MESSAGE_PROVIDER_NUM_PENDING_TXS, "l1_message_provider_num_pending_txs", "Number of L1 handler transactions that have been scraped (Full payload stored) but are not yet committed on L2" },
     },
 );
 

--- a/crates/apollo_l1_events/src/transaction_manager.rs
+++ b/crates/apollo_l1_events/src/transaction_manager.rs
@@ -229,6 +229,7 @@ impl TransactionManager {
         // This will also call maintain_indices to remove the tx from the proposable index.
         self.with_record(tx_hash, |r| r.mark_cancellation_finalized_on_l1());
         self.records.remove(&tx_hash);
+        self.update_pending_count_metric();
     }
 
     pub fn consume_tx(
@@ -263,10 +264,15 @@ impl TransactionManager {
             unix_now.saturating_sub(self.config.l1_handler_consumption_timelock_seconds.as_secs());
         let still_timelocked = self.consumed_queue.split_off(&BlockTimestamp(cutoff));
         let passed_timelock = std::mem::replace(&mut self.consumed_queue, still_timelocked);
+        let mut any_removed = false;
         for tx_hashes in passed_timelock.values() {
             for tx_hash in tx_hashes {
                 self.records.remove(tx_hash);
+                any_removed = true;
             }
+        }
+        if any_removed {
+            self.update_pending_count_metric();
         }
     }
 
@@ -332,7 +338,23 @@ impl TransactionManager {
         let record = self.records.get_mut_unchecked(hash)?;
         let result = f(record);
         self.maintain_indices(hash);
+        // TODO(Shahak): only recompute when the pending count can actually change.
+        self.update_pending_count_metric();
         Some(result)
+    }
+
+    /// Sets `L1_MESSAGE_PROVIDER_NUM_PENDING_TXS` to the number of records that have been
+    /// scraped (i.e. have a Full payload) but are not yet committed on L2.
+    fn update_pending_count_metric(&self) {
+        let num_pending_txs = self
+            .records
+            .iter()
+            .filter(|(_, record)| {
+                matches!(record.tx, TransactionPayload::Full { .. })
+                    && record.state != TransactionState::Committed
+            })
+            .count();
+        L1_MESSAGE_PROVIDER_NUM_PENDING_TXS.set_lossy(num_pending_txs);
     }
 
     fn create_record_if_not_exist(&mut self, hash: TransactionHash) -> bool {
@@ -382,9 +404,6 @@ impl TransactionManager {
                     Entry::Vacant(_) => {}
                 }
             }
-
-            let num_pending_txs = self.proposable_index.len();
-            L1_MESSAGE_PROVIDER_NUM_PENDING_TXS.set_lossy(num_pending_txs);
 
             // If this tx was consumed, add it to the consumed queue.
             if let Some(consumed_at) = record.get_consumed_at_timestamp() {


### PR DESCRIPTION
Goal
- Make L1_MESSAGE_PROVIDER_NUM_PENDING_TXS report the count of L1
  handler transactions that have been scraped (Full payload) and are not
  yet committed on L2, matching operator intent for "pending L1
  handlers".

Change summary
- Replace the gauge calculation in TransactionManager from
  proposable_index.len() (which counted BTreeMap timestamp buckets, not
  txs) with a count over self.records filtering for Full payload and
  state != Committed.
- Extract the calculation into update_pending_count_metric and call it
  after with_record, finalize_cancellation's records.remove, and
  clear_old_tx_from_consumed_queue so record removals (cancellation
  finalization, consumption-timelock cleanup) decrement the gauge
  promptly.
- Update the gauge description to match the new semantics.
- Add a unit test using PrometheusBuilder that exercises the
  collision-on-scrape-timestamp case (catches the bucket-vs-tx bug) and
  the commit path.

Decision points
- "Pending" means "scraped (Full payload) AND state != Committed".
  This includes records in transient non-committed states
  (CancellationStartedOnL2, Consumed before timelock cleanup, etc.).
  Operationally these are short-lived, and the simpler filter avoids
  tying the gauge to lifecycle internals.
- Added metrics, metrics-exporter-prometheus, and the apollo_metrics
  testing feature to dev-dependencies to enable the gauge assertion.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>