### PR TITLE
apollo_dashboard: METRICS add feeder gateway dashboard row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ dependencies = [
  "apollo_consensus",
  "apollo_consensus_manager",
  "apollo_consensus_orchestrator",
+ "apollo_feeder_gateway",
  "apollo_gateway",
  "apollo_http_server",
  "apollo_infra",

--- a/crates/apollo_dashboard/Cargo.toml
+++ b/crates/apollo_dashboard/Cargo.toml
@@ -22,6 +22,7 @@ apollo_config_manager.workspace = true
 apollo_consensus.workspace = true
 apollo_consensus_manager.workspace = true
 apollo_consensus_orchestrator.workspace = true
+apollo_feeder_gateway.workspace = true
 apollo_gateway.workspace = true
 apollo_http_server.workspace = true
 apollo_infra.workspace = true
@@ -55,6 +56,7 @@ apollo_config_manager = { workspace = true, features = ["testing"] }
 apollo_consensus = { workspace = true, features = ["testing"] }
 apollo_consensus_manager = { workspace = true, features = ["testing"] }
 apollo_consensus_orchestrator = { workspace = true, features = ["testing"] }
+apollo_feeder_gateway = { workspace = true, features = ["testing"] }
 apollo_gateway = { workspace = true, features = ["testing"] }
 apollo_http_server = { workspace = true, features = ["testing"] }
 apollo_infra = { workspace = true, features = ["testing"] }

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -1540,6 +1540,20 @@
       ],
       "collapsed": true
     },
