### PR TITLE
apollo_committer,starknet_committer: drop redundant commitment-infos delete on revert

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -398,26 +398,11 @@ where
              to {last_committed_block}"
         );
         block_measurements.start_measurement(Action::Write);
-        let n_write_entries = {
-            #[cfg(not(feature = "os_input"))]
-            {
-                self.forest_storage
-                    .write_with_metadata(&filled_forest, metadata, deleted_nodes)
-                    .await
-            }
-            #[cfg(feature = "os_input")]
-            {
-                self.forest_storage
-                    .write_with_metadata_and_commitment_infos(
-                        &filled_forest,
-                        metadata,
-                        deleted_nodes,
-                        CommitmentInfosUpdate::Delete(height),
-                    )
-                    .await
-            }
-        }
-        .map_err(|err| self.map_internal_error(err))?;
+        let n_write_entries = self
+            .forest_storage
+            .write_with_metadata(&filled_forest, metadata, deleted_nodes)
+            .await
+            .map_err(|err| self.map_internal_error(err))?;
         block_measurements.attempt_to_stop_measurement(Action::Write, n_write_entries).ok();
         block_measurements.attempt_to_stop_measurement(Action::EndToEnd, 0).ok();
         update_metrics(height, &block_measurements.block_measurement);

--- a/crates/starknet_committer/src/db/forest_trait_witnesses.rs
+++ b/crates/starknet_committer/src/db/forest_trait_witnesses.rs
@@ -61,6 +61,8 @@ pub trait ForestReaderWithWitnesses:
 
 /// Writes forest + metadata + deleted nodes, and applies [`CommitmentInfosUpdate`] in the same
 /// batch.
+// TODO(Yoav): Simplify write_with_metadata_and_commitment_infos: the revert flow no longer deletes
+// commitment infos, so the only caller passes CommitmentInfosUpdate::Write.
 #[async_trait]
 pub trait ForestWriterWithMetadataAndWitnesses: ForestWriterWithMetadata + Send {
     async fn write_with_metadata_and_commitment_infos(


### PR DESCRIPTION
The revert flow rolls the commitment offset back to the last committed
block, so commitment-info entries at the reverted height and above are
ignored on read (and overwritten by a future re-commit). The explicit
CommitmentInfosUpdate::Delete is dead work, so the revert flow now uses
a plain write_with_metadata. Add a TODO to drop the now-unused Delete
variant and simplify write_with_metadata_and_commitment_infos.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>