### PR TITLE
deployment: add monitoring endpoint port to hybrid common overlay

### DIFF
--- a/deployments/sequencer/configs/overlays/hybrid/common/common.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/common/common.yaml
@@ -5,6 +5,7 @@ image:
 config:
   sequencerConfig:
     eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
+    monitoring_endpoint_config.port: 8082
     strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d'
     versioned_constants_overrides.#is_none: true
     versioned_constants_overrides.max_n_events: 1000


### PR DESCRIPTION
Moves `monitoring_endpoint_config.port` from all hybrid environment overlays into the shared common overlay.

Devops counterpart (removal): https://github.com/starkware-industries/sequencer-devops/pull/751