### PR TITLE
starknet_transaction_prover: retry storage-proof RPC fetches with backoff

### DIFF
--- a/crates/starknet_transaction_prover/src/running/storage_proofs.rs
+++ b/crates/starknet_transaction_prover/src/running/storage_proofs.rs
@@ -41,7 +41,8 @@ use crate::running::virtual_block_executor::VirtualBlockExecutionData;
 /// `class_hashes.len() + contract_addresses.len() + total_storage_keys`.
 const MAX_KEYS_PER_REQUEST: usize = 100;
 
-/// Default number of attempts for a single `get_storage_proof` call before giving up.
+/// Default number of retries for a single `get_storage_proof` call, *on top of* the
+/// initial attempt — so the default `5` allows up to 6 calls (1 + 5) before giving up.
 /// Proving a virtual block fetches a storage proof per chunk of touched state; a public
 /// node will rate-limit a burst of these. Without retry, a single transient failure
 /// anywhere in input collection aborts a multi-minute prove. Overridable via
@@ -49,7 +50,8 @@ const MAX_KEYS_PER_REQUEST: usize = 100;
 const DEFAULT_RPC_MAX_RETRIES: u32 = 5;
 /// First backoff delay; each subsequent retry doubles it, capped at [`RPC_RETRY_MAX_DELAY`].
 const RPC_RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
