### PR TITLE
papyrus_base_layer,apollo_l1_events: classify transient vs permanent L1 errors (L-13)

### DIFF
--- a/crates/apollo_l1_events/src/l1_scraper.rs
+++ b/crates/apollo_l1_events/src/l1_scraper.rs
@@ -14,13 +14,20 @@ use async_trait::async_trait;
 use futures::future::{BoxFuture, FutureExt};
 use itertools::zip_eq;
 use papyrus_base_layer::constants::EventIdentifier;
-use papyrus_base_layer::{BaseLayerContract, L1BlockNumber, L1BlockReference, L1Event};
+use papyrus_base_layer::{
+    BaseLayerContract,
+    BaseLayerError,
+    BaseLayerErrorKind,
+    L1BlockNumber,
+    L1BlockReference,
+    L1Event,
+};
 use starknet_api::block::BlockNumber;
 use starknet_api::StarknetApiError;
 use static_assertions::const_assert;
 use thiserror::Error;
 use tokio::time::sleep;
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::metrics::{
     register_scraper_metrics,
@@ -105,6 +112,12 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1EventsScraper<Bas
             match self.send_events_to_l1_events_provider().await {
                 Err(L1EventsScraperError::BaseLayerError(e)) => {
                     L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT.increment(1);
+                    // A permanent error recurs on every poll; surface it so the supervisor
+                    // restarts the scraper instead of silently wedging.
+                    if e.error_kind() == BaseLayerErrorKind::Permanent {
+                        error!("Permanent BaseLayerError during scraping: {e:?}");
+                        return Err(L1EventsScraperError::BaseLayerError(e));
+                    }
                     warn!("BaseLayerError during scraping: {e:?}");
                 }
                 Ok(_) => {
@@ -385,6 +398,15 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1EventsScraper<Bas
     {
         loop {
             match func(self).await {
+                // Retrying a permanent error would loop forever; surface it so the supervisor
+                // restarts the scraper. Transient errors keep the sleep-and-retry behavior.
+                Err(L1EventsScraperError::BaseLayerError(e))
+                    if e.error_kind() == BaseLayerErrorKind::Permanent =>
+                {
+                    error!("Permanent base-layer error while {description}: {e}");
+                    L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT.increment(1);
+                    return Err(L1EventsScraperError::BaseLayerError(e));
+                }
                 Err(L1EventsScraperError::BaseLayerError(e)) => {
                     warn!("Error while {description}: {e}");
                     L1_MESSAGE_SCRAPER_BASELAYER_ERROR_COUNT.increment(1);

--- a/crates/apollo_l1_events/src/l1_scraper_tests.rs
+++ b/crates/apollo_l1_events/src/l1_scraper_tests.rs
@@ -1,11 +1,12 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use apollo_l1_events_config::config::L1EventsScraperConfig;
 use apollo_l1_events_types::errors::L1EventsProviderError;
 use apollo_l1_events_types::MockL1EventsProviderClient;
 use assert_matches::assert_matches;
-use papyrus_base_layer::{L1BlockHash, L1BlockReference, MockBaseLayerContract};
+use futures::FutureExt;
+use papyrus_base_layer::{L1BlockHash, L1BlockReference, MockBaseLayerContract, MockError};
 
 use crate::event_identifiers_to_track;
 use crate::l1_scraper::{L1EventsScraper, L1EventsScraperError};
@@ -198,6 +199,64 @@ async fn base_layer_returns_block_number_below_finality_causes_error() {
         scraper.send_events_to_l1_events_provider().await,
         Err(L1EventsScraperError::LatestBlockNumberTooLow { .. })
     );
+}
+
+// A permanent error must break out of the retry loop, calling the closure exactly once.
+#[tokio::test]
+async fn retry_loop_returns_immediately_on_permanent_error() {
+    let mut scraper = scraper_with_dummy().await;
+    let num_closure_calls = Arc::new(AtomicUsize::new(0));
+    let num_closure_calls_clone = num_closure_calls.clone();
+
+    let result = scraper
+        .retry_until_base_layer_success(
+            move |_this| {
+                let num_closure_calls = num_closure_calls_clone.clone();
+                async move {
+                    num_closure_calls.fetch_add(1, Ordering::Relaxed);
+                    Err::<(), _>(L1EventsScraperError::BaseLayerError(MockError::Permanent))
+                }
+                .boxed()
+            },
+            "test permanent error",
+        )
+        .await;
+
+    assert_eq!(result, Err(L1EventsScraperError::BaseLayerError(MockError::Permanent)));
+    assert_eq!(num_closure_calls.load(Ordering::Relaxed), 1, "permanent error must not be retried");
+}
+
+// A transient error keeps the sleep-and-retry behavior; the loop retries until success.
+// The zero polling interval keeps the retries from blocking the test.
+#[tokio::test]
+async fn retry_loop_retries_transient_until_success() {
+    const NUM_TRANSIENT_FAILURES: usize = 3;
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.polling_interval_seconds = std::time::Duration::ZERO;
+    let num_closure_calls = Arc::new(AtomicUsize::new(0));
+    let num_closure_calls_clone = num_closure_calls.clone();
+
+    let result = scraper
+        .retry_until_base_layer_success(
+            move |_this| {
+                let num_closure_calls = num_closure_calls_clone.clone();
+                async move {
+                    let call_index = num_closure_calls.fetch_add(1, Ordering::Relaxed);
+                    if call_index < NUM_TRANSIENT_FAILURES {
+                        // `MockError::MockError` classifies as Transient.
+                        Err(L1EventsScraperError::BaseLayerError(MockError::MockError))
+                    } else {
+                        Ok(call_index)
+                    }
+                }
+                .boxed()
+            },
+            "test transient error",
+        )
+        .await;
+
+    assert_eq!(result, Ok(NUM_TRANSIENT_FAILURES));
+    assert_eq!(num_closure_calls.load(Ordering::Relaxed), NUM_TRANSIENT_FAILURES + 1);
 }
 
 #[test]

--- a/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper.rs
+++ b/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper.rs
@@ -5,15 +5,24 @@ use apollo_config::secrets::Sensitive;
 use apollo_metrics::metrics::LossyIntoF64;
 use async_trait::async_trait;
 use starknet_api::block::BlockHashAndNumber;
-use tracing::info;
+use tracing::{error, info};
 use url::Url;
 
 use crate::metrics::{
     ScraperLabel,
+    L1_PERMANENT_BASELAYER_ERROR_COUNT,
     L1_PRIMARY_ENDPOINT_DOWN_SINCE_TIMESTAMP_SECONDS,
     LABEL_NAME_SCRAPER,
 };
-use crate::{BaseLayerContract, L1BlockHeader, L1BlockNumber, L1BlockReference, L1Event};
+use crate::{
+    BaseLayerContract,
+    BaseLayerError,
+    BaseLayerErrorKind,
+    L1BlockHeader,
+    L1BlockNumber,
+    L1BlockReference,
+    L1Event,
+};
 
 #[cfg(test)]
 #[path = "cyclic_base_layer_wrapper_test.rs"]
@@ -76,6 +85,17 @@ impl<B: BaseLayerContract + Send + Sync> CyclicBaseLayerWrapper<B> {
                     .set(0f64, &[(LABEL_NAME_SCRAPER, self.scraper.into())]);
             }
             return Some(result);
+        }
+        // A permanent error is identical on every endpoint, so don't cycle. Leave the down-since
+        // gauge untouched: a structural bug is not an endpoint outage, and mislabeling it would
+        // page on-call to swap a healthy endpoint.
+        if let Err(ref error) = result {
+            if error.error_kind() == BaseLayerErrorKind::Permanent {
+                error!("Permanent base-layer error, not cycling URLs: {error:?}");
+                L1_PERMANENT_BASELAYER_ERROR_COUNT
+                    .increment(1, &[(LABEL_NAME_SCRAPER, self.scraper.into())]);
+                return Some(result);
+            }
         }
         // Get the current URL (return error in case it fails to get it).
         let current_url_result = self.base_layer.get_url().await;

--- a/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
+++ b/crates/papyrus_base_layer/src/cyclic_base_layer_wrapper_test.rs
@@ -12,6 +12,7 @@ use url::Url;
 use crate::cyclic_base_layer_wrapper::CyclicBaseLayerWrapper;
 use crate::metrics::{
     ScraperLabel,
+    L1_PERMANENT_BASELAYER_ERROR_COUNT,
     L1_PRIMARY_ENDPOINT_DOWN_SINCE_TIMESTAMP_SECONDS,
     LABEL_NAME_SCRAPER,
 };
@@ -791,4 +792,68 @@ async fn test_primary_down_since_metric() {
         gauge_value.is_some_and(|timestamp| timestamp > 0),
         "Expected nonzero down-since timestamp after primary failover, got: {gauge_value:?}"
     );
+}
+
+// A permanent error must surface immediately without cycling the URL, calling the op once.
+// Starting on the primary, the only base-layer calls are is_at_primary, get_url, and the op.
+#[tokio::test]
+async fn permanent_error_surfaces_immediately_without_cycling() {
+    let primary_url = Sensitive::new(Url::parse("http://primary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    // On the primary, so retry_primary_if_due short-circuits after one is_at_primary call.
+    base_layer.expect_is_at_primary().times(1).returning(|| Ok(true));
+    // Only the start_url lookup; the permanent-error branch returns before any current/new lookup.
+    base_layer.expect_get_url().times(1).returning(move || Ok(primary_url.clone()));
+    base_layer.expect_get_proved_block_at().times(1).returning(|_| Err(MockError::Permanent));
+    // The critical assertion: cycling must never happen for a permanent error.
+    base_layer.expect_cycle_provider_url().never();
+
+    let mut wrapper = CyclicBaseLayerWrapper::new(
+        base_layer,
+        TEST_RETRY_PRIMARY_INTERVAL,
+        ScraperLabel::L1Events,
+    );
+
+    let result = wrapper.get_proved_block_at(1).await;
+    assert_eq!(result, Err(MockError::Permanent));
+}
+
+// A permanent error must not set the down-since gauge (a structural bug is not an endpoint
+// outage) and must increment the dedicated permanent-error counter instead.
+#[tokio::test]
+async fn permanent_error_does_not_set_primary_down_since_and_counts() {
+    let primary_url = Sensitive::new(Url::parse("http://primary_endpoint").unwrap())
+        .with_redactor(to_safe_string);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_is_at_primary().times(1).returning(|| Ok(true));
+    base_layer.expect_get_url().times(1).returning(move || Ok(primary_url.clone()));
+    base_layer.expect_get_proved_block_at().times(1).returning(|_| Err(MockError::Permanent));
+    base_layer.expect_cycle_provider_url().never();
+
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    let prometheus_handle = recorder.handle();
+
+    let mut wrapper = CyclicBaseLayerWrapper::new(
+        base_layer,
+        TEST_RETRY_PRIMARY_INTERVAL,
+        ScraperLabel::L1Events,
+    );
+
+    assert_eq!(wrapper.get_proved_block_at(1).await, Err(MockError::Permanent));
+
+    let scraper_label_value: &'static str = ScraperLabel::L1Events.into();
+    let metrics_str = prometheus_handle.render();
+    let gauge_value = L1_PRIMARY_ENDPOINT_DOWN_SINCE_TIMESTAMP_SECONDS
+        .parse_numeric_metric::<u64>(&metrics_str, &[(LABEL_NAME_SCRAPER, scraper_label_value)]);
+    assert!(
+        gauge_value.is_none_or(|timestamp| timestamp == 0),
+        "Permanent error must not set the down-since gauge, got: {gauge_value:?}"
+    );
+    let permanent_error_count = L1_PERMANENT_BASELAYER_ERROR_COUNT
+        .parse_numeric_metric::<u64>(&metrics_str, &[(LABEL_NAME_SCRAPER, scraper_label_value)]);
+    assert_eq!(permanent_error_count, Some(1));
 }

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -35,6 +35,8 @@ use validator::{Validate, ValidationError};
 use crate::eth_events::parse_event;
 use crate::{
     BaseLayerContract,
+    BaseLayerError,
+    BaseLayerErrorKind,
     L1BlockHash,
     L1BlockHeader,
     L1BlockNumber,
@@ -402,6 +404,26 @@ impl PartialEq for EthereumBaseLayerError {
                 let BlockHeaderMissingError(that) = other else { return false };
                 this == that
             }
+        }
+    }
+}
+
+impl BaseLayerError for EthereumBaseLayerError {
+    fn error_kind(&self) -> BaseLayerErrorKind {
+        use EthereumBaseLayerError::*;
+        match self {
+            // Structural errors return the same data from every endpoint, so cycling cannot help.
+            FeeOutOfRange(_)
+            | StarknetApiParsingError(_)
+            | CalldataValueOutOfRange(_)
+            | TypeError(_)
+            | UnhandledL1Event(_)
+            | BlockNumberMissingError(_)
+            | BlockHeaderMissingError(_) => BaseLayerErrorKind::Permanent,
+            // Transport/temporary faults: retrying against another endpoint may succeed.
+            // `RpcError` and `Contract` are ambiguous (they can wrap permanent rejections too),
+            // but default to Transient to preserve resilience for the common transport-fault case.
+            ProviderTimeout(_) | RpcError(_) | Contract(_) => BaseLayerErrorKind::Transient,
         }
     }
 }

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -51,13 +51,46 @@ pub enum MockError {
     MockError,
     #[error("mock error {0}")]
     Numbered(usize),
+    #[error("permanent mock error")]
+    Permanent,
+}
+
+// `MockError` and `Numbered` stay Transient so existing tests keep exercising the cycle-on-error
+// path; the dedicated `Permanent` variant exercises the short-circuit.
+#[cfg(any(feature = "testing", test))]
+impl BaseLayerError for MockError {
+    fn error_kind(&self) -> BaseLayerErrorKind {
+        match self {
+            MockError::Permanent => BaseLayerErrorKind::Permanent,
+            MockError::MockError | MockError::Numbered(_) => BaseLayerErrorKind::Transient,
+        }
+    }
+}
+
+/// Classifies a base-layer error as retryable (cycling endpoints might help) or permanent
+/// (no endpoint can fix it, so retrying is wasted work).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BaseLayerErrorKind {
+    /// Transport/temporary faults (timeouts, resets, rate-limits); another endpoint may succeed.
+    Transient,
+    /// Structural faults (decode/ABI mismatches, out-of-range conversions); identical on every
+    /// endpoint, so cycling cannot resolve them.
+    Permanent,
+}
+
+/// Lets `CyclicBaseLayerWrapper` classify an opaque [`BaseLayerContract::Error`] without matching
+/// on concrete variants. The default treats every error as [`BaseLayerErrorKind::Transient`].
+pub trait BaseLayerError {
+    fn error_kind(&self) -> BaseLayerErrorKind {
+        BaseLayerErrorKind::Transient
+    }
 }
 
 /// Interface for getting data from the Starknet base contract.
 #[cfg_attr(any(feature = "testing", test), automock(type Error = MockError;))]
 #[async_trait]
 pub trait BaseLayerContract {
-    type Error: Error + PartialEq + Display + Debug + Send + Sync;
+    type Error: BaseLayerError + Error + PartialEq + Display + Debug + Send + Sync;
 
     /// Get the latest Starknet block that is proved on the base layer at a specific L1 block
     /// number. If the number is too low, return an error.

--- a/crates/papyrus_base_layer/src/metrics.rs
+++ b/crates/papyrus_base_layer/src/metrics.rs
@@ -27,6 +27,15 @@ define_metrics!(
              non-functional for the labeled scraper; 0 when the primary is healthy.",
             labels = SCRAPER_LABELS
         },
+        LabeledMetricCounter {
+            L1_PERMANENT_BASELAYER_ERROR_COUNT,
+            "l1_permanent_baselayer_error_count",
+            "Count of permanent (structural) base-layer errors that were surfaced without cycling \
+             endpoints, for the labeled scraper. A nonzero value indicates a config/ABI/version \
+             bug that no endpoint can fix, not an endpoint outage.",
+            init = 0,
+            labels = SCRAPER_LABELS
+        },
     },
 );
 
@@ -34,5 +43,6 @@ pub fn register_metrics() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
         L1_PRIMARY_ENDPOINT_DOWN_SINCE_TIMESTAMP_SECONDS.register();
+        L1_PERMANENT_BASELAYER_ERROR_COUNT.register();
     });
 }


