### PR TITLE
apollo_deployments: derive override schema by evaluating applicative jsonnet

### DIFF
--- a/crates/apollo_deployments/src/deployment_definitions_test.rs
+++ b/crates/apollo_deployments/src/deployment_definitions_test.rs
@@ -19,16 +19,13 @@ use crate::jsonnet_test::{
     test_applicative_matches_app_configs,
     test_generator_config_is_node_loadable,
     test_generator_flat_input_matches_direct_build,
+    test_keys_to_be_replaced_are_covered_by_override_schema,
 };
-use crate::service::{NodeType, KEYS_TO_BE_REPLACED};
+use crate::service::NodeType;
 use crate::test_utils::SecretsConfigOverride;
-use crate::utils::is_path_prefix;
 
 const SECRETS_FOR_TESTING_ENV_PATH: &str =
     "crates/apollo_deployments/resources/testing_secrets.json";
-
-const APPLICATIVE_CONFIG_JSONNET_PATH: &str =
-    "crates/apollo_deployments/jsonnet/lib/applicative_config.libsonnet";
 
 /// Verifies the applicative config emitted by jsonnet matches the committed `app_configs/*.json`
 /// (the deployment's non-overridable value layer), up to overridable keys, secrets, and integers
@@ -140,76 +137,15 @@ fn replacer_config_entries_are_in_config() {
     }
 }
 
-/// Collects the overrided keys from the applicative-config jsonnet, i.e all keys that are
-/// referenced as `overrides.<path>`.
-fn override_schema_keys(jsonnet_source: &str) -> HashSet<String> {
-    const MARKER: &str = "overrides.";
-    let is_key_char = |c: char| c.is_ascii_alphanumeric() || c == '_' || c == '.';
-    jsonnet_source
-        .lines()
-        .filter(|line| !line.trim_start().starts_with("//"))
-        // The text following the (single) `overrides.` occurrence on the line, if any.
-        .filter_map(|line| line.split_once(MARKER))
-        // A key is the leading run of identifier/dot characters following the marker.
-        .filter_map(|(_, after_marker)| {
-            let key = after_marker.split(|c| !is_key_char(c)).next().unwrap_or("");
-            let key = key.trim_end_matches('.');
-            (!key.is_empty()).then(|| key.to_string())
-        })
-        .collect()
-}
-
-/// Enforces the invariant tying the Rust replacer set to the jsonnet override schema, both ways:
-/// (1) every key `f` in `KEYS_TO_BE_REPLACED` is covered by exactly one override key `t` that is a
-/// path-prefix of it (`t == f`, or `f` starts with `t.`); and (2) every `overrides.<path>` the
-/// applicative reads corresponds to some `KEYS_TO_BE_REPLACED` entry (one is a path-prefix of the
-/// other) — so no non-overridable (constant) value is read from `overrides`.
+/// Enforces the invariant tying the Rust replacer set (`KEYS_TO_BE_REPLACED`) to the applicative
+/// config's override schema, both ways. See the doc on
+/// `test_keys_to_be_replaced_are_covered_by_override_schema`.
 #[test]
 fn keys_to_be_replaced_are_covered_by_override_schema() {
     env::set_current_dir(resolve_project_relative_path("").unwrap())
         .expect("Couldn't set working dir.");
 
-    let jsonnet_source = std::fs::read_to_string(APPLICATIVE_CONFIG_JSONNET_PATH)
-        .expect("Failed to read applicative_config.libsonnet");
-    let override_keys = override_schema_keys(&jsonnet_source);
-
-    let mut uncovered_keys: Vec<&str> = Vec::new();
-    let mut ambiguous_keys: Vec<(&str, Vec<String>)> = Vec::new();
-    for replacer_key in KEYS_TO_BE_REPLACED.iter().copied() {
-        let covering_overrides: Vec<String> = override_keys
-            .iter()
-            .filter(|override_key| is_path_prefix(override_key, replacer_key))
-            .cloned()
-            .collect();
-        match covering_overrides.len() {
-            1 => {}                                 // Covered by exactly one override.
-            0 => uncovered_keys.push(replacer_key), // Not covered by any override.
-            _ => ambiguous_keys.push((replacer_key, covering_overrides)), /* Covered by more than
-                                                      * one override. */
-        }
-    }
-
-    // Reverse direction: every `overrides.<path>` the applicative reads must correspond to an
-    // overridable key — otherwise a constant is being read from `overrides` per-environment.
-    let non_overridable_refs: Vec<&str> = override_keys
-        .iter()
-        .filter(|override_key| {
-            !KEYS_TO_BE_REPLACED
-                .iter()
-                .any(|key| is_path_prefix(override_key, key) || is_path_prefix(key, override_key))
-        })
-        .map(String::as_str)
-        .collect();
-
-    assert!(
-        uncovered_keys.is_empty() && ambiguous_keys.is_empty() && non_overridable_refs.is_empty(),
-        "The applicative-config override schema drifted from KEYS_TO_BE_REPLACED.\nReplacer keys \
-         with no covering override (add an `overrides.<path>` that is a prefix): \
-         {uncovered_keys:#?}\nReplacer keys covered by more than one override (the override \
-         schema is ambiguous): {ambiguous_keys:#?}\n`overrides.<path>` references not in \
-         KEYS_TO_BE_REPLACED (make them constants, or add the key to KEYS_TO_BE_REPLACED): \
-         {non_overridable_refs:#?}"
-    );
+    test_keys_to_be_replaced_are_covered_by_override_schema();
 }
 
 // TODO(Tsabary): consider adding a test that loads a config and validates it; the challenge will be

