### PR TITLE
apollo_feeder_gateway: PARITY lock Felt JSON format

### DIFF
--- a/crates/apollo_feeder_gateway/src/felt_format_lock_test.rs
+++ b/crates/apollo_feeder_gateway/src/felt_format_lock_test.rs
@@ -1,0 +1,31 @@
+//! Locks the JSON serialization format of `Felt` and the `starknet_api` newtypes the feeder
+//! gateway emits. The entire byte-parity effort assumes felts serialize as lowercase `0x` hex with
+//! no leading zeros (e.g. `"0x0"`, `"0xf"`), matching the Python feeder gateway. If `starknet_api`
+//! ever changes this, these tests fail loudly here rather than as a confusing wire mismatch.
+
+use starknet_api::block::BlockHash;
+use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::hash::StarkHash;
+use starknet_api::state::StorageKey;
+use starknet_api::transaction::TransactionHash;
+
+#[test]
+fn felt_serializes_as_lowercase_hex_without_leading_zeros() {
+    assert_eq!(serde_json::to_string(&StarkHash::from(0_u128)).unwrap(), "\"0x0\"");
+    assert_eq!(serde_json::to_string(&StarkHash::from(15_u128)).unwrap(), "\"0xf\"");
+    assert_eq!(serde_json::to_string(&StarkHash::from(255_u128)).unwrap(), "\"0xff\"");
+}
+
+#[test]
+fn felt_newtypes_delegate_to_felt_serialization() {
+    let felt = StarkHash::from(0xabc_u128);
+    let expected = serde_json::to_string(&felt).unwrap();
+    assert_eq!(expected, "\"0xabc\"");
+
+    assert_eq!(serde_json::to_string(&ClassHash(felt)).unwrap(), expected);
+    assert_eq!(serde_json::to_string(&Nonce(felt)).unwrap(), expected);
+    assert_eq!(serde_json::to_string(&BlockHash(felt)).unwrap(), expected);
+    assert_eq!(serde_json::to_string(&TransactionHash(felt)).unwrap(), expected);
+    assert_eq!(serde_json::to_string(&ContractAddress::from(0xabc_u128)).unwrap(), expected);
+    assert_eq!(serde_json::to_string(&StorageKey::from(0xabc_u128)).unwrap(), expected);
+}

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -8,3 +8,7 @@ pub mod metrics;
 pub mod objects;
 pub mod reader;
 pub mod serialization;
+
+#[cfg(test)]
+#[path = "felt_format_lock_test.rs"]
+mod felt_format_lock_test;


### PR DESCRIPTION
## Goal
The entire byte-parity effort rests on one assumption: `Felt` (and the field-element newtypes the
feeder gateway emits) serialize as lowercase `0x` hex with no leading zeros, matching Python. That
serialization lives in starknet_api, outside this crate's control. This PR pins it with a test so a
future starknet_api change fails loudly here, as an obvious unit-test failure, instead of silently as
a confusing wire mismatch reported by a client.

## Summary of changes
Adds a lock test asserting `Felt` and the emitted newtypes (ClassHash, ContractAddress, Nonce,
BlockHash, TransactionHash, StorageKey) all serialize to lowercase `0x` hex (e.g. "0x0", "0xf").

## Key decision points
Covered the newtypes, not just bare `Felt`, because the feeder gateway emits the newtypes directly
and each could in principle diverge; testing only `Felt` would leave that gap. This is a guardrail
test by design — it asserts an external invariant the rest of the stack assumes, so it is cheap
insurance against an upstream change.