### PR TITLE
starknet_patricia: derive Serialize and Deserialize for SubTreeHeight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "simple_logger",
  "starknet-types-core",
  "starknet_api",
+ "starknet_committer",
  "tempfile",
  "test-case",
  "test-log",

--- a/crates/apollo_storage/Cargo.toml
+++ b/crates/apollo_storage/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "A storage implementation for a Starknet node."
 
 [features]
-os_input = ["dep:blockifier"]
+os_input = ["dep:blockifier", "dep:starknet_committer"]
 storage_cli = ["clap", "reqwest"]
 testing = ["reqwest", "starknet_api/testing", "tempfile", "tower"]
 
@@ -40,6 +40,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 starknet-types-core = { workspace = true, features = ["papyrus-serialization"] }
 starknet_api.workspace = true
+starknet_committer = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
@@ -69,6 +70,7 @@ rstest.workspace = true
 schemars.workspace = true
 simple_logger.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
+starknet_committer = { workspace = true, features = ["testing"] }
 tempfile = { workspace = true }
 test-case.workspace = true
 test-log.workspace = true

--- a/crates/apollo_storage/src/db/mod.rs
+++ b/crates/apollo_storage/src/db/mod.rs
@@ -46,7 +46,7 @@ use crate::db::table_types::TableType;
 #[cfg(not(feature = "os_input"))]
 const MAX_DBS: u64 = 25;
 #[cfg(feature = "os_input")]
-const MAX_DBS: u64 = 26;
+const MAX_DBS: u64 = 27;
 
 // Note that NO_TLS mode is used by default.
 type EnvironmentKind = WriteMap;

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -91,6 +91,8 @@ pub mod global_root_marker;
 #[allow(missing_docs)]
 pub mod metrics;
 pub mod partial_block_hash;
+#[cfg(feature = "os_input")]
+pub mod state_commitment_infos;
 pub mod storage_metrics;
 // TODO(yair): Make the compression_utils module pub(crate) or extract it from the crate.
 #[doc(hidden)]
@@ -186,6 +188,8 @@ use crate::header::StorageBlockHeader;
 use crate::metrics::{register_metrics, STORAGE_COMMIT_LATENCY};
 use crate::mmap_file::MMapFileStats;
 use crate::state::data::IndexedDeprecatedContractClass;
+#[cfg(feature = "os_input")]
+use crate::state_commitment_infos::StateCommitmentInfos;
 use crate::storage_reader_server::{
     create_storage_reader_server,
     ServerConfig,
@@ -280,6 +284,8 @@ fn open_storage_internal(
             .create_simple_table("stateless_compiled_class_hash_v2")?,
         #[cfg(feature = "os_input")]
         accessed_keys: db_writer.create_simple_table("accessed_keys")?,
+        #[cfg(feature = "os_input")]
+        state_commitment_infos: db_writer.create_simple_table("state_commitment_infos")?,
     });
     let (file_writers, file_readers) = open_storage_files(
         &storage_config.db_config,
@@ -959,7 +965,9 @@ struct_field_names! {
         stateless_compiled_class_hash_v2: TableIdentifier<ClassHash, NoVersionValueWrapper<CompiledClassHash>, SimpleTable>,
 
         #[cfg(feature = "os_input")]
-        accessed_keys: TableIdentifier<BlockNumber, VersionZeroWrapper<LocationInFile>, SimpleTable>
+        accessed_keys: TableIdentifier<BlockNumber, VersionZeroWrapper<LocationInFile>, SimpleTable>,
+        #[cfg(feature = "os_input")]
+        state_commitment_infos: TableIdentifier<BlockNumber, VersionZeroWrapper<LocationInFile>, SimpleTable>
     }
 }
 
