### PR TITLE
starknet_transaction_prover: treat non-success blocking-check status as inconclusive

### DIFF
--- a/crates/starknet_transaction_prover/src/blocking_check.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check.rs
@@ -117,6 +117,15 @@ impl BlockingCheckClient {
                 }
             };
 
+        // Only a 2xx response carries a trustworthy decision. A non-success status (e.g. a 5xx
+        // from a broken upstream) may still return a body without an `error` field, which would
+        // otherwise deserialize to `Allowed` and bypass the operator's fail-close policy.
+        let status = response.status();
+        if !status.is_success() {
+            warn!("Blocking check returned non-success HTTP status: {status}");
+            return BlockingCheckResult::Inconclusive;
+        }
+
         let body = match response.text().await {
             Ok(text) => text,
             Err(err) => {

--- a/crates/starknet_transaction_prover/src/blocking_check_test.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check_test.rs
@@ -144,6 +144,25 @@ async fn test_network_error_returns_inconclusive() {
 }
 
 #[tokio::test]
+async fn test_non_success_status_without_error_field_returns_inconclusive() {
+    // A broken upstream may return a 5xx whose body lacks an `error` field. Without a status
+    // check this would deserialize to `Allowed` and bypass the operator's fail-close policy.
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(500)
+        .with_body(r#"{"jsonrpc":"2.0","id":1}"#)
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    assert_eq!(result, BlockingCheckResult::Inconclusive);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn test_malformed_response_returns_inconclusive() {
     let mut server = Server::new_async().await;
     let mock = server.mock("POST", "/").with_status(200).with_body("not json").create_async().await;


### PR DESCRIPTION
## What

The blocking check (`starknet_checkTransaction`) never inspected the HTTP status of the upstream response. Because `error` is `#[serde(default)]`, **any** JSON body lacking an `error` field — e.g. a `500` returning `{"jsonrpc":"2.0","id":1}` from a broken/overloaded upstream — deserialized with `error: None` and mapped to `BlockingCheckResult::Allowed`, which proceeds straight to proving.

This **fails open**: an upstream failure the operator intended to deny (`fail_open=false`) was silently allowed for any non-error-shaped body, bypassing the fail-close policy entirely.

## Fix

Check `response.status().is_success()` before reading/parsing the body. On a non-success status, return `Inconclusive` so the configured `fail_open` / `fail_close` policy is honored (rather than implicitly allowing).

## Test

Adds `test_non_success_status_without_error_field_returns_inconclusive` — a `500` with `{"jsonrpc":"2.0","id":1}` now returns `Inconclusive` (previously `Allowed`). Full `blocking_check` suite (16 tests) passes.

> Found during a verification sweep of an autonomous bug-hunt report; this is bug #3 of that report. Scoped to this one fix per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)