### PR TITLE
apollo_starknet_client: PARITY serialize transaction type tag last for feeder gateway parity

### DIFF
--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -53,7 +53,7 @@ use crate::reader::ReaderClientError;
 /// Used in [`BlockPostV0_13_1::transactions`](crate::reader::objects::block::BlockPostV0_13_1::transactions)
 /// when syncing historical block data from the Feeder Gateway API.
 // TODO(dan): consider extracting common fields out (version, hash, type).
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 #[serde(tag = "type")]
 pub enum Transaction {
     #[serde(rename = "DECLARE")]
@@ -66,6 +66,44 @@ pub enum Transaction {
     Invoke(IntermediateInvokeTransaction),
     #[serde(rename = "L1_HANDLER")]
     L1Handler(L1HandlerTransaction),
+}
+
+/// Serialization helper emitting the payload's fields followed by a trailing `type` tag. The
+/// Python feeder gateway puts `type` LAST in every transaction object, while serde's
+/// `#[serde(tag = "type")]` representation emits it first; `Transaction` therefore derives only
+/// `Deserialize` (internally tagged deserialization accepts the tag at any position) and
+/// serializes through this wrapper. `#[serde(flatten)]` forwards the payload's fields in their
+/// declaration order, so byte parity is preserved with any serializer.
+#[derive(Serialize)]
+struct TypeTaggedLastTransaction<'a, Payload: Serialize> {
+    #[serde(flatten)]
+    payload: &'a Payload,
+    r#type: &'static str,
+}
+
+impl Serialize for Transaction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // The tag strings must match the variants' `#[serde(rename)]` attributes above.
+        match self {
+            Transaction::Declare(payload) => {
+                TypeTaggedLastTransaction { payload, r#type: "DECLARE" }.serialize(serializer)
+            }
+            Transaction::DeployAccount(payload) => {
+                TypeTaggedLastTransaction { payload, r#type: "DEPLOY_ACCOUNT" }
+                    .serialize(serializer)
+            }
+            Transaction::Deploy(payload) => {
+                TypeTaggedLastTransaction { payload, r#type: "DEPLOY" }.serialize(serializer)
+            }
+            Transaction::Invoke(payload) => {
+                TypeTaggedLastTransaction { payload, r#type: "INVOKE_FUNCTION" }
+                    .serialize(serializer)
+            }
+            Transaction::L1Handler(payload) => {
+                TypeTaggedLastTransaction { payload, r#type: "L1_HANDLER" }.serialize(serializer)
+            }
+        }
+    }
 }
 
 impl TryFrom<Transaction> for starknet_api::transaction::Transaction {

--- a/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
@@ -146,3 +146,30 @@ fn load_transaction_receipt_succeeds() {
         );
     }
 }
+
+/// The Python feeder gateway serializes the `type` tag LAST in every transaction object; serde's
+/// `#[serde(tag)]` would emit it first, so `Transaction` has a custom `Serialize`. Locks the tag
+/// position for every variant and proves the custom impl round-trips losslessly.
+#[test]
+fn transaction_serializes_type_tag_last() {
+    for (file_name, type_tag) in [
+        ("reader/declare_v0.json", "DECLARE"),
+        ("reader/declare_v3.json", "DECLARE"),
+        ("reader/deploy_account_v3.json", "DEPLOY_ACCOUNT"),
+        ("reader/deploy_v0.json", "DEPLOY"),
+        ("reader/invoke_v0.json", "INVOKE_FUNCTION"),
+        ("reader/invoke_v3.json", "INVOKE_FUNCTION"),
+        ("reader/l1_handler_v0.json", "L1_HANDLER"),
+    ] {
+        let transaction: Transaction =
+            serde_json::from_str(&read_resource_file(file_name)).unwrap();
+        let serialized = serde_json::to_string(&transaction).unwrap();
+        assert!(
+            serialized.ends_with(&format!(r#""type":"{type_tag}"}}"#)),
+            "`type` is not the last key for {file_name}: {serialized}"
+        );
+
+        let round_tripped: Transaction = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(round_tripped, transaction, "lossy serialization for {file_name}");
+    }
+}


### PR DESCRIPTION
## Goal
Resolve the recorded byte-parity blocker gating every tx-carrying feeder gateway endpoint
(get_block, get_transaction, get_transaction_receipt): the Python feeder gateway puts "type" LAST
in every transaction object (confirmed live and by the committed 0.14.3 block fixture), while
serde's #[serde(tag = "type")] emits it first.

## Summary of changes
Transaction now derives only Deserialize (internally tagged deserialization accepts the tag at any
position, unchanged) and gains a manual Serialize through a TypeTaggedLastTransaction wrapper:
#[serde(flatten)] payload first, then the type tag. flatten forwards the payload's fields in
declaration order, so the wire order is preserved with any serializer, including the feeder
gateway's spaced Python formatter. Adds a test deserializing all seven per-family/version fixtures,
asserting "type" is the last key for every variant, and round-tripping losslessly.

## Key decision points
The flatten wrapper was chosen over serializing through serde_json::Value with an appended tag:
Value's map is BTreeMap-backed (alphabetizes keys) unless the global preserve_order feature is
flipped, which would silently reorder every serde_json map in the workspace (config dumps, regen
files). An adjacently/untagged restructure was rejected because it changes the deserialization
contract. Blast radius was searched before changing the wire format: nothing in production
serializes the reader Transaction, and all existing tests compare structs or deserialize only.
Per-family FIELD order (M11) is intentionally NOT touched here: it must be driven by captured live
fixtures per family, next in the stack.