### PR TITLE
apollo_network_benchmark: record clock skew instead of crashing on it

### DIFF
--- a/crates/apollo_network_benchmark/config/k8s_grafana_deployment.json
+++ b/crates/apollo_network_benchmark/config/k8s_grafana_deployment.json
@@ -97,6 +97,7 @@
           "accessModes": [
             "ReadWriteOnce"
           ],
+          "storageClassName": "hyperdisk-balanced-baseline",
           "resources": {
             "requests": {
               "storage": "8Gi"

--- a/crates/apollo_network_benchmark/config/k8s_prometheus_deployment.json
+++ b/crates/apollo_network_benchmark/config/k8s_prometheus_deployment.json
@@ -93,6 +93,7 @@
           "accessModes": [
             "ReadWriteOnce"
           ],
+          "storageClassName": "hyperdisk-balanced-baseline",
           "resources": {
             "requests": {
               "storage": "16Gi"

--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/handlers.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/handlers.rs
@@ -20,6 +20,7 @@ use crate::metrics::{
     BROADCAST_MESSAGE_THEORETICAL_THROUGHPUT,
     RECEIVE_MESSAGE_BYTES,
     RECEIVE_MESSAGE_BYTES_SUM,
+    RECEIVE_MESSAGE_CLOCK_SKEW_SECONDS,
     RECEIVE_MESSAGE_COUNT,
     RECEIVE_MESSAGE_DELAY_SECONDS,
     RECEIVE_MESSAGE_PENDING_COUNT,
@@ -129,11 +130,14 @@ pub fn receive_stress_test_message(
     );
 
     let start_time = received_message.metadata.time;
-    // Intentionally panic on clock skew: any node clock running ahead of another node's
-    // clock invalidates the latency histogram, and we'd rather fail the benchmark loudly
-    // than silently report misleading percentiles. Operators must NTP-sync nodes.
-    let delay =
-        end_time.duration_since(start_time).expect("clock skew detected: sender clock is ahead");
+    // Negative delay means the sender's clock is ahead of ours; clamp to zero and report the skew.
+    let delay = match end_time.duration_since(start_time) {
+        Ok(delay) => delay,
+        Err(skew_error) => {
+            RECEIVE_MESSAGE_CLOCK_SKEW_SECONDS.set(skew_error.duration().as_secs_f64());
+            Duration::ZERO
+        }
+    };
     RECEIVE_MESSAGE_DELAY_SECONDS.record(delay.as_secs_f64());
 
     let indexed_message = IndexedMessage {

--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/metrics.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_node/metrics.rs
@@ -26,6 +26,7 @@ pub(crate) fn register_metrics() {
     RECEIVE_MESSAGE_COUNT.register();
     RECEIVE_MESSAGE_BYTES_SUM.register();
     RECEIVE_MESSAGE_DELAY_SECONDS.register();
+    RECEIVE_MESSAGE_CLOCK_SKEW_SECONDS.register();
     RECEIVE_MESSAGE_PENDING_COUNT.register();
 }
 

--- a/crates/apollo_network_benchmark/src/metrics.rs
+++ b/crates/apollo_network_benchmark/src/metrics.rs
@@ -14,6 +14,7 @@ define_metrics!(
         MetricCounter { RECEIVE_MESSAGE_COUNT, "receive_message_count", "Number of stress test messages received via broadcast", init = 0 },
         MetricCounter { RECEIVE_MESSAGE_BYTES_SUM, "receive_message_bytes_sum", "Sum of the stress test messages received via broadcast", init = 0 },
         MetricHistogram { RECEIVE_MESSAGE_DELAY_SECONDS, "receive_message_delay_seconds", "Message delay in seconds" },
+        MetricGauge { RECEIVE_MESSAGE_CLOCK_SKEW_SECONDS, "receive_message_clock_skew_seconds", "Clock skew in seconds when a sender's clock is ahead of the receiver" },
         MetricGauge { RECEIVE_MESSAGE_PENDING_COUNT, "receive_message_pending_count", "Number of stress test messages pending to be received" },
 
         MetricGauge { NETWORK_CONNECTED_PEERS, "network_connected_peers", "Number of connected peers in the network" },


### PR DESCRIPTION
## Goal
On a multi-node cluster, every received message computes `receive_time - send_time` and the node panicked whenever that was negative — i.e. when a sender's clock was even microseconds ahead. A live `--mode all` cluster run was killed by 17µs of inter-pod skew (the panic is in the shared receive path, so it hits every mode, not just `rr`), so the mesh never formed and no metrics came out.

## Summary of changes
Stop panicking on negative receive delay: clamp the latency sample to zero and record the observed skew in a new `RECEIVE_MESSAGE_CLOCK_SKEW_SECONDS` gauge (defined in the lib metrics, registered in the node, set from handlers.rs on each clamp).

## Key decision points
Record-and-clamp over the previous panic: the panic made every cluster run flaky (clocks are never perfectly synced across nodes), while sub-millisecond skew is harmless to the latency histogram once clamped. Surfacing skew as a metric rather than a hard in-code threshold lets operators see the magnitude — a dashboard stat flagging >1ms is added in a follow-up PR.