### PR TITLE
apollo_node,apollo_feeder_gateway: CORE select feeder gateway read backend by topology

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,7 @@ dependencies = [
  "apollo_config_manager_types",
  "apollo_consensus_manager",
  "apollo_feeder_gateway",
+ "apollo_feeder_gateway_config",
  "apollo_gateway",
  "apollo_gateway_types",
  "apollo_http_server",

--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use apollo_feeder_gateway_config::config::FeederGatewayConfig;
 use apollo_infra::component_definitions::ComponentStarter;
@@ -6,27 +7,28 @@ use apollo_infra_utils::type_name::short_type_name;
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use axum::routing::get;
-use axum::{serve, Router};
+use axum::{serve, Extension, Router};
 use tokio::net::TcpListener;
 use tracing::info;
 
 use crate::errors::FeederGatewayRunError;
+use crate::reader::{AppState, ChainDataReader};
 
 #[cfg(test)]
 #[path = "feeder_gateway_test.rs"]
 mod feeder_gateway_test;
 
 pub struct FeederGateway {
-    pub config: FeederGatewayConfig,
+    pub app_state: AppState,
 }
 
 impl FeederGateway {
-    pub fn new(config: FeederGatewayConfig) -> Self {
-        Self { config }
+    pub fn new(config: FeederGatewayConfig, reader: Arc<dyn ChainDataReader>) -> Self {
+        Self { app_state: AppState { reader, config } }
     }
 
     pub async fn run(&mut self) -> Result<(), FeederGatewayRunError> {
-        let (ip, port) = self.config.ip_and_port();
+        let (ip, port) = self.app_state.config.ip_and_port();
         let addr = SocketAddr::new(ip, port);
         let app = self.app();
         info!("FeederGateway running on {}", addr);
@@ -44,11 +46,15 @@ impl FeederGateway {
                 "/feeder_gateway/is_ready",
                 get(|| async { (StatusCode::OK, "FeederGateway is ready") }),
             )
+            .layer(Extension(self.app_state.clone()))
     }
 }
 
-pub fn create_feeder_gateway(config: FeederGatewayConfig) -> FeederGateway {
-    FeederGateway::new(config)
+pub fn create_feeder_gateway(
+    config: FeederGatewayConfig,
+    reader: Arc<dyn ChainDataReader>,
+) -> FeederGateway {
+    FeederGateway::new(config, reader)
 }
 
 #[async_trait]

--- a/crates/apollo_feeder_gateway/src/feeder_gateway_test.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway_test.rs
@@ -1,13 +1,17 @@
+use std::sync::Arc;
+
 use apollo_feeder_gateway_config::config::FeederGatewayConfig;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tower::util::ServiceExt;
 
 use crate::feeder_gateway::FeederGateway;
+use crate::reader::MockChainDataReader;
 
 #[tokio::test]
 async fn is_alive_returns_ok() {
-    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default());
+    let reader = Arc::new(MockChainDataReader::new());
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), reader);
     let app = feeder_gateway.app();
 
     let response = app

--- a/crates/apollo_feeder_gateway_config/src/config.rs
+++ b/crates/apollo_feeder_gateway_config/src/config.rs
@@ -1,28 +1,51 @@
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr};
 
-use apollo_config::dumping::{ser_param, SerializeConfig};
+use apollo_config::dumping::{ser_optional_param, ser_param, SerializeConfig};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 const FEEDER_GATEWAY_PORT: u16 = 8082; // configurable; intentionally NOT legacy 9713.
 
