### PR TITLE
scripts: bump pinned llvm.sh checksum after upstream default-version bump

### DIFF
--- a/scripts/install_llvm19.sh
+++ b/scripts/install_llvm19.sh
@@ -7,7 +7,10 @@
 
 set -e
 
-# Pinned SHA-256 of https://apt.llvm.org/llvm.sh. Recorded 2026-05-14.
+# Pinned SHA-256 of https://apt.llvm.org/llvm.sh. Recorded 2026-05-31; this hash
+# is the file at opencollab/llvm-jenkins.debian.net commit d9929ab5 ("update the
+# default version to 22"). Record the upstream commit so the next bump only needs
+# to review the diff since this one.
 #
 # Why pin: llvm.sh runs as root in our CI / Docker builds. TLS authenticates the
 # server, but not the *content* — an apt.llvm.org compromise, hijacked DNS, or
@@ -24,7 +27,7 @@ set -e
 #      cause is investigated.
 #
 # Same supply-chain hygiene as Cargo.lock pinning crate hashes.
-LLVM_SH_SHA256="14a4eda1349f23acf9dc0b564ed44b21bce3bd1703c78b5f7488870d7c6fe68f"
+LLVM_SH_SHA256="dd5978eafdd69ff7f95793b35f633beca37fe50d84101a9a4add2bf93512c511"
 
 [[ ${UID} == "0" ]] || SUDO="sudo"
 


### PR DESCRIPTION
Upstream apt.llvm.org/llvm.sh changed (opencollab/llvm-jenkins.debian.net
commit d9929ab5, "update the default version to 22"), so the pinned SHA-256
in install_llvm19.sh no longer matched and CI's `sha256sum -c` failed by
design. Reviewed the full diff against the previously-pinned version (commit
e8ed1494): the sole change is CURRENT_LLVM_STABLE 20 -> 22. That constant is
only the default version and is unused on our path, since we invoke
`bash llvm.sh 19 all` with an explicit version. Verified the live file is
byte-identical to the named upstream commit. Bumped the pin to the new hash.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>