### PR TITLE
apollo_network: remove stale allow(dead_code)

### DIFF
--- a/crates/apollo_network/src/gossipsub_impl.rs
+++ b/crates/apollo_network/src/gossipsub_impl.rs
@@ -57,7 +57,6 @@ pub enum ExternalEvent {
     /// 1. Forward the message to registered topic subscribers
     /// 2. Provide metadata about the message originator
     /// 3. Enable validation and potential peer reporting
-    #[allow(dead_code)]
     Received {
         /// The peer ID of the node that originally sent this message.
         originated_peer_id: PeerId,


### PR DESCRIPTION
## What

Removes a stale `#[allow(dead_code)]` annotation from the `Received` variant of `gossipsub_impl::ExternalEvent`. The code is **not** dead — only the annotation is removed.

## Why it's stale (live callers)

- Constructed in the `From<gossipsub::Event>` impl at `crates/apollo_network/src/gossipsub_impl.rs:88`.
- Destructured — with all three fields (`originated_peer_id`, `message`, `topic_hash`) read — in `crates/apollo_network/src/network_manager/mod.rs:974`, in the broadcast-message handling path.

Since the variant is constructed and its fields read, the `dead_code` lint no longer fires; the annotation was a leftover from before the consuming code existed.

## Note

This is unrelated to the previously-merged #14087 (which removed the unused `src/authentication/` directory). This addresses a separate stale annotation in `gossipsub_impl.rs`.

## Verification

- `scripts/rust_fmt.sh` — clean
- `cargo build -p apollo_network --tests` — no warnings
- `cargo clippy -p apollo_network --all-targets` — clean
- `SEED=0 cargo test -p apollo_network` — all passed

https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU)_