+    "Feeder Gateway": {
+      "panels": [
+        {
+          "title": "Feeder Gateway Requests Rate (RPS)",
+          "description": "The rate of requests received by the feeder gateway (1m window)",
+          "type": "timeseries",
+          "exprs": [
+            "rate(feeder_gateway_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[1m])"
+          ],
+          "extra_params": {}
+        }
+      ],
+      "collapsed": true
+    },
     "L1 Events": {
       "panels": [
         {
@@ -4455,6 +4469,58 @@
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.95 state_sync_processing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.50 state_sync_queueing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_hash\"}[5m])), \"label_name\", \"0.95 state_sync_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_number_by_hash (client-side)",
+          "description": "client-side infra metrics for request type get_block_number_by_hash",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.50 state_sync_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.95 state_sync_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.50 state_sync_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.95 state_sync_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.50 state_sync_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.95 state_sync_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_number_by_hash (server-side)",
+          "description": "server-side infra metrics for request type get_block_number_by_hash",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.50 state_sync_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.95 state_sync_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.50 state_sync_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_number_by_hash\"}[5m])), \"label_name\", \"0.95 state_sync_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_signature (client-side)",
+          "description": "client-side infra metrics for request type get_block_signature",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.50 state_sync_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.95 state_sync_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.50 state_sync_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.95 state_sync_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.50 state_sync_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.95 state_sync_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_block_signature (server-side)",
+          "description": "server-side infra metrics for request type get_block_signature",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.50 state_sync_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.95 state_sync_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.50 state_sync_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_block_signature\"}[5m])), \"label_name\", \"0.95 state_sync_queueing_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },

--- a/crates/apollo_dashboard/src/dashboard_definitions.rs
+++ b/crates/apollo_dashboard/src/dashboard_definitions.rs
@@ -31,6 +31,7 @@ use crate::panels::consensus::{
     get_panel_consensus_round,
     get_snip35_row,
 };
+use crate::panels::feeder_gateway::get_feeder_gateway_row;
 use crate::panels::gateway::{get_gateway_row, get_panel_gateway_add_tx_failure_by_reason};
 use crate::panels::http_server::{
     get_http_server_row,
@@ -104,6 +105,7 @@ pub fn get_apollo_dashboard() -> Dashboard {
             get_committer_row(),
             // ─── Sync & external sources ───
             get_state_sync_row(),
+            get_feeder_gateway_row(),
             get_l1_events_row(),
             get_l1_gas_price_row(),
             // ─── Operational ───

--- a/crates/apollo_dashboard/src/metric_definitions_test.rs
+++ b/crates/apollo_dashboard/src/metric_definitions_test.rs
@@ -20,6 +20,7 @@ use apollo_config_manager::metrics::{
 use apollo_consensus::metrics::CONSENSUS_ALL_METRICS;
 use apollo_consensus_manager::metrics::CONSENSUS_MANAGER_ALL_METRICS;
 use apollo_consensus_orchestrator::metrics::CONSENSUS_ORCHESTRATOR_ALL_METRICS;
+use apollo_feeder_gateway::metrics::FEEDER_GATEWAY_ALL_METRICS;
 use apollo_gateway::metrics::{GATEWAY_ALL_METRICS, INFRA_ALL_METRICS as GATEWAY_INFRA_METRICS};
 use apollo_http_server::metrics::HTTP_SERVER_ALL_METRICS;
 use apollo_infra::tokio_metrics::TOKIO_ALL_METRICS;
@@ -68,6 +69,7 @@ fn metric_names_no_duplications() {
         .chain(CONSENSUS_ALL_METRICS.iter())
         .chain(CONSENSUS_MANAGER_ALL_METRICS.iter())
         .chain(CONSENSUS_ORCHESTRATOR_ALL_METRICS.iter())
+        .chain(FEEDER_GATEWAY_ALL_METRICS.iter())
         .chain(GATEWAY_ALL_METRICS.iter())
         .chain(GATEWAY_INFRA_METRICS.iter())
         .chain(HTTP_SERVER_ALL_METRICS.iter())

--- a/crates/apollo_dashboard/src/panels.rs
+++ b/crates/apollo_dashboard/src/panels.rs
@@ -3,6 +3,7 @@ pub(crate) mod blockifier;
 pub(crate) mod class_manager;
 pub(crate) mod committer;
 pub(crate) mod consensus;
+pub(crate) mod feeder_gateway;
 pub(crate) mod gateway;
 pub(crate) mod http_server;
 pub(crate) mod l1_events;

--- a/crates/apollo_dashboard/src/panels/feeder_gateway.rs
+++ b/crates/apollo_dashboard/src/panels/feeder_gateway.rs
@@ -1,0 +1,18 @@
+use apollo_feeder_gateway::metrics::FEEDER_GATEWAY_REQUESTS_TOTAL;
+use apollo_metrics::metrics::MetricQueryName;
+
+use crate::dashboard::Row;
+use crate::panel::{Panel, PanelType};
+
+fn get_panel_feeder_gateway_requests_rate() -> Panel {
+    Panel::new(
+        "Feeder Gateway Requests Rate (RPS)",
+        "The rate of requests received by the feeder gateway (1m window)",
+        format!("rate({}[1m])", FEEDER_GATEWAY_REQUESTS_TOTAL.get_name_with_filter()),
+        PanelType::TimeSeries,
+    )
+}
+
+pub(crate) fn get_feeder_gateway_row() -> Row {
+    Row::new("Feeder Gateway", vec![get_panel_feeder_gateway_requests_rate()])
+}


### PR DESCRIPTION
## Goal
A metric is only useful if it is visible. The previous PR added the feeder gateway request counter;
this PR surfaces it on the Grafana dashboard so operators can actually watch feeder gateway traffic,
and registers the component with the dashboard's metric tooling.

## Summary of changes
Adds a feeder gateway panel module (a requests-rate panel over FEEDER_GATEWAY_REQUESTS_TOTAL) and a
"Feeder Gateway" row, placed in the "Sync & external sources" group; adds FEEDER_GATEWAY_ALL_METRICS
to the metric-name dedup test; adds the apollo_feeder_gateway dependency (and its testing dev-dep for
the metrics list); regenerates dev_grafana.json.

## Key decision points
Grouped the feeder gateway row under "Sync & external sources" rather than the transaction-ingestion
section, because the feeder gateway re-serves synced chain data — it is a read/serving component, not
part of the ingestion path. Started with a single requests-rate panel; richer per-endpoint and
latency panels follow once the request-recording middleware exists and more endpoints land, keeping
this PR aligned with the single metric defined so far. Added FEEDER_GATEWAY_ALL_METRICS to the dedup
test so the feeder gateway's metric names are checked for collisions like every other component's.