### PR TITLE
apollo_dashboard: alert when the primary L1 endpoint is down too long

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "apollo_transaction_converter",
  "blockifier",
  "indexmap 2.14.0",
+ "papyrus_base_layer",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/apollo_dashboard/Cargo.toml
+++ b/crates/apollo_dashboard/Cargo.toml
@@ -41,6 +41,7 @@ apollo_storage.workspace = true
 apollo_transaction_converter.workspace = true
 blockifier.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
+papyrus_base_layer.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 serde_with.workspace = true
@@ -68,4 +69,5 @@ apollo_staking = { workspace = true, features = ["testing"] }
 apollo_state_sync_metrics = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
 apollo_transaction_converter = { workspace = true, features = ["testing"] }
+papyrus_base_layer = { workspace = true, features = ["testing"] }
 rstest.workspace = true

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1913,6 +1913,58 @@
       "severity": "$$$preconfirmed_block_not_written-severity$$$"
     },
     {
+      "name": "primary_l1_endpoint_down_too_long_l1_events",
+      "title": "Primary L1 endpoint down too long (l1_events)",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(max((time() - l1_primary_endpoint_down_since_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", scraper=\"l1_events\"}) and (l1_primary_endpoint_down_since_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", scraper=\"l1_events\"} > 0))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              600.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "p4"
+    },
+    {
+      "name": "primary_l1_endpoint_down_too_long_l1_gas_price",
+      "title": "Primary L1 endpoint down too long (l1_gas_price)",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(max((time() - l1_primary_endpoint_down_since_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", scraper=\"l1_gas_price\"}) and (l1_primary_endpoint_down_since_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", scraper=\"l1_gas_price\"} > 0))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              600.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "p4"
+    },
+    {
       "name": "sierra_compiler_remote_server_number_of_connections",
       "title": "sierra_compiler - Remote server number of connections exceeds 80",
       "ruleGroup": "evaluation_rate_default",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -69,6 +69,7 @@ use crate::alert_scenarios::infra_alerts::{
     get_general_pod_state_not_ready,
     get_periodic_ping,
 };
+use crate::alert_scenarios::l1_endpoints::get_primary_l1_endpoint_down_too_long_alerts;
 use crate::alert_scenarios::l1_gas_prices::{
     get_eth_to_strk_success_count_alert,
     get_l1_gas_price_provider_insufficient_history_alert,
@@ -663,6 +664,7 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_l1_gas_price_scraper_success_count_alert());
     alerts.push(get_l1_message_scraper_no_successes_alert());
     alerts.push(get_l1_handler_transaction_waiting_in_l1_alert());
+    alerts.extend(get_primary_l1_endpoint_down_too_long_alerts());
     alerts.push(get_mempool_evictions_count_alert());
     alerts.push(get_mempool_p2p_peer_down());
     alerts.push(get_mempool_pool_size_increase());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_endpoints.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_endpoints.rs
@@ -1,0 +1,60 @@
+use apollo_metrics::metrics::MetricQueryName;
+use papyrus_base_layer::metrics::{
+    ScraperLabel,
+    L1_PRIMARY_ENDPOINT_DOWN_SINCE_TIMESTAMP_SECONDS,
+    LABEL_NAME_SCRAPER,
+};
+use strum::IntoEnumIterator;
+
+use crate::alerts::{
+    Alert,
+    AlertComparisonOp,
+    AlertCondition,
+    AlertLogicalOp,
+    AlertSeverity,
+    EvaluationRate,
+    ObserverApplicability,
+    PENDING_DURATION_DEFAULT,
+};
+
+// 10 minutes; change this constant and regenerate the dashboard to adjust the threshold.
+const MAX_PRIMARY_DOWN_SECONDS: f64 = 600.0;
+
+/// Returns one alert per scraper label (`l1_events`, `l1_gas_price`).
+///
+/// Alerting is already per apollo node: the monitoring build provisions each node's Grafana with
+/// its own copy of the rule, scoped to that node's `namespace`/`cluster` (see
+/// `inject_expr_placeholders` in the monitoring builder). So the rule only ever sees a single
+/// node's series, and there is no cross-node aggregation to worry about.
+///
+/// Each alert pins the `scraper` label to a single value and wraps the remaining per-pod series in
+/// `max(...)` to collapse the node's pods into one worst-case downtime value. This yields one
+/// alert per `(scraper, node)`: a long outage on the node fires the alert, without emitting a
+/// separate instance per pod.
+pub(crate) fn get_primary_l1_endpoint_down_too_long_alerts() -> Vec<Alert> {
+    ScraperLabel::iter()
+        .map(|scraper| {
+            let scraper_str: &'static str = scraper.into();
+            let alert_name = format!("primary_l1_endpoint_down_too_long_{scraper_str}");
+            let metric = L1_PRIMARY_ENDPOINT_DOWN_SINCE_TIMESTAMP_SECONDS
+                .get_name_with_filer_and_additional_fields(&format!(
+                    "{LABEL_NAME_SCRAPER}=\"{scraper_str}\""
+                ));
+            Alert::new(
+                alert_name,
+                format!("Primary L1 endpoint down too long ({scraper_str})"),
+                EvaluationRate::Default,
+                format!("max((time() - {metric}) and ({metric} > 0))"),
+                vec![AlertCondition::new(
+                    AlertComparisonOp::GreaterThan,
+                    MAX_PRIMARY_DOWN_SECONDS,
+                    AlertLogicalOp::And,
+                )],
+                PENDING_DURATION_DEFAULT,
+                // P4: fires only during official business hours (excludes nights/holidays).
+                AlertSeverity::WorkingHours,
+                ObserverApplicability::NotApplicable,
+            )
+        })
+        .collect()
+}

--- a/crates/apollo_dashboard/src/alert_scenarios/mod.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/mod.rs
@@ -2,6 +2,7 @@ pub mod block_production_delay;
 pub mod block_production_halt;
 pub mod config_manager;
 pub mod infra_alerts;
+pub mod l1_endpoints;
 pub mod l1_gas_prices;
 pub mod l1_handlers;
 pub mod mempool_size;

--- a/crates/apollo_dashboard/src/metric_definitions_test.rs
+++ b/crates/apollo_dashboard/src/metric_definitions_test.rs
@@ -48,6 +48,7 @@ use apollo_transaction_converter::metrics::{
     GATEWAY_ALL_METRICS as TRANSACTION_CONVERTER_GATEWAY_ALL_METRICS,
 };
 use blockifier::metrics::BLOCKIFIER_ALL_METRICS;
+use papyrus_base_layer::metrics::BASE_LAYER_ALL_METRICS;
 
 use crate::alert_scenarios::infra_alerts::POD_ALL_METRICS;
 
@@ -73,6 +74,7 @@ fn metric_names_no_duplications() {
         .chain(HTTP_SERVER_ALL_METRICS.iter())
         .chain(L1_GAS_PRICE_ALL_METRICS.iter())
         .chain(L1_GAS_PRICE_INFRA_METRICS.iter())
+        .chain(BASE_LAYER_ALL_METRICS.iter())
         .chain(L1_EVENTS_PROVIDER_ALL_METRICS.iter())
         .chain(L1_EVENTS_PROVIDER_INFRA_METRICS.iter())
         .chain(MEMPOOL_ALL_METRICS.iter())


### PR DESCRIPTION
**PR 3/3** of primary-L1-endpoint-down alerting (stacked on #14577).

Adds the Grafana alert `primary_l1_endpoint_down_too_long`, firing per scraper when `(time() - down_since) and (down_since > 0)` exceeds the threshold (`MAX_PRIMARY_DOWN_SECONDS`, default 600s — the tunable "configurable amount of time"; change + regenerate). Severity is a deployment placeholder. Regenerated `dev_grafana_alerts.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
