### PR TITLE
starknet_api: guard L1HandlerTransaction::payload_size against empty calldata

### DIFF
--- a/crates/starknet_api/src/executable_transaction.rs
+++ b/crates/starknet_api/src/executable_transaction.rs
@@ -398,7 +398,10 @@ impl L1HandlerTransaction {
 
     pub fn payload_size(&self) -> usize {
         // The calldata includes the "from" field, which is not a part of the payload.
-        self.tx.calldata.0.len() - 1
+        // `saturating_sub` guards the empty-calldata case (which would otherwise underflow to
+        // `usize::MAX` in release): `L1HandlerTransaction` derives `Deserialize` and `Calldata`
+        // has no non-empty invariant.
+        self.tx.calldata.0.len().saturating_sub(1)
     }
 }
 

--- a/crates/starknet_api/src/executable_transaction_test.rs
+++ b/crates/starknet_api/src/executable_transaction_test.rs
@@ -1,7 +1,16 @@
+use std::sync::Arc;
+
 use rstest::rstest;
 use starknet_types_core::felt::Felt;
 
-use crate::executable_transaction::TransactionType;
+use crate::core::Nonce;
+use crate::executable_transaction::{L1HandlerTransaction, TransactionType};
+use crate::transaction::fields::{Calldata, Fee};
+use crate::transaction::{
+    L1HandlerTransaction as RpcL1HandlerTransaction,
+    TransactionHash,
+    TransactionVersion,
+};
 
 #[rstest]
 #[case::invoke(TransactionType::InvokeFunction, "0x494e564f4b455f46554e4354494f4e")]
@@ -10,4 +19,21 @@ use crate::executable_transaction::TransactionType;
 #[case::declare(TransactionType::Declare, "0x4445434c415245")]
 fn tx_type_as_hex_regression(#[case] tx_type: TransactionType, #[case] expected_hex: &str) {
     assert_eq!(tx_type.tx_type_as_felt(), Felt::from_hex_unchecked(expected_hex));
+}
+
+/// `Calldata` has no non-empty invariant and `L1HandlerTransaction` derives `Deserialize`, so an
+/// empty calldata is constructible. `payload_size` must not underflow (debug panic / release wrap
+/// to usize::MAX); the payload of an empty calldata is just 0.
+#[test]
+fn l1_handler_payload_size_empty_calldata_does_not_underflow() {
+    let tx = RpcL1HandlerTransaction {
+        version: TransactionVersion::ZERO,
+        nonce: Nonce::default(),
+        contract_address: Default::default(),
+        entry_point_selector: Default::default(),
+        calldata: Calldata(Arc::new(vec![])),
+    };
+    let executable_tx =
+        L1HandlerTransaction { tx, tx_hash: TransactionHash::default(), paid_fee_on_l1: Fee(0) };
+    assert_eq!(executable_tx.payload_size(), 0);
 }


### PR DESCRIPTION
## Summary

`L1HandlerTransaction::payload_size` (`executable_transaction.rs:401`) computed `self.tx.calldata.0.len() - 1` unconditionally. `Calldata` is `Arc<Vec<Felt>>` with no non-empty invariant and `L1HandlerTransaction` derives `Deserialize`, so an empty calldata is constructible. On empty calldata this **panics in debug** ("attempt to subtract with overflow") or **wraps to `usize::MAX` in release**, which would corrupt downstream fee/message-segment accounting (called in production from `blockifier/.../l1_handler_transaction.rs`).

## Fix

Use `saturating_sub(1)` — an empty calldata yields a payload size of `0`. The `calldata[0] == from_address` convention is unchanged for the normal (non-empty) case.

## Test

`l1_handler_payload_size_empty_calldata_does_not_underflow` constructs an executable `L1HandlerTransaction` with empty calldata and asserts `payload_size() == 0`.

Verified both directions:
- ✅ Passes on the fix.
- ✅ Fails on the old code — confirmed by reverting: panics with `attempt to subtract with overflow` at `executable_transaction.rs:401`.

`RUSTC_WRAPPER="" cargo test -p starknet_api --lib l1_handler_payload_size_empty_calldata_does_not_underflow`

## Scope note

This is the only fix in this PR. A sibling finding (`Fee::checked_div_ceil` unchecked `+1`) was investigated and **dropped**: its overflow is unreachable from the sole production caller (`to_discounted_l1_gas`), and even in the impossible regime that caller already `panic!`s via `unwrap_or_else`, so a fix would only change one panic message — no behavioral benefit.

Real L1 handlers are system-built from L1 events that always prepend `from_address`, so `payload_size` is also not reachable from untrusted input today; this is a low-cost defense-in-depth guard against a real wrong-value failure mode (wrap to `usize::MAX`), not an exploit fix.

---
*Found by the nightly bug-hunt routine. Re-verified present on `main-v0.14.3` (HEAD `578fbab67b`).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)