### PR TITLE
apollo_compile_to_casm: read RUNTIME_ACCESSIBLE_OUT_DIR from runtime env when set

### DIFF
--- a/crates/apollo_compile_to_casm/src/compiler.rs
+++ b/crates/apollo_compile_to_casm/src/compiler.rs
@@ -53,6 +53,11 @@ impl SierraToCasmCompiler {
 }
 
 // Returns the OUT_DIR. This function is only operable at run time.
+// The compile-time fallback bakes the build machine's OUT_DIR into the binary, which breaks
+// prebuilt binaries on machines where that path does not exist; setting
+// `RUNTIME_ACCESSIBLE_OUT_DIR` in the runtime environment overrides it.
 fn out_dir() -> PathBuf {
-    env!("RUNTIME_ACCESSIBLE_OUT_DIR").into()
+    std::env::var("RUNTIME_ACCESSIBLE_OUT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| env!("RUNTIME_ACCESSIBLE_OUT_DIR").into())
 }

--- a/crates/apollo_compile_to_native/src/compiler.rs
+++ b/crates/apollo_compile_to_native/src/compiler.rs
@@ -57,6 +57,11 @@ impl SierraToNativeCompiler {
 }
 
 // Returns the OUT_DIR. This function is only operable at run time.
+// The compile-time fallback bakes the build machine's OUT_DIR into the binary, which breaks
+// prebuilt binaries on machines where that path does not exist; setting
+// `RUNTIME_ACCESSIBLE_OUT_DIR` in the runtime environment overrides it.
 fn out_dir() -> PathBuf {
-    env!("RUNTIME_ACCESSIBLE_OUT_DIR").into()
+    std::env::var("RUNTIME_ACCESSIBLE_OUT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| env!("RUNTIME_ACCESSIBLE_OUT_DIR").into())
 }


### PR DESCRIPTION
## Why

Fixes #14379.

On the privacy release line (`PRIVACY-0.14.2-RC.6`), `apollo_compile_to_casm` and `apollo_compile_to_native` locate their sidecar compiler binaries via `env!("RUNTIME_ACCESSIBLE_OUT_DIR")` — a compile-time value that bakes the build machine's `OUT_DIR` into the binary. Prebuilt binaries distributed to other machines (e.g. CI-built `starknet_transaction_prover` from a GitHub-hosted runner) then resolve `/Users/runner/work/…` (or `/home/runner/work/…`) at run time and panic on any execution that needs Sierra→Casm compilation:

```
Failed to compile Sierra to Casm: Unexpected compilation error: No such file or directory (os error 2)
```

Docker distributions can symlink the embedded path inside the image; native binary distributions (notably macOS) have no reasonable equivalent.

## What

`out_dir()` in both crates now reads `RUNTIME_ACCESSIBLE_OUT_DIR` from the **runtime environment** first and falls back to the compile-time value, so:

- existing behavior is unchanged when the variable is not set at run time;
- redistributed binaries can point at their actual install location with one env var, reusing the same variable name the build already uses.

`main` is unaffected — it already replaced this mechanism with the `$CARGO_TOOLS_ROOT` scheme in `apollo_compilation_utils::paths`. This targets only the privacy line.

## Validation

- `cargo check -p apollo_compile_to_casm` passes at the base ref (rust 1.92). `apollo_compile_to_native` couldn't be checked locally (cairo-native needs LLVM 19 on the build host) — the change there is identical; relying on CI for that crate.
- Field-validated equivalent: a prebuilt darwin-arm64 `starknet_transaction_prover` from this line fails exactly as described until the embedded path exists, then proves correctly (byte-identical output to a linux-x86_64 build of the same revision).

## Base-branch note

Based on `aviv/fix-PRIVACY-0.14.2-RC.6` (the only public branch containing the privacy line this affects) — happy to rebase onto whichever branch you cut privacy RCs from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
