### PR TITLE
apollo_rpc_execution,blockifier_reexecution: version-gate deploy-account address and hash

### DIFF
--- a/crates/apollo_rpc_execution/src/execution_test.rs
+++ b/crates/apollo_rpc_execution/src/execution_test.rs
@@ -599,9 +599,7 @@ fn simulate_invoke_from_new_account_validate_and_charge() {
     let ((storage_reader, storage_writer), _temp_dir) = get_test_storage();
     prepare_storage(storage_writer);
 
-    // Taken from the trace of the deploy account transaction.
-    let new_account_address =
-        contract_address!("0x0153ade9ef510502c4f3b879c049dcc3ad5866706cae665f0d9df9b01e794fdb");
+    let new_account_address = *NEW_ACCOUNT_ADDRESS;
     let txs = TxsScenarioBuilder::default()
         // Invoke contract from a newly deployed account.
         .deploy_account()

--- a/crates/apollo_rpc_execution/src/lib.rs
+++ b/crates/apollo_rpc_execution/src/lib.rs
@@ -63,12 +63,19 @@ use starknet_api::block::{
     StarknetVersion,
 };
 use starknet_api::contract_class::{ClassInfo, EntryPointType, SierraVersion};
-use starknet_api::core::{ChainId, ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::core::{
+    AddressDerivationHash,
+    ChainId,
+    ClassHash,
+    ContractAddress,
+    EntryPointSelector,
+};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::state::{StateNumber, ThinStateDiff};
 use starknet_api::transaction::fields::{Calldata, Fee};
 use starknet_api::transaction::{
+    CalculateContractAddress,
     DeclareTransaction,
     DeclareTransactionV0V1,
     DeclareTransactionV2,
@@ -81,7 +88,7 @@ use starknet_api::transaction::{
     TransactionOptions,
     TransactionVersion,
 };
-use starknet_api::transaction_hash::get_transaction_hash;
+use starknet_api::transaction_hash::get_transaction_hash_with_address_derivation;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_api::StarknetApiError;
 use starknet_types_core::felt::Felt;
@@ -207,6 +214,8 @@ pub enum ExecutionError {
     TransactionExecutionError { transaction_index: usize, execution_error: String },
     #[error("Failed to calculate transaction hash.")]
     TransactionHashCalculationFailed(StarknetApiError),
+    #[error("Failed to calculate the deploy-account contract address.")]
+    DeployAccountAddressCalculationFailed(StarknetApiError),
     #[error("Unknown builtin name: {builtin_name}")]
     UnknownBuiltin { builtin_name: BuiltinName },
     #[error(transparent)]
@@ -466,9 +475,18 @@ pub enum ExecutableTransactionInput {
 impl ExecutableTransactionInput {
     // TODO(Dan, Yair): consider box large elements (because of BadDeclareTransaction) or use ID
     // instead.
-    fn calc_tx_hash(self, chain_id: &ChainId) -> ExecutionResult<(Self, TransactionHash)> {
+    fn calc_tx_hash(
+        self,
+        chain_id: &ChainId,
+        address_derivation_hash: AddressDerivationHash,
+    ) -> ExecutionResult<(Self, TransactionHash)> {
         match self.apply_on_transaction(|tx, only_query| {
-            get_transaction_hash(tx, chain_id, &TransactionOptions { only_query })
+            get_transaction_hash_with_address_derivation(
+                tx,
+                chain_id,
+                &TransactionOptions { only_query },
+                address_derivation_hash,
+            )
         }) {
             (original_tx, Ok(tx_hash)) => Ok((original_tx, tx_hash)),
             (_, Err(err)) => Err(ExecutionError::TransactionHashCalculationFailed(err)),
@@ -596,10 +614,11 @@ impl ExecutableTransactionInput {
 fn calc_tx_hashes(
     txs: Vec<ExecutableTransactionInput>,
     chain_id: &ChainId,
+    address_derivation_hash: AddressDerivationHash,
 ) -> ExecutionResult<(Vec<ExecutableTransactionInput>, Vec<TransactionHash>)> {
     Ok(txs
         .into_iter()
-        .map(|tx| tx.calc_tx_hash(chain_id))
+        .map(|tx| tx.calc_tx_hash(chain_id, address_derivation_hash))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .unzip())
@@ -711,7 +730,11 @@ fn execute_transactions(
     let (txs, tx_hashes) = match tx_hashes {
         Some(tx_hashes) => (txs, tx_hashes),
         None => {
-            let tx_hashes = calc_tx_hashes(txs, chain_id)?;
+            let tx_hashes = calc_tx_hashes(
+                txs,
+                chain_id,
+                block_context.versioned_constants().address_derivation_hash(),
+            )?;
             trace!("Calculated tx hashes: {:?}", tx_hashes);
             tx_hashes
         }
@@ -745,7 +768,14 @@ fn execute_transactions(
             ) => Some(*class_hash),
             _ => None,
         };
-        let blockifier_tx = to_blockifier_tx(tx, tx_hash, transaction_index, charge_fee, validate)?;
+        let blockifier_tx = to_blockifier_tx(
+            tx,
+            tx_hash,
+            transaction_index,
+            charge_fee,
+            validate,
+            block_context.versioned_constants().address_derivation_hash(),
+        )?;
         // TODO(Yoni): use the TransactionExecutor instead.
         let tx_execution_info_result =
             blockifier_tx.execute(&mut transactional_state, &block_context);
@@ -807,6 +837,7 @@ fn to_blockifier_tx(
     transaction_index: usize,
     charge_fee: bool,
     validate: bool,
+    address_derivation_hash: AddressDerivationHash,
 ) -> ExecutionResult<BlockifierTransaction> {
     // TODO(yair): support only_query version bit (enable in the RPC v0.6 and use the correct
     // value).
@@ -829,12 +860,17 @@ fn to_blockifier_tx(
         ExecutableTransactionInput::DeployAccount(deploy_acc_tx, only_query) => {
             let execution_flags =
                 ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check };
+            // Derive the deployed address with the block's versioned-constants hash so it matches
+            // the address the block's execution deploys (Pedersen pre-0.14.4, Blake2 from 0.14.4).
+            let deployed_contract_address = deploy_acc_tx
+                .calculate_contract_address(address_derivation_hash)
+                .map_err(ExecutionError::DeployAccountAddressCalculationFailed)?;
             BlockifierTransaction::from_api(
                 Transaction::DeployAccount(deploy_acc_tx),
                 tx_hash,
                 None,
                 None,
-                None,
+                Some(deployed_contract_address),
                 execution_flags,
             )
             .map_err(|err| ExecutionError::from((transaction_index, err)))

--- a/crates/apollo_rpc_execution/src/test_utils.rs
+++ b/crates/apollo_rpc_execution/src/test_utils.rs
@@ -6,6 +6,7 @@ use apollo_storage::compiled_class::CasmStorageWriter;
 use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::state::StateStorageWriter;
 use apollo_storage::{StorageReader, StorageWriter};
+use blockifier::blockifier_versioned_constants::VersionedConstants;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use indexmap::indexmap;
 use lazy_static::lazy_static;
@@ -23,11 +24,18 @@ use starknet_api::block::{
 };
 use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
 use starknet_api::contract_class::SierraVersion;
-use starknet_api::core::{ChainId, ClassHash, ContractAddress, Nonce, SequencerContractAddress};
+use starknet_api::core::{
+    calculate_contract_address,
+    ChainId,
+    ClassHash,
+    ContractAddress,
+    Nonce,
+    SequencerContractAddress,
+};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::state::{SierraContractClass, StateNumber, ThinStateDiff};
 use starknet_api::test_utils::read_json_file;
-use starknet_api::transaction::fields::Fee;
+use starknet_api::transaction::fields::{Calldata, ContractAddressSalt, Fee};
 use starknet_api::transaction::{
     DeclareTransactionV0V1,
     DeclareTransactionV2,
@@ -37,6 +45,7 @@ use starknet_api::transaction::{
     InvokeTransactionV1,
     TransactionHash,
 };
+use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_api::{calldata, class_hash, compiled_class_hash, contract_address, felt, nonce};
 use starknet_types_core::felt::Felt;
 
@@ -60,9 +69,17 @@ lazy_static! {
     pub static ref CONTRACT_ADDRESS: ContractAddress = contract_address!("0x2");
     pub static ref ACCOUNT_CLASS_HASH: ClassHash = class_hash!("0x333");
     pub static ref ACCOUNT_ADDRESS: ContractAddress = contract_address!("0x444");
-    // Taken from the trace of the deploy account transaction.
-    pub static ref NEW_ACCOUNT_ADDRESS: ContractAddress =
-        contract_address!("0x0153ade9ef510502c4f3b879c049dcc3ad5866706cae665f0d9df9b01e794fdb");
+    // The address of the account deployed by `TxsScenarioBuilder::deploy_account` (default salt
+    // and empty constructor calldata). Derived with the latest versioned constants' hash so it
+    // tracks the active address-derivation scheme (Pedersen, or Blake2 from 0.14.4).
+    pub static ref NEW_ACCOUNT_ADDRESS: ContractAddress = calculate_contract_address(
+        ContractAddressSalt::default(),
+        *ACCOUNT_CLASS_HASH,
+        &Calldata::default(),
+        ContractAddress::default(),
+        VersionedConstants::latest_constants().address_derivation_hash(),
+    )
+    .unwrap();
     pub static ref TEST_ERC20_CONTRACT_CLASS_HASH: ClassHash = class_hash!("0x1010");
     pub static ref TEST_ERC20_CONTRACT_ADDRESS: ContractAddress = contract_address!("0x1001");
     pub static ref ACCOUNT_INITIAL_BALANCE: Felt = felt!(2 * MAX_FEE.0);

--- a/crates/blockifier_reexecution/src/state_reader/offline_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/offline_state_reader.rs
@@ -109,7 +109,10 @@ impl From<SerializableOfflineReexecutionData> for OfflineReexecutionData {
         // Use the declared classes from the reexecuted block to allow retrieving the class info.
         let reexecuted_block_transactions =
             OfflineStateReader { contract_class_mapping: declared_classes, ..Default::default() }
-                .api_txs_to_blockifier_txs(reexecuted_block_transactions)
+                .api_txs_to_blockifier_txs(
+                    reexecuted_block_transactions,
+                    VersionedConstants::get(&starknet_version).unwrap().address_derivation_hash(),
+                )
                 .expect("Failed to convert starknet-api transactions to blockifier transactions.");
 
         let mut versioned_constants = VersionedConstants::get(&starknet_version).unwrap().clone();

--- a/crates/blockifier_reexecution/src/state_reader/reexecution_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/reexecution_state_reader.rs
@@ -9,10 +9,10 @@ use blockifier::transaction::transaction_execution::Transaction as BlockifierTra
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::block_hash::block_hash_calculator::TransactionHashingData;
 use starknet_api::contract_class::{ClassInfo, SierraVersion};
-use starknet_api::core::ClassHash;
+use starknet_api::core::{AddressDerivationHash, ClassHash};
 use starknet_api::state::SierraContractClass;
 use starknet_api::transaction::fields::{Fee, TransactionSignature};
-use starknet_api::transaction::{Transaction, TransactionHash};
+use starknet_api::transaction::{CalculateContractAddress, Transaction, TransactionHash};
 use starknet_core::types::ContractClass as StarknetContractClass;
 use tokio::runtime::Handle;
 
@@ -64,18 +64,32 @@ pub trait ReexecutionStateReader {
     fn api_txs_to_blockifier_txs(
         &self,
         txs_and_hashes: Vec<(Transaction, TransactionHash)>,
+        address_derivation_hash: AddressDerivationHash,
     ) -> ReexecutionResult<Vec<BlockifierTransaction>> {
         let execution_flags = ExecutionFlags::default();
         txs_and_hashes
             .into_iter()
             .map(|(tx, tx_hash)| match tx {
-                Transaction::Invoke(_) | Transaction::DeployAccount(_) => {
+                Transaction::Invoke(_) => Ok(BlockifierTransaction::from_api(
+                    tx,
+                    tx_hash,
+                    None,
+                    None,
+                    None,
+                    execution_flags.clone(),
+                )?),
+                Transaction::DeployAccount(ref deploy_account_tx) => {
+                    // Derive the deployed address with the re-executed block's versioned-constants
+                    // hash so it matches the address the block originally deployed (Pedersen
+                    // pre-0.14.4, Blake2 from 0.14.4).
+                    let deployed_contract_address =
+                        deploy_account_tx.calculate_contract_address(address_derivation_hash)?;
                     Ok(BlockifierTransaction::from_api(
                         tx,
                         tx_hash,
                         None,
                         None,
-                        None,
+                        Some(deployed_contract_address),
                         execution_flags.clone(),
                     )?)
                 }

--- a/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
+++ b/crates/blockifier_reexecution/src/state_reader/rpc_state_reader.rs
@@ -28,9 +28,17 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockInfo, BlockNumber};
 use starknet_api::contract_class::SierraVersion;
-use starknet_api::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::core::{
+    AddressDerivationHash,
+    ChainId,
+    ClassHash,
+    CompiledClassHash,
+    ContractAddress,
+    Nonce,
+};
 use starknet_api::state::{SierraContractClass, StorageKey};
-use starknet_api::transaction::{Transaction, TransactionHash};
+use starknet_api::transaction::{Transaction, TransactionHash, TransactionOptions};
+use starknet_api::transaction_hash::get_transaction_hash_with_address_derivation;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_core::types::ContractClass as StarknetContractClass;
 use starknet_types_core::felt::Felt;
@@ -596,6 +604,14 @@ impl RpcBlockReexecutor {
         Ok(self.reexecuted_block_with_txs_cache.get_or_init(|| block_with_txs))
     }
 
+    /// The address-derivation hash of the re-executed block's Starknet version (Pedersen
+    /// pre-0.14.4, Blake2 from 0.14.4), used to derive deploy-account addresses consistently
+    /// with the block.
+    fn address_derivation_hash(&self) -> ReexecutionResult<AddressDerivationHash> {
+        Ok(VersionedConstants::get(&self.reexecuted_block_with_txs()?.block_info.starknet_version)?
+            .address_derivation_hash())
+    }
+
     pub fn get_block_header(&self) -> ReexecutionResult<BlockHeader> {
         Ok(self.reexecuted_block_with_txs()?.block_header.clone())
     }
@@ -606,8 +622,10 @@ impl RpcBlockReexecutor {
         let block_with_txs = self.reexecuted_block_with_txs()?;
         // Trigger api → blockifier conversion so the contract_class_mapping_dumper picks up every
         // declared class referenced by these transactions.
-        self.reexecuted_block_artifacts_reader
-            .api_txs_to_blockifier_txs(block_with_txs.transactions.clone())?;
+        self.reexecuted_block_artifacts_reader.api_txs_to_blockifier_txs(
+            block_with_txs.transactions.clone(),
+            self.address_derivation_hash()?,
+        )?;
         let declared_classes =
             self.reexecuted_block_artifacts_reader.get_contract_class_mapping_dumper().ok_or(
                 StateError::StateReadError("Contract class mapping dumper is None.".to_string()),
@@ -636,11 +654,18 @@ impl RpcBlockReexecutor {
         tx: Transaction,
     ) -> ReexecutionResult<(TransactionExecutionOutput, StateMaps, BlockContext)> {
         let chain_id = &self.reexecuted_block_artifacts_reader.chain_info.chain_id;
-        let transaction_hash = tx.calculate_transaction_hash(chain_id)?;
-
+        let address_derivation_hash = self.address_derivation_hash()?;
+        // Recompute the tx hash with the block's address-derivation hash so a deploy-account hash
+        // embeds the same (version-gated) address the block deploys at.
+        let transaction_hash = get_transaction_hash_with_address_derivation(
+            &tx,
+            chain_id,
+            &TransactionOptions::default(),
+            address_derivation_hash,
+        )?;
         let blockifier_txs = self
             .reexecuted_block_artifacts_reader
-            .api_txs_to_blockifier_txs(vec![(tx, transaction_hash)])?;
+            .api_txs_to_blockifier_txs(vec![(tx, transaction_hash)], address_derivation_hash)?;
         let blockifier_tx = blockifier_txs
             .first()
             .expect("API to Blockifier transaction conversion returned empty list");
@@ -657,29 +682,21 @@ impl RpcBlockReexecutor {
     /// Executes a single transaction from a JSON file or given a transaction hash, using RPC to
     /// fetch block context. Does not assert correctness, only prints the execution result.
     pub fn execute_single_transaction(self, tx_input: TransactionInput) -> ReexecutionResult<()> {
-        // Get transaction and hash based on input method.
-        let (transaction, _) = match tx_input {
+        // Get the transaction based on input method. The hash is recomputed (version-gated) inside
+        // execute_single_api_tx, so we don't compute it here.
+        let transaction = match tx_input {
             TransactionInput::FromHash { tx_hash } => {
                 // Fetch transaction from the reexecuted block (the block containing the
                 // transaction to execute).
-                let transaction =
-                    self.reexecuted_block_artifacts_reader.get_tx_by_hash(&tx_hash)?;
-                let transaction_hash = TransactionHash(Felt::from_hex_unchecked(&tx_hash));
-
-                (transaction, transaction_hash)
+                self.reexecuted_block_artifacts_reader.get_tx_by_hash(&tx_hash)?
             }
             TransactionInput::FromFile { tx_path } => {
                 // Load the transaction from a local JSON file.
                 let json_content = read_to_string(&tx_path).unwrap_or_else(|_| {
                     panic!("Failed to read transaction JSON file: {}.", tx_path)
                 });
-                let chain_id = &self.reexecuted_block_artifacts_reader.chain_info.chain_id;
-
                 let json_value: Value = serde_json::from_str(&json_content)?;
-                let transaction = deserialize_transaction_json_to_starknet_api_tx(json_value)?;
-                let transaction_hash = transaction.calculate_transaction_hash(chain_id)?;
-
-                (transaction, transaction_hash)
+                deserialize_transaction_json_to_starknet_api_tx(json_value)?
             }
         };
 
@@ -786,8 +803,11 @@ impl BlockReexecutor<StateReaderAndContractManager<BoxedFetchCompiledClasses>>
     }
 
     fn get_block_txs(&self) -> ReexecutionResult<Vec<BlockifierTransaction>> {
-        self.reexecuted_block_artifacts_reader
-            .api_txs_to_blockifier_txs(self.reexecuted_block_with_txs()?.transactions.clone())
+        let address_derivation_hash = self.address_derivation_hash()?;
+        self.reexecuted_block_artifacts_reader.api_txs_to_blockifier_txs(
+            self.reexecuted_block_with_txs()?.transactions.clone(),
+            address_derivation_hash,
+        )
     }
 
     fn get_block_state_diff(&self) -> ReexecutionResult<CommitmentStateDiff> {

--- a/crates/starknet_api/src/transaction_hash.rs
+++ b/crates/starknet_api/src/transaction_hash.rs
@@ -78,6 +78,25 @@ pub fn get_transaction_hash(
     chain_id: &ChainId,
     transaction_options: &TransactionOptions,
 ) -> Result<TransactionHash, StarknetApiError> {
+    get_transaction_hash_with_address_derivation(
+        transaction,
+        chain_id,
+        transaction_options,
+        AddressDerivationHash::Pedersen,
+    )
+}
+
+/// Like [get_transaction_hash], but derives the deploy / deploy-account contract address embedded
+/// in the hash with the given `address_derivation_hash`. Callers that recompute a deploy-account
+/// hash against a specific block (RPC execution, block re-execution) must pass that block's
+/// address-derivation hash, so the recomputed hash embeds the same address the block's execution
+/// deploys (Pedersen pre-0.14.4, Blake2 from 0.14.4).
+pub fn get_transaction_hash_with_address_derivation(
+    transaction: &Transaction,
+    chain_id: &ChainId,
+    transaction_options: &TransactionOptions,
+    address_derivation_hash: AddressDerivationHash,
+) -> Result<TransactionHash, StarknetApiError> {
     let transaction_version = &signed_tx_version_from_tx(transaction, transaction_options);
     match transaction {
         Transaction::Declare(declare) => match declare {
@@ -98,7 +117,7 @@ pub fn get_transaction_hash(
             deploy,
             chain_id,
             transaction_version,
-            deploy.calculate_contract_address(AddressDerivationHash::Pedersen)?,
+            deploy.calculate_contract_address(address_derivation_hash)?,
         ),
         Transaction::DeployAccount(deploy_account) => match deploy_account {
             DeployAccountTransaction::V1(deploy_account_v1) => {
@@ -106,8 +125,7 @@ pub fn get_transaction_hash(
                     deploy_account_v1,
                     chain_id,
                     transaction_version,
-                    deploy_account_v1
-                        .calculate_contract_address(AddressDerivationHash::Pedersen)?,
+                    deploy_account_v1.calculate_contract_address(address_derivation_hash)?,
                 )
             }
             DeployAccountTransaction::V3(deploy_account_v3) => {
@@ -115,8 +133,7 @@ pub fn get_transaction_hash(
                     deploy_account_v3,
                     chain_id,
                     transaction_version,
-                    deploy_account_v3
-                        .calculate_contract_address(AddressDerivationHash::Pedersen)?,
+                    deploy_account_v3.calculate_contract_address(address_derivation_hash)?,
                 )
             }
         },


### PR DESCRIPTION
The RPC execution path (estimate_fee/simulate/trace) and block re-execution
built executable deploy-account txs via from_api(.., None, ..) -> a hardcoded
Pedersen address, and recomputed the tx hash via the Pedersen-default
dispatcher. From StarknetVersion 0.14.4 the address is Blake2, so these paths
produced the wrong address and an inconsistent Pedersen tx hash.

Both now derive the deploy-account address AND the embedding tx hash with the
block's versioned-constants hash, via the new
starknet_api::transaction_hash::get_transaction_hash_with_address_derivation
(get_transaction_hash keeps the Pedersen default for legacy callers). Dormant
for pre-0.14.4 blocks. The rpc-execution NEW_ACCOUNT_ADDRESS test const is
computed from the deploy params with the latest VC hash. Re-execution dedups
the per-call VC lookup into RpcBlockReexecutor::address_derivation_hash and
drops a dead discarded-hash computation in execute_single_transaction.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>