### PR TITLE
scripts: drop the llvm.sh SHA pin in install_llvm19.sh

### DIFF
--- a/scripts/install_llvm19.sh
+++ b/scripts/install_llvm19.sh
@@ -7,25 +7,6 @@
 
 set -e
 
-# Pinned SHA-256 of https://apt.llvm.org/llvm.sh. Recorded 2026-05-14.
-#
-# Why pin: llvm.sh runs as root in our CI / Docker builds. TLS authenticates the
-# server, but not the *content* — an apt.llvm.org compromise, hijacked DNS, or
-# even an accidental upstream regression could quietly serve a different script.
-# Pinning a SHA means we trust this specific reviewed version, not "whatever the
-# URL serves today".
-#
-# If sha256sum -c fails (loud build break), one of two things happened:
-#   1. apt.llvm.org legitimately updated llvm.sh. Read the new file, review the
-#      diff (compare against the previous pinned commit's version), confirm it's
-#      safe, then bump LLVM_SH_SHA256 below in a reviewed commit. This is the
-#      change-control event we want.
-#   2. The upstream or network is compromised. Do NOT bump the SHA until the
-#      cause is investigated.
-#
-# Same supply-chain hygiene as Cargo.lock pinning crate hashes.
-LLVM_SH_SHA256="14a4eda1349f23acf9dc0b564ed44b21bce3bd1703c78b5f7488870d7c6fe68f"
-
 [[ ${UID} == "0" ]] || SUDO="sudo"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -62,8 +43,6 @@ function install_llvm19() {
         trap 'rm -rf "$workdir"' RETURN
         echo "Downloading LLVM installation script..."
         curl --proto "=https" --tlsv1.2 --fail -L -o "$llvm_sh" https://apt.llvm.org/llvm.sh
-        echo "Verifying llvm.sh checksum..."
-        echo "${LLVM_SH_SHA256}  ${llvm_sh}" | sha256sum -c -
         echo "Running LLVM 19 installation script..."
         $SUDO bash "$llvm_sh" 19 all
         echo "Installing LLVM-related packages (MLIR, Polly, etc.)..."


### PR DESCRIPTION
## What

Removes the SHA-256 pin of `apt.llvm.org/llvm.sh` from `scripts/install_llvm19.sh` — the `LLVM_SH_SHA256` variable, the `sha256sum -c` verification step, and the pin-justification comment block. The download keeps strict TLS (`--proto =https --tlsv1.2 --fail`).

## Why

The pin only authenticated the **install script's bytes** — not the LLVM **packages** it installs. Those are verified by the apt GPG key that `llvm.sh` fetches over TLS **at runtime, unpinned**. So the real trust root is already *"TLS-authenticated `apt.llvm.org`"*, which is the same trust we place in the apt packages themselves.

Pinning the script while leaving that key fetch unpinned is a half-measure: a network/host compromise of `apt.llvm.org` can swap the key and serve malicious (validly-"signed") packages regardless of the script hash — and `dpkg` runs their maintainer scripts as root. The two paths (swap the script / swap the key→packages) are equally severe and ride the same TLS link, so pinning only one doesn't stop the attacker.

There are really two self-consistent stances:
- **Trust `apt.llvm.org` over TLS → pin nothing** (this PR), or
- **Distrust the delivery path → pin everything** (own/vendor the script *and* vendor the GPG key).

We already trust `apt.llvm.org` for the key and packages, so this PR takes the first stance. Bonus: it ends the recurring CI break + hash-bump chore on every benign upstream edit to `llvm.sh`, and aligns this path with `crates/blockifier_reexecution/replay/Dockerfile`, which already fetches `llvm.sh` unpinned.

## Test

- `bash -n scripts/install_llvm19.sh` passes; no remaining references to `LLVM_SH_SHA256` / `sha256sum` in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
