### PR TITLE
apollo_node: forward os_input feature to apollo_committer

### DIFF
--- a/crates/apollo_node/Cargo.toml
+++ b/crates/apollo_node/Cargo.toml
@@ -8,6 +8,11 @@ description = "Main Starknet sequencer node orchestrating all components."
 
 [features]
 cairo_native = ["apollo_batcher/cairo_native", "apollo_gateway/cairo_native"]
+# Forwarded so that `--all-features` builds enable `apollo_committer/os_input` (and its transitive
+# `starknet_committer/os_input`), keeping the cross-crate feature gating unified. Without it, a
+# build that enables `starknet_committer/os_input` while leaving `apollo_committer/os_input` off
+# fails to compile `apollo_committer` (E0027 on the `os_input`-gated `BlockMeasurement` field).
+os_input = ["apollo_committer/os_input"]
 testing = ["tokio-util"]
 
 [lints]


### PR DESCRIPTION
## Problem

`--all-features` clippy builds (e.g. the `code_style` job, surfaced on #14295) fail with:

```
error[E0027]: pattern does not mention field `fetched_witnesses_count`
  --> crates/apollo_committer/src/committer.rs
error: could not compile `apollo_committer` (lib)
```

`BlockMeasurement.fetched_witnesses_count` is gated on `starknet_committer/os_input`, while the consuming destructure in `apollo_committer::update_metrics` gates the binding on `apollo_committer/os_input`. These features resolve **independently**: under `--all-features`, `starknet_committer/os_input` is enabled directly (field present in the compiled struct), but `apollo_node` exposed no `os_input` feature to propagate `apollo_committer/os_input`, so `apollo_committer` is built with it off (pattern omits the field) → E0027.

This is a pre-existing latent issue on `main` (reproduced on a clean checkout via `cargo clippy -p starknet_committer -p apollo_node --all-targets --all-features`). It is **not** caused by #14295 — that PR only happened to pull the triggering package set into a single `--changes_only` clippy invocation.

## Fix

Add an `os_input` feature to `apollo_node` that forwards to `apollo_committer/os_input` (transitively `apollo_committer_types/os_input` + `starknet_committer/os_input`), unifying the cross-crate gate under `--all-features`. No `#[cfg]` flags removed; no source code changed.

## Verification

All green:
- `cargo clippy -p starknet_committer -p apollo_node --all-targets --all-features` (the exact failing combo)
- `cargo clippy -p apollo_node --all-targets` (no-feature path)
- full PR-equivalent package set with `--all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)