### PR TITLE
papyrus_base_layer: add time-based retry of the primary L1 endpoint (#14521)

### DIFF
--- a/crates/apollo_base_layer_tests/src/anvil_base_layer.rs
+++ b/crates/apollo_base_layer_tests/src/anvil_base_layer.rs
@@ -267,6 +267,15 @@ impl BaseLayerContract for AnvilBaseLayer {
     async fn cycle_provider_url(&mut self) -> Result<(), Self::Error> {
         unimplemented!("Anvil base layer is tied to a an Anvil server, url is fixed.")
     }
+
+    async fn reset_provider_url_to_primary(&mut self) -> Result<(), Self::Error> {
+        unimplemented!("Anvil base layer is tied to a an Anvil server, url is fixed.")
+    }
+
+    // Anvil is tied to a single fixed URL, so it is always on its only (primary) endpoint.
+    async fn is_at_primary(&self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
 }
 
 /// Converts a given [L1 handler transaction](starknet_api::transaction::L1HandlerTransaction)

--- a/crates/apollo_deployments/resources/app_configs/base_layer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/base_layer_config.json
@@ -2,6 +2,7 @@
   "base_layer_config.bpo1_start_block_number": 9456501,
   "base_layer_config.bpo2_start_block_number": 9504747,
   "base_layer_config.fusaka_no_bpo_start_block_number": 9408577,
+  "base_layer_config.retry_primary_interval_seconds": 60,
   "base_layer_config.starknet_contract_address": "",
   "base_layer_config.timeout_millis": 1000
 }

--- a/crates/apollo_deployments/resources/app_configs/replacer_base_layer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_base_layer_config.json
@@ -2,6 +2,7 @@
   "base_layer_config.bpo1_start_block_number": "$$$_BASE_LAYER_CONFIG-BPO1_START_BLOCK_NUMBER_$$$",
   "base_layer_config.bpo2_start_block_number": "$$$_BASE_LAYER_CONFIG-BPO2_START_BLOCK_NUMBER_$$$",
   "base_layer_config.fusaka_no_bpo_start_block_number": "$$$_BASE_LAYER_CONFIG-FUSAKA_NO_BPO_START_BLOCK_NUMBER_$$$",
+  "base_layer_config.retry_primary_interval_seconds": 60,
   "base_layer_config.starknet_contract_address": "$$$_BASE_LAYER_CONFIG-STARKNET_CONTRACT_ADDRESS_$$$",
   "base_layer_config.timeout_millis": 1000
 }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -24,6 +24,11 @@
     "privacy": "Private",
     "value": "https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY"
   },
