### PR TITLE
apollo_mempool: use saturating_sub for n_stuck_txs accounting

### DIFF
--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -922,7 +922,7 @@ impl Mempool {
 
     fn decrement_stuck_txs_if_gap_account(&mut self, address: ContractAddress, n: usize) {
         if self.accounts_with_gap.contains(&address) {
-            self.n_stuck_txs -= n;
+            self.n_stuck_txs = self.n_stuck_txs.saturating_sub(n);
         }
     }
 
@@ -930,7 +930,8 @@ impl Mempool {
     // n_stuck_txs. No-op if the address was not tracked.
     fn remove_from_accounts_with_gap(&mut self, address: ContractAddress) {
         if self.accounts_with_gap.swap_remove(&address) {
-            self.n_stuck_txs -= self.tx_pool.n_txs_for_address(address);
+            self.n_stuck_txs =
+                self.n_stuck_txs.saturating_sub(self.tx_pool.n_txs_for_address(address));
         }
     }
 


### PR DESCRIPTION
## What

Replace the two unchecked `n_stuck_txs -=` subtractions in the mempool with `saturating_sub`:

- `decrement_stuck_txs_if_gap_account` (`mempool.rs:909`)
- `remove_from_accounts_with_gap` (`mempool.rs:917`)

## Why

`n_stuck_txs` is maintained incrementally across many interleaving paths (commit, reject, expire, prune, fee-escalation, eviction). The subtractions were unchecked, so any future accounting drift would:

- **panic** under overflow-checked builds (debug/CI), crashing the mempool component, and
- **silently wrap** to a huge `usize` in release, corrupting the `MEMPOOL_STUCK_TXS` gauge.

No reachable underflow exists in the current code (the accounting follows a consistent "remove-from-pool then deduct-remaining" discipline), so this is defensive hardening against future refactors — matching the existing code-style guidance to prefer saturating arithmetic where a guard could later be removed. `n_stuck_txs` feeds only the observability gauge, not any eviction/admission decision, so behavior on the verified-consistent paths is unchanged.

Raised as a finding (M-11) in the Sequencer Security Report.

## Testing

`SEED=0 cargo test -p apollo_mempool` — 112 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)