### PR TITLE
blockifier_reexecution: remove stale allow(dead_code)

### DIFF
--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -138,7 +138,6 @@ pub struct RpcStateReader {
     pub(crate) retry_config: RetryConfig,
 
     pub chain_info: ChainInfo,
-    #[allow(dead_code)]
     pub(crate) contract_class_mapping_dumper: Arc<Mutex<Option<StarknetContractClassMapping>>>,
 }
 


### PR DESCRIPTION
## What

Removes a stale `#[allow(dead_code)]` from the `contract_class_mapping_dumper` field of `RpcStateReader` in `crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs`. The field is **not** dead — only the annotation is removed. No behavior changes.

## Why it's stale (the field is read from non-test library code)

- `RpcStateReader::get_contract_class_mapping_dumper` (`rpc_state_reader.rs:393-395`) reads it: `self.contract_class_mapping_dumper.lock().unwrap().clone()`. This public method is called from `RpcBlockReexecutor::get_serializable_data_reexecuted_block` (`:613`).
- The `ReexecutionStateReader` impl for `RpcStateReader` reads/mutates it (`:518-521`) while collecting declared classes during reexecution.
- `RpcBlockReexecutor::new` clones it out of the base-block reader (`:572` — `base_block_state_reader.contract_class_mapping_dumper.clone()`).

Because the field is read from ordinary library code, the `dead_code` lint never fires for it, so the annotation suppresses nothing.

## Verification (`RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)

- `scripts/rust_fmt.sh` — clean
- `cargo build -p blockifier_reexecution` — **zero** dead_code/unused warnings (default cfg)
- `cargo clippy -p blockifier_reexecution --all-targets` — clean; compiles lib + test targets, confirming the `--tests` cfg builds with zero dead_code warnings.

This is a pure lint-attribute removal (no codegen/runtime effect), so the two clean builds above are the load-bearing proof.

### Environmental note

A full `cargo test -p blockifier_reexecution` run was not performed locally: the crate's reexecution tests exercise live GCloud/RPC network access, which is blocked in this sandbox. Removing a lint attribute cannot affect those tests, and they run in CI.

https://claude.ai/code/session_01JySgtGzptZGSVtkdguAaHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JySgtGzptZGSVtkdguAaHA)_