### PR TITLE
apollo_feeder_gateway: PARITY replicate live blockHash malformed-request messages

### DIFF
--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -99,14 +99,20 @@ fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
 /// prefix is required, matching the live feeder gateway (it rejects `0X`-prefixed and bare-hex
 /// forms).
 fn parse_block_hash(params: &HashMap<String, String>) -> FgResult<(BlockHash, &str)> {
-    let raw = params
-        .get("blockHash")
-        .ok_or_else(|| FeederGatewayError::MalformedRequest("missing blockHash".to_string()))?;
+    // Both message texts replicate the live service verbatim (verified 2026-06-03), including
+    // rejecting `null` and `0X`-prefixed forms with the same "should be a hexadecimal" message.
+    let raw = params.get("blockHash").ok_or_else(|| {
+        FeederGatewayError::MalformedRequest("Block hash must be given.".to_string())
+    })?;
+    let malformed_block_hash = || {
+        FeederGatewayError::MalformedRequest(format!(
+            "Block hash should be a hexadecimal string starting with 0x, or 'null'; got: {raw}."
+        ))
+    };
     if !raw.starts_with("0x") {
-        return Err(FeederGatewayError::MalformedRequest(format!("invalid blockHash: {raw}")));
+        return Err(malformed_block_hash());
     }
-    let felt_value = StarkHash::from_hex(raw)
-        .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockHash: {raw}")))?;
+    let felt_value = StarkHash::from_hex(raw).map_err(|_| malformed_block_hash())?;
     Ok((BlockHash(felt_value), raw))
 }
 


### PR DESCRIPTION
Message parity for the blockHash parameter errors. The live texts (verified 2026-06-03) are "Block
hash must be given." when missing and "Block hash should be a hexadecimal string starting with 0x,
or 'null'; got: {raw}." for every malformed form (bare hex, 0X prefix, non-hex, empty, and the
literal null, which this endpoint rejects despite the message's wording).

parse_block_hash produces the two live texts (one closure for the malformed form shared by the
prefix and hex checks), and the smoke test's missing-param expectation is updated plus a new
malformed-form case; both smoke expectations are the byte-exact live responses for the same probes.

The ';' inside the live malformed message is exactly why the sanitizer had to go first (it stripped
semicolons): this PR depends on the verbatim-echo change downstack. The blockId-side messages
(Python KeyError/json.loads echoes) are a separate, behavior-heavier PR.