### PR TITLE
apollo_starknet_client: PARITY make builtin_instance_counter deterministic with IndexMap

### DIFF
--- a/crates/apollo_starknet_client/src/reader/objects/test_utils.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/test_utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use apollo_test_utils::{auto_impl_get_test_instance, get_number_of_variants, GetTestInstance};
+use indexmap::IndexMap;
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     ClassHash,
@@ -164,7 +165,7 @@ auto_impl_get_test_instance! {
     }
     pub struct ExecutionResources {
         pub n_steps: u64,
-        pub builtin_instance_counter: HashMap<Builtin, u64>,
+        pub builtin_instance_counter: IndexMap<Builtin, u64>,
         pub n_memory_holes: u64,
         pub data_availability: Option<GasVector>,
         pub total_gas_consumed: Option<GasVector>,

--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -2,8 +2,7 @@
 #[path = "transaction_test.rs"]
 mod transaction_test;
 
-use std::collections::HashMap;
-
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use starknet_api::core::{
@@ -657,7 +656,9 @@ impl TryFrom<IntermediateInvokeTransaction> for starknet_api::transaction::Invok
 pub struct ExecutionResources {
     // Note: in starknet_api this field is named `steps`
     pub n_steps: u64,
-    pub builtin_instance_counter: HashMap<Builtin, u64>,
+    // PARITY: `IndexMap` (not `HashMap`) so builtin keys serialize in a deterministic, insertion
+    // order matching the Python feeder gateway, which does NOT sort them (Reference B).
+    pub builtin_instance_counter: IndexMap<Builtin, u64>,
     // Note: in starknet_api this field is named `memory_holes`
     pub n_memory_holes: u64,
     // This field is missing in blocks created before v0.13.1, even if the feeder gateway is of

--- a/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
@@ -1,7 +1,34 @@
 use assert_matches::assert_matches;
+use indexmap::IndexMap;
 
-use super::{Transaction, TransactionReceipt};
+use super::{Builtin, ExecutionResources, Transaction, TransactionReceipt};
 use crate::test_utils::read_resource::read_resource_file;
+
+/// The builtin counter must serialize in insertion order (the Python feeder gateway does not sort
+/// it), which is why it is an `IndexMap` rather than a `HashMap`.
+#[test]
+fn builtin_instance_counter_serializes_in_insertion_order() {
+    let mut builtin_instance_counter = IndexMap::new();
+    builtin_instance_counter.insert(Builtin::Poseidon, 1);
+    builtin_instance_counter.insert(Builtin::RangeCheck, 2);
+    builtin_instance_counter.insert(Builtin::Pedersen, 3);
+    let execution_resources = ExecutionResources {
+        n_steps: 0,
+        builtin_instance_counter,
+        n_memory_holes: 0,
+        data_availability: None,
+        total_gas_consumed: None,
+    };
+
+    let serialized = serde_json::to_string(&execution_resources).unwrap();
+    let poseidon = serialized.find("poseidon_builtin").unwrap();
+    let range_check = serialized.find("range_check_builtin").unwrap();
+    let pedersen = serialized.find("pedersen_builtin").unwrap();
+    assert!(
+        poseidon < range_check && range_check < pedersen,
+        "builtins serialized out of insertion order: {serialized}"
+    );
+}
 
 #[test]
 fn load_deploy_transaction_succeeds() {


### PR DESCRIPTION
## Goal
`ExecutionResources.builtin_instance_counter` is a `HashMap`, which serializes its keys in
randomized order. The Python feeder gateway does NOT sort these keys and emits them in a stable
insertion order, so a `HashMap` produces nondeterministic output that cannot be byte-equal to Python
— a real parity bug on every receipt. This PR makes the map deterministic.

## Summary of changes
Changes the field from `HashMap` to `IndexMap` (in the struct and in the auto_impl_get_test_instance
mirror) and adds a test that builds a counter with several builtins and asserts the serialized key
order follows insertion order.

## Key decision points
Used `IndexMap` (insertion-ordered) rather than `BTreeMap` (sorted): Python preserves the producer's
insertion order and does not sort, so a sorted map would also diverge — only insertion order can
match. Scoped this PR to the get_block-relevant counter and deferred the analogous
`ContractClass.entry_points_by_type` map to the classes endpoint work, because that change ripples
into starknet_api's `from_hash_map` signature and is on the get_class path, not the get_block path
being built now.