### PR TITLE
starknet_committer,apollo_storage: add shared StateCommitmentInfos compression codec

### DIFF
--- a/crates/apollo_committer_types/Cargo.toml
+++ b/crates/apollo_committer_types/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 description = "Type definitions and interfaces for the Apollo committer component."
 
 [features]
-os_input = ["dep:blockifier", "starknet_committer/os_input"]
+os_input = ["dep:blockifier", "starknet_committer/deserialize"]
 testing = ["mockall", "tokio"]
 
 [dependencies]

--- a/crates/apollo_storage/Cargo.toml
+++ b/crates/apollo_storage/Cargo.toml
@@ -7,7 +7,7 @@ license-file.workspace = true
 description = "A storage implementation for a Starknet node."
 
 [features]
-os_input = ["dep:blockifier", "dep:starknet_committer"]
+os_input = ["dep:blockifier", "dep:starknet_committer", "starknet_committer/os_input"]
 storage_cli = ["clap", "reqwest"]
 storage_validation = ["clap"]
 testing = ["reqwest", "starknet_api/testing", "tempfile", "tower"]

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -2,12 +2,12 @@
 
 use starknet_api::block::BlockNumber;
 pub use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfosCodecError;
 
 #[cfg(test)]
 #[path = "state_commitment_infos_test.rs"]
 mod state_commitment_infos_test;
 
-use crate::compression_utils::{compress, decompress};
 use crate::db::serialization::{StorageSerde, StorageSerdeError};
 use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
@@ -18,15 +18,22 @@ use crate::{OffsetKind, StorageResult, StorageTransaction};
 // bincode is positional and not schema-evolution tolerant, which is acceptable here.
 impl StorageSerde for StateCommitmentInfos {
     fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
-        let bytes = bincode::serialize(self)?;
-        let compressed = compress(bytes.as_slice())?;
+        let compressed = self.compress()?;
         compressed.serialize_into(res)
     }
 
     fn deserialize_from(bytes: &mut impl std::io::Read) -> Option<Self> {
         let compressed = Vec::<u8>::deserialize_from(bytes)?;
-        let data = decompress(compressed.as_slice()).ok()?;
-        bincode::deserialize(&data).ok()
+        Self::decompress(&compressed).ok()
+    }
+}
+
+impl From<StateCommitmentInfosCodecError> for StorageSerdeError {
+    fn from(error: StateCommitmentInfosCodecError) -> Self {
+        match error {
+            StateCommitmentInfosCodecError::Bincode(error) => StorageSerdeError::Bincode(error),
+            StateCommitmentInfosCodecError::Io(error) => StorageSerdeError::Io(error),
+        }
     }
 }
 

--- a/crates/starknet_committer/Cargo.toml
+++ b/crates/starknet_committer/Cargo.toml
@@ -7,7 +7,8 @@ license.workspace = true
 description = "Computes and manages Starknet state."
 
 [features]
-os_input = ["dep:bincode", "dep:blake2", "dep:digest", "dep:zstd"]
+deserialize = []
+os_input = ["deserialize", "dep:bincode", "dep:blake2", "dep:digest", "dep:zstd"]
 testing = ["starknet_patricia/testing"]
 
 [dependencies]

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -91,6 +91,31 @@ pub struct StateCommitmentInfos {
     pub storage_tries_commitment_infos: HashMap<ContractAddress, CommitmentInfo>,
 }
 
+#[cfg(feature = "os_input")]
+#[derive(Debug, thiserror::Error)]
+pub enum StateCommitmentInfosCodecError {
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+impl StateCommitmentInfos {
+    /// Bincode-serializes and zstd-compresses the commitment infos into a byte vector.
+    #[cfg(feature = "os_input")]
+    pub fn compress(&self) -> Result<Vec<u8>, StateCommitmentInfosCodecError> {
+        let bincode_payload = bincode::serialize(self)?;
+        Ok(zstd::encode_all(bincode_payload.as_slice(), zstd::DEFAULT_COMPRESSION_LEVEL)?)
+    }
+
+    /// Reverses [`StateCommitmentInfos::compress`]: zstd-decompresses then bincode-deserializes.
+    #[cfg(feature = "os_input")]
+    pub fn decompress(data: &[u8]) -> Result<Self, StateCommitmentInfosCodecError> {
+        let bincode_payload = zstd::decode_all(data)?;
+        Ok(bincode::deserialize(&bincode_payload)?)
+    }
+}
+
 impl StarknetForestProofs {
     pub fn build<Layout>(
         classes_trie_proof: PreimageMap,

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -57,8 +57,9 @@ pub struct StarknetForestProofs {
     pub contracts_trie_storage_proofs: HashMap<ContractAddress, PreimageMap>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "deserialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "deserialize", serde(deny_unknown_fields))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CommitmentInfo {
     pub previous_root: HashOutput,
     pub updated_root: HashOutput,
@@ -84,7 +85,8 @@ impl Default for CommitmentInfo {
 }
 
 /// Contains all commitment information for a block's state trees.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(feature = "deserialize", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct StateCommitmentInfos {
     pub contracts_trie_commitment_info: CommitmentInfo,
     pub classes_trie_commitment_info: CommitmentInfo,

--- a/crates/starknet_os/Cargo.toml
+++ b/crates/starknet_os/Cargo.toml
@@ -11,6 +11,7 @@ deserialize = [
   "blockifier/transaction_serde",
   "shared_execution_objects/deserialize",
   "starknet-types-core/serde",
+  "starknet_committer/deserialize",
   "starknet_patricia/deserialize",
 ]
 include_program_output = []


### PR DESCRIPTION
Add StateCommitmentInfos::compress/decompress (bincode + zstd) and a
StateCommitmentInfosCodecError on starknet_committer, and use them from
apollo_storage's StorageSerde impl in place of its local compress/decompress
helpers and inline bincode. A From<StateCommitmentInfosCodecError> for
StorageSerdeError preserves the underlying Bincode/Io variant.

apollo_storage/os_input now enables starknet_committer/os_input for the codec.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>