### PR TITLE
apollo_feeder_gateway: CORE map out-of-range blockId to MALFORMED_REQUEST per live behavior

### DIFF
--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -39,14 +39,22 @@ pub(crate) async fn get_signature(
 }
 
 /// `GET /feeder_gateway/get_block_hash_by_id?blockId=<n>` — returns the block hash of the given
-/// block, or the legacy error envelope if it is not synced. The query parameter is named `blockId`
-/// to match the Python feeder gateway (verified against the live service).
+/// block. The query parameter is named `blockId` to match the Python feeder gateway (verified
+/// against the live service).
 pub(crate) async fn get_block_hash_by_id(
     Extension(state): Extension<AppState>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Response, FeederGatewayError> {
     let block_number = parse_block_id(&params)?;
-    let block_hash = state.reader.block_hash(block_number).await?;
+    let block_hash = state.reader.block_hash(block_number).await.map_err(|error| match error {
+        // Verified live: a block id beyond the chain head is MALFORMED_REQUEST ("Block ID should
+        // be in the range [0, <head+1>); got: <id>."), NOT BLOCK_NOT_FOUND. A synced-storage miss
+        // is exactly that out-of-range condition (headers are stored contiguously from genesis).
+        FeederGatewayError::BlockNotFound => {
+            FeederGatewayError::MalformedRequest(format!("block id out of range: {block_number}"))
+        }
+        other => other,
+    })?;
     Ok(fg_json(&block_hash))
 }
 
@@ -71,8 +79,9 @@ pub(crate) async fn get_block_id_by_hash(
 /// adversarial: a missing or non-`u64` value yields a `MalformedRequest` (400) rather than a panic,
 /// and `u64` parsing caps the value inherently.
 ///
-/// TODO(feeder_gateway): `blockId` also accepts `latest`/`pending`/a block hash on the Python
-/// feeder gateway; only the numeric form is handled for now.
+/// Only the numeric form exists: the live feeder gateway parses `blockId` as a JSON integer and
+/// rejects `latest`/`pending`/hash/`null` forms as MALFORMED_REQUEST (verified live; an earlier
+/// plan note claiming otherwise was wrong).
 fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
     let raw = params
         .get("blockId")

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -9,6 +9,7 @@ use starknet_api::crypto::utils::{PublicKey, Signature};
 use starknet_api::hash::StarkHash;
 use tower::util::ServiceExt;
 
+use crate::errors::FeederGatewayError;
 use crate::feeder_gateway::FeederGateway;
 use crate::reader::MockChainDataReader;
 
@@ -216,6 +217,31 @@ async fn get_block_id_by_hash_non_hex_is_bad_request() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_block_hash_by_id_out_of_range_is_malformed_request() {
+    let mut reader = MockChainDataReader::new();
+    reader.expect_block_hash().returning(|_| Err(FeederGatewayError::BlockNotFound));
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_hash_by_id?blockId=99999999")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Verified live: a block id beyond the chain head is MALFORMED_REQUEST, not BLOCK_NOT_FOUND.
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body_text.contains("MALFORMED_REQUEST"));
+    assert!(!body_text.contains("BLOCK_NOT_FOUND"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Goal
Live verification disproved two assumptions about get_block_hash_by_id. First, the plan claimed
blockId also accepts latest/pending/hash forms; the live service parses it as a JSON integer and
rejects all of those as MALFORMED_REQUEST, so the handler TODO promising those forms was wrong.
Second, an in-format id beyond the chain head returns MALFORMED_REQUEST ("Block ID should be in the
range [0, <head+1>); got: <id>."), NOT the BLOCK_NOT_FOUND envelope this endpoint shipped with.

## Summary of changes
Maps the reader's BlockNotFound to MalformedRequest in the get_block_hash_by_id handler (a synced
storage miss is exactly the live out-of-range condition, since headers are stored contiguously),
replaces the disproved TODO with the verified behavior note, and adds a handler test asserting the
envelope code is MALFORMED_REQUEST and not BLOCK_NOT_FOUND.

## Key decision points
The numeric-only parse already matched live behavior, so no parser change: the fix is the error-code
mapping, which is observable behavior (clients branch on the code), not message cosmetics. The exact
live message embeds the chain head; producing it needs a latest-block read on the error path and the
shared sanitizer currently strips ';', so exact message bytes stay in the deferred parity-hardening
pass alongside the other message-parity items.