### PR TITLE
apollo_state_sync,apollo_gateway: CORE add GetBlockSignature and GetBlockNumberByHash reads

### DIFF
--- a/crates/apollo_gateway/src/sync_state_reader.rs
+++ b/crates/apollo_gateway/src/sync_state_reader.rs
@@ -23,7 +23,7 @@ use blockifier::state::errors::StateError;
 use blockifier::state::global_cache::CompiledClasses;
 use blockifier::state::state_api::{StateReader as BlockifierStateReader, StateResult};
 use blockifier::state::state_reader_and_contract_manager::FetchCompiledClasses;
-use starknet_api::block::{BlockHash, BlockHeader, BlockInfo, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHeader, BlockInfo, BlockNumber, BlockSignature};
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::state::{SierraContractClass, StorageKey};
@@ -241,6 +241,20 @@ impl StateSyncClient for SharedStateSyncClientMetricWrapper {
     }
     async fn get_block_hash(&self, block_number: BlockNumber) -> StateSyncClientResult<BlockHash> {
         self.run_command_with_metrics(self.state_sync_client.get_block_hash(block_number)).await
+    }
+    async fn get_block_signature(
+        &self,
+        block_number: BlockNumber,
+    ) -> StateSyncClientResult<BlockSignature> {
+        self.run_command_with_metrics(self.state_sync_client.get_block_signature(block_number))
+            .await
+    }
+    async fn get_block_number_by_hash(
+        &self,
+        block_hash: BlockHash,
+    ) -> StateSyncClientResult<Option<BlockNumber>> {
+        self.run_command_with_metrics(self.state_sync_client.get_block_number_by_hash(block_hash))
+            .await
     }
     async fn add_new_block(&self, sync_block: SyncBlock) -> StateSyncClientResult<()> {
         self.run_command_with_metrics(self.state_sync_client.add_new_block(sync_block)).await

--- a/crates/apollo_state_sync/src/lib.rs
+++ b/crates/apollo_state_sync/src/lib.rs
@@ -22,7 +22,7 @@ use apollo_storage::{StorageReader, StorageTxn};
 use async_trait::async_trait;
 use futures::channel::mpsc::{channel, Sender};
 use futures::SinkExt;
-use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 use starknet_api::block_hash::block_hash_calculator::BlockHeaderCommitments;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce, BLOCK_HASH_TABLE_ADDRESS};
 use starknet_api::state::{StateNumber, StorageKey};
@@ -119,6 +119,14 @@ impl ComponentRequestHandler<StateSyncRequest, StateSyncResponse> for StateSync 
             }
             StateSyncRequest::GetBlockHash(block_number) => {
                 StateSyncResponse::GetBlockHash(self.get_block_hash(block_number).await)
+            }
+            StateSyncRequest::GetBlockSignature(block_number) => {
+                StateSyncResponse::GetBlockSignature(self.get_block_signature(block_number).await)
+            }
+            StateSyncRequest::GetBlockNumberByHash(block_hash) => {
+                StateSyncResponse::GetBlockNumberByHash(
+                    self.get_block_number_by_hash(block_hash).await,
+                )
             }
             StateSyncRequest::AddNewBlock(sync_block) => StateSyncResponse::AddNewBlock(
                 self.new_block_sender.send(*sync_block).await.map_err(StateSyncError::from),
@@ -218,6 +226,23 @@ impl StateSync {
             }
             (None, None) => Err(StateSyncError::BlockNotFound(block_number)),
         }
