### PR TITLE
apollo_committer,starknet_committer: parallelize witness fetch with compute phase

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -24,7 +24,10 @@ use starknet_api::hash::PoseidonHash;
 use starknet_api::state::ThinStateDiff;
 use starknet_committer::block_committer::commit::commit_block;
 #[cfg(feature = "os_input")]
-use starknet_committer::block_committer::errors::CommitBlockWithWitnessesError;
+use starknet_committer::block_committer::commit::{
+    commit_block_with_witnesses,
+    CommitBlockWithWitnessesOutput,
+};
 use starknet_committer::block_committer::input::Input;
 use starknet_committer::block_committer::measurements_util::{
     Action,
@@ -551,67 +554,25 @@ where
                 let mut block_measurements = SingleBlockMeasurements::default();
                 block_measurements.start_measurement(Action::EndToEnd);
 
-                let pre_roots = self
-                    .forest_storage
-                    .read_roots(ForestDB::InitialReadContext::create_empty())
-                    .await
-                    .map_err(|e| self.map_internal_error(e))?;
-                block_measurements.start_measurement(Action::FetchWitnessesFirstPass);
-                let mut patricia_proofs = self
-                    .forest_storage
-                    .fetch_patricia_witnesses(
-                        pre_roots.classes_trie_root_hash,
-                        pre_roots.contracts_trie_root_hash,
-                        sorted_leaves.class_sorted,
-                        sorted_leaves.contract_sorted,
-                        &sorted_leaves.storage_sorted,
-                        None,
-                    )
-                    .await
-                    .map_err(|e| {
-                        self.map_internal_error(
-                            CommitBlockWithWitnessesError::PreCommitWitnessFetch(e),
-                        )
-                    })?;
-                block_measurements
-                    .attempt_to_stop_measurement(
-                        Action::FetchWitnessesFirstPass,
-                        patricia_proofs.get_nodes_count(),
-                    )
-                    .ok();
+                let input = Input {
+                    state_diff: state_diff.into(),
+                    initial_read_context: ForestDB::InitialReadContext::create_empty(),
+                    config: self.config.reader_config.clone(),
+                };
 
-                let CommitStateDiffOutput { filled_forest, global_root, deleted_nodes } =
-                    self.commit_state_diff(state_diff, &mut block_measurements).await?;
-                let post_roots = filled_forest.state_roots();
-
-                let forest_updates = ForestDB::serialize_forest(&filled_forest)
-                    .map_err(|e| self.map_internal_error(e))?;
-
-                block_measurements.start_measurement(Action::FetchWitnessesSecondPass);
-                let proof_after = self
-                    .forest_storage
-                    .fetch_patricia_witnesses(
-                        post_roots.classes_trie_root_hash,
-                        post_roots.contracts_trie_root_hash,
-                        sorted_leaves.class_sorted,
-                        sorted_leaves.contract_sorted,
-                        &sorted_leaves.storage_sorted,
-                        Some(forest_updates),
-                    )
-                    .await
-                    .map_err(|e| {
-                        self.map_internal_error(
-                            CommitBlockWithWitnessesError::PostCommitWitnessFetch(e),
-                        )
-                    })?;
-                block_measurements
-                    .attempt_to_stop_measurement(
-                        Action::FetchWitnessesSecondPass,
-                        proof_after.get_nodes_count(),
-                    )
-                    .ok();
-
-                patricia_proofs.extend(proof_after);
+                let CommitBlockWithWitnessesOutput {
+                    filled_forest,
+                    deleted_nodes,
+                    patricia_proofs,
+                    global_root,
+                } = commit_block_with_witnesses(
+                    input,
+                    &sorted_leaves,
+                    &mut self.forest_storage,
+                    &mut block_measurements,
+                )
+                .await
+                .map_err(|err| self.map_internal_error(err))?;
 
                 let (metadata, next_offset) =
                     commit_tip_metadata_bundle(height, global_root, state_diff_commitment);

--- a/crates/starknet_committer/Cargo.toml
+++ b/crates/starknet_committer/Cargo.toml
@@ -31,7 +31,7 @@ starknet_patricia.workspace = true
 starknet_patricia_storage.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 tracing.workspace = true
 zstd = { workspace = true, optional = true }
 

--- a/crates/starknet_committer/src/block_committer/commit.rs
+++ b/crates/starknet_committer/src/block_committer/commit.rs
@@ -1,5 +1,9 @@
 use std::collections::HashMap;
+#[cfg(feature = "os_input")]
+use std::time::Instant;
 
+#[cfg(feature = "os_input")]
+use starknet_api::core::GlobalRoot;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_patricia::patricia_merkle_tree::node_data::leaf::LeafModifications;
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices};
@@ -7,6 +11,8 @@ use starknet_types_core::felt::Felt;
 use tracing::{debug, warn};
 
 use crate::block_committer::errors::BlockCommitmentError;
