### PR TITLE
apollo_l1_events,apollo_l1_events_config: chunk L1 getLogs range into bounded windows (M-25)

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/l1_events_scraper_config.json
+++ b/crates/apollo_deployments/resources/app_configs/l1_events_scraper_config.json
@@ -1,6 +1,7 @@
 {
   "l1_events_scraper_config.finality": 10,
   "l1_events_scraper_config.l1_block_time_seconds": 12.0,
+  "l1_events_scraper_config.max_blocks_per_fetch": 1000,
   "l1_events_scraper_config.polling_interval_seconds": 30,
   "l1_events_scraper_config.set_provider_historic_height_to_l2_genesis": false,
   "l1_events_scraper_config.startup_rewind_time_seconds": 21600

--- a/crates/apollo_deployments/resources/app_configs/replacer_l1_events_scraper_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_l1_events_scraper_config.json
@@ -1,6 +1,7 @@
 {
   "l1_events_scraper_config.finality": 10,
   "l1_events_scraper_config.l1_block_time_seconds": 12.0,
+  "l1_events_scraper_config.max_blocks_per_fetch": 1000,
   "l1_events_scraper_config.polling_interval_seconds": 30,
   "l1_events_scraper_config.set_provider_historic_height_to_l2_genesis": false,
   "l1_events_scraper_config.startup_rewind_time_seconds": 21600

--- a/crates/apollo_l1_events/src/l1_scraper.rs
+++ b/crates/apollo_l1_events/src/l1_scraper.rs
@@ -207,25 +207,28 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1EventsScraper<Bas
     }
 
     /// Send an initialize message to the L1 provider, including the last L2 height that was proved
-    /// before the start block number, and all events scraped from that L1 block until current
-    /// block. The provider will return an error if it was already initialized (e.g., if the scraper
-    /// was restarted).
+    /// before the start block number, and the events scraped over the first bounded window (see
+    /// `fetch_events` / `max_blocks_per_fetch`). The provider returns an error if it was already
+    /// initialized (e.g., if the scraper was restarted).
+    ///
+    /// Returns the L1 block reference up to which events were scraped. When the catch-up range
+    /// exceeds one window, this is short of the latest block; the polling loop drains the remaining
+    /// windows via `add_events`.
     #[instrument(skip(self), err)]
     async fn initialize(
         &mut self,
         historic_l2_height: BlockNumber,
     ) -> L1EventsScraperResult<L1BlockReference, BaseLayerType> {
-        let (latest_l1_block, events) = self.fetch_events().await?;
+        let (window_end_block, events) = self.fetch_events().await?;
 
-        debug!("Latest L1 block for initialize: {latest_l1_block:?}");
+        debug!("Scraped up to L1 block for initialize: {window_end_block:?}");
         debug!("All events scraped during initialize: {events:?}");
 
-        // If this gets too high, send in batches.
         let initialize_result =
             self.l1_events_provider_client.initialize(historic_l2_height, events).await;
         handle_client_error(initialize_result)?;
 
-        Ok(latest_l1_block)
+        Ok(window_end_block)
     }
 
     /// Scrape recent events and send them to the L1 provider.
@@ -299,9 +302,31 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1EventsScraper<Bas
         }
 
         let scraping_start_number = scrape_from_this_l1_block.number + 1;
+        // Cap the fetched range to max_blocks_per_fetch so a large backlog is drained over
+        // successive polls rather than in one unbounded eth_getLogs request. The window is
+        // inclusive on both ends, hence the `- 1`; `.max(1)` and saturating arithmetic guard
+        // against underflow even though config validation already rejects 0. The finality ceiling
+        // (latest_l1_block.number) is preserved.
+        let window_end_number = latest_l1_block
+            .number
+            .min(scraping_start_number.saturating_add(self.config.max_blocks_per_fetch.max(1) - 1));
+
+        // Reuse latest_l1_block when the window already reaches it, to avoid a needless extra RPC.
+        let window_end_block = if window_end_number == latest_l1_block.number {
+            latest_l1_block
+        } else {
+            self.base_layer
+                .l1_block_at(window_end_number)
+                .await
+                .map_err(L1EventsScraperError::BaseLayerError)?
+                .ok_or(L1EventsScraperError::LatestL1BlockNumberNoBlockFound {
+                    block_number: window_end_number,
+                })?
+        };
+
         let scraping_result = self
             .base_layer
