### PR TITLE
starknet_transaction_prover,starknet_patricia: add compute_missing_sibling_keys helper

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/types.rs
@@ -68,21 +68,27 @@ impl NodeIndex {
     }
 
     // TODO(Amos, 1/5/2024): Move to EdgePath.
-    pub(crate) fn compute_bottom_index(
-        index: NodeIndex,
-        path_to_bottom: &PathToBottom,
-    ) -> NodeIndex {
+    pub fn compute_bottom_index(index: NodeIndex, path_to_bottom: &PathToBottom) -> NodeIndex {
         let PathToBottom { path, length, .. } = path_to_bottom;
         (index << u8::from(*length)) + Self::new(path.into())
     }
 
-    pub(crate) fn get_children_indices(&self) -> [Self; 2] {
+    pub fn get_children_indices(&self) -> [Self; 2] {
         let left_child = *self << 1;
         [left_child, left_child + 1]
     }
 
+    /// Returns `true` if `self` lies in the subtree rooted at `ancestor`, where a node is
+    /// considered a descendant of itself (`self == ancestor` returns `true`).
+    pub fn is_descendant_of(&self, ancestor: &NodeIndex) -> bool {
+        let self_bit_length = self.bit_length();
+        let ancestor_bit_length = ancestor.bit_length();
+        self_bit_length >= ancestor_bit_length
+            && (self.0 >> u32::from(self_bit_length - ancestor_bit_length)) == ancestor.0
+    }
+
     /// Returns the number of leading zeroes when represented with Self::BITS bits.
-    pub(crate) fn leading_zeros(&self) -> u8 {
+    pub fn leading_zeros(&self) -> u8 {
         (self.0.leading_zeros() - (U256::BITS - u32::from(Self::BITS)))
             .try_into()
             .expect("Leading zeroes are unexpectedly larger than a u8.")

--- a/crates/starknet_transaction_prover/src/running/storage_proofs.rs
+++ b/crates/starknet_transaction_prover/src/running/storage_proofs.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::collections::hash_map::RandomState;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use async_trait::async_trait;
 use blockifier::state::cached_state::StateMaps;
@@ -13,7 +14,7 @@ use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
     Preimage,
     PreimageMap,
 };
-use starknet_patricia::patricia_merkle_tree::types::SubTreeHeight;
+use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SubTreeHeight};
 use starknet_patricia_storage::map_storage::MapStorage;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
@@ -147,6 +148,143 @@ pub(crate) fn merge_storage_proofs(
     }
 
     RpcStorageProof { classes_proof, contracts_proof, contracts_storage_proofs, global_roots }
+}
+
+/// Per contract, returns crafted storage keys whose follow-up `get_storage_proof` exposes the
+/// sibling preimages the committer needs to canonicalize the trie after the deletes in
+/// `state_diff`.
+#[allow(dead_code)] // Wired into get_storage_proofs in a follow-up PR.
+pub(crate) fn compute_missing_sibling_keys(
+    rpc_proof: &RpcStorageProof,
+    query: &RpcStorageProofsQuery,
+    state_diff: &StateMaps,
+) -> Result<Vec<ContractStorageKeys>, ProofProviderError> {
+    // `contract_leaves_data` and `contracts_storage_proofs` share `contract_addresses`' order.
+    let address_to_index: HashMap<&ContractAddress, usize> =
+        query.contract_addresses.iter().enumerate().map(|(index, addr)| (addr, index)).collect();
+
+    // Deletes (writes of zero) interact within a trie, so collect them per contract.
+    let mut deleted_leaves_by_address: BTreeMap<ContractAddress, Vec<NodeIndex>> = BTreeMap::new();
+    for ((addr, key), value) in &state_diff.storage {
+        if *value == Felt::ZERO {
+            let entry = deleted_leaves_by_address.entry(*addr).or_default();
+            entry.push(NodeIndex::from_leaf_felt(key.0.key()));
+        }
+    }
+
+    let mut result = Vec::new();
+    for (addr, deleted_leaves) in deleted_leaves_by_address {
+        let Some(&idx) = address_to_index.get(&addr) else { continue };
+        // A missing `storage_root` is an empty trie; deleting from it is a no-op.
+        let Some(root) = rpc_proof.contracts_proof.contract_leaves_data[idx].storage_root else {
+            continue;
+        };
+        let nodes = &rpc_proof.contracts_storage_proofs[idx];
+
+        let mut crafted_keys = BTreeSet::new();
+        subtree_empties(NodeIndex::ROOT, root, &deleted_leaves, nodes, &mut crafted_keys)?;
+        if !crafted_keys.is_empty() {
+            result.push(ContractStorageKeys {
+                contract_address: *addr.0.key(),
+                storage_keys: crafted_keys.into_iter().collect(),
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+/// Whether the subtree at (`index`, `hash`) becomes empty after removing `deleted` (the deleted
+/// leaves under it), recording a crafted key for every collapse sibling that must be fetched.
+/// Errors if a node on a deleted leaf's path is missing from the proof.
+fn subtree_empties(
+    index: NodeIndex,
+    hash: Felt,
+    deleted: &[NodeIndex],
+    proof_nodes: &IndexMap<Felt, MerkleNode, RandomState>,
+    crafted_keys: &mut BTreeSet<Felt>,
+) -> Result<bool, ProofProviderError> {
+    if deleted.is_empty() {
+        return Ok(false);
+    }
+    if index.is_leaf() {
+        return Ok(true);
+    }
+    let Some(node) = proof_nodes.get(&hash) else {
+        // A deleted key is always read (hence queried), so a complete proof reaches its leaf.
+        return Err(ProofProviderError::InvalidProofResponse(format!(
+            "storage proof is missing inner node {hash:#x} on a deleted key's path"
+        )));
+    };
+    match node {
+        MerkleNode::BinaryNode(bn) => {
+            let [left_index, right_index] = index.get_children_indices();
+            let (left_deleted, right_deleted): (Vec<_>, Vec<_>) =
+                deleted.iter().copied().partition(|leaf| leaf.is_descendant_of(&left_index));
+            let left_empties =
+                subtree_empties(left_index, bn.left, &left_deleted, proof_nodes, crafted_keys)?;
+            let right_empties =
+                subtree_empties(right_index, bn.right, &right_deleted, proof_nodes, crafted_keys)?;
+            // The node collapses to its surviving child when exactly one side empties; only an
+            // unmodified (delete-free) survivor is an orphan whose preimage the committer lacks.
+            match (left_empties, right_empties) {
+                (true, false) if right_deleted.is_empty() => {
+                    record_collapse_sibling(right_index, bn.right, proof_nodes, crafted_keys)?;
+                }
+                (false, true) if left_deleted.is_empty() => {
+                    record_collapse_sibling(left_index, bn.left, proof_nodes, crafted_keys)?;
+                }
+                _ => {}
+            }
+            Ok(left_empties && right_empties)
+        }
+        MerkleNode::EdgeNode(_) => {
+            let Preimage::Edge(edge) = Preimage::from(node) else { unreachable!() };
+            // Guard the shift in `compute_bottom_index` against a malformed past-the-leaf edge.
+            if u8::from(edge.path_to_bottom.length) > index.leading_zeros() {
+                return Err(ProofProviderError::InvalidProofResponse(format!(
+                    "edge node {hash:#x} extends past the leaf level"
+                )));
+            }
+            let bottom_index = NodeIndex::compute_bottom_index(index, &edge.path_to_bottom);
+            // Deletes that don't pass through the edge target keys absent from the trie (no-ops).
+            let descending: Vec<_> = deleted
+                .iter()
+                .copied()
+                .filter(|leaf| leaf.is_descendant_of(&bottom_index))
+                .collect();
+            if descending.is_empty() {
+                return Ok(false);
+            }
+            subtree_empties(
+                bottom_index,
+                edge.bottom_data.0,
+                &descending,
+                proof_nodes,
+                crafted_keys,
+            )
+        }
+    }
+}
+
+fn record_collapse_sibling(
+    sibling_index: NodeIndex,
+    sibling_hash: Felt,
+    proof_nodes: &IndexMap<Felt, MerkleNode, RandomState>,
+    crafted_keys: &mut BTreeSet<Felt>,
+) -> Result<(), ProofProviderError> {
+    // A leaf-level sibling is merged by hash, and a present sibling is already known.
+    if sibling_index.is_leaf() || proof_nodes.contains_key(&sibling_hash) {
+        return Ok(());
+    }
+    // Routing to any leaf under the sibling exposes its preimage; pick the left-most one and strip
+    // the leading `FIRST_LEAF` bit to turn the leaf index back into a storage key.
+    let crafted_leaf_index = sibling_index << sibling_index.leading_zeros();
+    let crafted_key = Felt::try_from(crafted_leaf_index - NodeIndex::FIRST_LEAF).map_err(|e| {
+        ProofProviderError::InvalidProofResponse(format!("crafted sibling key out of range: {e}"))
+    })?;
+    crafted_keys.insert(crafted_key);
+    Ok(())
 }
 
 /// Configuration for storage proof provider behavior.

--- a/crates/starknet_transaction_prover/src/running/storage_proofs_test.rs
+++ b/crates/starknet_transaction_prover/src/running/storage_proofs_test.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use blockifier::context::BlockContext;
 use blockifier::state::cached_state::StateMaps;
+use indexmap::IndexMap;
 use rstest::rstest;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::block_hash::block_hash_calculator::BlockHeaderCommitments;
@@ -13,14 +14,17 @@ use starknet_rust_core::types::{
     ContractLeafData,
     ContractStorageKeys,
     ContractsProof,
+    EdgeNode,
     GlobalRoots,
     MerkleNode,
     StorageProof as RpcStorageProof,
 };
 use starknet_types_core::felt::Felt;
 
+use crate::errors::ProofProviderError;
 use crate::running::storage_proofs::{
     collect_query,
+    compute_missing_sibling_keys,
     count_total_keys,
     flatten_query,
     merge_storage_proofs,
@@ -32,6 +36,62 @@ use crate::running::storage_proofs::{
 };
 use crate::running::virtual_block_executor::{BaseBlockInfo, VirtualBlockExecutionData};
 use crate::test_utils::{rpc_provider, STRK_TOKEN_ADDRESS};
+
+fn binary(left: u64, right: u64) -> MerkleNode {
+    MerkleNode::BinaryNode(BinaryNode { left: Felt::from(left), right: Felt::from(right) })
+}
+
+fn edge(path: u64, length: u64, child: u64) -> MerkleNode {
+    MerkleNode::EdgeNode(EdgeNode { path: Felt::from(path), length, child: Felt::from(child) })
+}
+
+fn proof_nodes(entries: impl IntoIterator<Item = (u64, MerkleNode)>) -> IndexMap<Felt, MerkleNode> {
+    entries.into_iter().map(|(hash, node)| (Felt::from(hash), node)).collect()
+}
+
+/// Runs `compute_missing_sibling_keys` for a single contract whose storage trie has root hash
+/// `storage_root` (`None` = empty trie) and nodes `nodes`, applying `writes` (`(key, value)`; a
+/// zero value is a delete). Returns the crafted storage keys for that contract.
+fn missing_sibling_keys(
+    storage_root: Option<u64>,
+    nodes: IndexMap<Felt, MerkleNode>,
+    writes: &[(Felt, Felt)],
+) -> Result<Vec<Felt>, ProofProviderError> {
+    let addr = ContractAddress::try_from(Felt::from(100u64)).unwrap();
+    let query = RpcStorageProofsQuery {
+        class_hashes: vec![],
+        contract_addresses: vec![addr],
+        contract_storage_keys: vec![ContractStorageKeys {
+            contract_address: *addr.0.key(),
+            storage_keys: vec![],
+        }],
+    };
+    let proof = RpcStorageProof {
+        classes_proof: IndexMap::default(),
+        contracts_proof: ContractsProof {
+            nodes: IndexMap::default(),
+            contract_leaves_data: vec![ContractLeafData {
+                nonce: Felt::ZERO,
+                class_hash: Felt::ZERO,
+                storage_root: storage_root.map(Felt::from),
+            }],
+        },
+        contracts_storage_proofs: vec![nodes],
+        global_roots: GlobalRoots {
+            contracts_tree_root: Felt::ZERO,
+            classes_tree_root: Felt::ZERO,
+            block_hash: Felt::ZERO,
+        },
+    };
+    let mut state_diff = StateMaps::default();
+    for &(key, value) in writes {
+        state_diff.storage.insert((addr, StorageKey::try_from(key).unwrap()), value);
+    }
+    Ok(compute_missing_sibling_keys(&proof, &query, &state_diff)?
+        .into_iter()
+        .flat_map(|contract| contract.storage_keys)
+        .collect())
+}
 
 /// Fixture: Creates initial reads with the STRK contract and storage slot 0.
 #[rstest::fixture]
@@ -265,4 +325,84 @@ fn test_split_merge_roundtrip() {
     assert_split_merge_identity(&make_query(10, 20, &[]), 15);
     // Tight limit forces many small chunks.
     assert_split_merge_identity(&make_query(3, 4, &[8, 6, 3]), 3);
+}
+
+const DELETE: (Felt, Felt) = (Felt::ZERO, Felt::ZERO);
+
+// edge(len 3) -> binary{C, D=orphan}; C edge(len 247) -> leaf. Deleting key 0 collapses the binary
+// onto D (depth 4), whose orphan preimage must be fetched via a key routing there: bit 251-4=247.
+#[test]
+fn test_fetches_orphan_collapse_sibling() {
+    let nodes = proof_nodes([(1, edge(0, 3, 2)), (2, binary(3, 4)), (3, edge(0, 247, 5))]);
+    assert_eq!(
+        missing_sibling_keys(Some(1), nodes, &[DELETE]).unwrap(),
+        vec![Felt::TWO.pow(247_u32)]
+    );
+}
+
+// Two binaries on the path: binary{binary{C, S2=orphan}, S1=orphan}; C edge(len 249) -> leaf. Only
+// the deepest binary collapses (onto S2 at depth 2); the shallow S1 is merely re-hashed, not
+// fetched.
+#[test]
+fn test_fetches_only_deepest_collapse_sibling() {
+    let nodes = proof_nodes([(1, binary(2, 10)), (2, binary(3, 20)), (3, edge(0, 249, 5))]);
+    assert_eq!(
+        missing_sibling_keys(Some(1), nodes, &[DELETE]).unwrap(),
+        vec![Felt::TWO.pow(249_u32)]
+    );
+}
+
+// binary{binary{E1->L1, E2->L2}, S_A=orphan}. Deleting both L1 (key 0) and L2 (key 2^249) empties
+// the inner binary, so the collapse cascades to the root and fetches S_A (depth 1) — not E1/E2.
+#[test]
+fn test_cascades_to_parent_sibling_when_node_empties() {
+    let nodes = proof_nodes([
+        (1, binary(2, 30)),
+        (2, binary(4, 5)),
+        (4, edge(0, 249, 100)),
+        (5, edge(0, 249, 101)),
+    ]);
+    let deletes = [DELETE, (Felt::TWO.pow(249_u32), Felt::ZERO)];
+    assert_eq!(
+        missing_sibling_keys(Some(1), nodes, &deletes).unwrap(),
+        vec![Felt::TWO.pow(250_u32)]
+    );
+}
+
+// Deleting a key absent from the trie (its path diverges at the edge labelled 0b11) is a no-op,
+// even with a shallow orphan sibling on the way.
+#[test]
+fn test_no_op_delete_of_absent_key_fetches_nothing() {
+    let nodes = proof_nodes([(1, binary(2, 10)), (2, edge(0b11, 2, 5))]);
+    assert!(missing_sibling_keys(Some(1), nodes, &[DELETE]).unwrap().is_empty());
+}
+
+// A single-edge trie has no binary node; deleting its only leaf empties the trie, collapsing
+// nothing.
+#[test]
+fn test_single_edge_trie_fetches_nothing() {
+    let nodes = proof_nodes([(1, edge(0, 251, 5))]);
+    assert!(missing_sibling_keys(Some(1), nodes, &[DELETE]).unwrap().is_empty());
+}
+
+// An empty storage trie (no root) makes every delete a no-op.
+#[test]
+fn test_empty_trie_fetches_nothing() {
+    assert!(missing_sibling_keys(None, IndexMap::default(), &[DELETE]).unwrap().is_empty());
+}
+
+// Non-zero writes are updates, not deletes, and never trigger a fetch.
+#[test]
+fn test_non_zero_writes_fetch_nothing() {
+    let nodes = proof_nodes([(1, binary(2, 3))]);
+    let writes = [(Felt::ZERO, Felt::from(42u64))];
+    assert!(missing_sibling_keys(Some(1), nodes, &writes).unwrap().is_empty());
+}
+
+// A deleted key is always read, so a complete proof reaches its leaf; a missing on-path node (here
+// the root's left child, hash 2) is an incomplete-proof error rather than a silent skip.
+#[test]
+fn test_incomplete_proof_errors() {
+    let nodes = proof_nodes([(1, binary(2, 10))]);
+    assert!(missing_sibling_keys(Some(1), nodes, &[DELETE]).is_err());
 }


### PR DESCRIPTION
## What

When a storage leaf is deleted, the Patricia storage trie changes shape: the deepest binary node on the path to the deleted key collapses into an edge pointing at its sibling. To produce the canonical post-deletion tree (checked by `patricia.cairo`), the committer must merge that collapse edge with the sibling — which requires the **sibling's preimage**. A plain `get_storage_proof` does not return it: siblings on the path appear only as orphan hashes.

`compute_missing_sibling_keys` scans the storage deletes in a `state_diff`, walks each deleted key's proof to the deepest binary node, and returns one crafted storage key per contract. Queried on a follow-up `get_storage_proof`, each crafted key routes into the sibling's subtree and forces the RPC to expose exactly that sibling's preimage.

It is `#[allow(dead_code)]` for now and wired into `get_storage_proofs` in a follow-up.

## Why only the deepest sibling

For a single-leaf deletion, only the deepest binary node on the path collapses; every shallower binary node keeps a non-empty on-path child (the collapsed edge) and is merely rehashed, for which the committer already has the sibling's hash (carried by the parent / the dummy node from `add_dummy_nodes_for_orphan_hashes`, exactly as for non-deletion updates). The sibling's *structure* is only consumed when it is an edge (`node_from_edge_data` → `concat_paths`); when it is binary or a leaf, the existing dummy-node path already yields the correct node. We can't tell an orphan sibling's type from the base proof, so we fetch the deepest one whenever its preimage is absent and the committer ignores it harmlessly if it turns out non-edge.

Edge paths are validated against the key, so a zero-write to a key that isn't in the trie (a no-op) fetches nothing.

## Implementation notes

The walk is expressed over `NodeIndex`. To support it, `starknet_patricia` exposes `get_children_indices` and `from_felt_value` as `pub` and adds a non-panicking `is_descendant_of`.

## Tests

- orphan sibling on the delete path → the one crafted key;
- two binary nodes on the path → only the **deepest** sibling is fetched (not the shallow one);
- phantom delete (edge diverges from the key) → empty;
- non-delete writes → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)