### PR TITLE
starknet_committer,starknet_os,apollo_storage: relocate commitment infos and add storage table

### DIFF
--- a/crates/apollo_storage/Cargo.toml
+++ b/crates/apollo_storage/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "A storage implementation for a Starknet node."
 
 [features]
-os_input = ["dep:blockifier", "dep:starknet_committer"]
+os_input = ["dep:blockifier", "dep:starknet_committer", "starknet_committer/os_input"]
 storage_cli = ["clap", "reqwest"]
 storage_validation = ["clap"]
 testing = ["reqwest", "starknet_api/testing", "tempfile", "tower"]

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -2,12 +2,12 @@
 
 use starknet_api::block::BlockNumber;
 pub use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfosCodecError;
 
 #[cfg(test)]
 #[path = "state_commitment_infos_test.rs"]
 mod state_commitment_infos_test;
 
-use crate::compression_utils::{compress, decompress};
 use crate::db::serialization::{StorageSerde, StorageSerdeError};
 use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
@@ -18,15 +18,22 @@ use crate::{OffsetKind, StorageResult, StorageTransaction};
 // bincode is positional and not schema-evolution tolerant, which is acceptable here.
 impl StorageSerde for StateCommitmentInfos {
     fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
-        let bytes = bincode::serialize(self)?;
-        let compressed = compress(bytes.as_slice())?;
+        let compressed = self.compress()?;
         compressed.serialize_into(res)
     }
 
     fn deserialize_from(bytes: &mut impl std::io::Read) -> Option<Self> {
         let compressed = Vec::<u8>::deserialize_from(bytes)?;
-        let data = decompress(compressed.as_slice()).ok()?;
-        bincode::deserialize(&data).ok()
+        Self::decompress(&compressed).ok()
+    }
+}
+
+impl From<StateCommitmentInfosCodecError> for StorageSerdeError {
+    fn from(error: StateCommitmentInfosCodecError) -> Self {
+        match error {
+            StateCommitmentInfosCodecError::Bincode(error) => StorageSerdeError::Bincode(error),
+            StateCommitmentInfosCodecError::Io(error) => StorageSerdeError::Io(error),
+        }
     }
 }
 

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -91,6 +91,31 @@ pub struct StateCommitmentInfos {
     pub storage_tries_commitment_infos: HashMap<ContractAddress, CommitmentInfo>,
 }
 
+#[cfg(feature = "os_input")]
+#[derive(Debug, thiserror::Error)]
+pub enum StateCommitmentInfosCodecError {
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+impl StateCommitmentInfos {
+    /// Bincode-serializes and zstd-compresses the commitment infos into a byte vector.
+    #[cfg(feature = "os_input")]
+    pub fn compress(&self) -> Result<Vec<u8>, StateCommitmentInfosCodecError> {
+        let bincode_payload = bincode::serialize(self)?;
+        Ok(zstd::encode_all(bincode_payload.as_slice(), zstd::DEFAULT_COMPRESSION_LEVEL)?)
+    }
+
+    /// Reverses [`StateCommitmentInfos::compress`]: zstd-decompresses then bincode-deserializes.
+    #[cfg(feature = "os_input")]
+    pub fn decompress(data: &[u8]) -> Result<Self, StateCommitmentInfosCodecError> {
+        let bincode_payload = zstd::decode_all(data)?;
+        Ok(bincode::deserialize(&bincode_payload)?)
+    }
+}
+
 impl StarknetForestProofs {
     pub fn build<Layout>(
         classes_trie_proof: PreimageMap,


### PR DESCRIPTION
Squashes the commitment-infos work layered on the merge:
- starknet_patricia: serialize feature + derive Serialize for SubTreeHeight
- relocate CommitmentInfo / StateCommitmentInfos to starknet_committer (re-exported from starknet_os)
- apollo_storage: add the state_commitment_infos table
- share a single StateCommitmentInfos compress/decompress (bincode+zstd) codec across the committer and apollo_storage

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>