+// Schema placeholder for the `read_pool_size` default. A value of 0 (or an unset field) means the
+// pool size is derived at runtime as ~1.5x the available CPUs; see `read_pool_size`.
+const AUTO_READ_POOL_SIZE: usize = 0;
+
+/// Selects how the feeder gateway reads chain data, chosen by deployment topology.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ReadBackend {
+    /// Read directly from co-located `apollo_storage` in the same process (highest throughput).
+    #[default]
+    Colocated,
+    /// Read remotely from the state-sync process (different pod/node).
+    Remote,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
 pub struct FeederGatewayConfig {
     pub ip: IpAddr,
     pub port: u16,
+    pub read_backend: ReadBackend,
+    /// Maximum number of concurrent blocking reads. When unset (or 0), derived at runtime as ~1.5x
+    /// the available CPUs.
+    pub read_pool_size: Option<usize>,
 }
 
 impl Default for FeederGatewayConfig {
     fn default() -> Self {
-        Self { ip: IpAddr::from(Ipv4Addr::UNSPECIFIED), port: FEEDER_GATEWAY_PORT }
+        Self {
+            ip: IpAddr::from(Ipv4Addr::UNSPECIFIED),
+            port: FEEDER_GATEWAY_PORT,
+            read_backend: ReadBackend::default(),
+            read_pool_size: None,
+        }
     }
 }
 
 impl SerializeConfig for FeederGatewayConfig {
     fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
-        BTreeMap::from_iter([
+        let mut dump = BTreeMap::from_iter([
             ser_param(
                 "ip",
                 &self.ip.to_string(),
@@ -30,7 +53,23 @@ impl SerializeConfig for FeederGatewayConfig {
                 ParamPrivacyInput::Public,
             ),
             ser_param("port", &self.port, "The feeder gateway port.", ParamPrivacyInput::Public),
-        ])
+            ser_param(
+                "read_backend",
+                &self.read_backend,
+                "The feeder gateway read backend (Colocated reads local storage; Remote reads via \
+                 the state sync client).",
+                ParamPrivacyInput::Public,
+            ),
+        ]);
+        dump.extend(ser_optional_param(
+            &self.read_pool_size,
+            AUTO_READ_POOL_SIZE,
+            "read_pool_size",
+            "Maximum number of concurrent blocking reads. 0 (or unset) derives ~1.5x available \
+             CPUs at runtime.",
+            ParamPrivacyInput::Public,
+        ));
+        dump
     }
 }
 
@@ -38,4 +77,19 @@ impl FeederGatewayConfig {
     pub fn ip_and_port(&self) -> (IpAddr, u16) {
         (self.ip, self.port)
     }
+
+    /// The effective read pool size: the configured value, or ~1.5x the available CPUs when unset
+    /// or 0.
+    pub fn read_pool_size(&self) -> usize {
+        match self.read_pool_size {
+            Some(size) if size > 0 => size,
+            _ => default_read_pool_size(),
+        }
+    }
+}
+
+fn default_read_pool_size() -> usize {
+    let cores = std::thread::available_parallelism().map(|cores| cores.get()).unwrap_or(1);
+    // ~1.5x cores: MDBX reads are CPU/page-cache-bound, so an oversized pool just context-switches.
+    (cores * 3) / 2
 }

--- a/crates/apollo_node/Cargo.toml
+++ b/crates/apollo_node/Cargo.toml
@@ -28,6 +28,7 @@ apollo_config_manager.workspace = true
 apollo_config_manager_types.workspace = true
 apollo_consensus_manager.workspace = true
 apollo_feeder_gateway.workspace = true
+apollo_feeder_gateway_config.workspace = true
 apollo_gateway.workspace = true
 apollo_gateway_types.workspace = true
 apollo_http_server.workspace = true

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2964,6 +2964,21 @@
     "privacy": "Public",
     "value": 8082
   },
