### PR TITLE
apollo_feeder_gateway: PARITY drop error message sanitization per live behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,7 +1543,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "mockall",
- "regex",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -24,7 +24,6 @@ apollo_storage.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 mockall = { workspace = true, optional = true }
-regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet_api.workspace = true

--- a/crates/apollo_feeder_gateway/src/errors.rs
+++ b/crates/apollo_feeder_gateway/src/errors.rs
@@ -7,7 +7,6 @@ use apollo_gateway_types::deprecated_gateway_error::{
 };
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
-use regex::Regex;
 use thiserror::Error;
 
 use crate::serialization::to_python_json;
@@ -83,17 +82,12 @@ impl IntoResponse for FeederGatewayError {
     }
 }
 
-/// Serializes a [`StarknetError`] into a byte-parity error response. The message is sanitized like
-/// the Python feeder gateway (see `apollo_http_server`), and the body is serialized with the spaced
-/// Python formatter (not `serde_json::to_vec`) so the error envelope is byte-exact too.
+/// Serializes a [`StarknetError`] into a byte-parity error response: the spaced Python formatter
+/// (not `serde_json::to_vec`) so the envelope is byte-exact. The message is NOT sanitized: the
+/// live feeder gateway echoes request values verbatim in messages (verified 2026-06-03 with
+/// quotes/`;`/`<>` inputs), relying only on JSON string escaping; the `apollo_http_server`
+/// sanitizer belongs to the write gateway, not here.
 fn serialize_error(status: StatusCode, error: &StarknetError) -> Response {
-    let quote_re = Regex::new(r#"["`]"#).unwrap(); // " and ` => ' (single quote)
-    // All other non-alphanumeric characters except [:.,[](){}]'_ => ' ' (space).
-    let sanitize_re = Regex::new(r#"[^a-zA-Z0-9 :.,\[\]\(\)\{\}'_]"#).unwrap();
-    let message =
-        sanitize_re.replace_all(&quote_re.replace_all(&error.message, "'"), " ").to_string();
-    let sanitized_error = StarknetError { code: error.code.clone(), message };
-
-    let body = to_python_json(&sanitized_error).expect("StarknetError is serializable");
+    let body = to_python_json(error).expect("StarknetError is serializable");
     (status, [(header::CONTENT_TYPE, "application/json")], body).into_response()
 }

--- a/crates/apollo_feeder_gateway/src/errors_test.rs
+++ b/crates/apollo_feeder_gateway/src/errors_test.rs
@@ -42,11 +42,16 @@ async fn internal_envelope_is_byte_parity_and_leaks_nothing() {
 }
 
 #[tokio::test]
-async fn malformed_request_sanitizes_message() {
-    let (status, body) =
-        response_status_and_body(FeederGatewayError::MalformedRequest("bad \"x\" <y>".to_string()))
-            .await;
+async fn malformed_request_echoes_message_verbatim() {
+    // The live feeder gateway echoes request values verbatim with JSON escaping only (verified
+    // live: blockHash=zz";<>&x echoes as zz\";<>&x), so no sanitization is applied.
+    let (status, body) = response_status_and_body(FeederGatewayError::MalformedRequest(
+        "got: zz\";<>&x.".to_string(),
+    ))
+    .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    // Quotes become single quotes and disallowed characters (`<`, `>`) become spaces.
-    assert_eq!(body, r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "bad 'x'  y "}"#);
+    assert_eq!(
+        body,
+        r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "got: zz\";<>&x."}"#
+    );
 }


### PR DESCRIPTION
Live probing (2026-06-03) disproved the plan's Reference-E sanitization assumption: the feeder
gateway echoes request values VERBATIM in error messages (blockHash=zz";<>&x echoes unmodified,
JSON-escaped only), while our serialize_error applied the write gateway's sanitizer (quotes to
single quotes, ;<>& to spaces), mangling every value-bearing message the upcoming message-parity
PRs will produce.

serialize_error now serializes the StarknetError as-is through to_python_json (whose JSON string
escaping is exactly Python's json.dumps); the sanitize regexes and the now-unused regex dependency
are removed. The sanitization test is rewritten as a verbatim-echo test using the live-probed
input.

The sanitizer was copied from apollo_http_server per the plan's reuse pin, but that sanitizer
belongs to the WRITE gateway's error path; the live feeder gateway demonstrably does not sanitize.
Verbatim echo is safe here because to_python_json escapes per JSON (no header/HTML injection
surface in a JSON body), matching the live service's exposure exactly.