### PR TITLE
apollo_consensus_orchestrator: forward OS initial reads into the cende blob

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -47,6 +47,8 @@ use blockifier::fee::resources::{
 };
 #[cfg(feature = "os_input")]
 use blockifier::state::accessed_keys::AccessedKeys;
+#[cfg(feature = "os_input")]
+use blockifier::state::cached_state::StateMaps;
 use blockifier::state::cached_state::{
     CommitmentStateDiff,
     StateChangesCount,
@@ -785,6 +787,8 @@ fn central_blob() -> AerospikeBlob {
         recent_state_commitment_infos: recent_state_commitment_infos(),
         #[cfg(feature = "os_input")]
         accessed_keys: AccessedKeys::default(),
+        #[cfg(feature = "os_input")]
+        initial_reads: StateMaps::default(),
     };
 
     // This is to make the function sync (not async) so that it can be used as a case in the
@@ -818,6 +822,8 @@ fn central_blob_with_empty_or_none_fields() -> AerospikeBlob {
         recent_state_commitment_infos: vec![],
         #[cfg(feature = "os_input")]
         accessed_keys: AccessedKeys::default(),
+        #[cfg(feature = "os_input")]
+        initial_reads: StateMaps::default(),
     };
 
     // This is to make the function sync (not async) so that it can be used as a case in the
@@ -1173,8 +1179,8 @@ fn serialize_central_objects(#[case] rust_obj: impl Serialize, #[case] python_js
     let python_json: serde_json::Value = read_json_file(python_json_path);
     let rust_json = serde_json::to_value(rust_obj).unwrap();
 
-    // `recent_state_commitment_infos` and `accessed_keys` are os_input-only and absent from the
-    // central (python) blob, so strip them before comparing.
+    // `recent_state_commitment_infos`, `accessed_keys` and `initial_reads` are os_input-only and
+    // absent from the central (python) blob, so strip them before comparing.
     // TODO(Itamar): Remove this stripping once the python blob includes the fields.
     #[cfg(feature = "os_input")]
     let rust_json = {
@@ -1182,6 +1188,7 @@ fn serialize_central_objects(#[case] rust_obj: impl Serialize, #[case] python_js
         if let Some(object) = rust_json.as_object_mut() {
             object.remove("recent_state_commitment_infos");
             object.remove("accessed_keys");
+            object.remove("initial_reads");
         }
         rust_json
     };

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -15,6 +15,8 @@ use blockifier::bouncer::{BouncerWeights, CasmHashComputationData};
 #[cfg(feature = "os_input")]
 use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::CommitmentStateDiff;
+#[cfg(feature = "os_input")]
+use blockifier::state::cached_state::StateMaps;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use central_objects::{
     process_transactions,
@@ -108,6 +110,8 @@ pub struct AerospikeBlob {
     recent_state_commitment_infos: Vec<StateCommitmentInfosAndNumber>,
     #[cfg(feature = "os_input")]
     accessed_keys: AccessedKeys,
+    #[cfg(feature = "os_input")]
+    initial_reads: StateMaps,
 }
 
 #[cfg_attr(test, automock)]
@@ -405,6 +409,8 @@ pub struct BlobParameters {
     pub recent_state_commitment_infos: Vec<StateCommitmentInfosAndNumber>,
     #[cfg(feature = "os_input")]
     pub accessed_keys: AccessedKeys,
+    #[cfg(feature = "os_input")]
+    pub initial_reads: StateMaps,
 }
 
 impl AerospikeBlob {
@@ -464,6 +470,8 @@ impl AerospikeBlob {
             recent_state_commitment_infos: blob_parameters.recent_state_commitment_infos,
             #[cfg(feature = "os_input")]
             accessed_keys: blob_parameters.accessed_keys,
+            #[cfg(feature = "os_input")]
+            initial_reads: blob_parameters.initial_reads,
         })
     }
 }

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -622,6 +622,8 @@ impl SequencerConsensusContext {
                     .await,
                 #[cfg(feature = "os_input")]
                 accessed_keys: central_objects.accessed_keys,
+                #[cfg(feature = "os_input")]
+                initial_reads: central_objects.initial_reads,
             })
             .await
         {

--- a/crates/central_systest_blobs/src/cende_blob_regression_test.rs
+++ b/crates/central_systest_blobs/src/cende_blob_regression_test.rs
@@ -248,6 +248,8 @@ impl From<BlockData> for BlobParameters {
             recent_state_commitment_infos: vec![],
             #[cfg(feature = "os_input")]
             accessed_keys: Default::default(),
+            #[cfg(feature = "os_input")]
+            initial_reads: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Read CentralObjects.initial_reads (set by the batcher) and thread it through BlobParameters into the AerospikeBlob, alongside the committer's accessed keys. Gated behind os_input.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>