### PR TITLE
deployment: upgrade jsii to 1.134.0 in lockfile

### DIFF
--- a/deployments/anvil/Pipfile.lock
+++ b/deployments/anvil/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:5a44d7c3a5a326fa3d9befdb3770b380057e0a61e3804e7c4907f70d76afaaa2",
-                "sha256:c79c47899f53a7c3c4b20f80d3cd306628fe9ed1852eee970324c71eba1d974e"
+                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
+                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
             ],
-            "markers": "python_version ~= '3.8'",
-            "version": "==1.106.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==1.134.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/dummy_eth2strk_oracle/Pipfile.lock
+++ b/deployments/dummy_eth2strk_oracle/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:5a44d7c3a5a326fa3d9befdb3770b380057e0a61e3804e7c4907f70d76afaaa2",
-                "sha256:c79c47899f53a7c3c4b20f80d3cd306628fe9ed1852eee970324c71eba1d974e"
+                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
+                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
             ],
-            "markers": "python_version ~= '3.8'",
-            "version": "==1.106.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==1.134.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/dummy_recorder/Pipfile.lock
+++ b/deployments/dummy_recorder/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:5a44d7c3a5a326fa3d9befdb3770b380057e0a61e3804e7c4907f70d76afaaa2",
-                "sha256:c79c47899f53a7c3c4b20f80d3cd306628fe9ed1852eee970324c71eba1d974e"
+                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
+                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
             ],
-            "markers": "python_version ~= '3.8'",
-            "version": "==1.106.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==1.134.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/sequencer/Pipfile.lock
+++ b/deployments/sequencer/Pipfile.lock
@@ -128,11 +128,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:37664c25ac8dfaf6c1bab214ff58eec62d515e70311c349240b43bdd733beccb",
-                "sha256:895b1f27f67e1fac3797abeeeb0ded0e1a64a155a32e1547174735d293eca0cb"
+                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
+                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
             ],
-            "markers": "python_version ~= '3.9'",
-            "version": "==1.125.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==1.134.0"
         },
         "jsonschema": {
             "hashes": [

--- a/deployments/sequencer_simulator/Pipfile.lock
+++ b/deployments/sequencer_simulator/Pipfile.lock
@@ -60,11 +60,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:5a44d7c3a5a326fa3d9befdb3770b380057e0a61e3804e7c4907f70d76afaaa2",
-                "sha256:c79c47899f53a7c3c4b20f80d3cd306628fe9ed1852eee970324c71eba1d974e"
+                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
+                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
             ],
-            "markers": "python_version ~= '3.8'",
-            "version": "==1.106.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==1.134.0"
         },
         "publication": {
             "hashes": [


### PR DESCRIPTION
## Summary

Upgrades the transitive dependency **jsii** to `1.134.0` across all deployment lockfiles.

## Changes

Updated `jsii` in all five `deployments/*/Pipfile.lock` files:
- `sequencer`: `1.125.0` → `1.134.0`
- `anvil`, `dummy_recorder`, `dummy_eth2strk_oracle`, `sequencer_simulator`: `1.106.0` → `1.134.0`

For each entry the version, the two SHA-256 hashes (sdist + wheel, from PyPI), and the env marker (`python_version >= '3.10'`, matching jsii 1.134.0's `Requires-Python: >=3.10`) were updated.

## Why the dummy/anvil lockfiles were bumped too

The "Sequencer CdK8s Dry Test" job runs `cdk8s import` (which uses the current cdk8s-cli) and then `cdk8s synth`. The freshly generated `imports/k8s` code does `from jsii._type_checking import check_type`, but **jsii 1.106.0 does not contain the `_type_checking` module** — it was added in a later release. With 1.106.0 pinned, synth failed with `ModuleNotFoundError: No module named 'jsii._type_checking'`. Bumping these lockfiles to 1.134.0 (which ships `jsii/_type_checking.py`) resolves the synth failure.

jsii is pulled in transitively via `cdk8s`, so only the lockfiles were edited; no `Pipfile` changes were needed. CI runs on Python 3.12, so the raised `>=3.10` requirement is satisfied.

https://claude.ai/code/session_01GsL7G97J7NZgsKy7zQ55dT