### PR TITLE
apollo_node: migrate Starknet docs URLs to new paths

### DIFF
--- a/crates/apollo_l1_events_config/src/config.rs
+++ b/crates/apollo_l1_events_config/src/config.rs
@@ -154,7 +154,7 @@ impl SerializeConfig for L1EventsScraperConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_l1_gas_price_config/src/config.rs
+++ b/crates/apollo_l1_gas_price_config/src/config.rs
@@ -203,7 +203,7 @@ impl SerializeConfig for L1GasPriceScraperConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id",
+                "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_network/src/lib.rs
+++ b/crates/apollo_network/src/lib.rs
@@ -382,7 +382,7 @@ impl SerializeConfig for NetworkConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -335,7 +335,7 @@
     "value": 1
   },
   "batcher_config.static_config.storage.db_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -410,7 +410,7 @@
     "value": "starknet"
   },
   "chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "privacy": "TemporaryValue",
     "value": "PointerTarget"
   },
@@ -440,7 +440,7 @@
     "value": 4089446
   },
   "class_manager_config.static_config.class_storage_config.class_hash_storage_config.db_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -2590,7 +2590,7 @@
     "value": 5
   },
   "consensus_manager_config.consensus_manager_config.static_config.storage_config.db_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -2805,7 +2805,7 @@
     "value": 100000
   },
   "consensus_manager_config.network_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -3245,7 +3245,7 @@
     "value": false
   },
   "l1_events_scraper_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -3345,7 +3345,7 @@
     "value": false
   },
   "l1_gas_price_scraper_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -3480,7 +3480,7 @@
     "value": 100000
   },
   "mempool_p2p_config.network_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -3790,7 +3790,7 @@
     "value": 100000
   },
   "state_sync_config.static_config.network_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -3930,7 +3930,7 @@
     "value": 1000
   },
   "state_sync_config.static_config.rpc_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
