### PR TITLE
blockifier_reexecution,starknet_transaction_prover: fail early when the Sierra compiler is missing

### DIFF
--- a/crates/blockifier_reexecution/src/compile.rs
+++ b/crates/blockifier_reexecution/src/compile.rs
@@ -38,6 +38,14 @@ static SIERRA_COMPILER: LazyLock<SierraCompiler> = LazyLock::new(|| {
     })
 });
 
+/// Eagerly initializes the lazily-constructed Sierra compiler. Construction verifies that
+/// the compiler binary is installed and matches the required version, so calling this at
+/// process startup surfaces a missing or mismatched binary as an immediate, actionable
+/// failure instead of a panic on the first compilation that needs it.
+pub fn verify_sierra_compiler() {
+    LazyLock::force(&SIERRA_COMPILER);
+}
+
 /// Maps `LegacyEntryPointsByType` to a `HashMap` where each `EntryPointType`
 /// is associated with a vector of `EntryPoint`. Converts selectors and offsets
 /// from legacy format to new `EntryPoint` struct.

--- a/crates/starknet_transaction_prover/README.md
+++ b/crates/starknet_transaction_prover/README.md
@@ -306,6 +306,41 @@ A convenience script is available for parameterized builds:
 ./scripts/build_starknet_transaction_prover.sh --target-cpu znver5
 ```
 
+## Running natively (without Docker)
+
+The service shells out to the `starknet-sierra-compile` binary to compile Sierra classes during
+transaction re-execution. The Docker image bundles it; for a native run, install it first:
+
+```bash
+# From the repository root:
+bash scripts/install_compiler_binaries.sh --sierra
+```
+
+The script installs the binary to `$CARGO_TOOLS_ROOT/starknet-sierra-compile-<version>/bin/`
+(default `~/.cargo/tools`), which is where the service looks it up at runtime. The version is
+read from `crates/apollo_infra_utils/src/cairo_compiler_version.txt` — the same file the service
+binary embeds at build time — so run the script from the same checkout the service was built
+from. Installing from a different branch or commit can yield a version mismatch, which the
+service rejects at startup.
+
+Without a repository checkout, the equivalent direct installation is:
+
+```bash
+# <version> is the content of crates/apollo_infra_utils/src/cairo_compiler_version.txt
+# at the commit the service binary was built from.
+cargo install --locked starknet-sierra-compile --version <version> \
+    --root "$HOME/.cargo/tools/starknet-sierra-compile-<version>"
+```
+
+Notes:
+
+- Invoke the install script via `bash` as shown above: its `#!/bin/env bash` shebang does not
+  resolve on macOS, where `env` lives at `/usr/bin/env`.
+- Set `CARGO_TOOLS_ROOT` to use a non-default installation location; the service reads it at
+  startup.
+- If the compiler binary is missing or has the wrong version, the service exits at startup with
+  installation instructions.
+
 ## Kubernetes deployment
 
 Mount a ConfigMap containing your JSON config file and pass its path via `--config-file`.

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -13,6 +13,7 @@ async fn main() -> anyhow::Result<()> {
     use std::sync::Arc;
 
     use anyhow::Context;
+    use blockifier_reexecution::compile::verify_sierra_compiler;
     use clap::Parser;
     use starknet_transaction_prover::server::config::{
         CliArgs,
@@ -61,6 +62,10 @@ async fn main() -> anyhow::Result<()> {
         ohttp_enabled = config.ohttp_enabled,
         "Starting Starknet transaction prover."
     );
+
+    // Fail fast if the Sierra compiler binary is missing or has the wrong version, instead
+    // of panicking on the first proving request that needs Sierra compilation.
+    verify_sierra_compiler();
 
     // Build and start the JSON-RPC server.
     let rpc_impl = ProvingRpcServerImpl::from_config(&config);


### PR DESCRIPTION
## Why

The prover shells out to `starknet-sierra-compile`, resolved at runtime under `$CARGO_TOOLS_ROOT` (default `~/.cargo/tools`). Today, when the binary is missing — the common case for any native (non-Docker) run — the server starts cleanly and only panics on the first `starknet_proveTransaction` that touches a Sierra class, from inside a lazily-initialized static deep in the request path. Nothing in the docs tells a native user the dependency exists.

## What

- **Fail early**: `blockifier_reexecution::compile` exposes `verify_sierra_compiler()`, which forces the lazily-constructed compiler (whose construction verifies the binary exists and matches the pinned version). The prover calls it at startup, right after the banner — a missing or mismatched compiler now aborts boot with the actionable install message instead of failing mid-request.
- **Docs**: new "Running natively (without Docker)" section in the prover README covering `scripts/install_compiler_binaries.sh --sierra`, the version coupling with `cairo_compiler_version.txt`, the script-free `cargo install` equivalent, the `bash` invocation requirement on macOS (the script's `#!/bin/env bash` shebang does not resolve there), and `CARGO_TOOLS_ROOT`.

## Validation

- `cargo build -p starknet_transaction_prover --features stwo_proving` — passes (crate-local nightly toolchain).
- `cargo clippy --no-deps --all-targets` on both touched crates — clean.
- Ran the built binary with `CARGO_TOOLS_ROOT=/nonexistent`: exits at startup (code 101) with `starknet-sierra-compile not found. Run 'scripts/install_compiler_binaries.sh' to install the correct version.`
- Installed the compiler exactly per the new README instructions, re-ran: startup logs `Using Sierra compiler binary at: "~/.cargo/tools/starknet-sierra-compile-2.19.0-rc.2/bin/starknet-sierra-compile"` and the server stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)