### PR TITLE
apollo_feeder_gateway: CORE add legacy error envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ name = "apollo_feeder_gateway"
 version = "0.0.0"
 dependencies = [
  "apollo_feeder_gateway_config",
+ "apollo_gateway_types",
  "apollo_infra",
  "apollo_infra_utils",
  "apollo_state_sync_types",
@@ -1537,6 +1538,7 @@ dependencies = [
  "async-trait",
  "axum",
  "mockall",
+ "regex",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 apollo_feeder_gateway_config.workspace = true
+apollo_gateway_types.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
 apollo_state_sync_types.workspace = true
@@ -21,6 +22,7 @@ apollo_storage.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 mockall = { workspace = true, optional = true }
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet_api.workspace = true

--- a/crates/apollo_feeder_gateway/src/errors.rs
+++ b/crates/apollo_feeder_gateway/src/errors.rs
@@ -1,6 +1,20 @@
 use std::io;
 
+use apollo_gateway_types::deprecated_gateway_error::{
+    KnownStarknetErrorCode,
+    StarknetError,
+    StarknetErrorCode,
+};
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use regex::Regex;
 use thiserror::Error;
+
+use crate::serialization::to_python_json;
+
+#[cfg(test)]
+#[path = "errors_test.rs"]
+mod errors_test;
 
 #[derive(Debug, Error)]
 pub enum FeederGatewayRunError {
@@ -8,12 +22,78 @@ pub enum FeederGatewayRunError {
     ServerStartupError(#[from] io::Error),
 }
 
-/// Errors returned by feeder gateway request handling. The full client-facing error envelope
-/// (HTTP status + legacy `StarknetError` body) is implemented in a later PR.
+/// Errors returned by feeder gateway request handling. Each maps to the legacy Python feeder
+/// gateway error envelope (`{code, message}`) and HTTP status (see [`IntoResponse`]).
 #[derive(Debug, Error)]
 pub enum FeederGatewayError {
+    #[error("Block not found")]
+    BlockNotFound,
+    #[error("Transaction hash not found")]
+    TransactionNotFound,
+    #[error("Malformed request: {0}")]
+    MalformedRequest(String),
     // The source of an internal error is logged at the construction site and deliberately not
     // carried here, so nothing internal leaks to the client.
     #[error("Internal error")]
     Internal,
+}
+
+impl IntoResponse for FeederGatewayError {
+    fn into_response(self) -> Response {
+        // Status mapping mirrors the Python feeder gateway: a `StarknetErrorCode` body is HTTP 400
+        // (verified against the live feeder gateway: BLOCK_NOT_FOUND returns 400, not 404), and only
+        // unhandled internal errors are 500.
+        let (status, starknet_error) = match self {
+            FeederGatewayError::BlockNotFound => (
+                StatusCode::BAD_REQUEST,
+                StarknetError {
+                    code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
+                    message: "Block not found".to_string(),
+                },
+            ),
+            FeederGatewayError::TransactionNotFound => (
+                StatusCode::BAD_REQUEST,
+                StarknetError {
+                    code: StarknetErrorCode::UnknownErrorCode(
+                        "StarknetErrorCode.TRANSACTION_NOT_FOUND".to_string(),
+                    ),
+                    message: "Transaction hash not found".to_string(),
+                },
+            ),
+            FeederGatewayError::MalformedRequest(message) => (
+                StatusCode::BAD_REQUEST,
+                StarknetError {
+                    code: StarknetErrorCode::KnownErrorCode(
+                        KnownStarknetErrorCode::MalformedRequest,
+                    ),
+                    message,
+                },
+            ),
+            FeederGatewayError::Internal => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                StarknetError {
+                    code: StarknetErrorCode::UnknownErrorCode(
+                        "StarknetErrorCode.INTERNAL_ERROR".to_string(),
+                    ),
+                    message: "Internal error".to_string(),
+                },
+            ),
+        };
+        serialize_error(status, &starknet_error)
+    }
+}
+
+/// Serializes a [`StarknetError`] into a byte-parity error response. The message is sanitized like
+/// the Python feeder gateway (see `apollo_http_server`), and the body is serialized with the spaced
+/// Python formatter (not `serde_json::to_vec`) so the error envelope is byte-exact too.
+fn serialize_error(status: StatusCode, error: &StarknetError) -> Response {
+    let quote_re = Regex::new(r#"["`]"#).unwrap(); // " and ` => ' (single quote)
+    // All other non-alphanumeric characters except [:.,[](){}]'_ => ' ' (space).
+    let sanitize_re = Regex::new(r#"[^a-zA-Z0-9 :.,\[\]\(\)\{\}'_]"#).unwrap();
+    let message =
+        sanitize_re.replace_all(&quote_re.replace_all(&error.message, "'"), " ").to_string();
+    let sanitized_error = StarknetError { code: error.code.clone(), message };
+
+    let body = to_python_json(&sanitized_error).expect("StarknetError is serializable");
+    (status, [(header::CONTENT_TYPE, "application/json")], body).into_response()
 }

--- a/crates/apollo_feeder_gateway/src/errors_test.rs
+++ b/crates/apollo_feeder_gateway/src/errors_test.rs
@@ -1,0 +1,52 @@
+use axum::body::to_bytes;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::errors::FeederGatewayError;
+
+async fn response_status_and_body(error: FeederGatewayError) -> (StatusCode, String) {
+    let response = error.into_response();
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, String::from_utf8(body.to_vec()).unwrap())
+}
+
+#[tokio::test]
+async fn block_not_found_envelope_is_byte_parity() {
+    let (status, body) = response_status_and_body(FeederGatewayError::BlockNotFound).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body,
+        r#"{"code": "StarknetErrorCode.BLOCK_NOT_FOUND", "message": "Block not found"}"#
+    );
+}
+
+#[tokio::test]
+async fn transaction_not_found_envelope_is_byte_parity() {
+    let (status, body) = response_status_and_body(FeederGatewayError::TransactionNotFound).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body,
+        r#"{"code": "StarknetErrorCode.TRANSACTION_NOT_FOUND", "message": "Transaction hash not found"}"#
+    );
+}
+
+#[tokio::test]
+async fn internal_envelope_is_byte_parity_and_leaks_nothing() {
+    let (status, body) = response_status_and_body(FeederGatewayError::Internal).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        body,
+        r#"{"code": "StarknetErrorCode.INTERNAL_ERROR", "message": "Internal error"}"#
+    );
+}
+
+#[tokio::test]
+async fn malformed_request_sanitizes_message() {
+    let (status, body) =
+        response_status_and_body(FeederGatewayError::MalformedRequest("bad \"x\" <y>".to_string()))
+            .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    // Quotes become single quotes and disallowed characters (`<`, `>`) become spaces.
+    assert_eq!(body, r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "bad 'x'  y "}"#);
+}

--- a/crates/apollo_feeder_gateway/src/serialization.rs
+++ b/crates/apollo_feeder_gateway/src/serialization.rs
@@ -1,5 +1,7 @@
 use std::io;
 
+use axum::http::header;
+use axum::response::{IntoResponse, Response};
 use serde::Serialize;
 use serde_json::ser::{Formatter, Serializer};
 
@@ -89,4 +91,14 @@ pub fn to_python_json<T: Serialize>(value: &T) -> FgResult<String> {
         tracing::error!(error = %error, "feeder gateway JSON serialization produced invalid UTF-8");
         FeederGatewayError::Internal
     })
