### PR TITLE
apollo_storage: add patricia_proofs table for OS-input witnesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "simple_logger",
  "starknet-types-core",
  "starknet_api",
+ "starknet_committer",
  "tempfile",
  "test-case",
  "test-log",

--- a/crates/apollo_storage/Cargo.toml
+++ b/crates/apollo_storage/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "A storage implementation for a Starknet node."
 
 [features]
-os_input = ["dep:blockifier"]
+os_input = ["dep:blockifier", "starknet_committer/os_input"]
 storage_cli = ["clap", "reqwest"]
 testing = ["reqwest", "starknet_api/testing", "tempfile", "tower"]
 
@@ -40,6 +40,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 starknet-types-core = { workspace = true, features = ["papyrus-serialization"] }
 starknet_api.workspace = true
+starknet_committer = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/apollo_storage/src/db/mod.rs
+++ b/crates/apollo_storage/src/db/mod.rs
@@ -46,7 +46,7 @@ use crate::db::table_types::TableType;
 #[cfg(not(feature = "os_input"))]
 const MAX_DBS: u64 = 25;
 #[cfg(feature = "os_input")]
-const MAX_DBS: u64 = 26;
+const MAX_DBS: u64 = 27;
 
 // Note that NO_TLS mode is used by default.
 type EnvironmentKind = WriteMap;

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -91,6 +91,8 @@ pub mod global_root_marker;
 #[allow(missing_docs)]
 pub mod metrics;
 pub mod partial_block_hash;
+#[cfg(feature = "os_input")]
+pub mod patricia_proofs;
 pub mod storage_metrics;
 // TODO(yair): Make the compression_utils module pub(crate) or extract it from the crate.
 #[doc(hidden)]
@@ -183,6 +185,8 @@ use crate::db::{
 use crate::header::StorageBlockHeader;
 use crate::metrics::{register_metrics, STORAGE_COMMIT_LATENCY};
 use crate::mmap_file::MMapFileStats;
+#[cfg(feature = "os_input")]
+use crate::patricia_proofs::StarknetForestProofs;
 use crate::state::data::IndexedDeprecatedContractClass;
 use crate::storage_reader_server::{
     create_storage_reader_server,
@@ -278,6 +282,8 @@ fn open_storage_internal(
             .create_simple_table("stateless_compiled_class_hash_v2")?,
         #[cfg(feature = "os_input")]
         accessed_keys: db_writer.create_simple_table("accessed_keys")?,
+        #[cfg(feature = "os_input")]
+        patricia_proofs: db_writer.create_simple_table("patricia_proofs")?,
     });
     let (file_writers, file_readers) = open_storage_files(
         &storage_config.db_config,
@@ -712,7 +718,9 @@ struct_field_names! {
         stateless_compiled_class_hash_v2: TableIdentifier<ClassHash, NoVersionValueWrapper<CompiledClassHash>, SimpleTable>,
 
         #[cfg(feature = "os_input")]
-        accessed_keys: TableIdentifier<BlockNumber, VersionZeroWrapper<LocationInFile>, SimpleTable>
+        accessed_keys: TableIdentifier<BlockNumber, VersionZeroWrapper<LocationInFile>, SimpleTable>,
+        #[cfg(feature = "os_input")]
+        patricia_proofs: TableIdentifier<BlockNumber, VersionZeroWrapper<LocationInFile>, SimpleTable>
     }
 }
 
@@ -879,6 +887,8 @@ struct FileHandlers<Mode: TransactionKind> {
     transaction: FileHandler<VersionZeroWrapper<Transaction>, Mode>,
     #[cfg(feature = "os_input")]
     accessed_keys: FileHandler<VersionZeroWrapper<AccessedKeys>, Mode>,
+    #[cfg(feature = "os_input")]
+    patricia_proofs: FileHandler<VersionZeroWrapper<StarknetForestProofs>, Mode>,
 }
 
 impl FileHandlers<RW> {
@@ -921,6 +931,11 @@ impl FileHandlers<RW> {
         self.clone().accessed_keys.append(accessed_keys)
     }
 
+    #[cfg(feature = "os_input")]
+    fn append_patricia_proofs(&self, patricia_proofs: &StarknetForestProofs) -> LocationInFile {
+        self.clone().patricia_proofs.append(patricia_proofs)
+    }
+
     // TODO(dan): Consider 1. flushing only the relevant files, 2. flushing concurrently.
     #[latency_histogram("storage_file_handler_flush_latency_seconds", false)]
     fn flush(&self) {
@@ -933,6 +948,8 @@ impl FileHandlers<RW> {
         self.transaction.flush();
         #[cfg(feature = "os_input")]
         self.accessed_keys.flush();
+        #[cfg(feature = "os_input")]
+        self.patricia_proofs.flush();
     }
 }
 
@@ -948,6 +965,8 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
             ("transaction".to_string(), self.transaction.stats()),
             #[cfg(feature = "os_input")]
             ("accessed_keys".to_string(), self.accessed_keys.stats()),
+            #[cfg(feature = "os_input")]
+            ("patricia_proofs".to_string(), self.patricia_proofs.stats()),
         ])
     }
 
