### PR TITLE
apollo_feeder_gateway: CORE add FeederGateway component struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
 name = "apollo_feeder_gateway"
 version = "0.0.0"
 dependencies = [
+ "apollo_feeder_gateway_config",
  "apollo_infra",
  "apollo_infra_utils",
  "async-trait",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -13,6 +13,7 @@ testing = []
 workspace = true
 
 [dependencies]
+apollo_feeder_gateway_config.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
 async-trait.workspace = true

--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -1,0 +1,15 @@
+use apollo_feeder_gateway_config::config::FeederGatewayConfig;
+
+pub struct FeederGateway {
+    pub config: FeederGatewayConfig,
+}
+
+impl FeederGateway {
+    pub fn new(config: FeederGatewayConfig) -> Self {
+        Self { config }
+    }
+}
+
+pub fn create_feeder_gateway(config: FeederGatewayConfig) -> FeederGateway {
+    FeederGateway::new(config)
+}

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -1,1 +1,3 @@
 //! Feeder gateway read API server for the Apollo sequencer.
+
+pub mod feeder_gateway;


### PR DESCRIPTION
## Goal
Establish the component type that the node will own and run. Splitting the struct + constructor into
its own PR (before the run loop, server alias, and routes) keeps each later PR focused on one
behavior, and gives reviewers a clear anchor for the component's shape.

## Summary of changes
Adds feeder_gateway.rs with `FeederGateway { config }`, a `new()` constructor, and a
`create_feeder_gateway()` factory; adds the apollo_feeder_gateway_config dependency.

## Key decision points
Followed the apollo_http_server component shape (struct + `create_*` factory) rather than inventing
a new pattern, so this component is wired into the node exactly like the existing active components
and reviewers can pattern-match against http_server.