+  "base_layer_config.retry_primary_interval_seconds": {
+    "description": "The interval (seconds) after which the next base-layer access retries the primary (first) endpoint.",
+    "privacy": "Public",
+    "value": 60
+  },
   "base_layer_config.starknet_contract_address": {
     "description": "Starknet contract address in ethereum.",
     "privacy": "Public",

--- a/crates/apollo_node/src/components.rs
+++ b/crates/apollo_node/src/components.rs
@@ -314,7 +314,10 @@ pub async fn create_node_components(
                 .get_l1_gas_price_shared_client()
                 .expect("L1 gas price client should be available");
             let base_layer = EthereumBaseLayerContract::new(base_layer_config.clone());
-            let cyclic_base_layer_wrapper = CyclicBaseLayerWrapper::new(base_layer);
+            let cyclic_base_layer_wrapper = CyclicBaseLayerWrapper::new(
+                base_layer,
+                base_layer_config.retry_primary_interval_seconds,
+            );
 
             Some(L1GasPriceScraper::new(
                 l1_gas_price_scraper_config.clone(),
@@ -390,7 +393,10 @@ pub async fn create_node_components(
                 .expect("L1 Events Scraper config should be set");
             let l1_events_provider_client = clients.get_l1_events_provider_shared_client().unwrap();
             let base_layer = EthereumBaseLayerContract::new(base_layer_config.clone());
-            let cyclic_base_layer_wrapper = CyclicBaseLayerWrapper::new(base_layer);
+            let cyclic_base_layer_wrapper = CyclicBaseLayerWrapper::new(
+                base_layer,
+                base_layer_config.retry_primary_interval_seconds,
+            );
 
             Some(
                 L1EventsScraper::new(

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -36,3 +36,4 @@ pretty_assertions.workspace = true
 rstest.workspace = true
 starknet-types-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/papyrus_base_layer/src/base_layer_test.rs
+++ b/crates/papyrus_base_layer/src/base_layer_test.rs
@@ -134,6 +134,35 @@ async fn test_cycle_wraps_to_primary_through_full_list() {
     assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), primary_url);
 }
 
+#[tokio::test]
+async fn test_reset_provider_url_to_primary_repoints_live_provider() {
+    let primary_url = Url::parse("http://primary-endpoint.test/").unwrap();
+    let secondary_url = Url::parse("http://secondary-endpoint.test/").unwrap();
+    let tertiary_url = Url::parse("http://tertiary-endpoint.test/").unwrap();
+    let config = EthereumBaseLayerConfig {
+        ordered_l1_endpoint_urls: vec![
+            primary_url.clone().into(),
+            secondary_url.clone().into(),
+            tertiary_url.clone().into(),
+        ],
+        ..Default::default()
+    };
+    let mut base_layer = EthereumBaseLayerContract::new(config);
+
+    // Cycle twice to land on the tertiary endpoint.
+    base_layer.cycle_provider_url().await.unwrap();
+    base_layer.cycle_provider_url().await.unwrap();
+    assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), tertiary_url);
+
+    // Reset to primary.
+    base_layer.reset_provider_url_to_primary().await.unwrap();
+    assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), primary_url);
+
+    // Calling reset again when already on primary is a no-op.
+    base_layer.reset_provider_url_to_primary().await.unwrap();
+    assert_eq!(base_layer.get_url().await.unwrap().expose_secret(), primary_url);
+}
+
 #[test]
 fn create_l1_event_data_rejects_out_of_range_inputs() {
     let oversized = felt_max_u256() + U256::from(1_u8);

--- a/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper.rs
+++ b/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper.rs
@@ -1,4 +1,5 @@
 use std::ops::RangeInclusive;
+use std::time::Duration;
 
 use apollo_config::secrets::Sensitive;
 use async_trait::async_trait;
@@ -15,11 +16,28 @@ pub mod cyclic_base_layer_wrapper_test;
 #[derive(Debug)]
 pub struct CyclicBaseLayerWrapper<B: BaseLayerContract + Send + Sync> {
     base_layer: B,
+    retry_primary_interval: Duration,
+    last_primary_retry: tokio::time::Instant,
 }
 
 impl<B: BaseLayerContract + Send + Sync> CyclicBaseLayerWrapper<B> {
-    pub fn new(base_layer: B) -> Self {
-        Self { base_layer }
+    pub fn new(base_layer: B, retry_primary_interval: Duration) -> Self {
+        Self { base_layer, retry_primary_interval, last_primary_retry: tokio::time::Instant::now() }
+    }
+
+    // Retries the primary endpoint once the interval has elapsed since we left it. Does nothing
+    // while already on the primary, so the timer is untouched until a failover moves us off it.
+    async fn retry_primary_if_due(&mut self) -> Result<(), B::Error> {
+        if self.base_layer.is_at_primary().await? {
+            return Ok(());
+        }
+        if self.last_primary_retry.elapsed() >= self.retry_primary_interval {
+            // Advance the clock only after a successful reset, so a failed reset retries on the
+            // next access instead of waiting another full interval.
+            self.base_layer.reset_provider_url_to_primary().await?;
+            self.last_primary_retry = tokio::time::Instant::now();
+        }
+        Ok(())
     }
 
     // Check the result of a function call to the base layer. If it fails, cycle the URL and signal
@@ -38,11 +56,21 @@ impl<B: BaseLayerContract + Send + Sync> CyclicBaseLayerWrapper<B> {
         let Ok(current_url) = current_url_result else {
             return Some(Err(current_url_result.expect_err("result is checked at let-else")));
         };
+        // Record whether we are about to leave the primary, before cycling away from it.
+        let is_at_primary_result = self.base_layer.is_at_primary().await;
+        let Ok(was_at_primary) = is_at_primary_result else {
+            return Some(Err(is_at_primary_result.expect_err("result is checked at let-else")));
+        };
         // Otherwise, cycle the URL so we can try again. Return error in case it fails to cycle.
         let cycle_url_result = self.base_layer.cycle_provider_url().await;
         let Ok(()) = cycle_url_result else {
             return Some(Err(cycle_url_result.expect_err("result is checked at let-else")));
         };
+        // Restart the retry-primary clock only when this failover leaves the primary, so the wait
+        // is measured from when we left it; cycling between backups must not push the retry out.
+        if was_at_primary {
+            self.last_primary_retry = tokio::time::Instant::now();
+        }
         // Get the new URL (return error in case it fails to get it).
         let new_url_result = self.base_layer.get_url().await;
         let Ok(new_url) = new_url_result else {
@@ -69,6 +97,7 @@ impl<B: BaseLayerContract + Send + Sync> BaseLayerContract for CyclicBaseLayerWr
         &mut self,
         l1_block: L1BlockNumber,
     ) -> Result<BlockHashAndNumber, Self::Error> {
+        self.retry_primary_if_due().await?;
         let start_url = self.base_layer.get_url().await?;
         loop {
             let result = self.base_layer.get_proved_block_at(l1_block).await;
@@ -79,6 +108,7 @@ impl<B: BaseLayerContract + Send + Sync> BaseLayerContract for CyclicBaseLayerWr
     }
 
     async fn latest_l1_block_number(&mut self) -> Result<L1BlockNumber, Self::Error> {
+        self.retry_primary_if_due().await?;
         let start_url = self.base_layer.get_url().await?;
         loop {
             let result = self.base_layer.latest_l1_block_number().await;
@@ -92,6 +122,7 @@ impl<B: BaseLayerContract + Send + Sync> BaseLayerContract for CyclicBaseLayerWr
         &mut self,
         block_number: L1BlockNumber,
     ) -> Result<Option<L1BlockReference>, Self::Error> {
+        self.retry_primary_if_due().await?;
         let start_url = self.base_layer.get_url().await?;
         loop {
             let result = self.base_layer.l1_block_at(block_number).await;
@@ -106,6 +137,7 @@ impl<B: BaseLayerContract + Send + Sync> BaseLayerContract for CyclicBaseLayerWr
         block_range: RangeInclusive<L1BlockNumber>,
         event_identifiers: &'a [&'a str],
     ) -> Result<Vec<L1Event>, Self::Error> {
+        self.retry_primary_if_due().await?;
         let start_url = self.base_layer.get_url().await?;
         loop {
             let result = self.base_layer.events(block_range.clone(), event_identifiers).await;
@@ -119,6 +151,7 @@ impl<B: BaseLayerContract + Send + Sync> BaseLayerContract for CyclicBaseLayerWr
         &mut self,
         block_number: L1BlockNumber,
     ) -> Result<Option<L1BlockHeader>, Self::Error> {
+        self.retry_primary_if_due().await?;
         let start_url = self.base_layer.get_url().await?;
         loop {
             let result = self.base_layer.get_block_header(block_number).await;
@@ -128,6 +161,8 @@ impl<B: BaseLayerContract + Send + Sync> BaseLayerContract for CyclicBaseLayerWr
         }
     }
 
+    // Takes &self so it cannot cycle or retry endpoints; callers needing resilience use the &mut
+    // self methods.
     async fn get_block_header_immutable(
         &self,
         block_number: L1BlockNumber,
@@ -145,5 +180,13 @@ impl<B: BaseLayerContract + Send + Sync> BaseLayerContract for CyclicBaseLayerWr
 
     async fn cycle_provider_url(&mut self) -> Result<(), Self::Error> {
         self.base_layer.cycle_provider_url().await
+    }
+
+    async fn reset_provider_url_to_primary(&mut self) -> Result<(), Self::Error> {
+        self.base_layer.reset_provider_url_to_primary().await
+    }
+
+    async fn is_at_primary(&self) -> Result<bool, Self::Error> {
+        self.base_layer.is_at_primary().await
     }
 }

--- a/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
+++ b/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use apollo_config::secrets::Sensitive;
 use apollo_infra_utils::url::to_safe_string;
@@ -25,6 +26,7 @@ fn get_url_helper(num_url_calls_made: &AtomicUsize) -> Result<Sensitive<Url>, Mo
 // whether there are any URLs left to try. We use a base layer with two URLs that get cycled.
 
 const NUM_URLS: usize = 2;
+const TEST_RETRY_PRIMARY_INTERVAL: Duration = Duration::from_secs(3600);
 
 #[rstest]
 #[case::success(0)]
@@ -40,6 +42,7 @@ async fn cycle_get_proved_block_at(#[case] num_failing_calls: usize) {
     let num_url_calls_made_clone2 = num_url_calls_made.clone();
 
     let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer
         .expect_get_proved_block_at()
         .times(num_failing_calls)
@@ -56,7 +59,7 @@ async fn cycle_get_proved_block_at(#[case] num_failing_calls: usize) {
         num_url_calls_made_clone2.fetch_add(1, Ordering::Relaxed);
         Ok(())
     });
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.get_proved_block_at(1).await;
@@ -83,6 +86,7 @@ async fn cycle_latest_l1_block_number(#[case] num_failing_calls: usize) {
     let num_url_calls_made_clone2 = num_url_calls_made.clone();
 
     let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer
         .expect_latest_l1_block_number()
         .times(num_failing_calls)
@@ -96,7 +100,7 @@ async fn cycle_latest_l1_block_number(#[case] num_failing_calls: usize) {
         num_url_calls_made_clone2.fetch_add(1, Ordering::Relaxed);
         Ok(())
     });
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.latest_l1_block_number().await;
@@ -123,6 +127,7 @@ async fn cycle_l1_block_at(#[case] num_failing_calls: usize) {
     let num_url_calls_made_clone2 = num_url_calls_made.clone();
 
     let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer
         .expect_l1_block_at()
         .times(num_failing_calls)
@@ -139,7 +144,7 @@ async fn cycle_l1_block_at(#[case] num_failing_calls: usize) {
         num_url_calls_made_clone2.fetch_add(1, Ordering::Relaxed);
         Ok(())
     });
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.l1_block_at(1).await;
@@ -166,6 +171,7 @@ async fn cycle_events(#[case] num_failing_calls: usize) {
     let num_url_calls_made_clone2 = num_url_calls_made.clone();
 
     let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer
         .expect_events()
         .times(num_failing_calls)
@@ -179,7 +185,7 @@ async fn cycle_events(#[case] num_failing_calls: usize) {
         num_url_calls_made_clone2.fetch_add(1, Ordering::Relaxed);
         Ok(())
     });
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.events(0..=1_u64, &[]).await;
@@ -206,6 +212,7 @@ async fn cycle_get_block_header(#[case] num_failing_calls: usize) {
     let num_url_calls_made_clone2 = num_url_calls_made.clone();
 
     let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer
         .expect_get_block_header()
         .times(num_failing_calls)
@@ -222,7 +229,7 @@ async fn cycle_get_block_header(#[case] num_failing_calls: usize) {
         num_url_calls_made_clone2.fetch_add(1, Ordering::Relaxed);
         Ok(())
     });
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.get_block_header(1).await;
@@ -242,8 +249,9 @@ async fn get_url_itself_fails() {
     // Setup.
     let mut base_layer = MockBaseLayerContract::new();
 
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer.expect_get_url().times(1).returning(move || Err(MockError::MockError));
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.get_block_header(1).await;
@@ -257,13 +265,14 @@ async fn get_url_itself_fails() {
 async fn get_block_header_fails_after_cycle_error() {
     // Setup.
     let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer.expect_get_url().times(2).returning(move || {
         Ok(Sensitive::new(Url::parse("http://first_endpoint").unwrap())
             .with_redactor(to_safe_string))
     });
     base_layer.expect_get_block_header().times(1).returning(move |_| Err(MockError::MockError));
     base_layer.expect_cycle_provider_url().times(1).returning(move || Err(MockError::MockError));
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.get_block_header(1).await;
@@ -288,7 +297,7 @@ async fn pass_through_get_block_header_immutable(#[case] success: bool) {
             .expect_get_block_header_immutable()
             .returning(move |_| Err(MockError::MockError));
     }
-    let wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.get_block_header_immutable(1).await;
@@ -309,7 +318,7 @@ async fn pass_through_get_url() {
         Ok(Sensitive::new(Url::parse("http://first_endpoint").unwrap())
             .with_redactor(to_safe_string))
     });
-    let wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.get_url().await;
@@ -321,7 +330,7 @@ async fn pass_through_set_provider_url() {
     // Setup.
     let mut base_layer = MockBaseLayerContract::new();
     base_layer.expect_set_provider_url().returning(move |_| Ok(()));
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper
@@ -338,7 +347,7 @@ async fn pass_through_cycle_provider_url() {
     // Setup.
     let mut base_layer = MockBaseLayerContract::new();
     base_layer.expect_cycle_provider_url().returning(move || Ok(()));
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test.
     let result = wrapper.cycle_provider_url().await;
@@ -380,6 +389,7 @@ async fn test_exhaust_from_non_primary_index_returns_last_error() {
     let mut error_returns = (0..NUM_ATTEMPTS).map(MockError::Numbered);
 
     let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
     base_layer
         .expect_get_url()
         .times(num_get_url_calls)
@@ -391,9 +401,258 @@ async fn test_exhaust_from_non_primary_index_returns_last_error() {
         .returning(move |_| Err(error_returns.next().unwrap()));
     // Cycling succeeds once per failed attempt.
     base_layer.expect_cycle_provider_url().times(NUM_ATTEMPTS).returning(|| Ok(()));
-    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer);
+    // Use a large retry-primary interval so the primary retry never interferes with the cycling
+    // path.
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
 
     // Test: all attempts fail; the wrapper must return the last attempt's error.
     let result = wrapper.get_proved_block_at(1).await;
     assert_eq!(result, Err(MockError::Numbered(NUM_ATTEMPTS - 1)));
+}
+
+// Verifies that when the retry-primary interval has elapsed, the wrapper calls
+// reset_provider_url_to_primary before executing the cycling operation.
+#[tokio::test]
+async fn test_retry_primary_when_interval_elapsed() {
+    // Setup: use Duration::ZERO so the interval is always elapsed.
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
+    base_layer.expect_reset_provider_url_to_primary().times(1).returning(|| Ok(()));
+    base_layer.expect_get_url().times(1).returning(|| {
+        Ok(Sensitive::new(Url::parse("http://first_endpoint").unwrap())
+            .with_redactor(to_safe_string))
+    });
+    base_layer
+        .expect_get_proved_block_at()
+        .times(1)
+        .returning(|_| Ok(BlockHashAndNumber::default()));
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, Duration::ZERO);
+
+    // Test.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+}
+
+// Verifies that when the retry-primary interval has elapsed but reset_provider_url_to_primary
+// returns an error, the error propagates and the underlying operation is never called.
+#[tokio::test]
+async fn test_retry_primary_error_propagates_and_skips_operation() {
+    // Setup: use Duration::ZERO so the interval is always elapsed.
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
+    base_layer
+        .expect_reset_provider_url_to_primary()
+        .times(1)
+        .returning(|| Err(MockError::MockError));
+    // The underlying operation must never be reached when retry-primary errors out.
+    base_layer.expect_get_proved_block_at().times(0);
+
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, Duration::ZERO);
+
+    // Test.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(matches!(result, Err(MockError::MockError)));
+}
+
+// Verifies that when the retry-primary interval has not elapsed, the wrapper does not call
+// reset_provider_url_to_primary.
+#[tokio::test]
+async fn test_no_retry_primary_when_interval_not_elapsed() {
+    // Setup: use a large interval so it is never elapsed.
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
+    base_layer.expect_reset_provider_url_to_primary().times(0);
+    base_layer.expect_get_url().times(1).returning(|| {
+        Ok(Sensitive::new(Url::parse("http://first_endpoint").unwrap())
+            .with_redactor(to_safe_string))
+    });
+    base_layer
+        .expect_get_proved_block_at()
+        .times(1)
+        .returning(|_| Ok(BlockHashAndNumber::default()));
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, TEST_RETRY_PRIMARY_INTERVAL);
+
+    // Test.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+}
+
+// Verifies that when already on the primary endpoint, retry_primary_if_due skips the reset even
+// when the interval has elapsed (Duration::ZERO guarantees immediate elapse).
+#[tokio::test]
+async fn test_no_retry_primary_when_already_at_primary() {
+    // Setup: report primary position; the timer is irrelevant since is_at_primary short-circuits.
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(true));
+    base_layer.expect_reset_provider_url_to_primary().times(0);
+    base_layer.expect_get_url().times(1).returning(|| {
+        Ok(Sensitive::new(Url::parse("http://first_endpoint").unwrap())
+            .with_redactor(to_safe_string))
+    });
+    base_layer
+        .expect_get_proved_block_at()
+        .times(1)
+        .returning(|_| Ok(BlockHashAndNumber::default()));
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, Duration::ZERO);
+
+    // Test.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+}
+
+// Verifies that cycling between backup endpoints does not push out the primary-retry clock:
+// only the first failover that leaves the primary sets the clock, so the interval is measured
+// from the moment we departed the primary, not from the latest backup-to-backup switch.
+//
+// Scenario (3 operations, paused tokio time):
+//   Op1 @ T0:        starts on primary, fails once, cycles primary -> secondary (clock set to T0),
+//                    then succeeds on secondary.
+//   Op2 @ T0+30:     starts on secondary, fails once, cycles secondary -> tertiary
+//                    (backup -> backup: clock must NOT move), then succeeds on tertiary.
+//   Op3 @ T0+60:     starts on tertiary; retry_primary_if_due sees elapsed = 60 >= INTERVAL,
+//                    so reset fires and we return to primary, where the call succeeds.
+//
+// If the bug were present (clock reset on every cycle), Op3 would see elapsed = 30 < INTERVAL
+// and reset would NOT fire — so the `.times(1)` assertion on reset_provider_url_to_primary
+// would fail, distinguishing fixed code from the buggy version.
+#[tokio::test(start_paused = true)]
+async fn test_retry_clock_not_reset_by_backup_cycles() {
+    const INTERVAL: Duration = Duration::from_secs(60);
+
+    let primary_url = Sensitive::new(Url::parse("http://primary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+    let secondary_url = Sensitive::new(Url::parse("http://secondary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+    let tertiary_url = Sensitive::new(Url::parse("http://tertiary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+
+    // is_at_primary return sequence (5 calls total):
+    //   Op1 retry_primary_if_due:  true  (on primary, skip interval check)
+    //   Op1 cycle_url_on_error:    true  (was_at_primary → set clock to T0)
+    //   Op2 retry_primary_if_due:  false (on secondary, elapsed=30 < 60, no reset)
+    //   Op2 cycle_url_on_error:    false (backup → backup, clock must not move)
+    //   Op3 retry_primary_if_due:  false (on tertiary, elapsed=60 >= 60, reset fires)
+    let mut is_at_primary_returns = [true, true, false, false, false].into_iter();
+
+    // get_url return sequence (7 calls total):
+    //   Op1: start=primary, current=primary, new=secondary
+    //   Op2: start=secondary, current=secondary, new=tertiary
+    //   Op3: start=primary  (after reset_provider_url_to_primary)
+    let url_sequence = [
+        primary_url.clone(),
+        primary_url.clone(),
+        secondary_url.clone(),
+        secondary_url.clone(),
+        secondary_url.clone(),
+        tertiary_url.clone(),
+        primary_url.clone(),
+    ];
+    let mut get_url_returns = url_sequence.into_iter();
+
+    // get_proved_block_at return sequence (5 calls total):
+    //   Op1: Err (primary fails), Ok (secondary succeeds)
+    //   Op2: Err (secondary fails), Ok (tertiary succeeds)
+    //   Op3: Ok  (primary succeeds after reset)
+    let mut operation_returns: std::vec::IntoIter<Result<BlockHashAndNumber, MockError>> = vec![
+        Err(MockError::MockError),
+        Ok(BlockHashAndNumber::default()),
+        Err(MockError::MockError),
+        Ok(BlockHashAndNumber::default()),
+        Ok(BlockHashAndNumber::default()),
+    ]
+    .into_iter();
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer
+        .expect_is_at_primary()
+        .times(5)
+        .returning(move || Ok(is_at_primary_returns.next().unwrap()));
+    base_layer.expect_get_url().times(7).returning(move || Ok(get_url_returns.next().unwrap()));
+    base_layer
+        .expect_get_proved_block_at()
+        .times(5)
+        .returning(move |_| operation_returns.next().unwrap());
+    // Two cycles: primary -> secondary (Op1), secondary -> tertiary (Op2).
+    base_layer.expect_cycle_provider_url().times(2).returning(|| Ok(()));
+    // The key assertion: reset fires exactly once, at Op3. If backup cycles pushed the clock,
+    // elapsed at T0+60 would be only 30 s (< INTERVAL) and this would fire zero times.
+    base_layer.expect_reset_provider_url_to_primary().times(1).returning(|| Ok(()));
+
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, INTERVAL);
+
+    // Op1 @ T0: primary fails, cycles to secondary, succeeds.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+
+    // Advance to T0+30: half the interval has elapsed since leaving the primary.
+    tokio::time::advance(Duration::from_secs(30)).await;
+
+    // Op2 @ T0+30: secondary fails, cycles to tertiary (backup -> backup), succeeds.
+    // The primary-retry clock must not move.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+
+    // Advance to T0+60: the full interval has now elapsed since Op1 left the primary.
+    tokio::time::advance(Duration::from_secs(30)).await;
+
+    // Op3 @ T0+60: retry_primary_if_due fires, resets to primary, call succeeds.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+}
+
+// Verifies that retry_primary fires exactly once after the interval elapses. Uses
+// start_paused = true for deterministic tokio time control.
+#[tokio::test(start_paused = true)]
+async fn test_retry_primary_fires_only_after_interval_elapses() {
+    const INTERVAL: Duration = Duration::from_secs(60);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
+    base_layer.expect_get_url().returning(|| {
+        Ok(Sensitive::new(Url::parse("http://first_endpoint").unwrap())
+            .with_redactor(to_safe_string))
+    });
+    // Two successful operation calls: one before the interval elapses, one after.
+    base_layer
+        .expect_get_proved_block_at()
+        .times(2)
+        .returning(|_| Ok(BlockHashAndNumber::default()));
+    // Reset fires exactly once — when the second call runs after the interval has elapsed.
+    base_layer.expect_reset_provider_url_to_primary().times(1).returning(|| Ok(()));
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, INTERVAL);
+
+    // First call: elapsed is 0, which is less than INTERVAL, so no reset.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+
+    // Advance time past the interval so the next call finds elapsed >= INTERVAL.
+    tokio::time::advance(INTERVAL).await;
+
+    // Second call: elapsed >= INTERVAL, so reset fires exactly once.
+    let result = wrapper.get_proved_block_at(1).await;
+    assert!(result.is_ok());
+}
+
+// A failed primary retry must not advance the clock, so the next L1 access retries the primary
+// again instead of waiting another full interval.
+#[tokio::test(start_paused = true)]
+async fn test_retry_clock_not_advanced_when_reset_fails() {
+    const INTERVAL: Duration = Duration::from_secs(60);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
+    // Reset fails each time; the clock advances only on success, so each access stays due.
+    base_layer
+        .expect_reset_provider_url_to_primary()
+        .times(2)
+        .returning(|| Err(MockError::MockError));
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, INTERVAL);
+
+    // Make the retry due.
+    tokio::time::advance(INTERVAL).await;
+
+    // First access: retry is due, reset fails, so the operation errors.
+    assert!(wrapper.get_proved_block_at(1).await.is_err());
+    // Still due (the failed reset did not advance the clock): the next access retries again.
+    assert!(wrapper.get_proved_block_at(1).await.is_err());
 }

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -15,6 +15,7 @@ use alloy::sol_types::sol_data;
 use alloy::transports::TransportErrorKind;
 use apollo_config::converters::{
     deserialize_milliseconds_to_duration,
+    deserialize_seconds_to_duration,
     deserialize_vec,
     serialize_slice,
 };
@@ -83,6 +84,16 @@ impl CircularUrlIterator {
 
     pub fn get_current_url(&self) -> Sensitive<Url> {
         self.urls.get(self.index).cloned().expect("No endpoint URLs provided")
+    }
+
+    /// Returns true if the iterator is currently pointing at the primary (first) endpoint.
+    pub fn is_at_primary(&self) -> bool {
+        self.index == 0
+    }
+
+    /// Resets the iterator to point at the primary (first) endpoint.
+    pub fn reset_to_primary(&mut self) {
+        self.index = 0;
     }
 }
 
@@ -308,6 +319,19 @@ impl BaseLayerContract for EthereumBaseLayerContract {
         // `contract` querying the previous (failed) endpoint.
         self.set_provider_url(next_url).await
     }
+
+    async fn reset_provider_url_to_primary(&mut self) -> Result<(), Self::Error> {
+        // No-op if already on the primary endpoint, to avoid a needless provider rebuild.
+        if self.url_iterator.is_at_primary() {
+            return Ok(());
+        }
+        self.url_iterator.reset_to_primary();
+        self.set_provider_url(self.url_iterator.get_current_url()).await
+    }
+
+    async fn is_at_primary(&self) -> Result<bool, Self::Error> {
+        Ok(self.url_iterator.is_at_primary())
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -397,6 +421,10 @@ pub struct EthereumBaseLayerConfig {
     pub bpo2_start_block_number: L1BlockNumber,
     #[serde(deserialize_with = "deserialize_milliseconds_to_duration")]
     pub timeout_millis: Duration,
+    /// The interval (seconds) after which the next base-layer access retries the primary (first)
+    /// endpoint.
+    #[serde(deserialize_with = "deserialize_seconds_to_duration")]
+    pub retry_primary_interval_seconds: Duration,
 }
 
 impl Validate for EthereumBaseLayerConfig {
@@ -476,6 +504,13 @@ impl SerializeConfig for EthereumBaseLayerConfig {
                 "The timeout (milliseconds) for a query of the L1 base layer",
                 ParamPrivacyInput::Public,
             ),
+            ser_param(
+                "retry_primary_interval_seconds",
+                &self.retry_primary_interval_seconds.as_secs(),
+                "The interval (seconds) after which the next base-layer access retries the \
+                 primary (first) endpoint.",
+                ParamPrivacyInput::Public,
+            ),
         ])
     }
 }
@@ -494,6 +529,7 @@ impl Default for EthereumBaseLayerConfig {
             bpo1_start_block_number: 0,
             bpo2_start_block_number: 0,
             timeout_millis: Duration::from_millis(1000),
+            retry_primary_interval_seconds: Duration::from_secs(60),
         }
     }
 }

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -92,6 +92,12 @@ pub trait BaseLayerContract {
     async fn get_url(&self) -> Result<Sensitive<Url>, Self::Error>;
     async fn set_provider_url(&mut self, url: Sensitive<Url>) -> Result<(), Self::Error>;
     async fn cycle_provider_url(&mut self) -> Result<(), Self::Error>;
+    /// Resets the provider to the primary (first) endpoint. This is a no-op if the provider is
+    /// already on the primary endpoint.
+    async fn reset_provider_url_to_primary(&mut self) -> Result<(), Self::Error>;
+
+    /// Returns whether the active provider is currently the primary (first) endpoint.
+    async fn is_at_primary(&self) -> Result<bool, Self::Error>;
 }
 
 /// Reference to an L1 block, extend as needed.


### PR DESCRIPTION
Cherry-pick of #14521 onto `main-v0.14.3`.

Adds an opportunistic, time-based retry of the primary L1 endpoint after failover: once `retry_primary_interval_seconds` (default 60s) have elapsed since leaving the primary, the next L1 access reverts to it, so a recovered primary is used again.

Mirror of the equivalent PR on `main`: [#14521](https://github.com/starkware-libs/sequencer/pull/14521) (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
