### PR TITLE
apollo_feeder_gateway: CORE add WrapperServer type alias

### DIFF
--- a/crates/apollo_feeder_gateway/src/communication.rs
+++ b/crates/apollo_feeder_gateway/src/communication.rs
@@ -1,0 +1,5 @@
+use apollo_infra::component_server::WrapperServer;
+
+use crate::feeder_gateway::FeederGateway as FeederGatewayComponent;
+
+pub type FeederGateway = WrapperServer<FeederGatewayComponent>;

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -1,4 +1,5 @@
 //! Feeder gateway read API server for the Apollo sequencer.
 
+pub mod communication;
 pub mod errors;
 pub mod feeder_gateway;


### PR DESCRIPTION
## Goal
The node runs components-without-their-own-server through the infra `WrapperServer`. The feeder
gateway is such a component (it owns an axum server, not an mpsc request server), so it needs a
`WrapperServer<FeederGateway>` alias for the node's server-construction macro to instantiate. This
PR adds that alias so the node-wiring PRs can reference a concrete server type.

## Summary of changes
Adds communication.rs with `pub type FeederGateway = WrapperServer<FeederGatewayComponent>`.

## Key decision points
Used the `WrapperServer` alias (as apollo_http_server does) rather than a bespoke server type,
because the feeder gateway has no remote-client/request-response surface — it is a self-contained
HTTP server — so the wrapper is exactly the right abstraction and keeps node wiring uniform.