### PR TITLE
starknet_transaction_prover,blockifier_reexecution: drop sierra-compile sidecar from docker images

### DIFF
--- a/crates/blockifier_reexecution/replay/Dockerfile
+++ b/crates/blockifier_reexecution/replay/Dockerfile
@@ -86,11 +86,11 @@ RUN cargo chef cook --release -p blockifier_reexecution --features cairo_native 
 COPY . .
 RUN cargo build --release -p blockifier_reexecution --features cairo_native
 
-# Install compiler binaries used for Sierra compilation at runtime.
-# Binaries land under $CARGO_TOOLS_ROOT/<binary>-<version>/bin/<binary>; the
-# final stage below COPYs the entire $CARGO_TOOLS_ROOT tree so this layout is
-# preserved at runtime.
-RUN scripts/install_compiler_binaries.sh
+# Install the Sierra-to-Native compiler binary used at runtime (Sierra-to-Casm
+# compilation is done in-process). The binary lands under
+# $CARGO_TOOLS_ROOT/<binary>-<version>/bin/<binary>; the final stage below COPYs
+# the entire $CARGO_TOOLS_ROOT tree so this layout is preserved at runtime.
+RUN scripts/install_compiler_binaries.sh --native
 
 # =============================================================================
 # Stage 4: Final runtime image
@@ -108,9 +108,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV ID=1001
 WORKDIR /app
 
-# Copy the binary and both compilers (Sierra-to-CASM and Sierra-to-Native).
+# Copy the binary and the Sierra-to-Native compiler.
 COPY --from=builder /app/target/release/blockifier_reexecution ./target/release/blockifier_reexecution
-# Per-version compiler binaries; their absolute path is constructed from
+# Per-version compiler binary; its absolute path is constructed from
 # $CARGO_TOOLS_ROOT at runtime.
 ENV CARGO_TOOLS_ROOT=/opt/cargo-tools
 COPY --from=builder /var/tmp/rust/tools ${CARGO_TOOLS_ROOT}

--- a/crates/starknet_transaction_prover/Dockerfile
+++ b/crates/starknet_transaction_prover/Dockerfile
@@ -144,12 +144,6 @@ RUN BUILD_FLAGS=$([ "$BUILD_MODE" = "release" ] && echo "--release" || true); \
         cargo build $BUILD_FLAGS -p starknet_transaction_prover --features stwo_proving; \
     fi
 
-# Install compiler binary used for Sierra to CASM compilation at runtime.
-# Binary lands under $CARGO_TOOLS_ROOT/<binary>-<version>/bin/<binary>; the
-# final stage below COPYs the entire $CARGO_TOOLS_ROOT tree so this layout is
-# preserved at runtime.
-RUN scripts/install_compiler_binaries.sh --sierra
-
 # =============================================================================
 # Stage 4: Final runtime image
 # =============================================================================
@@ -171,11 +165,6 @@ COPY --from=builder /app/target/${BUILD_MODE}/starknet_transaction_prover ./targ
 
 # Copy resources needed by the service.
 COPY --from=builder /app/crates/starknet_transaction_prover/resources ./crates/starknet_transaction_prover/resources
-
-# Per-version Sierra-to-CASM compiler binary; its absolute path is constructed
-# from $CARGO_TOOLS_ROOT at runtime.
-ENV CARGO_TOOLS_ROOT=/opt/cargo-tools
-COPY --from=builder /var/tmp/rust/tools ${CARGO_TOOLS_ROOT}
 
 # Copy tini for proper init handling.
 COPY --from=builder /usr/bin/tini /usr/bin/tini


### PR DESCRIPTION
## Why

Follow-up to #14406 (merged), which made `blockifier_reexecution` compile Sierra→Casm in-process. Both Docker images that build on it shipped the `starknet-sierra-compile` sidecar binary purely for that path; it is now dead weight.

## What

- **`crates/starknet_transaction_prover/Dockerfile`**: the prover is built `--features stwo_proving` (cairo_native disabled), so Sierra→Casm was its *only* compiler dependency. Removed the `install_compiler_binaries.sh --sierra` step, the `CARGO_TOOLS_ROOT` env, and the COPY of the tools tree. The runtime image is now a single self-contained binary — no compiler sidecar at all.
- **`crates/blockifier_reexecution/replay/Dockerfile`**: built `--features cairo_native`, so it still needs `starknet-native-compile` (the compare-native path, unaffected by #14406). Switched the install from both compilers to `--native` only; kept the tools COPY and the `binutils`/`libc6-dev` runtime deps that `starknet-native-compile` requires. Comments updated accordingly.

## Validation

- `docker build --check` on both Dockerfiles — "Check complete, no warnings found."
- **Prover image** is built by PR CI (`starknet_transaction_prover_ci.yml` docker-build job). Additionally validated end-to-end locally on this branch (restacked onto `main-v0.14.3`):
  - Image ships zero compiler binaries: `/opt/cargo-tools` absent, `CARGO_TOOLS_ROOT` unset, no `starknet-sierra-compile` anywhere on disk.
  - The server boots and `starknet_proveTransaction` produced a STARK proof for a live mainnet Invoke V3 transaction (block 11641753, ~2 min). The sender account is a Sierra class, compiled to Casm **in-process** on a cold cache — proving the sidecar is genuinely unnecessary.
- **Replay image** is *not* built by PR CI (`blockifier_reexecution_docker_publish.yml` runs only on `workflow_dispatch`/tag pushes), so it was built and verified locally:
  - A real `docker build` succeeded, demonstrating `scripts/install_compiler_binaries.sh --native` works standalone (the base stage installs LLVM 19, satisfying the `llvm-config-19` gate).
  - `starknet-native-compile 0.9.0-rc.7` is present under `CARGO_TOOLS_ROOT` and executes (`--version` runs; the retained `binutils`/`libc6-dev` runtime deps satisfy its dynamic linking).
  - No `starknet-sierra-compile` anywhere in the image; the CLI `--help` is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
