### PR TITLE
apollo_starknet_client: PARITY serialize declare transactions in per-version live wire order

### DIFF
--- a/crates/apollo_starknet_client/resources/reader/declare_v3.json
+++ b/crates/apollo_starknet_client/resources/reader/declare_v3.json
@@ -21,6 +21,5 @@
     "tip": "0x0",
     "transaction_hash": "0x308104e126e1d6659ef499da73eeb88ba9f066a57ad75d8d27fa3ff420cded2",
     "version": "0x3",
-    "max_fee": "0x0",
     "type": "DECLARE"
 }

--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -241,7 +241,7 @@ impl From<starknet_api::data_availability::DataAvailabilityMode> for ReservedDat
 ///
 /// Supports multiple transaction versions (V0/V1/V2/V3) through optional fields.
 // TODO(shahak, 01/11/2023): Add serde tests for v3 transactions.
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct IntermediateDeclareTransaction {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -266,6 +266,51 @@ pub struct IntermediateDeclareTransaction {
     pub max_fee: Option<Fee>,
     pub version: TransactionVersion,
     pub transaction_hash: TransactionHash,
+}
+
+// PARITY LOCK: key order replicates the live Python feeder gateway DECLARE wire format per
+// version (captured 2026-06-03; fixtures in apollo_feeder_gateway resources/parity/transactions).
+// V0-V2 emit class_hash (and V2's compiled_class_hash) BEFORE sender_address; V3 emits
+// sender_address first, so a single derived field order cannot express the wire format.
+impl Serialize for IntermediateDeclareTransaction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("transaction_hash", &self.transaction_hash)?;
+        map.serialize_entry("version", &self.version)?;
+        if self.version == TransactionVersion::THREE {
+            map.serialize_entry("signature", &self.signature)?;
+            map.serialize_entry("nonce", &self.nonce)?;
+            serialize_entry_if_some(
+                &mut map,
+                "nonce_data_availability_mode",
+                &self.nonce_data_availability_mode,
+            )?;
+            serialize_entry_if_some(
+                &mut map,
+                "fee_data_availability_mode",
+                &self.fee_data_availability_mode,
+            )?;
+            serialize_entry_if_some(&mut map, "resource_bounds", &self.resource_bounds)?;
+            serialize_entry_if_some(&mut map, "tip", &self.tip)?;
+            serialize_entry_if_some(&mut map, "paymaster_data", &self.paymaster_data)?;
+            map.serialize_entry("sender_address", &self.sender_address)?;
+            map.serialize_entry("class_hash", &self.class_hash)?;
+            serialize_entry_if_some(&mut map, "compiled_class_hash", &self.compiled_class_hash)?;
+            serialize_entry_if_some(
+                &mut map,
+                "account_deployment_data",
+                &self.account_deployment_data,
+            )?;
+        } else {
+            serialize_entry_if_some(&mut map, "max_fee", &self.max_fee)?;
+            map.serialize_entry("signature", &self.signature)?;
+            map.serialize_entry("nonce", &self.nonce)?;
+            map.serialize_entry("class_hash", &self.class_hash)?;
+            serialize_entry_if_some(&mut map, "compiled_class_hash", &self.compiled_class_hash)?;
+            map.serialize_entry("sender_address", &self.sender_address)?;
+        }
+        map.end()
+    }
 }
 
 // TODO(shahak, 01/11/2023): Add conversion tests.

--- a/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
@@ -289,3 +289,66 @@ fn invoke_serializes_in_live_wire_order_per_version() {
         ],
     );
 }
+
+#[test]
+fn declare_serializes_in_live_wire_order_per_version() {
+    let declare_v0: Transaction =
+        serde_json::from_str(&read_resource_file("reader/declare_v0.json")).unwrap();
+    assert_serialized_key_order(
+        &declare_v0,
+        &[
+            "transaction_hash",
+            "version",
+            "max_fee",
+            "signature",
+            "nonce",
+            "class_hash",
+            "sender_address",
+            "type",
+        ],
+    );
+
+    // V2 inserts compiled_class_hash between class_hash and sender_address (verified live).
+    let declare_v2: Transaction = serde_json::from_str(
+        r#"{"transaction_hash": "0x1", "version": "0x2", "max_fee": "0x2", "signature": [],
+            "nonce": "0x0", "class_hash": "0x3", "compiled_class_hash": "0x4",
+            "sender_address": "0x5", "type": "DECLARE"}"#,
+    )
+    .unwrap();
+    assert_serialized_key_order(
+        &declare_v2,
+        &[
+            "transaction_hash",
+            "version",
+            "max_fee",
+            "signature",
+            "nonce",
+            "class_hash",
+            "compiled_class_hash",
+            "sender_address",
+            "type",
+        ],
+    );
+
+    let declare_v3: Transaction =
+        serde_json::from_str(&read_resource_file("reader/declare_v3.json")).unwrap();
+    assert_serialized_key_order(
+        &declare_v3,
+        &[
+            "transaction_hash",
+            "version",
+            "signature",
+            "nonce",
+            "nonce_data_availability_mode",
+            "fee_data_availability_mode",
+            "resource_bounds",
+            "tip",
+            "paymaster_data",
+            "sender_address",
+            "class_hash",
+            "compiled_class_hash",
+            "account_deployment_data",
+            "type",
+        ],
+    );
+}


### PR DESCRIPTION
## Goal
Byte parity for DECLARE. Live capture (2026-06-03) shows V0-V2 emit class_hash (and V2's
compiled_class_hash) BEFORE sender_address, while V3 emits sender_address first followed by
class_hash, compiled_class_hash and account_deployment_data; one derived field order cannot
express both.

## Summary of changes
IntermediateDeclareTransaction drops the derived Serialize for a manual impl: common
(transaction_hash, version) prefix, a V3 branch, and a legacy V0-V2 branch where V2's
compiled_class_hash is emitted presence-driven (reusing serialize_entry_if_some). Adds per-version
wire-order tests (V0 and V3 from fixtures, V2 inline). Also removes a bogus max_fee from the
declare_v3.json fixture: live V3 declares carry no max_fee (verified), and the artificial value
made the lossless round-trip test fail against the faithful serializer.

## Key decision points
The branch keys off version == THREE: V0/V1/V2 share one relative order where the only difference
(compiled_class_hash) is presence-driven, so no further branching. The fixture was corrected
rather than special-casing max_fee suppression in the V3 branch, since the fixture contradicted
the live wire format and masking it in code would hide real shape drift.