@@ -1017,6 +1036,18 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
             msg: format!("AccessedKeys at location {location:?} not found."),
         })
     }
+
+    #[cfg(feature = "os_input")]
+    // Returns the Patricia witness proofs at the given location or an error in case it doesn't
+    // exist.
+    pub(crate) fn get_patricia_proofs_unchecked(
+        &self,
+        location: LocationInFile,
+    ) -> StorageResult<StarknetForestProofs> {
+        self.patricia_proofs.get(location)?.ok_or(StorageError::DBInconsistency {
+            msg: format!("StarknetForestProofs at location {location:?} not found."),
+        })
+    }
 }
 
 fn open_storage_files(
@@ -1055,6 +1086,9 @@ fn open_storage_files(
     #[cfg(feature = "os_input")]
     let (accessed_keys_writer, accessed_keys_reader) =
         open_storage_file!("accessed_keys", AccessedKeys)?;
+    #[cfg(feature = "os_input")]
+    let (patricia_proofs_writer, patricia_proofs_reader) =
+        open_storage_file!("patricia_proofs", PatriciaProofs)?;
 
     Ok((
         FileHandlers {
@@ -1066,6 +1100,8 @@ fn open_storage_files(
             transaction: transaction_writer,
             #[cfg(feature = "os_input")]
             accessed_keys: accessed_keys_writer,
+            #[cfg(feature = "os_input")]
+            patricia_proofs: patricia_proofs_writer,
         },
         FileHandlers {
             thin_state_diff: thin_state_diff_reader,
@@ -1076,6 +1112,8 @@ fn open_storage_files(
             transaction: transaction_reader,
             #[cfg(feature = "os_input")]
             accessed_keys: accessed_keys_reader,
+            #[cfg(feature = "os_input")]
+            patricia_proofs: patricia_proofs_reader,
         },
     ))
 }
@@ -1098,4 +1136,7 @@ pub enum OffsetKind {
     /// An accessed-keys file.
     #[cfg(feature = "os_input")]
     AccessedKeys,
+    /// A Patricia witness proofs file.
+    #[cfg(feature = "os_input")]
+    PatriciaProofs,
 }

--- a/crates/apollo_storage/src/patricia_proofs.rs
+++ b/crates/apollo_storage/src/patricia_proofs.rs
@@ -1,0 +1,94 @@
+//! Storage for the merged Patricia witness proofs per block (input to the starknet OS).
+
+#[cfg(test)]
+#[path = "patricia_proofs_test.rs"]
+mod patricia_proofs_test;
+
+use starknet_api::block::BlockNumber;
+pub use starknet_committer::patricia_merkle_tree::types::StarknetForestProofs;
+
+use crate::compression_utils::{compress, decompress};
+use crate::db::serialization::{StorageSerde, StorageSerdeError};
+use crate::db::table_types::Table;
+use crate::db::{TransactionKind, RW};
+use crate::{OffsetKind, StorageResult, StorageTxn};
+
+impl StorageSerde for StarknetForestProofs {
+    fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
+        let bytes = serde_json::to_vec(self)?;
+        let compressed = compress(bytes.as_slice())?;
+        compressed.serialize_into(res)
+    }
+
+    fn deserialize_from(bytes: &mut impl std::io::Read) -> Option<Self> {
+        let compressed = Vec::<u8>::deserialize_from(bytes)?;
+        let data = decompress(compressed.as_slice()).ok()?;
+        serde_json::from_slice(&data).ok()
+    }
+}
+
+/// Interface for reading the Patricia witness proofs from storage.
+pub trait PatriciaProofsStorageReader<Mode: TransactionKind> {
+    /// Returns the Patricia witness proofs for the given block, or `None` if not stored.
+    fn get_patricia_proofs(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<StarknetForestProofs>>;
+}
+
+/// Interface for writing the Patricia witness proofs to storage.
+pub trait PatriciaProofsStorageWriter
+where
+    Self: Sized,
+{
+    /// Appends the Patricia witness proofs for the given block to storage.
+    fn append_patricia_proofs(
+        self,
+        block_number: BlockNumber,
+        patricia_proofs: &StarknetForestProofs,
+    ) -> StorageResult<Self>;
+
+    /// Removes the Patricia witness proofs for the given block from storage.
+    /// If no entry exists for the block, returns without error.
+    fn revert_patricia_proofs(self, block_number: BlockNumber) -> StorageResult<Self>;
+}
+
+impl<Mode: TransactionKind> PatriciaProofsStorageReader<Mode> for StorageTxn<'_, Mode> {
+    fn get_patricia_proofs(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<StarknetForestProofs>> {
+        let table = self.open_table(&self.tables.patricia_proofs)?;
+        let Some(location) = table.get(&self.txn, &block_number)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.file_handlers.get_patricia_proofs_unchecked(location)?))
+    }
+}
+
+impl PatriciaProofsStorageWriter for StorageTxn<'_, RW> {
+    fn append_patricia_proofs(
+        self,
+        block_number: BlockNumber,
+        patricia_proofs: &StarknetForestProofs,
+    ) -> StorageResult<Self> {
+        let file_offset_table = self.txn.open_table(&self.tables.file_offsets)?;
+        let patricia_proofs_table = self.open_table(&self.tables.patricia_proofs)?;
+
+        let location = self.file_handlers.append_patricia_proofs(patricia_proofs);
+        patricia_proofs_table.upsert(&self.txn, &block_number, &location)?;
+        file_offset_table.upsert(
+            &self.txn,
+            &OffsetKind::PatriciaProofs,
+            &location.next_offset(),
+        )?;
+
+        Ok(self)
+    }
+
+    fn revert_patricia_proofs(self, block_number: BlockNumber) -> StorageResult<Self> {
+        let patricia_proofs_table = self.open_table(&self.tables.patricia_proofs)?;
+        patricia_proofs_table.delete(&self.txn, &block_number)?;
+        Ok(self)
+    }
+}

