### PR TITLE
blockifier: record pre-migration compiled class hash as initial read

### DIFF
--- a/crates/blockifier/src/state/compiled_class_hash_migration.rs
+++ b/crates/blockifier/src/state/compiled_class_hash_migration.rs
@@ -6,6 +6,10 @@ use crate::blockifier::transaction_executor::CompiledClassHashV2ToV1;
 use crate::state::cached_state::CachedState;
 use crate::state::state_api::{State, StateReader, StateResult};
 
+#[cfg(test)]
+#[path = "compiled_class_hash_migration_test.rs"]
+mod compiled_class_hash_migration_test;
+
 pub trait CompiledClassHashMigrationUpdater {
     fn set_compiled_class_hash_migration(
         &mut self,
@@ -27,6 +31,9 @@ impl<S: StateReader> CompiledClassHashMigrationUpdater for CachedState<S> {
                 compiled_class_hash_v1, compiled_class_hash_v2,
                 "Classes for migration should hold v1 (Poseidon) hash in the state."
             );
+
+            // Capture the pre-block (v1) hash as an initial read before the v2 write shadows it.
+            self.get_compiled_class_hash(*class_hash)?;
 
             // TODO(Meshi): Consider panic here instead of returning an error.
             self.set_compiled_class_hash(*class_hash, *compiled_class_hash_v2)?;

--- a/crates/blockifier/src/state/compiled_class_hash_migration_test.rs
+++ b/crates/blockifier/src/state/compiled_class_hash_migration_test.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+
+use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_types_core::felt::Felt;
+
+use super::CompiledClassHashMigrationUpdater;
+use crate::state::cached_state::CachedState;
+use crate::state::state_api::StateReader;
+use crate::test_utils::dict_state_reader::DictStateReader;
+
+/// Migration must record the pre-block (v1) hash as an initial read.
+#[test]
+fn migration_records_pre_block_compiled_class_hash_as_initial_read() {
+    let class_hash = ClassHash(Felt::from(1234_u32));
+    let compiled_class_hash_v1 = CompiledClassHash(Felt::from(1_u32));
+    let compiled_class_hash_v2 = CompiledClassHash(Felt::from(2_u32));
+
+    // Pre-block state holds v1; the cache is empty, as if the hash was never force-read.
+    let dict_state_reader = DictStateReader {
+        class_hash_to_compiled_class_hash: HashMap::from([(class_hash, compiled_class_hash_v1)]),
+        ..Default::default()
+    };
+    let mut state = CachedState::new(dict_state_reader);
+
+    state
+        .set_compiled_class_hash_migration(&HashMap::from([(
+            class_hash,
+            (compiled_class_hash_v2, compiled_class_hash_v1),
+        )]))
+        .unwrap();
+
+    // Migration wrote v2.
+    assert_eq!(state.get_compiled_class_hash(class_hash).unwrap(), compiled_class_hash_v2);
+
+    // v1 was captured as an initial read, and the diff is a clean v1 -> v2 migration.
+    let state_diff = state.to_state_diff().unwrap().state_maps;
+    assert_eq!(
+        state_diff.compiled_class_hashes,
+        HashMap::from([(class_hash, compiled_class_hash_v2)])
+    );
+
+    #[cfg(feature = "reexecution")]
+    assert_eq!(
+        state.get_initial_reads().unwrap().compiled_class_hashes,
+        HashMap::from([(class_hash, compiled_class_hash_v1)]),
+    );
+}


### PR DESCRIPTION
When migrating a class's compiled class hash, `set_compiled_class_hash_migration`
wrote the post-migration (v2) value into the write cache without first recording
the pre-block (v1) value as an initial read. Since `get_compiled_class_hash`
resolves the write cache before the initial reads, the v2 write shadowed the
pre-block value, so it was never captured. This made `to_state_diff` panic in
`strict_subtract_mappings` (the migrated write had no matching initial read to
subtract against) and left the OS without the pre-block class-trie leaf needed to
replay the block.

Force-read the pre-migration compiled class hash into the initial reads before
applying the migration write, and add a unit test covering the fix.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>