### PR TITLE
apollo_deployments: generator accepts ordered --overlay jsonnet layers

### DIFF
--- a/crates/apollo_deployments/jsonnet/testing/overlay_partial_base.libsonnet
+++ b/crates/apollo_deployments/jsonnet/testing/overlay_partial_base.libsonnet
@@ -1,0 +1,18 @@
+// Test overlay layer — base/infrastructure partition: the first 10 of the 20 top-level override
+// keys. Together with `overlay_partial_services.libsonnet` it partitions the complete
+// `overrides.libsonnet` set exactly (no gaps, no overlaps). Values are projected from the canonical
+// fixture (imported relative to this file's own directory, exercising overlay-local import
+// resolution) so the two partial overlays stay in sync with the complete set by construction.
+local overrides = import 'overrides.libsonnet';
+{
+  chain_id: overrides.chain_id,
+  eth_fee_token_address: overrides.eth_fee_token_address,
+  strk_fee_token_address: overrides.strk_fee_token_address,
+  validator_id: overrides.validator_id,
+  native_classes_whitelist: overrides.native_classes_whitelist,
+  versioned_constants_overrides: overrides.versioned_constants_overrides,
+  base_layer_config: overrides.base_layer_config,
+  batcher_config: overrides.batcher_config,
+  class_manager_config: overrides.class_manager_config,
+  committer_config: overrides.committer_config,
+}

--- a/crates/apollo_deployments/jsonnet/testing/overlay_partial_services.libsonnet
+++ b/crates/apollo_deployments/jsonnet/testing/overlay_partial_services.libsonnet
@@ -1,0 +1,18 @@
+// Test overlay layer — services/networking partition: the remaining 10 of the 20 top-level
+// override keys. Together with `overlay_partial_base.libsonnet` it partitions the complete
+// `overrides.libsonnet` set exactly (no gaps, no overlaps). Values are projected from the canonical
+// fixture (imported relative to this file's own directory, exercising overlay-local import
+// resolution) so the two partial overlays stay in sync with the complete set by construction.
+local overrides = import 'overrides.libsonnet';
+{
+  consensus_manager_config: overrides.consensus_manager_config,
+  gateway_config: overrides.gateway_config,
+  http_server_config: overrides.http_server_config,
+  mempool_config: overrides.mempool_config,
+  mempool_p2p_config: overrides.mempool_p2p_config,
+  monitoring_endpoint_config: overrides.monitoring_endpoint_config,
+  sierra_compiler_config: overrides.sierra_compiler_config,
+  state_sync_config: overrides.state_sync_config,
+  recorder_url: overrides.recorder_url,
+  starknet_url: overrides.starknet_url,
+}

--- a/crates/apollo_deployments/src/bin/deployment_config_generator.rs
+++ b/crates/apollo_deployments/src/bin/deployment_config_generator.rs
@@ -1,18 +1,27 @@
 //! Generates the non-secret deployment config for a layout from `build(layout, overrides)`.
 //!
-//! Reads the deploy's flat dotted `sequencerConfig` overrides from a JSON file, translates them
-//! into the nested `overrides` shape, evaluates `build(layout, overrides)`, and prints each
-//! service's config in the node-loadable flat dotted format (the whole service-keyed map, or a
-//! single service with `--service`). Secrets are never produced here — they remain a separate
-//! mounted file.
+//! Override input comes in one of two mutually exclusive modes:
+//! - `--config_file`: the deploy's flat dotted `sequencerConfig` overrides as a single JSON file,
+//!   translated into the nested `overrides` shape.
+//! - `--overlay` (repeatable): one or more standalone jsonnet "overlay" layers, given in precedence
+//!   order (later layers win). Each overlay is evaluated rooted at its OWN directory (so its tree's
+//!   relative imports resolve locally), then the evaluated objects are deep-merged in Rust into a
+//!   single nested `overrides`. The overlay trees never share an import path with the
+//!   apollo_deployments jsonnet dir.
+//!
+//! Either way, the result evaluates `build(layout, overrides)` and prints each service's config in
+//! the node-loadable flat dotted format (the whole service-keyed map, or a single service with
+//! `--service`). Secrets are never produced here — they remain a separate mounted file.
 
 use std::collections::BTreeMap;
 use std::env;
 use std::path::PathBuf;
 
 use apollo_deployments::jsonnet_generation::{
+    deep_merge_values,
     eval_build_service_with_overrides,
     eval_build_with_overrides,
+    eval_overlay_at_path,
     overrides_from_sequencer_config,
     service_config_to_preset,
 };