@@ -3980,7 +3980,7 @@
     "privacy": "Public"
   },
   "state_sync_config.static_config.storage_config.db_config.chain_id": {
-    "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "description": "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
     "pointer_target": "chain_id",
     "privacy": "Public"
   },

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -67,7 +67,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
             ser_pointer_target_param(
                 "chain_id",
                 &POINTER_TARGET_VALUE.to_string(),
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
             ),
             set_pointing_param_paths(&[
                 "batcher_config.static_config.block_builder_config.chain_info.chain_id",

--- a/crates/apollo_protobuf/src/proto/p2p/proto/sync/header.proto
+++ b/crates/apollo_protobuf/src/proto/p2p/proto/sync/header.proto
@@ -7,7 +7,7 @@ option go_package = "github.com/starknet-io/starknet-p2pspecs/p2p/proto/sync/hea
 // Note: commitments may change to be for the previous blocks like comet/tendermint
 // hash of block header sent to L1
 message SignedBlockHeader {
-    Hash block_hash = 1; //  For the structure of the block hash, see https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/header/#block_hash
+    Hash block_hash = 1; //  For the structure of the block hash, see https://docs.starknet.io/learn/protocol/blocks#block-hash
     Hash parent_hash = 2;
     uint64 number = 3; // This can be deduced from context. We can consider removing this field.
     uint64 time = 4; // Encoded in Unix time.

--- a/crates/apollo_protobuf/src/protobuf/protoc_output.rs
+++ b/crates/apollo_protobuf/src/protobuf/protoc_output.rs
@@ -1165,7 +1165,7 @@ pub mod events_response {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignedBlockHeader {
-    ///   For the structure of the block hash, see <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/header/#block_hash>
+    ///   For the structure of the block hash, see <https://docs.starknet.io/learn/protocol/blocks#block-hash>
     #[prost(message, optional, tag = "1")]
     pub block_hash: ::core::option::Option<Hash>,
     #[prost(message, optional, tag = "2")]

--- a/crates/apollo_rpc/src/lib.rs
+++ b/crates/apollo_rpc/src/lib.rs
@@ -107,7 +107,7 @@ impl SerializeConfig for RpcConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_rpc/src/v0_8/api/test.rs
+++ b/crates/apollo_rpc/src/v0_8/api/test.rs
@@ -227,7 +227,7 @@ async fn chain_id() {
     // The result should be equal to the result of the following python code
     // hex(int.from_bytes(b'SN_SEPOLIA', byteorder="big", signed=False))
     // taken from starknet documentation:
-    // https://docs.starknet.io/documentation/develop/Blocks/transactions/#chain-id.
+    // https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.
     call_api_then_assert_and_validate_schema_for_result(
         &module,
         "starknet_V0_8_chainId",

--- a/crates/apollo_storage/src/db/mod.rs
+++ b/crates/apollo_storage/src/db/mod.rs
@@ -106,7 +106,7 @@ impl SerializeConfig for DbConfig {
             ser_param(
                 "chain_id",
                 &self.chain_id,
-                "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+                "The chain to follow. For more details see https://docs.starknet.io/learn/cheatsheets/transactions-reference#chain-id.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/starknet_api/src/hash.rs
+++ b/crates/starknet_api/src/hash.rs
@@ -163,7 +163,7 @@ impl L1HandlerTransaction {
 }
 
 /// Calculating the message hash of L1 -> L2 message.
-/// For more info: <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/messaging-mechanism/#structure_and_hashing_l1-l2>
+/// For more info: <https://docs.starknet.io/learn/protocol/messaging#l1-l2-message-hashing>
 pub fn l1_handler_message_hash(
     contract_address: &ContractAddress,
     nonce: Nonce,

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -459,7 +459,7 @@ macro_rules! impl_deploy_transaction_trait {
 impl<T: DeployTransactionTrait> CalculateContractAddress for T {
     /// Calculates the contract address for the contract deployed by a deploy account transaction.
     /// For more details see:
-    /// <https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-address/>
+    /// <https://docs.starknet.io/learn/cheatsheets/transactions-reference#deploy-account-v3>
     fn calculate_contract_address(&self) -> StarknetApiResult<ContractAddress> {
         // When the contract is deployed via a deploy-account transaction, the deployer address is
         // zero.

--- a/crates/starknet_committer/src/hash_function/hash.rs
+++ b/crates/starknet_committer/src/hash_function/hash.rs
@@ -45,7 +45,7 @@ pub struct TreeHashFunctionImpl;
 
 /// Implementation of TreeHashFunction for contracts trie.
 /// The implementation is based on the following reference:
-/// <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/starknet-state/#trie_construction>
+/// <https://docs.starknet.io/learn/protocol/state#trie-construction>
 impl TreeHashFunction<ContractState> for TreeHashFunctionImpl {
     fn compute_leaf_hash(contract_state: &ContractState) -> HashOutput {
         compute_contract_state_leaf_hash(contract_state)
@@ -79,7 +79,7 @@ fn compute_contract_state_leaf_hash<L: AsRef<ContractState>>(
 
 /// Implementation of TreeHashFunction for the classes trie.
 /// The implementation is based on the following reference:
-/// <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/starknet-state/#trie_construction>
+/// <https://docs.starknet.io/learn/protocol/state#trie-construction>
 impl TreeHashFunction<CompiledClassHash> for TreeHashFunctionImpl {
     fn compute_leaf_hash(compiled_class_hash: &CompiledClassHash) -> HashOutput {
         compute_compiled_class_leaf_hash(compiled_class_hash)
@@ -109,7 +109,7 @@ fn compute_compiled_class_leaf_hash<L: AsRef<CompiledClassHash>>(
 
 /// Implementation of TreeHashFunction for the storage trie.
 /// The implementation is based on the following reference:
-/// <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/starknet-state/#trie_construction>
+/// <https://docs.starknet.io/learn/protocol/state#trie-construction>
 impl TreeHashFunction<StarknetStorageValue> for TreeHashFunctionImpl {
     fn compute_leaf_hash(storage_value: &StarknetStorageValue) -> HashOutput {
         HashOutput(storage_value.0)

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/hash_function.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/hash_function.rs
@@ -23,7 +23,7 @@ pub trait TreeHashFunction<L: Leaf> {
     fn compute_node_hash(node_data: &NodeData<L, HashOutput>) -> HashOutput;
 
     /// The default implementation for internal nodes is based on the following reference:
-    /// <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/starknet-state/#trie_construction>
+    /// <https://docs.starknet.io/learn/protocol/state#trie-construction>
     /// This code is layout independent. After computing the children hashes, NodeData can be
     /// instantiated with the concrete HashOutput for ChildData, regardless of what's stored in the
     /// db.


### PR DESCRIPTION
Update documentation links per docs.starknet.io site restructure.