### PR TITLE
starknet_os_flow_tests: ungate get_initial_reads

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -293,10 +293,7 @@ impl<S: StateReader> CachedState<S> {
     pub fn get_initial_reads(&self) -> StateResult<StateMaps> {
         Ok(self.cache.borrow().initial_reads.clone())
     }
-}
 
-#[cfg(feature = "os_input")]
-impl<S: StateReader> CachedState<S> {
     /// Returns the pre-block values the OS needs to replay the block: the values read during
     /// execution, extended with the class hash and nonce of every accessed contract and the
     /// compiled class hash of every accessed class (the OS reads these trie leaves even when

--- a/crates/starknet_os_flow_tests/Cargo.toml
+++ b/crates/starknet_os_flow_tests/Cargo.toml
@@ -14,7 +14,7 @@ long_fuzz_test = []
 [dev-dependencies]
 apollo_integration_tests.workspace = true
 assert_matches.workspace = true
-blockifier = { workspace = true, features = ["os_input", "reexecution", "testing"] }
+blockifier = { workspace = true, features = ["reexecution", "testing"] }
 blockifier_test_utils.workspace = true
 cairo-lang-runner.workspace = true
 cairo-lang-starknet-classes.workspace = true


### PR DESCRIPTION
starknet_os: os resources test - invoke tx constant factor (#14146)

starknet_os_flow_tests: gate OS initial reads behind optional os_input feature

Make the os_input feature optional: when enabled, build the OS initial reads
via CachedState::get_os_initial_reads (production path); when disabled, fall
back to the legacy extended-initial-reads computation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>