### PR TITLE
ci: exclude top-level scripts/prod files from hybrid system test

### DIFF
--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -16,7 +16,7 @@ env:
   cluster_name: hybrid-system-test
   crate_triggers: "apollo_node,apollo_deployments,apollo_integration_tests"
   path_triggers: ".github/workflows/hybrid_system_test.yaml,scripts/**,deployments/sequencer/**,deployments/images/**"
-  path_triggers_exclude: "scripts/prod/**/*"
+  path_triggers_exclude: "scripts/prod/**"
   pvc_storage_class_name: "premium-rwo"
   anvil_port: "8545"
   dockerfile_base_path: ./deployments/images/sequencer
@@ -74,10 +74,10 @@ jobs:
           OUTPUT_FILE=$(mktemp)
 
           python ./scripts/check_test_trigger.py --output_file $OUTPUT_FILE \
-            --commit_id ${{ github.event.pull_request.base.sha }} \
-            --crate_triggers ${{ env.crate_triggers }} \
-            --path_triggers ${{ env.path_triggers }} \
-            --path_triggers_exclude ${{ env.path_triggers_exclude }}
+            --commit_id "${{ github.event.pull_request.base.sha }}" \
+            --crate_triggers "${{ env.crate_triggers }}" \
+            --path_triggers "${{ env.path_triggers }}" \
+            --path_triggers_exclude "${{ env.path_triggers_exclude }}"
 
           should_run=$(cat "$OUTPUT_FILE")
           echo "Captured output: $should_run"


### PR DESCRIPTION
The hybrid_system_test path-trigger exclude glob was "scripts/prod/**/*", which
under fnmatch requires a subdirectory and so did NOT match top-level files like
scripts/prod/common_lib.py. As a result, prod-script-only changes still triggered
the (irrelevant, infra-heavy) hybrid system test instead of being skipped.
Use "scripts/prod/**" so all files under scripts/prod are excluded, matching intent.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>