### PR TITLE
apollo_feeder_gateway: CORE serve get_block_hash_by_id

### DIFF
--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -50,6 +50,10 @@ impl FeederGateway {
                 "/feeder_gateway/get_contract_addresses",
                 get(crate::handlers::get_contract_addresses),
             )
+            .route(
+                "/feeder_gateway/get_block_hash_by_id",
+                get(crate::handlers::get_block_hash_by_id),
+            )
             .layer(Extension(self.app_state.clone()))
     }
 }

--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
+
+use axum::extract::Query;
 use axum::response::Response;
 use axum::Extension;
+use starknet_api::block::BlockNumber;
 
-use crate::reader::AppState;
+use crate::errors::FeederGatewayError;
+use crate::reader::{AppState, FgResult};
 use crate::serialization::fg_json;
 
 #[cfg(test)]
@@ -12,4 +17,32 @@ mod handlers_test;
 /// addresses in the legacy Python feeder gateway JSON shape.
 pub(crate) async fn get_contract_addresses(Extension(state): Extension<AppState>) -> Response {
     fg_json(&state.config.contract_addresses)
+}
+
+/// `GET /feeder_gateway/get_block_hash_by_id?blockId=<n>` — returns the block hash of the given
+/// block, or the legacy error envelope if it is not synced. The query parameter is named `blockId`
+/// to match the Python feeder gateway (verified against the live service).
+pub(crate) async fn get_block_hash_by_id(
+    Extension(state): Extension<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Response, FeederGatewayError> {
+    let block_number = parse_block_id(&params)?;
+    let block_hash = state.reader.block_hash(block_number).await?;
+    Ok(fg_json(&block_hash))
+}
+
+/// Parses the required `blockId` query parameter as a block number. Treats the request as
+/// adversarial: a missing or non-`u64` value yields a `MalformedRequest` (400) rather than a panic,
+/// and `u64` parsing caps the value inherently.
+///
+/// TODO(feeder_gateway): `blockId` also accepts `latest`/`pending`/a block hash on the Python feeder
+/// gateway; only the numeric form is handled for now.
+fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
+    let raw = params
+        .get("blockId")
+        .ok_or_else(|| FeederGatewayError::MalformedRequest("missing blockId".to_string()))?;
+    let block_number = raw
+        .parse::<u64>()
+        .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockId: {raw}")))?;
+    Ok(BlockNumber(block_number))
 }

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use apollo_feeder_gateway_config::config::{FeederGatewayConfig, FeederGatewayContractAddresses};
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
+use starknet_api::block::BlockHash;
 use starknet_api::core::ContractAddress;
+use starknet_api::hash::StarkHash;
 use tower::util::ServiceExt;
 
 use crate::feeder_gateway::FeederGateway;
@@ -34,4 +36,45 @@ async fn get_contract_addresses_returns_byte_parity_json() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     assert_eq!(&body[..], br#"{"Starknet": "0x1234", "GpsStatementVerifier": "0xabcd"}"#);
+}
+
+#[tokio::test]
+async fn get_block_hash_by_id_returns_byte_parity_hash() {
+    let mut reader = MockChainDataReader::new();
+    reader.expect_block_hash().returning(|_| Ok(BlockHash(StarkHash::from(0x1234_u128))));
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_hash_by_id?blockId=5")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&body[..], br#""0x1234""#);
+}
+
+#[tokio::test]
+async fn get_block_hash_by_id_missing_param_is_bad_request() {
+    let feeder_gateway =
+        FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_hash_by_id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }

--- a/crates/apollo_feeder_gateway/src/reader.rs
+++ b/crates/apollo_feeder_gateway/src/reader.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use apollo_feeder_gateway_config::config::FeederGatewayConfig;
 use async_trait::async_trait;
-use starknet_api::block::BlockHeader;
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
 
 use crate::errors::FeederGatewayError;
 
@@ -23,6 +23,10 @@ pub type FgResult<T> = Result<T, FeederGatewayError>;
 #[async_trait]
 pub trait ChainDataReader: Send + Sync + 'static {
     async fn latest_block_header(&self) -> FgResult<Option<BlockHeader>>;
+
+    /// The block hash of `block_number`, or [`FeederGatewayError::BlockNotFound`] if no such block
+    /// has been synced.
+    async fn block_hash(&self, block_number: BlockNumber) -> FgResult<BlockHash>;
 }
 
 /// Shared state handed to every axum handler via `Extension`.

--- a/crates/apollo_feeder_gateway/src/reader/colocated.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use apollo_storage::header::HeaderStorageReader;
 use apollo_storage::StorageReader;
 use async_trait::async_trait;
-use starknet_api::block::BlockHeader;
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
 
+use crate::errors::FeederGatewayError;
 use crate::reader::executor::ReadExecutor;
 use crate::reader::{internal_error, ChainDataReader, FgResult};
 
@@ -45,6 +46,18 @@ impl ChainDataReader for ColocatedStorageReader {
                     return Ok(None);
                 };
                 txn.get_block_header(latest_block_number).map_err(internal_error)
