### PR TITLE
apollo_deployments,deployment: convert mainnet hybrid overlay to in-place jsonnet

### DIFF
--- a/crates/apollo_deployments/src/deployment_definitions_test.rs
+++ b/crates/apollo_deployments/src/deployment_definitions_test.rs
@@ -15,12 +15,13 @@ use crate::deployments::distributed::DistributedNodeServiceName;
 use crate::deployments::hybrid::HybridNodeServiceName;
 use crate::jsonnet_test::{
     assert_build_deserializes,
+    assert_in_place_jsonnet_overlay_equivalence,
     assert_infra_matches_rust,
+    overlay_chain_id,
     test_applicative_matches_app_configs,
     test_eval_overlay_at_path_missing_file_errors,
     test_generator_config_is_node_loadable,
     test_generator_flat_input_matches_direct_build,
-    test_in_place_jsonnet_overlay_equivalence,
     test_keys_to_be_replaced_are_covered_by_override_schema,
     test_multi_overlay_merge_semantics,
     test_real_overlay_overrides_are_node_loadable,
@@ -156,14 +157,31 @@ fn real_overlay_overrides_are_node_loadable() {
     test_real_overlay_overrides_are_node_loadable();
 }
 
-/// Verifies the IN-PLACE per-layer jsonnet overlays reproduce the flat YAML overlays exactly
-/// (components.* excluded) and build into node-loadable configs with the env's real values intact.
+/// Verifies the IN-PLACE per-layer jsonnet overlays for `sepolia-integration` reproduce the flat
+/// YAML overlays exactly (components.* excluded) and build into node-loadable configs with the
+/// env's real values intact. The chain_id is asserted against the literal `SN_INTEGRATION_SEPOLIA`.
 #[test]
-fn in_place_jsonnet_overlay_equivalence() {
+fn in_place_jsonnet_overlay_equivalence_sepolia_integration() {
     env::set_current_dir(resolve_project_relative_path("").unwrap())
         .expect("Couldn't set working dir.");
 
-    test_in_place_jsonnet_overlay_equivalence();
+    assert_in_place_jsonnet_overlay_equivalence(
+        "sepolia-integration",
+        &Value::String("SN_INTEGRATION_SEPOLIA".to_string()),
+    );
+}
+
+/// Verifies the IN-PLACE per-layer jsonnet overlays for `mainnet` reproduce the flat YAML overlays
+/// exactly (components.* excluded) and build into node-loadable configs with the env's real values
+/// intact. The chain_id is read from the committed `mainnet/common.yaml` at runtime (not
+/// hard-coded), and asserted to survive into the built core service.
+#[test]
+fn in_place_jsonnet_overlay_equivalence_mainnet() {
+    env::set_current_dir(resolve_project_relative_path("").unwrap())
+        .expect("Couldn't set working dir.");
+
+    let expected_chain_id = overlay_chain_id("mainnet");
+    assert_in_place_jsonnet_overlay_equivalence("mainnet", &expected_chain_id);
 }
 
 /// Test that the deployment file is up to date.

--- a/crates/apollo_deployments/src/jsonnet_test.rs
+++ b/crates/apollo_deployments/src/jsonnet_test.rs
@@ -251,7 +251,7 @@ pub(crate) fn assert_built_services_node_loadable(built: &Value) {
 /// through the generator into node-loadable, validated configs for every hybrid service, with the
 /// environment's real values surviving into the built config.
 pub fn test_real_overlay_overrides_are_node_loadable() {
-    let flat_overrides = real_overlay_sequencer_config();
+    let flat_overrides = real_overlay_sequencer_config("sepolia-integration");
     let overrides = overrides_from_sequencer_config(&flat_overrides);
 
     assert_overrides_cover_schema(&overrides);
@@ -291,20 +291,19 @@ pub fn test_real_overlay_overrides_are_node_loadable() {
 }
 
 /// A real environment's merged overlay `sequencerConfig`, read from the committed YAML overlays
-/// (the single source of truth). It assembles the sepolia-integration hybrid config the way the
-/// deploy does: the shared `common` overlay (the base), the `sepolia-integration` overlay (which
-/// overrides common), and `dummy_for_testing` (layered last — it supplies the per-pod instance
-/// values, the P2P multiaddrs as dummy `None` and `validator_id`). Each layer contributes its
-/// `common.yaml` and `services/*.yaml` `config.sequencerConfig` entries; later layers win.
-/// (`components.*` infra keys are derived from the layout by the generator, not read from
-/// overrides.)
-pub(crate) fn real_overlay_sequencer_config() -> BTreeMap<String, Value> {
+/// (the single source of truth). It assembles the hybrid config for `env_name` the way the deploy
+/// does: the shared `common` overlay (the base), the `env_name` overlay (which overrides common),
+/// and `dummy_for_testing` (layered last — it supplies the per-pod instance values, the P2P
+/// multiaddrs as dummy `None` and `validator_id`). Each layer contributes its `common.yaml` and
+/// `services/*.yaml` `config.sequencerConfig` entries; later layers win. (`components.*` infra keys
+/// are derived from the layout by the generator, not read from overrides.)
+pub(crate) fn real_overlay_sequencer_config(env_name: &str) -> BTreeMap<String, Value> {
     const OVERLAY_DIR: &str = "deployments/sequencer/configs/overlays/hybrid";
-    // Low-to-high precedence, matching the deploy's overlay order: `common` is the base,
-    // `sepolia-integration` overrides it, and the per-pod `dummy_for_testing` is layered last.
+    // Low-to-high precedence, matching the deploy's overlay order: `common` is the base, the
+    // `env_name` overlay overrides it, and the per-pod `dummy_for_testing` is layered last.
     let layers = [
         format!("{OVERLAY_DIR}/common"),
-        format!("{OVERLAY_DIR}/sepolia-integration"),
+        format!("{OVERLAY_DIR}/{env_name}"),
         format!("{OVERLAY_DIR}/common/dummy_for_testing"),
     ];
 
@@ -340,6 +339,23 @@ pub(crate) fn real_overlay_sequencer_config() -> BTreeMap<String, Value> {
     merged
 }
 
+/// Reads an environment's real `chain_id` from its committed overlay `common.yaml`
+/// (`config.sequencerConfig.chain_id`), so equivalence assertions check against the source of truth
+/// rather than a hard-coded literal.
+pub(crate) fn overlay_chain_id(env_name: &str) -> Value {
+    let path = format!("deployments/sequencer/configs/overlays/hybrid/{env_name}/common.yaml");
+    let contents = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read overlay {path}: {error}"));
+    let document: Value = serde_yml::from_str(&contents)
+        .unwrap_or_else(|error| panic!("overlay {path} is not valid YAML: {error}"));
+    document
+        .get("config")
+        .and_then(|config| config.get("sequencerConfig"))
+        .and_then(|sequencer_config| sequencer_config.get("chain_id"))
+        .cloned()
+        .unwrap_or_else(|| panic!("overlay {path} has no config.sequencerConfig.chain_id"))
+}
+
 /// Recursively clones `value`, dropping every `components` key at any nesting level (the
 /// layout-derived component infra the YAML overlay carries but the generator computes itself, not
 /// reads as an override). Non-object values pass through unchanged.
@@ -357,37 +373,43 @@ fn filter_components_nested(value: &Value) -> Value {
 
 const IN_PLACE_OVERLAY_DIR: &str = "deployments/sequencer/configs/overlays/hybrid";
 
-/// The IN-PLACE nested-overrides jsonnet overlays reproduce the flat YAML overlays exactly and
-/// build into node-loadable configs. Evaluates the three per-layer `sequencer_config.jsonnet` files
-/// (each rooted at its own directory, so it must be self-contained), deep-merges them in deploy
-/// order (`common` -> `sepolia-integration` -> `dummy_for_testing`, later wins), and asserts the
-/// result equals the nested form of the committed-YAML baseline once `components.*` (the only
-/// divergence — layout-derived infra the generator does not read as overrides) is stripped from
-/// both sides. On match, the merged overlays build into node-loadable, validated configs for every
-/// hybrid service, with the environment's real values surviving into the built core service.
-pub fn test_in_place_jsonnet_overlay_equivalence() {
+/// The IN-PLACE nested-overrides jsonnet overlays for `env_name` reproduce the flat YAML overlays
+/// exactly and build into node-loadable configs. Evaluates the three per-layer
+/// `sequencer_config.jsonnet` files (each rooted at its own directory, so it must be
+/// self-contained), deep-merges them in deploy order (`common` -> `env_name` ->
+/// `dummy_for_testing`, later wins), and asserts the result equals the nested form of the
+/// committed-YAML baseline once `components.*` (the only divergence — layout-derived infra the
+/// generator does not read as overrides) is stripped from both sides. On match, the merged overlays
+/// build into node-loadable, validated configs for every hybrid service, with the environment's
+/// real values (`expected_chain_id` read from the env's own YAML by the caller) surviving into the
+/// built core service.
+pub(crate) fn assert_in_place_jsonnet_overlay_equivalence(
+    env_name: &str,
+    expected_chain_id: &Value,
+) {
     let common = eval_overlay_at_path(Path::new(&format!(
         "{IN_PLACE_OVERLAY_DIR}/common/sequencer_config.jsonnet"
     )))
     .unwrap_or_else(|error| panic!("failed to evaluate common jsonnet: {error}"));
-    let sepolia_integration = eval_overlay_at_path(Path::new(&format!(
-        "{IN_PLACE_OVERLAY_DIR}/sepolia-integration/sequencer_config.jsonnet"
+    let env_overlay = eval_overlay_at_path(Path::new(&format!(
+        "{IN_PLACE_OVERLAY_DIR}/{env_name}/sequencer_config.jsonnet"
     )))
-    .unwrap_or_else(|error| panic!("failed to evaluate sepolia-integration jsonnet: {error}"));
+    .unwrap_or_else(|error| panic!("failed to evaluate {env_name} jsonnet: {error}"));
     let dummy_for_testing = eval_overlay_at_path(Path::new(&format!(
         "{IN_PLACE_OVERLAY_DIR}/common/dummy_for_testing/sequencer_config.jsonnet"
     )))
     .unwrap_or_else(|error| panic!("failed to evaluate dummy_for_testing jsonnet: {error}"));
 
-    // Deep-merge in deploy order: common is the base, sepolia-integration overrides it, and the
+    // Deep-merge in deploy order: common is the base, the env overlay overrides it, and the
     // per-pod dummy_for_testing is layered last.
     let mut jsonnet_merged = common;
-    deep_merge_values(&mut jsonnet_merged, &sepolia_integration);
+    deep_merge_values(&mut jsonnet_merged, &env_overlay);
     deep_merge_values(&mut jsonnet_merged, &dummy_for_testing);
 
     // YAML baseline: the committed overlays, merged in deploy order and nested (folding
     // `#is_none`).
-    let yaml_baseline_nested = overrides_from_sequencer_config(&real_overlay_sequencer_config());
+    let yaml_baseline_nested =
+        overrides_from_sequencer_config(&real_overlay_sequencer_config(env_name));
 
     // `components.*` is the only expected divergence (the YAML sequencerConfig carries
     // layout-derived component infra the generator does not read as overrides); strip it from both.
@@ -451,9 +473,8 @@ pub fn test_in_place_jsonnet_overlay_equivalence() {
     for (key, value) in &core_config {
         if key.ends_with("chain_id") {
             assert_eq!(
-                value,
-                &json!("SN_INTEGRATION_SEPOLIA"),
-                "all chain_id values in core must be SN_INTEGRATION_SEPOLIA, but `{key}` differs"
+                value, expected_chain_id,
+                "all chain_id values in core must be {expected_chain_id}, but `{key}` differs"
             );
         }
     }

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/sequencer_config.jsonnet
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/sequencer_config.jsonnet
@@ -1,0 +1,81 @@
+// IN-PLACE nested-overrides for the hybrid `mainnet` overlay layer.
+//
+// Self-contained: holds only this layer's own `config.sequencerConfig` deltas, aggregated from
+// `common.yaml` and `services/*.yaml` and converted to nested, `#is_none`-folded form. Deep-merged
+// over the `common` layer at deploy order. No k8s scaffolding and no `components.*` keys.
+{
+  chain_id: 'SN_MAIN',
+  native_classes_whitelist: '["0x054c5afe61ed27be53b1e4dec5707209a9fcabdb14712fb800fbc60439090115"]',
+  recorder_url: 'http://starknet-mainnet.cende-recorder-proxy.starknet.io/',
+  starknet_url: 'https://feeder.alpha-mainnet.starknet.io/',
+  committer_config: {
+    storage_config: {
+      cache_size: 50000000,
+    },
+  },
+  batcher_config: {
+    dynamic_config: {
+      n_concurrent_txs: 100,
+    },
+    static_config: {
+      block_builder_config: {
+        bouncer_config: {
+          block_max_capacity: {
+            state_diff_size: 5000,
+          },
+        },
+        execute_config: {
+          n_workers: 12,
+        },
+      },
+      // `#is_none: false` with materialized children -> the children survive (`Some(value)`).
+      first_block_with_partial_block_hash: {
+        block_hash: '0x12889b177c93baa28b5ee3afc80cb6f4836adac086af4bef25ae1ac762e8a62',
+        block_number: 671813,
+        parent_block_hash: '0x1e68b0d22b14688dc97afa3006a53cf4e62ebcb02102e80f55e8b48f9a28b97',
+      },
+    },
+  },
+  consensus_manager_config: {
+    context_config: {
+      dynamic_config: {
+        min_l2_gas_price_per_height: '8269292:27400000000,8742344:30100000000',
+      },
+    },
+    staking_manager_config: {
+      dynamic_config: {
+        default_committee: '0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true;0x67,1,0x1,true;0x68,1,0x1,true',
+      },
+    },
+  },
+  state_sync_config: {
+    static_config: {
+      // `#is_none: false` with children -> survives as `Some`.
+      central_sync_client_config: {
+        sync_config: {
+          store_sierras_and_casms_block_threshold: 103129,
+        },
+      },
+      // `#is_none: false` with children -> survives as `Some`.
+      network_config: {
+        port: 55010,
+      },
+    },
+  },
+  gateway_config: {
+    static_config: {
+      proof_archive_writer_config: {
+        bucket_name: 'starkware-starknet-mainnet',
+      },
+    },
+  },
+  base_layer_config: {
+    bpo1_start_block_number: 23973546,
+    bpo2_start_block_number: 24168146,
+    fusaka_no_bpo_start_block_number: 23934586,
+    starknet_contract_address: '0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4',
+  },
+  sierra_compiler_config: {
+    audited_libfuncs_only: true,
+  },
+}


### PR DESCRIPTION
Convert the mainnet hybrid env overlay (mainnet/common.yaml + services/*.yaml
config.sequencerConfig) into a self-contained nested, #is_none-folded jsonnet in place,
reusing the already-converted common + dummy_for_testing layers. Generalize the
equivalence harness: real_overlay_sequencer_config now takes an env name and
overlay_chain_id reads the env's chain_id from its common.yaml, so the equivalence +
node-loadable assertions run for both sepolia-integration and mainnet (SN_MAIN).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>