### PR TITLE
apollo_starknet_client: inline StarknetClient into StarknetFeederGatewayClient

### DIFF
--- a/crates/apollo_starknet_client/src/lib.rs
+++ b/crates/apollo_starknet_client/src/lib.rs
@@ -10,32 +10,14 @@
 
 pub mod reader;
 pub mod retry;
-#[cfg(test)]
-mod starknet_client_test;
 pub mod starknet_error;
 #[cfg(test)]
 mod test_utils;
 
-use std::collections::HashMap;
+use reqwest::StatusCode;
 
-use apollo_config::secrets::Sensitive;
-use reqwest::header::HeaderMap;
-use reqwest::{Client, RequestBuilder, StatusCode};
-use tracing::warn;
-
-use self::retry::Retry;
 pub use self::retry::RetryConfig;
 pub use self::starknet_error::{KnownStarknetErrorCode, StarknetError, StarknetErrorCode};
-
-/// A [`Result`] in which the error is a [`ClientError`].
-type ClientResult<T> = Result<T, ClientError>;
-
-/// A starknet client.
-struct StarknetClient {
-    http_headers: HeaderMap,
-    pub internal_client: Client,
-    retry_config: RetryConfig,
-}
 
 /// Errors that might be encountered while creating the client.
 #[derive(thiserror::Error, Debug)]