--- a/crates/apollo_deployments/src/jsonnet_test.rs
+++ b/crates/apollo_deployments/src/jsonnet_test.rs
@@ -4,7 +4,7 @@ use apollo_config::dumping::SerializeConfig;
 use apollo_config::{FIELD_SEPARATOR, IS_NONE_MARK};
 use apollo_node_config::config_utils::{config_to_preset, private_parameters};
 use apollo_node_config::node_config::{SequencerNodeConfig, CONFIG_POINTERS};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use strum::IntoEnumIterator;
 use tempfile::NamedTempFile;
 
@@ -227,6 +227,112 @@ pub fn test_applicative_matches_app_configs() {
         mismatches.len(),
         mismatches.join("\n  ")
     );
+}
+
+/// Sentinel string injected at an override path; the suffix carries the dotted path so a value
+/// surviving into the applicative output identifies which override the applicative read.
+const OVERRIDE_SENTINEL_PREFIX: &str = "__override_sentinel__:";
+
+/// Enforces that the applicative config's override schema agrees with `KEYS_TO_BE_REPLACED`, by
+/// *evaluating* the applicative `function(overrides)` with a sentinel placed at every expected
+/// override path and checking which sentinels flow into the output — insensitive to the jsonnet's
+/// formatting (unlike scanning the source for `overrides.<path>` strings):
+/// - A sentinel absent from the output is an override the applicative never reads, i.e.
+///   `KEYS_TO_BE_REPLACED` declares a replacer key with no corresponding override read.
+/// - If the applicative reads an override path absent from the expected set, jsonnet fails to
+///   evaluate (the field is missing, or it indexes a sub-field of a scalar sentinel) — catching an
+///   `overrides.<path>` reference with no `KEYS_TO_BE_REPLACED` entry.
+pub fn test_keys_to_be_replaced_are_covered_by_override_schema() {
+    let expected_paths = expected_override_paths();
+    let applicative = eval_applicative_config(&sentinel_overrides(&expected_paths));
+
+    let mut consumed_paths = BTreeSet::new();
+    collect_sentinel_paths(&applicative, &mut consumed_paths);
+
+    let unread_paths: Vec<&String> = expected_paths.difference(&consumed_paths).collect();
+    assert!(
+        unread_paths.is_empty(),
+        "KEYS_TO_BE_REPLACED declares override paths the applicative config never reads (remove \
+         the replacer key, or read `overrides.<path>` in applicative_config.libsonnet): \
+         {unread_paths:#?}"
+    );
+}
+
+/// The override read-paths the applicative config is expected to read, derived from
+/// `KEYS_TO_BE_REPLACED`: an optional config marked `<path>.#is_none` is read whole at `<path>` (so
+/// its sub-field replacer keys collapse into that single read), and every other replacer key is
+/// read at its full path.
+fn expected_override_paths() -> BTreeSet<String> {
+    let is_none_suffix = format!("{FIELD_SEPARATOR}{IS_NONE_MARK}");
+    let option_roots: BTreeSet<&str> =
+        KEYS_TO_BE_REPLACED.iter().filter_map(|key| key.strip_suffix(&is_none_suffix)).collect();
+
+    let mut paths: BTreeSet<String> = option_roots.iter().map(|root| (*root).to_owned()).collect();
+    for key in KEYS_TO_BE_REPLACED.iter().copied() {
+        let is_marker = key.ends_with(&is_none_suffix);
+        let under_option_root = option_roots.iter().any(|root| is_path_prefix(root, key));
+        if !is_marker && !under_option_root {
+            paths.insert(key.to_owned());
+        }
+    }
+    paths
+}
+
+/// Builds a nested `overrides` object placing a path-encoding sentinel string at each dotted path.
+fn sentinel_overrides(paths: &BTreeSet<String>) -> Value {
+    let mut root = Map::new();
+    for path in paths {
+        let parts: Vec<&str> = path.split(FIELD_SEPARATOR).collect();
+        let (leaf, ancestors) = parts.split_last().expect("a path has at least one segment");
+        let mut current = &mut root;
+        for ancestor in ancestors {
+            current = current
+                .entry((*ancestor).to_owned())
+                .or_insert_with(|| Value::Object(Map::new()))
+                .as_object_mut()
+                .expect("override path prefix-conflicts with another override path");
+        }
+        current
+            .insert((*leaf).to_owned(), Value::String(format!("{OVERRIDE_SENTINEL_PREFIX}{path}")));
+    }
+    Value::Object(root)
+}
+
+/// Evaluates the applicative `function(overrides)` (`lib/applicative_config.libsonnet`) applied to
+/// `overrides`.
+fn eval_applicative_config(overrides: &Value) -> Value {
+    let overrides_literal = serde_json::to_string(overrides).expect("overrides is serializable");
+    let state = jsonnet_state();
+    let _guard = state.enter();
+    let snippet = format!("(import 'lib/applicative_config.libsonnet')({overrides_literal})");
+    let val = state
+        .evaluate_snippet("applicative_entry.jsonnet", snippet)
+        .expect("applicative_config.libsonnet failed to evaluate");
+    // jrsonnet evaluates lazily, so a bad field access surfaces here (when the thunks are forced),
+    // not at `evaluate_snippet`. A "no such field" error means the applicative reads an
+    // `overrides.<path>` with no KEYS_TO_BE_REPLACED entry, or indexes a sub-field of an optional
+    // config marked `.#is_none` (whose sentinel is a scalar).
+    serde_json::to_value(&val).unwrap_or_else(|error| {
+        panic!(
+            "applicative_config.libsonnet read an override path not declared in \
+             KEYS_TO_BE_REPLACED (add the key), or indexed a sub-field of a `.#is_none` optional \
+             config: {error}"
+        )
+    })
+}
+
+/// Collects the dotted paths encoded in every override sentinel string found anywhere in `value`.
+fn collect_sentinel_paths(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::String(string) => {
+            if let Some(path) = string.strip_prefix(OVERRIDE_SENTINEL_PREFIX) {
+                out.insert(path.to_owned());
+            }
+        }
+        Value::Array(items) => items.iter().for_each(|item| collect_sentinel_paths(item, out)),
+        Value::Object(map) => map.values().for_each(|child| collect_sentinel_paths(child, out)),
+        _ => {}
+    }
 }
 
 /// Merges every base `app_configs/<component>.json` (skipping the derived `replacer_*` files) into


### PR DESCRIPTION
The override-schema invariant test extracted overridable keys by scanning
applicative_config.libsonnet source for the substring `overrides.`
(split_once per line), which is brittle: a reformat that splits a
reference across lines, a second `overrides.` on one line, or the string
appearing in a comment all silently change the derived key set.

Replace the text scan with evaluation: build an `overrides` object that
places a path-encoding sentinel at every override path expected from
KEYS_TO_BE_REPLACED (collapsing optional configs marked `.#is_none` to
their option root, which the applicative reads whole), evaluate
`applicative_config(overrides)`, and check which sentinels reached the
output. A sentinel that never appears is a replacer key the applicative
never reads; an override the applicative reads but KEYS_TO_BE_REPLACED
does not declare makes jsonnet fail to evaluate (missing field). Both
failure directions are exercised by mutation testing. The check is now
about actual consumption and is insensitive to jsonnet formatting.

The distinct "covered by more than one override" diagnostic the source
scan produced now surfaces as an evaluation error (indexing a sub-field
of a scalar sentinel) rather than a dedicated message.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>