### PR TITLE
apollo_feeder_gateway: CORE serve get_block_id_by_hash

### DIFF
--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -54,6 +54,10 @@ impl FeederGateway {
                 "/feeder_gateway/get_block_hash_by_id",
                 get(crate::handlers::get_block_hash_by_id),
             )
+            .route(
+                "/feeder_gateway/get_block_id_by_hash",
+                get(crate::handlers::get_block_id_by_hash),
+            )
             .route("/feeder_gateway/get_public_key", get(crate::handlers::get_public_key))
             .route("/feeder_gateway/get_signature", get(crate::handlers::get_signature))
             .layer(Extension(self.app_state.clone()))

--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use axum::extract::Query;
 use axum::response::Response;
 use axum::Extension;
-use starknet_api::block::BlockNumber;
+use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::hash::StarkHash;
 
 use crate::errors::FeederGatewayError;
 use crate::objects::FeederGatewaySignature;
@@ -49,6 +50,23 @@ pub(crate) async fn get_block_hash_by_id(
     Ok(fg_json(&block_hash))
 }
 
+/// `GET /feeder_gateway/get_block_id_by_hash?blockHash=0x..` — returns the bare block number of
+/// the block with the given hash, or the legacy BLOCK_NOT_FOUND envelope if no synced block has it
+/// (verified against the live service: the parameter is `blockHash` and the response is an
+/// unquoted number).
+pub(crate) async fn get_block_id_by_hash(
+    Extension(state): Extension<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Response, FeederGatewayError> {
+    let block_hash = parse_block_hash(&params)?;
+    let block_number = state
+        .reader
+        .block_number_by_hash(block_hash)
+        .await?
+        .ok_or(FeederGatewayError::BlockNotFound)?;
+    Ok(fg_json(&block_number))
+}
+
 /// Parses the required `blockId` query parameter as a block number. Treats the request as
 /// adversarial: a missing or non-`u64` value yields a `MalformedRequest` (400) rather than a panic,
 /// and `u64` parsing caps the value inherently.
@@ -63,6 +81,22 @@ fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
         .parse::<u64>()
         .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockId: {raw}")))?;
     Ok(BlockNumber(block_number))
+}
+
+/// Parses the required `blockHash` query parameter as a block hash. Treats the request as
+/// adversarial: a missing value or a non-felt yields a `MalformedRequest` (400) rather than a
+/// panic. The lowercase `0x` prefix is required, matching the live feeder gateway (it rejects
+/// `0X`-prefixed and bare-hex forms).
+fn parse_block_hash(params: &HashMap<String, String>) -> FgResult<BlockHash> {
+    let raw = params
+        .get("blockHash")
+        .ok_or_else(|| FeederGatewayError::MalformedRequest("missing blockHash".to_string()))?;
+    if !raw.starts_with("0x") {
+        return Err(FeederGatewayError::MalformedRequest(format!("invalid blockHash: {raw}")));
+    }
+    let felt_value = StarkHash::from_hex(raw)
+        .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockHash: {raw}")))?;
+    Ok(BlockHash(felt_value))
 }
 
 /// Parses the required `blockNumber` query parameter as a block number (never panics on bad input;

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use apollo_feeder_gateway_config::config::{FeederGatewayConfig, FeederGatewayContractAddresses};
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
-use starknet_api::block::{BlockHash, BlockSignature};
+use starknet_api::block::{BlockHash, BlockNumber, BlockSignature};
 use starknet_api::core::{ContractAddress, SequencerPublicKey};
 use starknet_api::crypto::utils::{PublicKey, Signature};
 use starknet_api::hash::StarkHash;
@@ -112,6 +112,110 @@ async fn get_block_hash_by_id_returns_byte_parity_hash() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     assert_eq!(&body[..], br#""0x1234""#);
+}
+
+#[tokio::test]
+async fn get_block_id_by_hash_returns_byte_parity_number() {
+    let mut reader = MockChainDataReader::new();
+    reader.expect_block_number_by_hash().returning(|_| Ok(Some(BlockNumber(1))));
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_id_by_hash?blockHash=0x1234")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    // The live feeder gateway serves the block number as a bare unquoted number.
+    assert_eq!(&body[..], br#"1"#);
+}
+
+#[tokio::test]
+async fn get_block_id_by_hash_unknown_hash_is_block_not_found() {
+    let mut reader = MockChainDataReader::new();
+    reader.expect_block_number_by_hash().returning(|_| Ok(None));
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_id_by_hash?blockHash=0x1234")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Verified live: an unknown hash is the BLOCK_NOT_FOUND envelope with HTTP 400.
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert!(String::from_utf8(body.to_vec()).unwrap().contains("BLOCK_NOT_FOUND"));
+}
+
+#[tokio::test]
+async fn get_block_id_by_hash_missing_param_is_bad_request() {
+    let feeder_gateway =
+        FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_id_by_hash")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_block_id_by_hash_without_0x_prefix_is_bad_request() {
+    let feeder_gateway =
+        FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()));
+
+    // Verified live: bare-hex and 0X-prefixed forms are rejected as MALFORMED_REQUEST.
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_id_by_hash?blockHash=1234")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_block_id_by_hash_non_hex_is_bad_request() {
+    let feeder_gateway =
+        FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_id_by_hash?blockHash=0xzzz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/crates/apollo_feeder_gateway/src/reader.rs
+++ b/crates/apollo_feeder_gateway/src/reader.rs
@@ -34,6 +34,10 @@ pub trait ChainDataReader: Send + Sync + 'static {
         &self,
         block_number: BlockNumber,
     ) -> FgResult<(BlockHash, BlockSignature)>;
