### PR TITLE
apollo_feeder_gateway: CORE add ColocatedStorageReader backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,6 +1532,7 @@ dependencies = [
  "apollo_feeder_gateway_config",
  "apollo_infra",
  "apollo_infra_utils",
+ "apollo_storage",
  "async-trait",
  "axum",
  "mockall",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 apollo_feeder_gateway_config.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
+apollo_storage.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 mockall = { workspace = true, optional = true }
@@ -25,6 +26,7 @@ tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
 
 [dev-dependencies]
+apollo_storage = { workspace = true, features = ["testing"] }
 mockall.workspace = true
 rstest.workspace = true
 tower = { workspace = true, features = ["util"] }

--- a/crates/apollo_feeder_gateway/src/reader.rs
+++ b/crates/apollo_feeder_gateway/src/reader.rs
@@ -6,6 +6,7 @@ use starknet_api::block::BlockHeader;
 
 use crate::errors::FeederGatewayError;
 
+pub mod colocated;
 pub mod executor;
 
 #[cfg(test)]

--- a/crates/apollo_feeder_gateway/src/reader/colocated.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use apollo_storage::header::HeaderStorageReader;
+use apollo_storage::StorageReader;
+use async_trait::async_trait;
+use starknet_api::block::BlockHeader;
+
+use crate::errors::FeederGatewayError;
+use crate::reader::executor::ReadExecutor;
+use crate::reader::{ChainDataReader, FgResult};
+
+#[cfg(test)]
+#[path = "colocated_test.rs"]
+mod colocated_test;
+
+/// A [`ChainDataReader`] that reads directly from a co-located `apollo_storage::StorageReader`.
+///
+/// Every read is dispatched through the bounded [`ReadExecutor`] so MDBX reads run in parallel on
+/// the blocking pool (MVCC permits many concurrent read transactions) without blocking the async
+/// reactor. This mirrors how `apollo_rpc` is handed a `StorageReader` directly, but with the read
+/// pool bound applied.
+pub struct ColocatedStorageReader {
+    storage_reader: StorageReader,
+    executor: Arc<ReadExecutor>,
+}
+
+impl ColocatedStorageReader {
+    pub fn new(storage_reader: StorageReader, executor: Arc<ReadExecutor>) -> Self {
+        Self { storage_reader, executor }
+    }
+}
+
+#[async_trait]
+impl ChainDataReader for ColocatedStorageReader {
+    async fn latest_block_header(&self) -> FgResult<Option<BlockHeader>> {
+        // `StorageReader` is an `Arc<Environment>` internally, so cloning is cheap and shares the
+        // single MDBX environment.
+        let storage_reader = self.storage_reader.clone();
+        self.executor
+            .run(move || {
+                let txn = storage_reader.begin_ro_txn().map_err(internal)?;
+                let header_marker = txn.get_header_marker().map_err(internal)?;
+                // The header marker points one past the latest stored block; `prev()` is `None`
+                // only when no blocks have been synced yet.
+                let Some(latest_block_number) = header_marker.prev() else {
+                    return Ok(None);
+                };
+                txn.get_block_header(latest_block_number).map_err(internal)
+            })
+            .await?
+    }
+}
+
+/// Maps an internal read error to [`FeederGatewayError::Internal`], logging the source here (the
+/// only place it is observed) so no internal detail leaks to the client.
+fn internal<E: std::fmt::Display>(error: E) -> FeederGatewayError {
+    tracing::error!(error = %error, "feeder gateway internal read error");
+    FeederGatewayError::Internal
+}

--- a/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use apollo_storage::header::HeaderStorageWriter;
+use apollo_storage::test_utils::get_test_storage;
+use starknet_api::block::{BlockHeader, BlockNumber};
+
+use crate::reader::colocated::ColocatedStorageReader;
+use crate::reader::executor::ReadExecutor;
+use crate::reader::ChainDataReader;
+
+fn executor() -> Arc<ReadExecutor> {
+    Arc::new(ReadExecutor::new(2))
+}
+
+#[tokio::test]
+async fn latest_block_header_empty_storage_returns_none() {
+    let ((storage_reader, _writer), _temp_dir) = get_test_storage();
+    let reader = ColocatedStorageReader::new(storage_reader, executor());
+
+    assert!(reader.latest_block_header().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn latest_block_header_returns_appended_header() {
+    let ((storage_reader, mut writer), _temp_dir) = get_test_storage();
+    let header = BlockHeader::default();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_header(BlockNumber(0), &header)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    let reader = ColocatedStorageReader::new(storage_reader, executor());
+
+    assert_eq!(reader.latest_block_header().await.unwrap(), Some(header));
+}


### PR DESCRIPTION
## Goal
The primary, highest-throughput deployment runs the feeder gateway in the state-sync process and
reads MDBX directly. This PR adds that backend. It is the read path that lets a single pod saturate
its cores on reads without the per-request overhead of the local state-sync client (mpsc + oneshot +
component clone + concurrency semaphore), which measurements in the design put at ~30-50x slower at
saturation.

## Summary of changes
Adds reader/colocated.rs implementing `ChainDataReader` over an `apollo_storage::StorageReader`,
dispatching every read through the bounded `ReadExecutor`. `latest_block_header` reads the header
marker, takes its predecessor as the latest height, and returns that header. Tested via
`get_test_storage` for both empty storage (returns None) and an appended header (returns it).

## Key decision points
Routed reads through the `ReadExecutor` rather than raw `spawn_blocking`, so this backend inherits
the concurrency bound and backpressure. Cloned the `StorageReader` per read — it is an
`Arc<Environment>`, so the clone is nearly free and lets the closure be `'static` for the blocking
thread. Derived the latest height from the header marker (the first unwritten block) via `prev()`,
matching how sync writes headers, rather than the batcher-only `block_hashes` table which a
co-located reader would find empty.