### PR TITLE
apollo_committer,starknet_committer: store and return state commitment infos

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -39,9 +39,9 @@ use starknet_committer::block_committer::measurements_util::{
 };
 #[cfg(feature = "os_input")]
 use starknet_committer::db::forest_trait::forest_trait_witnesses::{
+    CommitmentInfosUpdate,
+    CommitmentInfosWrite,
     ForestStorageWithWitnesses,
-    PatriciaProofsUpdate,
-    PatriciaProofsWrite,
 };
 use starknet_committer::db::forest_trait::{
     EmptyInitialReadContext,
@@ -408,11 +408,11 @@ where
             #[cfg(feature = "os_input")]
             {
                 self.forest_storage
-                    .write_with_metadata_and_witnesses(
+                    .write_with_metadata_and_commitment_infos(
                         &filled_forest,
                         metadata,
                         deleted_nodes,
-                        PatriciaProofsUpdate::Delete(height),
+                        CommitmentInfosUpdate::Delete(height),
                     )
                     .await
             }
@@ -534,13 +534,13 @@ where
                         expected: digest,
                     });
                 }
-                let proofs = self
+                let state_commitment_infos = self
                     .forest_storage
-                    .read_witnesses(height)
+                    .read_commitment_infos(height)
                     .await
-                    .map_err(|error| self.map_internal_error_at_height(height, error))?;
-                let proofs = proofs.ok_or(CommitterError::MissingPatriciaPaths { height })?;
-                Ok(ReadPathsAndCommitBlockResponse { global_root, patricia_proofs: proofs })
+                    .map_err(|error| self.map_internal_error_at_height(height, error))?
+                    .ok_or(CommitterError::MissingPatriciaPaths { height })?;
+                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
             }
             // Flow overview:
             // 1. Fetch patricia paths for the accessed keys.
@@ -563,11 +563,8 @@ where
                 let CommitBlockWithWitnessesOutput {
                     filled_forest,
                     deleted_nodes,
-                    patricia_proofs,
+                    state_commitment_infos,
                     global_root,
-                    // Built here but not yet wired into the response/storage; the follow-up
-                    // switches the stored and returned payload to commitment infos.
-                    ..
                 } = commit_block_with_witnesses(
                     input,
                     &sorted_leaves,
@@ -581,23 +578,23 @@ where
                     commit_tip_metadata_bundle(height, global_root, state_diff_commitment);
 
                 info!(
-                    "For block number {height}, writing filled forest and {witness_count} \
-                     witnesses to storage with metadata: {metadata:?}, delete \
-                     {deleted_nodes_count} nodes",
-                    witness_count = patricia_proofs.get_nodes_count(),
+                    "For block number {height}, writing filled forest and \
+                     {commitment_facts_count} commitment facts to storage with metadata: \
+                     {metadata:?}, delete {deleted_nodes_count} nodes",
+                    commitment_facts_count = state_commitment_infos.n_commitment_facts(),
                     deleted_nodes_count = deleted_nodes.len(),
                 );
                 block_measurements.start_measurement(Action::Write);
                 let n_write_entries = self
                     .forest_storage
-                    .write_with_metadata_and_witnesses(
+                    .write_with_metadata_and_commitment_infos(
                         &filled_forest,
                         metadata,
                         deleted_nodes,
-                        PatriciaProofsUpdate::Write(PatriciaProofsWrite {
+                        CommitmentInfosUpdate::Write(CommitmentInfosWrite {
                             block_number: height,
                             keys_digest: digest,
-                            witnesses: patricia_proofs.clone(),
+                            commitment_infos: state_commitment_infos.clone(),
                         }),
                     )
                     .await
@@ -606,7 +603,7 @@ where
                 block_measurements.attempt_to_stop_measurement(Action::EndToEnd, 0).ok();
                 update_metrics(height, &block_measurements.block_measurement);
                 self.update_offset(next_offset);
-                Ok(ReadPathsAndCommitBlockResponse { global_root, patricia_proofs })
+                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
             }
         }
     }

--- a/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
+++ b/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
@@ -15,6 +15,7 @@ use starknet_api::core::{
     ClassHash,
     CompiledClassHash,
     ContractAddress,
+    Nonce,
     StateDiffCommitment,
     PATRICIA_KEY_UPPER_BOUND_FELT,
 };
@@ -26,18 +27,22 @@ use starknet_committer::block_committer::input::{
     StarknetStorageValue,
 };
 use starknet_committer::db::forest_trait::forest_trait_witnesses::ForestReaderWithWitnesses;
-use starknet_committer::db::forest_trait::{EmptyInitialReadContext, ForestReader};
-use starknet_committer::db::index_db::IndexDbReadContext;
 use starknet_committer::db::serde_db_utils::accessed_keys_digest;
 use starknet_committer::hash_function::hash::TreeHashFunctionImpl;
 use starknet_committer::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 use starknet_committer::patricia_merkle_tree::tree::LeavesRequest;
 use starknet_committer::patricia_merkle_tree::types::{
     class_hash_into_node_index,
+    CommitmentInfo,
     CompiledClassHash as CommitterCompiledClassHash,
-    StarknetForestProofs,
+    StateCommitmentInfos,
 };
-use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{BinaryData, NodeData};
+use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
+    BinaryData,
+    NodeData,
+    Preimage,
+    PreimageMap,
+};
 use starknet_patricia::patricia_merkle_tree::node_data::leaf::Leaf;
 use starknet_patricia::patricia_merkle_tree::storage_proof_verification::verify_patricia_proof;
 use starknet_patricia::patricia_merkle_tree::types::NodeIndex;
