### PR TITLE
starknet_api: replace LazyLock Felt/ContractAddress with const from_hex_unchecked

### DIFF
--- a/crates/apollo_rpc_execution/src/lib.rs
+++ b/crates/apollo_rpc_execution/src/lib.rs
@@ -20,7 +20,7 @@ pub mod testing_instances;
 pub mod objects;
 use std::cell::Cell;
 use std::collections::BTreeMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use apollo_class_manager_types::SharedClassManagerClient;
 use apollo_config::dumping::{ser_param, SerializeConfig};
@@ -63,7 +63,7 @@ use starknet_api::block::{
     StarknetVersion,
 };
 use starknet_api::contract_class::{ClassInfo, EntryPointType, SierraVersion};
-use starknet_api::core::{ChainId, ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::core::{ChainId, ClassHash, ContractAddress, EntryPointSelector, PatriciaKey};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::state::{StateNumber, ThinStateDiff};
@@ -84,7 +84,6 @@ use starknet_api::transaction::{
 use starknet_api::transaction_hash::get_transaction_hash;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_api::StarknetApiError;
-use starknet_types_core::felt::Felt;
 use state_reader::ExecutionStateReader;
 use tokio::runtime::Handle;
 use tracing::trace;
@@ -103,22 +102,12 @@ const DEFAULT_INITIAL_GAS_COST: u64 = 10000000000;
 pub type ExecutionResult<T> = Result<T, ExecutionError>;
 
 /// The address of the STRK fee contract on Starknet.
-pub static STRK_FEE_CONTRACT_ADDRESS: LazyLock<ContractAddress> = LazyLock::new(|| {
-    ContractAddress::try_from(
-        Felt::from_hex(STRK_FEE_CONTRACT_ADDRESS_STR)
-            .expect("Error converting strk fee contract address from hex"),
-    )
-    .expect("Error converting strk fee contract address from felt")
-});
+pub const STRK_FEE_CONTRACT_ADDRESS: ContractAddress =
+    ContractAddress(PatriciaKey::from_hex_unchecked(STRK_FEE_CONTRACT_ADDRESS_STR));
 
 /// The address of the ETH fee contract on Starknet.
-pub static ETH_FEE_CONTRACT_ADDRESS: LazyLock<ContractAddress> = LazyLock::new(|| {
-    ContractAddress::try_from(
-        Felt::from_hex(ETH_FEE_CONTRACT_ADDRESS_STR)
-            .expect("Error converting eth fee contract address from hex"),
-    )
-    .expect("Error converting eth fee contract address from felt")
-});
+pub const ETH_FEE_CONTRACT_ADDRESS: ContractAddress =
+    ContractAddress(PatriciaKey::from_hex_unchecked(ETH_FEE_CONTRACT_ADDRESS_STR));
 
 #[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq)]
 /// Parameters that are needed for execution.
@@ -134,8 +123,8 @@ pub struct ExecutionConfig {
 impl Default for ExecutionConfig {
     fn default() -> Self {
         ExecutionConfig {
-            strk_fee_contract_address: *STRK_FEE_CONTRACT_ADDRESS,
-            eth_fee_contract_address: *ETH_FEE_CONTRACT_ADDRESS,
+            strk_fee_contract_address: STRK_FEE_CONTRACT_ADDRESS,
+            eth_fee_contract_address: ETH_FEE_CONTRACT_ADDRESS,
             default_initial_gas_cost: DEFAULT_INITIAL_GAS_COST,
         }
     }

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -579,7 +579,7 @@ fn test_tx_info(
     let mut version = felt!(3_u8);
     let mut expected_version = if v1_bound_account && !high_tip { felt!(1_u8) } else { version };
     if only_query {
-        let simulate_version_base = *QUERY_VERSION_BASE;
+        let simulate_version_base = QUERY_VERSION_BASE;
         version += simulate_version_base;
         expected_version += simulate_version_base;
     }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/get_execution_info.rs
@@ -161,7 +161,7 @@ fn compute_expected_tx_version(
         flags.is_v1_bound_account && !flags.tip_exceeds_v1_bound_threshold;
     let mut version = if is_v1_bound_without_high_tip { 1.into() } else { tx_version.0 };
     if flags.only_query {
-        version += *QUERY_VERSION_BASE;
+        version += QUERY_VERSION_BASE;
     }
     version
 }

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/meta_tx.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/meta_tx.rs
@@ -96,8 +96,8 @@ fn test_meta_tx_v0(
     let nonce: Felt252 = 13.into();
     let tx_hash: Felt252 = 0xabcdef.into();
     let account_address: ContractAddress = 0xfedcba0000_u128.into();
-    let expected_version = felt!(3_u32) + (if only_query { *QUERY_VERSION_BASE } else { 0.into() });
-    let expected_meta_tx_version = if only_query { *QUERY_VERSION_BASE } else { 0.into() };
+    let expected_version = felt!(3_u32) + (if only_query { QUERY_VERSION_BASE } else { 0.into() });
+    let expected_meta_tx_version = if only_query { QUERY_VERSION_BASE } else { 0.into() };
 
     let expected_meta_tx_hash = InvokeTransactionV0 {
         max_fee: Fee(0),

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -1035,7 +1035,7 @@ impl ValidatableTransaction for AccountTransaction {
         if is_cairo1(&compiled_class) {
             // The account contract class is a Cairo 1.0 contract; the `validate` entry point should
             // return `VALID`.
-            let expected_retdata = retdata![*constants::VALIDATE_RETDATA];
+            let expected_retdata = retdata![constants::VALIDATE_RETDATA];
 
             if validate_call_info.execution.failed {
                 return Err(TransactionExecutionError::PanicInValidate {

--- a/crates/blockifier/src/transaction/test_utils.rs
+++ b/crates/blockifier/src/transaction/test_utils.rs
@@ -513,7 +513,7 @@ impl ExpectedExecutionInfo {
     ) -> Self {
         let mut version = Felt::THREE;
         if only_query {
-            version += *QUERY_VERSION_BASE;
+            version += QUERY_VERSION_BASE;
         }
         Self {
             version: TransactionVersion(version),

--- a/crates/blockifier/src/transaction/transactions_test.rs
+++ b/crates/blockifier/src/transaction/transactions_test.rs
@@ -283,7 +283,7 @@ fn expected_validate_call_info(
 ) -> Option<CallInfo> {
     let retdata = match cairo_version {
         CairoVersion::Cairo0 => Retdata::default(),
-        CairoVersion::Cairo1(_) => retdata!(*constants::VALIDATE_RETDATA),
+        CairoVersion::Cairo1(_) => retdata!(constants::VALIDATE_RETDATA),
     };
     let cairo_native = cairo_version.is_cairo_native();
     // Extra range checks in regular (invoke) validate call, due to calldata passed as array.

--- a/crates/blockifier_reexecution/src/utils.rs
+++ b/crates/blockifier_reexecution/src/utils.rs
@@ -66,8 +66,8 @@ pub fn get_fee_token_addresses(
         // Mainnet, testnet and integration systems have the same fee token addresses.
         ChainId::Mainnet | ChainId::Sepolia | ChainId::IntegrationSepolia => FeeTokenAddresses {
             strk_fee_token_address: strk_fee_token_address_override
-                .unwrap_or(*STRK_FEE_CONTRACT_ADDRESS),
-            eth_fee_token_address: *ETH_FEE_CONTRACT_ADDRESS,
+                .unwrap_or(STRK_FEE_CONTRACT_ADDRESS),
+            eth_fee_token_address: ETH_FEE_CONTRACT_ADDRESS,
         },
         unknown_chain => unimplemented!("Unknown chain ID {unknown_chain}."),
     }

--- a/crates/starknet_api/src/block_hash/block_hash_calculator.rs
+++ b/crates/starknet_api/src/block_hash/block_hash_calculator.rs
@@ -1,4 +1,3 @@
-use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -20,7 +19,6 @@ use crate::block::{
     StarknetVersion,
 };
 use crate::core::{
-    ascii_as_felt,
     EventCommitment,
     GlobalRoot,
     ReceiptCommitment,
@@ -41,15 +39,12 @@ use crate::{StarknetApiError, StarknetApiResult};
 #[path = "block_hash_calculator_test.rs"]
 mod block_hash_calculator_test;
 
-static STARKNET_BLOCK_HASH0: LazyLock<Felt> = LazyLock::new(|| {
-    ascii_as_felt("STARKNET_BLOCK_HASH0").expect("ascii_as_felt failed for 'STARKNET_BLOCK_HASH0'")
-});
-pub static STARKNET_BLOCK_HASH1: LazyLock<Felt> = LazyLock::new(|| {
-    ascii_as_felt("STARKNET_BLOCK_HASH1").expect("ascii_as_felt failed for 'STARKNET_BLOCK_HASH1'")
-});
-pub static STARKNET_GAS_PRICES0: LazyLock<Felt> = LazyLock::new(|| {
-    ascii_as_felt("STARKNET_GAS_PRICES0").expect("ascii_as_felt failed for 'STARKNET_GAS_PRICES0'")
-});
+const STARKNET_BLOCK_HASH0: Felt =
+    Felt::from_hex_unchecked("0x535441524b4e45545f424c4f434b5f4841534830");
+pub const STARKNET_BLOCK_HASH1: Felt =
+    Felt::from_hex_unchecked("0x535441524b4e45545f424c4f434b5f4841534831");
+pub const STARKNET_GAS_PRICES0: Felt =
+    Felt::from_hex_unchecked("0x535441524b4e45545f4741535f50524943455330");
 
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
@@ -88,8 +83,8 @@ type BlockHashConstant = Felt;
 impl From<BlockHashVersion> for BlockHashConstant {
     fn from(block_hash_version: BlockHashVersion) -> Self {
         match block_hash_version {
-            BlockHashVersion::V0_13_2 => *STARKNET_BLOCK_HASH0,
-            BlockHashVersion::V0_13_4 => *STARKNET_BLOCK_HASH1,
+            BlockHashVersion::V0_13_2 => STARKNET_BLOCK_HASH0,
+            BlockHashVersion::V0_13_4 => STARKNET_BLOCK_HASH1,
         }
     }
 }

--- a/crates/starknet_api/src/block_hash/state_diff_hash.rs
+++ b/crates/starknet_api/src/block_hash/state_diff_hash.rs
@@ -1,16 +1,7 @@
-use std::sync::LazyLock;
-
 use indexmap::IndexMap;
 use starknet_types_core::felt::Felt;
 
-use crate::core::{
-    ascii_as_felt,
-    ClassHash,
-    CompiledClassHash,
-    ContractAddress,
-    Nonce,
-    StateDiffCommitment,
-};
+use crate::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, StateDiffCommitment};
 use crate::crypto::utils::HashChain;
 use crate::hash::PoseidonHash;
 use crate::state::{StorageKey, ThinStateDiff};
@@ -19,9 +10,8 @@ use crate::state::{StorageKey, ThinStateDiff};
 #[path = "state_diff_hash_test.rs"]
 mod state_diff_hash_test;
 
-static STARKNET_STATE_DIFF0: LazyLock<Felt> = LazyLock::new(|| {
-    ascii_as_felt("STARKNET_STATE_DIFF0").expect("ascii_as_felt failed for 'STARKNET_STATE_DIFF0'")
-});
+const STARKNET_STATE_DIFF0: Felt =
+    Felt::from_hex_unchecked("0x535441524b4e45545f53544154455f4449464630");
 
 /// Poseidon(
 ///     "STARKNET_STATE_DIFF0", deployed_contracts, declared_classes, deprecated_declared_classes,

--- a/crates/starknet_api/src/contract_class/compiled_class_hash.rs
+++ b/crates/starknet_api/src/contract_class/compiled_class_hash.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::sync::LazyLock;
 
 use cairo_lang_starknet_classes::casm_contract_class::{CasmContractClass, CasmContractEntryPoint};
 use cairo_lang_starknet_classes::NestedIntList;
@@ -10,8 +9,8 @@ use starknet_types_core::hash::{Blake2Felt252, Poseidon, StarkHash};
 use crate::core::CompiledClassHash;
 
 /// Constant that defines the version of the compiled class hash algorithm.
-pub static COMPILED_CLASS_V1: LazyLock<Felt> =
-    LazyLock::new(|| Felt::from_bytes_be_slice(b"COMPILED_CLASS_V1"));
+pub const COMPILED_CLASS_V1: Felt =
+    Felt::from_hex_unchecked("0x434f4d50494c45445f434c4153535f5631");
 
 /// The version of the hash function used to compute the compiled class hash.
 #[derive(Clone, Copy, PartialEq)]
@@ -169,7 +168,7 @@ where
 
     // Compute total hash by hashing each component on top of the previous one.
     CompiledClassHash(H::hash_array(&[
-        *COMPILED_CLASS_V1,
+        COMPILED_CLASS_V1,
         external_funcs_hash,
         l1_handlers_hash,
         constructors_hash,

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -1,5 +1,3 @@
-use std::sync::LazyLock;
-
 use apollo_sizeof::SizeOf;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -53,10 +51,7 @@ mod transaction_test;
 pub mod constants;
 pub mod fields;
 
-pub static QUERY_VERSION_BASE: LazyLock<Felt> = LazyLock::new(|| {
-    const QUERY_VERSION_BASE_BIT: u32 = 128;
-    Felt::TWO.pow(QUERY_VERSION_BASE_BIT)
-});
+pub const QUERY_VERSION_BASE: Felt = Felt::from_hex_unchecked("0x100000000000000000000000000000000");
 
 pub trait TransactionHasher {
     fn calculate_transaction_hash(
@@ -968,7 +963,7 @@ pub fn signed_tx_version(
     transaction_options: &TransactionOptions,
 ) -> TransactionVersion {
     // If only_query is true, set the 128-th bit.
-    let query_only_bit = *QUERY_VERSION_BASE;
+    let query_only_bit = QUERY_VERSION_BASE;
     assert_eq!(
         tx_version.0.to_biguint() & query_only_bit.to_biguint(),
         BigUint::from(0_u8),

--- a/crates/starknet_api/src/transaction/constants.rs
+++ b/crates/starknet_api/src/transaction/constants.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use starknet_types_core::felt::Felt;
 
 use crate::abi::abi_utils::selector_from_name;
-use crate::core::{ascii_as_felt, EntryPointSelector};
+use crate::core::EntryPointSelector;
 
 pub const EXECUTE_ENTRY_POINT_NAME: &str = "__execute__";
 pub const TRANSFER_ENTRY_POINT_NAME: &str = "transfer";
@@ -19,8 +19,7 @@ pub const FELT_FALSE: u64 = 0;
 pub const FELT_TRUE: u64 = 1;
 
 // Expected return value of a `validate` entry point: `VALID`.
-pub static VALIDATE_RETDATA: LazyLock<Felt> =
-    LazyLock::new(|| ascii_as_felt("VALID").expect("Failed to parse ASCII"));
+pub const VALIDATE_RETDATA: Felt = Felt::from_hex_unchecked("0x56414c4944");
 
 pub static VALIDATE_DEPLOY_ENTRY_POINT_SELECTOR: LazyLock<EntryPointSelector> =
     LazyLock::new(|| selector_from_name(VALIDATE_DEPLOY_ENTRY_POINT_NAME));

--- a/crates/starknet_api/src/transaction_hash.rs
+++ b/crates/starknet_api/src/transaction_hash.rs
@@ -1,9 +1,7 @@
-use std::sync::LazyLock;
-
 use starknet_types_core::felt::Felt;
 
 use crate::block::BlockNumber;
-use crate::core::{ascii_as_felt, ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use crate::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use crate::crypto::utils::HashChain;
 use crate::data_availability::DataAvailabilityMode;
 use crate::transaction::fields::{
@@ -50,17 +48,11 @@ const L1_GAS: &ResourceName = b"\0L1_GAS";
 const L2_GAS: &ResourceName = b"\0L2_GAS";
 const L1_DATA_GAS: &ResourceName = b"L1_DATA";
 
-static DECLARE: LazyLock<Felt> =
-    LazyLock::new(|| ascii_as_felt("declare").expect("ascii_as_felt failed for 'declare'"));
-static DEPLOY: LazyLock<Felt> =
-    LazyLock::new(|| ascii_as_felt("deploy").expect("ascii_as_felt failed for 'deploy'"));
-static DEPLOY_ACCOUNT: LazyLock<Felt> = LazyLock::new(|| {
-    ascii_as_felt("deploy_account").expect("ascii_as_felt failed for 'deploy_account'")
-});
-static INVOKE: LazyLock<Felt> =
-    LazyLock::new(|| ascii_as_felt("invoke").expect("ascii_as_felt failed for 'invoke'"));
-static L1_HANDLER: LazyLock<Felt> =
-    LazyLock::new(|| ascii_as_felt("l1_handler").expect("ascii_as_felt failed for 'l1_handler'"));
+const DECLARE: Felt = Felt::from_hex_unchecked("0x6465636c617265");
+const DEPLOY: Felt = Felt::from_hex_unchecked("0x6465706c6f79");
+const DEPLOY_ACCOUNT: Felt = Felt::from_hex_unchecked("0x6465706c6f795f6163636f756e74");
+const INVOKE: Felt = Felt::from_hex_unchecked("0x696e766f6b65");
+const L1_HANDLER: Felt = Felt::from_hex_unchecked("0x6c315f68616e646c6572");
 const CONSTRUCTOR_ENTRY_POINT_SELECTOR: Felt =
     Felt::from_hex_unchecked("0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194");
 
@@ -488,9 +480,9 @@ fn get_common_l1_handler_transaction_hash(
         HashChain::new()
         .chain_if_fn(|| {
             if version == L1HandlerVersions::AsInvoke {
-                Some(*INVOKE)
+                Some(INVOKE)
             } else {
-                Some(*L1_HANDLER)
+                Some(L1_HANDLER)
             }
         })
         .chain_if_fn(|| {

--- a/crates/starknet_os/src/constants_test.rs
+++ b/crates/starknet_os/src/constants_test.rs
@@ -65,7 +65,7 @@ fn test_l2_to_l1_message_header_size() {
 
 #[test]
 fn test_compiled_class_version() {
-    assert_eq!(Const::CompiledClassVersion.fetch_from_os_program().unwrap(), *COMPILED_CLASS_V1);
+    assert_eq!(Const::CompiledClassVersion.fetch_from_os_program().unwrap(), COMPILED_CLASS_V1);
 }
 
 /// Asserts that the Rust VIRTUAL_OS_OUTPUT_VERSION constant matches the Cairo constant.

--- a/crates/starknet_os/src/hints/hint_implementation/block_hash/test.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/block_hash/test.rs
@@ -161,7 +161,7 @@ fn test_block_hash_version() {
     // NOTE: if these checks fail, it means the block hash version in the OS program is not the
     // latest, and a backward-compatibility flow must be added for the transition.
     assert_eq!(
-        *STARKNET_BLOCK_HASH1, latest_block_hash_version,
+        STARKNET_BLOCK_HASH1, latest_block_hash_version,
         "Latest block hash version constant mismatch"
     );
     assert_eq!(

--- a/crates/starknet_os/src/hints/hint_implementation/compiled_class/compiled_class_test.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/compiled_class/compiled_class_test.rs
@@ -299,7 +299,7 @@ fn run_compiled_class_hash_entry_point(
     // Create constants.
     let constants = HashMap::from([(
         <&'static str>::from(Const::CompiledClassVersion).to_string(),
-        *COMPILED_CLASS_V1,
+        COMPILED_CLASS_V1,
     )]);
 
     // Create explicit arguments for the Cairo entrypoint function.


### PR DESCRIPTION
## Summary

- Replace all `LazyLock<Felt>` statics that encode ASCII strings or compute simple values with `const Felt = Felt::from_hex_unchecked(...)` 
- Replace `LazyLock<ContractAddress>` statics that wrap known hex addresses with `const ContractAddress = ContractAddress(PatriciaKey::from_hex_unchecked(...))`
- Remove all `*` dereferences at call sites since `const Felt` is `Copy` and doesn't require deref
- Drop now-unused `LazyLock`, `ascii_as_felt`, and `Felt::from_hex` imports

Affected constants:
- `VALIDATE_RETDATA`, `STARKNET_BLOCK_HASH0/1`, `STARKNET_GAS_PRICES0`, `STARKNET_STATE_DIFF0`
- `COMPILED_CLASS_V1`, `DECLARE`, `DEPLOY`, `DEPLOY_ACCOUNT`, `INVOKE`, `L1_HANDLER`
- `QUERY_VERSION_BASE` (was `Felt::TWO.pow(128)`)
- `STRK_FEE_CONTRACT_ADDRESS`, `ETH_FEE_CONTRACT_ADDRESS`

## Test plan

- [x] `cargo build -p starknet_api` passes
- [x] `cargo build -p apollo_rpc_execution` passes
- [x] `cargo build -p blockifier` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)