### PR TITLE
starknet_patricia: collapse the let-else + re-match in node_from_edge_data into a single match

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use async_recursion::async_recursion;
 use starknet_api::hash::HashOutput;
@@ -69,18 +69,18 @@ enum LeafSource<L: Leaf> {
     /// `leaf_index_to_leaf_output`.
     ComputeLeaves {
         leaf_index_to_leaf_input: HashMap<NodeIndex, Mutex<Option<L::Input>>>,
-        leaf_index_to_leaf_output: Arc<HashMap<NodeIndex, Mutex<Option<L::Output>>>>,
+        leaf_index_to_leaf_output: Arc<HashMap<NodeIndex, OnceLock<L::Output>>>,
     },
 }
 
 impl<L: Leaf + 'static> FilledTreeImpl<L> {
     fn initialize_filled_tree_output_map_with_placeholders<'a>(
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
-    ) -> HashMap<NodeIndex, Mutex<Option<HashFilledNode<L>>>> {
+    ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
         let mut filled_tree_output_map = HashMap::new();
         for (index, node) in updated_skeleton.get_nodes() {
             if !matches!(node, UpdatedSkeletonNode::UnmodifiedSubTree(_)) {
-                filled_tree_output_map.insert(index, Mutex::new(None));
+                filled_tree_output_map.insert(index, OnceLock::new());
             }
         }
         filled_tree_output_map
@@ -88,55 +88,43 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
 
     fn initialize_leaf_output_map_with_placeholders(
         leaf_index_to_leaf_input: &HashMap<NodeIndex, L::Input>,
-    ) -> HashMap<NodeIndex, Mutex<Option<L::Output>>> {
-        leaf_index_to_leaf_input.keys().map(|index| (*index, Mutex::new(None))).collect()
+    ) -> HashMap<NodeIndex, OnceLock<L::Output>> {
+        leaf_index_to_leaf_input.keys().map(|index| (*index, OnceLock::new())).collect()
     }
 
     pub(crate) fn get_all_nodes(&self) -> &HashMap<NodeIndex, HashFilledNode<L>> {
         &self.tree_map
     }
 
-    /// Writes the hash and data to the output map. The writing is done in a thread-safe manner with
-    /// interior mutability to avoid thread contention.
-    fn write_to_output_map<T: Debug>(
-        output_map: &HashMap<NodeIndex, Mutex<Option<T>>>,
+    /// Writes the hash and data to the output map. Each slot is written exactly once.
+    fn write_to_output_map<T: Debug + Send + Sync>(
+        output_map: &HashMap<NodeIndex, OnceLock<T>>,
         index: NodeIndex,
         output: T,
     ) -> FilledTreeResult<()> {
         match output_map.get(&index) {
-            Some(node) => {
-                let mut node = node
-                    .lock()
-                    .expect("Output map mutex does not expect to panic at locking the mutex");
-                match node.take() {
-                    Some(existing_node) => Err(FilledTreeError::DoubleUpdate {
-                        index,
-                        existing_value_as_string: format!("{existing_node:?}"),
-                    }),
-                    None => {
-                        *node = Some(output);
-                        Ok(())
-                    }
+            Some(slot) => slot.set(output).map_err(|_| {
+                let existing_node = slot.get().expect("OnceLock is occupied after a failed set.");
+                FilledTreeError::DoubleUpdate {
+                    index,
+                    existing_value_as_string: format!("{existing_node:?}"),
                 }
-            }
+            }),
             None => Err(FilledTreeError::MissingNodePlaceholder(index)),
         }
     }
 
-    // Removes the `Arc` from the map and unwraps the `Mutex` and `Option` from the values.
-    fn remove_arc_mutex_and_option_from_output_map<V>(
-        output_map: Arc<HashMap<NodeIndex, Mutex<Option<V>>>>,
+    // Removes the `Arc` from the map and collects the value out of each `OnceLock` slot.
+    fn collect_output_map<V>(
+        output_map: Arc<HashMap<NodeIndex, OnceLock<V>>>,
         panic_if_empty_placeholder: bool,
     ) -> FilledTreeResult<HashMap<NodeIndex, V>> {
         let output_map = Arc::into_inner(output_map)
             .unwrap_or_else(|| panic!("Cannot retrieve output map from Arc."));
 
-        let mut hash_map_out = HashMap::new();
+        let mut hash_map_out = HashMap::with_capacity(output_map.len());
         for (key, value) in output_map {
-            let mut value = value
-                .lock()
-                .expect("Output map mutex does not expect to panic at locking the mutex");
-            match value.take() {
+            match value.into_inner() {
                 Some(unwrapped_value) => {
                     hash_map_out.insert(key, unwrapped_value);
                 }
@@ -182,7 +170,7 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
         updated_skeleton: Arc<impl UpdatedSkeletonTree<'a> + 'async_recursion + 'static>,
         index: NodeIndex,
         leaf_source: Arc<LeafSource<L>>,
-        filled_tree_output_map: Arc<HashMap<NodeIndex, Mutex<Option<HashFilledNode<L>>>>>,
+        filled_tree_output_map: Arc<HashMap<NodeIndex, OnceLock<HashFilledNode<L>>>>,
     ) -> FilledTreeResult<HashOutput>
     where
         TH: TreeHashFunction<L> + 'static,
@@ -304,7 +292,7 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
             return Ok((Self::create_empty(), HashMap::new()));
         }
 
-        // Wrap values in `Mutex<Option<T>>` for interior mutability.
+        // Wrap values in `OnceLock<T>` for write-once interior mutability.
         let filled_tree_output_map =
             Arc::new(Self::initialize_filled_tree_output_map_with_placeholders(&updated_skeleton));
         let leaf_index_to_leaf_output =
@@ -331,13 +319,10 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
 
         Ok((
             FilledTreeImpl {
-                tree_map: Self::remove_arc_mutex_and_option_from_output_map(
-                    filled_tree_output_map,
-                    true,
-                )?,
+                tree_map: Self::collect_output_map(filled_tree_output_map, true)?,
                 root_hash,
             },
-            Self::remove_arc_mutex_and_option_from_output_map(leaf_index_to_leaf_output, false)?,
+            Self::collect_output_map(leaf_index_to_leaf_output, false)?,
         ))
     }
 
@@ -353,7 +338,7 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
             return Ok(Self::create_empty());
         }
 
-        // Wrap values in `Mutex<Option<T>>`` for interior mutability.
+        // Wrap values in `OnceLock<T>` for write-once interior mutability.
         let filled_tree_output_map =
             Arc::new(Self::initialize_filled_tree_output_map_with_placeholders(&updated_skeleton));
 
@@ -367,10 +352,7 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
         .await?;
 
         Ok(FilledTreeImpl {
-            tree_map: Self::remove_arc_mutex_and_option_from_output_map(
-                filled_tree_output_map,
-                true,
-            )?,
+            tree_map: Self::collect_output_map(filled_tree_output_map, true)?,
             root_hash,
         })
     }

--- a/crates/starknet_patricia/src/patricia_merkle_tree/node_data/leaf.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/node_data/leaf.rs
@@ -29,7 +29,7 @@ pub trait Leaf:
     // add a default implementation for `create`.
     // [Issue](https://github.com/rust-lang/rust/issues/29661).
     type Input: Send + Sync + 'static;
-    type Output: Send + Debug + 'static;
+    type Output: Send + Sync + Debug + 'static;
 
     /// Returns true if leaf is empty.
     fn is_empty(&self) -> bool;

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
@@ -266,34 +266,29 @@ impl UpdatedSkeletonTreeImpl {
         bottom_index: &NodeIndex,
         bottom: &TempSkeletonNode,
     ) -> TempSkeletonNode {
-        let TempSkeletonNode::Original(original_node) = bottom else {
-            match bottom {
-                TempSkeletonNode::Empty => {
-                    return TempSkeletonNode::Empty;
-                }
-                TempSkeletonNode::Leaf => {
-                    // Leaf is finalized in the initial phase of updated skeleton creation.
-                    assert!(
-                        self.skeleton_tree.contains_key(bottom_index),
-                        "bottom {bottom_index:?} is a non-empty leaf but doesn't appear in the \
-                         skeleton."
-                    );
-                    return TempSkeletonNode::Original(OriginalSkeletonNode::Edge(*path));
-                }
-                TempSkeletonNode::Original(_) => unreachable!("bottom is not an Original variant."),
-            };
-        };
-        TempSkeletonNode::Original(match original_node {
-            OriginalSkeletonNode::Edge(path_to_bottom) => {
-                OriginalSkeletonNode::Edge(path.concat_paths(*path_to_bottom))
+        match bottom {
+            TempSkeletonNode::Empty => TempSkeletonNode::Empty,
+            TempSkeletonNode::Original(OriginalSkeletonNode::Edge(path_to_bottom)) => {
+                TempSkeletonNode::Original(OriginalSkeletonNode::Edge(
+                    path.concat_paths(*path_to_bottom),
+                ))
             }
-            OriginalSkeletonNode::Binary => {
+            TempSkeletonNode::Original(OriginalSkeletonNode::Binary) => {
                 // Finalize bottom - a binary descendant cannot change form.
                 self.skeleton_tree.insert(*bottom_index, UpdatedSkeletonNode::Binary);
-                OriginalSkeletonNode::Edge(*path)
+                TempSkeletonNode::Original(OriginalSkeletonNode::Edge(*path))
             }
-            OriginalSkeletonNode::UnmodifiedSubTree(_) => OriginalSkeletonNode::Edge(*path),
-        })
+            TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(_))
+            | TempSkeletonNode::Leaf => {
+                // Leaves and unmodified subtrees are finalized in the initial phase of updated
+                // skeleton creation.
+                assert!(
+                    self.skeleton_tree.contains_key(bottom_index),
+                    "bottom {bottom_index:?} doesn't appear in the skeleton."
+                );
+                TempSkeletonNode::Original(OriginalSkeletonNode::Edge(*path))
+            }
+        }
     }
 
     /// Update an original subtree rooted with an edge node.

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
@@ -232,17 +232,16 @@ fn test_node_from_binary_data(
 #[rstest]
 #[case::to_empty(
     &PathToBottom::LEFT_CHILD,
-    &NodeIndex::ROOT,
-    &TempSkeletonNode::Empty,
+    (&NodeIndex::ROOT, &TempSkeletonNode::Empty),
     &[],
     TempSkeletonNode::Empty,
     &[],
 )]
 #[case::to_edge(
     &PathToBottom::from("00"),
-    &NodeIndex::from(4),
-    &TempSkeletonNode::Original(
-        OriginalSkeletonNode::Edge(PathToBottom::from("11"))
+    (
+        &NodeIndex::from(4),
+        &TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::from("11"))),
     ),
     &[],
     TempSkeletonNode::Original(
@@ -252,18 +251,19 @@ fn test_node_from_binary_data(
 )]
 #[case::to_unmodified_bottom(
     &PathToBottom::from("101"),
-    &NodeIndex::from(5),
-    &TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(
-        HashOutput::ROOT_OF_EMPTY_TREE
-    )),
+    (
+        &NodeIndex::from(5),
+        &TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(
+            HashOutput::ROOT_OF_EMPTY_TREE
+        )),
+    ),
    &[],
     TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::from("101"))),
     &[],
 )]
 #[case::to_binary(
     &PathToBottom::RIGHT_CHILD,
