### PR TITLE
apollo_deployments,deployment: convert sepolia-integration hybrid overlays to in-place jsonnet

### DIFF
--- a/crates/apollo_deployments/src/deployment_definitions_test.rs
+++ b/crates/apollo_deployments/src/deployment_definitions_test.rs
@@ -20,6 +20,7 @@ use crate::jsonnet_test::{
     test_eval_overlay_at_path_missing_file_errors,
     test_generator_config_is_node_loadable,
     test_generator_flat_input_matches_direct_build,
+    test_in_place_jsonnet_overlay_equivalence,
     test_keys_to_be_replaced_are_covered_by_override_schema,
     test_multi_overlay_merge_semantics,
     test_real_overlay_overrides_are_node_loadable,
@@ -153,6 +154,16 @@ fn real_overlay_overrides_are_node_loadable() {
         .expect("Couldn't set working dir.");
 
     test_real_overlay_overrides_are_node_loadable();
+}
+
+/// Verifies the IN-PLACE per-layer jsonnet overlays reproduce the flat YAML overlays exactly
+/// (components.* excluded) and build into node-loadable configs with the env's real values intact.
+#[test]
+fn in_place_jsonnet_overlay_equivalence() {
+    env::set_current_dir(resolve_project_relative_path("").unwrap())
+        .expect("Couldn't set working dir.");
+
+    test_in_place_jsonnet_overlay_equivalence();
 }
 
 /// Test that the deployment file is up to date.

--- a/crates/apollo_deployments/src/jsonnet_test.rs
+++ b/crates/apollo_deployments/src/jsonnet_test.rs
@@ -201,7 +201,7 @@ pub fn test_generator_config_is_node_loadable() {
 /// output) through the node's real loader (`SequencerNodeConfig::load_and_process`, which resolves
 /// `CONFIG_POINTERS` + `#is_none`), and asserts it reconstructs exactly the built
 /// `SequencerNodeConfig` and passes `validate_node_config`.
-fn assert_built_services_node_loadable(built: &Value) {
+pub(crate) fn assert_built_services_node_loadable(built: &Value) {
     let services = built.as_object().expect("build result is a service-keyed object");
     for (service, config) in services {
         let direct: SequencerNodeConfig = serde_json::from_value(config.clone()).unwrap();
@@ -298,7 +298,7 @@ pub fn test_real_overlay_overrides_are_node_loadable() {
 /// `common.yaml` and `services/*.yaml` `config.sequencerConfig` entries; later layers win.
 /// (`components.*` infra keys are derived from the layout by the generator, not read from
 /// overrides.)
-fn real_overlay_sequencer_config() -> BTreeMap<String, Value> {
+pub(crate) fn real_overlay_sequencer_config() -> BTreeMap<String, Value> {
     const OVERLAY_DIR: &str = "deployments/sequencer/configs/overlays/hybrid";
     // Low-to-high precedence, matching the deploy's overlay order: `common` is the base,
     // `sepolia-integration` overrides it, and the per-pod `dummy_for_testing` is layered last.
@@ -338,6 +338,125 @@ fn real_overlay_sequencer_config() -> BTreeMap<String, Value> {
         }
     }
     merged
+}
+
+/// Recursively clones `value`, dropping every `components` key at any nesting level (the
+/// layout-derived component infra the YAML overlay carries but the generator computes itself, not
+/// reads as an override). Non-object values pass through unchanged.
+fn filter_components_nested(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .filter(|(key, _)| key.as_str() != "components")
+                .map(|(key, child)| (key.clone(), filter_components_nested(child)))
+                .collect(),
+        ),
+        leaf => leaf.clone(),
+    }
+}
+
+const IN_PLACE_OVERLAY_DIR: &str = "deployments/sequencer/configs/overlays/hybrid";
+
+/// The IN-PLACE nested-overrides jsonnet overlays reproduce the flat YAML overlays exactly and
+/// build into node-loadable configs. Evaluates the three per-layer `sequencer_config.jsonnet` files
+/// (each rooted at its own directory, so it must be self-contained), deep-merges them in deploy
+/// order (`common` -> `sepolia-integration` -> `dummy_for_testing`, later wins), and asserts the
+/// result equals the nested form of the committed-YAML baseline once `components.*` (the only
+/// divergence — layout-derived infra the generator does not read as overrides) is stripped from
+/// both sides. On match, the merged overlays build into node-loadable, validated configs for every
+/// hybrid service, with the environment's real values surviving into the built core service.
+pub fn test_in_place_jsonnet_overlay_equivalence() {
+    let common = eval_overlay_at_path(Path::new(&format!(
+        "{IN_PLACE_OVERLAY_DIR}/common/sequencer_config.jsonnet"
+    )))
+    .unwrap_or_else(|error| panic!("failed to evaluate common jsonnet: {error}"));
+    let sepolia_integration = eval_overlay_at_path(Path::new(&format!(
+        "{IN_PLACE_OVERLAY_DIR}/sepolia-integration/sequencer_config.jsonnet"
+    )))
+    .unwrap_or_else(|error| panic!("failed to evaluate sepolia-integration jsonnet: {error}"));
+    let dummy_for_testing = eval_overlay_at_path(Path::new(&format!(
+        "{IN_PLACE_OVERLAY_DIR}/common/dummy_for_testing/sequencer_config.jsonnet"
+    )))
+    .unwrap_or_else(|error| panic!("failed to evaluate dummy_for_testing jsonnet: {error}"));
+
+    // Deep-merge in deploy order: common is the base, sepolia-integration overrides it, and the
+    // per-pod dummy_for_testing is layered last.
+    let mut jsonnet_merged = common;
+    deep_merge_values(&mut jsonnet_merged, &sepolia_integration);
+    deep_merge_values(&mut jsonnet_merged, &dummy_for_testing);
+
+    // YAML baseline: the committed overlays, merged in deploy order and nested (folding
+    // `#is_none`).
+    let yaml_baseline_nested = overrides_from_sequencer_config(&real_overlay_sequencer_config());
+
+    // `components.*` is the only expected divergence (the YAML sequencerConfig carries
+    // layout-derived component infra the generator does not read as overrides); strip it from both.
+    let jsonnet_filtered = filter_components_nested(&jsonnet_merged);
+    let yaml_filtered = filter_components_nested(&yaml_baseline_nested);
+
+    if jsonnet_filtered != yaml_filtered {
+        let mut jsonnet_flat = BTreeMap::new();
+        flatten(&jsonnet_filtered, "", &mut jsonnet_flat);
+        let mut yaml_flat = BTreeMap::new();
+        flatten(&yaml_filtered, "", &mut yaml_flat);
+        let diffs: Vec<String> = jsonnet_flat
+            .keys()
+            .chain(yaml_flat.keys())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter(|key| jsonnet_flat.get(*key) != yaml_flat.get(*key))
+            .map(|key| {
+                format!("{key}: jsonnet={:?} yaml={:?}", jsonnet_flat.get(key), yaml_flat.get(key))
+            })
+            .collect();
+        panic!(
+            "in-place jsonnet overlays diverge from the YAML baseline (components.* excluded):\n  \
+             {}",
+            diffs.join("\n  ")
+        );
+    }
+
+    // The merged overlays build into node-loadable, validated configs for every hybrid service.
+    let built = eval_build_with_overrides("hybrid", &jsonnet_merged);
+    assert_built_services_node_loadable(&built);
+
+    // The environment's real values reached the built core service (which runs consensus): the P2P
+    // multiaddrs are dummy `None` (dummy_for_testing marks them `#is_none: true`) so they fold to
+    // `null`; validator id and chain id are the environment's own values. Asserted against literals
+    // (not re-read) so a build that drops a value, or merges the layers in the wrong order, fails.
+    let core = built.get("core").expect("hybrid has a core service");
+    let mut core_config = BTreeMap::new();
+    flatten(core, "", &mut core_config);
+    let unique_core_value = |suffix: &str| -> &Value {
+        let matches: Vec<&Value> =
+            core_config.iter().filter(|(key, _)| key.ends_with(suffix)).map(|(_, v)| v).collect();
+        assert_eq!(matches.len(), 1, "expected exactly one core config key ending in `{suffix}`");
+        matches[0]
+    };
+    assert_eq!(
+        unique_core_value("consensus_manager_config.network_config.advertised_multiaddr"),
+        &Value::Null,
+        "multiaddrs in core must be null (dummy_for_testing sets #is_none: true)"
+    );
+    assert_eq!(
+        unique_core_value("consensus_manager_config.network_config.bootstrap_peer_multiaddr"),
+        &Value::Null,
+        "multiaddrs in core must be null (dummy_for_testing sets #is_none: true)"
+    );
+    assert_eq!(
+        unique_core_value(".validator_id"),
+        &json!("0x64"),
+        "validator_id in core must be 0x64"
+    );
+    for (key, value) in &core_config {
+        if key.ends_with("chain_id") {
+            assert_eq!(
+                value,
+                &json!("SN_INTEGRATION_SEPOLIA"),
+                "all chain_id values in core must be SN_INTEGRATION_SEPOLIA, but `{key}` differs"
+            );
+        }
+    }
 }
 
 /// Asserts `overrides` supplies every override path the generator reads

--- a/deployments/sequencer/configs/overlays/hybrid/common/dummy_for_testing/sequencer_config.jsonnet
+++ b/deployments/sequencer/configs/overlays/hybrid/common/dummy_for_testing/sequencer_config.jsonnet
@@ -1,0 +1,22 @@
+// IN-PLACE nested-overrides for the hybrid `dummy_for_testing` overlay layer.
+//
+// Self-contained: holds only this layer's own `config.sequencerConfig` deltas, aggregated from
+// `common.yaml` and `services/*.yaml` and converted to nested, `#is_none`-folded form. Layered LAST
+// (deep-merged over `common` then `sepolia-integration`): it supplies the per-pod instance values —
+// the P2P multiaddrs as dummy `None` and the `validator_id`. No k8s scaffolding, no `components.*`.
+{
+  validator_id: '0x64',
+  consensus_manager_config: {
+    network_config: {
+      // `#is_none: true` -> dummy `None` multiaddrs fold to null.
+      advertised_multiaddr: null,
+      bootstrap_peer_multiaddr: null,
+    },
+  },
+  mempool_p2p_config: {
+    network_config: {
+      advertised_multiaddr: null,
+      bootstrap_peer_multiaddr: null,
+    },
+  },
+}

--- a/deployments/sequencer/configs/overlays/hybrid/common/sequencer_config.jsonnet
+++ b/deployments/sequencer/configs/overlays/hybrid/common/sequencer_config.jsonnet
@@ -1,0 +1,125 @@
+// IN-PLACE nested-overrides for the hybrid `common` overlay layer.
+//
+// Self-contained: holds only this layer's own `config.sequencerConfig` deltas, aggregated from
+// `common.yaml` and `services/*.yaml` and converted to nested, `#is_none`-folded form
+// (`a.b.c: v` -> `{a:{b:{c:v}}}`; `<path>.#is_none: true` -> `<path>: null`). No k8s scaffolding
+// and no `components.*` keys (layout-derived infra the generator computes, not overrides).
+{
+  eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
+  strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
+  monitoring_endpoint_config: {
+    port: 8082,
+  },
+  // `#is_none: true` -> the whole optional folds to null (its placeholder children are dropped).
+  versioned_constants_overrides: null,
+  committer_config: {
+    verify_state_diff_hash: true,
+    storage_config: {
+      inner_storage_config: {
+        cache_size: 8589934592,
+      },
+    },
+  },
+  batcher_config: {
+    dynamic_config: {
+      proposer_idle_detection_delay_millis: 2000,
+    },
+    static_config: {
+      block_builder_config: {
+        bouncer_config: {
+          block_max_capacity: {
+            n_events: 5000,
+            receipt_l2_gas: 5800000000,
+          },
+        },
+      },
+      storage_reader_server_static_config: {
+        port: 55011,
+      },
+    },
+  },
+  class_manager_config: {
+    static_config: {
+      class_manager_config: {
+        max_compiled_contract_class_object_size: 4089446,
+      },
+      class_storage_config: {
+        storage_reader_server_static_config: {
+          port: 55210,
+        },
+      },
+    },
+  },
+  consensus_manager_config: {
+    consensus_manager_config: {
+      dynamic_config: {
+        require_virtual_proposer_vote: false,
+        timeouts: {
+          proposal: {
+            base: 9.1,
+            max: 9.1,
+          },
+        },
+      },
+    },
+    context_config: {
+      dynamic_config: {
+        build_proposal_margin_millis: 1000,
+        compare_retrospective_block_hash: true,
+        override_eth_to_fri_rate: null,
+        override_l1_data_gas_price_fri: null,
+        override_l1_gas_price_fri: null,
+        override_l2_gas_price_fri: null,
+      },
+    },
+    network_config: {
+      port: 53080,
+    },
+    staking_manager_config: {
+      dynamic_config: {
+        override_committee: null,
+      },
+    },
+  },
+  state_sync_config: {
+    static_config: {
+      p2p_sync_client_config: null,
+      rpc_config: {
+        port: 8090,
+      },
+      storage_reader_server_static_config: {
+        port: 55014,
+      },
+    },
+  },
+  gateway_config: {
+    static_config: {
+      authorized_declarer_accounts: null,
+      stateful_tx_validator_config: {
+        max_allowed_nonce_gap: 200,
+      },
+      stateless_tx_validator_config: {
+        max_contract_bytecode_size: 81920,
+        min_gas_price: 8000000000,
+      },
+    },
+  },
+  http_server_config: {
+    static_config: {
+      port: 8080,
+    },
+  },
+  mempool_config: {
+    dynamic_config: {
+      transaction_ttl: 300,
+    },
+  },
+  mempool_p2p_config: {
+    network_config: {
+      port: 53200,
+    },
+  },
+  sierra_compiler_config: {
+    max_bytecode_size: 81920,
+  },
+}

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/sequencer_config.jsonnet
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/sequencer_config.jsonnet
@@ -1,0 +1,79 @@
+// IN-PLACE nested-overrides for the hybrid `sepolia-integration` overlay layer.
+//
+// Self-contained: holds only this layer's own `config.sequencerConfig` deltas, aggregated from
+// `common.yaml` and `services/*.yaml` and converted to nested, `#is_none`-folded form. Deep-merged
+// over the `common` layer at deploy order. No k8s scaffolding and no `components.*` keys.
+{
+  chain_id: 'SN_INTEGRATION_SEPOLIA',
+  native_classes_whitelist: 'All',
+  recorder_url: 'http://starknet-sepolia-integration.cende-recorder-proxy.starknet.io/',
+  starknet_url: 'https://feeder.integration-sepolia.starknet.io/',
+  committer_config: {
+    storage_config: {
+      cache_size: 10000000,
+    },
+  },
+  batcher_config: {
+    dynamic_config: {
+      n_concurrent_txs: 100,
+    },
+    static_config: {
+      block_builder_config: {
+        bouncer_config: {
+          block_max_capacity: {
+            state_diff_size: 4000,
+          },
+        },
+        execute_config: {
+          n_workers: 1,
+        },
+      },
+      // `#is_none: false` with materialized children -> the children survive (`Some(value)`).
+      first_block_with_partial_block_hash: {
+        block_hash: '0x1ea2a9cfa3df5297d58c0a04d09d276bc68d40fe64701305bbe2ed8f417e869',
+        block_number: 35748,
+        parent_block_hash: '0x77140bef51bbb4d1932f17cc5081825ff18465a1df4440ca0429a4fa80f1dc5',
+      },
+    },
+  },
+  consensus_manager_config: {
+    context_config: {
+      dynamic_config: {
+        min_l2_gas_price_per_height: '',
+      },
+    },
+    staking_manager_config: {
+      dynamic_config: {
+        default_committee: '0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true',
+      },
+    },
+  },
+  state_sync_config: {
+    static_config: {
+      // `#is_none: false` with children -> survives as `Some`.
+      central_sync_client_config: {
+        sync_config: {
+          store_sierras_and_casms_block_threshold: 0,
+        },
+      },
+      // `#is_none: true` -> folds to null; placeholder `port` is dropped.
+      network_config: null,
+    },
+  },
+  gateway_config: {
+    static_config: {
+      proof_archive_writer_config: {
+        bucket_name: 'starkware-starknet-integration',
+      },
+    },
+  },
+  base_layer_config: {
+    bpo1_start_block_number: 9456501,
+    bpo2_start_block_number: 9504747,
+    fusaka_no_bpo_start_block_number: 9408577,
+    starknet_contract_address: '0x4737c0c1B4D5b1A687B42610DdabEE781152359c',
+  },
+  sierra_compiler_config: {
+    audited_libfuncs_only: false,
+  },
+}


### PR DESCRIPTION
Convert the sepolia-integration hybrid overlay data (common, sepolia-integration,
common/dummy_for_testing layers) from flat-dotted config.sequencerConfig YAML into
nested, #is_none-folded jsonnet, in place under deployments/.../overlays/hybrid/.
Each layer is a self-contained sequencer_config.jsonnet (deltas only); they are
deep-merged in deploy order by the generator. The existing flat YAML is kept as the
equivalence baseline. A new test (in_place_jsonnet_overlay_equivalence) evaluates the
three files, deep-merges them, and asserts the result reproduces the YAML-derived
overrides (components.* excluded) and builds into node-loadable per-service configs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>