### PR TITLE
starknet_transaction_prover: relay opaque additional_data from check response

### DIFF
--- a/crates/starknet_transaction_prover/src/blocking_check.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check.rs
@@ -5,6 +5,7 @@
 
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use starknet_api::rpc_transaction::RpcTransaction;
 use tracing::warn;
 use url::Url;
@@ -19,8 +20,11 @@ const BLOCKED_ERROR_CODE: i32 = 10000;
 /// Result of a blocking check call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BlockingCheckResult {
-    /// External service returned success — transaction is allowed.
-    Allowed,
+    /// External service returned success — transaction is allowed. Carries the
+    /// opaque `additional_data` object the prover relays verbatim on the prove
+    /// response (the prover does not interpret its contents); `None` when the
+    /// allow response carried no `additional_data`.
+    Allowed(Option<Map<String, Value>>),
     /// External service returned error code 10000 — transaction is blocked.
     Blocked,
     /// Any other outcome (network error, non-10000 error, deserialization failure).
@@ -53,10 +57,24 @@ struct CheckTransactionParams {
 }
 
 /// JSON-RPC response envelope (only the fields we need).
+///
+/// `additional_data` is required to be a JSON object: a non-object value fails
+/// envelope deserialization and is treated as `Inconclusive` (deferring to the
+/// fail-open policy). Its contents are otherwise opaque — the prover relays
+/// them verbatim without interpreting any keys.
 #[derive(Deserialize)]
 struct JsonRpcResponse {
     #[serde(default)]
+    result: Option<CheckTransactionResult>,
+    #[serde(default)]
     error: Option<JsonRpcError>,
+}
+
+/// Allow-response payload (only the fields we need).
+#[derive(Deserialize)]
+struct CheckTransactionResult {
+    #[serde(default)]
+    additional_data: Option<Map<String, Value>>,
 }
 
 /// JSON-RPC error object (only the code field is needed for decision logic).
@@ -116,7 +134,9 @@ impl BlockingCheckClient {
         };
 
         match json_rpc_response.error {
-            None => BlockingCheckResult::Allowed,
+            None => BlockingCheckResult::Allowed(
+                json_rpc_response.result.and_then(|check_result| check_result.additional_data),
+            ),
             Some(err) if err.code == BLOCKED_ERROR_CODE => BlockingCheckResult::Blocked,
             Some(err) => {
                 warn!("Blocking check returned non-blocking error code: {}", err.code);

--- a/crates/starknet_transaction_prover/src/blocking_check_test.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check_test.rs
@@ -1,12 +1,13 @@
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use mockito::{Matcher, Server};
+use serde_json::{json, Map, Value};
 use starknet_api::invoke_tx_args;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::test_utils::invoke::rpc_invoke_tx;
 use starknet_api::transaction::fields::{AllResourceBounds, ValidResourceBounds};
 use url::Url;
 
-use super::{BlockingCheckClient, BlockingCheckResult};
+use crate::blocking_check::{BlockingCheckClient, BlockingCheckResult};
 
 fn test_transaction() -> RpcTransaction {
     rpc_invoke_tx(invoke_tx_args!(
@@ -35,7 +36,65 @@ async fn test_success_response_returns_allowed() {
     let client = client_for_server(&server);
     let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
 
-    assert_eq!(result, BlockingCheckResult::Allowed);
+    assert_eq!(result, BlockingCheckResult::Allowed(None));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_allow_with_additional_data_relays_it_verbatim() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(200)
+        .with_body(
+            r#"{"jsonrpc":"2.0","result":{"allowed":true,"additional_data":{"signature":{"issued_at":1716579600,"sig_r":"0x6e6f63c8","sig_s":"0x58a68a71"}}},"id":1}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    // The contents are opaque to the client; it relays the object as-is.
+    let expected: Map<String, Value> = serde_json::from_value(json!({
+        "signature": { "issued_at": 1716579600, "sig_r": "0x6e6f63c8", "sig_s": "0x58a68a71" }
+    }))
+    .unwrap();
+    assert_eq!(result, BlockingCheckResult::Allowed(Some(expected)));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_allow_without_additional_data_returns_allowed_none() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(200)
+        .with_body(r#"{"jsonrpc":"2.0","result":{"allowed":true},"id":1}"#)
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    assert_eq!(result, BlockingCheckResult::Allowed(None));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_allow_with_non_object_additional_data_returns_inconclusive() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(200)
+        .with_body(r#"{"jsonrpc":"2.0","result":{"allowed":true,"additional_data":42},"id":1}"#)
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    assert_eq!(result, BlockingCheckResult::Inconclusive);
     mock.assert_async().await;
 }
 

--- a/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
+++ b/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
@@ -239,7 +239,7 @@ impl<R: VirtualSnosRunner + 'static> VirtualSnosProver<R> {
                 info!("Transaction blocked by external check");
                 false
             }
-            Ok(BlockingCheckResult::Allowed) => {
+            Ok(BlockingCheckResult::Allowed(_)) => {
                 info!("Transaction allowed by external check");
                 true
             }


### PR DESCRIPTION
The external check's allow response may carry a screening signature
({ allowed: true, signature: { issued_at, sig_r, sig_s } }) for screened
transactions. BlockingCheckResult::Allowed now carries it as an Option.
An allow response with a malformed signature fails envelope parsing and
maps to Inconclusive (deferring to the fail-open policy) — a corrupt
signed-allow means the screening path is misbehaving, so it is not
treated as a clean allow.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>