### PR TITLE
apollo_starknet_client: PARITY reorder deploy and l1_handler fields to live wire order

### DIFF
--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -181,13 +181,15 @@ impl Transaction {
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 #[serde(deny_unknown_fields)]
+// PARITY LOCK: field order replicates the live Python feeder gateway L1_HANDLER wire order
+// (captured 2026-06-03, sepolia block 10); do not reorder.
 pub struct L1HandlerTransaction {
     pub transaction_hash: TransactionHash,
     pub version: TransactionVersion,
-    #[serde(default)]
-    pub nonce: Nonce,
     pub contract_address: ContractAddress,
     pub entry_point_selector: EntryPointSelector,
+    #[serde(default)]
+    pub nonce: Nonce,
     pub calldata: Calldata,
 }
 
@@ -385,14 +387,16 @@ impl TryFrom<IntermediateDeclareTransaction> for starknet_api::transaction::Decl
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+// PARITY LOCK: field order replicates the live Python feeder gateway DEPLOY wire order
+// (captured 2026-06-03, mainnet block 0); do not reorder.
 pub struct DeployTransaction {
+    pub transaction_hash: TransactionHash,
+    #[serde(default)]
+    pub version: TransactionVersion,
     pub contract_address: ContractAddress,
     pub contract_address_salt: ContractAddressSalt,
     pub class_hash: ClassHash,
     pub constructor_calldata: Calldata,
-    pub transaction_hash: TransactionHash,
-    #[serde(default)]
-    pub version: TransactionVersion,
 }
 
 impl From<DeployTransaction> for starknet_api::transaction::DeployTransaction {

--- a/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
@@ -173,3 +173,58 @@ fn transaction_serializes_type_tag_last() {
         assert_eq!(round_tripped, transaction, "lossy serialization for {file_name}");
     }
 }
+
+/// Asserts the top-level keys of the serialized transaction appear in exactly the given order
+/// (the live Python feeder gateway wire order; key sets and orders were captured live per
+/// transaction family and version on 2026-06-03).
+fn assert_serialized_key_order(transaction: &Transaction, expected_key_order: &[&str]) {
+    let serialized = serde_json::to_string(transaction).unwrap();
+    let mut key_positions = Vec::with_capacity(expected_key_order.len());
+    for key in expected_key_order {
+        let needle = format!(r#""{key}":"#);
+        let position = serialized
+            .find(&needle)
+            .unwrap_or_else(|| panic!("missing key {key} in: {serialized}"));
+        key_positions.push(position);
+    }
+    assert!(
+        key_positions.windows(2).all(|pair| pair[0] < pair[1]),
+        "keys serialized out of live wire order (expected {expected_key_order:?}): {serialized}"
+    );
+}
+
+#[test]
+fn deploy_serializes_in_live_wire_order() {
+    let transaction: Transaction =
+        serde_json::from_str(&read_resource_file("reader/deploy_v0.json")).unwrap();
+    assert_serialized_key_order(
+        &transaction,
+        &[
+            "transaction_hash",
+            "version",
+            "contract_address",
+            "contract_address_salt",
+            "class_hash",
+            "constructor_calldata",
+            "type",
+        ],
+    );
+}
+
+#[test]
+fn l1_handler_serializes_in_live_wire_order() {
+    let transaction: Transaction =
+        serde_json::from_str(&read_resource_file("reader/l1_handler_v0.json")).unwrap();
+    assert_serialized_key_order(
+        &transaction,
+        &[
+            "transaction_hash",
+            "version",
+            "contract_address",
+            "entry_point_selector",
+            "nonce",
+            "calldata",
+            "type",
+        ],
+    );
+}


### PR DESCRIPTION
## Goal
Byte parity for the two single-order transaction families. The live Python feeder gateway emits
DEPLOY as (transaction_hash, version, contract_address, contract_address_salt, class_hash,
constructor_calldata) and L1_HANDLER as (transaction_hash, version, contract_address,
entry_point_selector, nonce, calldata); both Rust structs declared different orders, which now
matters because serialization is wire-order-sensitive feeder gateway output.

## Summary of changes
Reorders DeployTransaction and L1HandlerTransaction fields to the live orders (captured 2026-06-03
from mainnet block 0 and sepolia block 10), adds PARITY LOCK comments, and adds per-family wire-
order tests via a shared assert_serialized_key_order helper (deserialize fixture, serialize,
assert exact top-level key order).

## Key decision points
These two families get plain reorders because each has a single live key order across versions;
the multi-version families (invoke/declare/deploy_account) have per-version order and key-name
conflicts confirmed live, so they need version-branched custom Serialize impls and follow in
separate PRs. Deserialization is by name and unaffected.