### PR TITLE
apollo_mempool,apollo_mempool_config: round up required fee-escalation bump on replacement

### DIFF
--- a/crates/apollo_mempool/src/fee_mempool_test.rs
+++ b/crates/apollo_mempool/src/fee_mempool_test.rs
@@ -828,12 +828,12 @@ fn fee_escalation_queue_removal() {
     let mut mempool = MempoolTestContentBuilder::new()
         .with_priority_queue([queued_tx_reference])
         .with_pool([queued_tx.clone(), tx_to_be_replaced])
-        .with_fee_escalation_percentage(0) // Always replace.
+        .with_fee_escalation_percentage(10)
         .build_full_mempool();
 
     // Test and assert: replacement doesn't affect queue.
 
-    let valid_replacement_input = add_tx_input!(tx_hash: 2, address: "0x0", tx_nonce: 1, tip: 0, max_l2_gas_price: min_gas_price);
+    let valid_replacement_input = add_tx_input!(tx_hash: 2, address: "0x0", tx_nonce: 1, tip: 1, max_l2_gas_price: min_gas_price + 1);
     add_tx(&mut mempool, &valid_replacement_input);
     let expected_mempool_content = MempoolTestContentBuilder::new()
         .with_pool([queued_tx, valid_replacement_input.tx])
@@ -849,12 +849,12 @@ fn test_fee_escalation_valid_replacement_minimum_values() {
     let tx = tx!(tx_hash: 0, tip: 0, max_l2_gas_price: min_gas_price);
     let mempool = MempoolTestContentBuilder::new()
         .with_pool([tx])
-        .with_fee_escalation_percentage(0) // Always replace.
+        .with_fee_escalation_percentage(10)
         .build_full_mempool();
 
-    // Test and assert: replacement with maximum values.
+    // Test and assert: smallest replacement that clears the minimum bump on both bounds.
     let valid_replacement_input =
-        add_tx_input!(tx_hash: 1, tip: 0, max_l2_gas_price: min_gas_price);
+        add_tx_input!(tx_hash: 1, tip: 1, max_l2_gas_price: min_gas_price + 1);
     validate_and_add_tx_and_verify_replacement_in_pool(mempool, valid_replacement_input);
 }
 
@@ -920,6 +920,32 @@ fn test_fee_escalation_invalid_replacement_overflow_gracefully_handled() {
         existing_tx,
         [invalid_replacement_input],
     );
+}
+
+#[rstest]
+fn test_fee_escalation_rounds_up_required_bump() {
+    // 10% of 5 is 0.5, which rounds up to a required increase of 1: an equal fee is rejected and a
+    // +1 replacement is accepted.
+    let existing_tx = tx!(tx_hash: 0, tip: 5, max_l2_gas_price: 5);
+
+    let equal_fee_replacement = add_tx_input!(tx_hash: 1, tip: 5, max_l2_gas_price: 5);
+    let mempool = MempoolTestContentBuilder::new()
+        .with_pool([existing_tx.clone()])
+        .with_fee_escalation_percentage(10)
+        .build_full_mempool();
+    validate_and_add_txs_and_verify_no_replacement_in_pool(
+        mempool,
+        existing_tx,
+        [equal_fee_replacement],
+    );
+
+    let existing_tx = tx!(tx_hash: 0, tip: 5, max_l2_gas_price: 5);
+    let plus_one_replacement = add_tx_input!(tx_hash: 2, tip: 6, max_l2_gas_price: 6);
+    let mempool = MempoolTestContentBuilder::new()
+        .with_pool([existing_tx])
+        .with_fee_escalation_percentage(10)
+        .build_full_mempool();
+    validate_and_add_tx_and_verify_replacement_in_pool(mempool, plus_one_replacement);
 }
 
 // `update_gas_price_threshold` tests.

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -821,13 +821,12 @@ impl Mempool {
     fn increased_enough(&self, existing_value: u128, incoming_value: u128) -> bool {
         let percentage = u128::from(self.config.static_config.fee_escalation_percentage);
 
-        // Note: To reduce precision loss, we first multiply by the percentage and then divide by
-        // 100. This could cause an overflow and an automatic rejection of the transaction, but the
-        // values aren't expected to be large enough for this to be an issue.
+        // Round up the required increase so any positive percentage always demands a strictly
+        // higher fee, even for small values.
         let Some(escalation_qualified_value) = existing_value
             .checked_mul(percentage)
-            .map(|v| v / 100)
-            .and_then(|increase| existing_value.checked_add(increase))
+            .map(|scaled| scaled.div_ceil(100))
+            .and_then(|required_increase| existing_value.checked_add(required_increase))
         else {
             // Overflow occurred during calculation; reject the transaction.
             return false;

--- a/crates/apollo_mempool_config/src/config.rs
+++ b/crates/apollo_mempool_config/src/config.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 use validator::Validate;
 
+#[cfg(test)]
+#[path = "config_test.rs"]
+mod config_test;
+
 /// Configuration for consensus containing both static and dynamic configs.
 #[derive(Debug, Deserialize, Default, Serialize, Clone, PartialEq, Validate)]
 pub struct MempoolConfig {
@@ -57,8 +61,8 @@ impl SerializeConfig for MempoolDynamicConfig {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Validate)]
 pub struct MempoolStaticConfig {
     pub enable_fee_escalation: bool,
-    // TODO(AlonH): consider adding validations; should be bounded?
     // Percentage increase for tip and max gas price to enable transaction replacement.
+    #[validate(range(min = 1, max = 100))]
     pub fee_escalation_percentage: u8, // E.g., 10 for a 10% increase.
     // If true, only transactions with max L2 gas price per unit bound that are above the threshold
     // are inserted into the priority queue. If false, all transactions are inserted into the

--- a/crates/apollo_mempool_config/src/config_test.rs
+++ b/crates/apollo_mempool_config/src/config_test.rs
@@ -1,0 +1,14 @@
+use validator::Validate;
+
+use super::MempoolStaticConfig;
+
+#[test]
+fn default_static_config_passes_validation() {
+    assert!(MempoolStaticConfig::default().validate().is_ok());
+}
+
+#[test]
+fn zero_fee_escalation_percentage_fails_validation() {
+    let static_config = MempoolStaticConfig { fee_escalation_percentage: 0, ..Default::default() };
+    assert!(static_config.validate().is_err());
+}


### PR DESCRIPTION
## What
Fee-escalation replacement now requires the bump to round **up**: `incoming >= existing + ceil(existing * pct / 100)`.

## Why
With truncating division, small fee values could truncate the required bump to zero, letting an equal-fee transaction replace an existing one at no added cost (replacement churn). Rounding up makes any `>= 1%` escalation force a strictly higher fee, even for small values.

No absolute minimum floor is needed — real fees are in the millions, so round-up alone closes the hole. The degenerate `0%` case is ruled out at config level by `#[validate(range(min = 1, max = 100))]` on `fee_escalation_percentage` (an integer percentage, e.g. `10` = 10%). Overflow during the calculation still gracefully rejects via `checked_*`.

## Tests
- Replaced the minimum-bump tests with `test_fee_escalation_rounds_up_required_bump` (existing fee 5 at 10% → required +1: 5 rejected, 6 accepted).
- Kept the overflow-graceful test and the config-validation test asserting `fee_escalation_percentage = 0` fails `validate()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
