### PR TITLE
apollo_starknet_client: PARITY serialize deploy_account transactions in live wire order

### DIFF
--- a/crates/apollo_starknet_client/src/reader/objects/transaction.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction.rs
@@ -460,7 +460,7 @@ impl From<DeployTransaction> for starknet_api::transaction::DeployTransaction {
 ///
 /// Supports multiple transaction versions (V1/V3) through optional fields.
 // TODO(shahak, 01/11/2023): Add serde tests for v3 transactions.
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct IntermediateDeployAccountTransaction {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -486,6 +486,44 @@ pub struct IntermediateDeployAccountTransaction {
     pub max_fee: Option<Fee>,
     pub transaction_hash: TransactionHash,
     pub version: TransactionVersion,
+}
+
+// PARITY LOCK: key order and names replicate the live Python feeder gateway DEPLOY_ACCOUNT wire
+// format (captured 2026-06-03; fixtures in apollo_feeder_gateway resources/parity/transactions).
+// V1 and V3 share one relative order (the V3-only fields are presence-driven), but the address
+// key is version-dependent: V1 serves the legacy `contract_address`, V3 `sender_address`.
+impl Serialize for IntermediateDeployAccountTransaction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("transaction_hash", &self.transaction_hash)?;
+        map.serialize_entry("version", &self.version)?;
+        serialize_entry_if_some(&mut map, "max_fee", &self.max_fee)?;
+        map.serialize_entry("signature", &self.signature)?;
+        map.serialize_entry("nonce", &self.nonce)?;
+        serialize_entry_if_some(
+            &mut map,
+            "nonce_data_availability_mode",
+            &self.nonce_data_availability_mode,
+        )?;
+        serialize_entry_if_some(
+            &mut map,
+            "fee_data_availability_mode",
+            &self.fee_data_availability_mode,
+        )?;
+        serialize_entry_if_some(&mut map, "resource_bounds", &self.resource_bounds)?;
+        serialize_entry_if_some(&mut map, "tip", &self.tip)?;
+        serialize_entry_if_some(&mut map, "paymaster_data", &self.paymaster_data)?;
+        let address_key = if self.version == TransactionVersion::THREE {
+            "sender_address"
+        } else {
+            "contract_address"
+        };
+        map.serialize_entry(address_key, &self.sender_address)?;
+        map.serialize_entry("contract_address_salt", &self.contract_address_salt)?;
+        map.serialize_entry("class_hash", &self.class_hash)?;
+        map.serialize_entry("constructor_calldata", &self.constructor_calldata)?;
+        map.end()
+    }
 }
 
 // TODO(shahak, 01/11/2023): Add conversion tests.

--- a/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
+++ b/crates/apollo_starknet_client/src/reader/objects/transaction_test.rs
@@ -352,3 +352,52 @@ fn declare_serializes_in_live_wire_order_per_version() {
         ],
     );
 }
+
+#[test]
+fn deploy_account_serializes_in_live_wire_order_per_version() {
+    let deploy_account_v1: Transaction = serde_json::from_str(
+        r#"{"transaction_hash": "0x1", "version": "0x1", "max_fee": "0x2", "signature": [],
+            "nonce": "0x0", "contract_address": "0x3", "contract_address_salt": "0x4",
+            "class_hash": "0x5", "constructor_calldata": [], "type": "DEPLOY_ACCOUNT"}"#,
+    )
+    .unwrap();
+    assert_serialized_key_order(
+        &deploy_account_v1,
+        &[
+            "transaction_hash",
+            "version",
+            "max_fee",
+            "signature",
+            "nonce",
+            "contract_address",
+            "contract_address_salt",
+            "class_hash",
+            "constructor_calldata",
+            "type",
+        ],
+    );
+    // V1 must serve the legacy address key, not the modern one.
+    assert!(!serde_json::to_string(&deploy_account_v1).unwrap().contains("sender_address"));
+
+    let deploy_account_v3: Transaction =
+        serde_json::from_str(&read_resource_file("reader/deploy_account_v3.json")).unwrap();
+    assert_serialized_key_order(
+        &deploy_account_v3,
+        &[
+            "transaction_hash",
+            "version",
+            "signature",
+            "nonce",
+            "nonce_data_availability_mode",
+            "fee_data_availability_mode",
+            "resource_bounds",
+            "tip",
+            "paymaster_data",
+            "sender_address",
+            "contract_address_salt",
+            "class_hash",
+            "constructor_calldata",
+            "type",
+        ],
+    );
+}


### PR DESCRIPTION
## Goal
Byte parity for DEPLOY_ACCOUNT. Live capture (2026-06-03) shows V1 and V3 share one relative key
order, but the address key NAME is version-dependent: V1 serves the legacy contract_address while
V3 serves sender_address; the serde alias only covers the deserialize side, so the derived
Serialize emitted the wrong key for V1.

## Summary of changes
IntermediateDeployAccountTransaction drops the derived Serialize for a manual impl: the single
shared key order with V3-only fields emitted presence-driven (serialize_entry_if_some) and the
address key chosen by version. Adds per-version wire-order tests (V1 inline, asserting the legacy
key and absence of sender_address; V3 from the fixture).

## Key decision points
Unlike invoke/declare there is no order branch, only the key-name conditional, so the impl is one
linear sequence; encoding it as a single branch keeps the live wire contract obvious. This
completes the per-version transaction serialization set: deploy/l1_handler (reorder), invoke,
declare, deploy_account (manual impls), all locked by wire-order tests, with byte-level round-trip
locks against the captured live fixtures landing next in apollo_feeder_gateway.