-/// Upper bound on a single backoff delay (5 attempts ≈ 0.5 + 1 + 2 + 4 = 7.5s of waiting).
+/// Upper bound on a single backoff delay (default 5 retries wait
+/// 0.5 + 1 + 2 + 4 + 8 = 15.5s in total).
 const RPC_RETRY_MAX_DELAY: Duration = Duration::from_secs(8);
 
 fn rpc_max_retries() -> u32 {
@@ -59,25 +61,32 @@ fn rpc_max_retries() -> u32 {
         .unwrap_or(DEFAULT_RPC_MAX_RETRIES)
 }
 
+/// Substrings that mark a rate-limit / throttling response, whether it arrives as a raw
+/// HTTP body or as the message of a structured JSON-RPC error.
+const RATE_LIMIT_NEEDLES: [&str; 4] =
+    ["too many requests", "rate limit", "limit exceeded", "429"];
+
 /// Whether a `get_storage_proof` failure is transient and worth retrying.
 ///
-/// A public node throttling a request returns a non-JSON body (an HTTP 429/5xx page),
-/// which `starknet-rs` fails to deserialize and surfaces as
+/// A public node throttling a request usually returns a non-JSON body (an HTTP 429/5xx
+/// page), which `starknet-rs` fails to deserialize and surfaces as
 /// `ProviderError::Other(..)` carrying a transport/parse message such as
-/// `expected value at line 1 column 1` — NOT as a structured JSON-RPC error. Those, plus
-/// explicit rate-limit / connection / timeout signals, are retryable.
+/// `expected value at line 1 column 1`. Some nodes instead signal throttling as a valid
+/// JSON-RPC error (e.g. "too many requests"). Both of those, plus explicit
+/// connection / timeout signals, are retryable.
 ///
-/// Structured upstream JSON-RPC errors (e.g. block-not-found, code `-32xxx`) are
-/// deterministic — retrying only wastes time — so they are explicitly excluded, mirroring
-/// the downcast in `impl From<ProviderError> for ProofProviderError`.
+/// Any *other* structured JSON-RPC error (e.g. block-not-found, code `-32xxx`) is
+/// deterministic — retrying only wastes time — so it fails fast, mirroring the downcast in
+/// `impl From<ProviderError> for ProofProviderError`.
 fn is_retryable_rpc_error(err: &ProviderError) -> bool {
     if let ProviderError::Other(inner) = err {
-        let is_structured_rpc_error = inner
-            .as_any()
-            .downcast_ref::<JsonRpcClientError<HttpTransportError>>()
-            .is_some_and(|e| matches!(e, JsonRpcClientError::JsonRpcError(_)));
-        if is_structured_rpc_error {
-            return false;
+        if let Some(JsonRpcClientError::JsonRpcError(rpc_err)) =
+            inner.as_any().downcast_ref::<JsonRpcClientError<HttpTransportError>>()
+        {
+            // A structured JSON-RPC error is deterministic — except when a node uses it to
+            // signal rate-limiting instead of returning an HTTP 429. Retry only that case.
+            let message = rpc_err.message.to_ascii_lowercase();
+            return RATE_LIMIT_NEEDLES.iter().any(|needle| message.contains(needle));
         }
     }
     let msg = err.to_string().to_ascii_lowercase();
@@ -85,6 +94,7 @@ fn is_retryable_rpc_error(err: &ProviderError) -> bool {
         "too many requests",
         "429",
         "rate limit",
+        "limit exceeded",
         "502",
         "503",
         "504",

--- a/crates/starknet_transaction_prover/src/running/storage_proofs.rs
+++ b/crates/starknet_transaction_prover/src/running/storage_proofs.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use blockifier::state::cached_state::StateMaps;
@@ -15,8 +16,8 @@ use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
 };
 use starknet_patricia::patricia_merkle_tree::types::SubTreeHeight;
 use starknet_patricia_storage::map_storage::MapStorage;
-use starknet_rust::providers::jsonrpc::HttpTransport;
-use starknet_rust::providers::{JsonRpcClient, Provider};
+use starknet_rust::providers::jsonrpc::{HttpTransport, HttpTransportError, JsonRpcClientError};
+use starknet_rust::providers::{JsonRpcClient, Provider, ProviderError};
 use starknet_rust_core::types::{
     ConfirmedBlockId,
     ContractStorageKeys,
@@ -25,6 +26,7 @@ use starknet_rust_core::types::{
     MerkleNode,
     StorageProof as RpcStorageProof,
 };
+use tracing::warn;
 
 use crate::errors::ProofProviderError;
 use crate::running::committer_utils::{
@@ -38,6 +40,67 @@ use crate::running::virtual_block_executor::VirtualBlockExecutionData;
 /// Pathfinder hard-codes `const MAX_KEYS: usize = 100` in `get_storage_proof`, counting
 /// `class_hashes.len() + contract_addresses.len() + total_storage_keys`.
 const MAX_KEYS_PER_REQUEST: usize = 100;
+
+/// Default number of attempts for a single `get_storage_proof` call before giving up.
+/// Proving a virtual block fetches a storage proof per chunk of touched state; a public
+/// node will rate-limit a burst of these. Without retry, a single transient failure
+/// anywhere in input collection aborts a multi-minute prove. Overridable via
+/// `STARKNET_PROVER_RPC_MAX_RETRIES`.
+const DEFAULT_RPC_MAX_RETRIES: u32 = 5;
+/// First backoff delay; each subsequent retry doubles it, capped at [`RPC_RETRY_MAX_DELAY`].
+const RPC_RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
+/// Upper bound on a single backoff delay (5 attempts ≈ 0.5 + 1 + 2 + 4 = 7.5s of waiting).
+const RPC_RETRY_MAX_DELAY: Duration = Duration::from_secs(8);
+
+fn rpc_max_retries() -> u32 {
+    std::env::var("STARKNET_PROVER_RPC_MAX_RETRIES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_RPC_MAX_RETRIES)
+}
+
+/// Whether a `get_storage_proof` failure is transient and worth retrying.
+///
+/// A public node throttling a request returns a non-JSON body (an HTTP 429/5xx page),
+/// which `starknet-rs` fails to deserialize and surfaces as
+/// `ProviderError::Other(..)` carrying a transport/parse message such as
+/// `expected value at line 1 column 1` — NOT as a structured JSON-RPC error. Those, plus
+/// explicit rate-limit / connection / timeout signals, are retryable.
+///
+/// Structured upstream JSON-RPC errors (e.g. block-not-found, code `-32xxx`) are
+/// deterministic — retrying only wastes time — so they are explicitly excluded, mirroring
+/// the downcast in `impl From<ProviderError> for ProofProviderError`.
+fn is_retryable_rpc_error(err: &ProviderError) -> bool {
+    if let ProviderError::Other(inner) = err {
+        let is_structured_rpc_error = inner
+            .as_any()
+            .downcast_ref::<JsonRpcClientError<HttpTransportError>>()
+            .is_some_and(|e| matches!(e, JsonRpcClientError::JsonRpcError(_)));
+        if is_structured_rpc_error {
+            return false;
+        }
+    }
+    let msg = err.to_string().to_ascii_lowercase();
+    [
+        "too many requests",
+        "429",
+        "rate limit",
+        "502",
+        "503",
+        "504",
+        "service unavailable",
+        "bad gateway",
+        "gateway timeout",
+        "expected value", // a non-JSON throttle/error page parsed as JSON
+        "error decoding response",
+        "error sending request",
+        "connection",
+        "timed out",
+        "timeout",
+    ]
+    .iter()
+    .any(|needle| msg.contains(needle))
+}
 
 /// Counts total keys in a query, mirroring Pathfinder's counting logic.
 pub(crate) fn count_total_keys(query: &RpcStorageProofsQuery) -> usize {
@@ -284,7 +347,13 @@ impl RpcStorageProofsProvider {
         Ok(merge_storage_proofs(proofs, &chunks, query))
     }
 
-    /// Sends a single `get_storage_proof` RPC call (no chunking).
+    /// Sends a single `get_storage_proof` RPC call (no chunking), retrying transient
+    /// failures with exponential backoff.
+    ///
+    /// Input collection issues one of these per chunk of touched state, so a public node
+    /// readily rate-limits a burst. A single un-retried 429/5xx here aborts a prove that
+    /// has already run for minutes; see [`is_retryable_rpc_error`] for what counts as
+    /// transient. Deterministic errors fail fast on the first attempt.
     async fn fetch_single_proof(
         &self,
         block_number: BlockNumber,
@@ -294,17 +363,40 @@ impl RpcStorageProofsProvider {
         let contract_addresses: Vec<Felt> =
             query.contract_addresses.iter().map(|a| *a.0.key()).collect();
 
-        let storage_proof = self
-            .0
-            .get_storage_proof(
-                block_id,
-                &query.class_hashes,
-                &contract_addresses,
-                &query.contract_storage_keys,
-            )
-            .await?;
+        let max_retries = rpc_max_retries();
+        let mut delay = RPC_RETRY_BASE_DELAY;
+        let mut attempt: u32 = 0;
+        loop {
+            let result = self
+                .0
+                .get_storage_proof(
+                    block_id,
+                    &query.class_hashes,
+                    &contract_addresses,
+                    &query.contract_storage_keys,
+                )
+                .await;
 
-        Ok(storage_proof)
+            match result {
+                Ok(storage_proof) => return Ok(storage_proof),
+                Err(err) if attempt < max_retries && is_retryable_rpc_error(&err) => {
+                    attempt += 1;
+                    warn!(
+                        block_number = block_number.0,
+                        attempt,
+                        max_retries,
+                        backoff_ms = delay.as_millis() as u64,
+                        error = %err,
+                        "get_storage_proof failed with a transient error; retrying after backoff",
+                    );
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(RPC_RETRY_MAX_DELAY);
+                }
+                // Non-retryable, or retries exhausted: surface the error (the `From` impl
+                // forwards a structured JSON-RPC error verbatim).
+                Err(err) => return Err(err.into()),
+            }
+        }
     }
 
     /// Creates commitment infos from RPC storage proof and state changes.

--- a/crates/starknet_transaction_prover/src/running/storage_proofs.rs
+++ b/crates/starknet_transaction_prover/src/running/storage_proofs.rs
@@ -399,7 +399,7 @@ impl RpcStorageProofsProvider {
                         block_number = block_number.0,
                         attempt,
                         max_retries,
-                        backoff_ms = delay.as_millis() as u64,
+                        backoff_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
                         error = %err,
                         "get_storage_proof failed with a transient error; retrying after backoff",
                     );

--- a/crates/starknet_transaction_prover/src/running/storage_proofs.rs
+++ b/crates/starknet_transaction_prover/src/running/storage_proofs.rs
@@ -61,10 +61,12 @@ fn rpc_max_retries() -> u32 {
         .unwrap_or(DEFAULT_RPC_MAX_RETRIES)
 }
 
-/// Substrings that mark a rate-limit / throttling response, whether it arrives as a raw
-/// HTTP body or as the message of a structured JSON-RPC error.
-const RATE_LIMIT_NEEDLES: [&str; 4] =
-    ["too many requests", "rate limit", "limit exceeded", "429"];
+/// Phrases that *unambiguously* mark a rate-limit / throttling response. These are matched
+/// against the message of a structured JSON-RPC error, which is otherwise deterministic, so
+/// the set must exclude loose tokens that deterministic errors also contain — e.g.
+/// "limit exceeded" (also "gas/query limit exceeded") or "429" (can appear inside a block
+/// number). Transport/parse failures get the broader needle list in `is_retryable_rpc_error`.
+const RATE_LIMIT_NEEDLES: [&str; 3] = ["too many requests", "rate limit", "throttled"];
 
 /// Whether a `get_storage_proof` failure is transient and worth retrying.
 ///
@@ -83,8 +85,10 @@ fn is_retryable_rpc_error(err: &ProviderError) -> bool {
         if let Some(JsonRpcClientError::JsonRpcError(rpc_err)) =
             inner.as_any().downcast_ref::<JsonRpcClientError<HttpTransportError>>()
         {
-            // A structured JSON-RPC error is deterministic — except when a node uses it to
-            // signal rate-limiting instead of returning an HTTP 429. Retry only that case.
+            // A structured JSON-RPC error is deterministic (block-not-found, gas/query
+            // limit exceeded, bad params, ...) — except when a node signals throttling this
+            // way instead of via an HTTP 429. Match only unambiguous rate-limit wording (see
+            // RATE_LIMIT_NEEDLES); never loose tokens that deterministic errors also carry.
             let message = rpc_err.message.to_ascii_lowercase();
             return RATE_LIMIT_NEEDLES.iter().any(|needle| message.contains(needle));
         }
@@ -94,7 +98,7 @@ fn is_retryable_rpc_error(err: &ProviderError) -> bool {
         "too many requests",
         "429",
         "rate limit",
-        "limit exceeded",
+        "throttled",
         "502",
         "503",
         "504",


### PR DESCRIPTION
## Problem

Proving a virtual block fetches a storage proof per 100-key chunk of touched state via `RpcStorageProofsProvider::fetch_single_proof` (`crates/starknet_transaction_prover/src/running/storage_proofs.rs`). Against a public RPC node, a burst of these gets rate-limited. The call is a bare `get_storage_proof().await?` with **no retry**, so a single HTTP 429/5xx aborts a prove that has already run for minutes.

The failure is also opaque: a throttling node returns a non-JSON body, which `starknet-rs` fails to deserialize and surfaces as `ProviderError::Other(..)` carrying `expected value at line 1 column 1` — not a structured JSON-RPC error.

Field data: a controlled replay of 150 small requests against a public node returned 137× HTTP 429; one anywhere in input collection killed the whole prove.

## Fix

Retry transient `get_storage_proof` failures with exponential backoff:

- 5 attempts, 0.5s → 8s (doubling, capped), configurable via `STARKNET_PROVER_RPC_MAX_RETRIES`.
- `is_retryable_rpc_error()` retries rate-limit / 5xx / transport / non-JSON-parse failures.
- **Deterministic structured JSON-RPC errors (block-not-found, etc.) are explicitly NOT retried** — detected via the same `JsonRpcClientError::JsonRpcError` downcast already used in `impl From<ProviderError> for ProofProviderError`, so real errors still fail fast.
- A `tracing::warn!` is emitted per retry with attempt / backoff / error context.

No new dependencies (uses `tokio::time` + `tracing`, both already in the crate).

## Testing

- `cargo check -p starknet_transaction_prover` passes. (Compiled on the `PRIVACY-0.14.2-RC.6` line, where this was found; main's error model — the `From<ProviderError>` downcast — and deps are identical, and the patch applies to `main` unchanged.)
- Not yet exercised against a live throttling node; backoff behavior under real 429s is unverified.