### PR TITLE
apollo_signature_manager: delete dead code (unsure, review carefully)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,7 +2554,6 @@ dependencies = [
  "expect-test",
  "hex",
  "starknet-core",
- "starknet-crypto 0.8.1",
  "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",

--- a/crates/apollo_signature_manager/Cargo.toml
+++ b/crates/apollo_signature_manager/Cargo.toml
@@ -18,7 +18,6 @@ async-trait.workspace = true
 blake2.workspace = true
 digest.workspace = true
 starknet-core.workspace = true
-starknet-crypto.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true

--- a/crates/apollo_signature_manager/src/signature_manager.rs
+++ b/crates/apollo_signature_manager/src/signature_manager.rs
@@ -19,7 +19,6 @@ use starknet_api::crypto::utils::{
 };
 use starknet_core::crypto::{ecdsa_sign, ecdsa_verify, EcdsaVerifyError};
 use starknet_core::types::Felt;
-use starknet_crypto::get_public_key;
 use thiserror::Error;
 
 use crate::blake_utils::blake2s_to_felt;
@@ -93,11 +92,6 @@ pub struct LocalKeyStore {
 }
 
 impl LocalKeyStore {
-    fn _new(private_key: PrivateKey) -> Self {
-        let public_key = PublicKey(get_public_key(&private_key));
-        Self { private_key, public_key }
-    }
-
     pub(crate) const fn new_for_testing() -> Self {
         // Created using `cairo-lang`.
         const PRIVATE_KEY: PrivateKey = PrivateKey(Felt::from_hex_unchecked(


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

## What this removes

- The unused private associated function `LocalKeyStore::_new`.
- Its now-unused `starknet_crypto::get_public_key` import.
- The now-unused `starknet-crypto` dependency (Cargo.toml + Cargo.lock).

## Why it appears dead

- `_new` is the real-private-key constructor for `LocalKeyStore` — it derives the public key from a private key.
- It has **zero callers** anywhere in this workspace or in either sibling repo (`starkware-industries/sequencer-devops`, `starkware-industries/starkware`).
- It is the only user of the `get_public_key` import, which in turn is the crate's only use of the `starknet-crypto` dependency (cargo-machete flagged `starknet-crypto` as unused once `_new` was removed).
- Every construction of `LocalKeyStore` — including the production path `LocalKeyStoreSignatureManager::new` in `lib.rs` — goes through `LocalKeyStore::new_for_testing()` instead.
- The `_` name prefix suppresses the rustc `dead_code` lint, so the compiler does not flag it, but the function is genuinely unreachable.

## Verification (all pass after removal)

- `cargo build -p apollo_signature_manager` — zero `dead_code`/`unused` warnings.
- `cargo build -p apollo_signature_manager --tests` — zero warnings.
- `cargo clippy -p apollo_signature_manager --all-targets` — clean.
- `cargo machete` — clean (the dep removal addresses the initial `code_style` failure).
- `SEED=0 cargo test -p apollo_signature_manager` — passes.

## What a human must verify

`_new` looks like **intentional scaffolding**. Per PR #7315, the `LocalKeyStore` variant was introduced as a temporary stand-in while the remote-KMS design is still pending, with `new_for_testing()` used "across the node" in the interim. `_new` may be deliberately kept to wire up real private-key loading later. **Please confirm whether `_new` is imminently needed for that work** — if so, keep it (and comment why) and close this PR.

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.