### PR TITLE
apollo_batcher: persist state commitment infos with the global root and block hash

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -67,6 +67,11 @@ use apollo_storage::partial_block_hash::{
 use apollo_storage::state::{StateStorageReader, StateStorageWriter};
 #[cfg(feature = "os_input")]
 use apollo_storage::state_commitment_infos::StateCommitmentInfosStorageReader;
+#[cfg(feature = "os_input")]
+use apollo_storage::state_commitment_infos::{
+    StateCommitmentInfos,
+    StateCommitmentInfosStorageWriter,
+};
 use apollo_storage::storage_reader_server::{
     DynamicConfigError,
     DynamicConfigProvider,
@@ -121,8 +126,6 @@ use starknet_api::core::{ContractAddress, GlobalRoot, Nonce, StateDiffCommitment
 use starknet_api::state::{StateNumber, ThinStateDiff};
 use starknet_api::transaction::fields::Calldata;
 use starknet_api::transaction::TransactionHash;
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use tokio::sync::Mutex;
 use tokio::task::AbortHandle;
 use tracing::{debug, error, info, instrument, trace, warn, Instrument};
@@ -1873,11 +1876,26 @@ pub trait BatcherStorageWriter: Send + Sync {
     /// Sets the global root and block hash (unless it's None) for the given height.
     /// Increments the block hash marker by 1.
     /// Block hash is optional because for old blocks, the block hash was set separately.
+    #[cfg(not(feature = "os_input"))]
     fn set_global_root_and_block_hash(
         &mut self,
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
+    ) -> StorageResult<()>;
+
+    /// Sets the global root and block hash (unless it's None) for the given height, and persists
+    /// the commitment infos (when present) in the same transaction.
+    /// Increments the block hash marker by 1.
+    /// Block hash is optional because for old blocks, the block hash was set separately.
+    /// Commitment infos are optional for blocks that doesn't come from decision_reached flow.
+    #[cfg(feature = "os_input")]
+    fn set_global_root_and_block_hash(
+        &mut self,
+        height: BlockNumber,
+        global_root: GlobalRoot,
+        block_hash: Option<BlockHash>,
+        state_commitment_infos: Option<StateCommitmentInfos>,
     ) -> StorageResult<()>;
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()>;
@@ -1923,10 +1941,20 @@ impl BatcherStorageWriter for StorageWriter {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
+        #[cfg(feature = "os_input")] state_commitment_infos: Option<StateCommitmentInfos>,
     ) -> StorageResult<()> {
+        #[cfg(not(feature = "os_input"))]
         info!(
             "Setting global root and block hash for height {height}. Root: {global_root:?}, Block \
              hash: {block_hash:?}."
+        );
+        #[cfg(feature = "os_input")]
+        info!(
+            "Setting global root and block hash for height {height}. Root: {global_root:?}, Block \
+             hash: {block_hash:?}, number of storage-trie commitment infos: {:?}.",
+            state_commitment_infos.as_ref().map(|state_commitment_infos| state_commitment_infos
+                .storage_tries_commitment_infos
+                .len())
         );
         let mut txn = self
             .begin_rw_txn()?
@@ -1934,6 +1962,10 @@ impl BatcherStorageWriter for StorageWriter {
             .checked_increment_global_root_marker(height)?;
         if let Some(block_hash) = block_hash {
             txn = txn.set_block_hash(&height, block_hash)?;
+        }
+        #[cfg(feature = "os_input")]
+        if let Some(state_commitment_infos) = state_commitment_infos {
+            txn = txn.append_state_commitment_infos(height, &state_commitment_infos)?;
         }
         txn.commit()
     }

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1827,12 +1827,17 @@ async fn get_block_hash_after_reading_commitment_results() {
         .expect_get_parent_hash_and_partial_block_hash_components()
         .with(eq(INITIAL_HEIGHT))
         .returning(move |_| Ok((Some(parent_hash), Some(partial_components.clone()))));
-    mock_dependencies
-        .storage_writer
-        .expect_set_global_root_and_block_hash()
-        .times(1)
+    let set_global_root_expectation =
+        mock_dependencies.storage_writer.expect_set_global_root_and_block_hash();
+    set_global_root_expectation.times(1);
+    #[cfg(not(feature = "os_input"))]
+    set_global_root_expectation
         .with(eq(INITIAL_HEIGHT), eq(global_root), always())
         .returning(|_, _, _| Ok(()));
+    #[cfg(feature = "os_input")]
+    set_global_root_expectation
+        .with(eq(INITIAL_HEIGHT), eq(global_root), always(), always())
+        .returning(|_, _, _, _| Ok(()));
 
     let mut batcher = create_batcher(mock_dependencies).await;
 

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
@@ -271,12 +271,17 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
             };
 
             // Get the final commitment.
-            let FinalBlockCommitment { height, block_hash, global_root } =
-                Self::finalize_commitment_output(
-                    storage_reader.clone(),
-                    commitment_task_output,
-                    should_finalize_block_hash,
-                )?;
+            let FinalBlockCommitment {
+                height,
+                block_hash,
+                global_root,
+                #[cfg(feature = "os_input")]
+                state_commitment_infos,
+            } = Self::finalize_commitment_output(
+                storage_reader.clone(),
+                commitment_task_output,
+                should_finalize_block_hash,
+            )?;
 
             // Verify the first new block hash matches the configured block hash.
             if let Some(FirstBlockWithPartialBlockHash {
@@ -304,7 +309,13 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
             }
 
             // Write the block hash and global root to storage.
-            storage_writer.set_global_root_and_block_hash(height, global_root, block_hash)?;
+            storage_writer.set_global_root_and_block_hash(
+                height,
+                global_root,
+                block_hash,
+                #[cfg(feature = "os_input")]
+                state_commitment_infos,
+            )?;
             GLOBAL_ROOT_HEIGHT.increment(1);
         }
 
@@ -515,13 +526,18 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
     // TODO(Amos): Test blocks [0,10] in OS flow tests.
     fn finalize_commitment_output<R: BatcherStorageReader + ?Sized>(
         storage_reader: Arc<R>,
-        CommitmentTaskOutput { response: CommitBlockResponse { global_root }, height }: CommitmentTaskOutput,
+        CommitmentTaskOutput {
+            response: CommitBlockResponse { global_root },
+            height,
+            #[cfg(feature = "os_input")]
+            state_commitment_infos,
+        }: CommitmentTaskOutput,
         should_finalize_block_hash: bool,
     ) -> CommitmentManagerResult<FinalBlockCommitment> {
-        match should_finalize_block_hash {
+        let block_hash = match should_finalize_block_hash {
             false => {
                 debug!("Finalized commitment for block {height} without calculating block hash.");
-                Ok(FinalBlockCommitment { height, block_hash: None, global_root })
+                None
             }
             true => {
                 debug!("Finalizing commitment for block {height} with calculating block hash.");
@@ -542,14 +558,20 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
                 debug!(
                     "Global root: {global_root:?}, previous block hash: {previous_block_hash:?}"
                 );
-                let block_hash = calculate_block_hash(
+                Some(calculate_block_hash(
                     &partial_block_hash_components,
                     global_root,
                     previous_block_hash,
-                )?;
-                Ok(FinalBlockCommitment { height, block_hash: Some(block_hash), global_root })
+                )?)
             }
-        }
+        };
+        Ok(FinalBlockCommitment {
+            height,
+            block_hash,
+            global_root,
+            #[cfg(feature = "os_input")]
+            state_commitment_infos,
+        })
     }
 
     fn update_task_duration_metric(

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
@@ -270,7 +270,7 @@ async fn test_add_missing_commitment_tasks(mut mock_dependencies: MockDependenci
 }
 
 /// When no accessed keys are stored for a height, the catch-up flow must fall back to `CommitBlock`
-/// (not `ReadPathsAndCommitBlock`).
+/// (not `ReadPathsAndCommitBlock`), and the resulting commitment carries no Patricia witnesses.
 #[cfg(feature = "os_input")]
 #[rstest]
 #[tokio::test]
@@ -325,6 +325,10 @@ async fn test_add_missing_commitment_tasks_without_accessed_keys(
     let results = await_items(&mut commitment_manager.results_receiver, 1).await;
     let result = results.first().unwrap().clone().expect_commitment();
     assert_eq!(result.height, global_root_height);
+    assert!(
+        result.state_commitment_infos.is_none(),
+        "The CommitBlock fallback should not produce commitment infos."
+    );
 }
 
 #[rstest]
@@ -396,12 +400,15 @@ async fn test_add_task_wait_for_full_channel(mut mock_dependencies: MockDependen
             .times(expected_n_calls.clone())
             .with(eq(height))
             .returning(|height| get_dummy_parent_hash_and_partial_block_hash_components(&height));
-        mock_dependencies
-            .storage_writer
-            .expect_set_global_root_and_block_hash()
-            .times(expected_n_calls)
-            .withf(move |h, _, _| *h == height)
-            .returning(|_, _, _| Ok(()));
+        let set_global_root_expectation =
+            mock_dependencies.storage_writer.expect_set_global_root_and_block_hash();
+        set_global_root_expectation.times(expected_n_calls);
+        #[cfg(not(feature = "os_input"))]
+        set_global_root_expectation.withf(move |h, _, _| *h == height).returning(|_, _, _| Ok(()));
+        #[cfg(feature = "os_input")]
+        set_global_root_expectation
+            .withf(move |h, _, _, _| *h == height)
+            .returning(|_, _, _, _| Ok(()));
     }
 
     let (mut commitment_manager, storage_reader, mut storage_writer) =

--- a/crates/apollo_batcher/src/commitment_manager/state_committer.rs
+++ b/crates/apollo_batcher/src/commitment_manager/state_committer.rs
@@ -118,13 +118,19 @@ async fn perform_task(
     }
 }
 
+/// Commits the block via `CommitBlock`, storing no Patricia witnesses.
 async fn perform_commit_block_task(
     commit_block_request: CommitBlockRequest,
     committer_client: &SharedCommitterClient,
 ) -> CommitterClientResult<CommitterTaskOutput> {
     let height = commit_block_request.height;
     let response = committer_client.commit_block(commit_block_request).await?;
-    Ok(CommitterTaskOutput::Commit(CommitmentTaskOutput { response, height }))
+    Ok(CommitterTaskOutput::Commit(CommitmentTaskOutput {
+        response,
+        height,
+        #[cfg(feature = "os_input")]
+        state_commitment_infos: None,
+    }))
 }
 
 /// Commits the block and fetches the Patricia witnesses for the accessed keys via
@@ -135,11 +141,12 @@ async fn perform_read_paths_and_commit_block_task(
     committer_client: &SharedCommitterClient,
 ) -> CommitterClientResult<CommitterTaskOutput> {
     let height = request.commit.height;
-    let ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos: _ } =
+    let ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos } =
         committer_client.read_paths_and_commit_block(request).await?;
     Ok(CommitterTaskOutput::ReadPathsAndCommitBlock(CommitmentTaskOutput {
         response: CommitBlockResponse { global_root },
         height,
+        state_commitment_infos: Some(state_commitment_infos),
     }))
 }
 

--- a/crates/apollo_batcher/src/commitment_manager/types.rs
+++ b/crates/apollo_batcher/src/commitment_manager/types.rs
@@ -13,6 +13,8 @@ use apollo_committer_types::committer_types::{
     RevertBlockResponse,
 };
 use apollo_committer_types::communication::CommitterRequestLabelValue;
+#[cfg(feature = "os_input")]
+use apollo_storage::state_commitment_infos::StateCommitmentInfos;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::GlobalRoot;
 use tracing::warn;
@@ -74,6 +76,10 @@ impl Display for CommitterTaskInput {
 pub(crate) struct CommitmentTaskOutput {
     pub(crate) response: CommitBlockResponse,
     pub(crate) height: BlockNumber,
+    // The commitment infos derived from the committer output. `None` when the block was committed
+    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    #[cfg(feature = "os_input")]
+    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
 }
 
 #[derive(Clone, Debug)]
@@ -125,6 +131,10 @@ pub(crate) struct FinalBlockCommitment {
     // cannot be finalized.
     pub(crate) block_hash: Option<BlockHash>,
     pub(crate) global_root: GlobalRoot,
+    // The commitment infos derived from the committer output. `None` when the block was committed
+    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    #[cfg(feature = "os_input")]
+    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
 }
 
 pub(crate) struct TaskTimer {

--- a/crates/apollo_reverts/src/lib.rs
+++ b/crates/apollo_reverts/src/lib.rs
@@ -14,6 +14,8 @@ use apollo_storage::global_root::GlobalRootStorageWriter;
 use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::partial_block_hash::PartialBlockHashComponentsStorageWriter;
 use apollo_storage::state::StateStorageWriter;
+#[cfg(feature = "os_input")]
+use apollo_storage::state_commitment_infos::StateCommitmentInfosStorageWriter;
 use apollo_storage::StorageWriter;
 use futures::future::pending;
 use futures::never::Never;
@@ -147,7 +149,11 @@ pub fn revert_block(storage_writer: &mut StorageWriter, target_block_marker: Blo
         .unwrap();
 
     #[cfg(feature = "os_input")]
-    let txn = txn.revert_accessed_keys(target_block_marker).unwrap();
+    let txn = txn
+        .revert_accessed_keys(target_block_marker)
+        .unwrap()
+        .revert_state_commitment_infos(target_block_marker)
+        .unwrap();
 
     txn.commit().unwrap();
 }


### PR DESCRIPTION
Extend set_global_root_and_block_hash to also persist the block's
StateCommitmentInfos (when present) in the same storage transaction, and revert
them alongside the global root and block hash. The commitment manager passes
None for now; the value is wired in once the committer returns it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

apollo_batcher: carry committer state commitment infos through to storage

The committer now returns StateCommitmentInfos from ReadPathsAndCommitBlock, so
CommitmentTaskOutput and FinalBlockCommitment carry them straight through to
set_global_root_and_block_hash (no derivation in the batcher). Updates the
commitment-manager tests accordingly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>