### PR TITLE
apollo_dashboard: widen l1_message_no_successes alert window to 15m

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1422,7 +1422,7 @@
       "name": "l1_message_no_successes",
       "title": "L1 message no successes",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(increase(l1_message_scraper_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[15m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
@@ -18,7 +18,7 @@ pub(crate) fn get_l1_message_scraper_no_successes_alert() -> Alert {
         ALERT_NAME,
         "L1 message no successes",
         EvaluationRate::Default,
-        format!("increase({}[5m])", L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
+        format!("increase({}[15m])", L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),


### PR DESCRIPTION
Goal: reduce false-positive pages on the L1 message scraper alert.

Since each sequencer moved to a single L1 provider, the
`l1_message_no_successes` alert (no successful scrapes within the
window) fires spuriously: a brief gap from the sole provider trips it
even though scraping recovers shortly after. Widening the evaluation
window from 5m to 15m tolerates these short gaps.

Change: bump the `increase(l1_message_scraper_success_count[...])`
range from 5m to 15m in the alert definition, and regenerate the
matching expression in dev_grafana_alerts.json.

Follow-up (not in this PR): revert to 5m once a fallback mechanism
that switches back to a specific provider per sequencer is in place.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>