--- a/crates/apollo_storage/src/patricia_proofs_test.rs
+++ b/crates/apollo_storage/src/patricia_proofs_test.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+
+use starknet_api::block::BlockNumber;
+use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::hash::HashOutput;
+use starknet_committer::patricia_merkle_tree::leaf::leaf_impl::ContractState;
+use starknet_committer::patricia_merkle_tree::types::ContractsTrieProof;
+use starknet_types_core::felt::Felt;
+
+use crate::patricia_proofs::{
+    PatriciaProofsStorageReader,
+    PatriciaProofsStorageWriter,
+    StarknetForestProofs,
+};
+use crate::test_utils::get_test_storage;
+
+fn empty_proofs() -> StarknetForestProofs {
+    StarknetForestProofs {
+        classes_trie_proof: HashMap::new(),
+        contracts_trie_proof: ContractsTrieProof { nodes: HashMap::new(), leaves: HashMap::new() },
+        contracts_trie_storage_proofs: HashMap::new(),
+    }
+}
+
+fn proofs_with_leaf() -> StarknetForestProofs {
+    let address = ContractAddress::try_from(Felt::from(1_u128)).unwrap();
+    let contract_state = ContractState {
+        nonce: Nonce(Felt::from(7_u128)),
+        storage_root_hash: HashOutput(Felt::from(8_u128)),
+        class_hash: ClassHash(Felt::from(9_u128)),
+    };
+    let mut proofs = empty_proofs();
+    proofs.contracts_trie_proof.leaves.insert(address, contract_state);
+    proofs
+}
+
+#[test]
+fn append_and_get_patricia_proofs() {
+    let (reader, mut writer) = get_test_storage().0;
+    let height = BlockNumber(5);
+    let proofs = proofs_with_leaf();
+
+    // No proofs stored for the height yet.
+    assert_eq!(reader.begin_ro_txn().unwrap().get_patricia_proofs(height).unwrap(), None);
+
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_patricia_proofs(height, &proofs)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    assert_eq!(reader.begin_ro_txn().unwrap().get_patricia_proofs(height).unwrap(), Some(proofs));
+    // A different height is still empty.
+    assert_eq!(reader.begin_ro_txn().unwrap().get_patricia_proofs(BlockNumber(6)).unwrap(), None);
+}
+
+#[test]
+fn append_and_get_empty_patricia_proofs() {
+    let (reader, mut writer) = get_test_storage().0;
+    let height = BlockNumber(0);
+    let proofs = empty_proofs();
+
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_patricia_proofs(height, &proofs)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    assert_eq!(reader.begin_ro_txn().unwrap().get_patricia_proofs(height).unwrap(), Some(proofs));
+}
+
+#[test]
+fn revert_patricia_proofs() {
+    let (reader, mut writer) = get_test_storage().0;
+    let height = BlockNumber(5);
+
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_patricia_proofs(height, &proofs_with_leaf())
+        .unwrap()
+        .revert_patricia_proofs(height)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    assert_eq!(reader.begin_ro_txn().unwrap().get_patricia_proofs(height).unwrap(), None);
+
+    // Reverting a height with no stored proofs is a no-op.
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_patricia_proofs(BlockNumber(99))
+        .unwrap()
+        .commit()
+        .unwrap();
+}

--- a/crates/apollo_storage/src/serialization/serializers.rs
+++ b/crates/apollo_storage/src/serialization/serializers.rs
@@ -372,6 +372,8 @@ auto_storage_serde! {
         Transaction = 5,
         #[cfg(feature = "os_input")]
         AccessedKeys = 6,
+        #[cfg(feature = "os_input")]
+        PatriciaProofs = 7,
     }
     pub struct PartialBlockHashComponents {
         pub header_commitments: BlockHeaderCommitments,


### PR DESCRIPTION
Mirrors the accessed_keys storage: a per-block table mapping BlockNumber to
a Patricia witness proofs payload (StarknetForestProofs), stored in an mmap
file. Gated behind the os_input feature. The batcher will use this to persist
the proofs returned by the committer's read_paths_and_commit_block endpoint.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>