### PR TITLE
workspace: CORE create empty apollo_feeder_gateway crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "apollo_feeder_gateway"
+version = "0.0.0"
+dependencies = [
+ "apollo_infra",
+ "apollo_infra_utils",
+ "async-trait",
+ "rstest",
+ "tracing",
+]
+
+[[package]]
 name = "apollo_feeder_gateway_config"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "crates/apollo_consensus_orchestrator_config",
   "crates/apollo_dashboard",
   "crates/apollo_deployments",
+  "crates/apollo_feeder_gateway",
   "crates/apollo_feeder_gateway_config",
   "crates/apollo_gateway",
   "crates/apollo_gateway_config",
@@ -164,6 +165,7 @@ apollo_consensus_orchestrator.path = "crates/apollo_consensus_orchestrator"
 apollo_consensus_orchestrator_config.path = "crates/apollo_consensus_orchestrator_config"
 apollo_dashboard.path = "crates/apollo_dashboard"
 apollo_deployments.path = "crates/apollo_deployments"
+apollo_feeder_gateway.path = "crates/apollo_feeder_gateway"
 apollo_feeder_gateway_config.path = "crates/apollo_feeder_gateway_config"
 apollo_gateway.path = "crates/apollo_gateway"
 apollo_gateway_config.path = "crates/apollo_gateway_config"

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "apollo_feeder_gateway"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Feeder gateway read API server for the Apollo sequencer."
+
+[features]
+testing = []
+
+[lints]
+workspace = true
+
+[dependencies]
+apollo_infra.workspace = true
+apollo_infra_utils.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -1,0 +1,1 @@
+//! Feeder gateway read API server for the Apollo sequencer.


### PR DESCRIPTION
## Goal
With the config crate in place, this PR adds the main feeder gateway crate that will host the
component, its server, the read backends, and the response handlers. As with the config crate it is
created empty so the workspace wiring and dependency surface are reviewable separately from any
behavior, keeping each step of the migration small.

## Summary of changes
Creates crates/apollo_feeder_gateway (manifest with a `testing = []` feature for the usual
test-gating pattern, plus a doc-only lib.rs) and adds its `members` and `[workspace.dependencies]`
entries.

## Key decision points
Registered this crate's workspace entries here rather than in the previous PR, for the same
eager-`members` reason: a member directory must exist before it is listed, or the build breaks.
Added the `testing` feature up front because crates in this repo that later use the metrics/mock
macros must keep `testing = []` even when it looks unused (the macros expand `cfg(feature =
"testing")` and `check-cfg` errors otherwise), so declaring it now avoids a churny follow-up.