### PR TITLE
apollo_feeder_gateway: METRICS record request metric via router middleware

### DIFF
--- a/crates/apollo_feeder_gateway/src/feeder_gateway.rs
+++ b/crates/apollo_feeder_gateway/src/feeder_gateway.rs
@@ -7,7 +7,7 @@ use apollo_infra_utils::type_name::short_type_name;
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use axum::routing::get;
-use axum::{serve, Extension, Router};
+use axum::{middleware, serve, Extension, Router};
 use tokio::net::TcpListener;
 use tracing::info;
 
@@ -40,14 +40,6 @@ impl FeederGateway {
     pub fn app(&self) -> Router {
         Router::new()
             .route(
-                "/feeder_gateway/is_alive",
-                get(|| async { (StatusCode::OK, "FeederGateway is alive") }),
-            )
-            .route(
-                "/feeder_gateway/is_ready",
-                get(|| async { (StatusCode::OK, "FeederGateway is ready") }),
-            )
-            .route(
                 "/feeder_gateway/get_contract_addresses",
                 get(crate::handlers::get_contract_addresses),
             )
@@ -61,6 +53,18 @@ impl FeederGateway {
             )
             .route("/feeder_gateway/get_public_key", get(crate::handlers::get_public_key))
             .route("/feeder_gateway/get_signature", get(crate::handlers::get_signature))
+            // A router layer wraps only the routes added before it, so the request metric counts
+            // API requests but not the health probes below (kubernetes polls those constantly,
+            // which would drown the metric in probe noise).
+            .layer(middleware::from_fn(crate::metrics::record_request_metrics))
+            .route(
+                "/feeder_gateway/is_alive",
+                get(|| async { (StatusCode::OK, "FeederGateway is alive") }),
+            )
+            .route(
+                "/feeder_gateway/is_ready",
+                get(|| async { (StatusCode::OK, "FeederGateway is ready") }),
+            )
             .layer(Extension(self.app_state.clone()))
     }
 }

--- a/crates/apollo_feeder_gateway/src/metrics.rs
+++ b/crates/apollo_feeder_gateway/src/metrics.rs
@@ -1,4 +1,7 @@
 use apollo_metrics::define_metrics;
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
 use tracing::info;
 
 #[cfg(test)]
@@ -14,4 +17,11 @@ define_metrics!(
 pub(crate) fn init_metrics() {
     info!("Initializing FeederGateway metrics");
     FEEDER_GATEWAY_REQUESTS_TOTAL.register();
+}
+
+/// Axum middleware recording the request metric. Applied once as a router layer over the API
+/// routes, rather than copied into each handler.
+pub(crate) async fn record_request_metrics(request: Request, next: Next) -> Response {
+    FEEDER_GATEWAY_REQUESTS_TOTAL.increment(1);
+    next.run(request).await
 }

--- a/crates/apollo_feeder_gateway/src/metrics_test.rs
+++ b/crates/apollo_feeder_gateway/src/metrics_test.rs
@@ -1,6 +1,14 @@
-use metrics_exporter_prometheus::PrometheusBuilder;
+use std::sync::Arc;
 
+use apollo_feeder_gateway_config::config::FeederGatewayConfig;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tower::util::ServiceExt;
+
+use crate::feeder_gateway::FeederGateway;
 use crate::metrics::{init_metrics, FEEDER_GATEWAY_REQUESTS_TOTAL};
+use crate::reader::MockChainDataReader;
 
 #[test]
 fn feeder_gateway_metrics_register_at_zero() {
@@ -11,4 +19,30 @@ fn feeder_gateway_metrics_register_at_zero() {
 
     let rendered = recorder.handle().render();
     FEEDER_GATEWAY_REQUESTS_TOTAL.assert_eq::<usize>(&rendered, 0);
+}
+
+#[tokio::test]
+async fn request_metric_counts_api_requests_but_not_health_probes() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    init_metrics();
+
+    let app =
+        FeederGateway::new(FeederGatewayConfig::default(), Arc::new(MockChainDataReader::new()))
+            .app();
+
+    let api_request_uris =
+        ["/feeder_gateway/get_public_key", "/feeder_gateway/get_contract_addresses"];
+    let health_probe_uris = ["/feeder_gateway/is_alive", "/feeder_gateway/is_ready"];
+    for uri in api_request_uris.iter().chain(&health_probe_uris) {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(*uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    let rendered = recorder.handle().render();
+    FEEDER_GATEWAY_REQUESTS_TOTAL.assert_eq::<usize>(&rendered, api_request_uris.len());
 }


### PR DESCRIPTION
FEEDER_GATEWAY_REQUESTS_TOTAL (PR13) is registered and charted on the dashboard (PR14), but nothing
increments it, so the panel reads a flat zero regardless of traffic. Close the gap by actually
recording requests, per the A4 observability plan: one axum middleware layer, not a per-handler copy.

Adds a record_request_metrics axum middleware to metrics.rs that increments the counter and forwards
the request, and applies it as a single router layer in app(). Adds a test driving API and health
requests through the router and asserting the counter counts exactly the API requests.

The layer is inserted after the API routes and before the health routes (an axum layer wraps only
routes added before it), so is_alive/is_ready probes do not count: kubernetes polls them constantly,
which would drown the metric in probe noise and make the dashboard panel useless for tracking real
usage. The A4 expansions (per-endpoint labels, failure counter, latency histogram, saturation gauge)
are deliberately left for follow-ups; this PR only makes the existing counter truthful.