### PR TITLE
ci: fix hybrid system test for prod-script changes and k3d install

### DIFF
--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -16,7 +16,7 @@ env:
   cluster_name: hybrid-system-test
   crate_triggers: "apollo_node,apollo_deployments,apollo_integration_tests"
   path_triggers: ".github/workflows/hybrid_system_test.yaml,scripts/**,deployments/sequencer/**,deployments/images/**"
-  path_triggers_exclude: "scripts/prod/**/*"
+  path_triggers_exclude: "scripts/prod/**"
   pvc_storage_class_name: "premium-rwo"
   anvil_port: "8545"
   dockerfile_base_path: ./deployments/images/sequencer
@@ -74,10 +74,10 @@ jobs:
           OUTPUT_FILE=$(mktemp)
 
           python ./scripts/check_test_trigger.py --output_file $OUTPUT_FILE \
-            --commit_id ${{ github.event.pull_request.base.sha }} \
-            --crate_triggers ${{ env.crate_triggers }} \
-            --path_triggers ${{ env.path_triggers }} \
-            --path_triggers_exclude ${{ env.path_triggers_exclude }}
+            --commit_id "${{ github.event.pull_request.base.sha }}" \
+            --crate_triggers "${{ env.crate_triggers }}" \
+            --path_triggers "${{ env.path_triggers }}" \
+            --path_triggers_exclude "${{ env.path_triggers_exclude }}"
 
           should_run=$(cat "$OUTPUT_FILE")
           echo "Captured output: $should_run"
@@ -147,6 +147,12 @@ jobs:
       - name: Create k3d cluster (Local k8s)
         uses: AbsaOSS/k3d-action@v2.4.0
         with:
+          # Pin k3d explicitly: the action's default (v5.4.6) predates the checksums.txt release
+          # asset that the current k3d install.sh fetches (with --fail), so its install 404s. v5.5.0
+          # is the earliest release that ships checksums.txt (smallest bump from the old default).
+          # Must be the k3d-version input (the composite action maps it to K3D_VERSION); a plain env
+          # var is overridden by the action's own empty input default.
+          k3d-version: v5.5.0
           # Assumption: only one PR can run per machine at a time.
           cluster-name: ${{ env.cluster_name }}
           args: >-
@@ -169,8 +175,11 @@ jobs:
           echo "🔧 Installing local-path-provisioner..."
           kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
 
-          echo "⏳ Waiting for local-path-provisioner pod to be ready..."
-          kubectl wait --for=condition=Ready pod -l app=local-path-provisioner -n local-path-storage --timeout=60s
+          echo "⏳ Waiting for local-path-provisioner to be ready..."
+          # Wait on the Deployment rollout rather than `kubectl wait -l <pod-label>`: `apply` creates
+          # the Deployment synchronously, but the Pod is created asynchronously by its ReplicaSet, so
+          # a pod-label wait races and errors with "no matching resources found".
+          kubectl rollout status deployment/local-path-provisioner -n local-path-storage --timeout=120s
 
           echo "✅ local-path-provisioner is ready."
 


### PR DESCRIPTION
Three fixes to hybrid_system_test:
1. Exclude glob 'scripts/prod/**/*' did not match top-level files like
   scripts/prod/common_lib.py under fnmatch (needs a sub-dir), so prod-script-only
   PRs wrongly triggered this infra-heavy test. Use 'scripts/prod/**'.
2. The trigger args were interpolated unquoted into the run step, so a glob like
   'scripts/prod/**' was shell-expanded before reaching check_test_trigger.py.
   Quote the interpolations.
3. AbsaOSS/k3d-action defaults to k3d v5.4.6, whose release predates the
   checksums.txt asset that the current k3d install.sh fetches (with --fail),
   causing a 404 / 'Failed to install k3d'. Pin K3D_VERSION=v5.5.0 (earliest
   release shipping checksums.txt; smallest bump from the old default).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>