### PR TITLE
apollo_feeder_gateway: CORE serve get_contract_addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "apollo_config",
  "rstest",
  "serde",
+ "starknet_api",
  "validator",
 ]
 

--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -46,6 +46,10 @@ impl FeederGateway {
                 "/feeder_gateway/is_ready",
                 get(|| async { (StatusCode::OK, "FeederGateway is ready") }),
             )
+            .route(
+                "/feeder_gateway/get_contract_addresses",
+                get(crate::handlers::get_contract_addresses),
+            )
             .layer(Extension(self.app_state.clone()))
     }
 }

--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -1,0 +1,15 @@
+use axum::response::Response;
+use axum::Extension;
+
+use crate::reader::AppState;
+use crate::serialization::fg_json;
+
+#[cfg(test)]
+#[path = "handlers_test.rs"]
+mod handlers_test;
+
+/// `GET /feeder_gateway/get_contract_addresses` — returns the configured well-known contract
+/// addresses in the legacy Python feeder gateway JSON shape.
+pub(crate) async fn get_contract_addresses(Extension(state): Extension<AppState>) -> Response {
+    fg_json(&state.config.contract_addresses)
+}

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use apollo_feeder_gateway_config::config::{FeederGatewayConfig, FeederGatewayContractAddresses};
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use starknet_api::core::ContractAddress;
+use tower::util::ServiceExt;
+
+use crate::feeder_gateway::FeederGateway;
+use crate::reader::MockChainDataReader;
+
+#[tokio::test]
+async fn get_contract_addresses_returns_byte_parity_json() {
+    let config = FeederGatewayConfig {
+        contract_addresses: FeederGatewayContractAddresses {
+            starknet: ContractAddress::from(0x1234_u128),
+            gps_statement_verifier: ContractAddress::from(0xabcd_u128),
+        },
+        ..Default::default()
+    };
+    let feeder_gateway = FeederGateway::new(config, Arc::new(MockChainDataReader::new()));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_contract_addresses")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&body[..], br#"{"Starknet": "0x1234", "GpsStatementVerifier": "0xabcd"}"#);
+}

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -3,5 +3,6 @@
 pub mod communication;
 pub mod errors;
 pub mod feeder_gateway;
+pub mod handlers;
 pub mod reader;
 pub mod serialization;

--- a/crates/apollo_feeder_gateway_config/Cargo.toml
+++ b/crates/apollo_feeder_gateway_config/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 apollo_config.workspace = true
 serde.workspace = true
+starknet_api.workspace = true
 validator.workspace = true
 
 [dev-dependencies]

--- a/crates/apollo_feeder_gateway_config/src/config.rs
+++ b/crates/apollo_feeder_gateway_config/src/config.rs
@@ -1,9 +1,15 @@
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr};
 
-use apollo_config::dumping::{ser_optional_param, ser_param, SerializeConfig};
+use apollo_config::dumping::{
+    prepend_sub_config_name,
+    ser_optional_param,
+    ser_param,
+    SerializeConfig,
+};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
+use starknet_api::core::ContractAddress;
 use validator::Validate;
 
 const FEEDER_GATEWAY_PORT: u16 = 8082; // configurable; intentionally NOT legacy 9713.
@@ -22,6 +28,36 @@ pub enum ReadBackend {
     Remote,
 }
 
+/// The well-known contract addresses served by `get_contract_addresses`. The field names use the
+/// Python feeder gateway's JSON key casing, since this struct is serialized directly into that
+/// endpoint's response.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Validate, PartialEq)]
+pub struct FeederGatewayContractAddresses {
+    #[serde(rename = "Starknet")]
+    pub starknet: ContractAddress,
+    #[serde(rename = "GpsStatementVerifier")]
+    pub gps_statement_verifier: ContractAddress,
+}
+
+impl SerializeConfig for FeederGatewayContractAddresses {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
+            ser_param(
+                "starknet",
+                &self.starknet,
+                "The Starknet core contract address.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "gps_statement_verifier",
+                &self.gps_statement_verifier,
+                "The GPS statement verifier contract address.",
+                ParamPrivacyInput::Public,
+            ),
+        ])
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
 pub struct FeederGatewayConfig {
     pub ip: IpAddr,
@@ -30,6 +66,8 @@ pub struct FeederGatewayConfig {
     /// Maximum number of concurrent blocking reads. When unset (or 0), derived at runtime as ~1.5x
     /// the available CPUs.
     pub read_pool_size: Option<usize>,
+    #[validate(nested)]
+    pub contract_addresses: FeederGatewayContractAddresses,
 }
 
 impl Default for FeederGatewayConfig {
@@ -39,6 +77,7 @@ impl Default for FeederGatewayConfig {
             port: FEEDER_GATEWAY_PORT,
             read_backend: ReadBackend::default(),
             read_pool_size: None,
+            contract_addresses: FeederGatewayContractAddresses::default(),
         }
     }
 }
@@ -69,6 +108,7 @@ impl SerializeConfig for FeederGatewayConfig {
              CPUs at runtime.",
             ParamPrivacyInput::Public,
         ));
+        dump.extend(prepend_sub_config_name(self.contract_addresses.dump(), "contract_addresses"));
         dump
     }
 }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2954,6 +2954,16 @@
     "privacy": "TemporaryValue",
     "value": false
   },
+  "feeder_gateway_config.contract_addresses.gps_statement_verifier": {
+    "description": "The GPS statement verifier contract address.",
+    "privacy": "Public",
+    "value": "0x0"
+  },
+  "feeder_gateway_config.contract_addresses.starknet": {
+    "description": "The Starknet core contract address.",
+    "privacy": "Public",
+    "value": "0x0"
+  },
   "feeder_gateway_config.ip": {
     "description": "The feeder gateway ip.",
     "privacy": "Public",


### PR DESCRIPTION
## Goal
`get_contract_addresses` is the simplest real feeder gateway endpoint (a static config-driven
response, no chain reads), which makes it the right first data endpoint: it exercises the whole
serve-a-byte-parity-JSON-response path — handler, `AppState`, `Extension`, the Python serializer —
end to end, without depending on the chain-read conversions still being built. It is also needed by
the pipeline-prover integration.

## Summary of changes
Adds a `FeederGatewayContractAddresses` config struct (Starknet / GpsStatementVerifier) and the
`get_contract_addresses` handler + route; adds an end-to-end test that drives the route through the
router and asserts the exact response bytes. Regenerates config_schema.json and deployment configs.

## Key decision points
Made the addresses config-driven rather than hard-coded, because they differ per network (mainnet vs
testnet vs integration). The response struct uses serde `rename` to emit the Python JSON key casing
("Starknet"/"GpsStatementVerifier"), and the handler serializes through `fg_json` — never axum
`Json<T>`, which is compact and would break byte parity. Tested through the full router (not just the
handler fn) so the `Extension` wiring and route path are covered, establishing the pattern later
endpoint tests follow.