### PR TITLE
apollo_consensus_orchestrator: track and cancel reproposal task on round change

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -917,6 +917,12 @@ impl ConsensusContext for SequencerConsensusContext {
     ) {
         info!(?proposal_commitment, ?build_param, "Reproposing.");
         let height = build_param.height;
+        let round = build_param.round;
+        // Tear down any proposal still tracked from a previous round before starting this one,
+        // mirroring build/validate. set_height_and_round already interrupts on round change; we
+        // repeat it here so the active-proposal slot is guaranteed free without asserting.
+        self.interrupt_active_proposal().await;
+
         let (init, txs, finished_info) = self
             .valid_proposals
             .lock()
@@ -926,20 +932,32 @@ impl ConsensusContext for SequencerConsensusContext {
         let next_l2_gas_price =
             self.calculate_next_l2_gas_price(init.height, finished_info.l2_gas_used);
         let transaction_converter = self.deps.transaction_converter.clone();
-        let mut stream_sender =
-            self.start_stream(HeightAndRound(height.0, build_param.round)).await;
+        let mut stream_sender = self.start_stream(HeightAndRound(height.0, round)).await;
+
+        // Track the reproposal task like build/validate so it is cancelled and awaited on
+        // round/height change. Otherwise a superseded reproposal keeps re-converting every
+        // transaction through the class manager and holding a full-block clone, with no
+        // backpressure on the number of in-flight tasks.
+        let cancel_token = CancellationToken::new();
+        let cancel_token_clone = cancel_token.clone();
         let handle = tokio::spawn(
             async move {
-                let res = send_reproposal(
-                    proposal_commitment,
-                    init,
-                    txs,
-                    finished_info,
-                    next_l2_gas_price,
-                    &mut stream_sender,
-                    transaction_converter,
-                )
-                .await;
+                let res = tokio::select! {
+                    biased;
+                    () = cancel_token.cancelled() => {
+                        info!(?height, round, "Reproposal cancelled for superseded round.");
+                        return;
+                    }
+                    res = send_reproposal(
+                        proposal_commitment,
+                        init,
+                        txs,
+                        finished_info,
+                        next_l2_gas_price,
+                        &mut stream_sender,
+                        transaction_converter,
+                    ) => res,
+                };
                 match res {
                     Ok(()) => {
                         info!(?proposal_commitment, ?build_param, "Reproposal succeeded.");
@@ -949,15 +967,11 @@ impl ConsensusContext for SequencerConsensusContext {
                     }
                 }
             }
-            .instrument(error_span!("consensus_repropose", round = build_param.round)),
+            .instrument(error_span!("consensus_repropose", round)),
         );
-        // Spawn a follow-up task to detect panics. Without this, if the reproposal
-        // task panics, the JoinError is silently swallowed when the handle is dropped.
-        tokio::spawn(async move {
-            if let Err(e) = handle.await {
-                error!("Reproposal task panicked: {e:?}");
-            }
-        });
+        // Panics in the task surface as a JoinError when interrupt_active_proposal awaits the
+        // handle on the next round/height change or on decision_reached, matching build/validate.
+        self.active_proposal = Some((cancel_token_clone, handle));
     }
 
     async fn broadcast(&mut self, message: Vote) -> Result<(), ConsensusError> {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -649,6 +649,74 @@ async fn propose_then_repropose(#[case] execute_all_txs: bool) {
     context.decision_reached(HEIGHT_0, ROUND_1, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
 }
 
+// M-27: a reproposal must be tracked in `active_proposal` like build/validate, so that advancing
+// the round cancels and tears down the (possibly in-flight) reproposal task instead of leaving it
+// detached and re-converting transactions for a superseded round.
+#[tokio::test]
+async fn repropose_is_tracked_and_cancelled_on_round_change() {
+    let (mut deps, mut network) = create_test_and_network_deps();
+    deps.setup_deps_for_build(SetupDepsArgs {
+        n_executed_txs_count: TX_BATCH.len(),
+        ..Default::default()
+    });
+
+    const TIMESTAMP: u64 = 123456;
+    let mut clock = MockClock::new();
+    clock.expect_unix_now().return_const(TIMESTAMP);
+    clock.expect_now().return_const(Utc.timestamp_opt(TIMESTAMP.try_into().unwrap(), 0).unwrap());
+    deps.clock = Arc::new(clock);
+
+    // A buffer of 1 guarantees the reproposal task parks mid-stream (after Init, before Fin) since
+    // its output stream is never drained, letting us observe that cancellation tears it down while
+    // it is still in flight.
+    let mut context = deps.build_context_with_config(ContextConfig {
+        static_config: ContextStaticConfig {
+            proposal_buffer_size: 1,
+            chain_id: CHAIN_ID,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    // Build a proposal at round 0 and drain it so the stored proposal exists and the build task
+    // completes.
+    let fin_receiver = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap();
+    let (_, mut build_receiver) = network.outbound_proposal_receiver.next().await.unwrap();
+    while build_receiver.next().await.is_some() {}
+    assert_eq!(fin_receiver.await.unwrap(), *TEST_PROPOSAL_COMMITMENT);
+
+    // Advance to round 1: interrupts the finished build and clears the active-proposal slot.
+    context.set_height_and_round(HEIGHT_0, ROUND_1).await.unwrap();
+    assert!(context.active_proposal.is_none(), "build task should be cleared after round change");
+
+    // Re-propose round 0's content at round 1, without draining the stream so the task stays in
+    // flight (parked once the single-slot buffer fills).
+    let build_param =
+        BuildParam { round: ROUND_1, valid_round: Some(ROUND_0), ..Default::default() };
+    context.repropose(*TEST_PROPOSAL_COMMITMENT, build_param).await;
+    let (_, mut reproposal_receiver) = network.outbound_proposal_receiver.next().await.unwrap();
+    assert!(
+        context.active_proposal.is_some(),
+        "reproposal task must be tracked in active_proposal"
+    );
+
+    // Advancing the round must cancel and await the in-flight reproposal task. If the task were not
+    // cancel-aware, interrupt_active_proposal would hang here on the parked stream send.
+    context.set_height_and_round(HEIGHT_0, ROUND_1 + 1).await.unwrap();
+    assert!(
+        context.active_proposal.is_none(),
+        "reproposal task should be cleared after round change"
+    );
+
+    // The cancelled task dropped its stream sender before reaching Fin, so the abandoned stream for
+    // the superseded round closes without ever delivering a Fin part.
+    let mut saw_fin = false;
+    while let Some(part) = reproposal_receiver.next().await {
+        saw_fin |= matches!(part, ProposalPart::Fin(_));
+    }
+    assert!(!saw_fin, "cancelled reproposal must not deliver a Fin for the superseded round");
+}
+
 #[tokio::test]
 async fn gas_price_fri_out_of_range() {
     let (mut deps, _network) = create_test_and_network_deps();


### PR DESCRIPTION
## What

Addresses security finding **M-27** (reproposal spawns unbounded detached tasks).

`repropose` spawned two detached `tokio::spawn` tasks that were never stored in `active_proposal` nor given a `CancellationToken`. `set_height_and_round` / `decision_reached` only cancel `active_proposal` (build/validate), so reproposal tasks were fully detached and never cancelled. Under sustained round churn, superseded reproposals kept re-converting every transaction through the shared class-manager client and holding full-block clones, with no backpressure on the number of in-flight tasks.

## Change

- Track the reproposal task in `active_proposal` with a `CancellationToken`, like the build and validate paths. It is now cancelled and awaited by the existing `interrupt_active_proposal` on round/height change and on `decision_reached`.
- Wrap `send_reproposal` in a cancel-aware `tokio::select!` so a superseded reproposal stops mid-stream (releasing the block clone and halting further tx re-conversion) instead of running to completion.
- Drop the separate panic-watcher `tokio::spawn`; a task panic now surfaces as a `JoinError` when `interrupt_active_proposal` awaits the handle, matching build/validate.
- Defensively `interrupt_active_proposal()` at the top of `repropose` so the slot is guaranteed free without an `assert`.

## Tests

- New `repropose_is_tracked_and_cancelled_on_round_change`: builds + reproposes with a 1-slot stream buffer so the task parks mid-stream, then asserts it is tracked in `active_proposal`, that advancing the round cancels and clears it (no hang on the parked send), and that the abandoned stream closes without a `Fin`.
- Verified the new test fails against the pre-fix (detached/untracked) behavior.
- Full suite: `SEED=0 cargo test -p apollo_consensus_orchestrator --features testing` → 167 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)