### PR TITLE
apollo_feeder_gateway: PARITY replicate live blockId and blockNumber parsing semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "mockall",
+ "num-traits",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/apollo_feeder_gateway/Cargo.toml
+++ b/crates/apollo_feeder_gateway/Cargo.toml
@@ -24,6 +24,7 @@ apollo_storage.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 mockall = { workspace = true, optional = true }
+num-traits.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet_api.workspace = true

--- a/crates/apollo_feeder_gateway/src/errors.rs
+++ b/crates/apollo_feeder_gateway/src/errors.rs
@@ -29,6 +29,11 @@ pub enum FeederGatewayRunError {
 pub enum FeederGatewayError {
     #[error("Block number {0} was not found.")]
     BlockNotFound(BlockNumber),
+    /// BLOCK_NOT_FOUND for a requested block number beyond `u64`: Python parses
+    /// arbitrary-precision integers and echoes the digits, and no such block can exist, so the
+    /// digits are carried as a string.
+    #[error("Block number {0} was not found.")]
+    OversizedBlockNumberNotFound(String),
     /// Carries the request's RAW hash string: the live service echoes it verbatim (an unpadded or
     /// short form is not normalized).
     #[error("Block hash {0} does not exist.")]
@@ -54,6 +59,13 @@ impl IntoResponse for FeederGatewayError {
                 StarknetError {
                     code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
                     message: format!("Block number {block_number} was not found."),
+                },
+            ),
+            FeederGatewayError::OversizedBlockNumberNotFound(python_int_echo) => (
+                StatusCode::BAD_REQUEST,
+                StarknetError {
+                    code: StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
+                    message: format!("Block number {python_int_echo} was not found."),
                 },
             ),
             FeederGatewayError::BlockHashNotFound(raw_block_hash) => (

--- a/crates/apollo_feeder_gateway/src/handlers.rs
+++ b/crates/apollo_feeder_gateway/src/handlers.rs
@@ -7,6 +7,7 @@ use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::hash::StarkHash;
 
 use crate::errors::FeederGatewayError;
+use crate::legacy_params::{parse_legacy_json_scalar, LegacyJsonScalar};
 use crate::objects::FeederGatewaySignature;
 use crate::reader::{AppState, FgResult};
 use crate::serialization::fg_json;
@@ -28,14 +29,30 @@ pub(crate) async fn get_public_key(Extension(state): Extension<AppState>) -> Res
 }
 
 /// `GET /feeder_gateway/get_signature?blockNumber=<n>` — returns the block hash and `[r, s]` block
-/// signature (verified against the live service; the parameter is `blockNumber` for this endpoint).
+/// signature. Live semantics (verified 2026-06-03): a missing or `null` blockNumber serves the
+/// LATEST synced block's signature; the value must be a non-negative JSON integer (booleans count,
+/// Python-style; floats are rejected); integers beyond u64 are BLOCK_NOT_FOUND.
 pub(crate) async fn get_signature(
     Extension(state): Extension<AppState>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Response, FeederGatewayError> {
-    let block_number = parse_block_number(&params)?;
+    let block_number = match parse_block_number(&params)? {
+        Some(block_number) => block_number,
+        None => latest_block_number(&state).await?,
+    };
     let (block_hash, signature) = state.reader.block_signature(block_number).await?;
     Ok(fg_json(&FeederGatewaySignature { block_hash, signature: [signature.0.r, signature.0.s] }))
+}
+
+/// The latest synced block number, for the endpoints whose missing/`null` block argument means
+/// "latest". An empty chain maps to the block-0 not-found envelope.
+async fn latest_block_number(state: &AppState) -> FgResult<BlockNumber> {
+    state
+        .reader
+        .latest_block_header()
+        .await?
+        .map(|header| header.block_header_without_hash.block_number)
+        .ok_or(FeederGatewayError::BlockNotFound(BlockNumber(0)))
 }
 
 /// `GET /feeder_gateway/get_block_hash_by_id?blockId=<n>` — returns the block hash of the given
@@ -45,17 +62,39 @@ pub(crate) async fn get_block_hash_by_id(
     Extension(state): Extension<AppState>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Response, FeederGatewayError> {
-    let block_number = parse_block_id(&params)?;
-    let block_hash = state.reader.block_hash(block_number).await.map_err(|error| match error {
-        // Verified live: a block id beyond the chain head is MALFORMED_REQUEST ("Block ID should
-        // be in the range [0, <head+1>); got: <id>."), NOT BLOCK_NOT_FOUND. A synced-storage miss
-        // is exactly that out-of-range condition (headers are stored contiguously from genesis).
-        FeederGatewayError::BlockNotFound(_) => {
-            FeederGatewayError::MalformedRequest(format!("block id out of range: {block_number}"))
+    let (block_number, python_int_echo) = match parse_block_id(&params)? {
+        CoercedBlockId::InRange { block_number, python_int_echo } => {
+            (block_number, python_int_echo)
         }
-        other => other,
-    })?;
-    Ok(fg_json(&block_hash))
+        CoercedBlockId::OutOfRange { python_int_echo } => {
+            return Err(block_id_out_of_range(&state, &python_int_echo).await);
+        }
+    };
+    match state.reader.block_hash(block_number).await {
+        Ok(block_hash) => Ok(fg_json(&block_hash)),
+        // Verified live: a block id beyond the chain head is MALFORMED_REQUEST with the range
+        // message, NOT BLOCK_NOT_FOUND; a synced-storage miss is exactly that out-of-range
+        // condition (headers are stored contiguously from genesis).
+        Err(FeederGatewayError::BlockNotFound(_)) => {
+            Err(block_id_out_of_range(&state, &python_int_echo).await)
+        }
+        Err(other) => Err(other),
+    }
+}
+
+/// Builds the live out-of-range blockId message; the bound is one past OUR latest synced block.
+/// The live service's bound is its block-ID assignment counter, which runs AHEAD of the latest
+/// finalized block (observed live: bound 10421102 vs latest 10415834) — instance state a
+/// re-serving node cannot replicate, so the FORMAT is parity while the bound reflects this node's
+/// view.
+async fn block_id_out_of_range(state: &AppState, python_int_echo: &str) -> FeederGatewayError {
+    let block_id_bound = match state.reader.latest_block_header().await {
+        Ok(Some(header)) => header.block_header_without_hash.block_number.0 + 1,
+        _ => 0,
+    };
+    FeederGatewayError::MalformedRequest(format!(
+        "Block ID should be in the range [0, {block_id_bound}); got: {python_int_echo}."
+    ))
 }
 
 /// `GET /feeder_gateway/get_block_id_by_hash?blockHash=0x..` — returns the bare block number of
@@ -76,21 +115,52 @@ pub(crate) async fn get_block_id_by_hash(
     Ok(fg_json(&block_number))
 }
 
-/// Parses the required `blockId` query parameter as a block number. Treats the request as
-/// adversarial: a missing or non-`u64` value yields a `MalformedRequest` (400) rather than a panic,
-/// and `u64` parsing caps the value inherently.
-///
-/// Only the numeric form exists: the live feeder gateway parses `blockId` as a JSON integer and
-/// rejects `latest`/`pending`/hash/`null` forms as MALFORMED_REQUEST (verified live; an earlier
-/// plan note claiming otherwise was wrong).
-fn parse_block_id(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
+/// A `blockId` value after Python's `int(json.loads(value))` coercion: a candidate block number,
+/// or a value that can never be a block (negative or beyond u64). `python_int_echo` is the
+/// coerced integer as Python would print it in the out-of-range message.
+enum CoercedBlockId {
+    InRange { block_number: BlockNumber, python_int_echo: String },
+    OutOfRange { python_int_echo: String },
+}
+
+/// Parses the required `blockId` query parameter with the live semantics (verified 2026-06-03):
+/// Python's `int(json.loads(value))`, so floats truncate (1.5 is block 1), booleans coerce (true
+/// is block 1), `null` fails `int(None)` with the echoed TypeError, a missing field echoes the
+/// KeyError, and non-JSON forms (`latest`/`pending`/hashes) echo the `json.loads` error. Treats
+/// the request as adversarial: every malformed form is a 400, never a panic.
+fn parse_block_id(params: &HashMap<String, String>) -> FgResult<CoercedBlockId> {
     let raw = params
         .get("blockId")
-        .ok_or_else(|| FeederGatewayError::MalformedRequest("missing blockId".to_string()))?;
-    let block_number = raw
-        .parse::<u64>()
-        .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockId: {raw}")))?;
-    Ok(BlockNumber(block_number))
+        .ok_or_else(|| FeederGatewayError::MalformedRequest("'blockId'".to_string()))?;
+    match parse_legacy_json_scalar(raw).map_err(FeederGatewayError::MalformedRequest)? {
+        LegacyJsonScalar::Null => Err(FeederGatewayError::MalformedRequest(
+            "int() argument must be a string, a bytes-like object or a number, not 'NoneType'"
+                .to_string(),
+        )),
+        LegacyJsonScalar::Bool(boolean_value) => Ok(CoercedBlockId::InRange {
+            block_number: BlockNumber(u64::from(boolean_value)),
+            python_int_echo: u64::from(boolean_value).to_string(),
+        }),
+        LegacyJsonScalar::Float { truncated, .. } => {
+            let python_int_echo = truncated.to_string();
+            match u64::try_from(truncated) {
+                Ok(block_number) => Ok(CoercedBlockId::InRange {
+                    block_number: BlockNumber(block_number),
+                    python_int_echo,
+                }),
+                Err(_) => Ok(CoercedBlockId::OutOfRange { python_int_echo }),
+            }
+        }
+        LegacyJsonScalar::Int { value: Some(block_number), python_repr, .. } => {
+            Ok(CoercedBlockId::InRange {
+                block_number: BlockNumber(block_number),
+                python_int_echo: python_repr,
+            })
+        }
+        LegacyJsonScalar::Int { python_repr, .. } => {
+            Ok(CoercedBlockId::OutOfRange { python_int_echo: python_repr })
+        }
+    }
 }
 
 /// Parses the required `blockHash` query parameter, returning the parsed hash and the raw string
@@ -116,14 +186,35 @@ fn parse_block_hash(params: &HashMap<String, String>) -> FgResult<(BlockHash, &s
     Ok((BlockHash(felt_value), raw))
 }
 
-/// Parses the required `blockNumber` query parameter as a block number (never panics on bad input;
-/// `u64` parsing caps the value). Some legacy endpoints use `blockNumber` rather than `blockId`.
-fn parse_block_number(params: &HashMap<String, String>) -> FgResult<BlockNumber> {
-    let raw = params
-        .get("blockNumber")
-        .ok_or_else(|| FeederGatewayError::MalformedRequest("missing blockNumber".to_string()))?;
-    let block_number = raw
-        .parse::<u64>()
-        .map_err(|_| FeederGatewayError::MalformedRequest(format!("invalid blockNumber: {raw}")))?;
-    Ok(BlockNumber(block_number))
+/// Parses the optional `blockNumber` query parameter with the live get_signature semantics
+/// (verified 2026-06-03): missing or `null` means latest (`None`); the value must be a
+/// non-negative JSON integer, where booleans count as 0/1 (Python's bool is an int subclass) but
+/// floats are rejected (NOT coerced like `blockId`); integers beyond u64 are BLOCK_NOT_FOUND
+/// since no such block can exist. Never panics on bad input.
+fn parse_block_number(params: &HashMap<String, String>) -> FgResult<Option<BlockNumber>> {
+    let Some(raw) = params.get("blockNumber") else {
+        return Ok(None);
+    };
+    let non_negative_integer_required = |python_typed_echo: String| {
+        FeederGatewayError::MalformedRequest(format!(
+            // The missing space after ';' replicates the live message exactly.
+            "Field blockNumber must be a non-negative integer, or 'null';got: {python_typed_echo}."
+        ))
+    };
+    match parse_legacy_json_scalar(raw).map_err(FeederGatewayError::MalformedRequest)? {
+        LegacyJsonScalar::Null => Ok(None),
+        LegacyJsonScalar::Bool(boolean_value) => Ok(Some(BlockNumber(u64::from(boolean_value)))),
+        LegacyJsonScalar::Int { value: Some(block_number), .. } => {
+            Ok(Some(BlockNumber(block_number)))
+        }
+        LegacyJsonScalar::Int { negative: true, python_repr, .. } => {
+            Err(non_negative_integer_required(format!("int({python_repr})")))
+        }
+        LegacyJsonScalar::Int { python_repr, .. } => {
+            Err(FeederGatewayError::OversizedBlockNumberNotFound(python_repr))
+        }
+        LegacyJsonScalar::Float { python_repr, .. } => {
+            Err(non_negative_integer_required(format!("float({python_repr})")))
+        }
+    }
 }

--- a/crates/apollo_feeder_gateway/src/handlers_test.rs
+++ b/crates/apollo_feeder_gateway/src/handlers_test.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use apollo_feeder_gateway_config::config::{FeederGatewayConfig, FeederGatewayContractAddresses};
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
-use starknet_api::block::{BlockHash, BlockNumber, BlockSignature};
+use rstest::rstest;
+use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 use starknet_api::core::{ContractAddress, SequencerPublicKey};
 use starknet_api::crypto::utils::{PublicKey, Signature};
 use starknet_api::hash::StarkHash;
@@ -225,6 +226,12 @@ async fn get_block_hash_by_id_out_of_range_is_malformed_request() {
     reader
         .expect_block_hash()
         .returning(|block_number| Err(FeederGatewayError::BlockNotFound(block_number)));
+    // The range bound in the message is one past the latest synced block.
+    reader.expect_latest_block_header().returning(|| {
+        let mut header = BlockHeader::default();
+        header.block_header_without_hash.block_number = BlockNumber(5);
+        Ok(Some(header))
+    });
     let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
 
     let response = feeder_gateway
@@ -238,16 +245,153 @@ async fn get_block_hash_by_id_out_of_range_is_malformed_request() {
         .await
         .unwrap();
 
-    // Verified live: a block id beyond the chain head is MALFORMED_REQUEST, not BLOCK_NOT_FOUND.
+    // Verified live: a block id beyond the chain head is MALFORMED_REQUEST with the range
+    // message, not BLOCK_NOT_FOUND.
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-    let body_text = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_text.contains("MALFORMED_REQUEST"));
-    assert!(!body_text.contains("BLOCK_NOT_FOUND"));
+    assert_eq!(
+        String::from_utf8(body.to_vec()).unwrap(),
+        r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "Block ID should be in the range [0, 6); got: 99999999."}"#
+    );
+}
+
+/// Live semantics: blockId goes through Python's int(json.loads(value)), so floats truncate and
+/// booleans coerce (verified live: blockId=1.5 and blockId=true both serve block 1).
+#[rstest]
+#[case::float_truncates("1.5")]
+#[case::bool_coerces("true")]
+#[tokio::test]
+async fn get_block_hash_by_id_coerces_to_int_like_python(#[case] block_id: &str) {
+    let mut reader = MockChainDataReader::new();
+    reader
+        .expect_block_hash()
+        .withf(|block_number| *block_number == BlockNumber(1))
+        .returning(|_| Ok(BlockHash(StarkHash::from(0x1234_u128))));
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/feeder_gateway/get_block_hash_by_id?blockId={block_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&body[..], br#""0x1234""#);
 }
 
 #[tokio::test]
-async fn get_block_hash_by_id_missing_param_is_bad_request() {
+async fn get_block_hash_by_id_null_echoes_python_none_int_error() {
+    let feeder_gateway =
+        FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/feeder_gateway/get_block_hash_by_id?blockId=null")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    // The exact live message: Python's int(None) TypeError echo.
+    assert_eq!(
+        String::from_utf8(body.to_vec()).unwrap(),
+        r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'"}"#
+    );
+}
+
+/// Live semantics: a missing or null blockNumber serves the LATEST synced block's signature.
+#[rstest]
+#[case::missing_param("")]
+#[case::null_param("?blockNumber=null")]
+#[tokio::test]
+async fn get_signature_without_block_number_serves_latest(#[case] query_string: &str) {
+    let mut reader = MockChainDataReader::new();
+    reader.expect_latest_block_header().returning(|| {
+        let mut header = BlockHeader::default();
+        header.block_header_without_hash.block_number = BlockNumber(9);
+        Ok(Some(header))
+    });
+    reader
+        .expect_block_signature()
+        .withf(|block_number| *block_number == BlockNumber(9))
+        .returning(|_| {
+            Ok((
+                BlockHash(StarkHash::from(0x1_u128)),
+                BlockSignature(Signature {
+                    r: StarkHash::from(0x2_u128),
+                    s: StarkHash::from(0x3_u128),
+                }),
+            ))
+        });
+    let feeder_gateway = FeederGateway::new(FeederGatewayConfig::default(), Arc::new(reader));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/feeder_gateway/get_signature{query_string}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&body[..], br#"{"block_hash": "0x1", "signature": ["0x2", "0x3"]}"#);
+}
+
+/// Every expected message is the exact live response text for the same input.
+#[rstest]
+#[case::negative_int(
+    "-1",
+    r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "Field blockNumber must be a non-negative integer, or 'null';got: int(-1)."}"#
+)]
+#[case::float_rejected(
+    "1.5",
+    r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "Field blockNumber must be a non-negative integer, or 'null';got: float(1.5)."}"#
+)]
+#[case::beyond_u64_is_not_found(
+    "99999999999999999999999",
+    r#"{"code": "StarknetErrorCode.BLOCK_NOT_FOUND", "message": "Block number 99999999999999999999999 was not found."}"#
+)]
+#[tokio::test]
+async fn get_signature_invalid_block_number_replicates_live_messages(
+    #[case] block_number: &str,
+    #[case] live_body: &str,
+) {
+    let feeder_gateway =
+        FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()));
+
+    let response = feeder_gateway
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/feeder_gateway/get_signature?blockNumber={block_number}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(String::from_utf8(body.to_vec()).unwrap(), live_body);
+}
+
+#[tokio::test]
+async fn get_block_hash_by_id_missing_param_echoes_python_key_error() {
     let feeder_gateway =
         FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()));
 
