### PR TITLE
apollo_mempool: track and prune delayed declares so they can't bypass eviction

### DIFF
--- a/crates/apollo_mempool/src/fee_mempool_test.rs
+++ b/crates/apollo_mempool/src/fee_mempool_test.rs
@@ -1752,13 +1752,76 @@ fn stale_delayed_declare_does_not_suppress_gap_detection() {
     commit_block(&mut mempool, [(addr, 1)], []);
     assert!(mempool.accounts_with_gap().contains(&contract_address!(addr)));
 
-    // Once the delay elapses, the stale declare is moved from delayed_declares into tx_pool
-    // (add_ready_declares has no nonce guard). It sits there with stale nonce 0 < account nonce
-    // 1, so it is never queued. The next commit_block will clean it up via
-    // remove_up_to_nonce_when_committed.
+    // commit_block prunes the now-stale delayed declare (nonce 0 < committed nonce 1), so it never
+    // reaches tx_pool. Once the delay elapses there is nothing left to pop.
     fake_clock.advance(declare_delay);
     mempool.get_txs(1).unwrap();
     assert!(mempool.mempool_snapshot().unwrap().delayed_declares.is_empty());
+}
+
+#[test]
+fn future_gap_delayed_declare_is_evictable_after_pop() {
+    let declare_delay = Duration::from_secs(100);
+    let fake_clock = Arc::new(FakeClock::default());
+    let mut mempool = Mempool::new(
+        MempoolConfig {
+            static_config: MempoolStaticConfig { declare_delay, ..Default::default() },
+            ..Default::default()
+        },
+        fake_clock.clone(),
+    );
+    let addr = "0x0";
+
+    // A declare with a future nonce (6) while the account is at nonce 5: it creates a gap and is
+    // the account's only transaction.
+    let mut gapped_declare = declare_add_tx_input(declare_tx_args!(
+        tx_hash: tx_hash!(1),
+        sender_address: contract_address!(addr),
+        nonce: nonce!(6)
+    ));
+    gapped_declare.account_state.nonce = nonce!(5);
+    add_tx(&mut mempool, &gapped_declare);
+    // Still buffered (not yet in the pool), so no gap is tracked yet.
+    assert!(!mempool.accounts_with_gap().contains(&contract_address!(addr)));
+
+    // After the delay the declare is popped into the pool. Its account must be tracked in
+    // accounts_with_gap so the stuck declare is evictable (otherwise it pollutes the mempool
+    // permanently, immune to eviction).
+    fake_clock.advance(declare_delay);
+    mempool.get_txs(1).unwrap();
+    assert!(mempool.accounts_with_gap().contains(&contract_address!(addr)));
+    assert!(mempool.mempool_snapshot().unwrap().transactions.contains(&tx_hash!(1)));
+}
+
+#[test]
+fn stale_delayed_declare_pruned_on_commit() {
+    let declare_delay = Duration::from_secs(100);
+    let fake_clock = Arc::new(FakeClock::default());
+    let mut mempool = Mempool::new(
+        MempoolConfig {
+            static_config: MempoolStaticConfig { declare_delay, ..Default::default() },
+            ..Default::default()
+        },
+        fake_clock.clone(),
+    );
+    let addr = "0x0";
+
+    // Delayed declare at nonce 5 (the account's only tx).
+    let declare = declare_add_tx_input(declare_tx_args!(
+        tx_hash: tx_hash!(1),
+        sender_address: contract_address!(addr),
+        nonce: nonce!(5)
+    ));
+    add_tx(&mut mempool, &declare);
+    assert_eq!(mempool.mempool_snapshot().unwrap().delayed_declares, vec![tx_hash!(1)]);
+
+    // Another sequencer commits the account past nonce 5; the buffered declare is now stale and
+    // can never execute. It must be pruned at commit, not inserted into the pool later (where it
+    // would be immune to eviction).
+    commit_block(&mut mempool, [(addr, 6)], []);
+    let snapshot = mempool.mempool_snapshot().unwrap();
+    assert!(snapshot.delayed_declares.is_empty());
+    assert!(!snapshot.transactions.contains(&tx_hash!(1)));
 }
 
 #[rstest]

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -112,6 +112,14 @@ impl MempoolState {
             .unwrap_or(incoming_account_nonce)
     }
 
+    /// Returns the committed Nonce for the address, ignoring staged (provisional, possibly
+    /// rewound) nonces. Falls back to incoming_account_nonce if no committed value is found. Used
+    /// to decide whether a transaction is stale (committed past), where staged nonces must not be
+    /// trusted since the staging block may not be committed.
+    fn committed_nonce(&self, address: ContractAddress, incoming_account_nonce: Nonce) -> Nonce {
+        self.committed.get(&address).copied().unwrap_or(incoming_account_nonce)
+    }
+
     fn contains_account(&self, address: ContractAddress) -> bool {
         self.staged.contains_key(&address) || self.committed.contains_key(&address)
     }
@@ -233,6 +241,23 @@ impl AddTransactionQueue {
             let tx = &tx_args.tx;
             tx.contract_address() == contract_address && tx.nonce() == nonce
         })
