### PR TITLE
papyrus_base_layer: re-point live provider on URL cycle so L1 failover works (#14520)

### DIFF
--- a/crates/apollo_base_layer_tests/Cargo.toml
+++ b/crates/apollo_base_layer_tests/Cargo.toml
@@ -23,4 +23,4 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-apollo_infra_utils.workspace = true
+apollo_infra_utils = { workspace = true, features = ["testing"] }

--- a/crates/apollo_base_layer_tests/src/anvil_base_layer.rs
+++ b/crates/apollo_base_layer_tests/src/anvil_base_layer.rs
@@ -13,7 +13,6 @@ use apollo_config::secrets::Sensitive;
 use async_trait::async_trait;
 use colored::*;
 use papyrus_base_layer::ethereum_base_layer_contract::{
-    CircularUrlIterator,
     EthereumBaseLayerConfig,
     EthereumBaseLayerContract,
     EthereumBaseLayerError,
@@ -116,13 +115,11 @@ curl -L \
             );
         });
         let config = Self::config(Self::url_static(port));
-        let url_iterator = CircularUrlIterator::new(config.ordered_l1_endpoint_urls.clone());
         let root_client = anvil_client.root().clone();
-        let contract = Starknet::new(config.starknet_contract_address, root_client);
 
         let anvil_base_layer = Self {
             anvil_provider: anvil_client.erased(),
-            ethereum_base_layer: EthereumBaseLayerContract { config, contract, url_iterator },
+            ethereum_base_layer: EthereumBaseLayerContract::new_with_provider(config, root_client),
             port,
         };
         anvil_base_layer.initialize_mocked_starknet_contract().await;

--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -4,6 +4,7 @@ use alloy::providers::mock::Asserter;
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::rpc::types::{Block, BlockTransactions, Header as AlloyRpcHeader};
 use pretty_assertions::assert_eq;
+use url::Url;
 
 use crate::eth_events::{create_l1_event_data, felt_max_u256, u256_exceeds_felt};
 use crate::ethereum_base_layer_contract::{
@@ -100,6 +101,37 @@ async fn get_gas_price_and_timestamps() {
     // Roughly e ** (BLOB_GAS / eip7691::BLOB_GASPRICE_UPDATE_FRACTION_PECTRA)
     let expected_pectra_blob_calc = 7;
     assert_eq!(header.blob_fee, expected_pectra_blob_calc);
+}
+
+#[tokio::test]
+async fn test_cycle_wraps_to_primary_through_full_list() {
+    let primary_url = Url::parse("http://primary-endpoint.test/").unwrap();
+    let secondary_url = Url::parse("http://secondary-endpoint.test/").unwrap();
+    let tertiary_url = Url::parse("http://tertiary-endpoint.test/").unwrap();
+    let config = EthereumBaseLayerConfig {
+        ordered_l1_endpoint_urls: vec![
+            primary_url.clone().into(),
+            secondary_url.clone().into(),
+            tertiary_url.clone().into(),
+        ],
+        ..Default::default()
+    };
+    let mut base_layer = EthereumBaseLayerContract::new(config);
+
+    // The live provider starts on the primary (first) endpoint.
+    assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), primary_url);
+
+    // First cycle moves to the secondary endpoint.
+    base_layer.cycle_provider_url().await.unwrap();
+    assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), secondary_url);
+
+    // Second cycle moves to the tertiary endpoint.
+    base_layer.cycle_provider_url().await.unwrap();
+    assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), tertiary_url);
+
+    // Third cycle wraps back to the primary endpoint.
+    base_layer.cycle_provider_url().await.unwrap();
+    assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), primary_url);
 }
 
 #[test]

--- a/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
+++ b/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
@@ -344,3 +344,56 @@ async fn pass_through_cycle_provider_url() {
     let result = wrapper.cycle_provider_url().await;
     assert!(result.is_ok());
 }
