### PR TITLE
apollo_feeder_gateway: CORE add run error and ComponentStarter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "apollo_infra_utils",
  "async-trait",
  "rstest",
+ "thiserror 1.0.69",
  "tracing",
 ]
 

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -17,6 +17,7 @@ apollo_feeder_gateway_config.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
 async-trait.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/apollo_feeder_gateway/src/errors.rs
+++ b/crates/apollo_feeder_gateway/src/errors.rs
@@ -1,0 +1,9 @@
+use std::io;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FeederGatewayRunError {
+    #[error(transparent)]
+    ServerStartupError(#[from] io::Error),
+}

--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -1,4 +1,10 @@
 use apollo_feeder_gateway_config::config::FeederGatewayConfig;
+use apollo_infra::component_definitions::ComponentStarter;
+use apollo_infra_utils::type_name::short_type_name;
+use async_trait::async_trait;
+use tracing::info;
+
+use crate::errors::FeederGatewayRunError;
 
 pub struct FeederGateway {
     pub config: FeederGatewayConfig,
@@ -12,4 +18,19 @@ impl FeederGateway {
 
 pub fn create_feeder_gateway(config: FeederGatewayConfig) -> FeederGateway {
     FeederGateway::new(config)
+}
+
+impl FeederGateway {
+    pub async fn run(&mut self) -> Result<(), FeederGatewayRunError> {
+        info!("FeederGateway run starting.");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ComponentStarter for FeederGateway {
+    async fn start(&mut self) {
+        info!("Starting component {}.", short_type_name::<Self>());
+        self.run().await.unwrap_or_else(|e| panic!("Failed to start FeederGateway: {e:?}"))
+    }
 }

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -1,3 +1,4 @@
 //! Feeder gateway read API server for the Apollo sequencer.
 
+pub mod errors;
 pub mod feeder_gateway;


### PR DESCRIPTION
## Goal
For the node to run the feeder gateway as an active component it must implement the infra
`ComponentStarter` contract and expose a typed run error. This PR adds exactly that scaffolding so
the next PR (the WrapperServer alias) and later PRs (the axum server) have something to start,
without yet pulling in axum.

## Summary of changes
Adds errors.rs with `FeederGatewayRunError`, plus an async `run()` (currently a no-op log) and a
`ComponentStarter` impl that starts `run()` and panics with context on startup failure.

## Key decision points
Mirrored apollo_http_server's ComponentStarter/run shape (verified the `ComponentStarter` and
`short_type_name` import paths against it) so the start/panic semantics match the other active
components. Kept `run()` a no-op here so this PR introduces only the trait wiring; the actual axum
serving lands in a dedicated PR, keeping the diffs reviewable one concern at a time.