### PR TITLE
apollo_starknet_client: PARITY serialize invoke transactions in per-version live wire order

### DIFF
--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -3,6 +3,7 @@
 mod transaction_test;
 
 use indexmap::IndexMap;
+use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use starknet_api::core::{
@@ -540,7 +541,7 @@ impl TryFrom<IntermediateDeployAccountTransaction>
 ///
 /// Supports multiple transaction versions (V0/V1/V3) through optional fields.
 // TODO(shahak, 01/11/2023): Add serde tests for v3 transactions.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Deserialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct IntermediateInvokeTransaction {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -572,6 +573,67 @@ pub struct IntermediateInvokeTransaction {
     pub proof_facts: Option<ProofFacts>,
     pub transaction_hash: TransactionHash,
     pub version: TransactionVersion,
+}
+
+/// Serializes `value` under `key` only when present, preserving the live feeder gateway behavior
+/// of omitting absent optional fields (the manual wire-order impls cannot use
+/// `skip_serializing_if`).
+fn serialize_entry_if_some<M: SerializeMap, T: Serialize>(
+    map: &mut M,
+    key: &str,
+    value: &Option<T>,
+) -> Result<(), M::Error> {
+    match value {
+        Some(value) => map.serialize_entry(key, value),
+        None => Ok(()),
+    }
+}
+
+// PARITY LOCK: key order and names replicate the live Python feeder gateway INVOKE_FUNCTION wire
+// format per version (captured 2026-06-03; fixtures in apollo_feeder_gateway
+// resources/parity/transactions). V0 differs from V1/V3 in both field order (calldata precedes
+// the address) and the address key name (`contract_address`), so a single derived field order
+// cannot express the wire format.
+impl Serialize for IntermediateInvokeTransaction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("transaction_hash", &self.transaction_hash)?;
+        map.serialize_entry("version", &self.version)?;
+        if self.version == TransactionVersion::ZERO {
+            serialize_entry_if_some(&mut map, "max_fee", &self.max_fee)?;
+            map.serialize_entry("signature", &self.signature)?;
+            serialize_entry_if_some(&mut map, "entry_point_selector", &self.entry_point_selector)?;
+            map.serialize_entry("calldata", &self.calldata)?;
+            // V0 predates the `sender_address` rename; the live service serves the legacy key.
+            map.serialize_entry("contract_address", &self.sender_address)?;
+        } else {
+            serialize_entry_if_some(&mut map, "max_fee", &self.max_fee)?;
+            map.serialize_entry("signature", &self.signature)?;
+            serialize_entry_if_some(&mut map, "nonce", &self.nonce)?;
+            serialize_entry_if_some(
+                &mut map,
+                "nonce_data_availability_mode",
+                &self.nonce_data_availability_mode,
+            )?;
+            serialize_entry_if_some(
+                &mut map,
+                "fee_data_availability_mode",
+                &self.fee_data_availability_mode,
+            )?;
+            serialize_entry_if_some(&mut map, "resource_bounds", &self.resource_bounds)?;
+            serialize_entry_if_some(&mut map, "tip", &self.tip)?;
+            serialize_entry_if_some(&mut map, "paymaster_data", &self.paymaster_data)?;
+            map.serialize_entry("sender_address", &self.sender_address)?;
+            map.serialize_entry("calldata", &self.calldata)?;
+            serialize_entry_if_some(
+                &mut map,
+                "account_deployment_data",
+                &self.account_deployment_data,
+            )?;
+            serialize_entry_if_some(&mut map, "proof_facts", &self.proof_facts)?;
+        }
+        map.end()
+    }
 }
 
 // TODO(shahak, 01/11/2023): Add conversion tests.

--- a/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
@@ -228,3 +228,64 @@ fn l1_handler_serializes_in_live_wire_order() {
         ],
     );
 }
+
+#[test]
+fn invoke_serializes_in_live_wire_order_per_version() {
+    let invoke_v0: Transaction =
+        serde_json::from_str(&read_resource_file("reader/invoke_v0.json")).unwrap();
+    assert_serialized_key_order(
+        &invoke_v0,
+        &[
+            "transaction_hash",
+            "version",
+            "max_fee",
+            "signature",
+            "entry_point_selector",
+            "calldata",
+            "contract_address",
+            "type",
+        ],
+    );
+    // V0 must serve the legacy address key, not the modern one.
+    assert!(!serde_json::to_string(&invoke_v0).unwrap().contains("sender_address"));
+
+    let invoke_v1: Transaction = serde_json::from_str(
+        r#"{"transaction_hash": "0x1", "version": "0x1", "max_fee": "0x2", "signature": [],
+            "nonce": "0x0", "sender_address": "0x3", "calldata": [], "type": "INVOKE_FUNCTION"}"#,
+    )
+    .unwrap();
+    assert_serialized_key_order(
+        &invoke_v1,
+        &[
+            "transaction_hash",
+            "version",
+            "max_fee",
+            "signature",
+            "nonce",
+            "sender_address",
+            "calldata",
+            "type",
+        ],
+    );
+
+    let invoke_v3: Transaction =
+        serde_json::from_str(&read_resource_file("reader/invoke_v3.json")).unwrap();
+    assert_serialized_key_order(
+        &invoke_v3,
+        &[
+            "transaction_hash",
+            "version",
+            "signature",
+            "nonce",
+            "nonce_data_availability_mode",
+            "fee_data_availability_mode",
+            "resource_bounds",
+            "tip",
+            "paymaster_data",
+            "sender_address",
+            "calldata",
+            "account_deployment_data",
+            "type",
+        ],
+    );
+}


### PR DESCRIPTION
Byte parity for INVOKE_FUNCTION. Live capture (2026-06-03) shows the versions disagree in ways a
single derived field order cannot express: V0 emits (max_fee, signature, entry_point_selector,
calldata, contract_address) with the LEGACY address key name, while V1/V3 emit the address as
sender_address BEFORE calldata (V3 adding the DA-mode/resource-bounds/tip/paymaster/
account_deployment_data/proof_facts fields in fixed positions).

IntermediateInvokeTransaction drops the derived Serialize for a manual impl: common
(transaction_hash, version) prefix, then a V0 branch and a shared V1/V3 branch whose optional
fields are emitted presence-driven via a serialize_entry_if_some helper (shared by the upcoming
declare/deploy_account impls). Deserialization (including the contract_address alias) is
unchanged. Adds a per-version wire-order test (V0 from the fixture asserting the legacy key and
the absence of sender_address; V1 inline; V3 from the fixture).

The version branch keys off version == ZERO only: V1 and V3 share one relative order with
presence-driven emission, so collapsing them avoids a third branch that would have to be kept in
sync. The address key name is decided in the branch (not a serde rename) because it is
version-dependent, a fact the live service confirmed and the alias only handles on the
deserialize side.