### PR TITLE
apollo_network_benchmark: wait for observability pods before port-forwarding

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_port_forward.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_port_forward.rs
@@ -1,8 +1,28 @@
 use std::process::{Command, Stdio};
 use std::thread;
 
-use crate::mod_utils::{connect_to_cluster, get_deployment_namespace, read_cluster_deployment};
+use crate::mod_utils::{
+    connect_to_cluster,
+    get_deployment_namespace,
+    read_cluster_deployment,
+    run_cmd,
+};
 use crate::pr;
+
+/// Block until the StatefulSet has a ready replica, so `kubectl port-forward service/...` finds
+/// a backing endpoint instead of failing immediately when the pods are still starting (a short
+/// benchmark can otherwise miss its whole window). Best-effort: a timeout still falls through to
+/// the port-forward attempt so the user can debug.
+fn wait_for_statefulset_ready(statefulset_name: &str, namespace_name: &str) {
+    let _ = run_cmd(
+        &format!(
+            "kubectl rollout status statefulset/{statefulset_name} -n {namespace_name} \
+             --timeout=180s"
+        ),
+        "none",
+        true,
+    );
+}
 
 fn port_forward(service_name: &str, local_port: u16, remote_port: u16, namespace_name: &str) {
     let status = Command::new("kubectl")
@@ -35,6 +55,10 @@ pub fn run() -> anyhow::Result<()> {
     let namespace_name = get_deployment_namespace(&deployment_data)?.to_string();
 
     connect_to_cluster()?;
+
+    pr!("Waiting for Prometheus and Grafana to be ready in namespace: {namespace_name}");
+    wait_for_statefulset_ready("prometheus", &namespace_name);
+    wait_for_statefulset_ready("grafana", &namespace_name);
 
     pr!("Port forwarding in namespace: {namespace_name}");
     pr!("  → Grafana:    http://localhost:3000");


### PR DESCRIPTION
## Goal
`cluster port-forward` runs `kubectl port-forward service/...` once with no readiness wait. Run right after `cluster start`, while the Prometheus/Grafana pods are still starting and their services have no endpoints, it fails immediately and exits — which can cost a short benchmark its entire observability window even when the pods are otherwise healthy.

## Summary of changes
Added `wait_for_statefulset_ready()` in cluster_port_forward.rs, which runs `kubectl rollout status statefulset/<name> --timeout=180s` for prometheus and grafana before spawning the port-forward threads.

## Key decision points
Made the wait best-effort (tolerates failure) so a rollout timeout still falls through to the port-forward attempt for debugging rather than hard-failing. Used `kubectl rollout status` over a hand-rolled poll loop since it already blocks until a ready replica exists.