### PR TITLE
apollo_l1_events: export oldest pending L1 handler L1 timestamp metric

### DIFF
--- a/crates/apollo_l1_events/src/metrics.rs
+++ b/crates/apollo_l1_events/src/metrics.rs
@@ -19,6 +19,7 @@ define_metrics!(
         MetricCounter { L1_MESSAGE_SCRAPER_REORG_DETECTED, "l1_message_scraper_reorg_detected", "Number of times the L1 message scraper detected a reorganization in the base layer", init=0},
         MetricGauge { L1_MESSAGE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS, "l1_message_scraper_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful L1 message scrape" },
         MetricGauge { L1_MESSAGE_PROVIDER_NUM_PENDING_TXS, "l1_message_provider_num_pending_txs", "The number of pending L1 handler transactions in the transaction manager" },
+        MetricGauge { L1_MESSAGE_PROVIDER_OLDEST_PENDING_TX_L1_TIMESTAMP_SECONDS, "l1_message_provider_oldest_pending_tx_l1_timestamp_seconds", "The L1 block timestamp (unix seconds) of the oldest pending (uncommitted) L1 handler transaction; 0 when none are pending" },
     },
 );
 
@@ -33,4 +34,5 @@ pub(crate) fn register_scraper_metrics() {
 
 pub(crate) fn register_provider_metrics() {
     L1_MESSAGE_PROVIDER_NUM_PENDING_TXS.register();
+    L1_MESSAGE_PROVIDER_OLDEST_PENDING_TX_L1_TIMESTAMP_SECONDS.register();
 }

--- a/crates/apollo_l1_events/src/transaction_manager.rs
+++ b/crates/apollo_l1_events/src/transaction_manager.rs
@@ -9,7 +9,11 @@ use starknet_api::executable_transaction::L1HandlerTransaction;
 use starknet_api::transaction::TransactionHash;
 use tracing::{debug, info, warn};
 
-use crate::metrics::{L1_MESSAGE_PROVIDER_NUM_PENDING_TXS, L1_MESSAGE_SCRAPER_L1_HANDLER_TX_COUNT};
+use crate::metrics::{
+    L1_MESSAGE_PROVIDER_NUM_PENDING_TXS,
+    L1_MESSAGE_PROVIDER_OLDEST_PENDING_TX_L1_TIMESTAMP_SECONDS,
+    L1_MESSAGE_SCRAPER_L1_HANDLER_TX_COUNT,
+};
 use crate::transaction_record::{
     Records,
     TransactionPayload,
@@ -352,6 +356,22 @@ impl TransactionManager {
         self.current_staging_epoch = self.current_staging_epoch.increment();
     }
 
+    /// The L1 block timestamp of the oldest pending (proposable, uncommitted) L1 handler tx, or
+    /// `None` when none are pending. Scans the proposable index (expected to hold few transactions)
+    /// for the minimal L1 emission timestamp, rather than relying on scrape order.
+    fn oldest_pending_l1_block_timestamp(&self) -> Option<BlockTimestamp> {
+        self.proposable_index
+            .values()
+            .flatten()
+            .filter_map(|tx_hash| match self.records.get(tx_hash)?.tx {
+                TransactionPayload::Full { created_at_block_timestamp, .. } => {
+                    Some(created_at_block_timestamp)
+                }
+                TransactionPayload::HashOnly(_) => None,
+            })
+            .min()
+    }
+
     // Update `proposable_index` and `consumed_queue` indices with this transaction.
     fn maintain_indices(&mut self, hash: TransactionHash) {
         if let Some(record) = self.records.get(&hash) {
@@ -388,6 +408,16 @@ impl TransactionManager {
 
             let num_pending_txs = self.proposable_index.len();
             L1_MESSAGE_PROVIDER_NUM_PENDING_TXS.set_lossy(num_pending_txs);
+
+            // Export the oldest pending tx's L1 block timestamp so an alert can fire when a single
+            // L1 handler waits on L1 for too long without being committed to L2. We export the
+            // timestamp (not the age) so the alert can compute `time() - timestamp` and have the
+            // age grow correctly even while the provider is idle. 0 means nothing is
+            // pending.
+            let oldest_pending_tx_timestamp =
+                self.oldest_pending_l1_block_timestamp().map_or(0, |timestamp| timestamp.0);
+            L1_MESSAGE_PROVIDER_OLDEST_PENDING_TX_L1_TIMESTAMP_SECONDS
+                .set_lossy(oldest_pending_tx_timestamp);
 
             // If this tx was consumed, add it to the consumed queue.
             if let Some(consumed_at) = record.get_consumed_at_timestamp() {
@@ -492,5 +522,66 @@ impl Sub<u128> for StagingEpoch {
 
     fn sub(self, rhs: u128) -> Self::Output {
         Self(self.0 - rhs)
+    }
+}
+
+#[cfg(test)]
+mod transaction_manager_tests {
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::test_utils::l1_handler;
+
+    /// Builds a `Pending`, full-payload record. The L1 block timestamp (what the metric reports) is
+    /// set independently of the scrape timestamp so tests can distinguish the two.
+    fn pending_record(
+        tx_hash: usize,
+        l1_block_timestamp: u64,
+        scrape_timestamp: UnixTimestamp,
+    ) -> (TransactionHash, UnixTimestamp, TransactionRecord) {
+        let tx = l1_handler(tx_hash);
+        let hash = tx.tx_hash;
+        let record = TransactionRecord::new(TransactionPayload::Full {
+            tx,
+            created_at_block_timestamp: BlockTimestamp(l1_block_timestamp),
+            scrape_timestamp,
+        });
+        (hash, scrape_timestamp, record)
+    }
+
+    fn manager_with_pending(
+        pending: Vec<(TransactionHash, UnixTimestamp, TransactionRecord)>,
+    ) -> TransactionManager {
+        let mut records = IndexMap::new();
+        let mut proposable_index: BTreeMap<UnixTimestamp, Vec<TransactionHash>> = BTreeMap::new();
+        for (hash, scrape_timestamp, record) in pending {
+            proposable_index.entry(scrape_timestamp).or_default().push(hash);
+            records.insert(hash, record);
+        }
+        TransactionManager::create_for_testing(
+            records.into(),
+            proposable_index,
+            StagingEpoch::new(),
+            TransactionManagerConfig::default(),
+            BTreeMap::new(),
+        )
+    }
+
+    #[test]
+    fn oldest_pending_l1_block_timestamp_returns_min_block_timestamp() {
+        // Scrape order (proposable index key) deliberately differs from L1 block order: the tx
+        // scraped first (key 10) has the newest L1 timestamp, so a "first entry" implementation
+        // would report the wrong value.
+        let manager = manager_with_pending(vec![
+            pending_record(1, 300, 10),
+            pending_record(2, 100, 20),
+            pending_record(3, 200, 30),
+        ]);
+        assert_eq!(manager.oldest_pending_l1_block_timestamp(), Some(BlockTimestamp(100)));
+    }
+
+    #[test]
+    fn oldest_pending_l1_block_timestamp_is_none_when_nothing_pending() {
+        assert_eq!(manager_with_pending(vec![]).oldest_pending_l1_block_timestamp(), None);
     }
 }

--- a/crates/apollo_l1_events/src/transaction_manager.rs
+++ b/crates/apollo_l1_events/src/transaction_manager.rs
@@ -22,6 +22,10 @@ use crate::transaction_record::{
     TransactionState,
 };
 
+#[cfg(test)]
+#[path = "transaction_manager_tests.rs"]
+mod transaction_manager_tests;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionManager {
     /// Storage of all l1 handler transactions --- keeps transactions until they can be safely
@@ -363,12 +367,7 @@ impl TransactionManager {
         self.proposable_index
             .values()
             .flatten()
-            .filter_map(|tx_hash| match self.records.get(tx_hash)?.tx {
-                TransactionPayload::Full { created_at_block_timestamp, .. } => {
-                    Some(created_at_block_timestamp)
-                }
-                TransactionPayload::HashOnly(_) => None,
-            })
+            .filter_map(|tx_hash| self.records.get(tx_hash)?.tx.created_at_block_timestamp())
             .min()
     }
 
@@ -414,8 +413,10 @@ impl TransactionManager {
             // timestamp (not the age) so the alert can compute `time() - timestamp` and have the
             // age grow correctly even while the provider is idle. 0 means nothing is
             // pending.
-            let oldest_pending_tx_timestamp =
-                self.oldest_pending_l1_block_timestamp().map_or(0, |timestamp| timestamp.0);
+            let oldest_pending_tx_timestamp = self
+                .oldest_pending_l1_block_timestamp()
+                .map(|timestamp| timestamp.0)
+                .unwrap_or_default();
             L1_MESSAGE_PROVIDER_OLDEST_PENDING_TX_L1_TIMESTAMP_SECONDS
                 .set_lossy(oldest_pending_tx_timestamp);
 
@@ -522,66 +523,5 @@ impl Sub<u128> for StagingEpoch {
 
     fn sub(self, rhs: u128) -> Self::Output {
         Self(self.0 - rhs)
-    }
-}
-
-#[cfg(test)]
-mod transaction_manager_tests {
-    use indexmap::IndexMap;
-
-    use super::*;
-    use crate::test_utils::l1_handler;
-
-    /// Builds a `Pending`, full-payload record. The L1 block timestamp (what the metric reports) is
-    /// set independently of the scrape timestamp so tests can distinguish the two.
-    fn pending_record(
-        tx_hash: usize,
-        l1_block_timestamp: u64,
-        scrape_timestamp: UnixTimestamp,
-    ) -> (TransactionHash, UnixTimestamp, TransactionRecord) {
-        let tx = l1_handler(tx_hash);
-        let hash = tx.tx_hash;
-        let record = TransactionRecord::new(TransactionPayload::Full {
-            tx,
-            created_at_block_timestamp: BlockTimestamp(l1_block_timestamp),
-            scrape_timestamp,
-        });
-        (hash, scrape_timestamp, record)
-    }
-
-    fn manager_with_pending(
-        pending: Vec<(TransactionHash, UnixTimestamp, TransactionRecord)>,
-    ) -> TransactionManager {
-        let mut records = IndexMap::new();
-        let mut proposable_index: BTreeMap<UnixTimestamp, Vec<TransactionHash>> = BTreeMap::new();
-        for (hash, scrape_timestamp, record) in pending {
-            proposable_index.entry(scrape_timestamp).or_default().push(hash);
-            records.insert(hash, record);
-        }
-        TransactionManager::create_for_testing(
-            records.into(),
-            proposable_index,
-            StagingEpoch::new(),
-            TransactionManagerConfig::default(),
-            BTreeMap::new(),
-        )
-    }
-
-    #[test]
-    fn oldest_pending_l1_block_timestamp_returns_min_block_timestamp() {
-        // Scrape order (proposable index key) deliberately differs from L1 block order: the tx
-        // scraped first (key 10) has the newest L1 timestamp, so a "first entry" implementation
-        // would report the wrong value.
-        let manager = manager_with_pending(vec![
-            pending_record(1, 300, 10),
-            pending_record(2, 100, 20),
-            pending_record(3, 200, 30),
-        ]);
-        assert_eq!(manager.oldest_pending_l1_block_timestamp(), Some(BlockTimestamp(100)));
-    }
-
-    #[test]
-    fn oldest_pending_l1_block_timestamp_is_none_when_nothing_pending() {
-        assert_eq!(manager_with_pending(vec![]).oldest_pending_l1_block_timestamp(), None);
     }
 }

--- a/crates/apollo_l1_events/src/transaction_manager_tests.rs
+++ b/crates/apollo_l1_events/src/transaction_manager_tests.rs
@@ -1,0 +1,62 @@
+use std::collections::BTreeMap;
+
+use indexmap::IndexMap;
+use starknet_api::block::{BlockTimestamp, UnixTimestamp};
+use starknet_api::transaction::TransactionHash;
+
+use super::{StagingEpoch, TransactionManager, TransactionManagerConfig};
+use crate::test_utils::l1_handler;
+use crate::transaction_record::{TransactionPayload, TransactionRecord};
+
+/// Builds a `Pending`, full-payload record. The L1 block timestamp (what the metric reports) is
+/// set independently of the scrape timestamp so tests can distinguish the two.
+fn pending_record(
+    tx_hash: usize,
+    l1_block_timestamp: u64,
+    scrape_timestamp: UnixTimestamp,
+) -> (TransactionHash, UnixTimestamp, TransactionRecord) {
+    let tx = l1_handler(tx_hash);
+    let hash = tx.tx_hash;
+    let record = TransactionRecord::new(TransactionPayload::Full {
+        tx,
+        created_at_block_timestamp: BlockTimestamp(l1_block_timestamp),
+        scrape_timestamp,
+    });
+    (hash, scrape_timestamp, record)
+}
+
+fn manager_with_pending(
+    pending: Vec<(TransactionHash, UnixTimestamp, TransactionRecord)>,
+) -> TransactionManager {
+    let mut records = IndexMap::new();
+    let mut proposable_index: BTreeMap<UnixTimestamp, Vec<TransactionHash>> = BTreeMap::new();
+    for (hash, scrape_timestamp, record) in pending {
+        proposable_index.entry(scrape_timestamp).or_default().push(hash);
+        records.insert(hash, record);
+    }
+    TransactionManager::create_for_testing(
+        records.into(),
+        proposable_index,
+        StagingEpoch::new(),
+        TransactionManagerConfig::default(),
+        BTreeMap::new(),
+    )
+}
+
+#[test]
+fn oldest_pending_l1_block_timestamp_returns_min_block_timestamp() {
+    // Scrape order (proposable index key) deliberately differs from L1 block order: the tx
+    // scraped first (key 10) has the newest L1 timestamp, so a "first entry" implementation
+    // would report the wrong value.
+    let manager = manager_with_pending(vec![
+        pending_record(1, 300, 10),
+        pending_record(2, 100, 20),
+        pending_record(3, 200, 30),
+    ]);
+    assert_eq!(manager.oldest_pending_l1_block_timestamp(), Some(BlockTimestamp(100)));
+}
+
+#[test]
+fn oldest_pending_l1_block_timestamp_is_none_when_nothing_pending() {
+    assert_eq!(manager_with_pending(vec![]).oldest_pending_l1_block_timestamp(), None);
+}

--- a/crates/apollo_l1_events/src/transaction_record.rs
+++ b/crates/apollo_l1_events/src/transaction_record.rs
@@ -242,6 +242,16 @@ impl TransactionPayload {
             TransactionPayload::Full { tx, .. } => tx.tx_hash,
         }
     }
+
+    /// The L1 block timestamp this tx was created at, if the full payload is present.
+    pub fn created_at_block_timestamp(&self) -> Option<BlockTimestamp> {
+        match self {
+            TransactionPayload::Full { created_at_block_timestamp, .. } => {
+                Some(*created_at_block_timestamp)
+            }
+            TransactionPayload::HashOnly(_) => None,
+        }
+    }
 }
 
 impl Default for TransactionPayload {


### PR DESCRIPTION
apollo_l1_events: export oldest pending L1 handler L1 timestamp metric

Goal: enable alerting when a single L1 handler transaction lingers on L1,
uncommitted to L2, for too long.

Change summary: add the gauge
`l1_message_provider_oldest_pending_tx_l1_timestamp_seconds`, holding the L1
block timestamp (unix seconds) of the oldest pending (proposable, uncommitted)
L1 handler tx, or 0 when none are pending. Populated in
`TransactionManager::maintain_indices` alongside the existing pending-count
gauge, via a new `oldest_pending_l1_block_timestamp` helper that scans the
(small) proposable index for the minimal L1 emission timestamp.

Decision points:
- Export the timestamp, not the age, so an alert can compute `time() - gauge`
  and have the age keep growing while the provider is idle (mirrors
  `l1_message_scraper_last_success_timestamp_seconds`).
- Use `created_at_block_timestamp` (L1 emission time), not `scrape_timestamp`,
  to faithfully measure time waited on L1.
- 0 sentinel when nothing is pending; the consuming alert must guard `> 0`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

apollo_l1_events: move transaction_manager tests to a separate file and simplify metric export

Goal: address the CLAUDE: review comments left on the oldest-pending-L1-timestamp
metric branch.

Changes:
- oldest pending tx timestamp now uses .map(|t| t.0).unwrap_or_default() instead of
  map_or(0, ...).
- Moved the transaction_manager unit tests out of transaction_manager.rs into a sibling
  transaction_manager_tests.rs, wired via #[cfg(test)] #[path = ...] mod, matching the
  crate's existing l1_scraper_tests.rs / l1_events_provider_tests.rs convention.

Decision points:
- The map/unwrap_or_default form follows the inline CLAUDE comment, though it runs
  counter to code-style.md's preference for map_or; applied as the comment directed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>