+  "feeder_gateway_config.read_backend": {
+    "description": "The feeder gateway read backend (Colocated reads local storage; Remote reads via the state sync client).",
+    "privacy": "Public",
+    "value": "Colocated"
+  },
+  "feeder_gateway_config.read_pool_size": {
+    "description": "Maximum number of concurrent blocking reads. 0 (or unset) derives ~1.5x available CPUs at runtime.",
+    "privacy": "Public",
+    "value": 0
+  },
+  "feeder_gateway_config.read_pool_size.#is_none": {
+    "description": "Flag for an optional field.",
+    "privacy": "TemporaryValue",
+    "value": true
+  },
   "gateway_config.#is_none": {
     "description": "Flag for an optional field.",
     "privacy": "TemporaryValue",

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -14,6 +14,11 @@ use apollo_consensus_manager::consensus_manager::{
     ConsensusManagerArgs,
 };
 use apollo_feeder_gateway::feeder_gateway::{create_feeder_gateway, FeederGateway};
+use apollo_feeder_gateway::reader::colocated::ColocatedStorageReader;
+use apollo_feeder_gateway::reader::executor::ReadExecutor;
+use apollo_feeder_gateway::reader::remote::RemoteChainDataReader;
+use apollo_feeder_gateway::reader::ChainDataReader;
+use apollo_feeder_gateway_config::config::ReadBackend;
 use apollo_gateway::gateway::{create_gateway, Gateway};
 use apollo_http_server::http_server::{create_http_server, HttpServer};
 use apollo_l1_events::event_identifiers_to_track;
@@ -286,15 +291,6 @@ pub async fn create_node_components(
         ActiveComponentExecutionMode::Disabled => None,
     };
 
-    let feeder_gateway = match config.components.feeder_gateway.execution_mode {
-        ActiveComponentExecutionMode::Enabled => {
-            let feeder_gateway_config =
-                config.feeder_gateway_config.as_ref().expect("Feeder gateway config should be set");
-            Some(create_feeder_gateway(feeder_gateway_config.clone()))
-        }
-        ActiveComponentExecutionMode::Disabled => None,
-    };
-
     let l1_gas_price_provider = match config.components.l1_gas_price_provider.execution_mode {
         ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
         | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
@@ -562,29 +558,55 @@ pub async fn create_node_components(
         ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => None,
     };
 
-    let (state_sync, state_sync_runner) = match config.components.state_sync.execution_mode {
-        ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
-        | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
-            let state_sync_config =
-                config.state_sync_config.as_ref().expect("State Sync config should be set");
-            let class_manager_client = clients
-                .get_class_manager_shared_client()
-                .expect("Class Manager client should be available");
-            let config_manager_client = clients
-                .get_config_manager_shared_client()
-                .expect("Config Manager client should be available");
-            // TODO(feeder_gateway): consume `_storage_reader` when wiring the co-located feeder
-            // gateway read backend.
-            let (state_sync, state_sync_runner, _storage_reader) = create_state_sync_and_runner(
-                state_sync_config.clone(),
-                class_manager_client,
-                config_manager_client,
-            );
-            (Some(state_sync), Some(state_sync_runner))
+    let (state_sync, state_sync_runner, state_sync_storage_reader) =
+        match config.components.state_sync.execution_mode {
+            ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
+            | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
+                let state_sync_config =
+                    config.state_sync_config.as_ref().expect("State Sync config should be set");
+                let class_manager_client = clients
+                    .get_class_manager_shared_client()
+                    .expect("Class Manager client should be available");
+                let config_manager_client = clients
+                    .get_config_manager_shared_client()
+                    .expect("Config Manager client should be available");
+                let (state_sync, state_sync_runner, storage_reader) = create_state_sync_and_runner(
+                    state_sync_config.clone(),
+                    class_manager_client,
+                    config_manager_client,
+                );
+                (Some(state_sync), Some(state_sync_runner), Some(storage_reader))
+            }
+            ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => {
+                (None, None, None)
+            }
+        };
+
+    // The feeder gateway read backend depends on whether state sync runs co-located in this
+    // process, so it is built after state sync.
+    let feeder_gateway = match config.components.feeder_gateway.execution_mode {
+        ActiveComponentExecutionMode::Enabled => {
+            let feeder_gateway_config =
+                config.feeder_gateway_config.as_ref().expect("Feeder gateway config should be set");
+            let reader: Arc<dyn ChainDataReader> = match feeder_gateway_config.read_backend {
+                ReadBackend::Colocated => {
+                    let storage_reader = state_sync_storage_reader.clone().expect(
+                        "Co-located feeder gateway requires a local state sync storage reader",
+                    );
+                    let executor =
+                        Arc::new(ReadExecutor::new(feeder_gateway_config.read_pool_size()));
+                    Arc::new(ColocatedStorageReader::new(storage_reader, executor))
+                }
+                ReadBackend::Remote => {
+                    let state_sync_client = clients
+                        .get_state_sync_shared_client()
+                        .expect("State Sync client should be available");
+                    Arc::new(RemoteChainDataReader::new(state_sync_client))
+                }
+            };
+            Some(create_feeder_gateway(feeder_gateway_config.clone(), reader))
         }
-        ReactiveComponentExecutionMode::Disabled | ReactiveComponentExecutionMode::Remote => {
-            (None, None)
-        }
+        ActiveComponentExecutionMode::Disabled => None,
     };
 
     SequencerNodeComponents {


### PR DESCRIPTION
## Goal
With both backends built, the running component must be given the right one based on deployment
topology, and handlers need that backend in `AppState`. This PR closes the loop: it lets operators
choose the backend by config and threads a concrete reader all the way into the component, so the
co-located fast path actually gets used.

## Summary of changes
Adds `read_backend` (default Colocated) and `read_pool_size` config fields; makes
`FeederGateway::new` take `Arc<dyn ChainDataReader>` and build `AppState` + the `Extension` layer;
in the node, constructs the `ReadExecutor` and selects `ColocatedStorageReader` (from state-sync's
storage reader) or `RemoteChainDataReader` (from the state-sync client) by config. Regenerates
config_schema.json and deployment configs.

## Key decision points
Relocated the feeder-gateway construction to AFTER the state-sync block in `create_node_components`,
and made the state-sync match also yield `Option<StorageReader>`, because the co-located backend
needs that reader and it does not exist earlier in the function — this is why construction could not
stay where the earlier PR put it. The `FeederGateway::new` signature change necessarily lands in this
same PR (spanning both crates) because this is the first point a reader exists to pass; splitting it
out would leave a non-compiling intermediate state. Dropped the plan's separate
`read_channel_capacity` field: the executor's Semaphore already is the bound, so a second knob would
be dead config.