+
+// Verifies that when an operation begins on a non-primary endpoint and every attempt fails, the
+// wrapper cycles through the entire URL list exactly once and returns the last error. The operation
+// starts on the tertiary endpoint, and cycling advances tertiary -> primary -> secondary ->
+// tertiary, at which point the wrapper detects it wrapped back to the start URL and returns the
+// error.
+#[tokio::test]
+async fn test_exhaust_from_non_primary_index_returns_last_error() {
+    // Setup: model a 3-URL list where the operation starts on the tertiary (non-primary) endpoint.
+    let primary_url = Sensitive::new(Url::parse("http://primary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+    let secondary_url = Sensitive::new(Url::parse("http://secondary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+    let tertiary_url = Sensitive::new(Url::parse("http://tertiary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+
+    // The wrapper calls get_url once for start_url, then per failed attempt calls get_url (current)
+    // + cycle_provider_url + get_url (new). With a tertiary start and all three attempts failing,
+    // the get_url return sequence is: start=tertiary; then current/new pairs as the index advances
+    // tertiary -> primary -> secondary -> tertiary.
+    let url_sequence = [
+        tertiary_url.clone(),
+        tertiary_url.clone(),
+        primary_url.clone(),
+        primary_url,
+        secondary_url.clone(),
+        secondary_url,
+        tertiary_url,
+    ];
+    const NUM_ATTEMPTS: usize = 3;
+    let num_get_url_calls = url_sequence.len();
+    // Each mocked call pops the next queued return, so the return order is explicit per call.
+    let mut get_url_returns = url_sequence.into_iter();
+    let mut error_returns = (0..NUM_ATTEMPTS).map(MockError::Numbered);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer
+        .expect_get_url()
+        .times(num_get_url_calls)
+        .returning(move || Ok(get_url_returns.next().unwrap()));
+    // Every attempt fails with a distinct numbered error so we can prove the last one is returned.
+    base_layer
+        .expect_get_proved_block_at()
+        .times(NUM_ATTEMPTS)
+        .returning(move |_| Err(error_returns.next().unwrap()));
+    // Cycling succeeds once per failed attempt.
+    base_layer.expect_cycle_provider_url().times(NUM_ATTEMPTS).returning(|| Ok(()));
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+
+    // Test: all attempts fail; the wrapper must return the last attempt's error.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert_eq!(result, Err(MockError::Numbered(NUM_ATTEMPTS - 1)));
+}

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -100,23 +100,26 @@ pub struct EthereumBaseLayerContract {
     pub url_iterator: CircularUrlIterator,
     pub config: EthereumBaseLayerConfig,
     pub contract: StarknetL1Contract,
+    // The URL that `contract`'s live provider is bound to. Kept in sync with `contract` on every
+    // rebuild so that `get_url` reflects the endpoint actually being queried, not just the
+    // iterator's position.
+    node_url: Sensitive<Url>,
 }
 
 impl EthereumBaseLayerContract {
     pub fn new(config: EthereumBaseLayerConfig) -> Self {
         let url_iterator = CircularUrlIterator::new(config.ordered_l1_endpoint_urls.clone());
-        let contract = build_contract_instance(
-            config.starknet_contract_address,
-            url_iterator.get_current_url(),
-        );
-        Self { url_iterator, contract, config }
+        let node_url = url_iterator.get_current_url();
+        let contract = build_contract_instance(config.starknet_contract_address, node_url.clone());
+        Self { url_iterator, contract, config, node_url }
     }
     #[cfg(any(test, feature = "testing"))]
     pub fn new_with_provider(config: EthereumBaseLayerConfig, provider: RootProvider) -> Self {
         let url_iterator = CircularUrlIterator::new(config.ordered_l1_endpoint_urls.clone());
+        let node_url = url_iterator.get_current_url();
         let starknet_contract_address = config.starknet_contract_address;
         let contract = Starknet::new(starknet_contract_address, provider);
-        Self { url_iterator, contract, config }
+        Self { url_iterator, contract, config, node_url }
     }
 }
 
@@ -286,20 +289,24 @@ impl BaseLayerContract for EthereumBaseLayerContract {
     }
 
     async fn get_url(&self) -> Result<Sensitive<Url>, Self::Error> {
-        Ok(self.url_iterator.get_current_url())
+        Ok(self.node_url.clone())
     }
 
     /// Rebuilds the provider on the new url.
     async fn set_provider_url(&mut self, url: Sensitive<Url>) -> Result<(), Self::Error> {
         self.contract = build_contract_instance(self.config.starknet_contract_address, url.clone());
+        self.node_url = url;
         Ok(())
     }
 
     async fn cycle_provider_url(&mut self) -> Result<(), Self::Error> {
-        self.url_iterator
+        let next_url = self
+            .url_iterator
             .next()
             .expect("URL list was validated to be non-empty when config was loaded");
-        Ok(())
+        // Rebuild the live provider on the new URL; advancing the iterator alone would leave
+        // `contract` querying the previous (failed) endpoint.
+        self.set_provider_url(next_url).await
     }
 }
 

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -46,8 +46,10 @@ impl std::fmt::Display for L1BlockHash {
 #[cfg(any(feature = "testing", test))]
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum MockError {
-    #[error("Mock error")]
+    #[error("mock error")]
     MockError,
+    #[error("mock error {0}")]
+    Numbered(usize),
 }
 
 /// Interface for getting data from the Starknet base contract.


### PR DESCRIPTION
Cherry-pick of #14520 onto `main-v0.14.3`.

L1 endpoint failover advanced an internal index but never rebuilt the live `alloy` provider, so calls kept hitting the failed endpoint. This tracks the live endpoint (`node_url`) and rebuilds the provider on each URL cycle, with offline failover tests.

Mirror of the equivalent PR on `main`: [#14520](https://github.com/starkware-libs/sequencer/pull/14520) (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
