### PR TITLE
apollo_network_benchmark: pin prometheus and grafana storage to hyperdisk-balanced

### DIFF
--- a/crates/apollo_network_benchmark/config/k8s_grafana_deployment.json
+++ b/crates/apollo_network_benchmark/config/k8s_grafana_deployment.json
@@ -97,6 +97,7 @@
           "accessModes": [
             "ReadWriteOnce"
           ],
+          "storageClassName": "hyperdisk-balanced-baseline",
           "resources": {
             "requests": {
               "storage": "8Gi"

--- a/crates/apollo_network_benchmark/config/k8s_prometheus_deployment.json
+++ b/crates/apollo_network_benchmark/config/k8s_prometheus_deployment.json
@@ -93,6 +93,7 @@
           "accessModes": [
             "ReadWriteOnce"
           ],
+          "storageClassName": "hyperdisk-balanced-baseline",
           "resources": {
             "requests": {
               "storage": "16Gi"


### PR DESCRIPTION
## Goal
The Prometheus and Grafana StatefulSets fail to start on sequencer-dev after the node pools migrated from n2 to n4: their PVCs request the cluster-default storage class (pd-balanced), which n4 machines cannot attach ("pd-balanced disk type cannot be used by n4-standard-4 machine type"), so the observability dashboards never come up and benchmark results are unrecoverable.

## Summary of changes
Set `storageClassName: hyperdisk-balanced` on the volumeClaimTemplates of both config/k8s_prometheus_deployment.json and config/k8s_grafana_deployment.json.

## Key decision points
Chose an explicit hyperdisk-balanced class over the alternatives: emptyDir (ephemeral, drops TSDB/dashboard state on restart) and pinning the pods to an n2 pool via nodeSelector (reintroduces pool coupling). Hyperdisk is the disk type n4 machines support, so this keeps persistence without coupling to a node pool. Assumes the cluster provides a `hyperdisk-balanced` StorageClass (GKE built-in on n4-capable clusters).