### PR TITLE
apollo_consensus_orchestrator: add initial_reads to the os_input blob

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -994,7 +994,7 @@ impl Batcher {
             state_diff.clone(), // TODO(Nimrod): Remove the clone here.
             Some(state_diff_commitment),
             #[cfg(feature = "os_input")]
-            Some(accessed_keys),
+            Some(accessed_keys.clone()),
         )
         .await?;
 
@@ -1023,6 +1023,8 @@ impl Batcher {
                 compiled_class_hashes_for_migration: block_execution_artifacts
                     .compiled_class_hashes_for_migration,
                 parent_proposal_commitment,
+                #[cfg(feature = "os_input")]
+                accessed_keys,
             },
         })
     }

--- a/crates/apollo_batcher_types/src/batcher_types.rs
+++ b/crates/apollo_batcher_types/src/batcher_types.rs
@@ -3,6 +3,8 @@ use std::ops::Deref;
 
 use blockifier::blockifier::transaction_executor::CompiledClassHashesForMigration;
 use blockifier::bouncer::{BouncerWeights, CasmHashComputationData};
+#[cfg(feature = "os_input")]
+use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::CommitmentStateDiff;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use chrono::prelude::*;
@@ -158,6 +160,8 @@ pub struct CentralObjects {
     pub casm_hash_computation_data_proving_gas: CasmHashComputationData,
     pub compiled_class_hashes_for_migration: CompiledClassHashesForMigration,
     pub parent_proposal_commitment: Option<ProposalCommitment>,
+    #[cfg(feature = "os_input")]
+    pub accessed_keys: AccessedKeys,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -45,6 +45,8 @@ use blockifier::fee::resources::{
     StateResources,
     TransactionResources,
 };
+#[cfg(feature = "os_input")]
+use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::{
     CommitmentStateDiff,
     StateChangesCount,
@@ -781,6 +783,8 @@ fn central_blob() -> AerospikeBlob {
         ],
         #[cfg(feature = "os_input")]
         recent_state_commitment_infos: recent_state_commitment_infos(),
+        #[cfg(feature = "os_input")]
+        accessed_keys: AccessedKeys::default(),
     };
 
     // This is to make the function sync (not async) so that it can be used as a case in the
@@ -812,6 +816,8 @@ fn central_blob_with_empty_or_none_fields() -> AerospikeBlob {
         recent_block_hashes: vec![],
         #[cfg(feature = "os_input")]
         recent_state_commitment_infos: vec![],
+        #[cfg(feature = "os_input")]
+        accessed_keys: AccessedKeys::default(),
     };
 
     // This is to make the function sync (not async) so that it can be used as a case in the
@@ -1167,14 +1173,15 @@ fn serialize_central_objects(#[case] rust_obj: impl Serialize, #[case] python_js
     let python_json: serde_json::Value = read_json_file(python_json_path);
     let rust_json = serde_json::to_value(rust_obj).unwrap();
 
-    // `recent_state_commitment_infos` is os_input-only and absent from the central (python) blob,
-    // so strip it before comparing.
-    // TODO(Itamar): Remove this stripping once the python blob includes the field.
+    // `recent_state_commitment_infos` and `accessed_keys` are os_input-only and absent from the
+    // central (python) blob, so strip them before comparing.
+    // TODO(Itamar): Remove this stripping once the python blob includes the fields.
     #[cfg(feature = "os_input")]
     let rust_json = {
         let mut rust_json = rust_json;
         if let Some(object) = rust_json.as_object_mut() {
             object.remove("recent_state_commitment_infos");
+            object.remove("accessed_keys");
         }
         rust_json
     };

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -12,6 +12,8 @@ use async_trait::async_trait;
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 use blockifier::blockifier::transaction_executor::CompiledClassHashesForMigration;
 use blockifier::bouncer::{BouncerWeights, CasmHashComputationData};
+#[cfg(feature = "os_input")]
+use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::CommitmentStateDiff;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use central_objects::{
@@ -104,6 +106,8 @@ pub struct AerospikeBlob {
     recent_block_hashes: Vec<BlockHashAndNumber>,
     #[cfg(feature = "os_input")]
     recent_state_commitment_infos: Vec<StateCommitmentInfosAndNumber>,
+    #[cfg(feature = "os_input")]
+    accessed_keys: AccessedKeys,
 }
 
 #[cfg_attr(test, automock)]
@@ -399,6 +403,8 @@ pub struct BlobParameters {
     pub recent_block_hashes: Vec<BlockHashAndNumber>,
     #[cfg(feature = "os_input")]
     pub recent_state_commitment_infos: Vec<StateCommitmentInfosAndNumber>,
+    #[cfg(feature = "os_input")]
+    pub accessed_keys: AccessedKeys,
 }
 
 impl AerospikeBlob {
@@ -456,6 +462,8 @@ impl AerospikeBlob {
             recent_block_hashes: blob_parameters.recent_block_hashes,
             #[cfg(feature = "os_input")]
             recent_state_commitment_infos: blob_parameters.recent_state_commitment_infos,
+            #[cfg(feature = "os_input")]
+            accessed_keys: blob_parameters.accessed_keys,
         })
     }
 }

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -620,6 +620,8 @@ impl SequencerConsensusContext {
                 recent_state_commitment_infos: self
                     .collect_recent_state_commitment_infos(height)
                     .await,
+                #[cfg(feature = "os_input")]
+                accessed_keys: central_objects.accessed_keys,
             })
             .await
         {

--- a/crates/central_systest_blobs/src/cende_blob_regression_test.rs
+++ b/crates/central_systest_blobs/src/cende_blob_regression_test.rs
@@ -246,6 +246,8 @@ impl From<BlockData> for BlobParameters {
             recent_block_hashes,
             #[cfg(feature = "os_input")]
             recent_state_commitment_infos: vec![],
+            #[cfg(feature = "os_input")]
+            accessed_keys: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Thread the block's accessed keys (AccessedKeys) from the batcher into the cende
blob under os_input: the batcher attaches the value it already computes to
CentralObjects, and the orchestrator carries it through BlobParameters onto the
AerospikeBlob as initial_reads.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>