-    &NodeIndex::from(7),
-    &TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    (&NodeIndex::from(7), &TempSkeletonNode::Original(OriginalSkeletonNode::Binary)),
     &[],
     TempSkeletonNode::Original(
         OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)
@@ -272,8 +272,7 @@ fn test_node_from_binary_data(
 )]
 #[case::to_non_empty_leaf(
     &PathToBottom::RIGHT_CHILD,
-    &NodeIndex::from(7),
-    &TempSkeletonNode::Leaf,
+    (&NodeIndex::from(7), &TempSkeletonNode::Leaf),
     &[(NodeIndex::from(7), 1)],
     TempSkeletonNode::Original(
         OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)
@@ -282,13 +281,13 @@ fn test_node_from_binary_data(
 )]
 fn test_node_from_edge_data(
     #[case] path: &PathToBottom,
-    #[case] bottom_index: &NodeIndex,
-    #[case] bottom: &TempSkeletonNode,
+    #[case] bottom_data: (&NodeIndex, &TempSkeletonNode),
     #[case] _leaf_modifications: &[(NodeIndex, u8)],
     #[case] expected_node: TempSkeletonNode,
     #[case] expected_skeleton_additions: &[(NodeIndex, UpdatedSkeletonNode)],
     #[with(&[], _leaf_modifications)] mut initial_updated_skeleton: UpdatedSkeletonTreeImpl,
 ) {
+    let (bottom_index, bottom) = bottom_data;
     let mut expected_skeleton_tree = initial_updated_skeleton.skeleton_tree.clone();
     expected_skeleton_tree.extend(expected_skeleton_additions.iter().cloned());
     let temp_node = initial_updated_skeleton.node_from_edge_data(path, bottom_index, bottom);

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
@@ -234,6 +234,7 @@ fn test_node_from_binary_data(
     &PathToBottom::LEFT_CHILD,
     (&NodeIndex::ROOT, &TempSkeletonNode::Empty),
     &[],
+    &[],
     TempSkeletonNode::Empty,
     &[],
 )]
