### PR TITLE
apollo_batcher: persist accessed keys before adding the commitment task

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -47,7 +47,11 @@ use apollo_reverts::revert_block;
 use apollo_state_reader::apollo_state::ApolloReader;
 use apollo_state_sync_types::state_sync_types::SyncBlock;
 #[cfg(feature = "os_input")]
-use apollo_storage::accessed_keys::{AccessedKeys, AccessedKeysStorageWriter};
+use apollo_storage::accessed_keys::{
+    AccessedKeys,
+    AccessedKeysStorageReader,
+    AccessedKeysStorageWriter,
+};
 use apollo_storage::block_hash::{BlockHashStorageReader, BlockHashStorageWriter};
 use apollo_storage::global_root::{GlobalRootStorageReader, GlobalRootStorageWriter};
 use apollo_storage::global_root_marker::{
@@ -962,13 +966,6 @@ impl Batcher {
         )
         .await?;
 
-        self.write_commitment_results_and_add_new_task(
-            height,
-            state_diff.clone(), // TODO(Nimrod): Remove the clone here.
-            Some(state_diff_commitment),
-        )
-        .await?;
-
         let (tx_hashes, tx_execution_infos): (Vec<TransactionHash>, Vec<TransactionExecutionInfo>) =
             block_execution_artifacts
                 .execution_data
@@ -984,6 +981,13 @@ impl Batcher {
             &block_execution_artifacts.execution_data.proof_facts_block_numbers,
             &tx_execution_infos,
         )?;
+
+        self.write_commitment_results_and_add_new_task(
+            height,
+            state_diff.clone(), // TODO(Nimrod): Remove the clone here.
+            Some(state_diff_commitment),
+        )
+        .await?;
 
         let execution_infos = tx_hashes.into_iter().zip(tx_execution_infos.into_iter()).collect();
 
@@ -1014,6 +1018,7 @@ impl Batcher {
         })
     }
 
+    /// Builds the accessed keys for the block, persists them to storage, and returns them.
     #[cfg(feature = "os_input")]
     fn write_block_accessed_keys(
         &mut self,
@@ -1021,7 +1026,7 @@ impl Batcher {
         commitment_state_diff: &CommitmentStateDiff,
         proof_facts_block_numbers: &IndexMap<TransactionHash, BlockNumber>,
         tx_execution_infos: &[TransactionExecutionInfo],
-    ) -> BatcherResult<()> {
+    ) -> BatcherResult<AccessedKeys> {
         let accessed_keys = AccessedKeys::new(
             tx_execution_infos.iter(),
             proof_facts_block_numbers.values(),
@@ -1031,7 +1036,8 @@ impl Batcher {
         self.storage_writer.write_accessed_keys(height, &accessed_keys).map_err(|err| {
             error!("Failed to write accessed keys to storage: {}", err);
             BatcherError::InternalError
-        })
+        })?;
+        Ok(accessed_keys)
     }
 
     async fn commit_proposal_and_block(
@@ -1719,6 +1725,9 @@ pub trait BatcherStorageReader: Send + Sync {
     ) -> StorageResult<(Option<BlockHash>, Option<PartialBlockHashComponents>)>;
 
     fn get_block_header(&self, block_number: BlockNumber) -> StorageResult<BlockHeaderWithoutHash>;
+
+    #[cfg(feature = "os_input")]
+    fn get_accessed_keys(&self, height: BlockNumber) -> StorageResult<Option<AccessedKeys>>;
 }
 
 impl BatcherStorageReader for StorageReader {
@@ -1833,6 +1842,11 @@ impl BatcherStorageReader for StorageReader {
                 resource_type: "block header".to_string(),
                 resource_id: block_number.to_string(),
             })
+    }
+
+    #[cfg(feature = "os_input")]
+    fn get_accessed_keys(&self, height: BlockNumber) -> StorageResult<Option<AccessedKeys>> {
+        self.begin_ro_txn()?.get_accessed_keys(height)
     }
 }
 

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
@@ -220,6 +220,10 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
                 CommitterTaskOutput::Commit(commitment_task_result) => {
                     commitment_results.push(commitment_task_result)
                 }
