### PR TITLE
starknet_api: do not panic on malformed resource_bounds in tx json deserializer

### DIFF
--- a/crates/starknet_api/src/serde_utils.rs
+++ b/crates/starknet_api/src/serde_utils.rs
@@ -160,23 +160,18 @@ where
 /// In old transactions, the resource bounds names are lowercase.
 /// Need to convert to uppercase for deserialization to work.
 fn upper_case_resource_bounds_names(raw_transaction: &mut Value) {
-    let resource_bounds = raw_transaction
-        .get_mut("resource_bounds")
-        .expect("tx should contain resource_bounds field")
-        .as_object_mut()
-        .expect("resource_bounds should be an object");
+    let Some(resource_bounds) =
+        raw_transaction.get_mut("resource_bounds").and_then(Value::as_object_mut)
+    else {
+        return;
+    };
 
-    if let Some(l1_gas_value) = resource_bounds.remove("l1_gas") {
-        resource_bounds.insert("L1_GAS".to_string(), l1_gas_value);
-
-        let l2_gas_value = resource_bounds
-            .remove("l2_gas")
-            .expect("If tx contains l1_gas, it should contain l2_gas");
-        resource_bounds.insert("L2_GAS".to_string(), l2_gas_value);
-    }
-
-    if let Some(l1_data_gas_value) = resource_bounds.remove("l1_data_gas") {
-        resource_bounds.insert("L1_DATA_GAS".to_string(), l1_data_gas_value);
+    for (lower_case_name, upper_case_name) in
+        [("l1_gas", "L1_GAS"), ("l2_gas", "L2_GAS"), ("l1_data_gas", "L1_DATA_GAS")]
+    {
+        if let Some(resource_bounds_value) = resource_bounds.remove(lower_case_name) {
+            resource_bounds.insert(upper_case_name.to_string(), resource_bounds_value);
+        }
     }
 }
 

--- a/crates/starknet_api/src/serde_utils_test.rs
+++ b/crates/starknet_api/src/serde_utils_test.rs
@@ -10,6 +10,7 @@ use crate::deprecated_contract_class::{
 use crate::serde_utils::{
     bytes_from_hex_str,
     deserialize_optional_contract_class_abi_entry_vector,
+    deserialize_transaction_json_to_starknet_api_tx,
     hex_str_from_bytes,
     BytesAsHex,
     InnerDeserializationError,
@@ -185,4 +186,26 @@ fn deserialize_optional_contract_class_abi_entry_vector_none() {
     "#;
     let res: DummyContractClass = serde_json::from_str(json).unwrap();
     assert_eq!(res, DummyContractClass { abi: None });
+}
+
+/// V3 transaction JSON may arrive from untrusted sources; a missing or malformed
+/// `resource_bounds` field must surface as a deserialization error, not a panic.
+#[test]
+fn deserialize_transaction_json_does_not_panic_on_malformed_resource_bounds() {
+    // Missing resource_bounds field.
+    let raw_transaction = serde_json::json!({"type": "INVOKE", "version": "0x3"});
+    assert!(deserialize_transaction_json_to_starknet_api_tx(raw_transaction).is_err());
+
+    // resource_bounds is not an object.
+    let raw_transaction =
+        serde_json::json!({"type": "INVOKE", "version": "0x3", "resource_bounds": 5});
+    assert!(deserialize_transaction_json_to_starknet_api_tx(raw_transaction).is_err());
+
+    // l1_gas without l2_gas.
+    let raw_transaction = serde_json::json!({
+        "type": "DECLARE",
+        "version": "0x3",
+        "resource_bounds": {"l1_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"}}
+    });
+    assert!(deserialize_transaction_json_to_starknet_api_tx(raw_transaction).is_err());
 }


### PR DESCRIPTION
## Why

`upper_case_resource_bounds_names` panics via `.expect()` when a V3 transaction JSON lacks a `resource_bounds` field, when the field is not an object, or when `l1_gas` is present without `l2_gas`. This is reachable from **user-controlled input**: `apollo_http_server`'s add-transaction endpoint feeds the raw request body to `deserialize_transaction_json_to_starknet_api_tx` on its deprecated-transaction metrics path, so the body `{"type":"INVOKE","version":"0x3"}` panics the serving task on every node. The panic predates the move into `starknet_api` (#14408), but a `pub fn … -> serde_json::Result` in a foundational crate must not hide panic paths — new callers will trust the signature.

## What

- `upper_case_resource_bounds_names` now leaves the transaction unchanged when `resource_bounds` is missing or not an object, and normalizes each resource-bound key independently. The typed deserialization that follows remains the authority on required fields and reports the error — malformed input now yields `Err` instead of a panic.
- Regression test covering all three former panic paths (missing field, non-object field, `l1_gas` without `l2_gas`), asserting `Err`.

Behavior for well-formed input is unchanged: `blockifier_reexecution`'s `raw_rpc_json_test` fixture suite (real invoke/declare/deploy-account/L1-handler JSONs across versions) passes unmodified.

## Validation

- New test passes (each scenario panicked before this change).
- `cargo test -p starknet_api` — 88 passed, 0 failed.
- `cargo test -p blockifier_reexecution raw_rpc` — 12 passed (happy-path parity).
- `cargo test -p apollo_http_server` — 37 passed.
- `cargo clippy -p starknet_api --no-deps --all-targets` — clean; `scripts/rust_fmt.sh` applied.

Stacked on #14408 (which moved the function into `starknet_api`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)