@@ -243,6 +244,7 @@ fn test_node_from_binary_data(
         &NodeIndex::from(4),
         &TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::from("11"))),
     ),
+    &[],
     &[],
     TempSkeletonNode::Original(
         OriginalSkeletonNode::Edge(PathToBottom::from("0011"))
@@ -258,12 +260,15 @@ fn test_node_from_binary_data(
         )),
     ),
    &[],
+    // The unmodified subtree is finalized in the initial phase, so it appears in the skeleton.
+    &[(NodeIndex::from(5), OriginalSkeletonNode::UnmodifiedSubTree(HashOutput::ROOT_OF_EMPTY_TREE))],
     TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::from("101"))),
     &[],
 )]
 #[case::to_binary(
     &PathToBottom::RIGHT_CHILD,
     (&NodeIndex::from(7), &TempSkeletonNode::Original(OriginalSkeletonNode::Binary)),
+    &[],
     &[],
     TempSkeletonNode::Original(
         OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)
@@ -274,6 +279,7 @@ fn test_node_from_binary_data(
     &PathToBottom::RIGHT_CHILD,
     (&NodeIndex::from(7), &TempSkeletonNode::Leaf),
     &[(NodeIndex::from(7), 1)],
+    &[],
     TempSkeletonNode::Original(
         OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)
     ),
