### PR TITLE
apollo_storage: remove stale allow(dead_code)

### DIFF
--- a/crates/apollo_storage/src/db/table_types/dup_sort_tables.rs
+++ b/crates/apollo_storage/src/db/table_types/dup_sort_tables.rs
@@ -101,7 +101,6 @@ where
 }
 
 impl DbWriter {
-    #[allow(dead_code)]
     pub(crate) fn create_common_prefix_table<
         MainKey: KeyTrait + Debug,
         SubKey: KeyTrait + Debug,
@@ -345,7 +344,6 @@ impl<'env, K: KeyTrait + Debug, V: ValueSerde + Debug, T: DupSortTableType + Dup
     // The sub-key is equal to the last sub-key of the given main-key.
     // NOTICE: if this returns an error, the transaction should not be committed. Doing so can cause
     // a corrupt database.
-    #[allow(dead_code)]
     pub(crate) fn append_greater_sub_key(
         &'env self,
         txn: &DbTransaction<'env, RW>,

--- a/crates/apollo_storage/src/db/table_types/mod.rs
+++ b/crates/apollo_storage/src/db/table_types/mod.rs
@@ -56,7 +56,6 @@ pub(crate) trait Table<'env> {
 
     // Append a key value pair to the end of the table. The key must be bigger than or equal to
     // the last key in the table; otherwise, an error will be returned.
-    #[allow(dead_code)]
     fn append(
         &'env self,
         txn: &DbTransaction<'env, RW>,

--- a/crates/apollo_storage/src/db/table_types/simple_table.rs
+++ b/crates/apollo_storage/src/db/table_types/simple_table.rs
@@ -112,7 +112,6 @@ impl<'env, K: KeyTrait + Debug, V: ValueSerde + Debug> Table<'env>
         Ok(())
     }
 
-    #[allow(dead_code)]
     fn append(
         &'env self,
         txn: &DbTransaction<'env, RW>,


### PR DESCRIPTION
## What

Removes four stale `#[allow(dead_code)]` annotations on `db/table_types` methods. The code is **not** dead — only the annotations are removed.

## Why each is stale (live production callers)

- **`DbWriter::create_common_prefix_table`** (`dup_sort_tables.rs`) — called in `lib.rs` when opening storage: `contract_storage` (249), `events` (257), `nonces` (261), `compiled_class_hash` (276).
- **`append_greater_sub_key`** (`dup_sort_tables.rs`) — called in `body/mod.rs:545` (events) and `state/mod.rs:875,920` (nonces, storage).
- **`Table::append`** trait method (`table_types/mod.rs`) and its **`SimpleTable` impl** (`simple_table.rs`) — called in `header.rs:331` and `body/mod.rs:508`.

Since all four have non-test callers, the `dead_code` lint never fires; the annotations were leftovers.

## Not touched

`DbIter::new` (`db/mod.rs`) keeps its annotation — it is only used from tests, so the annotation is load-bearing in non-test builds. The macro-generated `Tables` struct annotation is also kept.

## Verification

- `scripts/rust_fmt.sh` — clean
- `cargo build -p apollo_storage` (lib + `--tests`) — no dead_code warnings
- `cargo clippy -p apollo_storage --all-targets` — clean
- `SEED=0 cargo test -p apollo_storage` — 290 + 1 + 9 passed, 0 failed

https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU)_