### PR TITLE
ci: fix hybrid system test for prod-script changes and k3d install (#…

### DIFF
--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -16,7 +16,7 @@ env:
   cluster_name: hybrid-system-test
   crate_triggers: "apollo_node,apollo_deployments,apollo_integration_tests"
   path_triggers: ".github/workflows/hybrid_system_test.yaml,scripts/**,deployments/sequencer/**,deployments/images/**"
-  path_triggers_exclude: "scripts/prod/**/*"
+  path_triggers_exclude: "scripts/prod/**"
   pvc_storage_class_name: "premium-rwo"
   anvil_port: "8545"
   dockerfile_base_path: ./deployments/images/sequencer
@@ -74,10 +74,10 @@ jobs:
           OUTPUT_FILE=$(mktemp)
 
           python ./scripts/check_test_trigger.py --output_file $OUTPUT_FILE \
-            --commit_id ${{ github.event.pull_request.base.sha }} \
-            --crate_triggers ${{ env.crate_triggers }} \
-            --path_triggers ${{ env.path_triggers }} \
-            --path_triggers_exclude ${{ env.path_triggers_exclude }}
+            --commit_id "${{ github.event.pull_request.base.sha }}" \
+            --crate_triggers "${{ env.crate_triggers }}" \
+            --path_triggers "${{ env.path_triggers }}" \
+            --path_triggers_exclude "${{ env.path_triggers_exclude }}"
 
           should_run=$(cat "$OUTPUT_FILE")
           echo "Captured output: $should_run"
@@ -147,6 +147,12 @@ jobs:
       - name: Create k3d cluster (Local k8s)
         uses: AbsaOSS/k3d-action@v2.4.0
         with:
+          # Pin k3d explicitly: the action's default (v5.4.6) predates the checksums.txt release
+          # asset that the current k3d install.sh fetches (with --fail), so its install 404s. v5.5.0
+          # is the earliest release that ships checksums.txt (smallest bump from the old default).
+          # Must be the k3d-version input (the composite action maps it to K3D_VERSION); a plain env
+          # var is overridden by the action's own empty input default.
+          k3d-version: v5.5.0
           # Assumption: only one PR can run per machine at a time.
           cluster-name: ${{ env.cluster_name }}
           args: >-
@@ -169,8 +175,11 @@ jobs:
           echo "🔧 Installing local-path-provisioner..."
           kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
 
-          echo "⏳ Waiting for local-path-provisioner pod to be ready..."
-          kubectl wait --for=condition=Ready pod -l app=local-path-provisioner -n local-path-storage --timeout=60s
+          echo "⏳ Waiting for local-path-provisioner to be ready..."
+          # Wait on the Deployment rollout rather than `kubectl wait -l <pod-label>`: `apply` creates
+          # the Deployment synchronously, but the Pod is created asynchronously by its ReplicaSet, so
+          # a pod-label wait races and errors with "no matching resources found".
+          kubectl rollout status deployment/local-path-provisioner -n local-path-storage --timeout=120s
 
           echo "✅ local-path-provisioner is ready."
 


### PR DESCRIPTION
…14317)

- Exclude glob 'scripts/prod/**/*' missed top-level files under fnmatch; use 'scripts/prod/**' so prod-script-only PRs skip this infra-heavy test.
- Quote the trigger interpolations so a glob value isn't shell-expanded before reaching check_test_trigger.py.
- Pin k3d-version=v5.5.0 (action input): the default v5.4.6 predates the checksums.txt release asset the current k3d install.sh fetches with --fail, causing a 404.
- Wait on the local-path-provisioner Deployment rollout instead of a racy pod-label wait that errored 'no matching resources found'.