### PR TITLE
apollo_state_sync,apollo_state_sync_types,apollo_gateway: expose highest known block getter

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -4503,6 +4503,32 @@
           "extra_params": {}
         },
         {
+          "title": "get_highest_block_number (client-side)",
+          "description": "client-side infra metrics for request type get_highest_block_number",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.50 state_sync_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.95 state_sync_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.50 state_sync_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.95 state_sync_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.50 state_sync_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.95 state_sync_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "get_highest_block_number (server-side)",
+          "description": "server-side infra metrics for request type get_highest_block_number",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.50 state_sync_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.95 state_sync_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.50 state_sync_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(state_sync_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_highest_block_number\"}[5m])), \"label_name\", \"0.95 state_sync_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "get_latest_block_header (client-side)",
           "description": "client-side infra metrics for request type get_latest_block_header",
           "type": "timeseries",

--- a/crates/apollo_gateway/src/sync_state_reader.rs
+++ b/crates/apollo_gateway/src/sync_state_reader.rs
@@ -284,6 +284,9 @@ impl StateSyncClient for SharedStateSyncClientMetricWrapper {
     async fn get_latest_block_header(&self) -> StateSyncClientResult<Option<BlockHeader>> {
         self.run_command_with_metrics(self.state_sync_client.get_latest_block_header()).await
     }
+    async fn get_highest_block_number(&self) -> StateSyncClientResult<Option<BlockNumber>> {
+        self.run_command_with_metrics(self.state_sync_client.get_highest_block_number()).await
+    }
     async fn is_cairo_1_class_declared_at(
         &self,
         block_number: BlockNumber,

--- a/crates/apollo_state_sync/src/lib.rs
+++ b/crates/apollo_state_sync/src/lib.rs
@@ -22,7 +22,7 @@ use apollo_storage::{StorageReader, StorageTxn};
 use async_trait::async_trait;
 use futures::channel::mpsc::{channel, Sender};
 use futures::SinkExt;
-use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockHeader, BlockNumber};
 use starknet_api::block_hash::block_hash_calculator::BlockHeaderCommitments;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce, BLOCK_HASH_TABLE_ADDRESS};
 use starknet_api::state::{StateNumber, StorageKey};
@@ -41,14 +41,20 @@ pub fn create_state_sync_and_runner(
     config_manager_client: SharedConfigManagerClient,
 ) -> (StateSync, StateSyncRunner) {
     let (new_block_sender, new_block_receiver) = channel(BUFFER_SIZE);
-    let (state_sync_runner, storage_reader) = StateSyncRunner::new(
+    let (state_sync_runner, storage_reader, shared_highest_block) = StateSyncRunner::new(
         config.clone(),
         new_block_receiver,
         class_manager_client,
         config_manager_client.clone(),
     );
     (
-        StateSync::new(storage_reader, new_block_sender, config, config_manager_client),
+        StateSync::new(
+            storage_reader,
+            new_block_sender,
+            shared_highest_block,
+            config,
+            config_manager_client,
+        ),
         state_sync_runner,
     )
 }
@@ -57,6 +63,10 @@ pub fn create_state_sync_and_runner(
 pub struct StateSync {
     storage_reader: StorageReader,
     new_block_sender: Sender<SyncBlock>,
+    // The latest block known from the central source (feeder gateway) — the tip the sync is
+    // progressing toward. Updated by the central sync client; `None` when there is no central
+    // source (e.g. P2P-only) or no tip is known yet.
+    shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
     starknet_client: Option<Arc<dyn StarknetReader + Send + Sync>>,
     config_manager_client: SharedConfigManagerClient,
     dynamic_config: Arc<RwLock<StateSyncDynamicConfig>>,
@@ -66,6 +76,7 @@ impl StateSync {
     pub fn new(
         storage_reader: StorageReader,
         new_block_sender: Sender<SyncBlock>,
+        shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
         config: StateSyncConfig,
         config_manager_client: SharedConfigManagerClient,
     ) -> Self {
@@ -87,6 +98,7 @@ impl StateSync {
         Self {
             storage_reader,
             new_block_sender,
+            shared_highest_block,
             starknet_client,
             config_manager_client,
             dynamic_config: Arc::new(RwLock::new(config.dynamic_config)),
@@ -142,6 +154,9 @@ impl ComponentRequestHandler<StateSyncRequest, StateSyncResponse> for StateSync 
             }
             StateSyncRequest::GetLatestBlockHeader() => {
                 StateSyncResponse::GetLatestBlockHeader(self.get_latest_block_header().await)
+            }
+            StateSyncRequest::GetHighestBlockNumber() => {
+                StateSyncResponse::GetHighestBlockNumber(self.get_highest_block_number().await)
             }
             StateSyncRequest::IsCairo1ClassDeclaredAt(block_number, class_hash) => {
                 StateSyncResponse::IsCairo1ClassDeclaredAt(
@@ -294,6 +309,10 @@ impl StateSync {
             Some(block_number) => Ok(txn.get_block_header(block_number)?),
             None => Ok(None),
         }
+    }
+
+    async fn get_highest_block_number(&self) -> StateSyncResult<Option<BlockNumber>> {
+        Ok(self.shared_highest_block.read().await.as_ref().map(|block| block.number))
     }
 
     async fn is_cairo_1_class_declared_at(

--- a/crates/apollo_state_sync/src/runner/mod.rs
+++ b/crates/apollo_state_sync/src/runner/mod.rs
@@ -187,7 +187,7 @@ impl StateSyncRunner {
         new_block_receiver: Receiver<SyncBlock>,
         class_manager_client: SharedClassManagerClient,
         config_manager_client: SharedConfigManagerClient,
-    ) -> (Self, StorageReader) {
+    ) -> (Self, StorageReader, Arc<RwLock<Option<BlockHashAndNumber>>>) {
         let StateSyncConfig { static_config, dynamic_config } = config;
 
         let storage_reader_server_config = ServerConfig {
@@ -283,6 +283,7 @@ impl StateSyncRunner {
                     storage_reader_server_handle,
                 },
                 storage_reader,
+                shared_highest_block,
             );
         }
 
@@ -394,6 +395,7 @@ impl StateSyncRunner {
                 storage_reader_server_handle,
             },
             storage_reader,
+            shared_highest_block,
         )
     }
 

--- a/crates/apollo_state_sync/src/test.rs
+++ b/crates/apollo_state_sync/src/test.rs
@@ -16,7 +16,7 @@ use futures::channel::mpsc::channel;
 use indexmap::IndexMap;
 use mockall::predicate;
 use rand::Rng;
-use starknet_api::block::{Block, BlockHash, BlockHeader, BlockNumber};
+use starknet_api::block::{Block, BlockHash, BlockHashAndNumber, BlockHeader, BlockNumber};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkHash;
 use starknet_api::state::{StorageKey, ThinStateDiff};
@@ -26,6 +26,12 @@ use tokio::sync::RwLock;
 use crate::StateSync;
 
 fn setup() -> (StateSync, StorageWriter) {
+    setup_with_highest_block(None)
+}
+
+fn setup_with_highest_block(
+    highest_block: Option<BlockHashAndNumber>,
+) -> (StateSync, StorageWriter) {
     let ((storage_reader, storage_writer), _) = get_test_storage();
     let mut config_manager_client = MockConfigManagerClient::new();
     config_manager_client
@@ -34,11 +40,34 @@ fn setup() -> (StateSync, StorageWriter) {
     let state_sync = StateSync {
         storage_reader,
         new_block_sender: channel(0).0,
+        shared_highest_block: Arc::new(RwLock::new(highest_block)),
         starknet_client: None,
         config_manager_client: Arc::new(config_manager_client),
         dynamic_config: Arc::new(RwLock::new(StateSyncDynamicConfig::default())),
     };
     (state_sync, storage_writer)
+}
+
+#[tokio::test]
+async fn test_get_highest_block_number() {
+    // Returns the central-source tip when it is known.
+    let highest_block_number = BlockNumber(11_158_875);
+    let highest_block =
+        BlockHashAndNumber { hash: BlockHash::default(), number: highest_block_number };
+    let (mut state_sync, _storage_writer) = setup_with_highest_block(Some(highest_block));
+    let response = state_sync.handle_request(StateSyncRequest::GetHighestBlockNumber()).await;
+    let StateSyncResponse::GetHighestBlockNumber(Ok(returned)) = response else {
+        panic!("Expected StateSyncResponse::GetHighestBlockNumber(Ok(_)), but got {response:?}");
+    };
+    assert_eq!(returned, Some(highest_block_number));
+
+    // Returns None when no tip is known yet (e.g. no central source).
+    let (mut state_sync, _storage_writer) = setup();
+    let response = state_sync.handle_request(StateSyncRequest::GetHighestBlockNumber()).await;
+    let StateSyncResponse::GetHighestBlockNumber(Ok(returned)) = response else {
+        panic!("Expected StateSyncResponse::GetHighestBlockNumber(Ok(_)), but got {response:?}");
+    };
+    assert_eq!(returned, None);
 }
 
 #[tokio::test]
@@ -145,6 +174,7 @@ async fn test_get_block_hash_fallback_to_starknet_client() {
     let mut state_sync = StateSync {
         storage_reader,
         new_block_sender: channel(0).0,
+        shared_highest_block: Arc::new(RwLock::new(None)),
         starknet_client,
         config_manager_client: Arc::new(config_manager_client),
         dynamic_config: Arc::new(RwLock::new(StateSyncDynamicConfig::default())),

--- a/crates/apollo_state_sync_types/src/communication.rs
+++ b/crates/apollo_state_sync_types/src/communication.rs
@@ -87,6 +87,13 @@ pub trait StateSyncClient: Send + Sync {
     /// Returns None if no latest block was yet downloaded.
     async fn get_latest_block_header(&self) -> StateSyncClientResult<Option<BlockHeader>>;
 
+    /// Request the latest block number known from the central source (the feeder gateway), i.e. the
+    /// tip the sync is progressing toward. Unlike
+    /// [`get_latest_block_number`](Self::get_latest_block_number), this is independent of how far
+    /// the node has actually downloaded/applied. Returns None if there is no central source or
+    /// no tip is known yet.
+    async fn get_highest_block_number(&self) -> StateSyncClientResult<Option<BlockNumber>>;
+
     /// Returns whether the given class is a Cairo1 class and was declared at the given block or
     /// before it.
     async fn is_cairo_1_class_declared_at(
@@ -134,6 +141,7 @@ pub enum StateSyncRequest {
     GetClassHashAt(BlockNumber, ContractAddress),
     GetLatestBlockNumber(),
     GetLatestBlockHeader(),
+    GetHighestBlockNumber(),
     IsCairo1ClassDeclaredAt(BlockNumber, ClassHash),
     IsClassDeclaredAt(BlockNumber, ClassHash),
 }
@@ -151,6 +159,7 @@ impl PrioritizedRequest for StateSyncRequest {
             | StateSyncRequest::AddNewBlock(_)
             | StateSyncRequest::GetLatestBlockNumber()
             | StateSyncRequest::GetLatestBlockHeader()
+            | StateSyncRequest::GetHighestBlockNumber()
             | StateSyncRequest::IsCairo1ClassDeclaredAt(_, _)
             | StateSyncRequest::IsClassDeclaredAt(_, _) => RequestPriority::Normal,
         }
@@ -167,6 +176,7 @@ pub enum StateSyncResponse {
     GetClassHashAt(StateSyncResult<ClassHash>),
     GetLatestBlockNumber(StateSyncResult<Option<BlockNumber>>),
     GetLatestBlockHeader(StateSyncResult<Option<BlockHeader>>),
+    GetHighestBlockNumber(StateSyncResult<Option<BlockNumber>>),
     IsCairo1ClassDeclaredAt(StateSyncResult<bool>),
     IsClassDeclaredAt(StateSyncResult<bool>),
 }
@@ -288,6 +298,19 @@ where
             request,
             StateSyncResponse,
             GetLatestBlockHeader,
+            StateSyncClientError,
+            StateSyncError,
+            Direct
+        )
+    }
+
+    async fn get_highest_block_number(&self) -> StateSyncClientResult<Option<BlockNumber>> {
+        let request = StateSyncRequest::GetHighestBlockNumber();
+        handle_all_response_variants!(
+            self,
+            request,
+            StateSyncResponse,
+            GetHighestBlockNumber,
             StateSyncClientError,
             StateSyncError,
             Direct


### PR DESCRIPTION
Add StateSyncClient::get_highest_block_number(), returning the central-source (feeder
gateway) tip from shared_highest_block — the height the node is syncing toward,
independent of how far it has applied state. Unused by consumers for now.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>