### PR TITLE
apollo_feeder_gateway_config: CORE add empty FeederGatewayConfig

### DIFF
--- a/crates/apollo_feeder_gateway_config/src/config.rs
+++ b/crates/apollo_feeder_gateway_config/src/config.rs
@@ -1,0 +1,16 @@
+use std::collections::BTreeMap;
+
+use apollo_config::dumping::SerializeConfig;
+use apollo_config::{ParamPath, SerializedParam};
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+/// Configuration for the feeder gateway component.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Validate, PartialEq)]
+pub struct FeederGatewayConfig {}
+
+impl SerializeConfig for FeederGatewayConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::new()
+    }
+}

--- a/crates/apollo_feeder_gateway_config/src/lib.rs
+++ b/crates/apollo_feeder_gateway_config/src/lib.rs
@@ -1,1 +1,3 @@
 //! Configuration types for the Apollo feeder gateway.
+
+pub mod config;


### PR DESCRIPTION
## Goal
The component needs a configuration type to hold (eventually) its bind address, read backend, and
contract addresses. This PR introduces that type, empty, so the standard config plumbing
(SerializeConfig, the derive set used by the node config loader) can be reviewed before any fields
are added. Fields are added later, each in the PR that first reads it, per the repo's
config-when-needed rule.

## Summary of changes
Adds config.rs with an empty `FeederGatewayConfig` deriving the standard config traits and
implementing `SerializeConfig` with an empty `dump()`; exports it from lib.rs.

## Key decision points
Kept it genuinely empty (no speculative fields) so the config schema diff stays minimal and each
later field lands with the code that consumes it — this keeps the generated config schema reviewable
field-by-field rather than as one large unexplained block.