-            .events(scraping_start_number..=latest_l1_block.number, &self.tracked_event_identifiers)
+            .events(scraping_start_number..=window_end_number, &self.tracked_event_identifiers)
             .await;
 
         let l1_events = scraping_result.map_err(L1EventsScraperError::BaseLayerError)?;
@@ -368,7 +393,7 @@ impl<BaseLayerType: BaseLayerContract + Send + Sync + Debug> L1EventsScraper<Bas
         } else {
             debug!("Got Cancellation Started Events: {formatted_cancellation_started_events:?}");
         }
-        Ok((latest_l1_block, events))
+        Ok((window_end_block, events))
     }
 
     /// Retry the given function if it gets base layer errors. Returns the result of the function in

--- a/crates/apollo_l1_events/src/l1_scraper_tests.rs
+++ b/crates/apollo_l1_events/src/l1_scraper_tests.rs
@@ -3,9 +3,19 @@ use std::sync::{Arc, Mutex};
 
 use apollo_l1_events_config::config::L1EventsScraperConfig;
 use apollo_l1_events_types::errors::L1EventsProviderError;
-use apollo_l1_events_types::MockL1EventsProviderClient;
+use apollo_l1_events_types::{Event, MockL1EventsProviderClient};
 use assert_matches::assert_matches;
-use papyrus_base_layer::{L1BlockHash, L1BlockReference, MockBaseLayerContract};
+use papyrus_base_layer::{
+    L1BlockHash,
+    L1BlockReference,
+    L1Event,
+    MockBaseLayerContract,
+    MockError,
+};
+use starknet_api::block::BlockTimestamp;
+use starknet_api::transaction::fields::{Calldata, Fee};
+use starknet_api::transaction::L1HandlerTransaction;
+use starknet_types_core::felt::Felt;
 
 use crate::event_identifiers_to_track;
 use crate::l1_scraper::{L1EventsScraper, L1EventsScraperError};
@@ -198,6 +208,306 @@ async fn base_layer_returns_block_number_below_finality_causes_error() {
         scraper.send_events_to_l1_events_provider().await,
         Err(L1EventsScraperError::LatestBlockNumberTooLow { .. })
     );
