### PR TITLE
apollo_feeder_gateway: CORE serve get_signature

### DIFF
--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -55,6 +55,7 @@ impl FeederGateway {
                 get(crate::handlers::get_block_hash_by_id),
             )
             .route("/feeder_gateway/get_public_key", get(crate::handlers::get_public_key))
+            .route("/feeder_gateway/get_signature", get(crate::handlers::get_signature))
             .layer(Extension(self.app_state.clone()))
     }
 }

--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -6,6 +6,7 @@ use axum::Extension;
 use starknet_api::block::BlockNumber;
 
 use crate::errors::FeederGatewayError;
+use crate::objects::FeederGatewaySignature;
 use crate::reader::{AppState, FgResult};
 use crate::serialization::fg_json;
 
@@ -23,6 +24,17 @@ pub(crate) async fn get_contract_addresses(Extension(state): Extension<AppState>
 /// felt, matching the Python feeder gateway (verified against the live service).
 pub(crate) async fn get_public_key(Extension(state): Extension<AppState>) -> Response {
     fg_json(&state.config.sequencer_public_key)
+}
+
+/// `GET /feeder_gateway/get_signature?blockNumber=<n>` — returns the block hash and `[r, s]` block
+/// signature (verified against the live service; the parameter is `blockNumber` for this endpoint).
+pub(crate) async fn get_signature(
+    Extension(state): Extension<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Response, FeederGatewayError> {
+    let block_number = parse_block_number(&params)?;
+    let (block_hash, signature) = state.reader.block_signature(block_number).await?;
+    Ok(fg_json(&FeederGatewaySignature { block_hash, signature: [signature.0.r, signature.0.s] }))
 }
 
 /// `GET /feeder_gateway/get_block_hash_by_id?blockId=<n>` — returns the block hash of the given
@@ -50,5 +62,17 @@ fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
     let block_number = raw
         .parse::<u64>()
         .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockId: {raw}")))?;
+    Ok(BlockNumber(block_number))
+}
+
+/// Parses the required `blockNumber` query parameter as a block number (never panics on bad input;
+/// `u64` parsing caps the value). Some legacy endpoints use `blockNumber` rather than `blockId`.
+fn parse_block_number(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
+    let raw = params
+        .get("blockNumber")
+        .ok_or_else(|| FeederGatewayError::MalformedRequest("missing blockNumber".to_string()))?;
+    let block_number = raw
+        .parse::<u64>()
+        .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockNumber: {raw}")))?;
     Ok(BlockNumber(block_number))
 }

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use apollo_feeder_gateway_config::config::{FeederGatewayConfig, FeederGatewayContractAddresses};
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
-use starknet_api::block::BlockHash;
+use starknet_api::block::{BlockHash, BlockSignature};
 use starknet_api::core::{ContractAddress, SequencerPublicKey};
-use starknet_api::crypto::utils::PublicKey;
+use starknet_api::crypto::utils::{PublicKey, Signature};
 use starknet_api::hash::StarkHash;
 use tower::util::ServiceExt;
 
@@ -59,6 +59,37 @@ async fn get_public_key_returns_bare_felt() {
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     // The live feeder gateway serves the public key as a bare quoted felt (e.g. "0x1252b6...").
     assert_eq!(&body[..], br#""0x1252""#);
+}
+
+#[tokio::test]
+async fn get_signature_returns_byte_parity_json() {
+    let mut reader = MockChainDataReader::new();
+    reader.expect_block_signature().returning(|_| {
+        Ok((
+            BlockHash(StarkHash::from(0x1_u128)),
+            BlockSignature(Signature {
+                r: StarkHash::from(0x2_u128),
+                s: StarkHash::from(0x3_u128),
+            }),
+        ))
+    });
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_signature?blockNumber=1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    // Matches the live shape: {"block_hash": "0x..", "signature": ["0x..", "0x.."]}.
+    assert_eq!(&body[..], br#"{"block_hash": "0x1", "signature": ["0x2", "0x3"]}"#);
 }
 
 #[tokio::test]

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -4,5 +4,6 @@ pub mod communication;
 pub mod errors;
 pub mod feeder_gateway;
 pub mod handlers;
+pub mod objects;
 pub mod reader;
 pub mod serialization;

--- a/crates/apollo_feeder_gateway/src/objects.rs
+++ b/crates/apollo_feeder_gateway/src/objects.rs
@@ -1,0 +1,13 @@
+//! Feeder gateway response wire structs (serialized via `to_python_json` to match the legacy
+//! Python feeder gateway byte-for-byte).
+
+use serde::Serialize;
+use starknet_api::block::BlockHash;
+use starknet_api::hash::StarkHash;
+
+/// The `get_signature` response: the block hash and the `[r, s]` block signature.
+#[derive(Debug, Serialize)]
+pub(crate) struct FeederGatewaySignature {
+    pub block_hash: BlockHash,
+    pub signature: [StarkHash; 2],
+}

--- a/crates/apollo_feeder_gateway/src/reader.rs
+++ b/crates/apollo_feeder_gateway/src/reader.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use apollo_feeder_gateway_config::config::FeederGatewayConfig;
 use async_trait::async_trait;
-use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 
 use crate::errors::FeederGatewayError;
 
@@ -27,6 +27,13 @@ pub trait ChainDataReader: Send + Sync + 'static {
     /// The block hash of `block_number`, or [`FeederGatewayError::BlockNotFound`] if no such block
     /// has been synced.
     async fn block_hash(&self, block_number: BlockNumber) -> FgResult<BlockHash>;
+
+    /// The block hash and signature of `block_number`, or [`FeederGatewayError::BlockNotFound`] if
+    /// no such block (or its signature) has been synced.
+    async fn block_signature(
+        &self,
+        block_number: BlockNumber,
+    ) -> FgResult<(BlockHash, BlockSignature)>;
 }
 
 /// Shared state handed to every axum handler via `Extension`.

--- a/crates/apollo_feeder_gateway/src/reader/colocated.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use apollo_storage::header::HeaderStorageReader;
 use apollo_storage::StorageReader;
 use async_trait::async_trait;
-use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 
 use crate::errors::FeederGatewayError;
 use crate::reader::executor::ReadExecutor;
@@ -58,6 +58,28 @@ impl ChainDataReader for ColocatedStorageReader {
                 let header = txn.get_block_header(block_number).map_err(internal_error)?;
                 // Read the hash from the synced header (NOT the batcher-only block_hashes table).
                 header.map(|header| header.block_hash).ok_or(FeederGatewayError::BlockNotFound)
+            })
+            .await?
+    }
+
+    async fn block_signature(
+        &self,
+        block_number: BlockNumber,
+    ) -> FgResult<(BlockHash, BlockSignature)> {
+        let storage_reader = self.storage_reader.clone();
+        self.executor
+            .run(move || {
+                let txn = storage_reader.begin_ro_txn().map_err(internal_error)?;
+                let block_hash = txn
+                    .get_block_header(block_number)
+                    .map_err(internal_error)?
+                    .ok_or(FeederGatewayError::BlockNotFound)?
+                    .block_hash;
+                let signature = txn
+                    .get_block_signature(block_number)
+                    .map_err(internal_error)?
+                    .ok_or(FeederGatewayError::BlockNotFound)?;
+                Ok((block_hash, signature))
             })
             .await?
     }

