### PR TITLE
scripts: add Committer to Service options

### DIFF
--- a/scripts/prod/common_lib.py
+++ b/scripts/prod/common_lib.py
@@ -184,6 +184,8 @@ class Service(Enum):
     """Service types mapping to their configmap and pod names."""
 
     Core = ("sequencer-core-config", "sequencer-core-statefulset-0")
+    # Committer runs as a StatefulSet (like Core), so its pod ends in "-statefulset-0".
+    Committer = ("sequencer-committer-config", "sequencer-committer-statefulset-0")
     Gateway = ("sequencer-gateway-config", "sequencer-gateway-deployment")
     L1 = ("sequencer-l1-config", "sequencer-l1-deployment")
     Mempool = ("sequencer-mempool-config", "sequencer-mempool-deployment")

--- a/scripts/prod/test_enum_cli_tokens.py
+++ b/scripts/prod/test_enum_cli_tokens.py
@@ -24,6 +24,12 @@ def test_service_str_is_the_accepted_token():
         assert Service[str(service)] is service
 
 
+def test_committer_service_maps_to_statefulset_resources():
+    # Committer runs as a StatefulSet, so it follows the Core "-statefulset-0" pod pattern.
+    assert Service.Committer.config_map_name == "sequencer-committer-config"
+    assert Service.Committer.pod_name == "sequencer-committer-statefulset-0"
+
+
 def test_invalid_restart_strategy_raises_informative_error():
     # Enum value lookup raises ValueError; the converter must translate it to ArgumentTypeError
     # with the valid options, rather than letting argparse fall back to a generic message.


### PR DESCRIPTION
Add Committer to the Service enum, mapped to its StatefulSet resources
(sequencer-committer-config / sequencer-committer-statefulset-0), following the
Core pattern since the committer runs as a StatefulSet. It flows automatically
into the --service choices, help text, and converter.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>