@@ -1130,6 +1138,8 @@ struct FileHandlers<Mode: TransactionKind> {
     transaction: FileHandler<VersionZeroWrapper<Transaction>, Mode>,
     #[cfg(feature = "os_input")]
     accessed_keys: FileHandler<VersionZeroWrapper<AccessedKeys>, Mode>,
+    #[cfg(feature = "os_input")]
+    state_commitment_infos: FileHandler<VersionZeroWrapper<StateCommitmentInfos>, Mode>,
 }
 
 impl FileHandlers<RW> {
@@ -1172,6 +1182,14 @@ impl FileHandlers<RW> {
         self.clone().accessed_keys.append(accessed_keys)
     }
 
+    #[cfg(feature = "os_input")]
+    fn append_state_commitment_infos(
+        &self,
+        state_commitment_infos: &StateCommitmentInfos,
+    ) -> LocationInFile {
+        self.clone().state_commitment_infos.append(state_commitment_infos)
+    }
+
     // TODO(dan): Consider 1. flushing only the relevant files, 2. flushing concurrently.
     #[latency_histogram("storage_file_handler_flush_latency_seconds", false)]
     fn flush(&self) {
@@ -1184,6 +1202,8 @@ impl FileHandlers<RW> {
         self.transaction.flush();
         #[cfg(feature = "os_input")]
         self.accessed_keys.flush();
+        #[cfg(feature = "os_input")]
+        self.state_commitment_infos.flush();
     }
 }
 
@@ -1199,6 +1219,8 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
             ("transaction".to_string(), self.transaction.stats()),
             #[cfg(feature = "os_input")]
             ("accessed_keys".to_string(), self.accessed_keys.stats()),
+            #[cfg(feature = "os_input")]
+            ("state_commitment_infos".to_string(), self.state_commitment_infos.stats()),
         ])
     }
 
@@ -1268,6 +1290,17 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
             msg: format!("AccessedKeys at location {location:?} not found."),
         })
     }
