### PR TITLE
blockifier: remove stale allow(dead_code)

### DIFF
--- a/crates/blockifier/src/state/utils.rs
+++ b/crates/blockifier/src/state/utils.rs
@@ -9,7 +9,6 @@ use crate::state::state_api::{StateReader, StateResult};
 /// Returns the compiled class hash (v2) of the given class hash.
 /// Returns `StateError::MissingCompiledClassHashV2` if no v1_class is found for the given class
 /// hash.
-#[allow(dead_code)]
 pub fn get_compiled_class_hash_v2(
     state_reader: &impl StateReader,
     class_hash: ClassHash,


### PR DESCRIPTION
## What

Removes a stale `#[allow(dead_code)]` annotation from the free function `get_compiled_class_hash_v2` in `crates/blockifier/src/state/utils.rs`. The function is **not** dead — only the annotation is removed. No behavior changes.

## Why it's stale

- The function is `pub` and lives in a fully public module path: `pub mod state` (`lib.rs:16`) → `pub mod utils` (`state.rs:20`). It is therefore part of blockifier's public API, and the `dead_code` lint never fires on items reachable from the crate root via public visibility — the annotation suppresses nothing.
- It is also actively used cross-crate:
  - `blockifier_reexecution` imports it as `default_get_compiled_class_hash_v2` and calls it from `state_reader/rpc_state_reader.rs:483` and `state_reader/offline_state_reader.rs:189` (the `StateReader::get_compiled_class_hash_v2` default-impl plumbing).
  - `starknet_transaction_prover` calls it from `running/classes_provider.rs:73`.

## Verification (`RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)

- `scripts/rust_fmt.sh` — clean
- `cargo build -p blockifier` — **zero** dead_code/unused warnings (default cfg)
- `cargo clippy -p blockifier --all-targets` — clean; compiles lib + test + bench targets, so it also confirms the `--tests` cfg builds with zero dead_code warnings.

This is a pure lint-attribute removal (no codegen/runtime effect), so the two clean builds above are the load-bearing proof.

### Environmental note (cairo_native)

`cargo check -p blockifier --features cairo_native` could not run in this sandbox: the `tblgen v0.5.2` build dependency (an LLVM/MLIR TableGen binding pulled in transitively by `cairo_native`) fails its **build script** because the full LLVM-19 tooling is unavailable here. This failure occurs before blockifier itself is compiled, is unrelated to removing a lint attribute, and reproduces identically on `main`. The `#[cfg(feature = "cairo_native")]` match arm in the function is unaffected by this change.

https://claude.ai/code/session_01JySgtGzptZGSVtkdguAaHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JySgtGzptZGSVtkdguAaHA)_