+}
+
+/// Builds a feeder gateway JSON `Response` from `value`, serialized with the byte-parity
+/// [`to_python_json`] formatter (never axum `Json<T>`, which is compact). On the unexpected
+/// serialization failure, returns the internal-error envelope.
+pub fn fg_json<T: Serialize>(value: &T) -> Response {
+    match to_python_json(value) {
+        Ok(body) => ([(header::CONTENT_TYPE, "application/json")], body).into_response(),
+        Err(error) => error.into_response(),
+    }
 }


### PR DESCRIPTION
## Goal
Clients depend on the Python feeder gateway's exact error contract: a `{code, message}` body with
specific `StarknetErrorCode` strings and specific HTTP statuses. Before any data endpoint can return
errors compatibly, the feeder gateway needs that envelope. This PR adds it, byte-parity included, and
provides the `fg_json` response helper every handler will use.

## Summary of changes
Expands `FeederGatewayError` (BlockNotFound / TransactionNotFound / MalformedRequest / Internal) with
an `IntoResponse` impl and a `serialize_error` that sanitizes the message (regex copied from
apollo_http_server) and serializes via `to_python_json`. Adds `fg_json`. Tests assert the exact body
bytes and HTTP status for each variant, including message sanitization.

## Key decision points
Mapped every `StarknetErrorCode` body (including BLOCK_NOT_FOUND and TRANSACTION_NOT_FOUND) to HTTP
400, and only unhandled internal errors to 500. This was VERIFIED against the live feeder gateway:
`get_block?blockNumber=999999999` returns HTTP 400 with `{"code": "StarknetErrorCode.BLOCK_NOT_FOUND",
...}`. The plan's "Reference E" claimed 404 for not-found codes; the live service disproves that, so we
follow the live behavior. Serialized error bodies through `to_python_json` rather than
`serde_json::to_vec`, because the envelope must be byte-parity too, not just success responses. Kept
`Internal` detail-free (the source is logged at the construction site) so no internal information
leaks to clients. (Follow-up: the live BLOCK_NOT_FOUND message embeds the block number — "Block number
N was not found." — so full message parity needs the number threaded into the error variant.)