@@ -76,139 +58,4 @@ pub enum ClientError {
     /// A client error representing errors returned by the starknet client.
     #[error(transparent)]
     StarknetError(#[from] StarknetError),
-}
-
-// A wrapper error for request_with_retry to handle the case that clone failed.
-#[derive(thiserror::Error, Debug)]
-enum RequestWithRetryError {
-    #[error("Request is unclonable.")]
-    CloneError,
-    #[error(transparent)]
-    ClientError(#[from] ClientError),
-}
-
-impl StarknetClient {
-    /// Creates a new client for a starknet gateway at `url_str` with retry_config [`RetryConfig`].
-    pub fn new(
-        http_headers: Option<Sensitive<HashMap<String, String>>>,
-        node_version: &'static str,
-        retry_config: RetryConfig,
-    ) -> Result<Self, ClientCreationError> {
-        let header_map = match http_headers {
-            Some(inner) => (&inner.expose_secret())
-                .try_into()
-                .map_err(|_| ClientCreationError::HttpHeaderError)?,
-            None => HeaderMap::new(),
-        };
-        let info = os_info::get();
-        let system_information =
-            format!("{}; {}; {}", info.os_type(), info.version(), info.bitness());
-        let app_user_agent = format!(
-            "{product_name}/{product_version} ({system_information})",
-            product_name = "apollo",
-            product_version = node_version,
-            system_information = system_information
-        );
-        Ok(StarknetClient {
-            http_headers: header_map,
-            internal_client: Client::builder().user_agent(app_user_agent).build()?,
-            retry_config,
-        })
-    }
-
-    fn get_retry_error_code(err: &ClientError) -> Option<RetryErrorCode> {
-        match err {
-            ClientError::BadResponseStatus { code, message: _ } => match *code {
-                StatusCode::TEMPORARY_REDIRECT => Some(RetryErrorCode::Redirect),
-                StatusCode::REQUEST_TIMEOUT | StatusCode::GATEWAY_TIMEOUT => {
-                    Some(RetryErrorCode::Timeout)
-                }
-                StatusCode::TOO_MANY_REQUESTS => Some(RetryErrorCode::TooManyRequests),
-                StatusCode::SERVICE_UNAVAILABLE => Some(RetryErrorCode::ServiceUnavailable),
-                _ => None,
-            },
-
-            ClientError::RequestError(internal_err) => {
-                if internal_err.is_timeout() {
-                    Some(RetryErrorCode::Timeout)
-                } else if internal_err.is_request() {
-                    None
-                } else if internal_err.is_connect() {
-                    Some(RetryErrorCode::Disconnect)
-                } else if internal_err.is_redirect() {
-                    Some(RetryErrorCode::Redirect)
-                } else {
-                    None
-                }
-            }
-
-            ClientError::StarknetError(StarknetError {
-                code:
-                    StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::TransactionLimitExceeded),
-                message: _,
-            }) => Some(RetryErrorCode::TooManyRequests),
-            _ => None,
-        }
-    }
-
-    fn should_retry(err: &RequestWithRetryError) -> bool {
-        match err {
-            RequestWithRetryError::ClientError(err) => Self::get_retry_error_code(err).is_some(),
-            RequestWithRetryError::CloneError => false,
-        }
-    }
-
-    // If the request_builder is unclonable, the function will not retry the request upon failure.
-    pub async fn request_with_retry(
-        &self,
-        request_builder: RequestBuilder,
-    ) -> ClientResult<String> {
-        let res = Retry::new(&self.retry_config)
-            .start_with_condition(
-                || async {
-                    match request_builder.try_clone() {
-                        Some(request_builder) => self
-                            .request(request_builder)
-                            .await
-                            .map_err(RequestWithRetryError::ClientError),
-                        None => Err(RequestWithRetryError::CloneError),
-                    }
-                },
-                Self::should_retry,
-            )
-            .await;
-
-        match res {
-            Ok(string) => Ok(string),
-            Err(RequestWithRetryError::ClientError(err)) => Err(Self::get_retry_error_code(&err)
-                .map(|code| ClientError::RetryError { code, message: err.to_string() })
-                .unwrap_or(err)),
-            Err(RequestWithRetryError::CloneError) => {
-                warn!("Starknet client got an unclonable request. Can't retry upon failure.");
-                self.request(request_builder).await
-            }
-        }
-    }
-
-    async fn request(&self, request_builder: RequestBuilder) -> ClientResult<String> {
-        let res = request_builder.headers(self.http_headers.clone()).send().await;
-        let (code, message) = match res {
-            Ok(response) => (response.status(), response.text().await?),
-            Err(err) => {
-                let msg = err.to_string();
-                (err.status().ok_or(err)?, msg)
-            }
-        };
-        match code {
-            StatusCode::OK => Ok(message),
-            // TODO(Omri): The error code returned from SN changed from error 500 to error 400. For
-            // now, keeping both options. In the future, remove the '500' (INTERNAL_SERVER_ERROR)
-            // option.
-            StatusCode::INTERNAL_SERVER_ERROR | StatusCode::BAD_REQUEST => {
-                let starknet_error: StarknetError = serde_json::from_str(&message)?;
-                Err(ClientError::StarknetError(starknet_error))
-            }
-            _ => Err(ClientError::BadResponseStatus { code, message }),
-        }
-    }
 }

--- a/crates/apollo_starknet_client/src/reader/mod.rs
+++ b/crates/apollo_starknet_client/src/reader/mod.rs
@@ -4,6 +4,8 @@
 
 pub mod objects;
 #[cfg(test)]
+mod request_with_retry_test;
+#[cfg(test)]
 mod starknet_feeder_gateway_client_test;
 
 use std::collections::HashMap;
@@ -17,6 +19,8 @@ use cairo_lang_starknet_classes::casm_contract_class::{
 #[cfg(any(feature = "testing", test))]
 use mockall::automock;
 use papyrus_common::pending_classes::ApiContractClass;
+use reqwest::header::HeaderMap;
+use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
 use starknet_api::core::{ClassHash, SequencerPublicKey};
@@ -24,7 +28,7 @@ use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContract
 use starknet_api::transaction::TransactionHash;
 use starknet_api::StarknetApiError;
 use starknet_types_core::felt::Felt;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, warn};
 use url::Url;
 
 use crate::reader::objects::block::BlockStatus;
@@ -46,20 +50,20 @@ pub use crate::reader::objects::state::{
 };
 #[cfg(doc)]
 pub use crate::reader::objects::transaction::TransactionReceipt;
-use crate::retry::RetryConfig;
+use crate::retry::{Retry, RetryConfig};
 use crate::starknet_error::{KnownStarknetErrorCode, StarknetError, StarknetErrorCode};
-use crate::{ClientCreationError, ClientError, StarknetClient};
+use crate::{ClientCreationError, ClientError, RetryErrorCode};
 
 /// Errors that may be returned from a reader client.
 #[derive(thiserror::Error, Debug)]
 pub enum ReaderClientError {
-    /// A client error representing errors from the base StarknetClient.
+    /// A client error representing errors from the underlying HTTP client.
     #[error(transparent)]
     ClientError(#[from] ClientError),
     /// A client error representing deserialization errors.
     /// Note: [`ClientError`] contains SerdeError as well. The difference is that this variant is
     /// responsible for serde errors coming from [`StarknetReader`] and ClientError::SerdeError
-    /// is responsible for serde errors coming from StarknetClient.
+    /// is responsible for serde errors coming from the HTTP request layer.
     #[error(transparent)]
     SerdeError(#[from] serde_json::Error),
     /// A client error representing errors from [`starknet_api`].
@@ -127,12 +131,26 @@ pub trait StarknetReader {
     async fn sequencer_pub_key(&self) -> ReaderClientResult<SequencerPublicKey>;
 }
 
+/// A [`Result`] in which the error is a [`ClientError`].
+type ClientResult<T> = Result<T, ClientError>;
+
+// A wrapper error for request_with_retry to handle the case that clone failed.
+#[derive(thiserror::Error, Debug)]
+enum RequestWithRetryError {
+    #[error("Request is unclonable.")]
+    CloneError,
+    #[error(transparent)]
+    ClientError(#[from] ClientError),
+}
+
 /// A client for the [`Starknet`] feeder gateway.
 ///
 /// [`Starknet`]: https://starknet.io/
 pub struct StarknetFeederGatewayClient {
     urls: StarknetUrls,
-    client: StarknetClient,
+    http_headers: HeaderMap,
+    pub(crate) internal_client: Client,
+    retry_config: RetryConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -204,17 +222,133 @@ impl StarknetFeederGatewayClient {
         node_version: &'static str,
         retry_config: RetryConfig,
     ) -> Result<Self, ClientCreationError> {
+        let header_map = match http_headers {
+            Some(inner) => (&inner.expose_secret())
+                .try_into()
+                .map_err(|_| ClientCreationError::HttpHeaderError)?,
+            None => HeaderMap::new(),
+        };
+        let info = os_info::get();
+        let system_information =
+            format!("{}; {}; {}", info.os_type(), info.version(), info.bitness());
+        let app_user_agent = format!(
+            "{product_name}/{product_version} ({system_information})",
+            product_name = "apollo",
+            product_version = node_version,
+            system_information = system_information
+        );
         Ok(StarknetFeederGatewayClient {
             urls: StarknetUrls::new(url_str)?,
-            client: StarknetClient::new(http_headers, node_version, retry_config)?,
+            http_headers: header_map,
+            internal_client: Client::builder().user_agent(app_user_agent).build()?,
+            retry_config,
         })
+    }
+
+    fn get_retry_error_code(err: &ClientError) -> Option<RetryErrorCode> {
+        match err {
+            ClientError::BadResponseStatus { code, message: _ } => match *code {
+                StatusCode::TEMPORARY_REDIRECT => Some(RetryErrorCode::Redirect),
+                StatusCode::REQUEST_TIMEOUT | StatusCode::GATEWAY_TIMEOUT => {
+                    Some(RetryErrorCode::Timeout)
+                }
+                StatusCode::TOO_MANY_REQUESTS => Some(RetryErrorCode::TooManyRequests),
+                StatusCode::SERVICE_UNAVAILABLE => Some(RetryErrorCode::ServiceUnavailable),
+                _ => None,
+            },
+
+            ClientError::RequestError(internal_err) => {
+                if internal_err.is_timeout() {
+                    Some(RetryErrorCode::Timeout)
+                } else if internal_err.is_request() {
+                    None
+                } else if internal_err.is_connect() {
+                    Some(RetryErrorCode::Disconnect)
+                } else if internal_err.is_redirect() {
+                    Some(RetryErrorCode::Redirect)
+                } else {
+                    None
+                }
+            }
+
+            ClientError::StarknetError(StarknetError {
+                code:
+                    StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::TransactionLimitExceeded),
+                message: _,
+            }) => Some(RetryErrorCode::TooManyRequests),
+            _ => None,
+        }
+    }
+
+    fn should_retry(err: &RequestWithRetryError) -> bool {
+        match err {
+            RequestWithRetryError::ClientError(err) => {
+                Self::get_retry_error_code(err).is_some()
+            }
+            RequestWithRetryError::CloneError => false,
+        }
+    }
+
+    // If the request_builder is unclonable, the function will not retry the request upon failure.
+    pub(crate) async fn request_with_retry(
+        &self,
+        request_builder: RequestBuilder,
+    ) -> ClientResult<String> {
+        let res = Retry::new(&self.retry_config)
+            .start_with_condition(
+                || async {
+                    match request_builder.try_clone() {
+                        Some(request_builder) => self
+                            .request(request_builder)
+                            .await
+                            .map_err(RequestWithRetryError::ClientError),
+                        None => Err(RequestWithRetryError::CloneError),
+                    }
+                },
+                Self::should_retry,
+            )
+            .await;
+
+        match res {
+            Ok(string) => Ok(string),
+            Err(RequestWithRetryError::ClientError(err)) => {
+                Err(Self::get_retry_error_code(&err)
+                    .map(|code| ClientError::RetryError { code, message: err.to_string() })
+                    .unwrap_or(err))
+            }
+            Err(RequestWithRetryError::CloneError) => {
+                warn!("Starknet client got an unclonable request. Can't retry upon failure.");
+                self.request(request_builder).await
+            }
+        }
+    }
+
+    async fn request(&self, request_builder: RequestBuilder) -> ClientResult<String> {
+        let res = request_builder.headers(self.http_headers.clone()).send().await;
+        let (code, message) = match res {
+            Ok(response) => (response.status(), response.text().await?),
+            Err(err) => {
+                let msg = err.to_string();
+                (err.status().ok_or(err)?, msg)
+            }
+        };
+        match code {
+            StatusCode::OK => Ok(message),
+            // TODO(Omri): The error code returned from SN changed from error 500 to error 400. For
+            // now, keeping both options. In the future, remove the '500' (INTERNAL_SERVER_ERROR)
+            // option.
+            StatusCode::INTERNAL_SERVER_ERROR | StatusCode::BAD_REQUEST => {
+                let starknet_error: StarknetError = serde_json::from_str(&message)?;
+                Err(ClientError::StarknetError(starknet_error))
+            }
+            _ => Err(ClientError::BadResponseStatus { code, message }),
+        }
     }
 
     async fn request_with_retry_url(&self, url: Url) -> ReaderClientResult<String> {
         debug!("Call to feeder started. url={url:?}");
         let result = self
-            .client
-            .request_with_retry(self.client.internal_client.get(url.clone()))
+            .request_with_retry(self.internal_client.get(url.clone()))
             .await
             .map_err(Into::<ReaderClientError>::into);
         match &result {

--- a/crates/apollo_starknet_client/src/reader/request_with_retry_test.rs
+++ b/crates/apollo_starknet_client/src/reader/request_with_retry_test.rs
@@ -3,7 +3,9 @@ use reqwest::StatusCode;
 
 use crate::starknet_error::{KnownStarknetErrorCode, StarknetError, StarknetErrorCode};
 use crate::test_utils::retry::{get_test_config, MAX_RETRIES};
-use crate::{ClientError, RetryErrorCode, StarknetClient};
+use crate::{ClientError, RetryErrorCode};
+
+use super::StarknetFeederGatewayClient;
 
 const NODE_VERSION: &str = "NODE VERSION";
 const URL_SUFFIX: &str = "/query";
@@ -11,14 +13,13 @@ const URL_SUFFIX: &str = "/query";
 #[tokio::test]
 async fn request_with_retry_positive_flow() {
     const BODY: &str = "body";
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
     let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     let mock = server.mock("GET", URL_SUFFIX).with_status(200).with_body(BODY).create_async().await;
     let url = format!("{}{}", server.url(), URL_SUFFIX);
-    let result = apollo_starknet_client
-        .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-        .await;
+    let result = client.request_with_retry(client.internal_client.get(&url)).await;
     assert_eq!(result.unwrap(), BODY);
     mock.assert_async().await;
 }
@@ -26,15 +27,14 @@ async fn request_with_retry_positive_flow() {
 #[tokio::test]
 async fn request_with_retry_bad_response_status() {
     let error_code = StatusCode::NOT_FOUND;
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
     let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     let mock =
         server.mock("GET", URL_SUFFIX).with_status(error_code.as_u16().into()).create_async().await;
     let url = format!("{}{}", server.url(), URL_SUFFIX);
-    let result = apollo_starknet_client
-        .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-        .await;
+    let result = client.request_with_retry(client.internal_client.get(&url)).await;
     assert_matches!(
         result,
         Err(ClientError::BadResponseStatus { code, message: _ }) if code == error_code
@@ -44,13 +44,14 @@ async fn request_with_retry_bad_response_status() {
 
 #[tokio::test]
 async fn request_with_retry_starknet_error_no_retry() {
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     let expected_starknet_error = StarknetError {
         code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::UndeclaredClass),
         message: "message".to_string(),
     };
-    let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("GET", URL_SUFFIX)
         .with_status(StatusCode::BAD_REQUEST.as_u16().into())
@@ -58,9 +59,7 @@ async fn request_with_retry_starknet_error_no_retry() {
         .create_async()
         .await;
     let url = format!("{}{}", server.url(), URL_SUFFIX);
-    let result = apollo_starknet_client
-        .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-        .await;
+    let result = client.request_with_retry(client.internal_client.get(&url)).await;
     let Err(ClientError::StarknetError(starknet_error)) = result else {
         panic!("Did not get a StarknetError.");
     };
@@ -70,9 +69,10 @@ async fn request_with_retry_starknet_error_no_retry() {
 
 #[tokio::test]
 async fn request_with_retry_serde_error_in_starknet_error() {
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
     let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     let mock = server
         .mock("GET", URL_SUFFIX)
         .with_status(StatusCode::BAD_REQUEST.as_u16().into())
@@ -80,17 +80,17 @@ async fn request_with_retry_serde_error_in_starknet_error() {
         .create_async()
         .await;
     let url = format!("{}{}", server.url(), URL_SUFFIX);
-    let result = apollo_starknet_client
-        .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-        .await;
+    let result = client.request_with_retry(client.internal_client.get(&url)).await;
     assert_matches!(result, Err(ClientError::SerdeError(_)));
     mock.assert_async().await;
 }
 
 #[tokio::test]
 async fn request_with_retry_max_retries_reached() {
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     for (status_code, error_code) in [
         (StatusCode::TEMPORARY_REDIRECT, RetryErrorCode::Redirect),
         (StatusCode::REQUEST_TIMEOUT, RetryErrorCode::Timeout),
@@ -98,7 +98,6 @@ async fn request_with_retry_max_retries_reached() {
         (StatusCode::SERVICE_UNAVAILABLE, RetryErrorCode::ServiceUnavailable),
         (StatusCode::GATEWAY_TIMEOUT, RetryErrorCode::Timeout),
     ] {
-        let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", URL_SUFFIX)
             .with_status(status_code.as_u16().into())
@@ -106,9 +105,7 @@ async fn request_with_retry_max_retries_reached() {
             .create_async()
             .await;
         let url = format!("{}{}", server.url(), URL_SUFFIX);
-        let result = apollo_starknet_client
-            .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-            .await;
+        let result = client.request_with_retry(client.internal_client.get(&url)).await;
         assert_matches!(
             result, Err(ClientError::RetryError { code, message: _ }) if code == error_code
         );
@@ -120,8 +117,10 @@ async fn request_with_retry_max_retries_reached() {
 async fn request_with_retry_success_on_retry() {
     const BODY: &str = "body";
     assert_ne!(0, MAX_RETRIES);
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     for status_code in [
         StatusCode::TEMPORARY_REDIRECT,
         StatusCode::REQUEST_TIMEOUT,
@@ -129,7 +128,6 @@ async fn request_with_retry_success_on_retry() {
         StatusCode::SERVICE_UNAVAILABLE,
         StatusCode::GATEWAY_TIMEOUT,
     ] {
-        let mut server = mockito::Server::new_async().await;
         let mock_failure = server
             .mock("GET", URL_SUFFIX)
             .with_status(status_code.as_u16().into())
@@ -139,9 +137,7 @@ async fn request_with_retry_success_on_retry() {
         let mock_success =
             server.mock("GET", URL_SUFFIX).with_status(200).with_body(BODY).create_async().await;
         let url = format!("{}{}", server.url(), URL_SUFFIX);
-        let result = apollo_starknet_client
-            .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-            .await;
+        let result = client.request_with_retry(client.internal_client.get(&url)).await;
         assert_eq!(result.unwrap(), BODY);
         mock_failure.assert_async().await;
         mock_success.assert_async().await;
@@ -150,14 +146,15 @@ async fn request_with_retry_success_on_retry() {
 
 #[tokio::test]
 async fn request_with_retry_starknet_error_max_retries_reached() {
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     let starknet_error = StarknetError {
         code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::TransactionLimitExceeded),
         message: "message".to_string(),
     };
     let starknet_error_str = serde_json::to_string(&starknet_error).unwrap();
-    let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("GET", URL_SUFFIX)
         .with_status(StatusCode::BAD_REQUEST.as_u16().into())
@@ -166,9 +163,7 @@ async fn request_with_retry_starknet_error_max_retries_reached() {
         .create_async()
         .await;
     let url = format!("{}{}", server.url(), URL_SUFFIX);
-    let result = apollo_starknet_client
-        .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-        .await;
+    let result = client.request_with_retry(client.internal_client.get(&url)).await;
     assert_matches!(
         result,
         Err(ClientError::RetryError { code, message: _ }) if code == RetryErrorCode::TooManyRequests
@@ -180,14 +175,15 @@ async fn request_with_retry_starknet_error_max_retries_reached() {
 async fn request_with_retry_starknet_error_success_on_retry() {
     const BODY: &str = "body";
     assert_ne!(0, MAX_RETRIES);
-    let apollo_starknet_client =
-        StarknetClient::new(None, NODE_VERSION, get_test_config()).unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let client =
+        StarknetFeederGatewayClient::new(&server.url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
     let starknet_error = StarknetError {
         code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::TransactionLimitExceeded),
         message: "message".to_string(),
     };
     let starknet_error_str = serde_json::to_string(&starknet_error).unwrap();
-    let mut server = mockito::Server::new_async().await;
     let mock_failure = server
         .mock("GET", URL_SUFFIX)
         .with_status(StatusCode::BAD_REQUEST.as_u16().into())
@@ -198,9 +194,7 @@ async fn request_with_retry_starknet_error_success_on_retry() {
     let mock_success =
         server.mock("GET", URL_SUFFIX).with_status(200).with_body(BODY).create_async().await;
     let url = format!("{}{}", server.url(), URL_SUFFIX);
-    let result = apollo_starknet_client
-        .request_with_retry(apollo_starknet_client.internal_client.get(&url))
-        .await;
+    let result = client.request_with_retry(client.internal_client.get(&url)).await;
     assert_eq!(result.unwrap(), BODY);
     mock_failure.assert_async().await;
     mock_success.assert_async().await;


### PR DESCRIPTION
Move fields (http_headers, internal_client, retry_config) and methods
(request_with_retry, request, get_retry_error_code, should_retry) from the
now-deleted StarknetClient directly onto StarknetFeederGatewayClient.
Relocate request_with_retry tests into reader/request_with_retry_test.rs.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>