+                #[cfg(feature = "os_input")]
+                CommitterTaskOutput::ReadPathsAndCommitBlock(read_path_and_commit_task_result) => {
+                    commitment_results.push(read_path_and_commit_task_result)
+                }
                 CommitterTaskOutput::Revert(revert_task_result) => {
                     return (commitment_results, revert_task_result);
                 }

--- a/crates/apollo_batcher/src/commitment_manager/state_committer.rs
+++ b/crates/apollo_batcher/src/commitment_manager/state_committer.rs
@@ -1,6 +1,12 @@
 use std::time::Duration;
 
 use apollo_committer_types::committer_types::{CommitBlockRequest, RevertBlockRequest};
+#[cfg(feature = "os_input")]
+use apollo_committer_types::committer_types::{
+    CommitBlockResponse,
+    ReadPathsAndCommitBlockRequest,
+    ReadPathsAndCommitBlockResponse,
+};
 use apollo_committer_types::communication::SharedCommitterClient;
 use apollo_committer_types::errors::CommitterClientResult;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -90,6 +96,14 @@ async fn perform_task(
             CommitterTaskInput::Commit(commit_block_request) => {
                 perform_commit_block_task(commit_block_request.clone(), committer_client).await
             }
+            #[cfg(feature = "os_input")]
+            CommitterTaskInput::ReadPathsAndCommitBlock(read_paths_and_commit_block_request) => {
+                perform_read_paths_and_commit_block_task(
+                    read_paths_and_commit_block_request.clone(),
+                    committer_client,
+                )
+                .await
+            }
             CommitterTaskInput::Revert(revert_block_request) => {
                 perform_revert_block_task(revert_block_request.clone(), committer_client).await
             }
@@ -111,6 +125,22 @@ async fn perform_commit_block_task(
     let height = commit_block_request.height;
     let response = committer_client.commit_block(commit_block_request).await?;
     Ok(CommitterTaskOutput::Commit(CommitmentTaskOutput { response, height }))
+}
+
+/// Commits the block and fetches the Patricia witnesses for the accessed keys via
+/// `ReadPathsAndCommitBlock`.
+#[cfg(feature = "os_input")]
+async fn perform_read_paths_and_commit_block_task(
+    request: ReadPathsAndCommitBlockRequest,
+    committer_client: &SharedCommitterClient,
+) -> CommitterClientResult<CommitterTaskOutput> {
+    let height = request.commit.height;
+    let ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos: _ } =
+        committer_client.read_paths_and_commit_block(request).await?;
+    Ok(CommitterTaskOutput::ReadPathsAndCommitBlock(CommitmentTaskOutput {
+        response: CommitBlockResponse { global_root },
+        height,
+    }))
 }
 
 async fn perform_revert_block_task(

--- a/crates/apollo_batcher/src/commitment_manager/types.rs
+++ b/crates/apollo_batcher/src/commitment_manager/types.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::time::Instant;
 
+#[cfg(feature = "os_input")]
+use apollo_committer_types::committer_types::ReadPathsAndCommitBlockRequest;
 use apollo_committer_types::committer_types::{
     CommitBlockRequest,
     CommitBlockResponse,
@@ -20,6 +22,8 @@ use tracing::warn;
 #[cfg_attr(test, derive(Clone))]
 pub(crate) enum CommitterTaskInput {
     Commit(CommitBlockRequest),
+    #[cfg(feature = "os_input")]
+    ReadPathsAndCommitBlock(ReadPathsAndCommitBlockRequest),
     Revert(RevertBlockRequest),
 }
 
@@ -27,13 +31,18 @@ impl CommitterTaskInput {
     pub(crate) fn height(&self) -> BlockNumber {
         match self {
             Self::Commit(request) => request.height,
+            #[cfg(feature = "os_input")]
+            Self::ReadPathsAndCommitBlock(request) => request.commit.height,
             Self::Revert(request) => request.height,
         }
     }
 
+    /// The committer endpoint this task will use.
     pub(crate) fn task_type(&self) -> CommitterRequestLabelValue {
         match self {
             Self::Commit(_) => CommitterRequestLabelValue::CommitBlock,
+            #[cfg(feature = "os_input")]
+            Self::ReadPathsAndCommitBlock(_) => CommitterRequestLabelValue::ReadPathsAndCommitBlock,
             Self::Revert(_) => CommitterRequestLabelValue::RevertBlock,
         }
     }
@@ -46,6 +55,15 @@ impl Display for CommitterTaskInput {
                 f,
                 "Commit(height={}, state_diff_commitment={:?})",
                 request.height, request.state_diff_commitment
+            ),
+            #[cfg(feature = "os_input")]
+            Self::ReadPathsAndCommitBlock(request) => write!(
+                f,
+                "ReadPathsAndCommitBlock(height={}, state_diff_commitment={:?}, \
+                 num_accessed_keys={})",
+                request.commit.height,
+                request.commit.state_diff_commitment,
+                request.accessed_keys.len()
             ),
             Self::Revert(request) => write!(f, "Revert(height={})", request.height),
         }
@@ -67,6 +85,8 @@ pub(crate) struct RevertTaskOutput {
 #[derive(Clone, Debug)]
 pub(crate) enum CommitterTaskOutput {
     Commit(CommitmentTaskOutput),
+    #[cfg(feature = "os_input")]
+    ReadPathsAndCommitBlock(CommitmentTaskOutput),
     Revert(RevertTaskOutput),
 }
 
@@ -74,6 +94,8 @@ impl CommitterTaskOutput {
     pub(crate) fn expect_commitment(self) -> CommitmentTaskOutput {
         match self {
             Self::Commit(commitment_task_output) => commitment_task_output,
+            #[cfg(feature = "os_input")]
+            Self::ReadPathsAndCommitBlock(commitment_task_output) => commitment_task_output,
             Self::Revert(_) => panic!("Got revert output: {self:?}"),
         }
     }
@@ -81,14 +103,17 @@ impl CommitterTaskOutput {
     pub(crate) fn height(&self) -> BlockNumber {
         match self {
             Self::Commit(output) => output.height,
+            #[cfg(feature = "os_input")]
+            Self::ReadPathsAndCommitBlock(output) => output.height,
             Self::Revert(output) => output.height,
         }
     }
 
-    /// The committer endpoint that produced this output.
     pub(crate) fn task_label(&self) -> CommitterRequestLabelValue {
         match self {
             Self::Commit(_) => CommitterRequestLabelValue::CommitBlock,
+            #[cfg(feature = "os_input")]
+            Self::ReadPathsAndCommitBlock(_) => CommitterRequestLabelValue::ReadPathsAndCommitBlock,
             Self::Revert(_) => CommitterRequestLabelValue::RevertBlock,
         }
     }

--- a/crates/blockifier/src/state/accessed_keys.rs
+++ b/crates/blockifier/src/state/accessed_keys.rs
@@ -59,6 +59,15 @@ impl From<StateChangesKeys> for AccessedKeys {
 }
 
 impl AccessedKeys {
+    /// The total number of accessed trie leaves across all three tries.
+    pub fn len(&self) -> usize {
+        self.storage_keys.len() + self.accessed_contracts.len() + self.accessed_class_hashes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Builds the [`AccessedKeys`] the OS needs to read at the execution of a block.
     pub fn new<'a>(
         execution_infos: impl IntoIterator<Item = &'a TransactionExecutionInfo>,


### PR DESCRIPTION
decision_reached now persists the block's accessed keys before enqueueing the
commitment task, and write_block_accessed_keys returns them so they can be
handed to the commitment manager. Adds BatcherStorageReader::get_accessed_keys
so the commitment catch-up flow can read them back.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>