### PR TITLE
starknet_os: fix get_block_hash early-block underflow in buffer hint

### DIFF
--- a/crates/starknet_os/src/hints/hint_implementation/execute_syscalls.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/execute_syscalls.rs
@@ -10,8 +10,8 @@ pub(crate) fn is_block_number_in_block_hash_buffer(mut ctx: HintContext<'_>) -> 
     let request_block_number = ctx.get_integer(Ids::RequestBlockNumber)?;
     let current_block_number = ctx.get_integer(Ids::CurrentBlockNumber)?;
     let stored_block_hash_buffer = ctx.fetch_const(Const::StoredBlockHashBuffer)?;
-    let is_block_number_in_block_hash_buffer =
-        request_block_number > current_block_number - stored_block_hash_buffer;
+    let is_block_number_in_block_hash_buffer = current_block_number < *stored_block_hash_buffer
+        || request_block_number > current_block_number - stored_block_hash_buffer;
     ctx.insert_value(
         Ids::IsBlockNumberInBlockHashBuffer,
         Felt::from(is_block_number_in_block_hash_buffer),


### PR DESCRIPTION
## Problem

A contract that calls `get_block_hash` during the first 10 blocks of a fresh chain (appchain / L3 / devnet) triggers a divergence between the sequencer and the provable OS:

- **Blockifier** (`block_number_in_range`, `syscall_base.rs`) uses `current.checked_sub(STORED_BLOCK_HASH_BUFFER)` → `None` for `current < 10`, so the syscall **reverts gracefully** with `BLOCK_NUMBER_OUT_OF_RANGE` and the tx is still included.
- **Cairo OS**: the `is_block_number_in_block_hash_buffer` hint computed `current_block_number - stored_block_hash_buffer` in **felt arithmetic**. For `current < 10` this underflows to ≈P, so the hint wrongly reports "not in buffer", and the Cairo program then reaches `assert_nn_le(request, current - buffer)`, which also underflows and **aborts the OS**.

Result: the sequencer commits a block the OS cannot prove → **reorg**, reachable on the first 10 blocks of a fresh chain.

## Fix

Guard the felt subtraction in the hint so early blocks are always classified as in-buffer (the graceful revert branch), matching blockifier's `block_number_in_range`:

```rust
let is_block_number_in_block_hash_buffer = current_block_number < *stored_block_hash_buffer
    || request_block_number > current_block_number - stored_block_hash_buffer;
```

The subtraction is only evaluated when `current >= buffer`, so it can never underflow. The in-buffer branch's own `assert_lt(current, request + STORED_BLOCK_HASH_BUFFER)` is always satisfiable for `current < 10`, so the OS no longer aborts.

No blockifier change is needed — `block_number_in_range` already reverts gracefully for `current < 10`; it is the agreement target. No `.cairo` change — `assert_nn_le(request, current - buffer)` is now only reached when `current >= buffer`.

## Verification

`cargo build -p starknet_os` → Finished.

https://claude.ai/code/session_01VojMWzQzxTF7APVG7hzqnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VojMWzQzxTF7APVG7hzqnZ)_