### PR TITLE
apollo_compilation_utils: resolve tools root next to the executable when present

### DIFF
--- a/crates/apollo_compilation_utils/src/paths.rs
+++ b/crates/apollo_compilation_utils/src/paths.rs
@@ -2,10 +2,15 @@
 // It must not contain functionality that is available in only in one of these modes. Specifically,
 // it must avoid relying on env variables such as 'CARGO_*' or 'OUT_DIR'.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+#[path = "paths_test.rs"]
+pub mod test;
 
 /// Returns `<cargo_tools_root>/<binary>-<version>/bin/<binary>`, where
-/// `cargo_tools_root` resolves to `$CARGO_TOOLS_ROOT`, else `$CARGO_HOME/tools`,
+/// `cargo_tools_root` resolves to `$CARGO_TOOLS_ROOT`, else a `tools` directory
+/// next to the running executable (if one exists), else `$CARGO_HOME/tools`,
 /// else `$HOME/.cargo/tools`.
 ///
 /// The path is constructed deterministically; there is no `$PATH` lookup. The
@@ -22,8 +27,24 @@ fn cargo_tools_root() -> PathBuf {
     if let Ok(p) = std::env::var("CARGO_TOOLS_ROOT") {
         return PathBuf::from(p);
     }
+    // A `tools` directory next to the running executable takes precedence over the
+    // cargo-home default: distributed packages ship the compiler tree alongside the
+    // binary, so prebuilt binaries work on machines with no cargo installation and
+    // no environment setup.
+    if let Some(tools_root) =
+        std::env::current_exe().ok().and_then(|exe_path| exe_relative_tools_root(&exe_path))
+    {
+        return tools_root;
+    }
     let cargo_home = std::env::var("CARGO_HOME").map(PathBuf::from).unwrap_or_else(|_| {
         PathBuf::from(std::env::var("HOME").expect("HOME must be set")).join(".cargo")
     });
     cargo_home.join("tools")
+}
+
+/// Returns the `tools` directory next to `exe_path`, or `None` if there is no such
+/// directory (e.g. for executables under `target/`, which have no bundled tools).
+fn exe_relative_tools_root(exe_path: &Path) -> Option<PathBuf> {
+    let tools_dir = exe_path.parent()?.join("tools");
+    tools_dir.is_dir().then_some(tools_dir)
 }

--- a/crates/apollo_compilation_utils/src/paths_test.rs
+++ b/crates/apollo_compilation_utils/src/paths_test.rs
@@ -1,0 +1,32 @@
+use std::fs;
+
+use tempfile::TempDir;
+
+use crate::paths::exe_relative_tools_root;
+
+#[test]
+fn tools_directory_next_to_executable_is_resolved() {
+    let package_dir = TempDir::new().unwrap();
+    let tools_dir = package_dir.path().join("tools");
+    fs::create_dir(&tools_dir).unwrap();
+    let exe_path = package_dir.path().join("prover_binary");
+
+    assert_eq!(exe_relative_tools_root(&exe_path), Some(tools_dir));
+}
+
+#[test]
+fn missing_tools_directory_yields_none() {
+    let package_dir = TempDir::new().unwrap();
+    let exe_path = package_dir.path().join("prover_binary");
+
+    assert_eq!(exe_relative_tools_root(&exe_path), None);
+}
+
+#[test]
+fn tools_path_that_is_a_file_yields_none() {
+    let package_dir = TempDir::new().unwrap();
+    fs::write(package_dir.path().join("tools"), "not a directory").unwrap();
+    let exe_path = package_dir.path().join("prover_binary");
+
+    assert_eq!(exe_relative_tools_root(&exe_path), None);
+}


### PR DESCRIPTION
## Why

Prebuilt binaries distributed outside Docker (e.g. a natively-built `starknet_transaction_prover` for macOS) cannot run Sierra→CASM compilation out of the box: `binary_path()` resolves the sidecar compiler under `$CARGO_TOOLS_ROOT` (default `~/.cargo/tools`), which does not exist on a machine that never ran `scripts/install_compiler_binaries.sh`. The recipient currently must either install the toolchain and run the script, or know to set `CARGO_TOOLS_ROOT` manually — neither is documented for binary recipients. (Background: #14379 hit the harsher, unrecoverable variant of this on the privacy release line.)

## What

`cargo_tools_root()` now checks for a `tools` directory next to the running executable, after the explicit `$CARGO_TOOLS_ROOT` override but before the cargo-home default. This makes a packaged layout work with zero configuration:

```
package/
├── starknet_transaction_prover
└── tools/
    └── starknet-sierra-compile-<version>/
        └── bin/starknet-sierra-compile
```

The `tools/` subtree is exactly what `scripts/install_compiler_binaries.sh --sierra` produces under `CARGO_TOOLS_ROOT`, so a packaging job can stage it with:

```bash
CARGO_TOOLS_ROOT="$PKG_DIR/tools" scripts/install_compiler_binaries.sh --sierra
```

The version-suffixed directory layout and `verify_compiler_binary()` checks are unchanged, so a stale package still fails loudly with the exact expected path.

No behavior change for existing setups:
- Docker images set `CARGO_TOOLS_ROOT` explicitly (e.g. `/opt/cargo-tools`) — the env var branch still wins.
- Dev machines have no `tools` directory next to `target/{debug,release}` binaries — the `is_dir()` guard falls through to `~/.cargo/tools` as before.

## Validation

- `cargo build -p apollo_compilation_utils` — passes
- `SEED=0 cargo test -p apollo_compilation_utils` — 10 passed, 0 failed (includes 3 new tests for the exe-relative resolution)
- `cargo clippy -p apollo_compilation_utils --all-targets` — clean
- `scripts/rust_fmt.sh` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)