### PR TITLE
apollo_storage: relax append_classes marker check to permit forward skip

### DIFF
--- a/crates/apollo_central_sync/src/lib.rs
+++ b/crates/apollo_central_sync/src/lib.rs
@@ -706,9 +706,6 @@ impl<
                      block_contains_non_backwards_compatible_classes is false",
                     classes.keys().collect::<Vec<_>>()
                 );
-                // Still need to advance the class marker even when not storing classes,
-                // otherwise future blocks that DO have classes will fail with marker mismatch.
-                txn = txn.append_classes(block_number, &[], &[])?;
             }
             txn.commit()?;
             Ok(())

--- a/crates/apollo_storage/src/class.rs
+++ b/crates/apollo_storage/src/class.rs
@@ -268,7 +268,8 @@ impl<T: StorageTransaction<Mode = RW>> ClassStorageWriter for T {
 
         let marker_block_number =
             markers_table.get(self.txn(), &MarkerKind::Class)?.unwrap_or_default();
-        if block_number != marker_block_number {
+        // Forward skips auto-fast-forward via the upsert below; only backwards is corruption.
+        if block_number < marker_block_number {
             return Err(StorageError::MarkerMismatch {
                 marker_kind: MarkerKind::Class,
                 expected: marker_block_number,

--- a/crates/apollo_storage/src/class_test.rs
+++ b/crates/apollo_storage/src/class_test.rs
@@ -60,22 +60,39 @@ fn append_classes_writes_correct_data() {
 }
 
 #[test]
-fn append_classes_marker_mismatch() {
-    let ((_reader, mut writer), _temp_dir) = get_test_storage();
+fn append_classes_block_above_marker_fast_forwards() {
+    let ((reader, mut writer), _temp_dir) = get_test_storage();
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_state_diff(BlockNumber(0), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(1), &[], &[])
+        .unwrap()
+        .commit()
+        .unwrap();
+    assert_eq!(reader.begin_ro_txn().unwrap().get_class_marker().unwrap(), BlockNumber(2));
+}
 
+#[test]
+fn append_classes_block_below_marker_errors() {
+    let ((_reader, mut writer), _temp_dir) = get_test_storage();
     let Err(err) = writer
         .begin_rw_txn()
         .unwrap()
         .append_state_diff(BlockNumber(0), ThinStateDiff::default())
         .unwrap()
-        .append_classes(BlockNumber(1), &Vec::new(), &Vec::new())
+        .append_classes(BlockNumber(0), &[], &[])
+        .unwrap()
+        .append_state_diff(BlockNumber(1), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
     else {
         panic!("Unexpected Ok.");
     };
-
     assert_matches!(
         err,
-        StorageError::MarkerMismatch { marker_kind: MarkerKind::Class, expected, found } if expected.0 == 0 && found.0 == 1
+        StorageError::MarkerMismatch { marker_kind: MarkerKind::Class, expected, found } if expected.0 == 1 && found.0 == 0
     );
 }
 


### PR DESCRIPTION
PR #14442 added an empty-vec `append_classes` call so the Class marker stays locked in step with the state marker even on threshold-skipped blocks. DBs populated before that PR have a permanent Class marker lag (blocks at or above `store_sierras_and_casms_block_threshold` that declared only backward-compatible classes were skipped without advancing the marker), which now trips `MarkerMismatch` on the first class append after restart.

Loosen the strict equality check to `block_number < marker_block_number`, mirroring the spirit of #14569's `gate compiled class backlog panic on store threshold`. Forward-skip auto-fast-forwards the marker via the existing `markers_table.upsert(..&block_number.unchecked_next())` call below; genuine backwards-going corruption still errors.