### PR TITLE
starknet_os_flow_tests: commit blocks with witnesses via IndexDb

### DIFF
--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_impl.rs
@@ -145,8 +145,8 @@ impl<S: StateCommitterTrait> CommitmentManager<S> {
 
     /// Adds a task to the tasks channel. If the tasks channel is full, the behavior depends on the
     /// config: if `panic_if_task_channel_full` is true, it will panic; otherwise, it will retry
-    /// after reading results from the tasks channel. Any other error when sending the task will
-    /// also cause a panic.
+    /// after reading results from the tasks channel.
+    /// Any other error when sending the task will also cause a panic.
     async fn add_task_with_retries<
         R: BatcherStorageReader + ?Sized,
         W: BatcherStorageWriter + ?Sized,

--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -651,6 +651,11 @@ fn update_metrics(
         modifications_counts,
         #[cfg(feature = "os_input")]
         fetched_witnesses_count,
+        // TODO(Yoav): Remove the ".." where os_input becomes default.
+        // It is needed now for including `BlockMeasurement::fetched_witnesses_count` where
+        // `starknet_committer/os_input` is enabled by other crates, while
+        // `apollo_committer/os_input` is disabled.
+        ..
     }: &BlockMeasurement,
 ) {
     BLOCKS_COMMITTED.increment(1);

--- a/crates/starknet_os_flow_tests/Cargo.toml
+++ b/crates/starknet_os_flow_tests/Cargo.toml
@@ -36,7 +36,7 @@ starknet_os = { workspace = true, features = ["include_program_output", "testing
 starknet_patricia = { workspace = true, features = ["testing"] }
 starknet_patricia_storage = { workspace = true, features = ["testing"] }
 starknet_proof_verifier.workspace = true
-starknet_transaction_prover.workspace = true
+starknet_transaction_prover = { workspace = true, features = ["os_input"] }
 strum.workspace = true
 tokio.workspace = true
 

--- a/crates/starknet_os_flow_tests/src/initial_state.rs
+++ b/crates/starknet_os_flow_tests/src/initial_state.rs
@@ -33,11 +33,11 @@ use starknet_api::transaction::constants::DEPLOY_CONTRACT_FUNCTION_ENTRY_POINT_N
 use starknet_api::transaction::fields::{Calldata, ContractAddressSalt, ValidResourceBounds};
 use starknet_api::{calldata, deploy_account_tx_args, invoke_tx_args};
 use starknet_committer::block_committer::input::StateDiff;
-use starknet_committer::db::facts_db::FactsDb;
 use starknet_committer::db::forest_trait::StorageInitializer;
+use starknet_committer::db::index_db::IndexDb;
 use starknet_patricia_storage::map_storage::MapStorage;
 use starknet_transaction_prover::running::committer_utils::{
-    commit_state_diff,
+    commit_state_diff_to_index_db,
     state_maps_to_committer_state_diff,
 };
 use starknet_types_core::felt::Felt;
@@ -126,7 +126,7 @@ impl ExecutedContracts {
 
 pub(crate) struct InitialState<S: FlowTestState> {
     pub(crate) updatable_state: S,
-    pub(crate) commitment_storage: MapStorage,
+    pub(crate) commitment_storage: IndexDb<MapStorage>,
     // Current patricia roots.
     pub(crate) contracts_trie_root_hash: HashOutput,
     pub(crate) classes_trie_root_hash: HashOutput,
@@ -280,19 +280,12 @@ fn create_default_initial_state_txs_and_contracts<const N: usize>(
 
 pub(crate) async fn commit_initial_state_diff(
     committer_state_diff: StateDiff,
-) -> (StateRoots, MapStorage) {
-    let mut facts_db = FactsDb::new(MapStorage::default());
-    let classes_trie_root = HashOutput::ROOT_OF_EMPTY_TREE;
-    let contract_trie_root = HashOutput::ROOT_OF_EMPTY_TREE;
-    let state_roots = commit_state_diff(
-        &mut facts_db,
-        contract_trie_root,
-        classes_trie_root,
-        committer_state_diff,
-    )
-    .await
-    .expect("Failed to commit initial state diff.");
-    (state_roots, facts_db.consume_storage())
+) -> (StateRoots, IndexDb<MapStorage>) {
+    let mut index_db = IndexDb::new(MapStorage::default());
+    let state_roots = commit_state_diff_to_index_db(&mut index_db, committer_state_diff)
+        .await
+        .expect("Failed to commit initial state diff.");
+    (state_roots, index_db)
 }
 
 pub(crate) fn get_initial_deploy_account_tx() -> DeployAccountTransaction {

--- a/crates/starknet_os_flow_tests/src/test_manager.rs
+++ b/crates/starknet_os_flow_tests/src/test_manager.rs
@@ -63,9 +63,6 @@ use starknet_committer::block_committer::input::{
     StarknetStorageValue,
     StateDiff,
 };
-use starknet_committer::db::facts_db::FactsDb;
-use starknet_committer::db::forest_trait::StorageInitializer;
-use starknet_os::commitment_infos::build_state_commitment_infos;
 use starknet_os::hints::hint_implementation::state_diff_encryption::utils::compute_public_keys;
 use starknet_os::io::os_input::{OsBlockInput, OsHints, OsHintsConfig, StarknetOsInput};
 use starknet_os::io::os_output::{MessageToL2, OsStateDiff, StarknetOsRunnerOutput};
@@ -79,7 +76,7 @@ use starknet_os::io::test_utils::validate_kzg_segment;
 use starknet_os::runner::{run_os_stateless, DEFAULT_OS_LAYOUT};
 use starknet_os::test_utils::coverage::expect_hint_coverage;
 use starknet_transaction_prover::running::committer_utils::{
-    commit_state_diff,
+    commit_state_diff_with_witnesses,
     commitment_state_diff_to_committer_state_diff,
     state_maps_to_committer_state_diff,
 };
@@ -859,15 +856,14 @@ impl<S: FlowTestState> TestBuilder<S> {
         // TODO(Yoni): make this func sync.
         let mut os_block_inputs = vec![];
         let mut state = CachedState::new(self.initial_state.updatable_state);
-        let mut map_storage = self.initial_state.commitment_storage;
+        let mut commitment_db = self.initial_state.commitment_storage;
         let base_block_context = self.initial_state.block_context;
 
-        // The state roots updated after each block.
+        // The initial state roots, used for block-hash computation in virtual OS mode.
         let base_block_state_roots = StateRoots {
             contracts_trie_root_hash: self.initial_state.contracts_trie_root_hash,
             classes_trie_root_hash: self.initial_state.classes_trie_root_hash,
         };
-        let mut previous_state_roots = base_block_state_roots;
 
         let use_kzg_da = self.os_hints_config.use_kzg_da;
         let mut current_block_hash = BlockHash::default();
@@ -933,28 +929,17 @@ impl<S: FlowTestState> TestBuilder<S> {
                 &commitment_state_diff,
                 &accessed_keys_versioned_constants,
             );
-            // Commit the state diff.
+            // Commit the state diff, building the OS-input commitment infos from the Patricia
+            // witness paths gathered during the commit.
             let committer_state_diff =
                 commitment_state_diff_to_committer_state_diff(commitment_state_diff);
-            let mut db = FactsDb::new(map_storage);
-            let new_state_roots = commit_state_diff(
-                &mut db,
-                previous_state_roots.contracts_trie_root_hash,
-                previous_state_roots.classes_trie_root_hash,
+            let (new_state_roots, commitment_infos) = commit_state_diff_with_witnesses(
+                &mut commitment_db,
                 committer_state_diff,
-            )
-            .await
-            .expect("Failed to commit state diff.");
-            map_storage = db.consume_storage();
-
-            let commitment_infos = build_state_commitment_infos(
-                &previous_state_roots,
-                &new_state_roots,
-                &mut map_storage,
                 &accessed_keys,
             )
             .await
-            .unwrap();
+            .expect("Failed to commit state diff.");
             let tx_execution_infos = execution_outputs
                 .into_iter()
                 .map(|(execution_info, _)| execution_info.into())
@@ -998,7 +983,6 @@ impl<S: FlowTestState> TestBuilder<S> {
                 initial_reads,
             };
             os_block_inputs.push(os_block_input);
-            previous_state_roots = new_state_roots;
         }
         let starknet_os_input = StarknetOsInput {
             os_block_inputs,

--- a/crates/starknet_os_flow_tests/src/tests.rs
+++ b/crates/starknet_os_flow_tests/src/tests.rs
@@ -84,11 +84,14 @@ use starknet_committer::block_committer::input::{
     StarknetStorageValue,
     StateDiff,
 };
+use starknet_committer::db::forest_trait::StorageInitializer;
+use starknet_committer::db::index_db::IndexDb;
 use starknet_committer::patricia_merkle_tree::types::CompiledClassHash;
 use starknet_core::crypto::ecdsa_sign;
 use starknet_crypto::{get_public_key, Signature};
 use starknet_os::hints::hint_implementation::deprecated_compiled_class::class_hash::compute_deprecated_class_hash;
 use starknet_os::hints::vars::Const;
+use starknet_patricia_storage::map_storage::MapStorage;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Pedersen, StarkHash};
 
@@ -3032,7 +3035,7 @@ async fn test_load_bottom() {
 async fn test_initial_empty_block() {
     let empty_initial_state = InitialState {
         updatable_state: DictStateReader::default(),
-        commitment_storage: Default::default(),
+        commitment_storage: IndexDb::new(MapStorage::default()),
         contracts_trie_root_hash: HashOutput::ROOT_OF_EMPTY_TREE,
         classes_trie_root_hash: HashOutput::ROOT_OF_EMPTY_TREE,
         block_context: block_context_for_flow_tests(BlockNumber(0), false),


### PR DESCRIPTION
Replace the temporary `commit_state_diff` + `build_state_commitment_infos` shim
with `commit_state_diff_with_witnesses`, exercising the committer's own
`commit_block_with_witnesses` path that builds `StateCommitmentInfos` from the
Patricia witnesses gathered during the commit.

This requires `IndexDb` (which reads the prior block's roots from its own
storage) rather than `FactsDb` (which takes explicit roots and cannot implement
the witness traits). Genesis and the per-block loop now carry one
`IndexDb<MapStorage>`, dropping the explicit `previous_state_roots` tracking.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>