@@ -263,4 +407,10 @@ async fn get_block_hash_by_id_missing_param_is_bad_request() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    // The exact live message: Python's KeyError echo for the missing field.
+    assert_eq!(
+        String::from_utf8(body.to_vec()).unwrap(),
+        r#"{"code": "StarkErrorCode.MALFORMED_REQUEST", "message": "'blockId'"}"#
+    );
 }

--- a/crates/apollo_feeder_gateway/src/legacy_params.rs
+++ b/crates/apollo_feeder_gateway/src/legacy_params.rs
@@ -1,0 +1,121 @@
+//! Replicates how the legacy Python feeder gateway parses numeric query values:
+//! `json.loads(value)` followed by per-endpoint integer handling, including the exact live error
+//! messages (verified 2026-06-03). Documented divergences from Python, accepted as out of scope:
+//! JSON strings/arrays/objects as values (live coerces or type-errors on them; here they fall to
+//! the `Expecting value` message) and scientific-notation float echoes (Python's shortest-repr
+//! formatting differs from Rust's).
+
+use num_traits::ToPrimitive;
+
+#[cfg(test)]
+#[path = "legacy_params_test.rs"]
+mod legacy_params_test;
+
+/// A scalar parsed the way Python's `json.loads` parses a legacy numeric query value.
+#[derive(Debug, PartialEq)]
+pub(crate) enum LegacyJsonScalar {
+    /// A JSON integer. `python_repr` is the digits Python echoes (arbitrary precision); `value`
+    /// is its `u64` form, `None` when negative or beyond `u64` (no such block can exist).
+    Int {
+        python_repr: String,
+        negative: bool,
+        value: Option<u64>,
+    },
+    /// A JSON float; `truncated` is Python's `int()` coercion (toward zero).
+    Float {
+        python_repr: String,
+        truncated: i64,
+    },
+    Bool(bool),
+    Null,
+}
+
+/// Parses `raw` as Python's `json.loads` would parse a scalar; the error is the exact live
+/// MALFORMED_REQUEST message (a `json.loads` error echo).
+pub(crate) fn parse_legacy_json_scalar(raw: &str) -> Result<LegacyJsonScalar, String> {
+    const EXPECTING_VALUE: &str = "Expecting value: line 1 column 1 (char 0)";
+    match raw {
+        "null" => return Ok(LegacyJsonScalar::Null),
+        "true" => return Ok(LegacyJsonScalar::Bool(true)),
+        "false" => return Ok(LegacyJsonScalar::Bool(false)),
+        _ => {}
+    }
+
+    let number_prefix_length = json_number_prefix_length(raw);
+    if number_prefix_length == 0 {
+        return Err(EXPECTING_VALUE.to_string());
+    }
+    if number_prefix_length < raw.len() {
+        // json.loads parses the leading number and reports the rest, 1-based for the column.
+        return Err(format!(
+            "Extra data: line 1 column {} (char {})",
+            number_prefix_length + 1,
+            number_prefix_length
+        ));
+    }
+
+    if raw.contains(['.', 'e', 'E']) {
+        let parsed_float: f64 = raw.parse().map_err(|_| EXPECTING_VALUE.to_string())?;
+        // Truncation toward zero matches Python's int(); a float beyond i64 saturates, which is
+        // out of block-number range regardless.
+        let truncated = parsed_float
+            .trunc()
+            .to_i64()
+            .unwrap_or(if parsed_float.is_sign_negative() { i64::MIN } else { i64::MAX });
+        return Ok(LegacyJsonScalar::Float {
+            python_repr: format_python_float(parsed_float),
+            truncated,
+        });
+    }
+
+    let negative = raw.starts_with('-');
+    let value = if negative { None } else { raw.parse::<u64>().ok() };
+    Ok(LegacyJsonScalar::Int { python_repr: raw.to_string(), negative, value })
+}
+
+/// The length of the longest JSON-number prefix of `raw` (JSON grammar: optional `-`, then `0` or
+/// a non-zero-led digit run, then optional fraction and exponent), or 0 if none.
+fn json_number_prefix_length(raw: &str) -> usize {
+    let bytes = raw.as_bytes();
+    let mut index = 0;
+    if bytes.get(index) == Some(&b'-') {
+        index += 1;
+    }
+    match bytes.get(index) {
+        // JSON forbids leading zeros: `01` parses as `0` with trailing data.
+        Some(b'0') => index += 1,
+        Some(digit) if digit.is_ascii_digit() => {
+            while bytes.get(index).is_some_and(|byte| byte.is_ascii_digit()) {
+                index += 1;
+            }
+        }
+        _ => return 0,
+    }
+    if bytes.get(index) == Some(&b'.')
+        && bytes.get(index + 1).is_some_and(|byte| byte.is_ascii_digit())
+    {
+        index += 1;
+        while bytes.get(index).is_some_and(|byte| byte.is_ascii_digit()) {
+            index += 1;
+        }
+    }
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        let mut exponent_index = index + 1;
+        if matches!(bytes.get(exponent_index), Some(b'+' | b'-')) {
+            exponent_index += 1;
+        }
+        if bytes.get(exponent_index).is_some_and(|byte| byte.is_ascii_digit()) {
+            while bytes.get(exponent_index).is_some_and(|byte| byte.is_ascii_digit()) {
+                exponent_index += 1;
+            }
+            index = exponent_index;
+        }
+    }
+    index
+}
+
+/// Formats a float the way Python's repr does for plain decimal values (e.g. `1.5`, `2.0`).
+fn format_python_float(value: f64) -> String {
+    let formatted = format!("{value}");
+    if formatted.contains('.') { formatted } else { format!("{formatted}.0") }
+}

