### PR TITLE
apollo_feeder_gateway: CORE serve get_signature on the remote read backend

### DIFF
--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
 
 [dev-dependencies]
+apollo_state_sync_types = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
 mockall.workspace = true
 rstest.workspace = true

--- a/crates/apollo_feeder_gateway/src/reader/remote.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote.rs
@@ -6,6 +6,10 @@ use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 use crate::errors::FeederGatewayError;
 use crate::reader::{internal_error, ChainDataReader, FgResult};
 
+#[cfg(test)]
+#[path = "remote_test.rs"]
+mod remote_test;
+
 /// A [`ChainDataReader`] for different-pod/node deployments: it delegates every read to the
 /// state-sync process over the network via a [`SharedStateSyncClient`]. The feeder gateway is
 /// stateless in this mode and holds no local storage.
@@ -31,14 +35,13 @@ impl ChainDataReader for RemoteChainDataReader {
 
     async fn block_signature(
         &self,
-        _block_number: BlockNumber,
+        block_number: BlockNumber,
     ) -> FgResult<(BlockHash, BlockSignature)> {
-        // The state-sync client has no block-signature read yet (it needs a Reference-C extension:
-        // a GetBlockSignature request/response variant + handler). The remote backend is
-        // default-off (the node defaults to co-located), so this is a documented gap, not a
-        // default code path.
-        tracing::error!("get_signature is not yet supported on the remote feeder gateway backend");
-        Err(FeederGatewayError::Internal)
+        let block_hash =
+            self.client.get_block_hash(block_number).await.map_err(map_client_error)?;
+        let signature =
+            self.client.get_block_signature(block_number).await.map_err(map_client_error)?;
+        Ok((block_hash, signature))
     }
 }
 

--- a/crates/apollo_feeder_gateway/src/reader/remote_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote_test.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use apollo_state_sync_types::communication::{MockStateSyncClient, StateSyncClientError};
+use apollo_state_sync_types::errors::StateSyncError;
+use starknet_api::block::{BlockHash, BlockNumber, BlockSignature};
+use starknet_api::crypto::utils::Signature;
+use starknet_api::hash::StarkHash;
+
+use crate::errors::FeederGatewayError;
+use crate::reader::remote::RemoteChainDataReader;
+use crate::reader::ChainDataReader;
+
+#[tokio::test]
+async fn block_signature_returns_hash_and_signature_from_state_sync() {
+    let expected_block_hash = BlockHash(StarkHash::from(0x1_u128));
+    let expected_signature =
+        BlockSignature(Signature { r: StarkHash::from(0x2_u128), s: StarkHash::from(0x3_u128) });
+
+    let mut client = MockStateSyncClient::new();
+    client.expect_get_block_hash().returning(move |_| Ok(expected_block_hash));
+    client.expect_get_block_signature().returning(move |_| Ok(expected_signature));
+    let reader = RemoteChainDataReader::new(Arc::new(client));
+
+    let (block_hash, signature) = reader.block_signature(BlockNumber(7)).await.unwrap();
+
+    assert_eq!(block_hash, expected_block_hash);
+    assert_eq!(signature, expected_signature);
+}
+
+#[tokio::test]
+async fn block_signature_of_unsynced_block_is_block_not_found() {
+    let mut client = MockStateSyncClient::new();
+    client.expect_get_block_hash().returning(|block_number| {
+        Err(StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(block_number)))
+    });
+    let reader = RemoteChainDataReader::new(Arc::new(client));
+
+    let result = reader.block_signature(BlockNumber(7)).await;
+
+    assert!(matches!(result, Err(FeederGatewayError::BlockNotFound)));
+}
+
+#[tokio::test]
+async fn block_signature_missing_signature_is_block_not_found() {
+    let mut client = MockStateSyncClient::new();
+    client.expect_get_block_hash().returning(|_| Ok(BlockHash(StarkHash::from(0x1_u128))));
+    client.expect_get_block_signature().returning(|block_number| {
+        Err(StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(block_number)))
+    });
+    let reader = RemoteChainDataReader::new(Arc::new(client));
+
+    let result = reader.block_signature(BlockNumber(7)).await;
+
+    assert!(matches!(result, Err(FeederGatewayError::BlockNotFound)));
+}


### PR DESCRIPTION
Remote-backend get_signature was a documented gap: block_signature returned an internal error
because the state-sync client had no signature read. With GetBlockSignature now available, close
the gap so the endpoint behaves identically on both read backends.

Implements RemoteChainDataReader::block_signature as get_block_hash + get_block_signature client
reads, both mapped through map_client_error (BlockNotFound preserved for the legacy envelope), and
adds remote_test.rs covering the happy path and the two not-found paths (unsynced block, missing
signature).

Two client round trips rather than one combined read: the hash read already exists, block data at a
given height is immutable once synced (no torn-pair risk worth a bespoke combined variant), and the
remote backend is the default-off topology. A missing signature for a synced block maps to the same
BlockNotFound envelope as a missing block, matching the colocated backend's behavior.