### PR TITLE
apollo_consensus: remove stale allow(dead_code)

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -406,7 +406,6 @@ struct MultiHeightManager<ContextT: ConsensusContext> {
     // SingleHeightConsensus despite them not ever using it at the same time in a simpler way, due
     // rust limitations.
     voted_height_storage: Arc<Mutex<dyn HeightVotedStorageTrait>>,
-    #[allow(dead_code)]
     committee_provider: Arc<dyn CommitteeProvider>,
     // Proposal content streams keyed by (height, round)
     current_height_proposals_streams:


### PR DESCRIPTION
## What

Removes a stale `#[allow(dead_code)]` annotation from the `committee_provider` field of the consensus manager. The code is **not** dead — only the annotation is removed.

## Why it's stale (live callers)

`committee_provider` is read in production code:
- `crates/apollo_consensus/src/manager.rs:613` — `.committee_provider`
- `crates/apollo_consensus/src/manager.rs:804` — `get_proposer_for_height(&self.committee_provider, init.height, init.round)`

Since the field is read, the `dead_code` lint never fires for it; the annotation was stale leftover.

## What was deliberately NOT touched

The `#[allow(dead_code)]` on `EquivocationVoteReport` (same file) was kept. Its fields (`cached_vote`, `new_vote`) are only used via the derived `Debug` impl inside a `warn!` log, and rustc's dead-code analysis intentionally ignores derived impls — so that annotation is still load-bearing.

## Verification

- `scripts/rust_fmt.sh` — clean
- `cargo build -p apollo_consensus` (lib + `--tests`) — no warnings
- `cargo clippy -p apollo_consensus --all-targets` — clean
- `SEED=0 cargo test -p apollo_consensus` — 90 passed, 0 failed

https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU)_