### PR DESCRIPTION
## L-13 — Classify transient vs permanent L1 base-layer errors

**Security review finding:** L-13 (Low). The cyclic base-layer wrapper treated every error identically — it cycled the provider URL and signaled "retry" — so a permanent/structural failure (event decode/ABI mismatch, out-of-range conversion such as `FeeOutOfRange`, a missing required field) was swept across the **entire** URL pool before being surfaced, masking the real cause behind URL cycling. The events scraper's caller-side retry loop (`retry_until_base_layer_success`) then re-invoked that full pass forever, wedging L1-handler ingestion.

This PR sits **on top of** the already-merged primary-endpoint down-since gauge (`L1_PRIMARY_ENDPOINT_DOWN_SINCE_TIMESTAMP_SECONDS`, #14576/#14577) and corrects how it interacts with permanent errors: previously a permanent error would have cycled off the primary, set `primary_down_since`, and eventually fired the `primary-endpoint-down-too-long` alert — paging on-call to swap a **healthy** endpoint when the real cause is a config/ABI bug no endpoint can fix.

### What changed

- **Error taxonomy as a first-class concept.** Add `BaseLayerErrorKind { Transient, Permanent }` and a `BaseLayerError::error_kind()` classification, implemented next to each concrete error type (`papyrus_base_layer/src/lib.rs`, `ethereum_base_layer_contract.rs`). This keeps classification beside the concrete `EthereumBaseLayerError` while letting the generic wrapper act on it.
- **Wrapper short-circuits permanent errors** (`cyclic_base_layer_wrapper.rs`): a permanent error is surfaced immediately **without** cycling the pool and — crucially — **without** touching `primary_down_since` / the merged down-since gauge. A dedicated `l1_permanent_baselayer_error_count` counter (`metrics.rs`) is incremented instead, and the event is logged at `error!`, so alerting routes to "fix the config/ABI" rather than "swap the endpoint." Transient errors keep the existing cycle + down-since behavior intact.
- **Caller loop escalation** (`apollo_l1_events/src/l1_scraper.rs`): `retry_until_base_layer_success` and the steady-state `run` loop now escalate permanent errors (return → supervisor restart) instead of retrying forever; transient errors keep the sleep-and-retry behavior.

### Classification (documented in code)

The ambiguous `RpcError` / `Contract` wrappers default to **Transient** to preserve today's resilience (they cover both transport faults and server-side rejections). Only the unambiguously structural variants — `FeeOutOfRange`, `CalldataValueOutOfRange`, `StarknetApiParsingError`, `TypeError`, `UnhandledL1Event`, `BlockNumberMissingError`, `BlockHeaderMissingError` — are classified **Permanent**. `MockError` defaults to Transient so existing tests still exercise cycling; a `Permanent` variant covers the new path.

### Tests

`SEED=0 cargo nextest run -p papyrus_base_layer -p apollo_l1_events -p apollo_l1_events_config` — 121 passed. New cases include `permanent_error_does_not_set_primary_down_since_and_counts` (asserts the wrapped op runs once, no URL cycling, the down-since gauge is untouched, and the permanent-error counter increments) and scraper-loop escalation on a permanent base-layer error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
