### PR TITLE
apollo_feeder_gateway: CORE add RemoteChainDataReader backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,6 +1532,7 @@ dependencies = [
  "apollo_feeder_gateway_config",
  "apollo_infra",
  "apollo_infra_utils",
+ "apollo_state_sync_types",
  "apollo_storage",
  "async-trait",
  "axum",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 apollo_feeder_gateway_config.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
+apollo_state_sync_types.workspace = true
 apollo_storage.workspace = true
 async-trait.workspace = true
 axum.workspace = true

--- a/crates/apollo_feeder_gateway/src/reader.rs
+++ b/crates/apollo_feeder_gateway/src/reader.rs
@@ -8,6 +8,7 @@ use crate::errors::FeederGatewayError;
 
 pub mod colocated;
 pub mod executor;
+pub mod remote;
 
 #[cfg(test)]
 #[path = "reader_test.rs"]
@@ -29,4 +30,11 @@ pub trait ChainDataReader: Send + Sync + 'static {
 pub struct AppState {
     pub reader: Arc<dyn ChainDataReader>,
     pub config: FeederGatewayConfig,
+}
+
+/// Maps an internal read/backend error to [`FeederGatewayError::Internal`], logging the source here
+/// (the only place it is observed) so no internal detail leaks to the client.
+pub(crate) fn internal_error<E: std::fmt::Display>(error: E) -> FeederGatewayError {
+    tracing::error!(error = %error, "feeder gateway internal read error");
+    FeederGatewayError::Internal
 }

--- a/crates/apollo_feeder_gateway/src/reader/colocated.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated.rs
@@ -5,9 +5,8 @@ use apollo_storage::StorageReader;
 use async_trait::async_trait;
 use starknet_api::block::BlockHeader;
 
-use crate::errors::FeederGatewayError;
 use crate::reader::executor::ReadExecutor;
-use crate::reader::{ChainDataReader, FgResult};
+use crate::reader::{internal_error, ChainDataReader, FgResult};
 
 #[cfg(test)]
 #[path = "colocated_test.rs"]
@@ -38,22 +37,15 @@ impl ChainDataReader for ColocatedStorageReader {
         let storage_reader = self.storage_reader.clone();
         self.executor
             .run(move || {
-                let txn = storage_reader.begin_ro_txn().map_err(internal)?;
-                let header_marker = txn.get_header_marker().map_err(internal)?;
+                let txn = storage_reader.begin_ro_txn().map_err(internal_error)?;
+                let header_marker = txn.get_header_marker().map_err(internal_error)?;
                 // The header marker points one past the latest stored block; `prev()` is `None`
                 // only when no blocks have been synced yet.
                 let Some(latest_block_number) = header_marker.prev() else {
                     return Ok(None);
                 };
-                txn.get_block_header(latest_block_number).map_err(internal)
+                txn.get_block_header(latest_block_number).map_err(internal_error)
             })
             .await?
     }
-}
-
-/// Maps an internal read error to [`FeederGatewayError::Internal`], logging the source here (the
-/// only place it is observed) so no internal detail leaks to the client.
-fn internal<E: std::fmt::Display>(error: E) -> FeederGatewayError {
-    tracing::error!(error = %error, "feeder gateway internal read error");
-    FeederGatewayError::Internal
 }

--- a/crates/apollo_feeder_gateway/src/reader/remote.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote.rs
@@ -1,0 +1,25 @@
+use apollo_state_sync_types::communication::SharedStateSyncClient;
+use async_trait::async_trait;
+use starknet_api::block::BlockHeader;
+
+use crate::reader::{internal_error, ChainDataReader, FgResult};
+
+/// A [`ChainDataReader`] for different-pod/node deployments: it delegates every read to the
+/// state-sync process over the network via a [`SharedStateSyncClient`]. The feeder gateway is
+/// stateless in this mode and holds no local storage.
+pub struct RemoteChainDataReader {
+    client: SharedStateSyncClient,
+}
+
+impl RemoteChainDataReader {
+    pub fn new(client: SharedStateSyncClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ChainDataReader for RemoteChainDataReader {
+    async fn latest_block_header(&self) -> FgResult<Option<BlockHeader>> {
+        self.client.get_latest_block_header().await.map_err(internal_error)
+    }
+}


### PR DESCRIPTION
## Goal
In the own-pod (horizontally scaled) topology the feeder gateway has no local storage and must read
over the network from the state-sync process. This PR adds that backend so the same handlers work in
both topologies; it is kept default-off (the node defaults to co-located) and is the activation point
for the distributed deployment.

## Summary of changes
Adds reader/remote.rs implementing `ChainDataReader` by delegating to a `SharedStateSyncClient`
(latest_block_header). Extracts the shared `internal_error` mapper into reader.rs and switches the
co-located backend to use it.

## Key decision points
Implemented the remote backend against the existing `SharedStateSyncClient` rather than inventing a
new transport, so it reuses the node's configured local/remote client wiring. Extracted
`internal_error` to a shared helper at this point rather than duplicating it across both backends:
the second consumer is exactly when the repo's "extract shared utilities instead of copying" rule
applies, and a single mapper keeps the "log at source, leak nothing to the client" behavior in one
place.