+#[cfg(feature = "os_input")]
+use crate::block_committer::errors::CommitBlockWithWitnessesError;
 use crate::block_committer::input::{
     contract_address_into_node_index,
     skeleton_storage_updates,
@@ -20,7 +26,11 @@ use crate::block_committer::measurements_util::{
     BlockModificationsCounts,
     MeasurementsTrait,
 };
+#[cfg(feature = "os_input")]
+use crate::db::forest_trait::forest_trait_witnesses::ForestStorageWithWitnesses;
 use crate::db::forest_trait::ForestReader;
+#[cfg(feature = "os_input")]
+use crate::db::forest_trait::ForestWriter;
 use crate::forest::deleted_nodes::{find_deleted_nodes, DeletedNodes};
 use crate::forest::filled_forest::FilledForest;
 use crate::forest::forest_errors::ForestError;
@@ -28,6 +38,10 @@ use crate::forest::original_skeleton_forest::{ForestSortedIndices, OriginalSkele
 use crate::forest::updated_skeleton_forest::UpdatedSkeletonForest;
 use crate::hash_function::hash::TreeHashFunctionImpl;
 use crate::patricia_merkle_tree::leaf::leaf_impl::ContractState;
+#[cfg(feature = "os_input")]
+use crate::patricia_merkle_tree::tree::SortedLeavesRequest;
+#[cfg(feature = "os_input")]
+use crate::patricia_merkle_tree::types::StarknetForestProofs;
 use crate::patricia_merkle_tree::types::{class_hash_into_node_index, CompiledClassHash};
 
 pub type BlockCommitmentResult<T> = Result<T, BlockCommitmentError>;
@@ -59,6 +73,130 @@ pub async fn commit_block<Reader: ForestReader + Send, M: MeasurementsTrait + Se
         measurements,
     )
     .await
+}
+
+#[cfg(feature = "os_input")]
+pub type CommitBlockWithWitnessesResult<T> = Result<T, CommitBlockWithWitnessesError>;
+
+/// Output of [`commit_block_with_witnesses`].
+#[cfg(feature = "os_input")]
+pub struct CommitBlockWithWitnessesOutput {
+    pub filled_forest: FilledForest,
+    pub deleted_nodes: DeletedNodes,
+    pub patricia_proofs: StarknetForestProofs,
+    pub global_root: GlobalRoot,
+}
+
+/// Commits a block to the in-memory forest and returns the OS-input Patricia witness paths.
+///
+/// Phases:
+/// 1. Read the original forest skeleton from storage.
+/// 2. In parallel: fetch pre-commit witnesses (storage-bound) and compute the updated forest
+///    (CPU-bound; touches no storage).
+/// 3. Fetch post-commit witnesses against an in-memory overlay of the just-computed forest.
+///
+/// Does not persist the updated forest — the caller is responsible for writing
+/// `filled_forest`/`deleted_nodes` (together with any metadata bundle and the returned
+/// `patricia_proofs`) atomically.
+#[cfg(feature = "os_input")]
+pub async fn commit_block_with_witnesses<Storage, M>(
+    input: Input<Storage::InitialReadContext>,
+    sorted_leaves: &SortedLeavesRequest<'_>,
+    forest_storage: &mut Storage,
+    measurements: &mut M,
+) -> CommitBlockWithWitnessesResult<CommitBlockWithWitnessesOutput>
+where
+    Storage: ForestStorageWithWitnesses + Send,
+    M: MeasurementsTrait + Send,
+{
+    let pre_roots = forest_storage
+        .read_roots(input.initial_read_context.clone())
+        .await
+        .map_err(|e| BlockCommitmentError::from(ForestError::from(e)))?;
+
+    let mut modified_indices: ForestModifiedIndices = (&input.state_diff).into();
+    let n_contracts_trie_modifications = modified_indices.n_contracts_trie_modifications();
+    let forest_sorted_indices = modified_indices.as_sorted_indices();
+
+    // Phase 1 — read the original forest from storage.
+    let read_output = commit_block_read_phase(
+        &input,
+        &forest_sorted_indices,
+        n_contracts_trie_modifications,
+        forest_storage,
+        measurements,
+    )
+    .await?;
+
+    // Phase 2 — in parallel: fetch pre-commit witnesses while computing the updated forest.
+    // The Compute action is recorded by `commit_block_compute_phase`, which holds the &mut
+    // borrow of `measurements` for the duration of the join. The fetch branch therefore cannot
+    // touch `measurements`; it times itself with a local `Instant`.
+    let fetch_witnesses_first_pass = async {
+        // TODO(Yoav): Use a util from measurements_util.rs.
+        let fetch_timer = Instant::now();
+        let fetch_result = forest_storage
+            .fetch_patricia_witnesses(
+                pre_roots.classes_trie_root_hash,
+                pre_roots.contracts_trie_root_hash,
+                sorted_leaves.class_sorted,
+                sorted_leaves.contract_sorted,
+                &sorted_leaves.storage_sorted,
+                None,
+            )
+            .await;
+        (fetch_result, fetch_timer.elapsed().as_secs_f64())
+    };
+    let ((fetch_result, fetch_duration_seconds), compute_result) = tokio::join!(
+        fetch_witnesses_first_pass,
+        commit_block_compute_phase(
+            read_output,
+            &input.state_diff.address_to_class_hash,
+            &input.state_diff.address_to_nonce,
+            measurements,
+        ),
+    );
+    let mut patricia_proofs =
+        fetch_result.map_err(CommitBlockWithWitnessesError::PreCommitWitnessFetch)?;
+    measurements.record_measurement(
+        Action::FetchWitnessesFirstPass,
+        patricia_proofs.get_nodes_count(),
+        fetch_duration_seconds,
+    );
+    let (filled_forest, deleted_nodes) = compute_result?;
+
+    // Phase 3 — fetch post-commit witnesses against an in-memory overlay of the new forest.
+    let post_roots = filled_forest.state_roots();
+    let forest_updates = <Storage as ForestWriter>::serialize_forest(&filled_forest)?;
+
+    measurements.start_measurement(Action::FetchWitnessesSecondPass);
+    let proof_after = forest_storage
+        .fetch_patricia_witnesses(
+            post_roots.classes_trie_root_hash,
+            post_roots.contracts_trie_root_hash,
+            sorted_leaves.class_sorted,
+            sorted_leaves.contract_sorted,
+            &sorted_leaves.storage_sorted,
+            Some(forest_updates),
+        )
+        .await
+        .map_err(CommitBlockWithWitnessesError::PostCommitWitnessFetch)?;
+    measurements
+        .attempt_to_stop_measurement(
+            Action::FetchWitnessesSecondPass,
+            proof_after.get_nodes_count(),
+        )
+        .ok();
+
+    patricia_proofs.extend(proof_after);
+
+    let global_root = filled_forest.state_roots().global_root();
+    Ok(CommitBlockWithWitnessesOutput {
+        filled_forest,
+        deleted_nodes,
+        patricia_proofs,
+        global_root,
+    })
 }
 
 /// Owns the backing `Vec<NodeIndex>` storage required to build a `ForestSortedIndices`.


### PR DESCRIPTION
Add commit_block_with_witnesses (gated behind os_input) which runs
fetch_patricia_witnesses (pre-commit) concurrently with the compute phase via
tokio::join!. The committing logic lives in starknet_committer; apollo only
wires DB/communication and maps errors.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>