### PR TITLE
apollo_network_benchmark: tolerate recreate error during namespace cleanup

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_start.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_start.rs
@@ -143,7 +143,7 @@ fn run_experiment(args: ClusterStartArgs) -> anyhow::Result<()> {
     let deployment_file = cluster_deployment_file_path()?;
     write_deployment_file(&deployment_file, &deployment_data)?;
 
-    create_namespace(&namespace_name)?;
+    create_namespace(&namespace_name, false)?;
 
     let file_names = write_json_files(&image_tag, &args, &namespace_name)?;
     deployment_data["json_files"] = serde_json::json!(file_names);

--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_stop.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_stop.rs
@@ -32,9 +32,12 @@ pub fn run() -> anyhow::Result<()> {
         )?;
 
         // Namespace deletion can hang in "Terminating" state due to stuck finalizers.
-        // Re-creating then deleting forces Kubernetes to clean up.
+        // Re-creating then deleting forces Kubernetes to clean up. The re-create tolerates
+        // failure: when the first delete already finished (the common case) the namespace is
+        // mid-termination, so `kubectl create` errors with "being deleted" — that's expected
+        // and must not abort cleanup, which the surrounding deletes complete anyway.
         delete_namespace(namespace_name, true)?;
-        create_namespace(namespace_name)?;
+        create_namespace(namespace_name, true)?;
         delete_namespace(namespace_name, false)?;
     }
 

--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/mod_utils.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/mod_utils.rs
@@ -245,13 +245,18 @@ pub fn upload_image_to_registry(image_tag: &str) -> anyhow::Result<()> {
     )
 }
 
-pub fn create_namespace(namespace_name: &str) -> anyhow::Result<()> {
+pub fn create_namespace(namespace_name: &str, may_fail: bool) -> anyhow::Result<()> {
     pr!("Creating namespace {}", namespace_name);
-    run_cmd(&format!("kubectl create namespace {}", namespace_name), "none", false)
+    run_cmd(&format!("kubectl create namespace {}", namespace_name), "none", may_fail)
 }
 
 pub fn delete_namespace(namespace_name: &str, may_fail: bool) -> anyhow::Result<()> {
-    run_cmd(&format!("kubectl delete namespace {}", namespace_name), "none", may_fail)
+    // --ignore-not-found so deleting an already-gone namespace is a no-op rather than an error.
+    run_cmd(
+        &format!("kubectl delete namespace {} --ignore-not-found", namespace_name),
+        "none",
+        may_fail,
+    )
 }
 
 pub fn deploy_json_files_to_cluster(


### PR DESCRIPTION
## Goal
`cluster stop` force-clears a namespace stuck in Terminating via delete -> create -> delete. When the first delete already finished (the common case), the namespace is mid-termination, so the intermediate `kubectl create namespace` errors ("object is being deleted") and aborts cluster stop with a confusing failure even though deletion actually succeeds.

## Summary of changes
Added a `may_fail` parameter to `create_namespace` and pass `true` from the cleanup path (`false` from cluster_start, where the namespace must be created fresh). Added `--ignore-not-found` to `delete_namespace` so deleting an already-gone namespace is a no-op.

## Key decision points
Kept the existing recreate-then-delete finalizer-unsticking trick rather than replacing it with a finalizer patch, to minimize behavioral change — only made it non-fatal. The final delete stays authoritative (must-succeed) so genuine kubectl/connectivity failures still surface, since `--ignore-not-found` already covers the already-deleted case.