### PR TITLE
apollo_deployments: node-loadable regression across all layouts

### DIFF
--- a/crates/apollo_deployments/src/jsonnet_test.rs
+++ b/crates/apollo_deployments/src/jsonnet_test.rs
@@ -129,15 +129,17 @@ pub fn test_generator_flat_input_matches_direct_build() {
     );
 }
 
-/// The generator's flat output is node-loadable, valid, and faithful: for every hybrid service,
-/// feeding `service_config_to_preset` (the binary's output) through the node's real loader
+/// The generator's flat output is node-loadable, valid, and faithful: for every service of every
+/// layout, feeding `service_config_to_preset` (the binary's output) through the node's real loader
 /// (`SequencerNodeConfig::load_and_process`, which resolves `CONFIG_POINTERS` + `#is_none`)
 /// reconstructs exactly the `SequencerNodeConfig` that `build` produced and passes
 /// `validate_node_config` — in particular the cross-member rule that each `<component>_config` is
 /// set iff that component runs locally, which is what the per-service-tailored `build` satisfies.
 /// Uses `testing/overrides`.
 pub fn test_generator_config_is_node_loadable() {
-    assert_built_services_node_loadable(&eval_test_build("hybrid"));
+    for node_type in NodeType::iter() {
+        assert_built_services_node_loadable(&eval_test_build(&node_type.to_string()));
+    }
 }
 
 /// For every service in a `build(...)` result, feeds `service_config_to_preset` (the binary's


### PR DESCRIPTION
The generator node-loadable test only built the hybrid layout. Extend it
to every layout (consolidated, hybrid, distributed) so each layout's
per-service config is proven to round-trip through the node loader and
pass validate_node_config — in particular the cross-member rule that
each <component>_config is set iff that component runs locally, which
differs per layout (consolidated runs everything in one service;
distributed spreads components across services).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>