### PR TITLE
blockifier_reexecution: disable sccache wrapper in replay Dockerfile

### DIFF
--- a/crates/blockifier_reexecution/replay/Dockerfile
+++ b/crates/blockifier_reexecution/replay/Dockerfile
@@ -55,6 +55,10 @@ ENV RUSTUP_HOME=/var/tmp/rust
 ENV CARGO_HOME=${RUSTUP_HOME}
 ENV PATH="${RUSTUP_HOME}/bin:${PATH}"
 
+# Disabling the `rustc-wrapper = "sccache"` as sccache is not installed in this
+# image.
+ENV CARGO_BUILD_RUSTC_WRAPPER=""
+
 COPY rust-toolchain.toml rust-toolchain.toml
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none \
     && rustup toolchain install \


### PR DESCRIPTION
cargo-chef bakes the repo's .cargo/config.toml (which sets rustc-wrapper = sccache) into recipe.json during prepare and restores it during cook. sccache is not installed in the replay image, so the cook step failed with 'could not execute process sccache ... rustc'. Set CARGO_BUILD_RUSTC_WRAPPER= to override the config and skip the wrapper.