+    }
+
+    /// Removes every queued transaction for which `keep` returns `false`, keeping `size_in_bytes`
+    /// consistent.
+    fn retain(&mut self, mut keep: impl FnMut(&AddTransactionArgs) -> bool) {
+        let mut removed_bytes = 0;
+        self.elements.retain(|(_, args)| {
+            let should_keep = keep(args);
+            if !should_keep {
+                removed_bytes += args.tx.total_bytes();
+            }
+            should_keep
+        });
+        self.size_in_bytes = self
+            .size_in_bytes
+            .checked_sub(removed_bytes)
+            .expect("Underflow when pruning AddTransactionQueue.");
     }
 
     fn len(&self) -> usize {
@@ -599,14 +624,34 @@ impl Mempool {
 
     fn add_ready_declares(&mut self) {
         let now = self.clock.now();
+        // Collect the accounts of the popped declares so their nonce-gap status is (re)evaluated
+        // for eviction tracking. Without this, a popped declare with a nonce gap would never be
+        // added to `accounts_with_gap` and thus would be immune to eviction.
+        let mut account_nonce_updates = AddressToNonce::new();
         while let Some((submission_time, _args)) = self.delayed_declares.front() {
             if now - self.config.static_config.declare_delay < *submission_time {
                 break;
             }
             let (_submission_time, args) =
                 self.delayed_declares.pop_front().expect("Delay declare should exist.");
+            let address = args.account_state.address;
+            // Staleness is judged against the committed nonce only; staged nonces are provisional
+            // (the staging block may be rewound), so dropping against them could discard a valid
+            // declare.
+            let committed_nonce = self.state.committed_nonce(address, args.account_state.nonce);
+            if args.tx.nonce() < committed_nonce {
+                debug!(
+                    "Dropping stale delayed declare for account {address}: tx nonce {} < \
+                     committed nonce {committed_nonce}.",
+                    args.tx.nonce(),
+                );
+                continue;
+            }
+            account_nonce_updates
+                .insert(address, self.state.resolve_nonce(address, args.account_state.nonce));
             self.add_tx_inner(args);
         }
+        self.update_accounts_with_gap(account_nonce_updates);
         self.update_state_metrics();
     }
 
@@ -670,6 +715,19 @@ impl Mempool {
 
         // Committed nonces should overwrite rejected transactions.
         account_nonce_updates.extend(committed_nonce_updates);
+
+        // Prune delayed declares that became stale while waiting: their nonce was committed
+        // on-chain (e.g. by another sequencer) so they can never execute. Done after `state.commit`
+        // (which updated `committed` and cleared `staged`), so `resolve_nonce` reflects the
+        // committed nonce here. Pruning before `update_accounts_with_gap` lets it correctly
+        // re-detect any gap that the stale declare was masking.
+        {
+            let Mempool { state, delayed_declares, .. } = self;
+            delayed_declares.retain(|args| {
+                args.tx.nonce()
+                    >= state.resolve_nonce(args.account_state.address, args.account_state.nonce)
+            });
+        }
 
         self.update_accounts_with_gap(account_nonce_updates);
         self.update_state_metrics();


### PR DESCRIPTION
## Summary

Fixes **H-18** from the Sequencer Security Report (June 2026): *Eviction Bypass and Mempool Pollution via Popped and Stale Delayed Declare Transactions*.

The mempool buffers Declare transactions in `delayed_declares` and only evicts transactions from accounts tracked in `accounts_with_gap` (`try_make_space` → `get_evictable_account`). Two gaps let declares enter `tx_pool` while bypassing that tracking, so they could never be evicted:

1. **Missing gap tracking for popped declares.** `add_ready_declares` popped ready declares and inserted them via `add_tx_inner` but never called `update_accounts_with_gap`. A popped declare submitted with a future nonce (a gap) therefore landed in `tx_pool` without its account being added to `accounts_with_gap` → immune to eviction.
2. **Stale declares never pruned.** `commit_block` aligned `tx_pool`/state to committed nonces but never inspected `delayed_declares`. A declare whose nonce was committed on-chain (e.g. by another sequencer) while waiting was later popped and inserted stale (`nonce < state nonce`); `update_accounts_with_gap`'s gap check is `false` for it, so again immune.

An attacker with a funded account could submit future-nonce/stale declares (never executed → never charged) that permanently occupy `capacity_in_bytes`, eventually rejecting legitimate txs with `MempoolFull`.

## Fix

- **`add_ready_declares`**: collect the popped accounts and call `update_accounts_with_gap` (so popped gapped declares are tracked and evictable), and **drop** declares that are already stale (`tx nonce < committed nonce`) instead of inserting them. Staleness is judged against the **committed** nonce only — staged nonces are provisional (the staging block may be rewound), so judging against them could discard a still-valid declare.
- **`commit_block`**: prune stale delayed declares — done after `state.commit` (so `resolve_nonce` reflects the committed nonce and `staged` is cleared) and before `update_accounts_with_gap` (so any gap the stale declare was masking is re-detected).
- **`AddTransactionQueue`**: add a size-maintaining `retain` used by the prune.

## Tests

`fee_mempool_test.rs`:
- `future_gap_delayed_declare_is_evictable_after_pop` — a future-nonce declare that is an account's only tx is in `accounts_with_gap` after being popped (was absent → un-evictable before the fix).
- `stale_delayed_declare_pruned_on_commit` — a declare whose nonce is committed while buffered is pruned at `commit_block` and never enters `tx_pool`.
- Existing `stale_delayed_declare_does_not_suppress_gap_detection` still passes (comment updated to reflect commit-time pruning).

Full `apollo_mempool` suite (114 tests) passes; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)