### PR TITLE
apollo_rpc: delete client_transaction conversion impls

### DIFF
--- a/crates/apollo_rpc/src/v0_8/broadcasted_transaction.rs
+++ b/crates/apollo_rpc/src/v0_8/broadcasted_transaction.rs
@@ -10,11 +10,8 @@
 #[path = "broadcasted_transaction_test.rs"]
 mod broadcasted_transaction_test;
 
-use apollo_starknet_client::writer::objects::transaction as client_transaction;
 use apollo_starknet_client::writer::objects::transaction::DeprecatedContractClass;
-use apollo_storage::db::serialization::StorageSerdeError;
 use serde::{Deserialize, Serialize};
-use starknet_api::compression_utils::compress_and_encode;
 use starknet_api::core::{CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::transaction::fields::{
@@ -24,7 +21,6 @@ use starknet_api::transaction::fields::{
     Tip,
     TransactionSignature,
 };
-use starknet_api::transaction::TransactionVersion;
 
 use super::state::ContractClass;
 use super::transaction::{DeployAccountTransaction, InvokeTransaction, ResourceBoundsMapping};
@@ -123,73 +119,3 @@ pub enum DeclareType {
     Declare,
 }
 
-impl TryFrom<BroadcastedDeclareTransaction> for client_transaction::DeclareTransaction {
-    type Error = StorageSerdeError;
-
-    fn try_from(value: BroadcastedDeclareTransaction) -> Result<Self, Self::Error> {
-        match value {
-            BroadcastedDeclareTransaction::V1(declare_v1) => {
-                Ok(Self::DeclareV1(client_transaction::DeclareV1Transaction {
-                    contract_class: declare_v1.contract_class,
-                    sender_address: declare_v1.sender_address,
-                    nonce: declare_v1.nonce,
-                    max_fee: declare_v1.max_fee,
-                    signature: declare_v1.signature,
-                    version: TransactionVersion::ONE,
-                    r#type: client_transaction::DeclareType::default(),
-                }))
-            }
-            BroadcastedDeclareTransaction::V2(declare_v2) => {
-                Ok(Self::DeclareV2(client_transaction::DeclareV2Transaction {
-                    contract_class: client_transaction::ContractClass {
-                        compressed_sierra_program: compress_and_encode(
-                            &declare_v2.contract_class.sierra_program,
-                        )?,
-                        contract_class_version: declare_v2.contract_class.contract_class_version,
-                        entry_points_by_type: declare_v2
-                            .contract_class
-                            .entry_points_by_type
-                            .to_hash_map(),
-                        abi: declare_v2.contract_class.abi,
-                    },
-                    compiled_class_hash: declare_v2.compiled_class_hash,
-                    sender_address: declare_v2.sender_address,
-                    nonce: declare_v2.nonce,
-                    max_fee: declare_v2.max_fee,
-                    signature: declare_v2.signature,
-                    version: TransactionVersion::TWO,
-                    r#type: client_transaction::DeclareType::default(),
-                }))
-            }
-            BroadcastedDeclareTransaction::V3(declare_v3) => {
-                Ok(Self::DeclareV3(client_transaction::DeclareV3Transaction {
-                    contract_class: client_transaction::ContractClass {
-                        compressed_sierra_program: compress_and_encode(
-                            &declare_v3.contract_class.sierra_program,
-                        )?,
-                        contract_class_version: declare_v3.contract_class.contract_class_version,
-                        entry_points_by_type: declare_v3
-                            .contract_class
-                            .entry_points_by_type
-                            .to_hash_map(),
-                        abi: declare_v3.contract_class.abi,
-                    },
-                    resource_bounds: declare_v3.resource_bounds.into(),
-                    tip: declare_v3.tip,
-                    signature: declare_v3.signature,
-                    nonce: declare_v3.nonce,
-                    compiled_class_hash: declare_v3.compiled_class_hash,
-                    sender_address: declare_v3.sender_address,
-                    nonce_data_availability_mode:
-                        client_transaction::ReservedDataAvailabilityMode::Reserved,
-                    fee_data_availability_mode:
-                        client_transaction::ReservedDataAvailabilityMode::Reserved,
-                    paymaster_data: declare_v3.paymaster_data,
-                    account_deployment_data: declare_v3.account_deployment_data,
-                    version: TransactionVersion::THREE,
-                    r#type: client_transaction::DeclareType::Declare,
-                }))
-            }
-        }
-    }
-}

--- a/crates/apollo_rpc/src/v0_8/transaction.rs
+++ b/crates/apollo_rpc/src/v0_8/transaction.rs
@@ -8,7 +8,6 @@ use std::ops::Add;
 use std::sync::Arc;
 
 use apollo_rpc_execution::objects::PriceUnit;
-use apollo_starknet_client::writer::objects::transaction as client_transaction;
 use apollo_storage::body::BodyStorageReader;
 use apollo_storage::db::TransactionKind;
 use apollo_storage::StorageTxn;
@@ -348,43 +347,6 @@ impl TryFrom<starknet_api::transaction::DeployAccountTransaction> for DeployAcco
     }
 }
 
