### PR TITLE
apollo_protobuf: remove stale allow(dead_code)

### DIFF
--- a/crates/apollo_protobuf/src/converters/common.rs
+++ b/crates/apollo_protobuf/src/converters/common.rs
@@ -165,7 +165,6 @@ pub(super) fn l1_data_availability_mode_to_enum_int(value: L1DataAvailabilityMod
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn enum_int_to_volition_domain(
     value: i32,
 ) -> Result<DataAvailabilityMode, ProtobufConversionError> {


### PR DESCRIPTION
## What

Removes a stale `#[allow(dead_code)]` annotation from `enum_int_to_volition_domain` in `converters/common.rs`. The code is **not** dead — only the annotation is removed.

## Why it's stale (live, non-feature-gated callers)

`enum_int_to_volition_domain` is called unconditionally in production conversion code:
- `transaction.rs:67,70`
- `converters/transaction.rs:360,363,623,626`

(reads nonce/fee data-availability modes in the `TryFrom` proto→domain conversions). None of these call sites are feature-gated, so the function is live and the annotation is stale.

This is unrelated to the previously-merged #14109 (which removed `PATRICIA_HEIGHT` and the `TestInstance` trait from the same file).

## Verification

- `scripts/rust_fmt.sh` — clean
- `cargo build -p apollo_protobuf` (lib) — no dead_code warnings
- `cargo clippy -p apollo_protobuf --lib` — clean
- `SEED=0 cargo test -p apollo_protobuf` — 66 passed; 1 failed. The single failure is **environmental, not caused by this change**: a test that auto-downloads `protoc` from `api.github.com` fails with a TLS error (`InvalidCertificate(UnknownIssuer)`) because this sandbox blocks the GitHub release download. It fails identically on `main` and is independent of removing a lint attribute.

https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7hJW2RUD3vKpEaXj9uCcU)_