### PR TITLE
apollo_feeder_gateway: CORE add Python-style spaced JSON serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,6 +1538,8 @@ dependencies = [
  "axum",
  "mockall",
  "rstest",
+ "serde",
+ "serde_json",
  "starknet_api",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -21,6 +21,8 @@ apollo_storage.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 mockall = { workspace = true, optional = true }
+serde.workspace = true
+serde_json.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -4,3 +4,4 @@ pub mod communication;
 pub mod errors;
 pub mod feeder_gateway;
 pub mod reader;
+pub mod serialization;

--- a/crates/apollo_feeder_gateway/src/serialization.rs
+++ b/crates/apollo_feeder_gateway/src/serialization.rs
@@ -1,0 +1,92 @@
+use std::io;
+
+use serde::Serialize;
+use serde_json::ser::{Formatter, Serializer};
+
+use crate::errors::FeederGatewayError;
+use crate::reader::FgResult;
+
+#[cfg(test)]
+#[path = "serialization_test.rs"]
+mod serialization_test;
+
+/// A `serde_json` formatter that reproduces Python's `json.dumps` default output, so the feeder
+/// gateway is byte-identical to the legacy Python feeder gateway (backwards compatibility requires
+/// matching key order, separators, and escaping exactly):
+///
+/// - **Spaced separators**: `", "` between elements and `": "` after keys (serde's default is
+///   compact, `,`/`:`), on a single line with no indentation.
+/// - **`ensure_ascii=True`**: every non-ASCII scalar is escaped as `\uXXXX` (UTF-16 code units,
+///   surrogate pairs above the BMP), matching Python.
+///
+/// Everything else (number formatting, the standard `"`/`\`/control-character escapes) delegates to
+/// `serde_json`'s default `Formatter` methods.
+#[derive(Clone, Copy, Debug, Default)]
+struct PythonFormatter;
+
+impl Formatter for PythonFormatter {
+    fn begin_array_value<W: ?Sized + io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> io::Result<()> {
+        if first { Ok(()) } else { writer.write_all(b", ") }
+    }
+
+    fn begin_object_key<W: ?Sized + io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> io::Result<()> {
+        if first { Ok(()) } else { writer.write_all(b", ") }
+    }
+
+    fn begin_object_value<W: ?Sized + io::Write>(&mut self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(b": ")
+    }
+
+    fn write_string_fragment<W: ?Sized + io::Write>(
+        &mut self,
+        writer: &mut W,
+        fragment: &str,
+    ) -> io::Result<()> {
+        // `serde_json` has already routed quotes, backslashes, and control characters through
+        // `write_char_escape`, so this fragment only needs ASCII-escaping of the remaining
+        // non-ASCII scalars.
+        let mut ascii_run_start = 0;
+        for (index, character) in fragment.char_indices() {
+            if character.is_ascii() {
+                continue;
+            }
+            if ascii_run_start < index {
+                writer.write_all(&fragment.as_bytes()[ascii_run_start..index])?;
+            }
+            let mut utf16_buffer = [0u16; 2];
+            for code_unit in character.encode_utf16(&mut utf16_buffer) {
+                write!(writer, "\\u{code_unit:04x}")?;
+            }
+            ascii_run_start = index + character.len_utf8();
+        }
+        if ascii_run_start < fragment.len() {
+            writer.write_all(&fragment.as_bytes()[ascii_run_start..])?;
+        }
+        Ok(())
+    }
+}
+
+/// Serializes `value` to a JSON string byte-identical to Python's `json.dumps` default output (see
+/// [`PythonFormatter`]). Feeder gateway handlers MUST serialize responses through this function
+/// rather than `serde_json::to_string`/`to_vec` or axum `Json<T>` (those are compact and break byte
+/// parity).
+pub fn to_python_json<T: Serialize>(value: &T) -> FgResult<String> {
+    let mut buffer = Vec::new();
+    let mut serializer = Serializer::with_formatter(&mut buffer, PythonFormatter);
+    value.serialize(&mut serializer).map_err(|error| {
+        tracing::error!(error = %error, "feeder gateway JSON serialization failed");
+        FeederGatewayError::Internal
+    })?;
+    String::from_utf8(buffer).map_err(|error| {
+        tracing::error!(error = %error, "feeder gateway JSON serialization produced invalid UTF-8");
+        FeederGatewayError::Internal
+    })
+}

--- a/crates/apollo_feeder_gateway/src/serialization_test.rs
+++ b/crates/apollo_feeder_gateway/src/serialization_test.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::serialization::to_python_json;
+
+#[test]
+fn spaced_separators_match_python() {
+    let value = json!({"a": 1, "b": [1, 2]});
+    assert_eq!(to_python_json(&value).unwrap(), r#"{"a": 1, "b": [1, 2]}"#);
+}
+
+#[test]
+fn empty_containers() {
+    assert_eq!(to_python_json(&json!([])).unwrap(), "[]");
+    assert_eq!(to_python_json(&json!({})).unwrap(), "{}");
+}
+
+#[test]
+fn nested_containers() {
+    let value = json!({"outer": {"inner": [1, {"k": "v"}]}});
+    assert_eq!(to_python_json(&value).unwrap(), r#"{"outer": {"inner": [1, {"k": "v"}]}}"#);
+}
+
+#[test]
+fn non_ascii_is_escaped_like_python_ensure_ascii() {
+    // Python json.dumps("café", ensure_ascii=True) escapes the non-ASCII scalar as é.
+    assert_eq!(to_python_json(&json!("café")).unwrap(), "\"caf\\u00e9\"");
+    // Code point above the BMP -> UTF-16 surrogate pair (emoji "😀" = U+1F600).
+    assert_eq!(to_python_json(&json!("😀")).unwrap(), "\"\\ud83d\\ude00\"");
+}
+
+#[test]
+fn standard_escapes_still_apply() {
+    assert_eq!(to_python_json(&json!("a\"b\\c\n")).unwrap(), r#""a\"b\\c\n""#);
+}
+
+/// B4 round-trip lock: optional fields that are `None` must be omitted (never serialized as
+/// `null`), and a deserialize -> `to_python_json` round trip must reproduce the original bytes.
+#[test]
+fn optional_none_fields_are_omitted() {
+    #[derive(Serialize, Deserialize)]
+    struct Sample {
+        present: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        absent: Option<u64>,
+    }
+
+    let original = r#"{"present": 7}"#;
+    let parsed: Sample = serde_json::from_str(original).unwrap();
+    assert_eq!(to_python_json(&parsed).unwrap(), original);
+}


### PR DESCRIPTION
## Goal
Backwards compatibility for the feeder gateway is byte-exact, not just semantic: existing clients
depend on the precise JSON the Python service emits, including separator spacing and non-ASCII
escaping. serde's default output is compact (`,`/`:`) and emits raw UTF-8, so it does NOT match
Python's `json.dumps` default. This PR adds the serializer every handler must use so responses are
byte-identical to Python.

## Summary of changes
Adds serialization.rs with a `serde_json` `Formatter` that emits spaced separators (`", "` / `": "`)
on a single line and escapes non-ASCII as `\uXXXX` (UTF-16, surrogate pairs above the BMP), plus
`to_python_json()`. Tests cover spacing, empty containers, standard escapes, non-ASCII, and a
deserialize -> serialize round-trip that locks `None`-field omission.

## Key decision points
Built a custom `Formatter` (overriding only the three separator hooks plus string-fragment escaping,
delegating everything else to serde_json) rather than post-processing serde output or pulling in
another library — it is small, fast, and provably matches Python on the axes that matter. Implemented
`ensure_ascii` now rather than deferring it: `revert_error` is free text that reaches the get_block
path, so unescaped non-ASCII there would be a latent, hard-to-notice parity break. Deferred the
`fg_json` response helper to the error-envelope PR because it needs `FeederGatewayError:
IntoResponse`, which does not exist yet.