-impl From<DeployAccountTransaction> for client_transaction::DeployAccountTransaction {
-    fn from(tx: DeployAccountTransaction) -> Self {
-        match tx {
-            DeployAccountTransaction::Version1(deploy_account_tx) => {
-                Self::DeployAccountV1(client_transaction::DeployAccountV1Transaction {
-                    contract_address_salt: deploy_account_tx.contract_address_salt,
-                    class_hash: deploy_account_tx.class_hash,
-                    constructor_calldata: deploy_account_tx.constructor_calldata,
-                    nonce: deploy_account_tx.nonce,
-                    max_fee: deploy_account_tx.max_fee,
-                    signature: deploy_account_tx.signature,
-                    version: TransactionVersion::ONE,
-                    r#type: client_transaction::DeployAccountType::DeployAccount,
-                })
-            }
-            DeployAccountTransaction::Version3(deploy_account_tx) => {
-                Self::DeployAccountV3(client_transaction::DeployAccountV3Transaction {
-                    contract_address_salt: deploy_account_tx.contract_address_salt,
-                    class_hash: deploy_account_tx.class_hash,
-                    constructor_calldata: deploy_account_tx.constructor_calldata,
-                    nonce: deploy_account_tx.nonce,
-                    signature: deploy_account_tx.signature,
-                    version: TransactionVersion::THREE,
-                    resource_bounds: deploy_account_tx.resource_bounds.into(),
-                    tip: deploy_account_tx.tip,
-                    nonce_data_availability_mode:
-                        client_transaction::ReservedDataAvailabilityMode::Reserved,
-                    fee_data_availability_mode:
-                        client_transaction::ReservedDataAvailabilityMode::Reserved,
-                    paymaster_data: deploy_account_tx.paymaster_data,
-                    r#type: client_transaction::DeployAccountType::DeployAccount,
-                })
-            }
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct InvokeTransactionV0 {
     pub max_fee: Fee,
@@ -395,20 +357,6 @@ pub struct InvokeTransactionV0 {
     pub calldata: Calldata,
 }
 
-impl From<InvokeTransactionV0> for client_transaction::InvokeTransaction {
-    fn from(tx: InvokeTransactionV0) -> Self {
-        Self::InvokeV0(client_transaction::InvokeV0Transaction {
-            max_fee: tx.max_fee,
-            version: TransactionVersion::ZERO,
-            signature: tx.signature,
-            contract_address: tx.contract_address,
-            entry_point_selector: tx.entry_point_selector,
-            calldata: tx.calldata,
-            r#type: client_transaction::InvokeType::Invoke,
-        })
-    }
-}
-
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct InvokeTransactionV1 {
     pub max_fee: Fee,
@@ -417,20 +365,6 @@ pub struct InvokeTransactionV1 {
     pub nonce: Nonce,
     pub sender_address: ContractAddress,
     pub calldata: Calldata,
-}
-
-impl From<InvokeTransactionV1> for client_transaction::InvokeTransaction {
-    fn from(tx: InvokeTransactionV1) -> Self {
-        Self::InvokeV1(client_transaction::InvokeV1Transaction {
-            max_fee: tx.max_fee,
-            version: TransactionVersion::ONE,
-            signature: tx.signature,
-            nonce: tx.nonce,
-            sender_address: tx.sender_address,
-            calldata: tx.calldata,
-            r#type: client_transaction::InvokeType::Invoke,
-        })
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
@@ -447,37 +381,6 @@ pub struct InvokeTransactionV3 {
     pub nonce_data_availability_mode: DataAvailabilityMode,
     pub fee_data_availability_mode: DataAvailabilityMode,
     pub proof_facts: ProofFacts,
-}
-
-impl From<InvokeTransactionV3> for client_transaction::InvokeTransaction {
-    fn from(tx: InvokeTransactionV3) -> Self {
-        Self::InvokeV3(client_transaction::InvokeV3Transaction {
-            sender_address: tx.sender_address,
-            calldata: tx.calldata,
-            version: TransactionVersion::THREE,
-            signature: tx.signature,
-            nonce: tx.nonce,
-            resource_bounds: tx.resource_bounds.into(),
-            tip: tx.tip,
-            nonce_data_availability_mode:
-                client_transaction::ReservedDataAvailabilityMode::Reserved,
-            fee_data_availability_mode: client_transaction::ReservedDataAvailabilityMode::Reserved,
-            paymaster_data: tx.paymaster_data,
-            account_deployment_data: tx.account_deployment_data,
-            r#type: client_transaction::InvokeType::Invoke,
-            proof_facts: tx.proof_facts,
-        })
-    }
-}
-
-impl From<InvokeTransaction> for client_transaction::InvokeTransaction {
-    fn from(tx: InvokeTransaction) -> Self {
-        match tx {
-            InvokeTransaction::Version0(invoke_tx) => invoke_tx.into(),
-            InvokeTransaction::Version1(invoke_tx) => invoke_tx.into(),
-            InvokeTransaction::Version3(invoke_tx) => invoke_tx.into(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
@@ -1241,38 +1144,3 @@ fn eth_address_to_felt(eth_address: EthAddress) -> Felt {
     Felt::from_bytes_be(&bytes)
 }
 
-/// An InvokeTransactionV1 that has the type field. This enum can be used to serialize/deserialize
-/// invoke v1 transactions directly while `InvokeTransactionV1` can be serialized/deserialized only
-/// from the `Transaction` enum.
-/// This allows RPC methods to receive an invoke v1 transaction directly.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
-#[serde(tag = "type")]
-pub enum TypedInvokeTransaction {
-    #[serde(rename = "INVOKE")]
-    Invoke(InvokeTransaction),
-}
-
-impl From<TypedInvokeTransaction> for client_transaction::InvokeTransaction {
-    fn from(tx: TypedInvokeTransaction) -> Self {
-        let TypedInvokeTransaction::Invoke(tx) = tx;
-        tx.into()
-    }
-}
-
-/// A DeployAccountTransaction that has the type field. This enum can be used to
-/// serialize/deserialize deploy account transactions directly while `DeployAccountTransaction` can
-/// be serialized/deserialized only from the `Transaction` enum.
-/// This allows RPC methods to receive a deploy account transaction directly.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
-#[serde(tag = "type")]
-pub enum TypedDeployAccountTransaction {
-    #[serde(rename = "DEPLOY_ACCOUNT")]
-    DeployAccount(DeployAccountTransaction),
-}
-
-impl From<TypedDeployAccountTransaction> for client_transaction::DeployAccountTransaction {
-    fn from(tx: TypedDeployAccountTransaction) -> Self {
-        let TypedDeployAccountTransaction::DeployAccount(tx) = tx;
-        tx.into()
-    }
-}


### PR DESCRIPTION
Remove all From/TryFrom impls converting RPC transaction types to
apollo_starknet_client::writer::objects::transaction types. These were
only used by the add_*_transaction handlers removed in the previous PR.

Also removes TypedInvokeTransaction and TypedDeployAccountTransaction,
which were only needed as input types for the deleted handlers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>