### PR TITLE
apollo_network,apollo_integration_tests: retry port bind on node restart

### DIFF
--- a/crates/apollo_integration_tests/src/integration_test_manager.rs
+++ b/crates/apollo_integration_tests/src/integration_test_manager.rs
@@ -712,7 +712,7 @@ impl IntegrationTestManager {
         info!("All nodes have been shut down.");
 
         // Brief pause to let the OS release ports after SIGKILL before new processes bind them.
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_secs(2)).await;
     }
 
     pub async fn send_deploy_and_invoke_txs_and_verify(&mut self) {

--- a/crates/apollo_network/src/network_manager/mod.rs
+++ b/crates/apollo_network/src/network_manager/mod.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use apollo_network_types::network_types::{BroadcastedMessageMetadata, OpaquePeerId};
 use async_trait::async_trait;
@@ -40,6 +41,12 @@ use crate::{gossipsub_impl, mixed_behaviour, Bytes, NetworkConfig};
 
 const DEFAULT_ACTIVE_COMMITTEES_CAPACITY: usize = 2;
 const ADD_EPOCH_CHANNEL_CAPACITY: usize = 100;
+
+// When a node is restarted (e.g. integration tests that kill and respawn a node), the OS may not
+// have released the previous process's listening socket yet, so the first bind can transiently
+// fail with "address already in use". Retry a few times before giving up.
+const LISTEN_BIND_MAX_ATTEMPTS: usize = 5;
+const LISTEN_BIND_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Errors that can occur during network operations.
 ///
@@ -1266,9 +1273,28 @@ impl NetworkManager {
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_connection_timeout))
         .build();
 
-        swarm
-            .listen_on(listen_address.clone())
-            .unwrap_or_else(|_| panic!("Error while binding to {listen_address}"));
+        let mut bind_attempt = 1;
+        loop {
+            match swarm.listen_on(listen_address.clone()) {
+                Ok(_) => break,
+                Err(bind_error) if bind_attempt < LISTEN_BIND_MAX_ATTEMPTS => {
+                    warn!(
+                        "Failed to bind to {listen_address} (attempt \
+                         {bind_attempt}/{LISTEN_BIND_MAX_ATTEMPTS}): {bind_error}. Retrying in \
+                         {LISTEN_BIND_RETRY_DELAY:?}."
+                    );
+                    // `new` is synchronous and runs once at startup; a brief blocking sleep here is
+                    // acceptable. The port is freed by the previous (already-killed) process, so
+                    // blocking this thread does not delay that release.
+                    std::thread::sleep(LISTEN_BIND_RETRY_DELAY);
+                    bind_attempt += 1;
+                }
+                Err(bind_error) => panic!(
+                    "Error while binding to {listen_address} after {LISTEN_BIND_MAX_ATTEMPTS} \
+                     attempts: {bind_error}"
+                ),
+            }
+        }
 
         let advertised_multiaddr = advertised_multiaddr.map(|address| {
             address


### PR DESCRIPTION
## Problem

The `integration_test_revert_flow` CI job failed with:

```
thread 'main' panicked at crates/apollo_network/src/network_manager/mod.rs:1271:33:
Error while binding to /ip4/0.0.0.0/tcp/36042
→ Node node_index: 2 stopped unexpectedly. Exit status 256
→ "Node service Consolidated(Node) unexpectedly stopped." → exit code 1
```

The restart/revert integration tests SIGKILL a node and immediately respawn it on the **same ports**. Under CI load the OS hasn't released the previous process's listening socket yet, so the new process's first `listen_on` bind transiently fails with "address already in use". Today that's a hard `panic!`, which kills the node and fails the test.

This is a load-dependent race, unrelated to consensus — the block production + revert phases completed successfully before the node was restarted.

## Fix

1. **`apollo_network`** — retry the `listen_on` bind up to 5× with a 500ms delay before giving up, instead of panicking on the first failure. This removes the timing dependency entirely. `NetworkManager::new` is synchronous and runs once at startup, so a brief blocking sleep between attempts is acceptable (the port is freed by the already-killed previous process, so blocking this thread doesn't delay the release).

2. **`apollo_integration_tests`** — lengthen the post-shutdown port-release grace in `shutdown_nodes` from 100ms → 2s, so the first bind attempt usually succeeds without needing a retry.

The two are complementary: the grace makes the common case clean; the retry loop is the deterministic backstop.

## Blast radius

- The grace bump only runs inside `shutdown_nodes`, called only by restart/revert flows — it can only make those more robust.
- The bind-retry preserves existing behavior on success and only adds resilience on transient bind failure.

## Verification

- `cargo build -p apollo_network -p apollo_integration_tests` → green.
- Not run against the live e2e revert flow locally (needs a precompiled node binary; the failure is a load race so a single local pass wouldn't prove much). The retry loop is what makes it deterministic; CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)