+
+    #[cfg(feature = "os_input")]
+    // Returns the commitment infos at the given location or an error in case they don't exist.
+    pub(crate) fn get_state_commitment_infos_unchecked(
+        &self,
+        location: LocationInFile,
+    ) -> StorageResult<StateCommitmentInfos> {
+        self.state_commitment_infos.get(location)?.ok_or(StorageError::DBInconsistency {
+            msg: format!("StateCommitmentInfos at location {location:?} not found."),
+        })
+    }
 }
 
 fn open_storage_files(
@@ -1306,6 +1339,9 @@ fn open_storage_files(
     #[cfg(feature = "os_input")]
     let (accessed_keys_writer, accessed_keys_reader) =
         open_storage_file!("accessed_keys", AccessedKeys)?;
+    #[cfg(feature = "os_input")]
+    let (state_commitment_infos_writer, state_commitment_infos_reader) =
+        open_storage_file!("state_commitment_infos", StateCommitmentInfos)?;
 
     Ok((
         FileHandlers {
@@ -1317,6 +1353,8 @@ fn open_storage_files(
             transaction: transaction_writer,
             #[cfg(feature = "os_input")]
             accessed_keys: accessed_keys_writer,
+            #[cfg(feature = "os_input")]
+            state_commitment_infos: state_commitment_infos_writer,
         },
         FileHandlers {
             thin_state_diff: thin_state_diff_reader,
@@ -1327,6 +1365,8 @@ fn open_storage_files(
             transaction: transaction_reader,
             #[cfg(feature = "os_input")]
             accessed_keys: accessed_keys_reader,
+            #[cfg(feature = "os_input")]
+            state_commitment_infos: state_commitment_infos_reader,
         },
     ))
 }
@@ -1349,4 +1389,7 @@ pub enum OffsetKind {
     /// An accessed-keys file.
     #[cfg(feature = "os_input")]
     AccessedKeys,
+    /// A state-commitment-infos file.
+    #[cfg(feature = "os_input")]
+    StateCommitmentInfos,
 }

--- a/crates/apollo_storage/src/serialization/serializers.rs
+++ b/crates/apollo_storage/src/serialization/serializers.rs
@@ -372,6 +372,8 @@ auto_storage_serde! {
         Transaction = 5,
         #[cfg(feature = "os_input")]
         AccessedKeys = 6,
+        #[cfg(feature = "os_input")]
+        StateCommitmentInfos = 7,
     }
     pub struct PartialBlockHashComponents {
         pub header_commitments: BlockHeaderCommitments,

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -1,0 +1,94 @@
+//! Storage for the per-block OS-input commitment infos (state-trie commitment data for the OS).
+
+use starknet_api::block::BlockNumber;
+pub use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+
+#[cfg(test)]
+#[path = "state_commitment_infos_test.rs"]
+mod state_commitment_infos_test;
+
+use crate::compression_utils::{compress, decompress};
+use crate::db::serialization::{StorageSerde, StorageSerdeError};
+use crate::db::table_types::Table;
+use crate::db::{TransactionKind, RW};
+use crate::{OffsetKind, StorageResult, StorageTxn};
+
+impl StorageSerde for StateCommitmentInfos {
+    fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
+        let bytes = serde_json::to_vec(self)?;
+        let compressed = compress(bytes.as_slice())?;
+        compressed.serialize_into(res)
+    }
+
+    fn deserialize_from(bytes: &mut impl std::io::Read) -> Option<Self> {
+        let compressed = Vec::<u8>::deserialize_from(bytes)?;
+        let data = decompress(compressed.as_slice()).ok()?;
+        serde_json::from_slice(&data).ok()
+    }
+}
+
+/// Interface for reading the OS-input commitment infos from storage.
+pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
+    /// Returns the commitment infos for the given block, or `None` if not stored.
+    fn get_state_commitment_infos(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<StateCommitmentInfos>>;
+}
+
+/// Interface for writing the OS-input commitment infos to storage.
+pub trait StateCommitmentInfosStorageWriter
+where
+    Self: Sized,
+{
+    /// Appends the commitment infos for the given block to storage.
+    fn append_state_commitment_infos(
+        self,
+        block_number: BlockNumber,
+        state_commitment_infos: &StateCommitmentInfos,
+    ) -> StorageResult<Self>;
+
+    /// Removes the commitment infos for the given block from storage.
+    /// If no entry exists for the block, returns without error.
+    fn revert_state_commitment_infos(self, block_number: BlockNumber) -> StorageResult<Self>;
+}
+
+impl<Mode: TransactionKind> StateCommitmentInfosStorageReader<Mode> for StorageTxn<'_, Mode> {
+    fn get_state_commitment_infos(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<StateCommitmentInfos>> {
+        let table = self.open_table(&self.tables.state_commitment_infos)?;
+        let Some(location) = table.get(&self.txn, &block_number)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.file_handlers.get_state_commitment_infos_unchecked(location)?))
+    }
+}
+
+impl StateCommitmentInfosStorageWriter for StorageTxn<'_, RW> {
+    fn append_state_commitment_infos(
+        self,
+        block_number: BlockNumber,
+        state_commitment_infos: &StateCommitmentInfos,
+    ) -> StorageResult<Self> {
+        let file_offset_table = self.txn.open_table(&self.tables.file_offsets)?;
+        let state_commitment_infos_table = self.open_table(&self.tables.state_commitment_infos)?;
+
+        let location = self.file_handlers.append_state_commitment_infos(state_commitment_infos);
+        state_commitment_infos_table.upsert(&self.txn, &block_number, &location)?;
+        file_offset_table.upsert(
+            &self.txn,
+            &OffsetKind::StateCommitmentInfos,
+            &location.next_offset(),
+        )?;
+
+        Ok(self)
+    }
+
+    fn revert_state_commitment_infos(self, block_number: BlockNumber) -> StorageResult<Self> {
+        let state_commitment_infos_table = self.open_table(&self.tables.state_commitment_infos)?;
+        state_commitment_infos_table.delete(&self.txn, &block_number)?;
+        Ok(self)
+    }
+}

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+
+use starknet_api::block::BlockNumber;
+use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
+
+use crate::state_commitment_infos::{
+    StateCommitmentInfosStorageReader,
+    StateCommitmentInfosStorageWriter,
+};
+use crate::test_utils::get_test_storage;
+
+fn sample_state_commitment_infos() -> StateCommitmentInfos {
+    StateCommitmentInfos {
+        contracts_trie_commitment_info: CommitmentInfo::default(),
+        classes_trie_commitment_info: CommitmentInfo::default(),
+        storage_tries_commitment_infos: HashMap::new(),
+    }
+}
+
+#[test]
+fn append_and_get_state_commitment_infos() {
+    let (reader, mut writer) = get_test_storage().0;
+    let height = BlockNumber(5);
+    let state_commitment_infos = sample_state_commitment_infos();
+
+    // No infos stored for the height yet.
+    assert_eq!(reader.begin_ro_txn().unwrap().get_state_commitment_infos(height).unwrap(), None);
+
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_state_commitment_infos(height, &state_commitment_infos)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    assert_eq!(
+        reader.begin_ro_txn().unwrap().get_state_commitment_infos(height).unwrap(),
+        Some(state_commitment_infos)
+    );
+    // A different height is still empty.
+    assert_eq!(
+        reader.begin_ro_txn().unwrap().get_state_commitment_infos(BlockNumber(6)).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn revert_state_commitment_infos() {
+    let (reader, mut writer) = get_test_storage().0;
+    let height = BlockNumber(5);
+
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_state_commitment_infos(height, &sample_state_commitment_infos())
+        .unwrap()
+        .revert_state_commitment_infos(height)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    assert_eq!(reader.begin_ro_txn().unwrap().get_state_commitment_infos(height).unwrap(), None);
+
+    // Reverting a height with no stored infos is a no-op.
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_state_commitment_infos(BlockNumber(99))
+        .unwrap()
+        .commit()
+        .unwrap();
+}

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -7,7 +7,7 @@ use starknet_patricia::impl_from_hex_for_felt_wrapper;
 use starknet_patricia::patricia_merkle_tree::filled_tree::tree::FilledTreeImpl;
 use starknet_patricia::patricia_merkle_tree::node_data::inner_node::PreimageMap;
 use starknet_patricia::patricia_merkle_tree::node_data::leaf::SkeletonLeaf;
-use starknet_patricia::patricia_merkle_tree::types::NodeIndex;
+use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SubTreeHeight};
 use starknet_types_core::felt::{Felt, FromStrError};
 
 use crate::block_committer::input::{try_node_index_into_contract_address, StarknetStorageValue};
@@ -55,6 +55,40 @@ pub struct StarknetForestProofs {
     pub classes_trie_proof: PreimageMap,
     pub contracts_trie_proof: ContractsTrieProof,
     pub contracts_trie_storage_proofs: HashMap<ContractAddress, PreimageMap>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommitmentInfo {
+    pub previous_root: HashOutput,
+    pub updated_root: HashOutput,
+    pub tree_height: SubTreeHeight,
+    // TODO(Dori, 1/8/2025): The value type here should probably be more specific (NodeData<L> for
+    //   L: Leaf). This poses a problem in deserialization, as a serialized edge node and a
+    //   serialized contract state leaf are both currently vectors of 3 field elements; as the
+    //   semantics of the values are unimportant for the OS commitments, we make do with a vector
+    //   of field elements as values for now.
+    pub commitment_facts: HashMap<HashOutput, Vec<Felt>>,
+}
+
+#[cfg(any(feature = "testing", test))]
+impl Default for CommitmentInfo {
+    fn default() -> CommitmentInfo {
+        CommitmentInfo {
+            previous_root: HashOutput::default(),
+            updated_root: HashOutput::default(),
+            tree_height: SubTreeHeight::ACTUAL_HEIGHT,
+            commitment_facts: HashMap::default(),
+        }
+    }
+}
+
+/// Contains all commitment information for a block's state trees.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct StateCommitmentInfos {
+    pub contracts_trie_commitment_info: CommitmentInfo,
+    pub classes_trie_commitment_info: CommitmentInfo,
+    pub storage_tries_commitment_infos: HashMap<ContractAddress, CommitmentInfo>,
 }
 
 impl StarknetForestProofs {

--- a/crates/starknet_os/src/commitment_infos.rs
+++ b/crates/starknet_os/src/commitment_infos.rs
@@ -11,49 +11,17 @@ use starknet_committer::db::facts_db::create_facts_tree::get_leaves;
 use starknet_committer::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 use starknet_committer::patricia_merkle_tree::tree::fetch_previous_and_new_patricia_paths;
 use starknet_committer::patricia_merkle_tree::types::RootHashes;
+// `CommitmentInfo` and `StateCommitmentInfos` were relocated to `starknet_committer` so that
+// lower layers (e.g. `apollo_storage`) can store them without depending on `starknet_os`. They
+// are re-exported here to keep this module's public API stable for OS consumers.
+pub use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 use starknet_patricia::patricia_merkle_tree::node_data::inner_node::flatten_preimages;
 use starknet_patricia::patricia_merkle_tree::original_skeleton_tree::errors::OriginalSkeletonTreeError;
 use starknet_patricia::patricia_merkle_tree::traversal::TraversalError;
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SortedLeafIndices, SubTreeHeight};
 use starknet_patricia_storage::db_object::EmptyKeyContext;
 use starknet_patricia_storage::map_storage::MapStorage;
-use starknet_types_core::felt::Felt;
 use thiserror::Error;
-
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-#[cfg_attr(feature = "deserialize", serde(deny_unknown_fields))]
-#[derive(Debug)]
-pub struct CommitmentInfo {
-    pub previous_root: HashOutput,
-    pub updated_root: HashOutput,
-    pub tree_height: SubTreeHeight,
-    // TODO(Dori, 1/8/2025): The value type here should probably be more specific (NodeData<L> for
-    //   L: Leaf). This poses a problem in deserialization, as a serialized edge node and a
-    //   serialized contract state leaf are both currently vectors of 3 field elements; as the
-    //   semantics of the values are unimportant for the OS commitments, we make do with a vector
-    //   of field elements as values for now.
-    pub commitment_facts: HashMap<HashOutput, Vec<Felt>>,
-}
-
-#[cfg(any(feature = "testing", test))]
-impl Default for CommitmentInfo {
-    fn default() -> CommitmentInfo {
-        CommitmentInfo {
-            previous_root: HashOutput::default(),
-            updated_root: HashOutput::default(),
-            tree_height: SubTreeHeight::ACTUAL_HEIGHT,
-            commitment_facts: HashMap::default(),
-        }
-    }
-}
-
-// TODO(Aviv): Use this struct in `OsBlockInput`
-/// Contains all commitment information for a block's state trees.
-pub struct StateCommitmentInfos {
-    pub contracts_trie_commitment_info: CommitmentInfo,
-    pub classes_trie_commitment_info: CommitmentInfo,
-    pub storage_tries_commitment_infos: HashMap<ContractAddress, CommitmentInfo>,
-}
 
 /// Error type for commitment infos creation.
 #[derive(Debug, Error)]
@@ -66,83 +34,82 @@ pub enum CommitmentInfosError {
     FetchStorageProofs(#[from] TraversalError),
 }
 
-impl StateCommitmentInfos {
-    /// Creates the commitment infos for the OS from previous and new state roots and the
-    /// keys that were read during execution.
-    pub async fn new(
-        previous_state_roots: &StateRoots,
-        new_state_roots: &StateRoots,
-        commitments: &mut MapStorage,
-        accessed_keys: &AccessedKeys,
-    ) -> Result<Self, CommitmentInfosError> {
-        let addresses: Vec<ContractAddress> =
-            accessed_keys.accessed_contracts.iter().copied().collect();
+/// Creates the commitment infos for the OS from previous and new state roots and the
+/// keys that were read during execution.
+// TODO(ItamarS): Temporary — to be deleted once the committer builds `StateCommitmentInfos` from
+// its own storage; tests against that new committer API will be added then. Kept here (as a free
+// function rather than an inherent method) because the struct now lives in `starknet_committer`
+// and the orphan rule forbids an inherent impl on a foreign type.
+pub async fn build_state_commitment_infos(
+    previous_state_roots: &StateRoots,
+    new_state_roots: &StateRoots,
+    commitments: &mut MapStorage,
+    accessed_keys: &AccessedKeys,
+) -> Result<StateCommitmentInfos, CommitmentInfosError> {
+    let addresses: Vec<ContractAddress> =
+        accessed_keys.accessed_contracts.iter().copied().collect();
 
-        let previous_storage_roots = get_storage_roots(
-            &addresses,
-            previous_state_roots.contracts_trie_root_hash,
-            commitments,
-        )
-        .await?;
-        let new_storage_roots =
-            get_storage_roots(&addresses, new_state_roots.contracts_trie_root_hash, commitments)
-                .await?;
+    let previous_storage_roots =
+        get_storage_roots(&addresses, previous_state_roots.contracts_trie_root_hash, commitments)
+            .await?;
+    let new_storage_roots =
+        get_storage_roots(&addresses, new_state_roots.contracts_trie_root_hash, commitments)
+            .await?;
 
-        let storage_proofs = fetch_previous_and_new_patricia_paths(
-            commitments,
-            RootHashes {
-                previous_root_hash: previous_state_roots.classes_trie_root_hash,
-                new_root_hash: new_state_roots.classes_trie_root_hash,
-            },
-            RootHashes {
-                previous_root_hash: previous_state_roots.contracts_trie_root_hash,
-                new_root_hash: new_state_roots.contracts_trie_root_hash,
-            },
-            accessed_keys,
-        )
-        .await?;
+    let storage_proofs = fetch_previous_and_new_patricia_paths(
+        commitments,
+        RootHashes {
+            previous_root_hash: previous_state_roots.classes_trie_root_hash,
+            new_root_hash: new_state_roots.classes_trie_root_hash,
+        },
+        RootHashes {
+            previous_root_hash: previous_state_roots.contracts_trie_root_hash,
+            new_root_hash: new_state_roots.contracts_trie_root_hash,
+        },
+        accessed_keys,
+    )
+    .await?;
 
-        let contracts_trie_commitment_info = CommitmentInfo {
-            previous_root: previous_state_roots.contracts_trie_root_hash,
-            updated_root: new_state_roots.contracts_trie_root_hash,
-            tree_height: SubTreeHeight::ACTUAL_HEIGHT,
-            commitment_facts: flatten_preimages(&storage_proofs.contracts_trie_proof.nodes),
-        };
-        let classes_trie_commitment_info = CommitmentInfo {
-            previous_root: previous_state_roots.classes_trie_root_hash,
-            updated_root: new_state_roots.classes_trie_root_hash,
-            tree_height: SubTreeHeight::ACTUAL_HEIGHT,
-            commitment_facts: flatten_preimages(&storage_proofs.classes_trie_proof),
-        };
-        let storage_tries_commitment_infos = previous_storage_roots
-            .iter()
-            .map(|(address, previous_root_hash)| {
-                // Not all contracts in `previous_storage_roots` have storage proofs. For
-                // example, a contract that only had its nonce changed.
-                let storage_proof = flatten_preimages(
-                    storage_proofs
-                        .contracts_trie_storage_proofs
-                        .get(address)
-                        .unwrap_or(&HashMap::new()),
-                );
-                (
-                    *address,
-                    CommitmentInfo {
-                        previous_root: *previous_root_hash,
-                        updated_root: new_storage_roots[address],
-                        tree_height: SubTreeHeight::ACTUAL_HEIGHT,
-                        commitment_facts: storage_proof,
-                    },
-                )
-            })
-            .collect();
-
-        Ok(Self {
-            contracts_trie_commitment_info,
-            classes_trie_commitment_info,
-            storage_tries_commitment_infos,
+    let contracts_trie_commitment_info = CommitmentInfo {
+        previous_root: previous_state_roots.contracts_trie_root_hash,
+        updated_root: new_state_roots.contracts_trie_root_hash,
+        tree_height: SubTreeHeight::ACTUAL_HEIGHT,
+        commitment_facts: flatten_preimages(&storage_proofs.contracts_trie_proof.nodes),
+    };
+    let classes_trie_commitment_info = CommitmentInfo {
+        previous_root: previous_state_roots.classes_trie_root_hash,
+        updated_root: new_state_roots.classes_trie_root_hash,
+        tree_height: SubTreeHeight::ACTUAL_HEIGHT,
+        commitment_facts: flatten_preimages(&storage_proofs.classes_trie_proof),
+    };
+    let storage_tries_commitment_infos = previous_storage_roots
+        .iter()
+        .map(|(address, previous_root_hash)| {
+            // Not all contracts in `previous_storage_roots` have storage proofs. For
+            // example, a contract that only had its nonce changed.
+            let storage_proof = flatten_preimages(
+                storage_proofs
+                    .contracts_trie_storage_proofs
+                    .get(address)
+                    .unwrap_or(&HashMap::new()),
+            );
+            (
+                *address,
+                CommitmentInfo {
+                    previous_root: *previous_root_hash,
+                    updated_root: new_storage_roots[address],
+                    tree_height: SubTreeHeight::ACTUAL_HEIGHT,
+                    commitment_facts: storage_proof,
+                },
+            )
         })
-    }
+        .collect();
+
+    Ok(StateCommitmentInfos {
+        contracts_trie_commitment_info,
+        classes_trie_commitment_info,
+        storage_tries_commitment_infos,
+    })
 }
 
 /// Fetches the storage root hash of each contract from the contracts trie at the given root.

--- a/crates/starknet_os_flow_tests/src/test_manager.rs
+++ b/crates/starknet_os_flow_tests/src/test_manager.rs
@@ -65,7 +65,7 @@ use starknet_committer::block_committer::input::{
 };
 use starknet_committer::db::facts_db::FactsDb;
 use starknet_committer::db::forest_trait::StorageInitializer;
-use starknet_os::commitment_infos::StateCommitmentInfos;
+use starknet_os::commitment_infos::build_state_commitment_infos;
 use starknet_os::hints::hint_implementation::state_diff_encryption::utils::compute_public_keys;
 use starknet_os::io::os_input::{OsBlockInput, OsHints, OsHintsConfig, StarknetOsInput};
 use starknet_os::io::os_output::{MessageToL2, OsStateDiff, StarknetOsRunnerOutput};
@@ -940,7 +940,7 @@ impl<S: FlowTestState> TestBuilder<S> {
             .expect("Failed to commit state diff.");
             map_storage = db.consume_storage();
 
-            let commitment_infos = StateCommitmentInfos::new(
+            let commitment_infos = build_state_commitment_infos(
                 &previous_state_roots,
                 &new_state_roots,
                 &mut map_storage,

--- a/crates/starknet_transaction_prover/src/running/storage_proofs.rs
+++ b/crates/starknet_transaction_prover/src/running/storage_proofs.rs
@@ -8,7 +8,11 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::{HashOutput, StateRoots};
-use starknet_os::commitment_infos::{CommitmentInfo, StateCommitmentInfos};
+use starknet_os::commitment_infos::{
+    build_state_commitment_infos,
+    CommitmentInfo,
+    StateCommitmentInfos,
+};
 use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
     flatten_preimages,
     Preimage,
@@ -348,7 +352,7 @@ impl RpcStorageProofsProvider {
 
         // TODO(Aviv): Try to undertand if we can create classes trie commitment info
         // without the compiled class hashes.
-        let mut commitment_infos = StateCommitmentInfos::new(
+        let mut commitment_infos = build_state_commitment_infos(
             &previous_state_roots,
             &new_roots,
             &mut map_storage,


### PR DESCRIPTION
starknet_patricia: derive Serialize and Deserialize for SubTreeHeight

starknet_committer,starknet_os: relocate commitment infos to starknet_committer

apollo_storage: add state_commitment_infos table

Merge remote-tracking branch 'origin/apollo_storage_state_commitment_infos_table' into yoav/parallelize-witness-fetch-with-compute