### PR TITLE
apollo_network_benchmark: opt benchmark namespace out of sleepod auto-sleep

### DIFF
--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_start.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/cluster_start.rs
@@ -81,6 +81,7 @@ fn write_json_files(
             )?,
         ),
         (headless_service_file_name.as_str(), STRESS_TEST_HEADLESS_SERVICE_JSON.to_string()),
+        ("sleep-policy.json", get_sleep_policy_json()?),
         ("prometheus-rbac.json", get_prometheus_rbac_json(namespace_name)?),
         ("prometheus-config.json", get_prometheus_json_file(args.shared.num_nodes)?),
         ("prometheus-statefulset.json", PROMETHEUS_DEPLOYMENT_JSON.to_string()),

--- a/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/yaml_maker.rs
+++ b/crates/apollo_network_benchmark/src/bin/apollo_network_benchmark_run/yaml_maker.rs
@@ -274,6 +274,21 @@ pub fn get_prometheus_rbac_json(namespace: &str) -> anyhow::Result<String> {
     generate_json(data)
 }
 
+/// Opts the namespace out of the cluster's `sleepod` controller, which otherwise scales the
+/// Prometheus/Grafana StatefulSets to zero during its nightly sleep window.
+pub fn get_sleep_policy_json() -> anyhow::Result<String> {
+    generate_json(json!({
+        "apiVersion": "sleepod.sleepod.io/v1alpha1",
+        "kind": "SleepPolicy",
+        "metadata": {"name": "default-sleeppolicy"},
+        "spec": {
+            "deployments": {"default": {"enable": false}},
+            "statefulSets": {"default": {"enable": false}},
+            "timezone": "UTC"
+        }
+    }))
+}
+
 pub fn get_grafana_configmap_json_file() -> anyhow::Result<String> {
     use crate::grafana_config::*;
 


### PR DESCRIPTION
## Goal
On sequencer-dev the cluster's sleepod controller sleeps StatefulSets by default on a nightly 20:00-05:00 UTC schedule. A benchmark started in that window has its Prometheus/Grafana StatefulSets scaled to 0 ~20s after deploy, so the dashboards never come up.

## Summary of changes
`cluster start` now deploys a SleepPolicy (deployments + statefulSets `enable: false`) into the run's namespace alongside the existing prometheus-rbac, opting the namespace out of sleepod. It's namespaced, applied by the same kubectl bundle, and removed with the namespace on `cluster stop`.

## Key decision points
Opt-out policy over a manual `kubectl scale` (which the controller can re-apply during the sleep window) — this is the controller's own documented exclusion, matching what the echonet namespaces do. Applied in the deploy bundle so it is in place before the controller's ~20s (SLEEPOD_NAMESPACE_DELAY_SECONDS) first reconcile. No new RBAC: a namespaced SleepPolicy is less privileged than the cluster-scoped ClusterRole the tool already creates for Prometheus.