+
+    /// The block number of the synced block with hash `block_hash`, or `None` if no synced block
+    /// has this hash.
+    async fn block_number_by_hash(&self, block_hash: BlockHash) -> FgResult<Option<BlockNumber>>;
 }
 
 /// Shared state handed to every axum handler via `Extension`.

--- a/crates/apollo_feeder_gateway/src/reader/colocated.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated.rs
@@ -83,4 +83,14 @@ impl ChainDataReader for ColocatedStorageReader {
             })
             .await?
     }
+
+    async fn block_number_by_hash(&self, block_hash: BlockHash) -> FgResult<Option<BlockNumber>> {
+        let storage_reader = self.storage_reader.clone();
+        self.executor
+            .run(move || {
+                let txn = storage_reader.begin_ro_txn().map_err(internal_error)?;
+                txn.get_block_number_by_hash(&block_hash).map_err(internal_error)
+            })
+            .await?
+    }
 }

--- a/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
-use starknet_api::block::{BlockHeader, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
+use starknet_api::hash::StarkHash;
 
 use crate::errors::FeederGatewayError;
 use crate::reader::colocated::ColocatedStorageReader;
@@ -64,4 +65,32 @@ async fn block_hash_missing_block_is_block_not_found() {
         reader.block_hash(BlockNumber(7)).await,
         Err(FeederGatewayError::BlockNotFound)
     ));
+}
+
+#[tokio::test]
+async fn block_number_by_hash_returns_appended_block_number() {
+    let ((storage_reader, mut writer), _temp_dir) = get_test_storage();
+    let header = BlockHeader::default();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_header(BlockNumber(0), &header)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    let reader = ColocatedStorageReader::new(storage_reader, executor());
+
+    assert_eq!(reader.block_number_by_hash(header.block_hash).await.unwrap(), Some(BlockNumber(0)));
+}
+
+#[tokio::test]
+async fn block_number_by_unknown_hash_returns_none() {
+    let ((storage_reader, _writer), _temp_dir) = get_test_storage();
+    let reader = ColocatedStorageReader::new(storage_reader, executor());
+
+    assert_eq!(
+        reader.block_number_by_hash(BlockHash(StarkHash::from(0x1234_u128))).await.unwrap(),
+        None
+    );
 }

--- a/crates/apollo_feeder_gateway/src/reader/remote.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote.rs
@@ -43,6 +43,10 @@ impl ChainDataReader for RemoteChainDataReader {
             self.client.get_block_signature(block_number).await.map_err(map_client_error)?;
         Ok((block_hash, signature))
     }
+
+    async fn block_number_by_hash(&self, block_hash: BlockHash) -> FgResult<Option<BlockNumber>> {
+        self.client.get_block_number_by_hash(block_hash).await.map_err(internal_error)
+    }
 }
 
 /// Maps a state-sync client error to a feeder gateway error, preserving the not-found case (so it

--- a/crates/apollo_feeder_gateway/src/reader/remote_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote_test.rs
@@ -41,6 +41,18 @@ async fn block_signature_of_unsynced_block_is_block_not_found() {
 }
 
 #[tokio::test]
+async fn block_number_by_hash_delegates_to_state_sync() {
+    let mut client = MockStateSyncClient::new();
+    client.expect_get_block_number_by_hash().returning(|_| Ok(Some(BlockNumber(7))));
+    let reader = RemoteChainDataReader::new(Arc::new(client));
+
+    let block_number =
+        reader.block_number_by_hash(BlockHash(StarkHash::from(0x1_u128))).await.unwrap();
+
+    assert_eq!(block_number, Some(BlockNumber(7)));
+}
+
+#[tokio::test]
 async fn block_signature_missing_signature_is_block_not_found() {
     let mut client = MockStateSyncClient::new();
     client.expect_get_block_hash().returning(|_| Ok(BlockHash(StarkHash::from(0x1_u128))));


### PR DESCRIPTION
## Goal
Complete the E8 id-to-hash mapping pair: get_block_hash_by_id is served, but the reverse
get_block_id_by_hash was missing. Verified live before implementing: the parameter is `blockHash`,
the success response is a bare unquoted number (HTTP 200), an unknown hash is the BLOCK_NOT_FOUND
envelope (HTTP 400), and missing/malformed values (bare hex, 0X prefix, null) are MALFORMED_REQUEST.

## Summary of changes
Adds a block_number_by_hash reader method (colocated: get_block_number_by_hash via the bounded
executor; remote: the new GetBlockNumberByHash client read), a parse_block_hash helper requiring a
lowercase 0x-prefixed felt, the handler mapping None to BlockNotFound, the route, and tests: bare
number byte parity, unknown-hash envelope, missing/prefixless/non-hex params, both backends.

## Key decision points
The reader returns Option<BlockNumber> rather than erroring, mirroring the state-sync read: an
unknown hash is an ordinary outcome, and the handler centralizes the envelope mapping. The 0x prefix
check is explicit (StarkHash::from_hex alone is laxer than the live service, which rejects bare-hex
and 0X forms). Error message texts stay in the existing generic style; exact live message parity
(values embedded in messages) is the deferred parity-hardening pass.