### PR TITLE
apollo_rpc,apollo_state_sync: remove writer_client plumbing from RPC server

### DIFF
--- a/crates/apollo_rpc/src/api.rs
+++ b/crates/apollo_rpc/src/api.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use apollo_class_manager_types::SharedClassManagerClient;
 use apollo_rpc_execution::ExecutionConfig;
 use apollo_starknet_client::reader::PendingData;
-use apollo_starknet_client::writer::StarknetWriter;
 use apollo_storage::StorageReader;
 use jsonrpsee::{Methods, RpcModule};
 use papyrus_common::pending_classes::PendingClasses;
@@ -51,7 +50,6 @@ pub struct CallRequest {
 
 /// Returns a `Methods` object with all the methods from the supported APIs.
 /// Whenever adding a new API version we need to add the new version mapping here.
-#[allow(clippy::too_many_arguments)]
 pub fn get_methods_from_supported_apis(
     chain_id: &ChainId,
     execution_config: ExecutionConfig,
@@ -62,7 +60,6 @@ pub fn get_methods_from_supported_apis(
     shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
     pending_data: Arc<RwLock<PendingData>>,
     pending_classes: Arc<RwLock<PendingClasses>>,
-    starknet_writer: Arc<dyn StarknetWriter>,
     class_manager_client: Option<SharedClassManagerClient>,
 ) -> Methods {
     let mut methods: Methods = Methods::new();
@@ -76,7 +73,6 @@ pub fn get_methods_from_supported_apis(
         shared_highest_block,
         pending_data,
         pending_classes,
-        starknet_writer,
         class_manager_client,
     };
     version_config::VERSION_CONFIG
@@ -105,7 +101,6 @@ pub fn get_methods_from_supported_apis(
 }
 
 pub trait JsonRpcServerTrait: Sized {
-    #[allow(clippy::too_many_arguments)]
     fn new(
         chain_id: ChainId,
         execution_config: ExecutionConfig,
@@ -116,7 +111,6 @@ pub trait JsonRpcServerTrait: Sized {
         shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
         pending_data: Arc<RwLock<PendingData>>,
         pending_classes: Arc<RwLock<PendingClasses>>,
-        starknet_writer: Arc<dyn StarknetWriter>,
         class_manager_client: Option<SharedClassManagerClient>,
     ) -> Self;
 
@@ -134,8 +128,6 @@ struct JsonRpcServerImplGenerator {
     shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
     pending_data: Arc<RwLock<PendingData>>,
     pending_classes: Arc<RwLock<PendingClasses>>,
-    // TODO(shahak): Change this struct to be with a generic type of StarknetWriter.
-    starknet_writer: Arc<dyn StarknetWriter>,
     class_manager_client: Option<SharedClassManagerClient>,
 }
 
@@ -149,7 +141,6 @@ type JsonRpcServerImplParams = (
     Arc<RwLock<Option<BlockHashAndNumber>>>,
     Arc<RwLock<PendingData>>,
     Arc<RwLock<PendingClasses>>,
-    Arc<dyn StarknetWriter>,
     Option<SharedClassManagerClient>,
 );
 
@@ -165,7 +156,6 @@ impl JsonRpcServerImplGenerator {
             self.shared_highest_block,
             self.pending_data,
             self.pending_classes,
-            self.starknet_writer,
             self.class_manager_client,
         )
     }
@@ -184,7 +174,6 @@ impl JsonRpcServerImplGenerator {
             shared_highest_block,
             pending_data,
             pending_classes,
-            starknet_writer,
             class_manager_client,
         ) = self.get_params();
         Into::<Methods>::into(
@@ -198,7 +187,6 @@ impl JsonRpcServerImplGenerator {
                 shared_highest_block,
                 pending_data,
                 pending_classes,
-                starknet_writer,
                 class_manager_client,
             )
             .into_rpc_module(),

--- a/crates/apollo_rpc/src/lib.rs
+++ b/crates/apollo_rpc/src/lib.rs
@@ -24,7 +24,6 @@ use apollo_config::validators::validate_ascii;
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use apollo_rpc_execution::ExecutionConfig;
 use apollo_starknet_client::reader::PendingData;
-use apollo_starknet_client::writer::StarknetGatewayClient;
 use apollo_starknet_client::RetryConfig;
 use apollo_storage::base_layer::BaseLayerStorageReader;
 use apollo_storage::body::events::EventIndex;
@@ -213,7 +212,6 @@ pub async fn run_server(
     pending_data: Arc<RwLock<PendingData>>,
     pending_classes: Arc<RwLock<PendingClasses>>,
     storage_reader: StorageReader,
-    node_version: &'static str,
     class_manager_client: Option<SharedClassManagerClient>,
 ) -> anyhow::Result<(SocketAddr, ServerHandle)> {
     debug!("Started get_last_synced_block");
@@ -228,11 +226,6 @@ pub async fn run_server(
         shared_highest_block,
         pending_data,
         pending_classes,
-        Arc::new(StarknetGatewayClient::new(
-            &config.starknet_url,
-            node_version,
-            config.apollo_gateway_retry_config,
-        )?),
         class_manager_client,
     );
     let addr;

--- a/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
+++ b/crates/apollo_rpc/src/rpc_metrics/rpc_metrics_test.rs
@@ -166,7 +166,6 @@ async fn server_metrics() {
         get_test_pending_data(),
         get_test_pending_classes(),
         storage_reader,
-        "NODE VERSION",
         None,
     )
     .await

--- a/crates/apollo_rpc/src/rpc_test.rs
+++ b/crates/apollo_rpc/src/rpc_test.rs
@@ -38,7 +38,6 @@ async fn run_server_no_blocks() {
         pending_data,
         pending_classes,
         storage_reader,
-        "NODE VERSION",
         None,
     )
     .await

--- a/crates/apollo_rpc/src/test_utils.rs
+++ b/crates/apollo_rpc/src/test_utils.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use apollo_rpc_execution::ExecutionConfig;
 use apollo_starknet_client::reader::PendingData;
-use apollo_starknet_client::writer::MockStarknetWriter;
 use apollo_storage::test_utils::get_test_storage_by_scope;
 use apollo_storage::{StorageScope, StorageWriter};
 use jsonrpsee::core::RpcResult;
@@ -57,17 +56,15 @@ pub(crate) fn get_test_pending_classes() -> Arc<RwLock<PendingClasses>> {
 
 pub(crate) fn get_test_rpc_server_and_storage_writer<T: JsonRpcServerTrait>()
 -> (RpcModule<T>, StorageWriter) {
-    get_test_rpc_server_and_storage_writer_from_params(None, None, None, None, None)
+    get_test_rpc_server_and_storage_writer_from_params(None, None, None, None)
 }
 
 pub(crate) fn get_test_rpc_server_and_storage_writer_from_params<T: JsonRpcServerTrait>(
-    mock_client: Option<MockStarknetWriter>,
     shared_highest_block: Option<Arc<RwLock<Option<BlockHashAndNumber>>>>,
     pending_data: Option<Arc<RwLock<PendingData>>>,
     pending_classes: Option<Arc<RwLock<PendingClasses>>>,
     storage_scope: Option<StorageScope>,
 ) -> (RpcModule<T>, StorageWriter) {
-    let mock_client = mock_client.unwrap_or_default();
     let shared_highest_block = shared_highest_block.unwrap_or(get_test_highest_block());
     let pending_data = pending_data.unwrap_or(get_test_pending_data());
     let pending_classes = pending_classes.unwrap_or(get_test_pending_classes());
@@ -75,7 +72,6 @@ pub(crate) fn get_test_rpc_server_and_storage_writer_from_params<T: JsonRpcServe
 
     let ((storage_reader, storage_writer), _temp_dir) = get_test_storage_by_scope(storage_scope);
     let config = get_test_rpc_config();
-    let mock_client_arc = Arc::new(mock_client);
     (
         T::new(
             config.chain_id,
@@ -87,7 +83,6 @@ pub(crate) fn get_test_rpc_server_and_storage_writer_from_params<T: JsonRpcServe
             shared_highest_block,
             pending_data,
             pending_classes,
-            mock_client_arc,
             None,
         )
         .into_rpc_module(),

--- a/crates/apollo_rpc/src/v0_8/api/api_impl.rs
+++ b/crates/apollo_rpc/src/v0_8/api/api_impl.rs
@@ -20,7 +20,6 @@ use apollo_starknet_client::reader::objects::transaction::{
     TransactionReceipt as ClientTransactionReceipt,
 };
 use apollo_starknet_client::reader::PendingData;
-use apollo_starknet_client::writer::StarknetWriter;
 use apollo_storage::body::events::{EventIndex, EventsReader};
 use apollo_storage::body::{BodyStorageReader, TransactionIndex};
 use apollo_storage::compiled_class::CasmStorageReader;
@@ -151,7 +150,6 @@ pub struct JsonRpcServerImpl {
     pub shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
     pub pending_data: Arc<RwLock<PendingData>>,
     pub pending_classes: Arc<RwLock<PendingClasses>>,
-    pub writer_client: Arc<dyn StarknetWriter>,
     pub class_manager_client: Option<SharedClassManagerClient>,
 }
 
@@ -1723,7 +1721,6 @@ impl JsonRpcServerTrait for JsonRpcServerImpl {
         shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
         pending_data: Arc<RwLock<PendingData>>,
         pending_classes: Arc<RwLock<PendingClasses>>,
-        writer_client: Arc<dyn StarknetWriter>,
         class_manager_client: Option<SharedClassManagerClient>,
     ) -> Self {
         Self {
@@ -1736,7 +1733,6 @@ impl JsonRpcServerTrait for JsonRpcServerImpl {
             shared_highest_block,
             pending_data,
             pending_classes,
-            writer_client,
             class_manager_client,
         }
     }

--- a/crates/apollo_rpc/src/v0_8/api/test.rs
+++ b/crates/apollo_rpc/src/v0_8/api/test.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
 use std::iter;
 use std::net::SocketAddr;
 use std::ops::Index;
@@ -31,7 +30,6 @@ use apollo_storage::test_utils::get_test_storage;
 use apollo_storage::StorageScope;
 use apollo_test_utils::{
     auto_impl_get_test_instance,
-    get_number_of_variants,
     get_rng,
     get_test_block,
     get_test_body,
@@ -51,7 +49,6 @@ use papyrus_common::pending_classes::{ApiContractClass, PendingClassesTrait};
 use pretty_assertions::assert_eq;
 use rand::{random, RngCore};
 use rand_chacha::ChaCha8Rng;
-use serde::{Deserialize, Serialize};
 use starknet_api::block::{
     Block as StarknetApiBlock,
     BlockHash,
@@ -124,10 +121,8 @@ use super::super::state::{
     ThinStateDiff,
 };
 use super::super::transaction::{
-    DeployAccountTransaction,
     Event,
     GeneralTransactionReceipt,
-    InvokeTransaction,
     PendingTransactionFinalityStatus,
     PendingTransactionOutput,
     PendingTransactionReceipt,
@@ -164,14 +159,7 @@ use crate::test_utils::{
 };
 use crate::v0_8::api::CompiledContractClass;
 use crate::version_config::VERSION_0_8 as VERSION;
-use crate::{
-    internal_server_error,
-    internal_server_error_with_msg,
-    run_server,
-    ContinuationTokenAsStruct,
-};
-
-const NODE_VERSION: &str = "NODE VERSION";
+use crate::{internal_server_error_with_msg, run_server, ContinuationTokenAsStruct};
 
 #[tokio::test]
 async fn spec_version() {
@@ -329,7 +317,6 @@ async fn syncing() {
 
     let shared_highest_block = get_test_highest_block();
     let (module, _) = get_test_rpc_server_and_storage_writer_from_params::<JsonRpcServerImpl>(
-        None,
         Some(shared_highest_block.clone()),
         None,
         None,
@@ -365,7 +352,7 @@ async fn get_block_transaction_count() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let transaction_count = 5;
     let block = get_test_block(transaction_count, None, None, None);
     storage_writer
@@ -456,7 +443,7 @@ async fn get_block_w_full_transactions() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
 
     let mut block = get_test_block(1, None, None, None);
     let block_hash = BlockHash(random::<u64>().into());
@@ -642,7 +629,7 @@ async fn get_block_w_full_transactions_and_receipts() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
 
     let mut block = get_test_block(1, None, None, None);
     let block_hash = BlockHash(random::<u64>().into());
@@ -844,7 +831,7 @@ async fn get_block_w_transaction_hashes() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
 
     let mut block = get_test_block(1, None, None, None);
     let block_hash = BlockHash(random::<u64>().into());
@@ -1031,7 +1018,7 @@ async fn get_class() {
     let pending_classes = get_test_pending_classes();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, None, Some(pending_classes.clone()), None);
+    >(None, None, Some(pending_classes.clone()), None);
     let parent_header = BlockHeader::default();
     let header = BlockHeader {
         block_hash: BlockHash(felt!("0x1")),
@@ -1213,7 +1200,7 @@ async fn get_transaction_status() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
@@ -1332,7 +1319,7 @@ async fn get_transaction_receipt() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
@@ -1457,7 +1444,6 @@ async fn get_class_at() {
     let pending_classes = get_test_pending_classes();
     let (module, mut storage_writer) =
         get_test_rpc_server_and_storage_writer_from_params::<JsonRpcServerImpl>(
-            None,
             None,
             Some(pending_data.clone()),
             Some(pending_classes.clone()),
@@ -1671,7 +1657,7 @@ async fn get_class_hash_at() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
     let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
@@ -1834,7 +1820,7 @@ async fn get_nonce() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
     let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
@@ -1978,7 +1964,7 @@ async fn get_storage_at() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
     let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
@@ -2248,7 +2234,7 @@ async fn get_transaction_by_hash() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let mut block = get_test_block(1, None, None, None);
     // Change the transaction hash from 0 to a random value, so that later on we can add a
     // transaction with 0 hash to the pending block.
@@ -2322,7 +2308,6 @@ async fn get_transaction_by_hash_state_only() {
         None,
         None,
         None,
-        None,
         Some(StorageScope::StateOnly),
     );
 
@@ -2339,7 +2324,7 @@ async fn get_transaction_by_block_id_and_index() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
@@ -2472,7 +2457,7 @@ async fn get_state_update() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let parent_header = BlockHeader::default();
     let expected_pending_old_root = GlobalRoot(felt!("0x1234"));
     let header = BlockHeader {
@@ -2638,7 +2623,7 @@ async fn get_state_update_with_replaced_class() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let parent_header = BlockHeader::default();
     let expected_pending_old_root = GlobalRoot(felt!("0x1234"));
     let header = BlockHeader {
@@ -2722,7 +2707,7 @@ async fn get_state_update_with_empty_storage_diff() {
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let state_diff = starknet_api::state::ThinStateDiff {
         storage_diffs: indexmap!(ContractAddress::default() => indexmap![]),
         ..Default::default()
@@ -2861,7 +2846,7 @@ async fn test_get_events(
     let pending_data = get_test_pending_data();
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data.clone()), None, None);
+    >(None, Some(pending_data.clone()), None, None);
     let mut rng = get_rng();
 
     let mut event_index_to_event = HashMap::<EventIndex, Event>::new();
@@ -3533,7 +3518,6 @@ async fn serialize_returns_valid_json() {
         get_test_pending_data(),
         get_test_pending_classes(),
         storage_reader,
-        NODE_VERSION,
         None,
     )
     .await
@@ -3744,7 +3728,7 @@ async fn get_compiled_class() {
     let method_name = "starknet_V0_8_getCompiledContractClass";
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, None, None, None);
+    >(None, None, None, None);
     let cairo1_contract_class = CasmContractClass::get_test_instance(&mut get_rng());
     // We need to save the Sierra component of the Cairo 1 contract in storage to maintain
     // consistency.

--- a/crates/apollo_rpc/src/v0_8/execution_test.rs
+++ b/crates/apollo_rpc/src/v0_8/execution_test.rs
@@ -334,7 +334,7 @@ async fn pending_execution_call() {
     let (module, storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
     >(
-        None, None, Some(pending_data), Some(pending_classes), None
+        None, Some(pending_data), Some(pending_classes), None
     );
     write_empty_block(storage_writer);
 
@@ -516,7 +516,7 @@ async fn pending_call_estimate_fee() {
     let (module, storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
     >(
-        None, None, Some(pending_data), Some(pending_classes), None
+        None, Some(pending_data), Some(pending_classes), None
     );
     write_empty_block(storage_writer);
 
@@ -571,7 +571,7 @@ async fn pending_call_simulate() {
     let (module, storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
     >(
-        None, None, Some(pending_data), Some(pending_classes), None
+        None, Some(pending_data), Some(pending_classes), None
     );
     write_empty_block(storage_writer);
 
@@ -915,7 +915,7 @@ async fn trace_block_transactions_regular_and_pending() {
 
     let (module, storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data), None, None);
+    >(None, Some(pending_data), None, None);
 
     prepare_storage_for_execution(storage_writer);
 
@@ -1167,7 +1167,7 @@ async fn pending_trace_block_transactions_and_trace_transaction_execution_contex
 
     let (module, storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
-    >(None, None, Some(pending_data), None, None);
+    >(None, Some(pending_data), None, None);
 
     prepare_storage_for_execution(storage_writer);
 

--- a/crates/apollo_state_sync/src/runner/mod.rs
+++ b/crates/apollo_state_sync/src/runner/mod.rs
@@ -518,7 +518,6 @@ fn spawn_rpc_server(
             pending_data,
             pending_classes,
             storage_reader,
-            VERSION_FULL,
             class_manager_client,
         )
         .await


### PR DESCRIPTION
Remove the StarknetWriter dependency from apollo_rpc:
- Drop writer_client field from JsonRpcServerImpl
- Drop starknet_writer parameter from JsonRpcServerTrait::new,
  get_methods_from_supported_apis, and related generator infrastructure
- Drop StarknetGatewayClient instantiation from run_server; drop
  the now-unused node_version parameter from run_server
- Update test harness to remove mock_client parameter

Update apollo_state_sync runner to match the new run_server signature.

After this PR, nothing in apollo_rpc references apollo_starknet_client::writer.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>