@@ -28,9 +37,15 @@ struct Args {
     /// Deployment layout: `consolidated`, `hybrid`, or `distributed`.
     #[arg(long)]
     layout: String,
-    /// Path to the flat dotted overrides JSON (the deploy's merged `sequencerConfig`).
+    /// Path to the flat dotted overrides JSON (the deploy's merged `sequencerConfig`). Mutually
+    /// exclusive with `--overlay`.
     #[arg(long)]
-    config_file: PathBuf,
+    config_file: Option<PathBuf>,
+    /// Path to an overlay jsonnet layer. Repeat in precedence order (later layers win); the
+    /// evaluated layers are deep-merged into the nested `overrides`. Mutually exclusive with
+    /// `--config_file`.
+    #[arg(long, value_name = "PATH")]
+    overlay: Vec<PathBuf>,
     /// When set, print only this service's config instead of the whole service-keyed map.
     #[arg(long)]
     service: Option<String>,
@@ -46,18 +61,48 @@ fn main() {
         args.layout
     );
 
-    // Read the overrides relative to the invocation directory, before switching to the project root
-    // (where `build`'s jsonnet imports resolve).
-    let config_contents = std::fs::read_to_string(&args.config_file).unwrap_or_else(|error| {
-        panic!("failed to read overrides file {:?}: {error}", args.config_file)
-    });
-    let flat_overrides: BTreeMap<String, Value> = serde_json::from_str(&config_contents)
-        .expect("overrides file must be a flat dotted JSON object");
+    // Resolve the overrides relative to the invocation directory, before switching to the project
+    // root (where `build`'s jsonnet imports resolve). Exactly one input mode must be supplied:
+    // either a single flat `--config_file` or one-or-more jsonnet `--overlay` layers.
+    let overrides = match (&args.config_file, args.overlay.as_slice()) {
+        (Some(_), [_, ..]) => panic!("Must specify either --config_file or --overlay (not both)"),
+        (None, []) => panic!("Must specify at least one of --config_file or --overlay"),
+        (Some(config_file), []) => {
+            let config_contents = std::fs::read_to_string(config_file).unwrap_or_else(|error| {
+                panic!("failed to read overrides file {config_file:?}: {error}")
+            });
+            let flat_overrides: BTreeMap<String, Value> = serde_json::from_str(&config_contents)
+                .expect("overrides file must be a flat dotted JSON object");
 
-    env::set_current_dir(resolve_project_relative_path("").unwrap())
-        .expect("Couldn't set working dir.");
+            env::set_current_dir(resolve_project_relative_path("").unwrap())
+                .expect("Couldn't set working dir.");
+            overrides_from_sequencer_config(&flat_overrides)
+        }
+        (None, overlays) => {
+            // Evaluate each overlay rooted at its own directory before the chdir, resolving every
+            // path against the invocation dir so each tree's relative imports stay local.
+            // Deep-merge the evaluated layers in order (later overlays win) into a
+            // single nested `overrides`.
+            let overlay_layers: Vec<Value> = overlays
+                .iter()
+                .map(|overlay| {
+                    let overlay_path = overlay.canonicalize().unwrap_or_else(|error| {
+                        panic!("failed to resolve overlay path {overlay:?}: {error}")
+                    });
+                    eval_overlay_at_path(&overlay_path)
+                        .unwrap_or_else(|error| panic!("overlay {overlay:?} failed: {error}"))
+                })
+                .collect();
+            let mut merged = Value::Object(serde_json::Map::new());
+            for layer in &overlay_layers {
+                deep_merge_values(&mut merged, layer);
+            }
 
-    let overrides = overrides_from_sequencer_config(&flat_overrides);
+            env::set_current_dir(resolve_project_relative_path("").unwrap())
+                .expect("Couldn't set working dir.");
+            merged
+        }
+    };
 
     let output = match &args.service {
         // Build only the requested service: a per-service deploy supplies just that service's

--- a/crates/apollo_deployments/src/deployment_definitions_test.rs
+++ b/crates/apollo_deployments/src/deployment_definitions_test.rs
@@ -17,9 +17,11 @@ use crate::jsonnet_test::{
     assert_build_deserializes,
     assert_infra_matches_rust,
     test_applicative_matches_app_configs,
+    test_eval_overlay_at_path_missing_file_errors,
     test_generator_config_is_node_loadable,
     test_generator_flat_input_matches_direct_build,
     test_keys_to_be_replaced_are_covered_by_override_schema,
+    test_multi_overlay_merge_semantics,
     test_real_overlay_overrides_are_node_loadable,
 };
 use crate::service::NodeType;
@@ -113,6 +115,25 @@ fn generator_flat_input_matches_direct_build() {
         .expect("Couldn't set working dir.");
 
     test_generator_flat_input_matches_direct_build();
+}
+
+/// Verifies the generator's multi-overlay path: deep-merging two partial overlay layers builds the
+/// same config as building from the complete fixture directly.
+#[test]
+fn multi_overlay_merge_semantics() {
+    env::set_current_dir(resolve_project_relative_path("").unwrap())
+        .expect("Couldn't set working dir.");
+
+    test_multi_overlay_merge_semantics();
+}
+
+/// Verifies evaluating a non-existent overlay path returns an error naming the path.
+#[test]
+fn eval_overlay_at_path_missing_file_errors() {
+    env::set_current_dir(resolve_project_relative_path("").unwrap())
+        .expect("Couldn't set working dir.");
+
+    test_eval_overlay_at_path_missing_file_errors();
 }
 
 /// Verifies the generator's flat output is node-loadable and round-trips through the node loader.

--- a/crates/apollo_deployments/src/jsonnet_generation.rs
+++ b/crates/apollo_deployments/src/jsonnet_generation.rs
@@ -2,7 +2,7 @@
 //! `build(layout, overrides)`. Shared by the deployment-config generator and the crate tests.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use apollo_config::dumping::SerializeConfig;
 use apollo_config::{FIELD_SEPARATOR, IS_NONE_MARK};
@@ -23,6 +23,61 @@ pub(crate) fn jsonnet_state() -> State {
     builder.context_initializer(jrsonnet_stdlib::ContextInitializer::new(PathResolver::Absolute));
     builder.import_resolver(FileImportResolver::new(vec![PathBuf::from(JSONNET_DIR)]));
     builder.build()
+}
+
+/// Evaluates a standalone overlay jsonnet file to a nested JSON `overrides` object, rooted at the
+/// overlay's OWN directory: the import resolver points at `overlay_path`'s parent, so the overlay
+/// tree's relative imports (e.g. `import '_common.jsonnet'`) resolve locally and NEVER against the
+/// apollo_deployments `JSONNET_DIR`. Each overlay layer is its own self-contained jsonnet tree; the
+/// layers are merged later, in Rust (see `deep_merge_values`), so the two jsonnet import paths
+/// never mix.
+///
+/// `overlay_path` is read as given (callers pass an absolute path, since the generator evaluates
+/// overlays before switching to the project root). Returns the parse/eval error as a `String` with
+/// the offending path for context.
+pub fn eval_overlay_at_path(overlay_path: &Path) -> Result<Value, String> {
+    let parent_dir = overlay_path
+        .parent()
+        .ok_or_else(|| format!("overlay path {overlay_path:?} has no parent directory"))?;
+    let file_name = overlay_path
+        .file_name()
+        .ok_or_else(|| format!("overlay path {overlay_path:?} has no file name"))?
+        .to_str()
+        .ok_or_else(|| format!("overlay path {overlay_path:?} is not valid UTF-8"))?;
+
+    let mut builder = State::builder();
+    builder.context_initializer(jrsonnet_stdlib::ContextInitializer::new(PathResolver::Absolute));
+    builder.import_resolver(FileImportResolver::new(vec![parent_dir.to_path_buf()]));
+    let state = builder.build();
+
+    let _guard = state.enter();
+    let val = state
+        .evaluate_snippet("overlay_entry.jsonnet", format!("import '{file_name}'"))
+        .map_err(|error| format!("failed to evaluate overlay at {overlay_path:?}: {error}"))?;
+    serde_json::to_value(&val)
+        .map_err(|error| format!("overlay at {overlay_path:?} is not serializable: {error}"))
+}
+
+/// Recursively deep-merges `right` into `left`, with `right` winning on every leaf. When both sides
+/// hold a JSON object at a key, their keys are merged recursively; for every other shape (scalars,
+/// arrays, `null`, or an object overwriting a non-object and vice versa) `right`'s value completely
+/// replaces `left`'s. In particular, `null` from `right` is a legitimate override value: it fully
+/// replaces whatever `left` held at that key (null-wins semantics). Used to combine ordered overlay
+/// layers into a single `overrides` object, later layers winning.
+pub fn deep_merge_values(left: &mut Value, right: &Value) {
+    match (left, right) {
+        (Value::Object(left_map), Value::Object(right_map)) => {
+            for (key, right_value) in right_map {
+                match left_map.get_mut(key) {
+                    Some(left_value) => deep_merge_values(left_value, right_value),
+                    None => {
+                        left_map.insert(key.clone(), right_value.clone());
+                    }
+                }
+            }
+        }
+        (left_slot, right_value) => *left_slot = right_value.clone(),
+    }
 }
 
 /// Evaluates `build(layout, overrides)`.

--- a/crates/apollo_deployments/src/jsonnet_test.rs
+++ b/crates/apollo_deployments/src/jsonnet_test.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use apollo_config::dumping::SerializeConfig;
 use apollo_config::{FIELD_SEPARATOR, IS_NONE_MARK};
@@ -11,8 +11,10 @@ use tempfile::NamedTempFile;
 
 use crate::deployment_definitions::BASE_APP_CONFIGS_DIR_PATH;
 use crate::jsonnet_generation::{
+    deep_merge_values,
     eval_build_with_expr,
     eval_build_with_overrides,
+    eval_overlay_at_path,
     eval_overrides_file,
     jsonnet_state,
     overrides_from_sequencer_config,
@@ -127,6 +129,59 @@ pub fn test_generator_flat_input_matches_direct_build() {
         eval_build_with_overrides("hybrid", &overrides_from_sequencer_config(&flat)),
         eval_test_build("hybrid"),
     );
+}
+
+const OVERLAY_BASE_PATH: &str =
+    "crates/apollo_deployments/jsonnet/testing/overlay_partial_base.libsonnet";
+const OVERLAY_SERVICES_PATH: &str =
+    "crates/apollo_deployments/jsonnet/testing/overlay_partial_services.libsonnet";
+
+/// The generator's multi-overlay path: two PARTIAL overlay layers (each supplying a disjoint half
+/// of the override set), each evaluated rooted at its OWN directory, deep-merged in Rust into a
+/// single nested `overrides`, build to exactly the same per-service config as building from the
+/// complete `testing/overrides.libsonnet` directly. The fixtures partition all 20 top-level keys
+/// with no gaps or overlaps; because they are disjoint, the merge is order-independent here (the
+/// merge's later-wins semantics is exercised by the `deep_merge_values` unit tests).
+pub fn test_multi_overlay_merge_semantics() {
+    let base = eval_overlay_at_path(Path::new(OVERLAY_BASE_PATH)).expect("base overlay evaluates");
+    let services =
+        eval_overlay_at_path(Path::new(OVERLAY_SERVICES_PATH)).expect("services overlay evaluates");
+    assert!(base.is_object(), "base overlay is an object");
+    assert!(services.is_object(), "services overlay is an object");
+
+    let mut merged = base;
+    deep_merge_values(&mut merged, &services);
+
+    // The merged overlays reconstruct the complete override set, key for key.
+    let complete = eval_overrides_file("testing/overrides.libsonnet");
+    assert_eq!(
+        merged.as_object().unwrap().keys().collect::<BTreeSet<_>>(),
+        complete.as_object().unwrap().keys().collect::<BTreeSet<_>>(),
+        "the two partial overlays must partition all top-level keys of testing/overrides",
+    );
+
+    // ...so building from the merged overlays equals building from the complete fixture directly.
+    assert_eq!(eval_build_with_overrides("hybrid", &merged), eval_test_build("hybrid"));
+
+    // Disjoint fixtures merge order-independently: reversing the layer order yields the same
+    // result.
+    let mut reverse_merged =
+        eval_overlay_at_path(Path::new(OVERLAY_SERVICES_PATH)).expect("services overlay evaluates");
+    deep_merge_values(
+        &mut reverse_merged,
+        &eval_overlay_at_path(Path::new(OVERLAY_BASE_PATH)).expect("base overlay evaluates"),
+    );
+    assert_eq!(merged, reverse_merged, "disjoint overlays merge identically in either order");
+}
+
+/// A non-existent overlay path surfaces as an `Err` naming the offending path, rather than
+/// panicking.
+pub fn test_eval_overlay_at_path_missing_file_errors() {
+    let error = eval_overlay_at_path(Path::new(
+        "crates/apollo_deployments/jsonnet/testing/does_not_exist.libsonnet",
+    ))
+    .expect_err("a missing overlay file must error");
+    assert!(error.contains("does_not_exist"), "error should name the offending path: {error}");
 }
 
 /// The generator's flat output is node-loadable, valid, and faithful: for every service of every
@@ -537,6 +592,50 @@ fn without_url_port(components: &serde_json::Map<String, Value>) -> serde_json::
 
 fn flat(pairs: &[(&str, Value)]) -> BTreeMap<String, Value> {
     pairs.iter().map(|(key, value)| (key.to_string(), value.clone())).collect()
+}
+
+#[test]
+fn deep_merge_combines_disjoint_keys() {
+    let mut left = json!({ "a": 1 });
+    deep_merge_values(&mut left, &json!({ "b": 2 }));
+    assert_eq!(left, json!({ "a": 1, "b": 2 }));
+}
+
+#[test]
+fn deep_merge_right_overwrites_scalar() {
+    let mut left = json!({ "a": 1 });
+    deep_merge_values(&mut left, &json!({ "a": 2 }));
+    assert_eq!(left, json!({ "a": 2 }));
+}
+
+#[test]
+fn deep_merge_recurses_into_nested_objects() {
+    let mut left = json!({ "x": { "a": 1 } });
+    deep_merge_values(&mut left, &json!({ "x": { "b": 2 } }));
+    assert_eq!(left, json!({ "x": { "a": 1, "b": 2 } }));
+}
+
+#[test]
+fn deep_merge_null_from_right_wins() {
+    // `null` is a legitimate override value: it replaces whatever the left held.
+    let mut left = json!({ "a": 1 });
+    deep_merge_values(&mut left, &json!({ "a": null }));
+    assert_eq!(left, json!({ "a": null }));
+}
+
+#[test]
+fn deep_merge_replaces_arrays_wholesale() {
+    // Arrays are leaves: the right array replaces the left one, it is not element-merged.
+    let mut left = json!({ "a": [1, 2] });
+    deep_merge_values(&mut left, &json!({ "a": [3] }));
+    assert_eq!(left, json!({ "a": [3] }));
+}
+
+#[test]
+fn deep_merge_fills_empty_object() {
+    let mut left = json!({ "x": {} });
+    deep_merge_values(&mut left, &json!({ "x": { "a": 1 } }));
+    assert_eq!(left, json!({ "x": { "a": 1 } }));
 }
 
 #[test]


### PR DESCRIPTION
The deployment_config_generator now accepts overrides either as the existing flat
--config_file (unchanged) or as one-or-more ordered --overlay jsonnet layers
(exactly one mode). Each overlay is evaluated rooted at its own directory (so its
relative imports resolve locally, never against JSONNET_DIR) and the layers are
deep-merged in Rust (later wins) into the nested overrides fed to build().

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>