### PR TITLE
ci: move ephemeral port range off integration-test static ports to fix EADDRINUSE flakiness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,6 +170,15 @@ jobs:
         run: echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
       - run: pip install -r scripts/requirements.txt
 
+      # Integration tests assign node listener ports from a static range starting at BASE_PORT
+      # (11000), see crates/apollo_infra_utils/src/test_utils.rs. The kernel's default ephemeral
+      # range overlaps it, so an outbound connection can transiently claim a port that a node later
+      # tries to bind as a listener, causing EADDRINUSE and a node startup failure (flaky
+      # "should be alive" timeouts). Move the ephemeral range entirely below BASE_PORT so the two
+      # ranges can never overlap.
+      - name: "Move ephemeral port range below the integration-test static port range"
+        run: sudo sysctl -w net.ipv4.ip_local_port_range="2000 10999"
+
       - name: "Run integration tests"
         run: |
           scripts/run_tests.py --command integration --changes_only --include_dependencies --commit_id ${{ github.event.pull_request.base.sha || 'origin/main' }}

--- a/.github/workflows/main_nightly.yml
+++ b/.github/workflows/main_nightly.yml
@@ -74,6 +74,14 @@ jobs:
           LD_LIBRARY_PATH: ${{ env.Python3_ROOT_DIR }}/bin
         run: echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
       - run: pip install -r scripts/requirements.txt
+      # Integration tests assign node listener ports from a static range starting at BASE_PORT
+      # (11000), see crates/apollo_infra_utils/src/test_utils.rs. The kernel's default ephemeral
+      # range overlaps it, so an outbound connection can transiently claim a port that a node later
+      # tries to bind as a listener, causing EADDRINUSE and a node startup failure (flaky
+      # "should be alive" timeouts). Move the ephemeral range entirely below BASE_PORT so the two
+      # ranges can never overlap.
+      - name: "Move ephemeral port range below the integration-test static port range"
+        run: sudo sysctl -w net.ipv4.ip_local_port_range="2000 10999"
       - name: "Run integration tests pull request"
         run: |
           scripts/run_tests.py --command integration --is_nightly


### PR DESCRIPTION
## Problem

The integration-tests flow has been very flaky, surfacing as:

```
Waiting for node to be alive: Condition not met after the maximum number of 2500 attempts.
thread 'main' panicked at integration_test_manager.rs: Executable { node_index: N, ... } should be alive.
```

The "should be alive" timeout is misleading. The real cause, found in the job logs ([example](https://github.com/starkware-libs/sequencer/actions/runs/27265282370/job/80520763769?pr=14433)), is:

```
Failed to start MonitoringEndpoint: Os { code: 98, kind: AddrInUse, message: "Address already in use" }
Node NodeRunner { node_index: 4, ... } stopped unexpectedly.
```

A node fails to bind its monitoring port because the port is already taken, the node dies at startup, and the harness then polls the dead port for ~250s before failing.

## Root cause

The test port allocator (`crates/apollo_infra_utils/src/test_utils.rs`) hands out **listener** ports from a static range starting at `BASE_PORT = 11000` (ceiling ≈ 63000). Linux's default **ephemeral** range (`32768–60999`) overlaps this heavily. Every outbound connection a node makes (p2p, L1 RPC, oracles, recorder, inter-node) can transiently claim a static listener port as its source port, so the next `TcpListener::bind` on that port fails with `EADDRINUSE`.

This got worse recently as more instances/tests were added (more allocated ports pushed deeper into the ephemeral range, more outbound connections racing for them).

## Fix

Move the kernel ephemeral port range **entirely below** `BASE_PORT` in the integration-test CI jobs (`net.ipv4.ip_local_port_range="2000 10999"`), so the ephemeral and static ranges can never overlap. All integration-test listeners (including anvil) draw from the allocator at `≥ 11000`, so a low ephemeral window is safe and robust to future growth of the static range (which only extends upward).

Applied to both `main.yml` and `main_nightly.yml`.

## Notes / follow-ups

- The misleading 250s timeout itself was already improved upstream in #14459 (faster, more informative node-crash detection) — this PR addresses the underlying collision so the crash stops happening in the first place.
- A durable, environment-independent fix (also covering local `cargo test`) would be to eliminate the TOCTOU in the allocator by handing components pre-bound listeners (or binding port 0 and reading the port back), and to shrink the static footprint so it fits below the ephemeral range by construction. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)