### PR TITLE
apollo_deployments,deployment: convert sepolia-alpha hybrid overlay to in-place jsonnet

### DIFF
--- a/crates/apollo_deployments/src/deployment_definitions_test.rs
+++ b/crates/apollo_deployments/src/deployment_definitions_test.rs
@@ -184,6 +184,19 @@ fn in_place_jsonnet_overlay_equivalence_mainnet() {
     assert_in_place_jsonnet_overlay_equivalence("mainnet", &expected_chain_id);
 }
 
+/// Verifies the IN-PLACE per-layer jsonnet overlays for `sepolia-alpha` reproduce the flat YAML
+/// overlays exactly (components.* excluded) and build into node-loadable configs with the env's
+/// real values intact. The chain_id is read from the committed `sepolia-alpha/common.yaml` at
+/// runtime (not hard-coded), and asserted to survive into the built core service.
+#[test]
+fn in_place_jsonnet_overlay_equivalence_sepolia_alpha() {
+    env::set_current_dir(resolve_project_relative_path("").unwrap())
+        .expect("Couldn't set working dir.");
+
+    let expected_chain_id = overlay_chain_id("sepolia-alpha");
+    assert_in_place_jsonnet_overlay_equivalence("sepolia-alpha", &expected_chain_id);
+}
+
 /// Test that the deployment file is up to date.
 #[test]
 fn deployment_files_are_up_to_date() {

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/sequencer_config.jsonnet
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/sequencer_config.jsonnet
@@ -1,0 +1,82 @@
+// IN-PLACE nested-overrides for the hybrid `sepolia-alpha` overlay layer.
+//
+// Self-contained: holds only this layer's own `config.sequencerConfig` deltas, aggregated from
+// `common.yaml` and `services/*.yaml` and converted to nested, `#is_none`-folded form. Deep-merged
+// over the `common` layer at deploy order. No k8s scaffolding and no `components.*` keys.
+{
+  chain_id: 'SN_SEPOLIA',
+  native_classes_whitelist: 'All',
+  recorder_url: 'http://starknet-sepolia-alpha.cende-recorder-proxy.starknet.io/',
+  starknet_url: 'https://feeder.alpha-sepolia.starknet.io/',
+  committer_config: {
+    storage_config: {
+      cache_size: 10000000,
+      inner_storage_config: {
+        cache_size: 1073741824,
+      },
+    },
+  },
+  batcher_config: {
+    dynamic_config: {
+      n_concurrent_txs: 8,
+    },
+    static_config: {
+      block_builder_config: {
+        bouncer_config: {
+          block_max_capacity: {
+            state_diff_size: 5000,
+          },
+        },
+        execute_config: {
+          n_workers: 5,
+        },
+      },
+      // `#is_none: false` with materialized children -> the children survive (`Some(value)`).
+      first_block_with_partial_block_hash: {
+        block_hash: '0x578b4e2f34e4da24e7482de643b4e3435fa7e34770cdb8d71002bb19e415ffa',
+        block_number: 86311,
+        parent_block_hash: '0x5c980ea7747167d2ae98fa7ef7d62f52243e924c453b4934045443d977458d3',
+      },
+    },
+  },
+  consensus_manager_config: {
+    context_config: {
+      dynamic_config: {
+        min_l2_gas_price_per_height: '',
+      },
+    },
+    staking_manager_config: {
+      dynamic_config: {
+        default_committee: '0,10:0x64,1,0x1,true;0x65,1,0x1,true;0x66,1,0x1,true;0x67,1,0x1,true;0x68,1,0x1,true',
+      },
+    },
+  },
+  state_sync_config: {
+    static_config: {
+      // `#is_none: false` with children -> survives as `Some`.
+      central_sync_client_config: {
+        sync_config: {
+          store_sierras_and_casms_block_threshold: 0,
+        },
+      },
+      // `#is_none: true` -> folds to null; placeholder `port` is dropped.
+      network_config: null,
+    },
+  },
+  gateway_config: {
+    static_config: {
+      proof_archive_writer_config: {
+        bucket_name: 'starkware-starknet-alpha',
+      },
+    },
+  },
+  base_layer_config: {
+    bpo1_start_block_number: 9456501,
+    bpo2_start_block_number: 9504747,
+    fusaka_no_bpo_start_block_number: 9408577,
+    starknet_contract_address: '0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057',
+  },
+  sierra_compiler_config: {
+    audited_libfuncs_only: true,
+  },
+}


### PR DESCRIPTION
Convert the sepolia-alpha hybrid env overlay into a self-contained nested,
#is_none-folded jsonnet in place, reusing the converted common + dummy_for_testing
layers and the parameterized equivalence harness. Adds one #[test] wrapper
(env=sepolia-alpha, chain_id read from its common.yaml). Completes the jsonnet-repo
hybrid overlay conversion (sepolia-integration, mainnet, sepolia-alpha).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>