--- a/crates/apollo_feeder_gateway/src/reader/remote.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote.rs
@@ -1,7 +1,7 @@
 use apollo_state_sync_types::communication::{SharedStateSyncClient, StateSyncClientError};
 use apollo_state_sync_types::errors::StateSyncError;
 use async_trait::async_trait;
-use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 
 use crate::errors::FeederGatewayError;
 use crate::reader::{internal_error, ChainDataReader, FgResult};
@@ -28,10 +28,22 @@ impl ChainDataReader for RemoteChainDataReader {
     async fn block_hash(&self, block_number: BlockNumber) -> FgResult<BlockHash> {
         self.client.get_block_hash(block_number).await.map_err(map_client_error)
     }
+
+    async fn block_signature(
+        &self,
+        _block_number: BlockNumber,
+    ) -> FgResult<(BlockHash, BlockSignature)> {
+        // The state-sync client has no block-signature read yet (it needs a Reference-C extension:
+        // a GetBlockSignature request/response variant + handler). The remote backend is
+        // default-off (the node defaults to co-located), so this is a documented gap, not a
+        // default code path.
+        tracing::error!("get_signature is not yet supported on the remote feeder gateway backend");
+        Err(FeederGatewayError::Internal)
+    }
 }
 
 /// Maps a state-sync client error to a feeder gateway error, preserving the not-found case (so it
-/// becomes a 404) and treating everything else as an internal error.
+/// becomes the legacy BlockNotFound envelope, HTTP 400) and treating everything else as internal.
 fn map_client_error(error: StateSyncClientError) -> FeederGatewayError {
     match error {
         StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(_)) => {


### PR DESCRIPTION
Add the get_signature endpoint, another live, byte-parity-verified read. It returns the block hash
and the [r, s] block signature with no transaction payload, so it is unaffected by the
transaction-serialization blocker and is implementable on the co-located backend today.

Adds a `FeederGatewaySignature` wire struct ({block_hash, signature: [felt; 2]}), a
`block_signature(block_number) -> (BlockHash, BlockSignature)` method on ChainDataReader, the
co-located implementation (reads the synced header's hash + `get_block_signature` from storage,
mapping a missing block/signature to the legacy not-found envelope), the get_signature handler +
route, and an end-to-end byte-parity test of the `{"block_hash": ..., "signature": [...]}` shape.

Modeled the response as a minimal `{block_hash, signature: [r, s]}` struct matching the live service
(verified: `get_signature?blockNumber=1` returns exactly that), rather than the richer
`BlockSignatureData` enum the client carries, since the live wire shape is the two-field form. Used
the `blockNumber` query parameter (verified accepted by the live endpoint; note other endpoints like
get_block_hash_by_id use `blockId` — the legacy parameter names are per-endpoint). The remote backend
returns a documented internal error because the state-sync client has no signature read yet (it needs
a Reference-C `GetBlockSignature` extension); this is acceptable because the remote backend is
default-off (the node defaults to co-located), so it is not a default code path.