--- a/crates/apollo_feeder_gateway/src/legacy_params_test.rs
+++ b/crates/apollo_feeder_gateway/src/legacy_params_test.rs
@@ -1,0 +1,52 @@
+use rstest::rstest;
+
+use crate::legacy_params::{parse_legacy_json_scalar, LegacyJsonScalar};
+
+/// Every message here is the exact live response text for the same input (verified 2026-06-03).
+#[rstest]
+#[case::letters("zzz", "Expecting value: line 1 column 1 (char 0)")]
+#[case::latest("latest", "Expecting value: line 1 column 1 (char 0)")]
+#[case::pending("pending", "Expecting value: line 1 column 1 (char 0)")]
+#[case::empty("", "Expecting value: line 1 column 1 (char 0)")]
+#[case::bare_minus("-", "Expecting value: line 1 column 1 (char 0)")]
+#[case::block_hash(
+    "0x78b67b11f8c23850041e11fb0f3b39db0bcb2c99d756d5a81321d1b483d79f6",
+    "Extra data: line 1 column 2 (char 1)"
+)]
+#[case::leading_zero("01", "Extra data: line 1 column 2 (char 1)")]
+#[case::digits_then_letters("123abc", "Extra data: line 1 column 4 (char 3)")]
+fn json_loads_error_messages(#[case] raw_value: &str, #[case] live_message: &str) {
+    assert_eq!(parse_legacy_json_scalar(raw_value), Err(live_message.to_string()));
+}
+
+#[rstest]
+#[case::null("null", LegacyJsonScalar::Null)]
+#[case::bool_true("true", LegacyJsonScalar::Bool(true))]
+#[case::bool_false("false", LegacyJsonScalar::Bool(false))]
+#[case::small_int(
+    "7",
+    LegacyJsonScalar::Int { python_repr: "7".to_string(), negative: false, value: Some(7) }
+)]
+#[case::negative_int(
+    "-1",
+    LegacyJsonScalar::Int { python_repr: "-1".to_string(), negative: true, value: None }
+)]
+#[case::beyond_u64_int(
+    "99999999999999999999999",
+    LegacyJsonScalar::Int {
+        python_repr: "99999999999999999999999".to_string(),
+        negative: false,
+        value: None
+    }
+)]
+#[case::float_truncates(
+    "1.5",
+    LegacyJsonScalar::Float { python_repr: "1.5".to_string(), truncated: 1 }
+)]
+#[case::negative_float_truncates_toward_zero(
+    "-1.5",
+    LegacyJsonScalar::Float { python_repr: "-1.5".to_string(), truncated: -1 }
+)]
+fn json_loads_scalars(#[case] raw_value: &str, #[case] expected_scalar: LegacyJsonScalar) {
+    assert_eq!(parse_legacy_json_scalar(raw_value), Ok(expected_scalar));
+}

