### PR TITLE
apollo_feeder_gateway: CORE add bounded ReadExecutor

### DIFF
--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -21,7 +21,7 @@ axum.workspace = true
 mockall = { workspace = true, optional = true }
 starknet_api.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/apollo_feeder_gateway/src/reader.rs
+++ b/crates/apollo_feeder_gateway/src/reader.rs
@@ -6,6 +6,8 @@ use starknet_api::block::BlockHeader;
 
 use crate::errors::FeederGatewayError;
 
+pub mod executor;
+
 #[cfg(test)]
 #[path = "reader_test.rs"]
 mod reader_test;

--- a/crates/apollo_feeder_gateway/src/reader/executor.rs
+++ b/crates/apollo_feeder_gateway/src/reader/executor.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+use crate::errors::FeederGatewayError;
+use crate::reader::FgResult;
+
+#[cfg(test)]
+#[path = "executor_test.rs"]
+mod executor_test;
+
+/// A bounded executor for synchronous, page-cache-bound MDBX reads (per the read-execution design).
+///
+/// MDBX reads must not run inline on the async reactor (a slow page-cache miss would block a worker
+/// thread and starve HTTP scheduling), and they must not be dispatched to the global blocking pool
+/// without a bound (its queue is unbounded, so a spike grows threads until the box thrashes). Every
+/// read is therefore routed through this executor, which caps the number of concurrent blocking
+/// reads with a semaphore sized ~1.5x physical cores.
+///
+/// Backpressure model: [`ReadExecutor::run`] AWAITS for a permit when the executor is saturated and
+/// never rejects, so a full read queue simply slows request acceptance (the desired natural
+/// throttle) rather than surfacing an overload error.
+pub struct ReadExecutor {
+    semaphore: Arc<Semaphore>,
+    read_pool_size: usize,
+}
+
+impl ReadExecutor {
+    pub fn new(read_pool_size: usize) -> Self {
+        Self { semaphore: Arc::new(Semaphore::new(read_pool_size)), read_pool_size }
+    }
+
+    /// Runs a blocking read closure on the blocking pool, bounded by the executor's concurrency
+    /// limit. Awaits a permit if the executor is saturated; never rejects. The returned
+    /// `FgResult` reports only executor-level failure (the spawned task panicking); the closure's
+    /// own success type carries any read error.
+    pub async fn run<F, T>(&self, f: F) -> FgResult<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        // The permit is held for the duration of the blocking work, so at most `read_pool_size`
+        // reads execute concurrently.
+        let _permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| FeederGatewayError::Internal)?;
+        tokio::task::spawn_blocking(f).await.map_err(|join_error| {
+            tracing::error!(error = %join_error, "feeder gateway read task failed to join");
+            FeederGatewayError::Internal
+        })
+    }
+
+    /// The maximum number of concurrent reads (the semaphore size). Exposed for a saturation
+    /// metric.
+    pub fn max_concurrency(&self) -> usize {
+        self.read_pool_size
+    }
+
+    /// The number of reads currently executing (held permits). Exposed for a saturation metric.
+    pub fn in_flight(&self) -> usize {
+        self.read_pool_size.saturating_sub(self.semaphore.available_permits())
+    }
+}

--- a/crates/apollo_feeder_gateway/src/reader/executor_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/executor_test.rs
@@ -1,0 +1,51 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::reader::executor::ReadExecutor;
+
+#[tokio::test]
+async fn run_respects_concurrency_bound_and_completes_all() {
+    const READ_POOL_SIZE: usize = 4;
+    const NUM_TASKS: usize = 32;
+
+    let executor = Arc::new(ReadExecutor::new(READ_POOL_SIZE));
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_in_flight = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    let mut handles = Vec::new();
+    for _ in 0..NUM_TASKS {
+        let executor = executor.clone();
+        let in_flight = in_flight.clone();
+        let max_in_flight = max_in_flight.clone();
+        let completed = completed.clone();
+        handles.push(tokio::spawn(async move {
+            executor
+                .run(move || {
+                    let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_in_flight.fetch_max(current, Ordering::SeqCst);
+                    // Hold the permit long enough that excess tasks must queue.
+                    std::thread::sleep(Duration::from_millis(10));
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                })
+                .await
+                .unwrap();
+            completed.fetch_add(1, Ordering::SeqCst);
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    // Every task completed (no rejection under saturation).
+    assert_eq!(completed.load(Ordering::SeqCst), NUM_TASKS);
+    assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+    // Concurrency never exceeded the bound.
+    let observed_max = max_in_flight.load(Ordering::SeqCst);
+    assert!(
+        observed_max <= READ_POOL_SIZE,
+        "observed {observed_max} concurrent reads, bound is {READ_POOL_SIZE}"
+    );
+}


### PR DESCRIPTION
## Goal
The feeder gateway targets very high RPS, and MDBX reads are synchronous and page-cache-bound.
Running them inline on the async runtime would cap parallelism at the core count and let a slow
(page-cache-miss) read block an HTTP-scheduling worker. Dispatching them to tokio's global blocking
pool is also wrong: that pool grows to hundreds of threads with an unbounded queue, so a spike causes
thread thrash and unbounded memory/latency growth. This PR adds the bounded executor that every read
will go through, so reads run truly in parallel but with a hard concurrency bound and natural
backpressure.

## Summary of changes
Adds reader/executor.rs: a `ReadExecutor` that gates `spawn_blocking` with a bounded tokio
`Semaphore` sized `read_pool_size`; `run()` awaits a permit then runs the closure on a blocking
thread; adds `max_concurrency()`/`in_flight()` accessors for a future saturation metric. Includes a
test asserting in-flight never exceeds the bound and all calls complete.

## Key decision points
Implemented the executor as a Semaphore over `spawn_blocking` rather than a dedicated `std::thread`
worker pool. Both bound concurrency, but the Semaphore is ~10 lines versus a hand-rolled pool, and
the design explicitly says to start simple and only adopt the thread pool if the perf test shows
tokio's lazy thread-spawn matters. Chose await-on-saturation (never reject): a full read queue should
slow request acceptance — the desired throttle — not surface an overload error, so handlers need no
overflow branch. This is why there is no `ServiceOverloaded` path.