### PR TITLE
apollo_l1_gas_price: enforce configured storage_limit in RingBuffer

### DIFF
--- a/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
@@ -31,17 +31,20 @@ use crate::metrics::{
 pub mod l1_gas_price_provider_test;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct RingBuffer<T>(VecDeque<T>);
+struct RingBuffer<T> {
+    queue: VecDeque<T>,
+    limit: usize,
+}
 impl<T: Clone> RingBuffer<T> {
-    fn new(size: usize) -> Self {
-        Self(VecDeque::with_capacity(size))
+    fn new(limit: usize) -> Self {
+        Self { queue: VecDeque::with_capacity(limit), limit }
     }
 
     fn push(&mut self, item: T) {
-        if self.0.len() == self.0.capacity() {
-            self.0.pop_front();
+        if self.queue.len() >= self.limit {
+            self.queue.pop_front();
         }
-        self.0.push_back(item);
+        self.queue.push_back(item);
     }
 }
 // Deref lets us use .iter() and .back(), etc.
@@ -51,7 +54,7 @@ impl<T: Clone> std::ops::Deref for RingBuffer<T> {
     type Target = VecDeque<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.queue
     }
 }
 

--- a/crates/apollo_l1_gas_price/src/l1_gas_price_provider_test.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_provider_test.rs
@@ -4,7 +4,7 @@ use apollo_l1_gas_price_config::config::L1GasPriceProviderConfig;
 use apollo_l1_gas_price_types::{GasPriceData, MockExchangeRateOracleClientTrait, PriceInfo};
 use starknet_api::block::{BlockTimestamp, GasPrice};
 
-use crate::l1_gas_price_provider::{L1GasPriceProvider, L1GasPriceProviderError};
+use crate::l1_gas_price_provider::{L1GasPriceProvider, L1GasPriceProviderError, RingBuffer};
 
 // Make a provider with five block prices. Timestamps are 2 seconds apart, starting from 0.
 // To get the prices for the middle three blocks use the timestamp for block[3].
@@ -39,6 +39,30 @@ fn make_provider() -> (L1GasPriceProvider, Vec<PriceInfo>, u64) {
             .unwrap();
     }
     (provider, prices, timestamp3)
+}
+
+#[test]
+fn ring_buffer_enforces_configured_limit() {
+    const LIMIT: usize = 3;
+    const NUM_VALUES_PUSHED: i32 = 100;
+    // After pushing 0..NUM_VALUES_PUSHED, only the most recent LIMIT values remain, oldest-first.
+    const EXPECTED_REMAINING: [i32; LIMIT] = [97, 98, 99];
+
+    let mut buffer = RingBuffer::new(LIMIT);
+
+    // Push well past the limit. The allocator may round the underlying VecDeque's capacity up
+    // above LIMIT, but the buffer must drop the oldest item and never retain more than LIMIT.
+    for value in 0..NUM_VALUES_PUSHED {
+        buffer.push(value);
+        assert!(
+            buffer.len() <= LIMIT,
+            "buffer retained {} items, exceeding limit {LIMIT}",
+            buffer.len()
+        );
+    }
+
+    let remaining: Vec<_> = buffer.iter().copied().collect();
+    assert_eq!(remaining, EXPECTED_REMAINING);
 }
 
 #[test]


### PR DESCRIPTION
## Goal
Fix audit finding **L-1**: the `RingBuffer` in `l1_gas_price_provider.rs` enforced the allocator's rounded-up `VecDeque::capacity()` as its size limit instead of the configured `storage_limit`. Since `with_capacity(n)` returns capacity `>= n` (allocator rounds up), the buffer retained more samples in memory than configured, so the operator-set limit had no precise effect.

## Changes
- `RingBuffer` now stores `limit` as an explicit field; `push` compares `len() >= limit` (popping the oldest) instead of `len() == capacity()`.
- `Deref` points at the inner `queue`; all read-side call sites (`.iter()`, `.back()`, indexing) are unchanged.
- Added `ring_buffer_enforces_configured_limit` regression test asserting the buffer never exceeds its limit across many pushes and retains only the most recent items.

## Decisions
- Kept the `RingBuffer` wrapper with `Deref` but no `DerefMut`, preserving the invariant that callers cannot grow the buffer past its limit (vs. inlining a bare `VecDeque`).

## Verification
`cargo build` and `cargo test -p apollo_l1_gas_price` pass (18 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)