### PR TITLE
starknet_patricia: remove stale allow(dead_code)

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/original_skeleton_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/original_skeleton_tree/tree.rs
@@ -16,7 +16,6 @@ pub type OriginalSkeletonTreeResult<T> = Result<T, OriginalSkeletonTreeError>;
 pub trait OriginalSkeletonTree<'a>: Sized {
     fn get_nodes(&self) -> &OriginalSkeletonNodeMap;
 
-    #[allow(dead_code)]
     fn get_sorted_leaf_indices(&self) -> SortedLeafIndices<'a>;
 }
 


### PR DESCRIPTION
## What

Removes a stale `#[allow(dead_code)]` annotation from the `OriginalSkeletonTree::get_sorted_leaf_indices` trait method. The code is **not** dead — only the annotation is removed.

## Why it's stale (live callers)

- Called in production at `updated_skeleton_tree/create_tree_helper.rs:97`, inside the non-test `pub(crate)` method `finalize_middle_layers`, via `original_skeleton.get_sorted_leaf_indices()` where `original_skeleton: &impl OriginalSkeletonTree`.
- The `OriginalSkeletonTree` trait is public API used cross-crate (e.g. `starknet_committer`).

Note: the identically-named `SubTreeTrait::get_sorted_leaf_indices` in `traversal.rs` is a *different* method on a *different* trait (it returns `&SortedLeafIndices`), so it is unrelated to this annotation.

## Verification

- `scripts/rust_fmt.sh` — clean
- `cargo build -p starknet_patricia` (lib + `--tests`) — no dead_code warnings
- `cargo clippy -p starknet_patricia --all-targets` — clean
- `SEED=0 cargo test -p starknet_patricia` — 107 passed, 0 failed

https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU)_