### PR TITLE
apollo_infra_utils: resolve cargo_manifest_dir at runtime

### DIFF
--- a/crates/apollo_infra_utils/src/path.rs
+++ b/crates/apollo_infra_utils/src/path.rs
@@ -7,11 +7,23 @@ use tracing::error;
 #[path = "path_test.rs"]
 mod path_test;
 
-// TODO(Tsabary): find a stable way to get access to the current crate directory at compile time.
+/// Returns the current crate's manifest directory (`CARGO_MANIFEST_DIR`), resolved at runtime.
+///
+/// Cargo and nextest set `CARGO_MANIFEST_DIR` in the environment of the test/build process they
+/// spawn, so reading it at runtime yields the path of the checkout that is actually executing.
+/// Falls back to the compile-time `env!` value when the variable is absent (e.g. a binary run
+/// outside Cargo).
+///
+/// Runtime resolution is deliberate. `env!("CARGO_MANIFEST_DIR")` bakes the path in at compile
+/// time, and a shared `rustc-wrapper` cache (e.g. sccache with a shared cache directory) can serve
+/// an object that was compiled in a *different* checkout. In a git worktree that makes `env!`
+/// return another checkout's path, so `expect_file!`/fixture writes land in the wrong repository.
+/// Reading the variable at runtime always reflects the checkout that is executing.
 #[macro_export]
-macro_rules! compile_time_cargo_manifest_dir {
+macro_rules! cargo_manifest_dir {
     () => {
-        env!("CARGO_MANIFEST_DIR")
+        ::std::env::var("CARGO_MANIFEST_DIR")
+            .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string())
     };
 }
 
