### PR TITLE
apollo_node_config: remove stale allow(dead_code)

### DIFF
--- a/crates/apollo_node_config/src/version.rs
+++ b/crates/apollo_node_config/src/version.rs
@@ -13,7 +13,6 @@ const VERSION_PATCH: u32 = 0;
 
 /// Version metadata to append to the version string.
 /// Expected values are `dev` and `stable`.
-#[allow(dead_code)]
 const VERSION_META: Metadata = Metadata::Dev;
 
 /// Textual version string.


### PR DESCRIPTION
## What

Removes a stale `#[allow(dead_code)]` annotation from the `VERSION_META` constant in `crates/apollo_node_config/src/version.rs`. The constant is **not** dead — only the annotation is removed. No behavior changes.

## Why it's stale (live, non-feature-gated reader)

`VERSION_META` is read unconditionally in production code:

- `full_version_str()` matches on `VERSION_META` (`version.rs:43`) to decide whether to append the dev metadata suffix.
- `full_version_str()` is evaluated by `pub const VERSION_FULL` (`version.rs:22`), a public entry point.

So `VERSION_META` is reachable from a live public root; the dead-code annotation is stale.

## Sibling annotations intentionally KEPT (load-bearing)

The other `#[allow(dead_code)]` annotations in this file are **not** removed because the items are genuinely dead in the default build (only reachable from `version_test.rs`):
- `Metadata` enum / `Metadata::Stable` variant — `Stable` is never constructed in non-test code (`VERSION_META == Metadata::Dev`).
- `metadata_str` — only called from `version_test.rs`.
- `STABLE_VERSION_META` — only referenced from the test-only `metadata_str`.

Removing those would re-introduce `dead_code`/`never constructed` warnings, so they stay.

## Verification (`RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)

- `scripts/rust_fmt.sh` — clean
- `cargo build -p apollo_node_config` — **zero** dead_code warnings (default cfg)
- `cargo clippy -p apollo_node_config --all-targets` — clean (covers `--tests` cfg)
- `SEED=0 cargo test -p apollo_node_config` — 16 passed, 0 failed

https://claude.ai/code/session_01JySgtGzptZGSVtkdguAaHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JySgtGzptZGSVtkdguAaHA)_