### PR TITLE
apollo_consensus_orchestrator: fix inverted round comparison discarding queued proposals

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1090,14 +1090,17 @@ impl ConsensusContext for SequencerConsensusContext {
         let mut to_process = None;
         while let Some(entry) = self.queued_proposals.first_entry() {
             match self.current_round.cmp(entry.key()) {
-                std::cmp::Ordering::Less => {
+                // The queued proposal is for a past round; drop it and keep scanning.
+                std::cmp::Ordering::Greater => {
                     entry.remove();
                 }
+                // The queued proposal is for the current round; take it and stop.
                 std::cmp::Ordering::Equal => {
                     to_process = Some(entry.remove());
                     break;
                 }
-                std::cmp::Ordering::Greater => return Ok(()),
+                // The queued proposal is for a future round; preserve it for later.
+                std::cmp::Ordering::Less => break,
             }
         }
         // Validate the proposal for the current round if exists.

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -344,6 +344,53 @@ async fn proposals_from_different_rounds() {
     assert!(fin_receiver_future_round.now_or_never().is_none());
 }
 
+// Regression test: a round skip (e.g. round 1 times out) must not strand a queued future
+// proposal nor permanently poison the queue. Previously the round comparison in
+// set_height_and_round was inverted, so a queued proposal for a skipped past round caused an
+// early return that halted consensus liveness for the height.
+#[tokio::test]
+async fn skipped_round_does_not_block_future_proposal() {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.setup_deps_for_validate(SetupDepsArgs::default());
+    let mut context = deps.build_context();
+    // Initialize the context for a specific height, starting with round 0.
+    context.set_height_and_round(HEIGHT_0, ROUND_0).await.unwrap();
+
+    let prop_part_txs =
+        ProposalPart::Transactions(TransactionBatch { transactions: TX_BATCH.to_vec() });
+    let prop_part_fin = ProposalPart::Fin(ProposalFin {
+        proposal_commitment: *TEST_PROPOSAL_COMMITMENT,
+        executed_transaction_count: INTERNAL_TX_BATCH.len().try_into().unwrap(),
+        fin_payload: Some(ProposalFinPayload::default()),
+    });
+
+    // Queue a proposal for round 1 (a future round while we are at round 0).
+    let (mut content_sender_round_1, content_receiver_round_1) =
+        mpsc::channel(context.config.static_config.proposal_buffer_size);
+    content_sender_round_1.send(prop_part_txs.clone()).await.unwrap();
+    let fin_receiver_round_1 = context
+        .validate_proposal(proposal_init(HEIGHT_0, ROUND_1), TIMEOUT, content_receiver_round_1)
+        .await;
+
+    // Queue a proposal for round 2 (also a future round while we are at round 0).
+    let (mut content_sender_round_2, content_receiver_round_2) =
+        mpsc::channel(context.config.static_config.proposal_buffer_size);
+    content_sender_round_2.send(prop_part_txs.clone()).await.unwrap();
+    content_sender_round_2.send(prop_part_fin.clone()).await.unwrap();
+    let fin_receiver_round_2 = context
+        .validate_proposal(proposal_init(HEIGHT_0, 2), TIMEOUT, content_receiver_round_2)
+        .await;
+
+    // Advance directly to round 2, skipping round 1 (e.g. round 1 timed out).
+    context.set_height_and_round(HEIGHT_0, 2).await.unwrap();
+
+    // The skipped round-1 proposal is discarded; its fin sender is dropped.
+    assert!(fin_receiver_round_1.await.is_err());
+    // The round-2 proposal is found in the queue and validated, proving the skipped past round
+    // did not poison the queue.
+    assert_eq!(fin_receiver_round_2.await.unwrap(), *TEST_PROPOSAL_COMMITMENT);
+}
+
 #[tokio::test]
 async fn interrupt_active_proposal() {
     let (mut deps, _network) = create_test_and_network_deps();


### PR DESCRIPTION
## Summary

Fixes **H-20** from the Sequencer Security Report (June 2026): *Backwards Comparison of Queued Proposals' Rounds Discards Future Proposals and Permanently Halts Consensus Liveness*.

In `SequencerConsensusContext::set_height_and_round`, the comparison between `self.current_round` and a queued proposal's round (`entry.key()`) was inverted:

- `Ordering::Less` (queued proposal is for a **future** round) → deleted the proposal instead of keeping it.
- `Ordering::Greater` (queued proposal is for a **past** round) → returned `Ok(())` early instead of cleaning it up.

The early-return path is the dangerous one: a stale past-round entry sits at the front of the `BTreeMap` and poisons the queue. Every subsequent round advancement hits it and returns early, so the current/future-round proposals are never validated — a permanent consensus liveness halt for the height.

## Fix

Correct the match arms:
- `Greater` (past round) → `entry.remove()` and keep scanning.
- `Equal` (current round) → take and process.
- `Less` (future round) → `break`, preserving it for later.

## Test

Added `skipped_round_does_not_block_future_proposal`: queues proposals for rounds 1 and 2 while at round 0, advances directly to round 2 (round 1 skipped), and asserts the stale round-1 proposal is dropped while the round-2 proposal is still validated.

Verified against the same test binary: the buggy version **hangs** (liveness halt — `fin_receiver` never resolves, killed by timeout, exit 124); the fixed version passes in 0.01s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)