### PR TITLE
apollo_central_sync: gate compiled class backlog panic on store threshold

### DIFF
--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -288,7 +288,12 @@ impl<
         // new StateDiffAvailable events. Fix: enumerate blocks from
         // initial_compiled_class_marker to initial_state_marker, read their state diffs,
         // and send CompiledClassRequests for declared classes.
-        if initial_compiled_class_marker < initial_state_marker {
+        // Only blocks below store_sierras_and_casms_block_threshold persist compiled classes;
+        // at or above the threshold the marker is advanced without storing casms, so a marker
+        // lag there is expected and not a backlog to recover.
+        if initial_compiled_class_marker < initial_state_marker
+            && initial_compiled_class_marker.0 < self.config.store_sierras_and_casms_block_threshold
+        {
             panic!(
                 "Compiled class marker ({}) is behind state marker ({}). Compiled class backlog \
                  recovery is not yet implemented.",


### PR DESCRIPTION
## Summary
The startup check in `sync_while_ok` panics when the compiled class marker lags behind the state marker (compiled class backlog recovery is not yet implemented). This panic was too aggressive: blocks at or above `store_sierras_and_casms_block_threshold` advance the compiled class marker *without* storing casms, so a marker lag in that range is expected and harmless — not a backlog to recover.

## Change
- Gate the panic on `initial_compiled_class_marker.0 < store_sierras_and_casms_block_threshold` in addition to the existing `< initial_state_marker` check.
- Update the doc comment to explain why the threshold matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)