### PR TITLE
apollo_feeder_gateway: PARITY replicate live BLOCK_NOT_FOUND message formats

### DIFF
--- a/crates/apollo_feeder_gateway/src/errors.rs
+++ b/crates/apollo_feeder_gateway/src/errors.rs
@@ -7,6 +7,7 @@ use apollo_gateway_types::deprecated_gateway_error::{
 };
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
+use starknet_api::block::BlockNumber;
 use thiserror::Error;
 
 use crate::serialization::to_python_json;
@@ -22,11 +23,16 @@ pub enum FeederGatewayRunError {
 }
 
 /// Errors returned by feeder gateway request handling. Each maps to the legacy Python feeder
-/// gateway error envelope (`{code, message}`) and HTTP status (see [`IntoResponse`]).
+/// gateway error envelope (`{code, message}`) and HTTP status (see [`IntoResponse`]); the message
+/// texts replicate the live service (verified 2026-06-03).
 #[derive(Debug, Error)]
 pub enum FeederGatewayError {
-    #[error("Block not found")]
-    BlockNotFound,
+    #[error("Block number {0} was not found.")]
+    BlockNotFound(BlockNumber),
+    /// Carries the request's RAW hash string: the live service echoes it verbatim (an unpadded or
+    /// short form is not normalized).
+    #[error("Block hash {0} does not exist.")]
+    BlockHashNotFound(String),
     #[error("Transaction hash not found")]
     TransactionNotFound,
     #[error("Malformed request: {0}")]
@@ -43,11 +49,18 @@ impl IntoResponse for FeederGatewayError {
         // (verified against the live feeder gateway: BLOCK_NOT_FOUND returns 400, not 404), and
         // only unhandled internal errors are 500.
         let (status, starknet_error) = match self {
-            FeederGatewayError::BlockNotFound => (
+            FeederGatewayError::BlockNotFound(block_number) => (
                 StatusCode::BAD_REQUEST,
                 StarknetError {
                     code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
-                    message: "Block not found".to_string(),
+                    message: format!("Block number {block_number} was not found."),
+                },
+            ),
+            FeederGatewayError::BlockHashNotFound(raw_block_hash) => (
+                StatusCode::BAD_REQUEST,
+                StarknetError {
+                    code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
+                    message: format!("Block hash {raw_block_hash} does not exist."),
                 },
             ),
             FeederGatewayError::TransactionNotFound => (

--- a/crates/apollo_feeder_gateway/src/errors_test.rs
+++ b/crates/apollo_feeder_gateway/src/errors_test.rs
@@ -1,6 +1,7 @@
 use axum::body::to_bytes;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use starknet_api::block::BlockNumber;
 
 use crate::errors::FeederGatewayError;
 
@@ -13,11 +14,26 @@ async fn response_status_and_body(error: FeederGatewayError) -> (StatusCode, Str
 
 #[tokio::test]
 async fn block_not_found_envelope_is_byte_parity() {
-    let (status, body) = response_status_and_body(FeederGatewayError::BlockNotFound).await;
+    // Live format: get_block?blockNumber=999999999 echoes the number (verified 2026-06-03).
+    let (status, body) =
+        response_status_and_body(FeederGatewayError::BlockNotFound(BlockNumber(999999999))).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         body,
-        r#"{"code": "StarknetErrorCode.BLOCK_NOT_FOUND", "message": "Block not found"}"#
+        r#"{"code": "StarknetErrorCode.BLOCK_NOT_FOUND", "message": "Block number 999999999 was not found."}"#
+    );
+}
+
+#[tokio::test]
+async fn block_hash_not_found_envelope_is_byte_parity() {
+    // Live format: get_block_id_by_hash?blockHash=0xdeadbeef echoes the raw hash string.
+    let (status, body) =
+        response_status_and_body(FeederGatewayError::BlockHashNotFound("0xdeadbeef".to_string()))
+            .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body,
+        r#"{"code": "StarknetErrorCode.BLOCK_NOT_FOUND", "message": "Block hash 0xdeadbeef does not exist."}"#
     );
 }
 

--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -50,7 +50,7 @@ pub(crate) async fn get_block_hash_by_id(
         // Verified live: a block id beyond the chain head is MALFORMED_REQUEST ("Block ID should
         // be in the range [0, <head+1>); got: <id>."), NOT BLOCK_NOT_FOUND. A synced-storage miss
         // is exactly that out-of-range condition (headers are stored contiguously from genesis).
-        FeederGatewayError::BlockNotFound => {
+        FeederGatewayError::BlockNotFound(_) => {
             FeederGatewayError::MalformedRequest(format!("block id out of range: {block_number}"))
         }
         other => other,
@@ -66,12 +66,13 @@ pub(crate) async fn get_block_id_by_hash(
     Extension(state): Extension<AppState>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Response, FeederGatewayError> {
-    let block_hash = parse_block_hash(&params)?;
+    let (block_hash, raw_block_hash) = parse_block_hash(&params)?;
     let block_number = state
         .reader
         .block_number_by_hash(block_hash)
         .await?
-        .ok_or(FeederGatewayError::BlockNotFound)?;
+        // The live message echoes the request's raw hash string verbatim.
+        .ok_or_else(|| FeederGatewayError::BlockHashNotFound(raw_block_hash.to_string()))?;
     Ok(fg_json(&block_number))
 }
 
@@ -92,11 +93,12 @@ fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
     Ok(BlockNumber(block_number))
 }
 
-/// Parses the required `blockHash` query parameter as a block hash. Treats the request as
-/// adversarial: a missing value or a non-felt yields a `MalformedRequest` (400) rather than a
-/// panic. The lowercase `0x` prefix is required, matching the live feeder gateway (it rejects
-/// `0X`-prefixed and bare-hex forms).
-fn parse_block_hash(params: &HashMap<String, String>) -> FgResult<BlockHash> {
+/// Parses the required `blockHash` query parameter, returning the parsed hash and the raw string
+/// (live error messages echo the raw form verbatim). Treats the request as adversarial: a missing
+/// value or a non-felt yields a `MalformedRequest` (400) rather than a panic. The lowercase `0x`
+/// prefix is required, matching the live feeder gateway (it rejects `0X`-prefixed and bare-hex
+/// forms).
+fn parse_block_hash(params: &HashMap<String, String>) -> FgResult<(BlockHash, &str)> {
     let raw = params
         .get("blockHash")
         .ok_or_else(|| FeederGatewayError::MalformedRequest("missing blockHash".to_string()))?;
@@ -105,7 +107,7 @@ fn parse_block_hash(params: &HashMap<String, String>) -> FgResult<BlockHash> {
     }
     let felt_value = StarkHash::from_hex(raw)
         .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockHash: {raw}")))?;
-    Ok(BlockHash(felt_value))
+    Ok((BlockHash(felt_value), raw))
 }
 
 /// Parses the required `blockNumber` query parameter as a block number (never panics on bad input;

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -222,7 +222,9 @@ async fn get_block_id_by_hash_non_hex_is_bad_request() {
 #[tokio::test]
 async fn get_block_hash_by_id_out_of_range_is_malformed_request() {
     let mut reader = MockChainDataReader::new();
-    reader.expect_block_hash().returning(|_| Err(FeederGatewayError::BlockNotFound));
+    reader
+        .expect_block_hash()
+        .returning(|block_number| Err(FeederGatewayError::BlockNotFound(block_number)));
     let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
 
     let response = feeder_gateway

--- a/crates/apollo_feeder_gateway/src/reader/colocated.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated.rs
@@ -57,7 +57,9 @@ impl ChainDataReader for ColocatedStorageReader {
                 let txn = storage_reader.begin_ro_txn().map_err(internal_error)?;
                 let header = txn.get_block_header(block_number).map_err(internal_error)?;
                 // Read the hash from the synced header (NOT the batcher-only block_hashes table).
-                header.map(|header| header.block_hash).ok_or(FeederGatewayError::BlockNotFound)
+                header
+                    .map(|header| header.block_hash)
+                    .ok_or(FeederGatewayError::BlockNotFound(block_number))
             })
             .await?
     }
@@ -73,12 +75,12 @@ impl ChainDataReader for ColocatedStorageReader {
                 let block_hash = txn
                     .get_block_header(block_number)
                     .map_err(internal_error)?
-                    .ok_or(FeederGatewayError::BlockNotFound)?
+                    .ok_or(FeederGatewayError::BlockNotFound(block_number))?
                     .block_hash;
                 let signature = txn
                     .get_block_signature(block_number)
                     .map_err(internal_error)?
-                    .ok_or(FeederGatewayError::BlockNotFound)?;
+                    .ok_or(FeederGatewayError::BlockNotFound(block_number))?;
                 Ok((block_hash, signature))
             })
             .await?

--- a/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/colocated_test.rs
@@ -63,7 +63,7 @@ async fn block_hash_missing_block_is_block_not_found() {
 
     assert!(matches!(
         reader.block_hash(BlockNumber(7)).await,
-        Err(FeederGatewayError::BlockNotFound)
+        Err(FeederGatewayError::BlockNotFound(_))
     ));
 }
 

--- a/crates/apollo_feeder_gateway/src/reader/remote.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote.rs
@@ -53,8 +53,8 @@ impl ChainDataReader for RemoteChainDataReader {
 /// becomes the legacy BlockNotFound envelope, HTTP 400) and treating everything else as internal.
 fn map_client_error(error: StateSyncClientError) -> FeederGatewayError {
     match error {
-        StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(_)) => {
-            FeederGatewayError::BlockNotFound
+        StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(block_number)) => {
+            FeederGatewayError::BlockNotFound(block_number)
         }
         other => internal_error(other),
     }

--- a/crates/apollo_feeder_gateway/src/reader/remote_test.rs
+++ b/crates/apollo_feeder_gateway/src/reader/remote_test.rs
@@ -37,7 +37,7 @@ async fn block_signature_of_unsynced_block_is_block_not_found() {
 
     let result = reader.block_signature(BlockNumber(7)).await;
 
-    assert!(matches!(result, Err(FeederGatewayError::BlockNotFound)));
+    assert!(matches!(result, Err(FeederGatewayError::BlockNotFound(BlockNumber(7)))));
 }
 
 #[tokio::test]
@@ -63,5 +63,5 @@ async fn block_signature_missing_signature_is_block_not_found() {
 
     let result = reader.block_signature(BlockNumber(7)).await;
 
-    assert!(matches!(result, Err(FeederGatewayError::BlockNotFound)));
+    assert!(matches!(result, Err(FeederGatewayError::BlockNotFound(BlockNumber(7)))));
 }


### PR DESCRIPTION
Message parity for the not-found envelopes. The live service embeds the request value: a missing
block number is "Block number {n} was not found." and an unknown block hash is "Block hash {raw}
does not exist." (different wording per lookup key, both StarknetErrorCode.BLOCK_NOT_FOUND / 400);
ours served a fixed "Block not found".

FeederGatewayError::BlockNotFound now carries the BlockNumber and a new BlockHashNotFound(String)
carries the request's RAW hash string (the live service echoes it verbatim, not a normalized felt:
0xdeadbeef stays 0xdeadbeef). Both readers construct BlockNotFound from their block-number
argument, map_client_error preserves the number carried by StateSyncError::BlockNotFound, and
get_block_id_by_hash echoes the raw parameter via parse_block_hash now returning it. Envelope,
handler, reader, and smoke tests updated; the smoke get_block_id_by_hash?blockHash=0xdeadbeef
expectation is now the byte-exact live response for the same probe.

Two variants instead of one message-carrying variant: the reader layer knows the block number (its
argument) but not the endpoint's wording, so the number-keyed variant is constructed at the source
while the hash wording stays in the one handler that owns the raw string. The raw string (not the
parsed BlockHash) is carried because live does not normalize the echo.