### PR TITLE
apollo_node: CORE add feeder_gateway execution-mode field

### DIFF
--- a/crates/apollo_deployments/resources/services/consolidated/replacer_node.json
+++ b/crates/apollo_deployments/resources/services/consolidated/replacer_node.json
@@ -48,6 +48,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Enabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "LocalExecutionWithRemoteDisabled",
   "components.gateway.local_server_config.#is_none": false,
   "components.gateway.local_server_config.high_priority_requests_channel_capacity": 1024,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_batcher.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_batcher.json
@@ -65,6 +65,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_class_manager.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_class_manager.json
@@ -45,6 +45,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_committer.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_committer.json
@@ -55,6 +55,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_consensus_manager.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_consensus_manager.json
@@ -53,6 +53,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Enabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_gateway.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_gateway.json
@@ -43,6 +43,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "LocalExecutionWithRemoteEnabled",
   "components.gateway.local_server_config.#is_none": false,
   "components.gateway.local_server_config.high_priority_requests_channel_capacity": 1024,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_http_server.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_http_server.json
@@ -33,6 +33,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Remote",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": "$$$_COMPONENTS-GATEWAY-PORT_$$$",

--- a/crates/apollo_deployments/resources/services/distributed/replacer_l1.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_l1.json
@@ -43,6 +43,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_mempool.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_mempool.json
@@ -43,6 +43,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Remote",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": "$$$_COMPONENTS-GATEWAY-PORT_$$$",

--- a/crates/apollo_deployments/resources/services/distributed/replacer_proof_manager.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_proof_manager.json
@@ -33,6 +33,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_sierra_compiler.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_sierra_compiler.json
@@ -33,6 +33,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_signature_manager.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_signature_manager.json
@@ -33,6 +33,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/distributed/replacer_state_sync.json
+++ b/crates/apollo_deployments/resources/services/distributed/replacer_state_sync.json
@@ -43,6 +43,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/hybrid/replacer_committer.json
+++ b/crates/apollo_deployments/resources/services/hybrid/replacer_committer.json
@@ -55,6 +55,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/hybrid/replacer_core.json
+++ b/crates/apollo_deployments/resources/services/hybrid/replacer_core.json
@@ -67,6 +67,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Enabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/hybrid/replacer_gateway.json
+++ b/crates/apollo_deployments/resources/services/hybrid/replacer_gateway.json
@@ -43,6 +43,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "LocalExecutionWithRemoteEnabled",
   "components.gateway.local_server_config.#is_none": false,
   "components.gateway.local_server_config.high_priority_requests_channel_capacity": 1024,

--- a/crates/apollo_deployments/resources/services/hybrid/replacer_l1.json
+++ b/crates/apollo_deployments/resources/services/hybrid/replacer_l1.json
@@ -43,6 +43,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/resources/services/hybrid/replacer_mempool.json
+++ b/crates/apollo_deployments/resources/services/hybrid/replacer_mempool.json
@@ -43,6 +43,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Remote",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": "$$$_COMPONENTS-GATEWAY-PORT_$$$",

--- a/crates/apollo_deployments/resources/services/hybrid/replacer_sierra_compiler.json
+++ b/crates/apollo_deployments/resources/services/hybrid/replacer_sierra_compiler.json
@@ -33,6 +33,7 @@
   "components.config_manager.remote_server_config.#is_none": true,
   "components.config_manager.url": "localhost",
   "components.consensus_manager.execution_mode": "Disabled",
+  "components.feeder_gateway.execution_mode": "Disabled",
   "components.gateway.execution_mode": "Disabled",
   "components.gateway.local_server_config.#is_none": true,
   "components.gateway.port": 0,

--- a/crates/apollo_deployments/src/deployments/consolidated.rs
+++ b/crates/apollo_deployments/src/deployments/consolidated.rs
@@ -63,6 +63,7 @@ fn get_consolidated_config() -> ComponentConfig {
         committer: base.clone(),
         config_manager: base.clone(),
         consensus_manager: ActiveComponentExecutionConfig::enabled(),
+        feeder_gateway: ActiveComponentExecutionConfig::disabled(),
         gateway: base.clone(),
         http_server: ActiveComponentExecutionConfig::enabled(),
         l1_events_provider: base.clone(),

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -1164,6 +1164,11 @@
     "privacy": "Public",
     "value": "Enabled"
   },
+  "components.feeder_gateway.execution_mode": {
+    "description": "The component execution mode.",
+    "privacy": "Public",
+    "value": "Enabled"
+  },
   "components.gateway.execution_mode": {
     "description": "The component execution mode.",
     "privacy": "Public",

--- a/crates/apollo_node_config/src/component_config.rs
+++ b/crates/apollo_node_config/src/component_config.rs
@@ -55,6 +55,8 @@ pub struct ComponentConfig {
     #[validate(nested)]
     pub consensus_manager: ActiveComponentExecutionConfig,
     #[validate(nested)]
+    pub feeder_gateway: ActiveComponentExecutionConfig,
+    #[validate(nested)]
     pub http_server: ActiveComponentExecutionConfig,
     #[validate(nested)]
     pub l1_events_scraper: ActiveComponentExecutionConfig,
@@ -72,6 +74,7 @@ impl SerializeConfig for ComponentConfig {
             prepend_sub_config_name(self.committer.dump(), "committer"),
             prepend_sub_config_name(self.config_manager.dump(), "config_manager"),
             prepend_sub_config_name(self.consensus_manager.dump(), "consensus_manager"),
+            prepend_sub_config_name(self.feeder_gateway.dump(), "feeder_gateway"),
             prepend_sub_config_name(self.gateway.dump(), "gateway"),
             prepend_sub_config_name(self.http_server.dump(), "http_server"),
             prepend_sub_config_name(self.l1_events_provider.dump(), "l1_events_provider"),
@@ -99,6 +102,7 @@ impl ComponentConfig {
             committer: ReactiveComponentExecutionConfig::disabled(),
             config_manager: ReactiveComponentExecutionConfig::disabled(),
             consensus_manager: ActiveComponentExecutionConfig::disabled(),
+            feeder_gateway: ActiveComponentExecutionConfig::disabled(),
             http_server: ActiveComponentExecutionConfig::disabled(),
             gateway: ReactiveComponentExecutionConfig::disabled(),
             l1_events_provider: ReactiveComponentExecutionConfig::disabled(),


### PR DESCRIPTION
## Goal
Operators must be able to turn the feeder gateway on/off per deployment. The node's `ComponentConfig`
is the single place execution modes live, so it needs a `feeder_gateway` active-component field
before the node can construct or skip the component. This is the first of the node-wiring PRs.

## Summary of changes
Adds `feeder_gateway: ActiveComponentExecutionConfig` to `ComponentConfig` (struct field, `dump()`
entry, and `disabled()` entry), adds the disabled entry to the consolidated deployment's component
literal, and regenerates config_schema.json and the deployment configs (committed in this PR per the
regen-gate rule).

## Key decision points
Deliberately did NOT add `feeder_gateway` to `validate_tx_ingestion_components_disabled`, even though
the written plan said to. That validation enforces that *transaction-ingestion* components (gateway,
http_server, mempool, mempool_p2p) are off on validation-only nodes. The feeder gateway is read-only
— not a tx-ingestion component — so adding it there would wrongly forbid running it on exactly the
read/validation nodes where re-serving chain data is most useful. Placed the field alphabetically in
the active-component group to match the existing ordering and keep the generated schema diff clean.