### PR TITLE
apollo_feeder_gateway_config: CORE add bind ip and port

### DIFF
--- a/crates/apollo_feeder_gateway_config/src/config.rs
+++ b/crates/apollo_feeder_gateway_config/src/config.rs
@@ -1,16 +1,41 @@
 use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
 
-use apollo_config::dumping::SerializeConfig;
-use apollo_config::{ParamPath, SerializedParam};
+use apollo_config::dumping::{ser_param, SerializeConfig};
+use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-/// Configuration for the feeder gateway component.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Validate, PartialEq)]
-pub struct FeederGatewayConfig {}
+const FEEDER_GATEWAY_PORT: u16 = 8082; // configurable; intentionally NOT legacy 9713.
+
+#[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
+pub struct FeederGatewayConfig {
+    pub ip: IpAddr,
+    pub port: u16,
+}
+
+impl Default for FeederGatewayConfig {
+    fn default() -> Self {
+        Self { ip: IpAddr::from(Ipv4Addr::UNSPECIFIED), port: FEEDER_GATEWAY_PORT }
+    }
+}
 
 impl SerializeConfig for FeederGatewayConfig {
     fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
-        BTreeMap::new()
+        BTreeMap::from_iter([
+            ser_param(
+                "ip",
+                &self.ip.to_string(),
+                "The feeder gateway ip.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param("port", &self.port, "The feeder gateway port.", ParamPrivacyInput::Public),
+        ])
+    }
+}
+
+impl FeederGatewayConfig {
+    pub fn ip_and_port(&self) -> (IpAddr, u16) {
+        (self.ip, self.port)
     }
 }


### PR DESCRIPTION
## Goal
The next PR makes the component serve HTTP, which requires a bind address. Per config-when-needed,
the ip/port fields are added here, in the PR immediately before the one that reads them.

## Summary of changes
Replaces the empty config with `ip`/`port` fields (default 0.0.0.0:8082), their `SerializeConfig`
dump entries, and an `ip_and_port()` accessor.

## Key decision points
Defaulted the port to 8082, intentionally NOT the legacy Python feeder gateway's 9713: the migration
plan runs the new service ALONGSIDE the Python one (step 1 of an eventual removal), so they must not
contend for the same port. Exposed `ip_and_port()` as a small accessor so callers bind without
reaching into individual fields.