### PR TITLE
apollo_state_sync,apollo_node: CORE return storage_reader from create_state_sync_and_runner

### DIFF
--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -573,7 +573,9 @@ pub async fn create_node_components(
             let config_manager_client = clients
                 .get_config_manager_shared_client()
                 .expect("Config Manager client should be available");
-            let (state_sync, state_sync_runner) = create_state_sync_and_runner(
+            // TODO(feeder_gateway): consume `_storage_reader` when wiring the co-located feeder
+            // gateway read backend.
+            let (state_sync, state_sync_runner, _storage_reader) = create_state_sync_and_runner(
                 state_sync_config.clone(),
                 class_manager_client,
                 config_manager_client,

--- a/crates/apollo_state_sync/src/lib.rs
+++ b/crates/apollo_state_sync/src/lib.rs
@@ -39,7 +39,7 @@ pub fn create_state_sync_and_runner(
     config: StateSyncConfig,
     class_manager_client: SharedClassManagerClient,
     config_manager_client: SharedConfigManagerClient,
-) -> (StateSync, StateSyncRunner) {
+) -> (StateSync, StateSyncRunner, StorageReader) {
     let (new_block_sender, new_block_receiver) = channel(BUFFER_SIZE);
     let (state_sync_runner, storage_reader) = StateSyncRunner::new(
         config.clone(),
@@ -48,8 +48,9 @@ pub fn create_state_sync_and_runner(
         config_manager_client.clone(),
     );
     (
-        StateSync::new(storage_reader, new_block_sender, config, config_manager_client),
+        StateSync::new(storage_reader.clone(), new_block_sender, config, config_manager_client),
         state_sync_runner,
+        storage_reader,
     )
 }
 


### PR DESCRIPTION
## Goal
The co-located read backend needs the same `StorageReader` state-sync already opened — opening a
second handle is impossible (MDBX is opened exclusive) and wasteful. `create_state_sync_and_runner`
already constructs that reader but discards it. This refactor surfaces it to the node so the
backend-selection PR can hand it to the co-located reader. This is the storage-threading prerequisite
called out in the design's read-architecture section.

## Summary of changes
Changes `create_state_sync_and_runner` to return `(StateSync, StateSyncRunner, StorageReader)`
(cloning the reader, which is a cheap `Arc<Environment>` clone), and updates the single node call
site to bind the new value.

## Key decision points
This is a pure forward of an already-bound value: `StateSyncRunner::new` already returns the reader
and the function already used it only to build `StateSync`, so there is no behavior change and the
exclusive-open constraint is exactly why we clone-and-share rather than re-open. Bound it as
`_storage_reader` (underscored) at the call site to satisfy deny-level unused-variable clippy, since
the first consumer lands in the backend-selection PR; the underscore is removed there.