### PR TITLE
apollo_l1_events,apollo_l1_events_config: reject zero L1 block time in scraper config

### DIFF
--- a/crates/apollo_l1_events/src/l1_scraper.rs
+++ b/crates/apollo_l1_events/src/l1_scraper.rs
@@ -144,6 +144,8 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1EventsScraper<Bas
         debug!("Latest L1 block number: {latest_l1_block_number:?}");
 
         // Estimate the number of blocks in the interval, to rewind from the latest block.
+        // The divisor is validated to be non-zero at config-load time (see
+        // `validate_non_zero_secs`).
         let blocks_in_interval = self.config.startup_rewind_time_seconds.as_secs()
             / self.config.l1_block_time_seconds.as_secs();
         debug!("Blocks in interval: {blocks_in_interval}");

--- a/crates/apollo_l1_events_config/src/config.rs
+++ b/crates/apollo_l1_events_config/src/config.rs
@@ -7,7 +7,7 @@ use apollo_config::validators::validate_ascii;
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use serde::{Deserialize, Serialize};
 use starknet_api::core::ChainId;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Validate, PartialEq, Eq)]
 pub struct L1EventsProviderConfig {
@@ -114,7 +114,18 @@ pub struct L1EventsScraperConfig {
     pub polling_interval_seconds: Duration,
     pub set_provider_historic_height_to_l2_genesis: bool,
     #[serde(deserialize_with = "deserialize_float_seconds_to_duration")]
+    #[validate(custom(function = "validate_non_zero_secs"))]
     pub l1_block_time_seconds: Duration,
+}
+
+/// The scraper uses `l1_block_time_seconds.as_secs()` (whole seconds) as a division divisor when
+/// estimating how many L1 blocks to rewind on startup, so a value rounding down to zero seconds
+/// would cause a division-by-zero panic. Reject such values at config-load time.
+fn validate_non_zero_secs(l1_block_time_seconds: &Duration) -> Result<(), ValidationError> {
+    if l1_block_time_seconds.as_secs() == 0 {
+        return Err(ValidationError::new("l1_block_time_seconds must be at least one second"));
+    }
+    Ok(())
 }
 
 impl Default for L1EventsScraperConfig {

--- a/crates/apollo_l1_events_config/src/config_test.rs
+++ b/crates/apollo_l1_events_config/src/config_test.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use validator::Validate;
+
+use crate::config::L1EventsScraperConfig;
+
+#[test]
+fn default_config_passes_validation() {
+    assert!(L1EventsScraperConfig::default().validate().is_ok());
+}
+
+#[test]
+fn zero_l1_block_time_seconds_is_rejected() {
+    let config =
+        L1EventsScraperConfig { l1_block_time_seconds: Duration::ZERO, ..Default::default() };
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn sub_second_l1_block_time_seconds_is_rejected() {
+    // `as_secs()` truncates to whole seconds, so a sub-second block time rounds to a zero divisor.
+    let config = L1EventsScraperConfig {
+        l1_block_time_seconds: Duration::from_millis(500),
+        ..Default::default()
+    };
+    assert!(config.validate().is_err());
+}

--- a/crates/apollo_l1_events_config/src/lib.rs
+++ b/crates/apollo_l1_events_config/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod config;
+
+#[cfg(test)]
+mod config_test;


### PR DESCRIPTION
Goal: Fix audit finding [L-12] — the L1 events scraper divides
startup_rewind_time_seconds by l1_block_time_seconds.as_secs() with no
zero guard, so a config value of 0 (or any sub-second value that
truncates to 0 whole seconds) panics the scraper startup task with a
division by zero.

Change summary:
- Add a `validate_non_zero_secs` custom validator on the
  `l1_block_time_seconds` field of `L1EventsScraperConfig`. It is
  enforced at node startup via the derived `Validate` /
  `validate_node_config`, so a misconfigured node fails fast with a
  clear error instead of panicking mid-run.
- Document the non-zero-divisor invariant at the division site in
  l1_scraper.rs, pointing at the validator.
- Add config tests: default config validates; zero and sub-second
  block times are rejected.

Decision points:
- Validated `as_secs() == 0` (not just a zero Duration) because the
  division uses whole seconds, so a 0.5s value also truncates to a
  zero divisor.
- The gas-price scraper was named in the finding but does not perform
  this division (uses saturating_sub / checked_sub), so no change there.
- Dropped an earlier runtime `.max(1)` guard at the division site as
  redundant once the config is validated at load time.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>