### PR TITLE
apollo_feeder_gateway: GROUNDWORK add finalized block-status mapping

### DIFF
--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -9,6 +9,7 @@ pub mod metrics;
 pub mod objects;
 pub mod reader;
 pub mod serialization;
+pub mod status;
 
 #[cfg(test)]
 #[path = "felt_format_lock_test.rs"]

--- a/crates/apollo_feeder_gateway/src/status.rs
+++ b/crates/apollo_feeder_gateway/src/status.rs
@@ -1,0 +1,26 @@
+use apollo_starknet_client::reader::objects::block::BlockStatus;
+use starknet_api::block::BlockNumber;
+
+#[cfg(test)]
+#[path = "status_test.rs"]
+mod status_test;
+
+/// Computes the legacy feeder gateway status of a finalized synced block.
+///
+/// `base_layer_marker` follows the `apollo_storage` marker convention: it is the first block
+/// number NOT yet accepted on the base layer, so blocks strictly below it are `ACCEPTED_ON_L1` and
+/// the rest are `ACCEPTED_ON_L2` (the Python default for finalized blocks).
+///
+/// `PENDING`/`ABORTED` apply only to non-finalized/reorged blocks, which synced storage does not
+/// hold, and `PROVEN_ON_L2` is config-gated in Python (`enable_proven_on_l2_status`) with no
+/// proven marker in synced storage to derive it from; none of them is produced here.
+pub fn finalized_block_status(
+    block_number: BlockNumber,
+    base_layer_marker: BlockNumber,
+) -> BlockStatus {
+    if block_number < base_layer_marker {
+        BlockStatus::AcceptedOnL1
+    } else {
+        BlockStatus::AcceptedOnL2
+    }
+}

--- a/crates/apollo_feeder_gateway/src/status_test.rs
+++ b/crates/apollo_feeder_gateway/src/status_test.rs
@@ -1,0 +1,35 @@
+use apollo_starknet_client::reader::objects::block::BlockStatus;
+use rstest::rstest;
+use starknet_api::block::BlockNumber;
+
+use crate::serialization::to_python_json;
+use crate::status::finalized_block_status;
+
+#[rstest]
+#[case::below_marker_is_accepted_on_l1(BlockNumber(4), BlockNumber(5), BlockStatus::AcceptedOnL1)]
+#[case::at_marker_is_accepted_on_l2(BlockNumber(5), BlockNumber(5), BlockStatus::AcceptedOnL2)]
+#[case::above_marker_is_accepted_on_l2(BlockNumber(6), BlockNumber(5), BlockStatus::AcceptedOnL2)]
+#[case::genesis_with_zero_marker_is_accepted_on_l2(
+    BlockNumber(0),
+    BlockNumber(0),
+    BlockStatus::AcceptedOnL2
+)]
+#[case::genesis_with_advanced_marker_is_accepted_on_l1(
+    BlockNumber(0),
+    BlockNumber(1),
+    BlockStatus::AcceptedOnL1
+)]
+fn finalized_block_status_against_base_layer_marker(
+    #[case] block_number: BlockNumber,
+    #[case] base_layer_marker: BlockNumber,
+    #[case] expected_status: BlockStatus,
+) {
+    assert_eq!(finalized_block_status(block_number, base_layer_marker), expected_status);
+}
+
+#[test]
+fn block_status_serializes_to_legacy_strings() {
+    // Locks the wire strings the status computation feeds into responses.
+    assert_eq!(to_python_json(&BlockStatus::AcceptedOnL1).unwrap(), r#""ACCEPTED_ON_L1""#);
+    assert_eq!(to_python_json(&BlockStatus::AcceptedOnL2).unwrap(), r#""ACCEPTED_ON_L2""#);
+}


### PR DESCRIPTION
Land the E0.b/M7 core: the legacy block-status computation that every status-carrying response
(get_block, get_transaction_status) will need, so the deferred endpoint PRs only wire it up. It is
a pure mapping, implementable and testable today without the blocked transaction serialization.

Adds status.rs with finalized_block_status(block_number, base_layer_marker) -> BlockStatus:
ACCEPTED_ON_L1 strictly below the marker, ACCEPTED_ON_L2 otherwise, using the apollo_storage marker
convention (first block NOT yet on the base layer). Reuses the wire enum from
apollo_starknet_client (new dependency) rather than redeclaring it. Tests cover the marker
boundary (below/at/above, genesis with zero and advanced markers) and lock the ACCEPTED_ON_L1/
ACCEPTED_ON_L2 wire strings through to_python_json.

Only ACCEPTED_ON_L1/ACCEPTED_ON_L2 are produced: PENDING/ABORTED describe non-finalized or reorged
blocks that synced storage does not hold, and PROVEN_ON_L2 is config-gated in Python with no proven
marker in synced storage to derive it from; documented in the function instead of guessing. The
base-layer-marker plumbing (colocated storage read, remote state-sync extension) deliberately ships
with the first consumer endpoint, not here, so this PR stays a leaf with no unused reader surface.
E3.b finality-status is NOT included: its wire enum belongs to the deferred get_transaction_status
response objects, and defining it without them would invent unverified wire shapes.