@@ -46,11 +58,7 @@ pub fn project_path() -> Result<PathBuf, std::io::Error> {
 fn path_of_project_root() -> PathBuf {
     // Ascend two directories to get to the project root. This assumes that the project root is two
     // directories above the current file.
-    PathBuf::from(compile_time_cargo_manifest_dir!())
-        .ancestors()
-        .nth(2)
-        .expect("Cannot navigate up")
-        .into()
+    PathBuf::from(cargo_manifest_dir!()).ancestors().nth(2).expect("Cannot navigate up").into()
 }
 
 // TODO(Tsabary/ Arni): consider alternatives.

--- a/crates/apollo_starknet_os_program/build/compile_program.rs
+++ b/crates/apollo_starknet_os_program/build/compile_program.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use apollo_infra_utils::cairo0_compiler::{compile_cairo0_program, Cairo0CompilerError};
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 
 pub async fn compile_and_output_program(
     out_dir: PathBuf,
@@ -56,5 +56,5 @@ pub async fn compile_test_contracts(out_dir: PathBuf) {
 }
 
 pub fn cairo_root_path() -> PathBuf {
-    PathBuf::from(compile_time_cargo_manifest_dir!()).join("src/cairo")
+    PathBuf::from(cargo_manifest_dir!()).join("src/cairo")
 }

--- a/crates/apollo_starknet_os_program/build/dump_source.rs
+++ b/crates/apollo_starknet_os_program/build/dump_source.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
 
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 
 /// Returns all cairo file paths in the given directory, recursively.
 pub fn get_cairo_file_paths(dir_path: &Path) -> Vec<PathBuf> {
@@ -33,7 +33,7 @@ pub fn dump_source_files(dump_to: &PathBuf) {
     println!("cargo::warning=Dumping OS source files...");
 
     // Recursively fetch all cairo files and contents, and convert the paths to relative paths.
-    let base_path = PathBuf::from(compile_time_cargo_manifest_dir!()).join("src/cairo");
+    let base_path = PathBuf::from(cargo_manifest_dir!()).join("src/cairo");
     let map_without_prefixes: HashMap<String, String> = get_cairo_file_paths(&base_path)
         .into_iter()
         .map(|path| {

--- a/crates/apollo_starknet_os_program/src/cairo_formatting_test.rs
+++ b/crates/apollo_starknet_os_program/src/cairo_formatting_test.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use apollo_infra_utils::cairo0_compiler_test_utils::cairo0_format_batch;
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use expect_test::expect_file;
 use rstest::rstest;
 
@@ -24,8 +24,7 @@ static CAIRO_FILES_TO_FORMAT: LazyLock<HashMap<String, String>> = LazyLock::new(
 #[test]
 fn test_cairo0_formatting() {
     // Get the path to the apollo_starknet_os directory.
-    let apollo_starknet_os_path =
-        PathBuf::from(compile_time_cargo_manifest_dir!()).join("src/cairo");
+    let apollo_starknet_os_path = PathBuf::from(cargo_manifest_dir!()).join("src/cairo");
 
     // Format all files in a single batch (much faster than per-file).
     let formatted_files = cairo0_format_batch(CAIRO_FILES_TO_FORMAT.clone());

--- a/crates/apollo_starknet_os_program/src/constants_test.rs
+++ b/crates/apollo_starknet_os_program/src/constants_test.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use apollo_infra_utils::cairo0_compiler_test_utils::cairo0_format;
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use blockifier::blockifier_versioned_constants::{OsConstants, VersionedConstants};
 use blockifier::execution::syscalls::vm_syscall_utils::SyscallSelector;
 use expect_test::expect_file;
@@ -246,8 +246,6 @@ fn generate_constants_file() -> String {
 fn test_os_constants() {
     // Generate `constants.cairo` from the current OS constants.
     let generated = generate_constants_file();
-    let path = PathBuf::from(compile_time_cargo_manifest_dir!())
-        .join("src/cairo")
-        .join(CONSTANTS_CAIRO_PATH);
+    let path = PathBuf::from(cargo_manifest_dir!()).join("src/cairo").join(CONSTANTS_CAIRO_PATH);
     expect_file![path].assert_eq(&generated);
 }

--- a/crates/apollo_starknet_os_program/src/program_hash_test.rs
+++ b/crates/apollo_starknet_os_program/src/program_hash_test.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use expect_test::expect_file;
 use tokio::task::spawn_blocking;
 
@@ -13,9 +13,8 @@ use crate::program_hash::{
     ProgramHashes,
 };
 
-static PROGRAM_HASH_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
-    PathBuf::from(compile_time_cargo_manifest_dir!()).join("src/program_hash.json")
-});
+static PROGRAM_HASH_PATH: LazyLock<PathBuf> =
+    LazyLock::new(|| PathBuf::from(cargo_manifest_dir!()).join("src/program_hash.json"));
 
 /// Asserts the program hash of the compiled Starknet OS program matches the program hash in the
 /// JSON.

--- a/crates/blockifier/src/versioned_constants_test.rs
+++ b/crates/blockifier/src/versioned_constants_test.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use cached::proc_macro::cached;
 use expect_test::expect_file;
 use glob::{glob, Paths};
@@ -17,7 +17,7 @@ use super::*;
 
 /// Returns all JSON files in the resources directory (should be all versioned constants files).
 fn all_jsons_in_dir() -> Paths {
-    glob(format!("{}/resources/*.json", compile_time_cargo_manifest_dir!()).as_str()).unwrap()
+    glob(format!("{}/resources/*.json", cargo_manifest_dir!()).as_str()).unwrap()
 }
 
 /// Assert versioned constants overrides are used when provided.

--- a/crates/blockifier_test_utils/src/compile_cache.rs
+++ b/crates/blockifier_test_utils/src/compile_cache.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use apollo_infra_utils::path::project_path;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use digest::Digest;
@@ -141,7 +141,7 @@ pub fn ensure_cairo1_compiled(contract: &FeatureContract) {
     let casm_path = cached_compiled_path(contract);
     let sierra_path = cached_sierra_path(contract);
     let version = contract.fixed_version();
-    let crate_root = PathBuf::from(compile_time_cargo_manifest_dir!());
+    let crate_root = PathBuf::from(cargo_manifest_dir!());
     let source_path = crate_root.join(contract.get_source_path());
     let libfunc_arg = contract.libfunc_arg();
     let abs_libfunc_arg = match &libfunc_arg {
@@ -188,7 +188,7 @@ pub fn ensure_cairo1_compiled(contract: &FeatureContract) {
 pub fn ensure_erc20_compiled_class_hashes() {
     let contract = FeatureContract::ERC20(CairoVersion::Cairo1(RunnableCairo1::Casm));
 
-    let crate_root = PathBuf::from(compile_time_cargo_manifest_dir!());
+    let crate_root = PathBuf::from(cargo_manifest_dir!());
     let casm_abs = crate_root.join(contract.get_compiled_path());
     let casm_content = fs::read_to_string(&casm_abs)
         .unwrap_or_else(|e| panic!("Cannot read ERC20 CASM at {casm_abs:?}: {e}"));

--- a/crates/blockifier_test_utils/src/contracts.rs
+++ b/crates/blockifier_test_utils/src/contracts.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use apollo_infra_utils::cairo_compiler_version::CAIRO1_COMPILER_VERSION;
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use cairo_lang_starknet_classes::contract_class::ContractClass as CairoLangContractClass;
 use starknet_api::contract_class::compiled_class_hash::HashVersion;
 use starknet_api::contract_class::SierraVersion;
@@ -599,7 +599,7 @@ pub fn get_raw_contract_class(contract_path: &str) -> String {
     let path: PathBuf = if std::path::Path::new(contract_path).is_absolute() {
         PathBuf::from(contract_path)
     } else {
-        [compile_time_cargo_manifest_dir!(), contract_path].iter().collect()
+        PathBuf::from(cargo_manifest_dir!()).join(contract_path)
     };
     fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("Failed to read contract from {path:?}: {e}"))

--- a/crates/central_systest_blobs/src/cende_blob_regression_test.rs
+++ b/crates/central_systest_blobs/src/cende_blob_regression_test.rs
@@ -20,7 +20,7 @@ use apollo_consensus_orchestrator::cende::{
 };
 use apollo_consensus_orchestrator::dynamic_gas_price::FeeProposalInfo;
 use apollo_consensus_orchestrator::fee_market::FeeMarketInfo;
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 use blockifier::blockifier::config::TransactionExecutorConfig;
 use blockifier::blockifier::transaction_executor::TransactionExecutor;
@@ -125,9 +125,8 @@ const GCS_ERROR_CODE_NOT_FOUND: u16 = 404;
 
 const BLOBS_BUCKET_NAME: &str = "apollo-central-systest-blobs";
 const BLOBS_FILE_NAME: &str = "blobs.json";
-static BLOBS_GENERATION_FILE: LazyLock<PathBuf> = LazyLock::new(|| {
-    PathBuf::from(compile_time_cargo_manifest_dir!()).join("resources/blob_file_generation")
-});
+static BLOBS_GENERATION_FILE: LazyLock<PathBuf> =
+    LazyLock::new(|| PathBuf::from(cargo_manifest_dir!()).join("resources/blob_file_generation"));
 
 static CHAIN_ID: LazyLock<ChainId> =
     LazyLock::new(|| ChainId::Other("SN_PREINTEGRATION_SEPOLIA".to_string()));

--- a/crates/starknet_transaction_prover/src/running/rpc_records.rs
+++ b/crates/starknet_transaction_prover/src/running/rpc_records.rs
@@ -20,7 +20,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use apollo_infra_utils::compile_time_cargo_manifest_dir;
+use apollo_infra_utils::cargo_manifest_dir;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::response::IntoResponse;
@@ -178,7 +178,7 @@ impl MockRpcServer {
 
 /// Returns the path to the RPC records directory for the starknet_transaction_prover crate.
 pub fn records_dir() -> PathBuf {
-    PathBuf::from(compile_time_cargo_manifest_dir!()).join("resources").join("rpc_records")
+    PathBuf::from(cargo_manifest_dir!()).join("resources").join("rpc_records")
 }
 
 /// Returns the path to a specific test's record file.


### PR DESCRIPTION
## Problem

`compile_time_cargo_manifest_dir!()` expands to `env!("CARGO_MANIFEST_DIR")`, which `rustc` bakes in **at compile time**. With a shared `rustc-wrapper` cache (sccache, default shared `~/.cache/sccache`), an object compiled in one checkout can be served to another. In a **git worktree** this makes the macro return a *different* checkout's manifest dir, so `expect_file!` / fixture-regeneration paths (program_hash.json, hint_coverage, cende `preconfirmed_block`, …) read/write the **wrong repository** — the test passes locally against the wrong copy and the worktree's committed fixtures stay stale (then fail CI).

This is a recurring footgun when regenerating fixtures from a worktree.

## Fix

Resolve `CARGO_MANIFEST_DIR` at **runtime** — Cargo and nextest set it in the test/build process environment, so it reflects the checkout that's actually executing — with a compile-time `env!` **fallback** for execution outside Cargo (e.g. deployed binaries; behavior there is unchanged).

Renamed `compile_time_cargo_manifest_dir!` → `cargo_manifest_dir!` since it no longer resolves at compile time. Pure mechanical rename across the 11 call sites; one array site in `contracts.rs` adjusted for the `String` return type.

## Verification

`cargo test -p apollo_infra_utils` passes (path_test exercises the runtime resolution). CI verifies the full build across the call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)