### PR TITLE
starknet_api: avoid double-parse in TryFrom<ProofFacts> for SnosProofFacts error path

### DIFF
--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -696,10 +696,17 @@ pub const VIRTUAL_OS_OUTPUT_VERSION: Felt =
 
 /// Client-provided proof facts used for client-side proving.
 /// Only needed when the client supplies a proof; otherwise empty.
-#[derive(
-    Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, SizeOf,
-)]
+#[derive(Clone, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, SizeOf)]
 pub struct ProofFacts(pub Arc<Vec<Felt>>);
+
+impl fmt::Debug for ProofFacts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match ProofFactsVariant::try_from(self) {
+            Ok(variant) => write!(f, "ProofFacts({variant:?})"),
+            Err(_) => write!(f, "ProofFacts([<{} elements>])", self.0.len()),
+        }
+    }
+}
 
 impl ProofFacts {
     pub fn is_empty(&self) -> bool {
@@ -716,6 +723,7 @@ impl ProofFacts {
 /// Currently, only SNOS proof facts are supported.
 /// The `Empty` variant indicates that the transaction does not utilize the client-side proving
 /// feature.
+#[derive(Debug)]
 pub enum ProofFactsVariant {
     Empty,
     Snos(SnosProofFacts),
@@ -795,6 +803,7 @@ impl TryFrom<&ProofFacts> for ProofFactsVariant {
 /// Contains the required fields for valid SNOS proof facts.
 ///
 /// A valid SNOS proof facts structure must include these fields as its first five entries.
+#[derive(Debug)]
 pub struct SnosProofFacts {
     pub proof_version: ProofVersion,
     pub program_hash: StarkHash,

--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -824,7 +824,7 @@ impl TryFrom<ProofFacts> for SnosProofFacts {
         match ProofFactsVariant::try_from(&proof_facts)? {
             ProofFactsVariant::Snos(snos_proof_facts) => Ok(snos_proof_facts),
             ProofFactsVariant::Empty => Err(StarknetApiError::InvalidProofFacts(
-                "expected SNOS proof facts, got empty".to_string(),
+                "Expected SNOS proof facts, got empty".to_string(),
             )),
         }
     }

--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -821,11 +821,11 @@ impl From<Vec<Felt>> for ProofFacts {
 impl TryFrom<ProofFacts> for SnosProofFacts {
     type Error = StarknetApiError;
     fn try_from(proof_facts: ProofFacts) -> Result<Self, Self::Error> {
-        match ProofFactsVariant::try_from(&proof_facts) {
-            Ok(ProofFactsVariant::Snos(snos_proof_facts)) => Ok(snos_proof_facts),
-            _ => Err(StarknetApiError::InvalidProofFacts(format!(
-                "Invalid SNOS proof facts: {proof_facts:?}",
-            ))),
+        match ProofFactsVariant::try_from(&proof_facts)? {
+            ProofFactsVariant::Snos(snos_proof_facts) => Ok(snos_proof_facts),
+            ProofFactsVariant::Empty => Err(StarknetApiError::InvalidProofFacts(
+                "expected SNOS proof facts, got empty".to_string(),
+            )),
         }
     }
 }

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -80,14 +80,13 @@ fn snos_proof_facts_try_from_rejects_empty() {
 }
 
 #[test]
-fn snos_proof_facts_try_from_propagates_inner_error_without_reparsing() {
-    // A proof with an unrecognised version marker — the inner try_from error should be
-    // propagated directly without triggering a second parse via the Debug impl.
+fn snos_proof_facts_try_from_propagates_inner_error() {
+    // A proof with an unknown version marker — the specific inner parse error should be
+    // propagated directly rather than wrapped in a generic message.
     let facts = proof_facts_given_proof_version(Felt::from_hex_unchecked("0xDEAD"));
     let err = SnosProofFacts::try_from(facts).expect_err("bad version should be rejected");
     let StarknetApiError::InvalidProofFacts(msg) = err else {
         panic!("expected InvalidProofFacts, got {err:?}");
     };
-    // The inner error already contains the specific reason; it must not be a generic wrapper.
-    assert!(!msg.contains("Invalid SNOS proof facts:"), "should propagate inner error, got: {msg}");
+    assert!(msg.contains("Expected first field"), "should propagate inner error, got: {msg}");
 }

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -61,3 +61,33 @@ fn proof_facts_debug_falls_back_for_unparseable() {
     let facts = ProofFacts(Arc::new(vec![Felt::from_hex_unchecked("0xDEAD")]));
     assert_eq!(format!("{:?}", facts), "ProofFacts([<1 elements>])");
 }
+
+#[test]
+fn snos_proof_facts_try_from_succeeds_for_valid_snos() {
+    let snos =
+        SnosProofFacts::try_from(ProofFacts::snos_proof_facts_for_testing()).expect("valid SNOS");
+    assert_eq!(snos.proof_version, ProofVersion::V1);
+}
+
+#[test]
+fn snos_proof_facts_try_from_rejects_empty() {
+    let err =
+        SnosProofFacts::try_from(ProofFacts::default()).expect_err("empty should be rejected");
+    let StarknetApiError::InvalidProofFacts(msg) = err else {
+        panic!("expected InvalidProofFacts, got {err:?}");
+    };
+    assert!(msg.contains("empty"), "expected 'empty' in error, got: {msg}");
+}
+
+#[test]
+fn snos_proof_facts_try_from_propagates_inner_error_without_reparsing() {
+    // A proof with an unrecognised version marker — the inner try_from error should be
+    // propagated directly without triggering a second parse via the Debug impl.
+    let facts = proof_facts_given_proof_version(Felt::from_hex_unchecked("0xDEAD"));
+    let err = SnosProofFacts::try_from(facts).expect_err("bad version should be rejected");
+    let StarknetApiError::InvalidProofFacts(msg) = err else {
+        panic!("expected InvalidProofFacts, got {err:?}");
+    };
+    // The inner error already contains the specific reason; it must not be a generic wrapper.
+    assert!(!msg.contains("Invalid SNOS proof facts:"), "should propagate inner error, got: {msg}");
+}

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -40,3 +40,24 @@ fn proof_version_str_encodes_to_felt() {
         assert_eq!(from_short_string, version.as_felt());
     }
 }
+
+#[test]
+fn proof_facts_debug_decodes_snos_without_dumping_felts() {
+    let debug = format!("{:?}", ProofFacts::snos_proof_facts_for_testing());
+    // Decoded via the variant's derived `Debug`, not the raw-felt length fallback.
+    assert!(debug.starts_with("ProofFacts(Snos(SnosProofFacts {"), "got: {debug}");
+    assert!(debug.contains("proof_version: V1"), "got: {debug}");
+    assert!(debug.contains("block_number: BlockNumber("), "got: {debug}");
+    assert!(!debug.contains("elements"), "should not hit the fallback: {debug}");
+}
+
+#[test]
+fn proof_facts_debug_empty() {
+    assert_eq!(format!("{:?}", ProofFacts::default()), "ProofFacts(Empty)");
+}
+
+#[test]
+fn proof_facts_debug_falls_back_for_unparseable() {
+    let facts = ProofFacts(Arc::new(vec![Felt::from_hex_unchecked("0xDEAD")]));
+    assert_eq!(format!("{:?}", facts), "ProofFacts([<1 elements>])");
+}


### PR DESCRIPTION
## Summary

Follow-up optimization to #14598.

PR #14598 introduced a custom `Debug` impl for `ProofFacts` that internally calls `ProofFactsVariant::try_from`. This exposed a latent inefficiency in `TryFrom<ProofFacts> for SnosProofFacts`: its error arm used `{proof_facts:?}` in the format string, which now triggers a **redundant second call** to `ProofFactsVariant::try_from` — the inner error from the first call was being discarded and the data re-parsed just to build the error message.

### Change

- Replace the wildcard `_` error arm with explicit matching: propagate the inner `Err` via `?` (reusing its already-descriptive message), and handle the `Empty` variant separately with a clear message.
- Add three tests: success path, empty-input rejection, and inner-error propagation (ensuring the generic wrapper string is no longer produced).

### Before / After

**Before** — error path triggered two parses:
```rust
match ProofFactsVariant::try_from(&proof_facts) {
    Ok(ProofFactsVariant::Snos(snos)) => Ok(snos),
    _ => Err(StarknetApiError::InvalidProofFacts(format!(
        "Invalid SNOS proof facts: {proof_facts:?}",  // ← second try_from here
    ))),
}
```

**After** — inner error propagated directly:
```rust
match ProofFactsVariant::try_from(&proof_facts)? {
    ProofFactsVariant::Snos(snos) => Ok(snos),
    ProofFactsVariant::Empty => Err(StarknetApiError::InvalidProofFacts(
        "expected SNOS proof facts, got empty".to_string(),
    )),
}
```

### Expected impact

Eliminates one redundant `ProofFactsVariant::try_from` call on every error path through `TryFrom<ProofFacts> for SnosProofFacts`. Also produces more specific error messages (the inner parse error explains exactly what was wrong, rather than a generic wrapper).

## Test plan

```
RUSTC_WRAPPER="" SEED=0 cargo test -p starknet_api --features testing -- fields_test
```

All 9 tests pass, including 3 new ones added by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012LisVr816uithGQwsdLQA7)_