### PR TITLE
apollo_staking: delete dead code

### DIFF
--- a/crates/apollo_staking/src/contract_types.rs
+++ b/crates/apollo_staking/src/contract_types.rs
@@ -15,15 +15,6 @@ mod contract_types_test;
 pub(crate) const GET_STAKERS_ENTRY_POINT: &str = "get_stakers";
 pub(crate) const GET_CURRENT_EPOCH_DATA_ENTRY_POINT: &str = "get_current_epoch_data";
 pub(crate) const GET_PREVIOUS_EPOCH_DATA_ENTRY_POINT: &str = "get_previous_epoch_data";
-#[allow(dead_code)]
-pub(crate) const EPOCH_LENGTH: u64 = 100; // Number of heights in an epoch.
-
-// Represents a Cairo1 `Array` containing elements that can be deserialized to `T`.
-// `T` must implement `TryFrom<[Felt; N]>`, where `N` is the size of `T`'s Cairo equivalent.
-#[derive(Debug, PartialEq, Eq)]
-// TODO(Dafna): Remove this when we have a CairoStakingContract implementation.
-#[allow(dead_code)]
-struct ArrayRetdata<T>(Vec<T>);
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct ContractStaker {


### PR DESCRIPTION
## Description

Remove two unused items from `crates/apollo_staking/src/contract_types.rs`. Both carried `#[allow(dead_code)]` and have zero references anywhere in the workspace.

- **`EPOCH_LENGTH`** — a `pub(crate) const u64 = 100`. Being `pub(crate)`, it is not reachable outside the crate, and within `apollo_staking` it is never imported or referenced. The `EPOCH_LENGTH` names that *are* used elsewhere are unrelated definitions: `MockStakingContract::EPOCH_LENGTH` (= 30), the local `const EPOCH_LENGTH` in `mock_staking_contract_test.rs`, `MIN_EPOCH_LENGTH` in `staking_manager.rs`, and the `STAKING_CURRENT_EPOCH_LENGTH` metric.
- **`ArrayRetdata<T>`** — a private tuple struct (`struct ArrayRetdata<T>(Vec<T>)`) with zero references. It was early scaffolding (its TODO read "Remove this when we have a `CairoStakingContract` implementation"); the actual deserialization path uses `CairoArray::try_from(retdata)` in `ContractStaker::from_retdata_many`, so the struct was never adopted.

## Evidence
- Workspace-wide grep for `EPOCH_LENGTH` and `ArrayRetdata`: the only hit for the deleted const/struct is its own definition; no `use crate::contract_types::EPOCH_LENGTH`/`ArrayRetdata` anywhere, and the test module does not reference either.
- `ArrayRetdata` returns 0 results across the entire `starkware-industries` org as well. `EPOCH_LENGTH` is `pub(crate)`, so cross-repo use is impossible.
- Remaining imports in the file (`CairoArray`, `RetdataDeserializationError`, `TryFromIterator`) are still used by the surviving code, so no import becomes unused.

## Test plan
- `cargo build -p apollo_staking` — passes
- `cargo clippy -p apollo_staking --all-targets` — clean
- `SEED=0 cargo test -p apollo_staking` — 91 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN9FeCnjWnrLmswjmmzKCw)_