### PR TITLE
apollo_feeder_gateway: PARITY add EIP-55 checksum address formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,6 +1548,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sha3 0.10.8",
  "starknet_api",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -28,6 +28,7 @@ mockall = { workspace = true, optional = true }
 num-traits.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha3.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }

--- a/crates/apollo_feeder_gateway/src/eip55.rs
+++ b/crates/apollo_feeder_gateway/src/eip55.rs
@@ -1,0 +1,31 @@
+use sha3::{Digest, Keccak256};
+use starknet_api::core::EthAddress;
+
+#[cfg(test)]
+#[path = "eip55_test.rs"]
+mod eip55_test;
+
+/// Formats an L1 address with the EIP-55 mixed-case checksum, e.g.
+/// `0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`. The live Python feeder gateway serves the
+/// well-known L1 contract addresses in this format (verified 2026-06-03), while `EthAddress`'s
+/// own serde emits plain lowercase hex.
+///
+/// Per EIP-55: keccak256 the 40-character lowercase hex form (without the `0x` prefix) and
+/// uppercase every hex letter whose corresponding keccak nibble is >= 8.
+pub fn eip55_checksum_address(address: &EthAddress) -> String {
+    let lowercase_hex = format!("{:x}", address.0);
+    let keccak_digest = Keccak256::digest(lowercase_hex.as_bytes());
+    let mut checksummed_address = String::with_capacity(2 + lowercase_hex.len());
+    checksummed_address.push_str("0x");
+    for (nibble_index, hex_character) in lowercase_hex.chars().enumerate() {
+        let keccak_byte = keccak_digest[nibble_index / 2];
+        let keccak_nibble =
+            if nibble_index % 2 == 0 { keccak_byte >> 4 } else { keccak_byte & 0x0f };
+        if keccak_nibble >= 8 {
+            checksummed_address.push(hex_character.to_ascii_uppercase());
+        } else {
+            checksummed_address.push(hex_character);
+        }
+    }
+    checksummed_address
+}

--- a/crates/apollo_feeder_gateway/src/eip55_test.rs
+++ b/crates/apollo_feeder_gateway/src/eip55_test.rs
@@ -1,0 +1,24 @@
+use rstest::rstest;
+use starknet_api::core::EthAddress;
+use starknet_api::hash::StarkHash;
+
+use crate::eip55::eip55_checksum_address;
+
+/// Every case is a ground-truth value served by the live Python feeder gateway's
+/// get_contract_addresses on mainnet or sepolia (captured 2026-06-03).
+#[rstest]
+#[case::mainnet_starknet("0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4")]
+#[case::mainnet_gps_statement_verifier("0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60")]
+#[case::sepolia_starknet("0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057")]
+#[case::sepolia_gps_statement_verifier("0xf294781D719D2F4169cE54469C28908E6FA752C1")]
+#[case::sepolia_memory_page_fact_registry("0x5628E75245Cc69eCA0994F0449F4dDA9FbB5Ec6a")]
+#[case::sepolia_merkle_statement_contract("0xd414f8f535D4a96cB00fFC8E85160b353cb7809c")]
+#[case::sepolia_fri_statement_contract("0x55d049b4C82807808E76e61a08C6764bbf2ffB55")]
+#[case::sepolia_hybrid_gps_fact_adapter("0x68cb84164E27cbf65222F604BAef58CC4149FCFC")]
+fn checksum_matches_live_feeder_gateway(#[case] live_checksummed_address: &str) {
+    let address = EthAddress::try_from(
+        StarkHash::from_hex(&live_checksummed_address.to_lowercase()).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(eip55_checksum_address(&address), live_checksummed_address);
+}

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -1,6 +1,7 @@
 //! Feeder gateway read API server for the Apollo sequencer.
 
 pub mod communication;
+pub mod eip55;
 pub mod errors;
 pub mod feeder_gateway;
 pub mod handlers;


### PR DESCRIPTION
## Goal
get_contract_addresses byte parity needs EIP-55: the live service serves the well-known L1
contract addresses mixed-case checksummed (e.g. 0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4), while
EthAddress's own serde emits plain lowercase hex. Land the formatter first as a leaf PR.

## Summary of changes
Adds eip55::eip55_checksum_address (keccak256 of the lowercase hex form; uppercase every hex
letter whose keccak nibble is >= 8) with sha3 as a new dependency, and a test asserting the
checksum of all eight L1 addresses served by the live mainnet and sepolia feeder gateways
(captured 2026-06-03) reproduces the live mixed-case form exactly.

## Key decision points
Implemented locally rather than pulling an Ethereum utility crate: the algorithm is ten lines, the
workspace already ships sha3, and a new external dependency for one function is not warranted. The
test cases are ground-truth live values rather than the EIP-55 spec vectors, since matching the
live service is the actual requirement (the spec vectors would pass too, being the same algorithm).