+}
+
+// A single fetch must never request more than max_blocks_per_fetch blocks, even when latest is far
+// ahead, and the cursor must advance by exactly one window (not jump to latest).
+#[tokio::test]
+async fn fetch_events_caps_range_to_max_blocks_per_fetch() {
+    const MAX_BLOCKS_PER_FETCH: u64 = 100;
+    const START_BLOCK_NUMBER: u64 = 0;
+    const LATEST_BLOCK_NUMBER: u64 = 1000;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+    // Inclusive window [start+1 ..= start+max], so the expected end is start + max.
+    const EXPECTED_WINDOW_END: u64 = START_BLOCK_NUMBER + MAX_BLOCKS_PER_FETCH;
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    // The requested range width must be exactly the configured cap.
+    base_layer
+        .expect_events()
+        .withf(|block_range, _| {
+            *block_range.start() == START_BLOCK_NUMBER + 1
+                && *block_range.end() == EXPECTED_WINDOW_END
+        })
+        .times(1)
+        .returning(|_, _| Ok(vec![]));
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.scrape_from_this_l1_block =
+        Some(L1BlockReference { number: START_BLOCK_NUMBER, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+
+    let (window_end_block, events) = scraper.fetch_events().await.unwrap();
+    assert!(events.is_empty());
+    assert_eq!(window_end_block.number, EXPECTED_WINDOW_END);
+}
+
+// When the backlog is smaller than one window, the fetch requests only up to the latest
+// (finality-adjusted) block and advances the cursor to it.
+#[tokio::test]
+async fn fetch_events_partial_window_stops_at_latest() {
+    const MAX_BLOCKS_PER_FETCH: u64 = 1000;
+    const START_BLOCK_NUMBER: u64 = 10;
+    const LATEST_BLOCK_NUMBER: u64 = 25;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    base_layer
+        .expect_events()
+        .withf(|block_range, _| {
+            *block_range.start() == START_BLOCK_NUMBER + 1
+                && *block_range.end() == LATEST_BLOCK_NUMBER
+        })
+        .times(1)
+        .returning(|_, _| Ok(vec![]));
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.scrape_from_this_l1_block =
+        Some(L1BlockReference { number: START_BLOCK_NUMBER, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+
+    let (window_end_block, _events) = scraper.fetch_events().await.unwrap();
+    assert_eq!(window_end_block.number, LATEST_BLOCK_NUMBER);
+}
+
+// The window ceiling is finality-adjusted: it must never request beyond latest - finality.
+#[tokio::test]
+async fn fetch_events_window_respects_finality_ceiling() {
+    const MAX_BLOCKS_PER_FETCH: u64 = 1000;
+    const FINALITY: u64 = 6;
+    const START_BLOCK_NUMBER: u64 = 50;
+    const LATEST_BLOCK_NUMBER: u64 = 60;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+    // The backlog (10 blocks) is smaller than the window, so the ceiling is latest - finality.
+    const EXPECTED_WINDOW_END: u64 = LATEST_BLOCK_NUMBER - FINALITY;
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    base_layer
+        .expect_events()
+        .withf(|block_range, _| *block_range.end() == EXPECTED_WINDOW_END)
+        .times(1)
+        .returning(|_, _| Ok(vec![]));
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.config.finality = FINALITY;
+    scraper.scrape_from_this_l1_block =
+        Some(L1BlockReference { number: START_BLOCK_NUMBER, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+
+    let (window_end_block, _events) = scraper.fetch_events().await.unwrap();
+    assert_eq!(window_end_block.number, EXPECTED_WINDOW_END);
+}
+
+// A large backlog is drained one window per poll until the cursor reaches latest.
+#[tokio::test]
+async fn catch_up_drains_backlog_over_multiple_polls() {
+    const MAX_BLOCKS_PER_FETCH: u64 = 100;
+    const LATEST_BLOCK_NUMBER: u64 = 250;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    base_layer.expect_events().returning(|_, _| Ok(vec![]));
+
+    let mut l1_events_provider_client = MockL1EventsProviderClient::default();
+    l1_events_provider_client.expect_add_events().returning(|_| Ok(()));
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.scrape_from_this_l1_block = Some(L1BlockReference { number: 0, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+    scraper.l1_events_provider_client = Arc::new(l1_events_provider_client);
+
+    // Each poll advances by one window (100, 200, then 250 = latest).
+    let expected_cursor_progression = [100, 200, LATEST_BLOCK_NUMBER];
+    for expected_cursor in expected_cursor_progression {
+        scraper.send_events_to_l1_events_provider().await.unwrap();
+        assert_eq!(scraper.scrape_from_this_l1_block.unwrap().number, expected_cursor);
+    }
+}
+
+// A convertible LogMessageToL2 event: calldata must lead with a from_address for msg-hash calc.
+fn log_message_to_l2_event() -> L1Event {
+    L1Event::LogMessageToL2 {
+        tx: L1HandlerTransaction {
+            calldata: Calldata(vec![Felt::ONE].into()),
+            ..Default::default()
+        },
+        fee: Fee::default(),
+        l1_tx_hash: None,
+        block_timestamp: BlockTimestamp::default(),
+    }
+}
+
+// A getLogs failure must not advance the cursor; the same window is retried on the next poll.
+#[tokio::test]
+async fn cursor_not_advanced_on_events_rpc_failure() {
+    const START_BLOCK_NUMBER: u64 = 42;
+    const MAX_BLOCKS_PER_FETCH: u64 = 1000;
+    const LATEST_BLOCK_NUMBER: u64 = START_BLOCK_NUMBER + 5;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    base_layer.expect_events().returning(|_, _| Err(MockError::MockError));
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.scrape_from_this_l1_block =
+        Some(L1BlockReference { number: START_BLOCK_NUMBER, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+
+    assert_matches!(
+        scraper.send_events_to_l1_events_provider().await,
+        Err(L1EventsScraperError::BaseLayerError(_))
+    );
+    assert_eq!(scraper.scrape_from_this_l1_block.unwrap().number, START_BLOCK_NUMBER);
+}
+
+// A commit (add_events) failure must not advance the cursor, so the events are not skipped.
+#[tokio::test]
+async fn cursor_not_advanced_on_add_events_failure() {
+    const START_BLOCK_NUMBER: u64 = 42;
+    const MAX_BLOCKS_PER_FETCH: u64 = 1000;
+    const LATEST_BLOCK_NUMBER: u64 = START_BLOCK_NUMBER + 5;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    base_layer.expect_events().returning(|_, _| Ok(vec![log_message_to_l2_event()]));
+
+    let mut l1_events_provider_client = MockL1EventsProviderClient::default();
+    l1_events_provider_client.expect_add_events().once().returning(|_| {
+        Err(apollo_l1_events_types::errors::L1EventsProviderClientError::L1EventsProviderError(
+            L1EventsProviderError::Uninitialized,
+        ))
+    });
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.scrape_from_this_l1_block =
+        Some(L1BlockReference { number: START_BLOCK_NUMBER, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+    scraper.l1_events_provider_client = Arc::new(l1_events_provider_client);
+
+    assert!(scraper.send_events_to_l1_events_provider().await.is_err());
+    assert_eq!(scraper.scrape_from_this_l1_block.unwrap().number, START_BLOCK_NUMBER);
+}
+
+// After a getLogs failure the retry must re-request the exact same [start, end] window (no bisect).
+#[tokio::test]
+async fn retry_refetches_same_window() {
+    const START_BLOCK_NUMBER: u64 = 10;
+    const MAX_BLOCKS_PER_FETCH: u64 = 100;
+    const LATEST_BLOCK_NUMBER: u64 = 1000;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+    // Inclusive window [start+1 ..= start+max], so the expected end is start + max.
+    const EXPECTED_WINDOW_END: u64 = START_BLOCK_NUMBER + MAX_BLOCKS_PER_FETCH;
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    // First attempt fails while requesting the capped window.
+    base_layer
+        .expect_events()
+        .withf(|block_range, _| {
+            *block_range.start() == START_BLOCK_NUMBER + 1
+                && *block_range.end() == EXPECTED_WINDOW_END
+        })
+        .times(1)
+        .returning(|_, _| Err(MockError::MockError));
+    // The retry must request the identical window, not a bisected one.
+    base_layer
+        .expect_events()
+        .withf(|block_range, _| {
+            *block_range.start() == START_BLOCK_NUMBER + 1
+                && *block_range.end() == EXPECTED_WINDOW_END
+        })
+        .times(1)
+        .returning(|_, _| Ok(vec![]));
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.scrape_from_this_l1_block =
+        Some(L1BlockReference { number: START_BLOCK_NUMBER, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+
+    assert_matches!(
+        scraper.send_events_to_l1_events_provider().await,
+        Err(L1EventsScraperError::BaseLayerError(_))
+    );
+    assert_eq!(scraper.scrape_from_this_l1_block.unwrap().number, START_BLOCK_NUMBER);
+
+    scraper.send_events_to_l1_events_provider().await.unwrap();
+    assert_eq!(scraper.scrape_from_this_l1_block.unwrap().number, EXPECTED_WINDOW_END);
+}
+
+// Capping the block range must never drop events: every event in the dense window is forwarded.
+#[tokio::test]
+async fn fetch_events_returns_all_events_in_dense_window() {
+    const MAX_BLOCKS_PER_FETCH: u64 = 10;
+    const START_BLOCK_NUMBER: u64 = 0;
+    const LATEST_BLOCK_NUMBER: u64 = 1000;
+    const NUM_EVENTS: usize = 500;
+    const L1_BLOCK_HASH: L1BlockHash = L1BlockHash([7; 32]);
+    // Inclusive window [start+1 ..= start+max], so the expected end is start + max.
+    const EXPECTED_WINDOW_END: u64 = START_BLOCK_NUMBER + MAX_BLOCKS_PER_FETCH;
+
+    let mut base_layer = MockBaseLayerContract::new();
+    base_layer.expect_latest_l1_block_number().returning(|| Ok(LATEST_BLOCK_NUMBER));
+    base_layer
+        .expect_l1_block_at()
+        .returning(move |number| Ok(Some(L1BlockReference { number, hash: L1_BLOCK_HASH })));
+    base_layer
+        .expect_events()
+        .times(1)
+        .returning(|_, _| Ok((0..NUM_EVENTS).map(|_| log_message_to_l2_event()).collect()));
+
+    let forwarded_events: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(vec![]));
+    let forwarded_events_clone = forwarded_events.clone();
+    let mut l1_events_provider_client = MockL1EventsProviderClient::default();
+    l1_events_provider_client.expect_add_events().once().returning(move |events| {
+        *forwarded_events_clone.lock().unwrap() = events;
+        Ok(())
+    });
+
+    let mut scraper = scraper_with_dummy().await;
+    scraper.config.max_blocks_per_fetch = MAX_BLOCKS_PER_FETCH;
+    scraper.scrape_from_this_l1_block =
+        Some(L1BlockReference { number: START_BLOCK_NUMBER, hash: L1_BLOCK_HASH });
+    scraper.base_layer = base_layer;
+    scraper.l1_events_provider_client = Arc::new(l1_events_provider_client);
+
+    scraper.send_events_to_l1_events_provider().await.unwrap();
+
+    assert_eq!(forwarded_events.lock().unwrap().len(), NUM_EVENTS);
+    assert_eq!(scraper.scrape_from_this_l1_block.unwrap().number, EXPECTED_WINDOW_END);
 }
 
 #[test]

--- a/crates/apollo_l1_events_config/src/config.rs
+++ b/crates/apollo_l1_events_config/src/config.rs
@@ -115,6 +115,11 @@ pub struct L1EventsScraperConfig {
     pub set_provider_historic_height_to_l2_genesis: bool,
     #[serde(deserialize_with = "deserialize_float_seconds_to_duration")]
     pub l1_block_time_seconds: Duration,
+    /// Maximum number of L1 blocks fetched per `events` (eth_getLogs) request. Caps the catch-up
+    /// window so a large backlog is drained over successive polls instead of one unbounded
+    /// request.
+    #[validate(range(min = 1))]
+    pub max_blocks_per_fetch: u64,
 }
 
 impl Default for L1EventsScraperConfig {
@@ -126,6 +131,10 @@ impl Default for L1EventsScraperConfig {
             polling_interval_seconds: Duration::from_secs(30),
             set_provider_historic_height_to_l2_genesis: false,
             l1_block_time_seconds: Duration::from_secs(12),
+            // Conservative default: well under the common public-RPC eth_getLogs block-range caps
+            // (~1k-10k) and the 1s base-layer timeout. Operators on permissive private RPCs may
+            // raise it.
+            max_blocks_per_fetch: 1000,
         }
     }
 }
@@ -168,6 +177,14 @@ impl SerializeConfig for L1EventsScraperConfig {
                 "l1_block_time_seconds",
                 &self.l1_block_time_seconds.as_secs(),
                 "The time it takes for a new L1 block to be created.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "max_blocks_per_fetch",
+                &self.max_blocks_per_fetch,
+                "Maximum number of L1 blocks fetched per events (eth_getLogs) request. Caps the \
+                 catch-up window so a large backlog is drained over successive polls instead of in \
+                 one unbounded request.",
                 ParamPrivacyInput::Public,
             ),
         ])

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3299,6 +3299,11 @@
     "privacy": "Public",
     "value": 12
   },
+  "l1_events_scraper_config.max_blocks_per_fetch": {
+    "description": "Maximum number of L1 blocks fetched per events (eth_getLogs) request. Caps the catch-up window so a large backlog is drained over successive polls instead of in one unbounded request.",
+    "privacy": "Public",
+    "value": 1000
+  },
   "l1_events_scraper_config.polling_interval_seconds": {
     "description": "Interval in Seconds between each scraping attempt of L1.",
     "privacy": "Public",


### PR DESCRIPTION
## M-25 — Chunk the L1 getLogs range into bounded windows

**Security review finding:** M-25 (Low–Medium). The L1 events scraper built the inclusive range `scraping_start..=latest_l1_block` and asked the base layer for **all** tracked events across that entire range in a single `events()` / `eth_getLogs` call, with no per-iteration cap and no chunking (a `// If this gets too high, send in batches.` comment acknowledged the gap). After downtime, an L1 outage, or with a large startup rewind, that range can span thousands of L1 blocks. The dominant failure mode is a **liveness stall**: the single call is wrapped in a 1 s timeout plus an N+1 per-event header fetch, so an oversized range times out and the scraper spins in its retry loop, never advancing — and (via the cyclic wrapper) misfires the primary-down-since signal. Unbounded `Vec<L1Event>` / `Vec<Event>` materialization is a secondary memory risk.

### What changed

- **New config param** `l1_events_scraper_config.max_blocks_per_fetch: u64` (`apollo_l1_events_config`), default **1000**, validated `>= 1`.
- **Bounded fetch window** (`apollo_l1_events/src/l1_scraper.rs`): `fetch_events` now requests `scraping_start..=min(latest, start + max_blocks_per_fetch - 1)` and returns the `L1BlockReference` for the window end, so the cursor advances by exactly one window per poll and the steady-state loop drains a backlog over successive polls. The finality ceiling and the once-per-poll reorg check are preserved. `initialize` sends the first bounded window via the provider's `initialize()` and lets the steady loop drain the rest via `add_events`, so the provider's initialize-once contract is unchanged. Saturating arithmetic guards a 0 cap even though validation rejects it.
- **Deployment presets updated.** `l1_events_scraper_config.max_blocks_per_fetch: 1000` added to the hand-maintained `l1_events_scraper_config.json` and `replacer_l1_events_scraper_config.json` presets, and `config_schema.json` regenerated. A new required schema param missing from the presets would `MissingParam`-panic the deployed node at startup (CrashLoopBackOff in `system_test_hybrid`) — exactly the bug L-16 (#14590) hit.

### Assumptions (documented in code)

Default 1000 is conservative versus common public-RPC `eth_getLogs` caps (~1k–10k) and the 1 s timeout; operators on private RPCs may raise it.

### Tests

`SEED=0 cargo nextest run -p papyrus_base_layer -p apollo_l1_events -p apollo_l1_events_config` — 125 passed (new: range-cap, partial-window, finality-ceiling, multi-poll backlog drain). `cargo nextest run -p apollo_deployments` (incl. `deployment_files_are_up_to_date`) and `-p apollo_node_config` (`default_config_file_is_up_to_date`) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