@@ -283,9 +289,11 @@ fn test_node_from_edge_data(
     #[case] path: &PathToBottom,
     #[case] bottom_data: (&NodeIndex, &TempSkeletonNode),
     #[case] _leaf_modifications: &[(NodeIndex, u8)],
+    #[case] _original_skeleton: &[(NodeIndex, OriginalSkeletonNode)],
     #[case] expected_node: TempSkeletonNode,
     #[case] expected_skeleton_additions: &[(NodeIndex, UpdatedSkeletonNode)],
-    #[with(&[], _leaf_modifications)] mut initial_updated_skeleton: UpdatedSkeletonTreeImpl,
+    #[with(_original_skeleton, _leaf_modifications)]
+    mut initial_updated_skeleton: UpdatedSkeletonTreeImpl,
 ) {
     let (bottom_index, bottom) = bottom_data;
     let mut expected_skeleton_tree = initial_updated_skeleton.skeleton_tree.clone();


### PR DESCRIPTION
Replace the let-else followed by a re-match on the bottom node with a single
flat match over all TempSkeletonNode variants. This drops the now-redundant
unreachable arm for the non-Original case.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

starknet_patricia: assert unmodified-subtree edge bottom is present in the skeleton

Mirror the leaf sanity-check in node_from_edge_data: an unmodified subtree bottom
must already be finalized in the skeleton (from finalize_bottom_layer), so merge
its arm with the leaf arm under the shared presence assertion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>