+            })
+            .await?
+    }
+
+    async fn block_hash(&self, block_number: BlockNumber) -> FgResult<BlockHash> {
+        let storage_reader = self.storage_reader.clone();
+        self.executor
+            .run(move || {
+                let txn = storage_reader.begin_ro_txn().map_err(internal_error)?;
+                let header = txn.get_block_header(block_number).map_err(internal_error)?;
+                // Read the hash from the synced header (NOT the batcher-only block_hashes table).
+                header.map(|header| header.block_hash).ok_or(FeederGatewayError::BlockNotFound)
             })
             .await?
     }

--- a/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
@@ -4,6 +4,7 @@ use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
 use starknet_api::block::{BlockHeader, BlockNumber};
 
+use crate::errors::FeederGatewayError;
 use crate::reader::colocated::ColocatedStorageReader;
 use crate::reader::executor::ReadExecutor;
 use crate::reader::ChainDataReader;
@@ -35,4 +36,32 @@ async fn latest_block_header_returns_appended_header() {
     let reader = ColocatedStorageReader::new(storage_reader, executor());
 
     assert_eq!(reader.latest_block_header().await.unwrap(), Some(header));
+}
+
+#[tokio::test]
+async fn block_hash_returns_appended_block_hash() {
+    let ((storage_reader, mut writer), _temp_dir) = get_test_storage();
+    let header = BlockHeader::default();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_header(BlockNumber(0), &header)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    let reader = ColocatedStorageReader::new(storage_reader, executor());
+
+    assert_eq!(reader.block_hash(BlockNumber(0)).await.unwrap(), header.block_hash);
+}
+
+#[tokio::test]
+async fn block_hash_missing_block_is_block_not_found() {
+    let ((storage_reader, _writer), _temp_dir) = get_test_storage();
+    let reader = ColocatedStorageReader::new(storage_reader, executor());
+
+    assert!(matches!(
+        reader.block_hash(BlockNumber(7)).await,
+        Err(FeederGatewayError::BlockNotFound)
+    ));
 }

--- a/crates/apollo_feeder_gateway/src/reader/remote.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote.rs
@@ -1,7 +1,9 @@
-use apollo_state_sync_types::communication::SharedStateSyncClient;
+use apollo_state_sync_types::communication::{SharedStateSyncClient, StateSyncClientError};
+use apollo_state_sync_types::errors::StateSyncError;
 use async_trait::async_trait;
-use starknet_api::block::BlockHeader;
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
 
+use crate::errors::FeederGatewayError;
 use crate::reader::{internal_error, ChainDataReader, FgResult};
 
 /// A [`ChainDataReader`] for different-pod/node deployments: it delegates every read to the
@@ -21,5 +23,20 @@ impl RemoteChainDataReader {
 impl ChainDataReader for RemoteChainDataReader {
     async fn latest_block_header(&self) -> FgResult<Option<BlockHeader>> {
         self.client.get_latest_block_header().await.map_err(internal_error)
+    }
+
+    async fn block_hash(&self, block_number: BlockNumber) -> FgResult<BlockHash> {
+        self.client.get_block_hash(block_number).await.map_err(map_client_error)
+    }
+}
+
+/// Maps a state-sync client error to a feeder gateway error, preserving the not-found case (so it
+/// becomes a 404) and treating everything else as an internal error.
+fn map_client_error(error: StateSyncClientError) -> FeederGatewayError {
+    match error {
+        StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(_)) => {
+            FeederGatewayError::BlockNotFound
+        }
+        other => internal_error(other),
     }
 }


### PR DESCRIPTION
## Goal
Begin serving real chain-data endpoints over the co-located read backend, starting with one that is
fully byte-parity-verifiable today: get_block_hash_by_id returns a bare block hash, so it has no
transaction payload and is unaffected by the transaction-serialization blocker that gates get_block.
It establishes the parameterized-read path (parse a block id, read storage, map not-found to the
legacy error envelope) that the remaining read endpoints reuse.

## Summary of changes
Adds a `block_hash(block_number) -> FgResult<BlockHash>` method to ChainDataReader (both backends: the
co-located reader reads the synced header's hash; the remote reader delegates to the state-sync client
and maps its BlockNotFound). Adds the get_block_hash_by_id handler + route reading the `blockId` query
parameter, with a never-panic parser, and tests for the co-located read (hit and miss), the byte-parity
response, and the malformed-request 400.

## Key decision points
Named the query parameter `blockId` (not `blockNumber`) and confirmed the bare-hash-string response,
both VERIFIED against the live feeder gateway (`get_block_hash_by_id?blockId=1` returns
`"0x78b6..."`; `blockNumber` is rejected as a malformed request). Only the numeric `blockId` form is
handled for now — `latest`/`pending`/hash forms are a documented follow-up. Read the hash from the
synced header (header.block_hash), NOT the batcher-only block_hashes table, which would be empty for a
co-located feeder gateway re-serving synced data. The reader owns the not-found mapping so handlers
stay trivial.