### PR TITLE
apollo_dashboard: alert on L1 handler pending on L1 too long

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1419,6 +1419,32 @@
       "severity": "$$$l1_gas_price_scraper_success_count-severity$$$"
     },
     {
+      "name": "l1_handler_transaction_waiting_in_L1",
+      "title": "L1 handler transaction waiting in L1 too long",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "((time() - l1_message_provider_oldest_pending_tx_l1_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}) and (l1_message_provider_oldest_pending_tx_l1_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"} > 0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              600.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "$$$l1_handler_transaction_waiting_in_L1-severity$$$"
+    },
+    {
       "name": "l1_message_no_successes",
       "title": "L1 message no successes",
       "ruleGroup": "evaluation_rate_default",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -74,7 +74,10 @@ use crate::alert_scenarios::l1_gas_prices::{
     get_l1_gas_price_provider_insufficient_history_alert,
     get_l1_gas_price_scraper_success_count_alert,
 };
-use crate::alert_scenarios::l1_handlers::get_l1_message_scraper_no_successes_alert;
+use crate::alert_scenarios::l1_handlers::{
+    get_l1_handler_transaction_waiting_in_l1_alert,
+    get_l1_message_scraper_no_successes_alert,
+};
 use crate::alert_scenarios::mempool_size::{
     get_mempool_evictions_count_alert,
     get_mempool_pool_size_increase,
@@ -659,6 +662,7 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_l1_gas_price_provider_insufficient_history_alert());
     alerts.push(get_l1_gas_price_scraper_success_count_alert());
     alerts.push(get_l1_message_scraper_no_successes_alert());
+    alerts.push(get_l1_handler_transaction_waiting_in_l1_alert());
     alerts.push(get_mempool_evictions_count_alert());
     alerts.push(get_mempool_p2p_peer_down());
     alerts.push(get_mempool_pool_size_increase());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_handlers.rs
@@ -1,4 +1,7 @@
-use apollo_l1_events::metrics::L1_MESSAGE_SCRAPER_SUCCESS_COUNT;
+use apollo_l1_events::metrics::{
+    L1_MESSAGE_PROVIDER_OLDEST_PENDING_TX_L1_TIMESTAMP_SECONDS,
+    L1_MESSAGE_SCRAPER_SUCCESS_COUNT,
+};
 use apollo_metrics::metrics::MetricQueryName;
 
 use crate::alert_placeholders::SeverityValueOrPlaceholder;
@@ -20,6 +23,32 @@ pub(crate) fn get_l1_message_scraper_no_successes_alert() -> Alert {
         EvaluationRate::Default,
         format!("increase({}[15m])", L1_MESSAGE_SCRAPER_SUCCESS_COUNT.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
+        PENDING_DURATION_DEFAULT,
+        SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+        ObserverApplicability::NotApplicable,
+    )
+}
+
+/// Fires when a single L1 handler transaction has been waiting in L1 (uncommitted to L2) for too
+/// long. The provider exports the L1 block timestamp of the oldest pending tx, so the current age
+/// is `time() - <timestamp>`. The `and (... > 0)` guard suppresses the alert when nothing is
+/// pending (the metric reports 0 in that case, which would otherwise look infinitely old).
+pub(crate) fn get_l1_handler_transaction_waiting_in_l1_alert() -> Alert {
+    const ALERT_NAME: &str = "l1_handler_transaction_waiting_in_L1";
+    // 10 minutes; well above the proposal cooldown, so normal cooldown waits don't trip it.
+    const MAX_PENDING_SECONDS: f64 = 600.0;
+    let oldest_pending_timestamp =
+        L1_MESSAGE_PROVIDER_OLDEST_PENDING_TX_L1_TIMESTAMP_SECONDS.get_name_with_filter();
+    Alert::new(
+        ALERT_NAME,
+        "L1 handler transaction waiting in L1 too long",
+        EvaluationRate::Default,
+        format!("(time() - {oldest_pending_timestamp}) and ({oldest_pending_timestamp} > 0)"),
+        vec![AlertCondition::new(
+            AlertComparisonOp::GreaterThan,
+            MAX_PENDING_SECONDS,
+            AlertLogicalOp::And,
+        )],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,


### PR DESCRIPTION
Goal: page when a single L1 handler transaction has been waiting on L1,
uncommitted to L2, for more than 10 minutes.

Change summary: add `get_l1_handler_pending_too_long_alert`, register it in
`get_apollo_alerts`, and regenerate the dev Grafana alerts resource. The alert
expression is `(time() - <oldest_pending_ts>) and (<oldest_pending_ts> > 0)`
with a 600s threshold, built on the metric added in the parent commit.

Decision points:
- Threshold 600s (10m), above the ~70s proposal cooldown so normal cooldown
  waits don't trip it.
- The `and (... > 0)` guard suppresses the alert when nothing is pending (the
  metric reports 0, which would otherwise read as infinitely old).
- Severity left as a placeholder so the deployment config chooses the page
  level, matching the sibling l1_message_no_successes alert.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>