### PR TITLE
apollo_http_server: avoid logging transaction proofs

### DIFF
--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -696,10 +696,20 @@ pub const VIRTUAL_OS_OUTPUT_VERSION: Felt =
 
 /// Client-provided proof facts used for client-side proving.
 /// Only needed when the client supplies a proof; otherwise empty.
-#[derive(
-    Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, SizeOf,
-)]
+#[derive(Clone, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, SizeOf)]
 pub struct ProofFacts(pub Arc<Vec<Felt>>);
+
+impl fmt::Debug for ProofFacts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.0.len();
+
+        if len == 0 {
+            write!(f, "ProofFacts([])")
+        } else {
+            write!(f, "ProofFacts(<{} elements>)", len)
+        }
+    }
+}
 
 impl ProofFacts {
     pub fn is_empty(&self) -> bool {

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -33,6 +33,15 @@ fn proof_facts_variant_rejects_unknown_version() {
 }
 
 #[test]
+fn proof_facts_debug_redacts_values() {
+    let facts = ProofFacts::snos_proof_facts_for_testing();
+    let debug_output = format!("{facts:?}");
+
+    assert_eq!(debug_output, "ProofFacts(<8 elements>)");
+    assert!(!debug_output.contains("0x50524f4f4631"));
+}
+
+#[test]
 fn proof_version_str_encodes_to_felt() {
     for version in ProofVersion::iter() {
         let from_short_string =


### PR DESCRIPTION
## Summary
- Redact `ProofFacts` debug output to match `Proof`'s existing length-only debug behavior.
- Allow typed `add_rpc_transaction` spans to keep recording the transaction with redacted proof/proof-facts fields.
- Keep skipping the legacy `add_transaction` raw body span, because that endpoint receives a JSON string and bypasses typed `Debug` redaction.

## Test plan
- `cargo test -p starknet_api proof_facts_debug_redacts_values`
- `cargo test -p apollo_http_server record_region_test`
- `cargo test -p apollo_http_server`
- `cargo check -p apollo_http_server`
- `cargo check -p starknet_api`

Note: repo-wide `cargo fmt -- --check` and `cargo +nightly fmt -- --check` report pre-existing formatting diffs unrelated to this PR.