### PR TITLE
apollo_l1_gas_price: reject zero exchange rate from oracle

### DIFF
--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
@@ -185,6 +185,11 @@ fn resolve_query(
     let rate = u128::from_str_radix(price.trim_start_matches("0x"), 16).map_err(|e| {
         ExchangeRateOracleClientError::ParseError(format!("Failed to parse price {price}: {e}"))
     })?;
+    if rate == 0 {
+        return Err(ExchangeRateOracleClientError::InvalidRateError(
+            "rate must be non-zero".to_string(),
+        ));
+    }
     // Extract decimals from API response. Also returns MissingFieldError if value is not a number.
     let decimals = match json.get("decimals").and_then(|v| v.as_u64()) {
         Some(decimals) => decimals,

--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle_test.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle_test.rs
@@ -231,6 +231,40 @@ async fn eth_to_fri_rate_two_urls() {
 }
 
 #[tokio::test]
+async fn eth_to_fri_rate_zero_price_rejected() {
+    const LAG_INTERVAL_SECONDS: u64 = 60;
+    const TIMESTAMP: u64 = 1234567890;
+
+    let mut server = mockito::Server::new_async().await;
+
+    let _mock_response = make_server(&mut server, json!({"price": "0x0", "decimals": 18})).await;
+
+    let url_and_headers =
+        UrlAndHeaders { url: Url::parse(&server.url()).unwrap(), headers: BTreeMap::new() };
+    let config = ExchangeRateOracleConfig {
+        url_header_list: Some(vec![url_and_headers.into()]),
+        lag_interval_seconds: LAG_INTERVAL_SECONDS,
+        ..Default::default()
+    };
+    let client = ExchangeRateOracleClient::new(config, ETH_TO_STRK_ORACLE_METRICS);
+
+    // First call triggers the background query and returns QueryNotReadyError.
+    assert!(matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    ));
+    // Wait for the query to resolve; a zero rate must be rejected (AllUrlsFailedError).
+    loop {
+        match client.fetch_rate(TIMESTAMP).await {
+            Err(ExchangeRateOracleClientError::QueryNotReadyError(_)) => {}
+            Err(ExchangeRateOracleClientError::AllUrlsFailedError(..)) => break,
+            other => panic!("Expected AllUrlsFailedError for zero rate, got: {other:?}"),
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+#[tokio::test]
 async fn eth_to_fri_rate_non_success_status_code() {
     const LAG_INTERVAL_SECONDS: u64 = 60;
     const TIMESTAMP: u64 = 1234567890;

--- a/crates/apollo_l1_gas_price_types/src/errors.rs
+++ b/crates/apollo_l1_gas_price_types/src/errors.rs
@@ -47,6 +47,8 @@ pub enum ExchangeRateOracleClientError {
     QueryNotReadyError(u64),
     #[error("All URLs in the list failed for timestamp {0}, starting with index {1}")]
     AllUrlsFailedError(u64, usize),
+    #[error("Invalid rate from oracle: {0}")]
+    InvalidRateError(String),
 }
 
 impl From<reqwest::Error> for ExchangeRateOracleClientError {


### PR DESCRIPTION
## Summary
- Add a zero-rate check in `resolve_query` — a `0x0` price from the oracle is now rejected with `InvalidRateError` before it can be cached or returned to callers
- Add `InvalidRateError` variant to `ExchangeRateOracleClientError`
- Add test `eth_to_fri_rate_zero_price_rejected` covering the zero-rate case

## Context
Audit finding: `resolve_query` accepted a zero rate from the oracle without validation. A misbehaving/compromised oracle returning `{"price":"0x0","decimals":18}` would pass straight through, get cached, and propagate into the gas-pricing pipeline — producing zero FRI gas prices or triggering a `panic!` in `fri_to_wei` on the override path.

The oracle layer is the correct single validation point for untrusted external output. This fix keeps downstream callers free from having to re-check.

## Test plan
- [ ] `cargo test -p apollo_l1_gas_price` — new test `eth_to_fri_rate_zero_price_rejected` passes, all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)