### PR TITLE
apollo_feeder_gateway: CORE serve get_public_key

### DIFF
--- a/crates/apollo_feeder_gateway/src/errors.rs
+++ b/crates/apollo_feeder_gateway/src/errors.rs
@@ -41,8 +41,8 @@ pub enum FeederGatewayError {
 impl IntoResponse for FeederGatewayError {
     fn into_response(self) -> Response {
         // Status mapping mirrors the Python feeder gateway: a `StarknetErrorCode` body is HTTP 400
-        // (verified against the live feeder gateway: BLOCK_NOT_FOUND returns 400, not 404), and only
-        // unhandled internal errors are 500.
+        // (verified against the live feeder gateway: BLOCK_NOT_FOUND returns 400, not 404), and
+        // only unhandled internal errors are 500.
         let (status, starknet_error) = match self {
             FeederGatewayError::BlockNotFound => (
                 StatusCode::BAD_REQUEST,

--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -54,6 +54,7 @@ impl FeederGateway {
                 "/feeder_gateway/get_block_hash_by_id",
                 get(crate::handlers::get_block_hash_by_id),
             )
+            .route("/feeder_gateway/get_public_key", get(crate::handlers::get_public_key))
             .layer(Extension(self.app_state.clone()))
     }
 }

--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -19,6 +19,12 @@ pub(crate) async fn get_contract_addresses(Extension(state): Extension<AppState>
     fg_json(&state.config.contract_addresses)
 }
 
+/// `GET /feeder_gateway/get_public_key` — returns the configured sequencer public key as a bare
+/// felt, matching the Python feeder gateway (verified against the live service).
+pub(crate) async fn get_public_key(Extension(state): Extension<AppState>) -> Response {
+    fg_json(&state.config.sequencer_public_key)
+}
+
 /// `GET /feeder_gateway/get_block_hash_by_id?blockId=<n>` — returns the block hash of the given
 /// block, or the legacy error envelope if it is not synced. The query parameter is named `blockId`
 /// to match the Python feeder gateway (verified against the live service).
@@ -35,8 +41,8 @@ pub(crate) async fn get_block_hash_by_id(
 /// adversarial: a missing or non-`u64` value yields a `MalformedRequest` (400) rather than a panic,
 /// and `u64` parsing caps the value inherently.
 ///
-/// TODO(feeder_gateway): `blockId` also accepts `latest`/`pending`/a block hash on the Python feeder
-/// gateway; only the numeric form is handled for now.
+/// TODO(feeder_gateway): `blockId` also accepts `latest`/`pending`/a block hash on the Python
+/// feeder gateway; only the numeric form is handled for now.
 fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
     let raw = params
         .get("blockId")

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -4,7 +4,8 @@ use apollo_feeder_gateway_config::config::{FeederGatewayConfig, FeederGatewayCon
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use starknet_api::block::BlockHash;
-use starknet_api::core::ContractAddress;
+use starknet_api::core::{ContractAddress, SequencerPublicKey};
+use starknet_api::crypto::utils::PublicKey;
 use starknet_api::hash::StarkHash;
 use tower::util::ServiceExt;
 
@@ -36,6 +37,28 @@ async fn get_contract_addresses_returns_byte_parity_json() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     assert_eq!(&body[..], br#"{"Starknet": "0x1234", "GpsStatementVerifier": "0xabcd"}"#);
+}
+
+#[tokio::test]
+async fn get_public_key_returns_bare_felt() {
+    let config = FeederGatewayConfig {
+        sequencer_public_key: SequencerPublicKey(PublicKey(StarkHash::from(0x1252_u128))),
+        ..Default::default()
+    };
+    let feeder_gateway = FeederGateway::new(config, Arc::new(MockChainDataReader::new()));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder().uri("/feeder_gateway/get_public_key").body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    // The live feeder gateway serves the public key as a bare quoted felt (e.g. "0x1252b6...").
+    assert_eq!(&body[..], br#""0x1252""#);
 }
 
 #[tokio::test]

--- a/crates/apollo_feeder_gateway_config/src/config.rs
+++ b/crates/apollo_feeder_gateway_config/src/config.rs
@@ -9,7 +9,7 @@ use apollo_config::dumping::{
 };
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
-use starknet_api::core::ContractAddress;
+use starknet_api::core::{ContractAddress, SequencerPublicKey};
 use validator::Validate;
 
 const FEEDER_GATEWAY_PORT: u16 = 8082; // configurable; intentionally NOT legacy 9713.
@@ -68,6 +68,8 @@ pub struct FeederGatewayConfig {
     pub read_pool_size: Option<usize>,
     #[validate(nested)]
     pub contract_addresses: FeederGatewayContractAddresses,
+    /// The sequencer public key served by `get_public_key` (a bare felt). Network-specific.
+    pub sequencer_public_key: SequencerPublicKey,
 }
 
 impl Default for FeederGatewayConfig {
@@ -78,6 +80,7 @@ impl Default for FeederGatewayConfig {
             read_backend: ReadBackend::default(),
             read_pool_size: None,
             contract_addresses: FeederGatewayContractAddresses::default(),
+            sequencer_public_key: SequencerPublicKey::default(),
         }
     }
 }
@@ -109,6 +112,12 @@ impl SerializeConfig for FeederGatewayConfig {
             ParamPrivacyInput::Public,
         ));
         dump.extend(prepend_sub_config_name(self.contract_addresses.dump(), "contract_addresses"));
+        dump.extend([ser_param(
+            "sequencer_public_key",
+            &self.sequencer_public_key,
+            "The sequencer public key served by get_public_key.",
+            ParamPrivacyInput::Public,
+        )]);
         dump
     }
 }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2989,6 +2989,11 @@
     "privacy": "TemporaryValue",
     "value": true
   },
+  "feeder_gateway_config.sequencer_public_key": {
+    "description": "The sequencer public key served by get_public_key.",
+    "privacy": "Public",
+    "value": "0x0"
+  },
   "gateway_config.#is_none": {
     "description": "Flag for an optional field.",
     "privacy": "TemporaryValue",


### PR DESCRIPTION
## Goal
Add another live, byte-parity-verified feeder gateway endpoint. get_public_key is the cleanest
remaining one: the live service returns the sequencer public key as a bare felt, with no chain read
and no transaction payload, so it is unaffected by the transaction-serialization blocker and works
identically on both read backends (it reads only config).

## Summary of changes
Adds a `sequencer_public_key: SequencerPublicKey` field to FeederGatewayConfig (default 0x0, dumped to
the config schema; deployment configs regenerated) and the get_public_key handler + route, which
serializes it via fg_json. Adds an end-to-end byte-parity test asserting the bare-felt response.

## Key decision points
Sourced the key from config rather than from synced signature data: it is network-specific and
constant, config is the simplest model, and it keeps the endpoint backend-agnostic (no reader method,
so no remote-backend gap). Deriving it from the synced BlockSignature instead is a documented
follow-up. Used `SequencerPublicKey` (which serializes as a bare felt) so the response matches the
live service exactly (verified: `get_public_key` returns `"0x1252b6..."`), and confirmed the four
state-read endpoints (get_storage_at/get_nonce/get_class_hash_at, plus get_transaction_receipt) are
DEPRECATED on the live feeder gateway, so they are intentionally not implemented.