### PR TITLE
apollo_consensus_orchestrator: add per-attempt timeout to cende recorder client

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -152,9 +152,20 @@ impl CendeAmbassador {
                 .recorder_url
                 .join(RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH)
                 .expect("Failed to construct get latest received block URL"),
-            client: ClientBuilder::new(reqwest::Client::new())
-                .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-                .build(),
+            // Bound each attempt by the max retry interval. Without a per-attempt timeout
+            // `RetryTransientMiddleware` only retries attempts that *return* a transient error, so
+            // a request that hangs against a slow recorder would block until the build deadline
+            // instead of being retried. Capping an attempt at the backoff's upper bound turns such
+            // a hang into a timeout error the retry policy can act on, while leaving room for
+            // multiple attempts within `max_retry_duration_secs`.
+            client: ClientBuilder::new(
+                reqwest::Client::builder()
+                    .timeout(cende_config.max_retry_interval_ms)
+                    .build()
+                    .expect("Failed to build cende recorder client"),
+            )
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build(),
             class_manager,
         }
     }


### PR DESCRIPTION
## Problem

On Mainnet, isolated round>0 events trace to the proposer aborting its proposal with `CendeWriteError("Writing blob to Aerospike didn't return in time")`, which leaves validators with a truncated stream (`ProposalPartFailed`) and forces a round change.

Root cause: the cende recorder client is built with `reqwest::Client::new()` — **no per-request timeout**. `RetryTransientMiddleware` only retries attempts that *return* a transient error (connection refused, 5xx, …); it cannot preempt a request that is slow/hung (connection open, no response). So a single stalled request blocks until the proposer's build deadline, surfacing as the outer `tokio::time::timeout` firing — `CendeWriteError("…didn't return in time")` — with **zero retries actually attempted**. The retry policy only protected against the case it almost never needs (fast-failing errors), not the real failure mode (a slow recorder).

## Fix

Bound each attempt with `reqwest`'s per-request `.timeout()`, derived from the existing `max_retry_interval_ms` (no new config). A hang now fails fast as a timeout error, which `RetryTransientMiddleware` classifies as transient and retries — with room for multiple attempts within `max_retry_duration_secs`.

## Testing

- `cargo build -p apollo_consensus_orchestrator` ✅
- Note: the `testing`-feature test build is already broken on `main-v0.14.3` (`CentralTransactionExecutionInfo` lacks `Deserialize`/`PartialEq`), unrelated to this change, so the cende tests could not be run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)