@@ -219,46 +224,52 @@ where
         .collect()
 }
 
-/// Verifies that `patricia_proofs` contains a valid proof for the membership of each leaf in
-/// `accessed_leaves`.
+/// Reconstructs a [`PreimageMap`] of inner nodes from a commitment info's flattened
+/// `commitment_facts`. This is the inverse of `flatten_preimages`; it relies on `commitment_facts`
+/// holding inner nodes only (binary `[left, right]` or edge `[length, path, bottom]`).
+fn preimage_map_from_commitment_info(commitment_info: &CommitmentInfo) -> PreimageMap {
+    commitment_info
+        .commitment_facts
+        .iter()
+        .map(|(hash, raw_preimage)| {
+            (*hash, Preimage::try_from(raw_preimage).expect("commitment fact is a valid preimage"))
+        })
+        .collect()
+}
+
+/// Verifies that `commitment_infos` contains valid Patricia proofs for the membership of each
+/// accessed leaf.
 fn verify_witness_patricia_paths(
-    patricia_proofs: &StarknetForestProofs,
+    commitment_infos: &StateCommitmentInfos,
     accessed_keys: &AccessedKeys,
     class_leaves: &HashMap<ClassHash, CommitterCompiledClassHash>,
+    contract_leaves: &HashMap<ContractAddress, ContractState>,
     storage_leaves: &HashMap<ContractAddress, HashMap<StarknetStorageKey, StarknetStorageValue>>,
-    classes_trie_root: HashOutput,
-    contracts_trie_root: HashOutput,
 ) {
+    let classes_trie_info = &commitment_infos.classes_trie_commitment_info;
     verify_patricia_proof::<CommitterCompiledClassHash, TreeHashFunctionImpl>(
-        classes_trie_root,
-        &patricia_proofs.classes_trie_proof,
+        classes_trie_info.updated_root,
+        &preimage_map_from_commitment_info(classes_trie_info),
         &leaf_hashes(class_leaves, class_hash_into_node_index),
     )
     .unwrap_or_else(|error| panic!("classes trie proof verification failed: {error}"));
 
+    let contracts_trie_info = &commitment_infos.contracts_trie_commitment_info;
     verify_patricia_proof::<ContractState, TreeHashFunctionImpl>(
-        contracts_trie_root,
-        &patricia_proofs.contracts_trie_proof.nodes,
-        &leaf_hashes(
-            &patricia_proofs.contracts_trie_proof.leaves,
-            contract_address_into_node_index,
-        ),
+        contracts_trie_info.updated_root,
+        &preimage_map_from_commitment_info(contracts_trie_info),
+        &leaf_hashes(contract_leaves, contract_address_into_node_index),
     )
     .unwrap_or_else(|error| panic!("contracts trie proof verification failed: {error}"));
 
     for contract_address in &accessed_keys.accessed_contracts {
-        let storage_proof = patricia_proofs
-            .contracts_trie_storage_proofs
-            .get(contract_address)
-            .unwrap_or_else(|| panic!("missing storage trie proof for {contract_address:?}"));
-        let contract_state = patricia_proofs
-            .contracts_trie_proof
-            .leaves
-            .get(contract_address)
-            .unwrap_or_else(|| panic!("missing contracts trie leaf for {contract_address:?}"));
+        let storage_info =
+            commitment_infos.storage_tries_commitment_infos.get(contract_address).unwrap_or_else(
+                || panic!("missing storage trie commitment info for {contract_address:?}"),
+            );
         verify_patricia_proof::<StarknetStorageValue, TreeHashFunctionImpl>(
-            contract_state.storage_root_hash,
-            storage_proof,
+            storage_info.updated_root,
+            &preimage_map_from_commitment_info(storage_info),
             &leaf_hashes(
                 storage_leaves.get(contract_address).unwrap_or_else(|| {
                     panic!("missing storage leaves for contract {contract_address:?}")
@@ -275,15 +286,15 @@ fn verify_witness_patricia_paths(
 async fn assert_witnesses_and_digest_present(
     committer: &mut ApolloTestCommitter,
     height: BlockNumber,
-    expected_patricia_proofs: &StarknetForestProofs,
+    expected_commitment_infos: &StateCommitmentInfos,
 ) {
     assert_eq!(
         committer.load_witnesses_digest(height).await.unwrap(),
         Some(*EXPECTED_ACCESSED_KEYS_DIGEST),
     );
     assert_eq!(
-        committer.forest_storage.read_witnesses(height).await.unwrap().as_ref(),
-        Some(expected_patricia_proofs),
+        committer.forest_storage.read_commitment_infos(height).await.unwrap().as_ref(),
+        Some(expected_commitment_infos),
     );
 }
 
@@ -292,7 +303,7 @@ async fn assert_witnesses_and_digest_absent(
     height: BlockNumber,
 ) {
     assert!(committer.load_witnesses_digest(height).await.unwrap().is_none());
-    assert!(committer.forest_storage.read_witnesses(height).await.unwrap().is_none());
+    assert!(committer.forest_storage.read_commitment_infos(height).await.unwrap().is_none());
 }
 
 /// Flow overview:
@@ -319,27 +330,43 @@ async fn read_paths_and_commit_block_happy_flow() {
 
     let response = committer.read_paths_and_commit_block(request.clone()).await.unwrap();
     assert_eq!(committer.offset, BlockNumber(height + 1));
-    let roots =
-        committer.forest_storage.read_roots(IndexDbReadContext::create_empty()).await.unwrap();
+    // The commitment infos don't retain the contract-trie leaves, so reconstruct the expected
+    // contract states for the accessed contracts: storage root from the commitment infos, class
+    // hash from the block-0 deployment, and the default (zero) nonce.
+    let contract_leaves: HashMap<ContractAddress, ContractState> = response
+        .state_commitment_infos
+        .storage_tries_commitment_infos
+        .iter()
+        .map(|(address, storage_info)| {
+            (
+                *address,
+                ContractState {
+                    nonce: Nonce::default(),
+                    storage_root_hash: storage_info.updated_root,
+                    class_hash: *ACCESSED_CLASS_HASH,
+                },
+            )
+        })
+        .collect();
     verify_witness_patricia_paths(
-        &response.patricia_proofs,
+        &response.state_commitment_infos,
         &accessed_keys,
         &ACCESSED_CLASS_LEAVES,
+        &contract_leaves,
         &ACCESSED_STORAGE_LEAVES,
-        roots.classes_trie_root_hash,
-        roots.contracts_trie_root_hash,
     );
 
-    // Historical replay should load persisted witnesses, removing trie nodes to assert this.
+    // Historical replay should load the persisted commitment infos; remove trie nodes to assert
+    // the historical path reads from storage rather than recomputing.
     committer.forest_storage.clear_patricia_trie_nodes_for_test();
 
     let replay_response = committer.read_paths_and_commit_block(request).await.unwrap();
     assert_eq!(response.global_root, replay_response.global_root);
-    assert_eq!(response.patricia_proofs, replay_response.patricia_proofs);
+    assert_eq!(response.state_commitment_infos, replay_response.state_commitment_infos);
     assert_witnesses_and_digest_present(
         &mut committer,
         BlockNumber(height),
-        &response.patricia_proofs,
+        &response.state_commitment_infos,
     )
     .await;
 }
@@ -370,7 +397,7 @@ async fn revert_removes_witnesses_and_digest() {
     assert_witnesses_and_digest_present(
         &mut committer,
         BlockNumber(height_1),
-        &block_1_response.patricia_proofs,
+        &block_1_response.state_commitment_infos,
     )
     .await;
 
@@ -458,7 +485,11 @@ async fn test_bottom_of_new_edge_to_an_unmoidifed_subtree_is_present() {
     // This in turn also proves that G is not an edge node, as it's the bottom of an old
     // edge node, without explicitly requesting an opening of E.
     assert!(
-        response.patricia_proofs.classes_trie_proof.contains_key(&node_g_hash),
+        response
+            .state_commitment_infos
+            .classes_trie_commitment_info
+            .commitment_facts
+            .contains_key(&node_g_hash),
         "missing bottom of a new edge node in a proof",
     );
 }
@@ -527,7 +558,11 @@ async fn test_bottom_of_new_edge_which_was_not_bottom_of_an_old_edge_is_present(
     }));
 
     assert!(
-        response.patricia_proofs.classes_trie_proof.contains_key(&node_e_hash),
+        response
+            .state_commitment_infos
+            .classes_trie_commitment_info
+            .commitment_facts
+            .contains_key(&node_e_hash),
         "missing bottom of a new edge node in a proof",
     );
 }

--- a/crates/apollo_committer_types/src/committer_types.rs
+++ b/crates/apollo_committer_types/src/committer_types.rs
@@ -5,7 +5,7 @@ use starknet_api::block::BlockNumber;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
 use starknet_api::state::ThinStateDiff;
 #[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StarknetForestProofs;
+use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommitBlockRequest {
@@ -50,5 +50,5 @@ pub struct ReadPathsAndCommitBlockRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReadPathsAndCommitBlockResponse {
     pub global_root: GlobalRoot,
-    pub patricia_proofs: StarknetForestProofs,
+    pub state_commitment_infos: StateCommitmentInfos,
 }

--- a/crates/starknet_committer/src/block_committer/commit.rs
+++ b/crates/starknet_committer/src/block_committer/commit.rs
@@ -42,9 +42,9 @@ use crate::hash_function::hash::TreeHashFunctionImpl;
 use crate::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 #[cfg(feature = "os_input")]
 use crate::patricia_merkle_tree::tree::SortedLeavesRequest;
-use crate::patricia_merkle_tree::types::{class_hash_into_node_index, CompiledClassHash};
 #[cfg(feature = "os_input")]
-use crate::patricia_merkle_tree::types::{StarknetForestProofs, StateCommitmentInfos};
+use crate::patricia_merkle_tree::types::StateCommitmentInfos;
+use crate::patricia_merkle_tree::types::{class_hash_into_node_index, CompiledClassHash};
 
 pub type BlockCommitmentResult<T> = Result<T, BlockCommitmentError>;
 
@@ -85,7 +85,6 @@ pub type CommitBlockWithWitnessesResult<T> = Result<T, CommitBlockWithWitnessesE
 pub struct CommitBlockWithWitnessesOutput {
     pub filled_forest: FilledForest,
     pub deleted_nodes: DeletedNodes,
-    pub patricia_proofs: StarknetForestProofs,
     pub state_commitment_infos: StateCommitmentInfos,
     pub global_root: GlobalRoot,
 }
@@ -214,7 +213,6 @@ where
     Ok(CommitBlockWithWitnessesOutput {
         filled_forest,
         deleted_nodes,
-        patricia_proofs,
         state_commitment_infos,
         global_root,
     })

--- a/crates/starknet_committer/src/db/forest_trait_witnesses.rs
+++ b/crates/starknet_committer/src/db/forest_trait_witnesses.rs
@@ -19,33 +19,32 @@ use crate::forest::deleted_nodes::DeletedNodes;
 use crate::forest::filled_forest::FilledForest;
 use crate::forest::forest_errors::ForestResult;
 use crate::patricia_merkle_tree::tree::SortedLeafIndices;
-use crate::patricia_merkle_tree::types::StarknetForestProofs;
+use crate::patricia_merkle_tree::types::{StarknetForestProofs, StateCommitmentInfos};
 
-/// The information required to write Patricia proofs to the database.
-pub struct PatriciaProofsWrite {
+/// The information required to write the OS-input commitment infos to the database.
+pub struct CommitmentInfosWrite {
     pub block_number: BlockNumber,
     pub keys_digest: [u8; 32],
-    pub witnesses: StarknetForestProofs,
+    pub commitment_infos: StateCommitmentInfos,
 }
 
-/// Patricia proofs DB operation, which can be either delete or write.
-/// Expected by [ForestWriterWithMetadataAndWitnesses::write_with_metadata_and_witnesses], which
-/// accumulates all DB operations to guarantee atomicity.
-pub enum PatriciaProofsUpdate {
-    Write(PatriciaProofsWrite),
+/// Commitment-infos DB operation, which can be either delete or write.
+/// Expected by [ForestWriterWithMetadataAndWitnesses::write_with_metadata_and_commitment_infos],
+/// which accumulates all DB operations to guarantee atomicity.
+pub enum CommitmentInfosUpdate {
+    Write(CommitmentInfosWrite),
     Delete(BlockNumber),
 }
 
-/// Reads committed OS-input witness payload (structured [`StarknetForestProofs`]) for a block
-/// height.
+/// Reads the committed OS-input commitment infos ([`StateCommitmentInfos`]) for a block height.
 #[async_trait]
 pub trait ForestReaderWithWitnesses:
     ForestReader<InitialReadContext: EmptyInitialReadContext> + Send
 {
-    async fn read_witnesses(
+    async fn read_commitment_infos(
         &mut self,
         height: BlockNumber,
-    ) -> ForestResult<Option<StarknetForestProofs>>;
+    ) -> ForestResult<Option<StateCommitmentInfos>>;
 
     /// Fetches Patricia witness paths for OS input, optionally staging serialized trie node KVs on
     /// an in-memory overlay so reads match post-commit state before the forest is persisted.
@@ -60,16 +59,16 @@ pub trait ForestReaderWithWitnesses:
     ) -> TraversalResult<StarknetForestProofs>;
 }
 
-/// Writes forest + metadata + deleted nodes, and applies [`PatriciaProofsUpdate`] in the same
+/// Writes forest + metadata + deleted nodes, and applies [`CommitmentInfosUpdate`] in the same
 /// batch.
 #[async_trait]
 pub trait ForestWriterWithMetadataAndWitnesses: ForestWriterWithMetadata + Send {
-    async fn write_with_metadata_and_witnesses(
+    async fn write_with_metadata_and_commitment_infos(
         &mut self,
         filled_forest: &FilledForest,
         metadata: HashMap<ForestMetadataType, DbValue>,
         deleted_nodes: DeletedNodes,
-        patricia_proofs_update: PatriciaProofsUpdate,
+        commitment_infos_update: CommitmentInfosUpdate,
     ) -> SerializationResult<usize>;
 }
 

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -42,10 +42,10 @@ use crate::block_committer::input::{InputContext, ReaderConfig, StarknetStorageV
 use crate::db::db_layout::DbLayout;
 #[cfg(feature = "os_input")]
 use crate::db::forest_trait::forest_trait_witnesses::{
+    CommitmentInfosUpdate,
+    CommitmentInfosWrite,
     ForestReaderWithWitnesses,
     ForestWriterWithMetadataAndWitnesses,
-    PatriciaProofsUpdate,
-    PatriciaProofsWrite,
 };
 use crate::db::forest_trait::{
     read_forest,
@@ -84,7 +84,7 @@ use crate::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 use crate::patricia_merkle_tree::tree::{fetch_all_patricia_paths, SortedLeafIndices};
 use crate::patricia_merkle_tree::types::CompiledClassHash;
 #[cfg(feature = "os_input")]
-use crate::patricia_merkle_tree::types::StarknetForestProofs;
+use crate::patricia_merkle_tree::types::{StarknetForestProofs, StateCommitmentInfos};
 
 /// Set to 2^251 + 1 to avoid collisions with contract addresses prefixes.
 pub(crate) static FIRST_AVAILABLE_PREFIX_FELT: LazyLock<Felt> =
@@ -369,17 +369,19 @@ fn block_number_based_key(prefix: &[u8; 32], block_number: DbBlockNumber) -> Vec
 impl<S: Storage + ImmutableReadOnlyStorage + Sync + Send + 'static> ForestReaderWithWitnesses
     for IndexDb<S>
 {
-    async fn read_witnesses(
+    async fn read_commitment_infos(
         &mut self,
         height: BlockNumber,
-    ) -> ForestResult<Option<StarknetForestProofs>> {
+    ) -> ForestResult<Option<StateCommitmentInfos>> {
         let db_key = DbKey(block_number_based_key(&PATRICIA_PATHS_PREFIX, DbBlockNumber(height)));
 
         Ok(match self.get_from_storage(db_key).await? {
             None => None,
             Some(DbValue(bytes)) => {
-                Some(StarknetForestProofs::deserialize(&DbValue(bytes)).map_err(|e| {
-                    ForestError::PatriciaStorage(PatriciaStorageError::Deserialization(e))
+                Some(StateCommitmentInfos::decompress(&bytes).map_err(|e| {
+                    ForestError::PatriciaStorage(PatriciaStorageError::Deserialization(
+                        DeserializationError::ValueError(Box::new(e)),
+                    ))
                 })?)
             }
         })
@@ -427,17 +429,17 @@ impl<S: Storage + ImmutableReadOnlyStorage + Sync + Send + 'static> ForestReader
 #[cfg(feature = "os_input")]
 #[async_trait]
 impl<S: Storage + Send> ForestWriterWithMetadataAndWitnesses for IndexDb<S> {
-    async fn write_with_metadata_and_witnesses(
+    async fn write_with_metadata_and_commitment_infos(
         &mut self,
         filled_forest: &FilledForest,
         metadata: HashMap<ForestMetadataType, DbValue>,
         deleted_nodes: DeletedNodes,
-        patricia_proofs_update: PatriciaProofsUpdate,
+        commitment_infos_update: CommitmentInfosUpdate,
     ) -> SerializationResult<usize> {
         let mut operations = DbOperationMap::new();
         Self::append_forest_and_metadata(&mut operations, filled_forest, metadata, deleted_nodes)?;
-        match patricia_proofs_update {
-            PatriciaProofsUpdate::Delete(block_number) => {
+        match commitment_infos_update {
+            CommitmentInfosUpdate::Delete(block_number) => {
                 operations.insert(
                     Self::metadata_key(ForestMetadataType::AccessedKeysDigest(DbBlockNumber(
                         block_number,
@@ -452,12 +454,12 @@ impl<S: Storage + Send> ForestWriterWithMetadataAndWitnesses for IndexDb<S> {
                     DbOperation::Delete,
                 );
             }
-            PatriciaProofsUpdate::Write(PatriciaProofsWrite {
+            CommitmentInfosUpdate::Write(CommitmentInfosWrite {
                 block_number,
                 keys_digest,
-                witnesses,
+                commitment_infos,
             }) => {
-                let encoded = witnesses.serialize()?;
+                let encoded = DbValue(commitment_infos.compress()?);
                 operations.insert(
                     Self::metadata_key(ForestMetadataType::AccessedKeysDigest(DbBlockNumber(
                         block_number,

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -11,6 +11,8 @@ use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
 };
 use starknet_patricia::patricia_merkle_tree::node_data::leaf::SkeletonLeaf;
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SubTreeHeight};
+#[cfg(feature = "os_input")]
+use starknet_patricia_storage::errors::SerializationError;
 use starknet_types_core::felt::{Felt, FromStrError};
 
 use crate::block_committer::input::{try_node_index_into_contract_address, StarknetStorageValue};
@@ -101,6 +103,18 @@ pub enum StateCommitmentInfosCodecError {
     Bincode(#[from] bincode::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+}
+
+#[cfg(feature = "os_input")]
+impl From<StateCommitmentInfosCodecError> for SerializationError {
+    fn from(error: StateCommitmentInfosCodecError) -> Self {
+        match error {
+            StateCommitmentInfosCodecError::Bincode(error) => {
+                SerializationError::IOSerialize(std::io::Error::other(error))
+            }
+            StateCommitmentInfosCodecError::Io(error) => SerializationError::IOSerialize(error),
+        }
+    }
 }
 
 impl StateCommitmentInfos {


### PR DESCRIPTION
Switch the committer's stored and returned payload from StarknetForestProofs to
StateCommitmentInfos: rename the witness write/read structs and methods, persist via
the shared StateCommitmentInfos::compress/decompress codec, return the infos from
read_paths_and_commit_block, and have the historical/replay path read them back.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>