### PR TITLE
apollo_l1_events: handle missing rejected tx in commit_txs gracefully

### DIFF
--- a/crates/apollo_l1_events/src/transaction_manager.rs
+++ b/crates/apollo_l1_events/src/transaction_manager.rs
@@ -149,8 +149,10 @@ impl TransactionManager {
         }
         for &tx_hash in rejected_txs {
             self.with_record(tx_hash, |r| r.mark_rejected()).expect(
-                "Storage inconsistency: a transaction sent to the batcher was removed \
-                 unexpectedly.",
+                "Rejected L1 handler tx has no record. Unreachable: all L1 handler txs in a \
+                 committed block were validated as known (validation rejects unknown hashes), \
+                 sync commits with empty rejected_txs, and records are only removed via L1 \
+                 cancellation/consumption, which can't race a block.",
             );
         }
     }


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>