### PR TITLE
apollo_node: CORE construct feeder gateway component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "apollo_config_manager",
  "apollo_config_manager_types",
  "apollo_consensus_manager",
+ "apollo_feeder_gateway",
  "apollo_gateway",
  "apollo_gateway_types",
  "apollo_http_server",

--- a/crates/apollo_node/Cargo.toml
+++ b/crates/apollo_node/Cargo.toml
@@ -27,6 +27,7 @@ apollo_config.workspace = true
 apollo_config_manager.workspace = true
 apollo_config_manager_types.workspace = true
 apollo_consensus_manager.workspace = true
+apollo_feeder_gateway.workspace = true
 apollo_gateway.workspace = true
 apollo_gateway_types.workspace = true
 apollo_http_server.workspace = true

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -13,6 +13,7 @@ use apollo_consensus_manager::consensus_manager::{
     ConsensusManager,
     ConsensusManagerArgs,
 };
+use apollo_feeder_gateway::feeder_gateway::{create_feeder_gateway, FeederGateway};
 use apollo_gateway::gateway::{create_gateway, Gateway};
 use apollo_http_server::http_server::{create_http_server, HttpServer};
 use apollo_l1_events::event_identifiers_to_track;
@@ -52,6 +53,7 @@ pub struct SequencerNodeComponents {
     pub config_manager: Option<ConfigManager>,
     pub config_manager_runner: Option<ConfigManagerRunner>,
     pub consensus_manager: Option<ConsensusManager>,
+    pub feeder_gateway: Option<FeederGateway>,
     pub gateway: Option<Gateway>,
     pub http_server: Option<HttpServer>,
     pub l1_events_scraper:
@@ -280,6 +282,15 @@ pub async fn create_node_components(
                 config_manager_client,
                 gateway_client,
             ))
+        }
+        ActiveComponentExecutionMode::Disabled => None,
+    };
+
+    let feeder_gateway = match config.components.feeder_gateway.execution_mode {
+        ActiveComponentExecutionMode::Enabled => {
+            let feeder_gateway_config =
+                config.feeder_gateway_config.as_ref().expect("Feeder gateway config should be set");
+            Some(create_feeder_gateway(feeder_gateway_config.clone()))
         }
         ActiveComponentExecutionMode::Disabled => None,
     };
@@ -581,6 +592,7 @@ pub async fn create_node_components(
         config_manager,
         config_manager_runner,
         consensus_manager,
+        feeder_gateway,
         gateway,
         http_server,
         l1_events_scraper,


### PR DESCRIPTION
## Goal
The node must actually build a `FeederGateway` instance when the component is enabled (and skip it
when disabled). This PR adds that construction so the component exists in the node's component set;
the following PR runs its server.

## Summary of changes
Adds the `feeder_gateway` field to `SequencerNodeComponents` and a construction match arm in
`create_node_components` that builds the component from its config when enabled; adds the
apollo_feeder_gateway dependency.

## Key decision points
Constructed from config alone at this stage. The read backend (co-located storage vs remote client)
depends on data that is only available later in `create_node_components` (state-sync's storage
reader), so threading it in now would force an awkward ordering; instead the backend-selection PR
relocates this construction below state-sync. Keeping construction config-only here makes this PR a
clean, reviewable "component appears in the node" step.