### PR TITLE
papyrus_base_layer: advance primary-retry clock only after a successful reset

### DIFF
--- a/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper.rs
+++ b/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper.rs
@@ -32,8 +32,10 @@ impl<B: BaseLayerContract + Send + Sync> CyclicBaseLayerWrapper<B> {
             return Ok(());
         }
         if self.last_primary_retry.elapsed() >= self.retry_primary_interval {
-            self.last_primary_retry = tokio::time::Instant::now();
+            // Advance the clock only after a successful reset, so a failed reset retries on the
+            // next access instead of waiting another full interval.
             self.base_layer.reset_provider_url_to_primary().await?;
+            self.last_primary_retry = tokio::time::Instant::now();
         }
         Ok(())
     }

--- a/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
+++ b/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
@@ -632,3 +632,27 @@ async fn test_retry_primary_fires_only_after_interval_elapses() {
     let result = wrapper.get_proved_block_at(1).await;
     assert!(result.is_ok());
 }
+
+// A failed primary retry must not advance the clock, so the next L1 access retries the primary
+// again instead of waiting another full interval.
+#[tokio::test(start_paused = true)]
+async fn test_retry_clock_not_advanced_when_reset_fails() {
+    const INTERVAL: Duration = Duration::from_secs(60);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().returning(|| Ok(false));
+    // Reset fails each time; the clock advances only on success, so each access stays due.
+    base_layer
+        .expect_reset_provider_url_to_primary()
+        .times(2)
+        .returning(|| Err(MockError::MockError));
+    let mut wrapper = CyclicBaseLayerWrapper::new(base_layer, INTERVAL);
+
+    // Make the retry due.
+    tokio::time::advance(INTERVAL).await;
+
+    // First access: retry is due, reset fails, so the operation errors.
+    assert!(wrapper.get_proved_block_at(1).await.is_err());
+    // Still due (the failed reset did not advance the clock): the next access retries again.
+    assert!(wrapper.get_proved_block_at(1).await.is_err());
+}


### PR DESCRIPTION
Follow-up fix to #14521. In `retry_primary_if_due`, advance `last_primary_retry` only **after** a successful `reset_provider_url_to_primary`. Previously the clock was bumped before the reset, so if the reset errored, the endpoint stayed on a backup but the next primary retry waited a full `retry_primary_interval` instead of retrying on the next access.

Adds `test_retry_clock_not_advanced_when_reset_fails`. The same fix is in the `main-v0.14.3` mirror #14565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
