### PR TITLE
apollo_committer,starknet_committer: add CommitBlockWithWitnessesError and use it for witness fetch

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -23,6 +23,8 @@ use starknet_api::core::{GlobalRoot, StateDiffCommitment};
 use starknet_api::hash::PoseidonHash;
 use starknet_api::state::ThinStateDiff;
 use starknet_committer::block_committer::commit::commit_block;
+#[cfg(feature = "os_input")]
+use starknet_committer::block_committer::errors::CommitBlockWithWitnessesError;
 use starknet_committer::block_committer::input::Input;
 use starknet_committer::block_committer::measurements_util::{
     Action,
@@ -566,9 +568,10 @@ where
                         None,
                     )
                     .await
-                    .map_err(|e| CommitterError::PatriciaPathsCollectionFailed {
-                        height,
-                        message: format!("pre-commit witness paths: {e:?}"),
+                    .map_err(|e| {
+                        self.map_internal_error(
+                            CommitBlockWithWitnessesError::PreCommitWitnessFetch(e),
+                        )
                     })?;
                 block_measurements
                     .attempt_to_stop_measurement(
@@ -596,9 +599,10 @@ where
                         Some(forest_updates),
                     )
                     .await
-                    .map_err(|e| CommitterError::PatriciaPathsCollectionFailed {
-                        height,
-                        message: format!("post-commit witness paths: {e:?}"),
+                    .map_err(|e| {
+                        self.map_internal_error(
+                            CommitBlockWithWitnessesError::PostCommitWitnessFetch(e),
+                        )
                     })?;
                 block_measurements
                     .attempt_to_stop_measurement(

--- a/crates/starknet_committer/src/block_committer/errors.rs
+++ b/crates/starknet_committer/src/block_committer/errors.rs
@@ -1,4 +1,6 @@
 use starknet_patricia::patricia_merkle_tree::traversal::TraversalError;
+#[cfg(feature = "os_input")]
+use starknet_patricia_storage::errors::SerializationError;
 use thiserror::Error;
 
 use crate::forest::forest_errors::ForestError;
@@ -9,4 +11,17 @@ pub enum BlockCommitmentError {
     ForestError(#[from] ForestError),
     #[error(transparent)]
     Traversal(#[from] TraversalError),
+}
+
+#[cfg(feature = "os_input")]
+#[derive(Debug, Error)]
+pub enum CommitBlockWithWitnessesError {
+    #[error(transparent)]
+    BlockCommitment(#[from] BlockCommitmentError),
+    #[error("pre-commit witness paths: {0:?}")]
+    PreCommitWitnessFetch(TraversalError),
+    #[error("post-commit witness paths: {0:?}")]
+    PostCommitWitnessFetch(TraversalError),
+    #[error(transparent)]
+    Serialization(#[from] SerializationError),
 }


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>