### PR TITLE
starknet_api: enforce minimum SNOS proof-facts length

### DIFF
--- a/crates/apollo_batcher/src/block_builder_test.rs
+++ b/crates/apollo_batcher/src/block_builder_test.rs
@@ -1238,6 +1238,7 @@ fn invoke_tx_with_snos_proof_facts(
     let program_hash = Felt::from(0xAA_u32);
     let block_hash = Felt::from(0xBB_u32);
     let config_hash = Felt::from(0xCC_u32);
+    let n_l2_to_l1_messages = Felt::ZERO;
     let proof_facts = proof_facts![
         PROOF_VERSION_V1,
         VIRTUAL_SNOS,
@@ -1245,7 +1246,8 @@ fn invoke_tx_with_snos_proof_facts(
         VIRTUAL_OS_OUTPUT_VERSION,
         Felt::from(block_number.0),
         block_hash,
-        config_hash
+        config_hash,
+        n_l2_to_l1_messages
     ];
     InternalConsensusTransaction::RpcTransaction(internal_invoke_tx(InvokeTxArgs {
         tx_hash,

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -2221,6 +2221,7 @@ fn test_missing_validate_entrypoint_rejects(
 
 /// Converts SnosProofFacts to ProofFacts for testing.
 fn snos_to_proof_facts(snos: SnosProofFacts) -> ProofFacts {
+    let n_l2_to_l1_messages = Felt::ZERO;
     vec![
         snos.proof_version.as_felt(),
         VIRTUAL_SNOS,
@@ -2229,6 +2230,7 @@ fn snos_to_proof_facts(snos: SnosProofFacts) -> ProofFacts {
         felt!(snos.block_number.0),
         snos.block_hash.0,
         snos.config_hash,
+        n_l2_to_l1_messages,
     ]
     .into()
 }

--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -756,8 +756,17 @@ impl TryFrom<&ProofFacts> for ProofFactsVariant {
             )));
         }
 
-        let [program_hash, output_version, block_number_felt, block_hash, config_hash, ..] =
-            snos_fields
+        // Bind the trailing `n_l2_to_l1_messages` (unused) so the parser requires 8 felts,
+        // matching the Cairo OS `check_proof_facts` floor (3 + 5).
+        let [
+            program_hash,
+            output_version,
+            block_number_felt,
+            block_hash,
+            config_hash,
+            _n_l2_to_l1_messages,
+            ..,
+        ] = snos_fields
         else {
             return Err(StarknetApiError::InvalidProofFacts(format!(
                 "SNOS proof facts is too small with {} fields",

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -33,6 +33,18 @@ fn proof_facts_variant_rejects_unknown_version() {
 }
 
 #[test]
+fn proof_facts_variant_rejects_missing_message_count() {
+    // A 7-felt array (one short of the OS floor of 8) must be rejected. Truncate rather than
+    // pop the last felt, so the array stays one short even if the fixture grows past 8 felts.
+    let mut facts = ProofFacts::snos_proof_facts_for_testing();
+    Arc::make_mut(&mut facts.0).truncate(7);
+    assert!(matches!(
+        ProofFactsVariant::try_from(&facts),
+        Err(StarknetApiError::InvalidProofFacts(_))
+    ));
+}
+
+#[test]
 fn proof_version_str_encodes_to_felt() {
     for version in ProofVersion::iter() {
         let from_short_string =


### PR DESCRIPTION
## Summary

Hardens `ProofFactsVariant::try_from` so the parser's minimum proof-facts length matches the Cairo OS `check_proof_facts` floor.

Previously the rest-pattern read 5 SNOS fields after a 2-felt prefix, accepting as few as **7 felts** and silently dropping the trailing `n_l2_to_l1_messages`. The Cairo OS asserts `ProofHeader.SIZE(3) + VirtualOsOutputHeader.SIZE(5) = 8 <= proof_facts_size`. The fix binds the trailing felt (unused) so the parser now requires **8 felts**, matching the OS.

This is a latent structural inconsistency, not an E2E-reachable bug: a non-empty `proof_facts` requires a valid STARK proof, and a genuine SNOS proof output always includes the message count (≥8 felts), so a 7-felt array is rejected by proof verification before sequencing. This change makes the floor an explicit check rather than a byproduct of proof soundness.

## Changes
- `crates/starknet_api/src/transaction/fields.rs`: bind the trailing `n_l2_to_l1_messages` felt in the destructure pattern.
- `crates/starknet_api/src/transaction/fields_test.rs`: regression test asserting a 7-felt array is rejected.

https://claude.ai/code/session_019kE76rLnwNwZHv2b4BTWGj