--- a/crates/apollo_feeder_gateway/src/lib.rs
+++ b/crates/apollo_feeder_gateway/src/lib.rs
@@ -4,6 +4,7 @@ pub mod communication;
 pub mod errors;
 pub mod feeder_gateway;
 pub mod handlers;
+pub(crate) mod legacy_params;
 pub mod metrics;
 pub mod objects;
 pub mod reader;


### PR DESCRIPTION
The live service parses numeric query values as Python int(json.loads(value)) with per-endpoint
rules, and its error messages are literal Python error echoes. Probing (2026-06-03) pinned the
behaviors: blockId coerces floats and booleans (1.5 and true both serve block 1), null fails
int(None) with the TypeError echo, a missing field echoes the KeyError ('blockId'), non-JSON forms
echo json.loads errors with exact positions, and out-of-range ids get the range message. By
contrast get_signature accepts only non-negative integers (plus booleans, Python's int subclass),
rejects floats with the "Field blockNumber" message, treats missing/null as LATEST (it served the
tip signature, where we returned an error), and maps beyond-u64 integers to BLOCK_NOT_FOUND with
the arbitrary-precision digits echoed.

Adds legacy_params: a json.loads-equivalent scalar parser producing the exact live error strings
(Expecting value / Extra data with computed 1-based positions, JSON's leading-zero rule) and
int/float/bool/null scalars with Python echo forms. get_block_hash_by_id coerces via the parser
and produces the live range message whose bound is one past OUR latest synced block (the live
bound is its block-ID assignment counter, observed ~5K AHEAD of its finalized tip; instance state
a re-serving node cannot replicate, so format is the parity contract). get_signature gains the
latest-default path (new latest_block_number helper) and the strict field validation; a new
OversizedBlockNumberNotFound error carries beyond-u64 digits. Tests pin every probed live body
byte-exactly; the smoke test exercises the range bound and latest-signature paths end-to-end.

Python's json.loads/int() quirks were replicated mechanically rather than approximated, because
each probed message is testable; the documented exceptions (JSON strings/arrays as values,
scientific-notation float echoes) require a Python repr clone for inputs no real client sends.
Floats truncate via `as` (toward zero, like int()) and booleans coerce on BOTH endpoints since
bool is an int subclass in Python, which live confirmed by serving block 1 for blockNumber=true.