### PR TITLE
blockifier: select address-derivation hash from versioned constants

### DIFF
--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -14,7 +14,7 @@ use serde::de::Error as DeserializationError;
 use serde::{Deserialize, Deserializer, Serialize};
 use starknet_api::block::{GasPrice, StarknetVersion};
 use starknet_api::contract_class::SierraVersion;
-use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::core::{AddressDerivationHash, ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::define_versioned_constants;
 use starknet_api::executable_transaction::TransactionType;
 use starknet_api::execution_resources::{GasAmount, GasVector};
@@ -461,6 +461,15 @@ impl VersionedConstants {
 
     pub fn disable_casm_hash_migration(&mut self) {
         self.enable_casm_hash_migration = false;
+    }
+
+    /// The hash function used to derive contract addresses for blocks under these constants.
+    pub fn address_derivation_hash(&self) -> AddressDerivationHash {
+        if self.use_blake_address_derivation {
+            AddressDerivationHash::Blake2
+        } else {
+            AddressDerivationHash::Pedersen
+        }
     }
 
     #[cfg(any(feature = "testing", test))]

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -20,7 +20,6 @@ use starknet_api::block::{BlockInfo, BlockNumber, BlockTimestamp};
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     calculate_contract_address,
-    AddressDerivationHash,
     ClassHash,
     ContractAddress,
     EntryPointSelector,
@@ -618,7 +617,7 @@ impl DeprecatedSyscallExecutor for DeprecatedSyscallHintProcessor<'_> {
             request.class_hash,
             &request.constructor_calldata,
             deployer_address_for_calculation,
-            AddressDerivationHash::Pedersen,
+            versioned_constants.address_derivation_hash(),
         )?;
 
         // Increment the Deploy syscall's linear cost counter by the number of elements in the

--- a/crates/blockifier/src/execution/syscalls/syscall_base.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_base.rs
@@ -8,7 +8,6 @@ use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     calculate_contract_address,
-    AddressDerivationHash,
     ClassHash,
     ContractAddress,
     EntryPointSelector,
@@ -408,7 +407,7 @@ impl<'state> SyscallHandlerBase<'state> {
             class_hash,
             &constructor_calldata,
             deployer_address_for_calculation,
-            AddressDerivationHash::Pedersen,
+            versioned_constants.address_derivation_hash(),
         )?;
 
         let ctor_context = ConstructorContext {

--- a/crates/blockifier/src/versioned_constants_test.rs
+++ b/crates/blockifier/src/versioned_constants_test.rs
@@ -9,6 +9,7 @@ use pretty_assertions::assert_eq;
 use rstest::rstest;
 use serde_json::Value;
 use starknet_api::block::StarknetVersion;
+use starknet_api::core::AddressDerivationHash;
 
 use super::*;
 
@@ -42,6 +43,18 @@ fn test_versioned_constants_overrides() {
     assert_eq!(result.validate_max_n_steps, updated_validate_max_n_steps);
     assert_eq!(result.max_recursion_depth, updated_max_recursion_depth);
     assert_eq!(result.tx_event_limits.max_n_emitted_events, updated_max_n_events);
+}
+
+/// Assert the address-derivation hash is selected by the `use_blake_address_derivation` flag.
+#[test]
+fn test_address_derivation_hash_selection() {
+    let mut versioned_constants = VersionedConstants::latest_constants().clone();
+
+    versioned_constants.use_blake_address_derivation = false;
+    assert_eq!(versioned_constants.address_derivation_hash(), AddressDerivationHash::Pedersen);
+
+    versioned_constants.use_blake_address_derivation = true;
+    assert_eq!(versioned_constants.address_derivation_hash(), AddressDerivationHash::Blake2);
 }
 
 #[rstest]


### PR DESCRIPTION
Add VersionedConstants::address_derivation_hash(), which maps the
use_blake_address_derivation flag to AddressDerivationHash, and use it in
the deploy and deprecated-deploy syscalls instead of a hardcoded Pedersen.
The flag is false in every version, so both paths still derive with
Pedersen - this only wires the selection. The deploy-account transaction
path has no VersionedConstants in scope and is handled in a later PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>