### PR TITLE
apollo_l1_events: respawn sync task if it finished during target raise, relax atomic ordering

### DIFF
--- a/crates/apollo_l1_events/src/catchupper.rs
+++ b/crates/apollo_l1_events/src/catchupper.rs
@@ -106,13 +106,16 @@ impl Catchupper {
     }
 
     pub fn target_height(&self) -> BlockNumber {
-        BlockNumber(self.target_height.load(Ordering::Acquire))
+        // Relaxed: this atomic carries only its own value, it publishes no other memory, so no
+        // ordering against other operations is needed.
+        BlockNumber(self.target_height.load(Ordering::Relaxed))
     }
 
     /// Raises the target height of the running sync task so it keeps syncing up to `target_height`.
     /// Uses `fetch_max` so the target only moves forward; a lower height is ignored.
     pub fn update_target_height(&self, target_height: BlockNumber) {
-        self.target_height.fetch_max(target_height.0, Ordering::Release);
+        // Relaxed: see `target_height`.
+        self.target_height.fetch_max(target_height.0, Ordering::Relaxed);
     }
 
     /// Returns true while an L2 sync task is in flight (spawned and not yet finished).
@@ -170,12 +173,12 @@ async fn l2_sync_task(
     // The target is re-read every iteration so an `update_target_height` call from the provider
     // (a higher block committed before catch-up finishes) extends this same task instead of
     // spawning a competing one.
-    while current_height.0 <= target_height.load(Ordering::Acquire) {
+    while current_height.0 <= target_height.load(Ordering::Relaxed) {
         // TODO(Gilad): add tracing instrument.
         debug!(
             "Syncing L1EventsProvider with L2 height: {} to target height: {}",
             current_height,
-            target_height.load(Ordering::Acquire)
+            target_height.load(Ordering::Relaxed)
         );
         let block = sync_client.get_block(current_height).await.inspect_err(|err| debug!("{err}"));
 

--- a/crates/apollo_l1_events/src/l1_events_provider.rs
+++ b/crates/apollo_l1_events/src/l1_events_provider.rs
@@ -360,7 +360,14 @@ impl L1EventsProvider {
         // Recreating the catchupper here and detaching the current task would leak racing tasks.
         if self.catchupper.is_sync_task_running() {
             self.catchupper.update_target_height(target_height);
-            return;
+            // Re-check: the task may have exited its sync loop between the check above and the
+            // target raise, which would leave the raised target on a finished task with nothing
+            // syncing. If it's still running it picks up the new target; otherwise fall through to
+            // respawn. (A task that finishes even after this second check is recovered by
+            // `sync_task_health_check`.)
+            if self.catchupper.is_sync_task_running() {
+                return;
+            }
         }
         self.reset_catchupper();
         self.catchupper.start_l2_sync(self.current_height, target_height);


### PR DESCRIPTION
Goal: address asaf-sw's review notes on PR #14518 in a follow-up branch (the base commit is left untouched per request).

Changes:
- start_catching_up: after raising the target on a running sync task, re-check is_sync_task_running(); if the task finished in the TOCTOU window, fall through to respawn instead of leaving the provider stuck in CatchingUp with no sync task.
- target_height atomic: Acquire/Release -> Relaxed on both load and fetch_max sides, since the atomic carries only its own value and publishes no other memory.

Decision points:
- TOCTOU: chose respawn-on-finish (double-check) over comment-only. sync_task_health_check remains the backstop for the residual narrow window where a task finishes even after the second check.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>