### PR TITLE
starknet_os_flow_tests: build OS initial reads via get_os_initial_reads

### DIFF
--- a/crates/starknet_os_flow_tests/Cargo.toml
+++ b/crates/starknet_os_flow_tests/Cargo.toml
@@ -14,7 +14,7 @@ long_fuzz_test = []
 [dev-dependencies]
 apollo_integration_tests.workspace = true
 assert_matches.workspace = true
-blockifier = { workspace = true, features = ["reexecution", "testing"] }
+blockifier = { workspace = true, features = ["os_input", "reexecution", "testing"] }
 blockifier_test_utils.workspace = true
 cairo-lang-runner.workspace = true
 cairo-lang-starknet-classes.workspace = true

--- a/crates/starknet_os_flow_tests/src/test_manager.rs
+++ b/crates/starknet_os_flow_tests/src/test_manager.rs
@@ -95,7 +95,6 @@ use crate::tests::NON_TRIVIAL_RESOURCE_BOUNDS;
 use crate::utils::{
     divide_vec_into_n_parts,
     execute_transactions,
-    get_extended_initial_reads,
     maybe_dummy_block_hash_and_number,
     ExecutionOutput,
 };
@@ -393,7 +392,7 @@ impl<S: FlowTestState> TestRunner<S> {
     pub(crate) fn run(mut self) -> OsTestOutput<S> {
         // This cached state holds the diff of the entire execution.
         let entire_state_diff = self.entire_cached_state.to_state_diff().unwrap().state_maps;
-        let entire_initial_reads = get_extended_initial_reads(&self.entire_cached_state);
+        let entire_initial_reads = self.entire_cached_state.get_os_initial_reads().unwrap();
         self.entire_cached_state.state.apply_writes(
             &entire_state_diff,
             &self.entire_cached_state.class_hash_to_class.borrow(),
@@ -902,7 +901,7 @@ impl<S: FlowTestState> TestBuilder<S> {
                 &event_expectations_per_tx,
                 &execution_outputs,
             );
-            let initial_reads = get_extended_initial_reads(&final_state);
+            let initial_reads = final_state.get_os_initial_reads().unwrap();
             let state_diff = final_state.to_state_diff().unwrap().state_maps;
             // Update the wrapped state.
             state = final_state.state;

--- a/crates/starknet_os_flow_tests/src/utils.rs
+++ b/crates/starknet_os_flow_tests/src/utils.rs
@@ -8,7 +8,7 @@ use blockifier::blockifier::transaction_executor::{
     TransactionExecutor,
 };
 use blockifier::context::BlockContext;
-use blockifier::state::cached_state::{CachedState, StateMaps};
+use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::StateReader;
 use blockifier::test_utils::contracts::FeatureContractTrait;
 use blockifier::transaction::transaction_execution::Transaction;
@@ -145,28 +145,6 @@ pub(crate) fn create_declare_tx(
     )
     .unwrap();
     AccountTransaction::Declare(tx)
-}
-
-/// Gets the extended initial reads for the OS run.
-/// The extended initial reads are the initial reads with the class hash and nonce of each accessed
-/// contract.
-pub(crate) fn get_extended_initial_reads<S: StateReader>(state: &CachedState<S>) -> StateMaps {
-    let raw_initial_reads = state.get_initial_reads().unwrap();
-    // Populate the state initial reads with the class hash and nonce of each accessed contract.
-    for contract_address in raw_initial_reads.get_contract_addresses() {
-        state.get_class_hash_at(contract_address).unwrap();
-        state.get_nonce_at(contract_address).unwrap();
-    }
-
-    for class_hash in raw_initial_reads.declared_contracts.keys() {
-        state.get_compiled_class_hash(*class_hash).unwrap();
-    }
-
-    // Take the initial reads again to get the updated initial reads.
-    let mut extended_initial_reads = state.get_initial_reads().unwrap();
-    // This field is not used by the OS, so we clear it.
-    extended_initial_reads.declared_contracts.clear();
-    extended_initial_reads
 }
 
 pub(crate) fn maybe_dummy_block_hash_and_number(


### PR DESCRIPTION
Enable blockifier/os_input for the flow tests and replace the local get_extended_initial_reads helper with CachedState::get_os_initial_reads, so the tests build the OS initial reads exactly as production does.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>