### PR TITLE
apollo_dashboard: add L1 handler scrape rate panel

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -1599,6 +1599,15 @@
           "extra_params": {}
         },
         {
+          "title": "L1 Handler Tx Scrape Rate (per minute)",
+          "description": "Number of unique L1 handler transactions scraped from L1 over the last 1m window",
+          "type": "timeseries",
+          "exprs": [
+            "increase(l1_message_scraper_l1_handler_tx_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[1m])"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "L1 Message Scraper Success Count",
           "description": "The increase in the number of times the L1 message scraper successfully scraped messages (10m window)",
           "type": "timeseries",

--- a/crates/apollo_dashboard/src/panels/l1_events.rs
+++ b/crates/apollo_dashboard/src/panels/l1_events.rs
@@ -1,6 +1,7 @@
 use apollo_l1_events::metrics::{
     L1_MESSAGE_PROVIDER_NUM_PENDING_TXS,
     L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT,
+    L1_MESSAGE_SCRAPER_L1_HANDLER_TX_COUNT,
     L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS,
     L1_MESSAGE_SCRAPER_LATEST_SCRAPED_BLOCK,
     L1_MESSAGE_SCRAPER_REORG_DETECTED,
@@ -49,6 +50,14 @@ fn get_panel_l1_message_scraper_latest_scraped_block() -> Panel {
 fn get_panel_l1_events_num_pending_txs() -> Panel {
     Panel::from_gauge(&L1_MESSAGE_PROVIDER_NUM_PENDING_TXS, PanelType::TimeSeries)
 }
+fn get_panel_l1_message_scraper_l1_handler_tx_rate() -> Panel {
+    Panel::new(
+        "L1 Handler Tx Scrape Rate (per minute)",
+        "Number of unique L1 handler transactions scraped from L1 over the last 1m window",
+        increase(&L1_MESSAGE_SCRAPER_L1_HANDLER_TX_COUNT, "1m"),
+        PanelType::TimeSeries,
+    )
+}
 
 fn get_panel_l1_message_scraper_seconds_since_last_successful_scrape() -> Panel {
     Panel::new(
@@ -70,6 +79,7 @@ pub(crate) fn get_l1_events_row() -> Row {
             get_panel_l1_message_scraper_seconds_since_last_successful_scrape(),
             get_panel_l1_message_scraper_latest_scraped_block(),
             get_panel_l1_events_num_pending_txs(),
+            get_panel_l1_message_scraper_l1_handler_tx_rate(),
             get_panel_l1_message_scraper_success_count(),
             get_panel_l1_message_scraper_baselayer_error_count(),
             get_panel_l1_message_scraper_reorg_detected(),


### PR DESCRIPTION
Goal
- Surface L1 handler ingestion rate next to the pending-tx gauge so
  operators can see "rate in vs. backlog" side-by-side on the L1 Events
  dashboard row.

Change summary
- Add get_panel_l1_message_scraper_l1_handler_tx_rate which renders
  increase(L1_MESSAGE_SCRAPER_L1_HANDLER_TX_COUNT[1m]) for a readable
  per-minute view (matches the typical operator mental model of "TPS").
- Insert the panel into get_l1_events_row between the pending-tx gauge
  and the scraper success counter.

Decision points
- Window is 1m (vs. the existing DEFAULT_DURATION = 10m) because L1
  handler throughput is low and a 10m window smears short bursts to be
  unreadable.
- Regenerated dev_grafana.json fixture to reflect (a) the new panel and
  (b) the gauge description change from the parent commit
  "apollo_l1_events: count scraped-but-uncommitted txs in pending gauge".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>