### PR TITLE
apollo_batcher: persist patricia proofs returned by the committer

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -64,6 +64,8 @@ use apollo_storage::partial_block_hash::{
     PartialBlockHashComponentsStorageReader,
     PartialBlockHashComponentsStorageWriter,
 };
+#[cfg(feature = "os_input")]
+use apollo_storage::patricia_proofs::{PatriciaProofsStorageWriter, StarknetForestProofs};
 use apollo_storage::state::{StateStorageReader, StateStorageWriter};
 use apollo_storage::storage_reader_server::{
     DynamicConfigError,
@@ -1841,11 +1843,26 @@ pub trait BatcherStorageWriter: Send + Sync {
     /// Sets the global root and block hash (unless it's None) for the given height.
     /// Increments the block hash marker by 1.
     /// Block hash is optional because for old blocks, the block hash was set separately.
+    #[cfg(not(feature = "os_input"))]
     fn set_global_root_and_block_hash(
         &mut self,
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
+    ) -> StorageResult<()>;
+
+    /// Sets the global root and block hash (unless it's None) for the given height, and persists
+    /// the Patricia witnesses (when present) in the same transaction.
+    /// Increments the block hash marker by 1.
+    /// Block hash is optional because for old blocks, the block hash was set separately.
+    /// Patricia witnesses are optional for blocks that doesn't come from decision_reached flow.
+    #[cfg(feature = "os_input")]
+    fn set_global_root_and_block_hash(
+        &mut self,
+        height: BlockNumber,
+        global_root: GlobalRoot,
+        block_hash: Option<BlockHash>,
+        patricia_proofs: Option<StarknetForestProofs>,
     ) -> StorageResult<()>;
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()>;
@@ -1891,10 +1908,18 @@ impl BatcherStorageWriter for StorageWriter {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
+        #[cfg(feature = "os_input")] patricia_proofs: Option<StarknetForestProofs>,
     ) -> StorageResult<()> {
+        #[cfg(not(feature = "os_input"))]
         info!(
             "Setting global root and block hash for height {height}. Root: {global_root:?}, Block \
              hash: {block_hash:?}."
+        );
+        #[cfg(feature = "os_input")]
+        info!(
+            "Setting global root and block hash for height {height}. Root: {global_root:?}, Block \
+             hash: {block_hash:?}, Patricia proofs length: {:?}.",
+            patricia_proofs.as_ref().map(|patricia_proofs| patricia_proofs.get_nodes_count())
         );
         let mut txn = self
             .begin_rw_txn()?
@@ -1902,6 +1927,10 @@ impl BatcherStorageWriter for StorageWriter {
             .checked_increment_global_root_marker(height)?;
         if let Some(block_hash) = block_hash {
             txn = txn.set_block_hash(&height, block_hash)?;
+        }
+        #[cfg(feature = "os_input")]
+        if let Some(patricia_proofs) = patricia_proofs {
+            txn = txn.append_patricia_proofs(height, &patricia_proofs)?;
         }
         txn.commit()
     }

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1833,21 +1833,27 @@ async fn get_block_hash_after_reading_commitment_results() {
         .expect_get_parent_hash_and_partial_block_hash_components()
         .with(eq(INITIAL_HEIGHT))
         .returning(move |_| Ok((Some(parent_hash), Some(partial_components.clone()))));
-    mock_dependencies
-        .storage_writer
-        .expect_set_global_root_and_block_hash()
-        .times(1)
+    let set_global_root_expectation =
+        mock_dependencies.storage_writer.expect_set_global_root_and_block_hash();
+    set_global_root_expectation.times(1);
+    #[cfg(not(feature = "os_input"))]
+    set_global_root_expectation
         .with(eq(INITIAL_HEIGHT), eq(global_root), always())
         .returning(|_, _, _| Ok(()));
+    #[cfg(feature = "os_input")]
+    set_global_root_expectation
+        .with(eq(INITIAL_HEIGHT), eq(global_root), always(), always())
+        .returning(|_, _, _, _| Ok(()));
 
     let mut batcher = create_batcher(mock_dependencies).await;
 
     // Send a commitment task directly to the state committer so a result will be available.
-    let task = CommitterTaskInput::Commit(CommitBlockRequest {
+    let commit_block_request = CommitBlockRequest {
         height: INITIAL_HEIGHT,
         state_diff: ThinStateDiff::default(),
         state_diff_commitment: None,
-    });
+    };
+    let task = CommitterTaskInput::Commit(commit_block_request);
     batcher.commitment_manager.tasks_sender.send(task).await.unwrap();
     wait_for_n_items(&mut batcher.commitment_manager.results_receiver, 1).await;
 

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
@@ -271,12 +271,17 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
             };
 
             // Get the final commitment.
-            let FinalBlockCommitment { height, block_hash, global_root } =
-                Self::finalize_commitment_output(
-                    storage_reader.clone(),
-                    commitment_task_output,
-                    should_finalize_block_hash,
-                )?;
+            let FinalBlockCommitment {
+                height,
+                block_hash,
+                global_root,
+                #[cfg(feature = "os_input")]
+                patricia_proofs,
+            } = Self::finalize_commitment_output(
+                storage_reader.clone(),
+                commitment_task_output,
+                should_finalize_block_hash,
+            )?;
 
             // Verify the first new block hash matches the configured block hash.
             if let Some(FirstBlockWithPartialBlockHash {
@@ -304,7 +309,13 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
             }
 
             // Write the block hash and global root to storage.
-            storage_writer.set_global_root_and_block_hash(height, global_root, block_hash)?;
+            storage_writer.set_global_root_and_block_hash(
+                height,
+                global_root,
+                block_hash,
+                #[cfg(feature = "os_input")]
+                patricia_proofs,
+            )?;
             GLOBAL_ROOT_HEIGHT.increment(1);
         }
 
@@ -515,13 +526,18 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
     // TODO(Amos): Test blocks [0,10] in OS flow tests.
     fn finalize_commitment_output<R: BatcherStorageReader + ?Sized>(
         storage_reader: Arc<R>,
-        CommitmentTaskOutput { response: CommitBlockResponse { global_root }, height }: CommitmentTaskOutput,
+        CommitmentTaskOutput {
+            response: CommitBlockResponse { global_root },
+            height,
+            #[cfg(feature = "os_input")]
+            patricia_proofs,
+        }: CommitmentTaskOutput,
         should_finalize_block_hash: bool,
     ) -> CommitmentManagerResult<FinalBlockCommitment> {
-        match should_finalize_block_hash {
+        let block_hash = match should_finalize_block_hash {
             false => {
                 debug!("Finalized commitment for block {height} without calculating block hash.");
-                Ok(FinalBlockCommitment { height, block_hash: None, global_root })
+                None
             }
             true => {
                 debug!("Finalizing commitment for block {height} with calculating block hash.");
@@ -542,14 +558,20 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
                 debug!(
                     "Global root: {global_root:?}, previous block hash: {previous_block_hash:?}"
                 );
-                let block_hash = calculate_block_hash(
+                Some(calculate_block_hash(
                     &partial_block_hash_components,
                     global_root,
                     previous_block_hash,
-                )?;
-                Ok(FinalBlockCommitment { height, block_hash: Some(block_hash), global_root })
+                )?)
             }
-        }
+        };
+        Ok(FinalBlockCommitment {
+            height,
+            block_hash,
+            global_root,
+            #[cfg(feature = "os_input")]
+            patricia_proofs,
+        })
     }
 
     fn update_task_duration_metric(

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
@@ -270,7 +270,7 @@ async fn test_add_missing_commitment_tasks(mut mock_dependencies: MockDependenci
 }
 
 /// When no accessed keys are stored for a height, the catch-up flow must fall back to `CommitBlock`
-/// (not `ReadPathsAndCommitBlock`).
+/// (not `ReadPathsAndCommitBlock`), and the resulting commitment carries no Patricia witnesses.
 #[cfg(feature = "os_input")]
 #[rstest]
 #[tokio::test]
@@ -325,6 +325,10 @@ async fn test_add_missing_commitment_tasks_without_accessed_keys(
     let results = await_items(&mut commitment_manager.results_receiver, 1).await;
     let result = results.first().unwrap().clone().expect_commitment();
     assert_eq!(result.height, global_root_height);
+    assert!(
+        result.patricia_proofs.is_none(),
+        "The CommitBlock fallback should not produce Patricia witnesses."
+    );
 }
 
 #[rstest]
@@ -396,12 +400,15 @@ async fn test_add_task_wait_for_full_channel(mut mock_dependencies: MockDependen
             .times(expected_n_calls.clone())
             .with(eq(height))
             .returning(|height| get_dummy_parent_hash_and_partial_block_hash_components(&height));
-        mock_dependencies
-            .storage_writer
-            .expect_set_global_root_and_block_hash()
-            .times(expected_n_calls)
-            .withf(move |h, _, _| *h == height)
-            .returning(|_, _, _| Ok(()));
+        let set_global_root_expectation =
+            mock_dependencies.storage_writer.expect_set_global_root_and_block_hash();
+        set_global_root_expectation.times(expected_n_calls);
+        #[cfg(not(feature = "os_input"))]
+        set_global_root_expectation.withf(move |h, _, _| *h == height).returning(|_, _, _| Ok(()));
+        #[cfg(feature = "os_input")]
+        set_global_root_expectation
+            .withf(move |h, _, _, _| *h == height)
+            .returning(|_, _, _, _| Ok(()));
     }
 
     let (mut commitment_manager, storage_reader, mut storage_writer) =

--- a/crates/apollo_batcher/src/commitment_manager/state_committer.rs
+++ b/crates/apollo_batcher/src/commitment_manager/state_committer.rs
@@ -118,13 +118,19 @@ async fn perform_task(
     }
 }
 
+/// Commits the block via `CommitBlock`, storing no Patricia witnesses.
 async fn perform_commit_block_task(
     commit_block_request: CommitBlockRequest,
     committer_client: &SharedCommitterClient,
 ) -> CommitterClientResult<CommitterTaskOutput> {
     let height = commit_block_request.height;
     let response = committer_client.commit_block(commit_block_request).await?;
-    Ok(CommitterTaskOutput::Commit(CommitmentTaskOutput { response, height }))
+    Ok(CommitterTaskOutput::Commit(CommitmentTaskOutput {
+        response,
+        height,
+        #[cfg(feature = "os_input")]
+        patricia_proofs: None,
+    }))
 }
 
 /// Commits the block and fetches the Patricia witnesses for the accessed keys via
@@ -135,11 +141,12 @@ async fn perform_read_paths_and_commit_block_task(
     committer_client: &SharedCommitterClient,
 ) -> CommitterClientResult<CommitterTaskOutput> {
     let height = request.commit.height;
-    let ReadPathsAndCommitBlockResponse { global_root, patricia_proofs: _ } =
+    let ReadPathsAndCommitBlockResponse { global_root, patricia_proofs } =
         committer_client.read_paths_and_commit_block(request).await?;
     Ok(CommitterTaskOutput::ReadPathsAndCommitBlock(CommitmentTaskOutput {
         response: CommitBlockResponse { global_root },
         height,
+        patricia_proofs: Some(patricia_proofs),
     }))
 }
 

--- a/crates/apollo_batcher/src/commitment_manager/types.rs
+++ b/crates/apollo_batcher/src/commitment_manager/types.rs
@@ -13,6 +13,8 @@ use apollo_committer_types::committer_types::{
     RevertBlockResponse,
 };
 use apollo_committer_types::communication::CommitterRequestLabelValue;
+#[cfg(feature = "os_input")]
+use apollo_storage::patricia_proofs::StarknetForestProofs;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::GlobalRoot;
 use tracing::warn;
@@ -74,6 +76,10 @@ impl Display for CommitterTaskInput {
 pub(crate) struct CommitmentTaskOutput {
     pub(crate) response: CommitBlockResponse,
     pub(crate) height: BlockNumber,
+    // The Patricia witnesses returned by the committer. `None` when the block was committed via
+    // `CommitBlock` (no accessed keys were available to request the witnesses).
+    #[cfg(feature = "os_input")]
+    pub(crate) patricia_proofs: Option<StarknetForestProofs>,
 }
 
 #[derive(Clone, Debug)]
@@ -125,6 +131,9 @@ pub(crate) struct FinalBlockCommitment {
     // cannot be finalized.
     pub(crate) block_hash: Option<BlockHash>,
     pub(crate) global_root: GlobalRoot,
+    // `None` when the block was committed via `CommitBlock` (no Patricia witnesses requested).
+    #[cfg(feature = "os_input")]
+    pub(crate) patricia_proofs: Option<StarknetForestProofs>,
 }
 
 pub(crate) struct TaskTimer {

--- a/crates/apollo_reverts/src/lib.rs
+++ b/crates/apollo_reverts/src/lib.rs
@@ -13,6 +13,8 @@ use apollo_storage::class_manager::ClassManagerStorageWriter;
 use apollo_storage::global_root::GlobalRootStorageWriter;
 use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::partial_block_hash::PartialBlockHashComponentsStorageWriter;
+#[cfg(feature = "os_input")]
+use apollo_storage::patricia_proofs::PatriciaProofsStorageWriter;
 use apollo_storage::state::StateStorageWriter;
 use apollo_storage::StorageWriter;
 use futures::future::pending;
@@ -147,7 +149,11 @@ pub fn revert_block(storage_writer: &mut StorageWriter, target_block_marker: Blo
         .unwrap();
 
     #[cfg(feature = "os_input")]
-    let txn = txn.revert_accessed_keys(target_block_marker).unwrap();
+    let txn = txn
+        .revert_accessed_keys(target_block_marker)
+        .unwrap()
+        .revert_patricia_proofs(target_block_marker)
+        .unwrap();
 
     txn.commit().unwrap();
 }


### PR DESCRIPTION
The Patricia witnesses returned by ReadPathsAndCommitBlock now flow through
CommitmentTaskOutput and FinalBlockCommitment, and are persisted together
with the global root and block hash in a single storage transaction.

Fixes carried over from the original squashed commit: drops a stale
duplicate ReadPathsAndCommitBlock metric arm (unreachable pattern under
os_input) and logs the proof size via the existing
StarknetForestProofs::get_nodes_count.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>