+    }
+
+    async fn get_block_signature(
+        &self,
+        block_number: BlockNumber,
+    ) -> StateSyncResult<BlockSignature> {
+        self.storage_reader
+            .begin_ro_txn()?
+            .get_block_signature(block_number)?
+            .ok_or(StateSyncError::BlockNotFound(block_number))
+    }
+
+    async fn get_block_number_by_hash(
+        &self,
+        block_hash: BlockHash,
+    ) -> StateSyncResult<Option<BlockNumber>> {
+        Ok(self.storage_reader.begin_ro_txn()?.get_block_number_by_hash(&block_hash)?)
     }
 
     async fn get_storage_at(

--- a/crates/apollo_state_sync/src/test.rs
+++ b/crates/apollo_state_sync/src/test.rs
@@ -16,7 +16,7 @@ use futures::channel::mpsc::channel;
 use indexmap::IndexMap;
 use mockall::predicate;
 use rand::Rng;
-use starknet_api::block::{Block, BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{Block, BlockHash, BlockHeader, BlockNumber, BlockSignature};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkHash;
 use starknet_api::state::{StorageKey, ThinStateDiff};
@@ -121,6 +121,92 @@ async fn test_get_block_hash() {
     };
 
     assert_eq!(block_hash, expected_header.block_hash);
+}
+
+#[tokio::test]
+async fn test_get_block_signature() {
+    let (mut state_sync, mut storage_writer) = setup();
+
+    let Block { header: expected_header, .. } = get_test_block(1, None, None, None);
+    let block_number = expected_header.block_header_without_hash.block_number;
+    let expected_signature = BlockSignature::get_test_instance(&mut get_rng());
+
+    storage_writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_header(block_number, &expected_header)
+        .unwrap()
+        .append_block_signature(block_number, &expected_signature)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    let response =
+        state_sync.handle_request(StateSyncRequest::GetBlockSignature(block_number)).await;
+    let StateSyncResponse::GetBlockSignature(Ok(signature)) = response else {
+        panic!("Expected StateSyncResponse::GetBlockSignature::Ok(_), but got {response:?}");
+    };
+
+    assert_eq!(signature, expected_signature);
+}
+
+#[tokio::test]
+async fn test_get_block_signature_of_unsynced_block_returns_block_not_found() {
+    let (mut state_sync, _storage_writer) = setup();
+
+    let block_number = BlockNumber(0);
+    let response =
+        state_sync.handle_request(StateSyncRequest::GetBlockSignature(block_number)).await;
+    let StateSyncResponse::GetBlockSignature(Err(StateSyncError::BlockNotFound(
+        not_found_block_number,
+    ))) = response
+    else {
+        panic!(
+            "Expected StateSyncResponse::GetBlockSignature::Err(BlockNotFound(_)), but got \
+             {response:?}"
+        );
+    };
+
+    assert_eq!(not_found_block_number, block_number);
+}
+
+#[tokio::test]
+async fn test_get_block_number_by_hash() {
+    let (mut state_sync, mut storage_writer) = setup();
+
+    let Block { header: expected_header, .. } = get_test_block(1, None, None, None);
+    let block_number = expected_header.block_header_without_hash.block_number;
+
+    storage_writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_header(block_number, &expected_header)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    let response = state_sync
+        .handle_request(StateSyncRequest::GetBlockNumberByHash(expected_header.block_hash))
+        .await;
+    let StateSyncResponse::GetBlockNumberByHash(Ok(Some(found_block_number))) = response else {
+        panic!(
+            "Expected StateSyncResponse::GetBlockNumberByHash::Ok(Some(_)), but got {response:?}"
+        );
+    };
+
+    assert_eq!(found_block_number, block_number);
+}
+
+#[tokio::test]
+async fn test_get_block_number_by_unknown_hash_returns_none() {
+    let (mut state_sync, _storage_writer) = setup();
+
+    let unknown_block_hash = BlockHash(StarkHash::from_hex_unchecked("0x1234"));
+    let response =
+        state_sync.handle_request(StateSyncRequest::GetBlockNumberByHash(unknown_block_hash)).await;
+    let StateSyncResponse::GetBlockNumberByHash(Ok(None)) = response else {
+        panic!("Expected StateSyncResponse::GetBlockNumberByHash::Ok(None), but got {response:?}");
+    };
 }
 
 #[tokio::test]

--- a/crates/apollo_state_sync_types/src/communication.rs
+++ b/crates/apollo_state_sync_types/src/communication.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
 use mockall::automock;
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::state::StorageKey;
 use starknet_types_core::felt::Felt;
@@ -40,6 +40,21 @@ pub trait StateSyncClient: Send + Sync {
     /// Returns a [BlockNotFound](StateSyncError::BlockNotFound) error if the block doesn't exist or
     /// the sync hasn't downloaded it yet.
     async fn get_block_hash(&self, block_number: BlockNumber) -> StateSyncClientResult<BlockHash>;
+
+    /// Request for a block signature at a specific height.
+    /// Returns a [BlockNotFound](StateSyncError::BlockNotFound) error if the block doesn't exist
+    /// or the sync hasn't downloaded its signature yet.
+    async fn get_block_signature(
+        &self,
+        block_number: BlockNumber,
+    ) -> StateSyncClientResult<BlockSignature>;
+
+    /// Request for the block number of the block with the given hash.
+    /// Returns None if no synced block has this hash.
+    async fn get_block_number_by_hash(
+        &self,
+        block_hash: BlockHash,
+    ) -> StateSyncClientResult<Option<BlockNumber>>;
 
     /// Notify the sync that a new block has been created within the node so that other peers can
     /// learn about it through sync.
@@ -128,6 +143,8 @@ pub type StateSyncRequestWrapper = RequestWrapper<StateSyncRequest, StateSyncRes
 pub enum StateSyncRequest {
     GetBlock(BlockNumber),
     GetBlockHash(BlockNumber),
+    GetBlockSignature(BlockNumber),
+    GetBlockNumberByHash(BlockHash),
     AddNewBlock(Box<SyncBlock>),
     GetStorageAt(BlockNumber, ContractAddress, StorageKey),
     GetNonceAt(BlockNumber, ContractAddress),
@@ -145,7 +162,9 @@ impl PrioritizedRequest for StateSyncRequest {
             StateSyncRequest::GetBlock(_) | StateSyncRequest::GetBlockHash(_) => {
                 RequestPriority::High
             }
-            StateSyncRequest::GetStorageAt(_, _, _)
+            StateSyncRequest::GetBlockSignature(_)
+            | StateSyncRequest::GetBlockNumberByHash(_)
+            | StateSyncRequest::GetStorageAt(_, _, _)
             | StateSyncRequest::GetNonceAt(_, _)
             | StateSyncRequest::GetClassHashAt(_, _)
             | StateSyncRequest::AddNewBlock(_)
@@ -161,6 +180,8 @@ impl PrioritizedRequest for StateSyncRequest {
 pub enum StateSyncResponse {
     GetBlock(StateSyncResult<Box<SyncBlock>>),
     GetBlockHash(StateSyncResult<BlockHash>),
+    GetBlockSignature(StateSyncResult<BlockSignature>),
+    GetBlockNumberByHash(StateSyncResult<Option<BlockNumber>>),
     AddNewBlock(StateSyncResult<()>),
     GetStorageAt(StateSyncResult<Felt>),
     GetNonceAt(StateSyncResult<Nonce>),
@@ -197,6 +218,38 @@ where
             request,
             StateSyncResponse,
             GetBlockHash,
+            StateSyncClientError,
+            StateSyncError,
+            Direct
+        )
+    }
+
+    async fn get_block_signature(
+        &self,
+        block_number: BlockNumber,
+    ) -> StateSyncClientResult<BlockSignature> {
+        let request = StateSyncRequest::GetBlockSignature(block_number);
+        handle_all_response_variants!(
+            self,
+            request,
+            StateSyncResponse,
+            GetBlockSignature,
+            StateSyncClientError,
+            StateSyncError,
+            Direct
+        )
+    }
+
+    async fn get_block_number_by_hash(
+        &self,
+        block_hash: BlockHash,
+    ) -> StateSyncClientResult<Option<BlockNumber>> {
+        let request = StateSyncRequest::GetBlockNumberByHash(block_hash);
+        handle_all_response_variants!(
+            self,
+            request,
+            StateSyncResponse,
+            GetBlockNumberByHash,
             StateSyncClientError,
             StateSyncError,
             Direct


### PR DESCRIPTION
## Goal
The feeder gateway's remote read backend delegates every read to the state-sync client, but the
client has no block-signature or number-by-hash reads: remote get_signature currently returns a
documented internal error, and the upcoming get_block_id_by_hash endpoint needs the reverse hash
mapping. Add both reads per the plan's Reference C extension pattern (E1.a/E8.a).

## Summary of changes
Adds GetBlockSignature(BlockNumber) -> BlockSignature and GetBlockNumberByHash(BlockHash) ->
Option<BlockNumber> to the StateSyncClient trait, request/response enums, blanket client impl, and
priority match (Normal); the apollo_state_sync handler arms + storage-backed impls
(get_block_signature/get_block_number_by_hash from header storage); pass-through impls in the
gateway's SharedStateSyncClientMetricWrapper; and four handler tests (found, unsynced-block
BlockNotFound, found-by-hash, unknown-hash None).

## Key decision points
get_block_signature returns a BlockNotFound ERROR for a missing block/signature, deviating from the
plan table's Option<BlockSignature>: every existing per-block-number read (get_block_hash, get_block)
uses the BlockNotFound convention, and an Option would force each caller to invent its own not-found
meaning. get_block_number_by_hash DOES return Option since no StateSyncError variant carries a hash
and an unknown hash is an ordinary outcome, matching the plan. No starknet-client fallback for the
signature read (get_block_hash has one): signatures are served from synced storage only, and a
fallback would be new behavior the plan doesn't call for. GetBlockTransactionsWithOutputs (the third
planned E1.a read) is deliberately NOT added: its only consumers are the tx-carrying endpoints, which
are deferred on the transaction tag-position serialization decision.