### PR TITLE
apollo_central_sync: return error on class type mismatch instead of panicking

### DIFF
--- a/crates/apollo_central_sync/src/sources/central/state_update_stream.rs
+++ b/crates/apollo_central_sync/src/sources/central/state_update_stream.rs
@@ -287,18 +287,17 @@ fn client_to_central_state_update(
                 )),
                 declared_classes: declared_classes
                     .into_iter()
-                    .map(|(class_hash, class)| {
-                        (class_hash, class.into_cairo1().expect("Expected Cairo1 class."))
-                    })
                     .zip(
                         declared_class_hashes
                             .into_iter()
                             .map(|hash_entry| hash_entry.compiled_class_hash),
                     )
                     .map(|((class_hash, class), compiled_class_hash)| {
-                        (class_hash, (compiled_class_hash, class))
+                        let cairo1_class =
+                            class.into_cairo1().ok_or(CentralError::BadContractClassType)?;
+                        Ok((class_hash, (compiled_class_hash, cairo1_class)))
                     })
-                    .collect(),
+                    .collect::<CentralResult<_>>()?,
                 migrated_compiled_classes: migrated_compiled_classes
                     .into_iter()
                     .map(|entry| (entry.class_hash, entry.compiled_class_hash))
@@ -306,9 +305,12 @@ fn client_to_central_state_update(
                 deprecated_declared_classes: deprecated_classes
                     .into_iter()
                     .map(|(class_hash, generic_class)| {
-                        (class_hash, generic_class.into_cairo0().expect("Expected Cairo0 class."))
+                        let cairo0_class = generic_class
+                            .into_cairo0()
+                            .ok_or(CentralError::BadContractClassType)?;
+                        Ok((class_hash, cairo0_class))
                     })
-                    .collect(),
+                    .collect::<CentralResult<_>>()?,
                 nonces,
             };
             // Filter out deployed contracts of new classes because since 0.11 new classes can not


### PR DESCRIPTION
## Problem

An audit identified two panic sites in `client_to_central_state_update` (in `state_update_stream.rs`):

```rust
class.into_cairo1().expect("Expected Cairo1 class.")
generic_class.into_cairo0().expect("Expected Cairo0 class.")
```

If the Feeder Gateway returns a Cairo 0 class where a Cairo 1 class is expected (or vice versa), these panic instead of returning an error.

**Blast radius**: the panic is not isolated to the sync task. Component server futures run in a `FuturesUnordered` without `tokio::spawn` isolation, so the panic propagates through `StateSyncRunner::start()` → `run_component_servers()` → `main()`, crashing the entire node process.

This can be triggered by:
- A buggy or misconfigured Feeder Gateway (e.g. during upgrades/rollbacks)
- A compromised FG or MITM returning wrong class types
- Misconfiguring the node to point at a test/staging gateway

## Fix

Replace both `.expect()` calls with `.ok_or(CentralError::BadContractClassType)?`.

`CentralError::BadContractClassType` was already defined but never used — it was clearly intended for exactly this case.

With the fix, a class type mismatch returns a `CentralSourceError`, which `is_recoverable` classifies as recoverable. The sync loop sleeps 3 seconds and retries from the same block (since it was never committed to storage). The node stays alive and auto-recovers when the FG returns correct data — no manual intervention needed.

Note: P2P sync already handles class type mismatches correctly via pattern matching and explicit error returns. This brings central sync in line with the same approach.