### PR TITLE
apollo_node: forward os_input feature to committer/batcher deps

### DIFF
--- a/crates/apollo_node/Cargo.toml
+++ b/crates/apollo_node/Cargo.toml
@@ -8,6 +8,11 @@ description = "Main Starknet sequencer node orchestrating all components."
 
 [features]
 cairo_native = ["apollo_batcher/cairo_native", "apollo_gateway/cairo_native"]
+os_input = [
+  "apollo_batcher/os_input",
+  "apollo_committer/os_input",
+  "apollo_committer_types/os_input",
+]
 testing = ["tokio-util"]
 
 [lints]


### PR DESCRIPTION
## Problem

`--all-features` clippy builds (e.g. the `code_style` job) fail to compile because `apollo_node` exposed no `os_input` feature. Under `--all-features`, the `os_input` gates on shared types (`apollo_committer_types`, `starknet_committer`) get enabled, while the consumers' own `os_input` stays off, yielding cross-crate errors:

- **E0027** in `apollo_committer::update_metrics` — the `os_input`-gated `BlockMeasurement.fetched_witnesses_count` field is present in the compiled struct but omitted from the exhaustive destructure.
- **E0004** in `apollo_batcher` — non-exhaustive match on the `os_input`-gated `CommitterRequestLabelValue::ReadPathsAndCommitBlock` variant (added in #14003).

Reproduced on a clean `main` post-#14003 via `cargo clippy -p apollo_node --all-targets --all-features`.

Note: #14003 was expected to resolve this but does not — the E0027 still reproduces after it merged, and it additionally introduced the E0004 site.

## Fix

Forward `os_input` from `apollo_node` to every direct dependency that defines it (`apollo_batcher`, `apollo_committer`, `apollo_committer_types`), unifying the cross-crate gate under `--all-features`. No `#[cfg]` flags removed; no source code changed.

## Verification

All green against current `main`:
- full PR-equivalent clippy package set with `--all-features`
- `cargo clippy -p apollo_node --all-targets --all-features`
- `cargo clippy -p apollo_node --all-targets` (no-feature path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)