### PR TITLE
apollo_feeder_gateway: CORE serve axum app with health routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,8 +1533,11 @@ dependencies = [
  "apollo_infra",
  "apollo_infra_utils",
  "async-trait",
+ "axum",
  "rstest",
  "thiserror 1.0.69",
+ "tokio",
+ "tower",
  "tracing",
 ]
 

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -17,8 +17,11 @@ apollo_feeder_gateway_config.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
 async-trait.workspace = true
+axum.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+tower = { workspace = true, features = ["util"] }

--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -1,10 +1,20 @@
+use std::net::SocketAddr;
+
 use apollo_feeder_gateway_config::config::FeederGatewayConfig;
 use apollo_infra::component_definitions::ComponentStarter;
 use apollo_infra_utils::type_name::short_type_name;
 use async_trait::async_trait;
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::{serve, Router};
+use tokio::net::TcpListener;
 use tracing::info;
 
 use crate::errors::FeederGatewayRunError;
+
+#[cfg(test)]
+#[path = "feeder_gateway_test.rs"]
+mod feeder_gateway_test;
 
 pub struct FeederGateway {
     pub config: FeederGatewayConfig,
@@ -14,17 +24,31 @@ impl FeederGateway {
     pub fn new(config: FeederGatewayConfig) -> Self {
         Self { config }
     }
+
+    pub async fn run(&mut self) -> Result<(), FeederGatewayRunError> {
+        let (ip, port) = self.config.ip_and_port();
+        let addr = SocketAddr::new(ip, port);
+        let app = self.app();
+        info!("FeederGateway running on {}", addr);
+        let listener = TcpListener::bind(&addr).await?;
+        Ok(serve(listener, app).await?)
+    }
+
+    pub fn app(&self) -> Router {
+        Router::new()
+            .route(
+                "/feeder_gateway/is_alive",
+                get(|| async { (StatusCode::OK, "FeederGateway is alive") }),
+            )
+            .route(
+                "/feeder_gateway/is_ready",
+                get(|| async { (StatusCode::OK, "FeederGateway is ready") }),
+            )
+    }
 }
 
 pub fn create_feeder_gateway(config: FeederGatewayConfig) -> FeederGateway {
     FeederGateway::new(config)
-}
-
-impl FeederGateway {
-    pub async fn run(&mut self) -> Result<(), FeederGatewayRunError> {
-        info!("FeederGateway run starting.");
-        Ok(())
-    }
 }
 
 #[async_trait]

--- a/crates/apollo_feeder_gateway/src/feeder_gateway_test.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway_test.rs
@@ -1,0 +1,19 @@
+use apollo_feeder_gateway_config::config::FeederGatewayConfig;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::util::ServiceExt;
+
+use crate::feeder_gateway::FeederGateway;
+
+#[tokio::test]
+async fn is_alive_returns_ok() {
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default());
+    let app = feeder_gateway.app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/feeder_gateway/is_alive").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Goal
Make the component a real HTTP server so the node can boot it and Kubernetes can probe it. Health
routes are the minimal first surface: they let the deployment liveness/readiness checks pass before
any data endpoints exist, so the component can be wired into the node and deployed (disabled by
default) while the read endpoints are built incrementally.

## Summary of changes
`run()` now binds a `TcpListener` and serves an axum `Router`; `app()` exposes
`/feeder_gateway/is_alive` and `/feeder_gateway/is_ready`. Adds axum + tokio(rt) deps and a
tower(util) dev-dep, plus a `tower::oneshot` test asserting is_alive returns 200.

## Key decision points
Built the router in a separate `app()` method (rather than inline in `run()`) specifically so it can
be exercised by `tower::oneshot` in tests without binding a real socket — this is the pattern every
later endpoint test reuses. Mirrored the http_server serve/bind sequence so failure modes (bind
errors) surface identically to the existing server.