### PR TITLE
blockifier: avoid full StateMaps clone in get_os_initial_reads

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -303,15 +303,23 @@ impl<S: StateReader> CachedState<S> {
         // Back-fill write-only storage cells so their pre-block values are part of the initial
         // reads.
         self.update_initial_values_of_write_only_access()?;
-        let raw_initial_reads = self.get_initial_reads()?;
+
+        // Extract the keys needed for the force-reads.
+        let (contract_addresses, declared_class_hashes) = {
+            let cache = self.cache.borrow();
+            (
+                cache.initial_reads.get_contract_addresses(),
+                cache.initial_reads.declared_contracts.keys().copied().collect::<Vec<_>>(),
+            )
+        };
         // Force-read the contract-trie and class-trie leaves so their pre-block values are cached
         // in the initial reads.
-        for contract_address in raw_initial_reads.get_contract_addresses() {
+        for contract_address in contract_addresses {
             self.get_class_hash_at(contract_address)?;
             self.get_nonce_at(contract_address)?;
         }
-        for class_hash in raw_initial_reads.declared_contracts.keys() {
-            self.get_compiled_class_hash(*class_hash)?;
+        for class_hash in declared_class_hashes {
+            self.get_compiled_class_hash(class_hash)?;
         }
         let mut os_initial_reads = self.get_initial_reads()?;
         os_initial_reads.declared_contracts.clear();

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -302,15 +302,23 @@ impl<S: StateReader> CachedState<S> {
         // Back-fill write-only storage cells so their pre-block values are part of the initial
         // reads.
         self.update_initial_values_of_write_only_access()?;
-        let raw_initial_reads = self.get_initial_reads()?;
+
+        // Extract the keys needed for the force-reads.
+        let (contract_addresses, declared_class_hashes) = {
+            let cache = self.cache.borrow();
+            (
+                cache.initial_reads.get_contract_addresses(),
+                cache.initial_reads.declared_contracts.keys().copied().collect::<Vec<_>>(),
+            )
+        };
         // Force-read the contract-trie and class-trie leaves so their pre-block values are cached
         // in the initial reads.
-        for contract_address in raw_initial_reads.get_contract_addresses() {
+        for contract_address in contract_addresses {
             self.get_class_hash_at(contract_address)?;
             self.get_nonce_at(contract_address)?;
         }
-        for class_hash in raw_initial_reads.declared_contracts.keys() {
-            self.get_compiled_class_hash(*class_hash)?;
+        for class_hash in declared_class_hashes {
+            self.get_compiled_class_hash(class_hash)?;
         }
         let mut os_initial_reads = self.get_initial_reads()?;
         os_initial_reads.declared_contracts.clear();


### PR DESCRIPTION
## Summary

Follow-up performance optimization to #14621.

`get_os_initial_reads` called `get_initial_reads()` twice — the first call cloned the full `StateMaps` (all five `HashMap`s including the potentially-large `storage` map) only to iterate over contract addresses and declared-class keys. That snapshot is immediately thrown away after the force-read loops.

This PR replaces the first full clone with a targeted borrow that extracts only the two small collections actually needed for iteration:

- `HashSet<ContractAddress>` via `get_contract_addresses()` — already computed in both old and new paths
- `Vec<ClassHash>` of declared-contract keys — a handful of entries

**Impact:** For a busy block the `storage` map in `initial_reads` can hold tens of thousands of entries (one per unique storage read across all transactions). Skipping its clone avoids an O(storage-reads-per-block) allocation on the critical post-execution path, reducing memory pressure and improving cache locality.

No semantic change — the second `get_initial_reads()` clone (the actual return value) is unchanged.

## Test plan

- [x] `cargo test -p blockifier --features "reexecution,testing" cached_state` — all 43 tests pass
- [ ] CI green

---

_Generated by_ [_Claude Code_](https://claude.ai/code/session_01UuYJnStAwUa9Ri8Vag4kwp)