### PR TITLE
apollo_node,apollo_consensus_manager: propagate os_input to apollo_consensus_orchestrator

### DIFF
--- a/crates/apollo_consensus_manager/Cargo.toml
+++ b/crates/apollo_consensus_manager/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "Manages consensus operations and coordinates between consensus and other node components."
 
 [features]
+os_input = ["apollo_consensus_orchestrator/os_input"]
 testing = []
 
 [lints]

--- a/crates/apollo_node/Cargo.toml
+++ b/crates/apollo_node/Cargo.toml
@@ -12,6 +12,7 @@ os_input = [
   "apollo_batcher/os_input",
   "apollo_committer/os_input",
   "apollo_committer_types/os_input",
+  "apollo_consensus_manager/os_input",
 ]
 testing = ["tokio-util"]
 


### PR DESCRIPTION
apollo_node's os_input feature did not reach apollo_consensus_orchestrator: the
chain runs apollo_node -> apollo_consensus_manager -> apollo_consensus_orchestrator,
but apollo_consensus_manager had no os_input feature and apollo_node did not forward
to it. Add the missing feature to apollo_consensus_manager and forward to it from
apollo_node so `--features os_input` enables it on the orchestrator.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>