### PR TITLE
starknet_patricia: assert unmodified-subtree binary child is present in the skeleton

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
@@ -244,11 +244,11 @@ impl UpdatedSkeletonTreeImpl {
             TempSkeletonNode::Original(OriginalSkeletonNode::Edge(path_to_bottom)) => {
                 UpdatedSkeletonNode::Edge(*path_to_bottom)
             }
-            TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(_)) => return,
-            TempSkeletonNode::Leaf => {
+            TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(_))
+            | TempSkeletonNode::Leaf => {
                 assert!(
                     self.skeleton_tree.contains_key(&index),
-                    "Leaf index {index:?} doesn't appear in the skeleton."
+                    "Index {index:?} doesn't appear in the skeleton."
                 );
                 return;
             }


### PR DESCRIPTION
Mirror the leaf sanity-check in finalize_binary_child: an unmodified subtree child
must already be finalized in the skeleton (from finalize_bottom_layer).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>