### PR TITLE
scripts: make --service a required argument

### DIFF
--- a/scripts/prod/update_config_and_restart_nodes.py
+++ b/scripts/prod/update_config_and_restart_nodes.py
@@ -137,11 +137,10 @@ Examples:
         "-j",
         "--service",
         type=service_type_converter,
-        default=Service.Core,
+        required=True,
         metavar="SERVICE",
         help="Service type to operate on; determines configmap and pod names. One of: "
-        + ", ".join(str(service) for service in Service)
-        + " (default: Core)",
+        + ", ".join(str(service) for service in Service),
     )
 
     args_builder.add_argument(


### PR DESCRIPTION
Drop the implicit Service.Core default for --service in update_config_and_restart_nodes
and require it explicitly, so the targeted service is always a conscious choice
rather than silently defaulting to Core.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>