### PR TITLE
apollo_consensus,apollo_consensus_orchestrator: skip proposing when far behind the tip

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -62,6 +62,8 @@ use crate::votes_threshold::QuorumType;
 pub(crate) const CONSENSUS_RUNNING_PAST_STOP_HEIGHT: &str =
     "Consensus is running past stop height, going to sleep...";
 
+pub(crate) const SKIPPED_PROPOSER_FAR_BEHIND: &str = "Skipped proposer: far behind tip";
+
 /// Arguments for running consensus.
 pub struct RunConsensusArguments {
     /// Consensus configuration (static + dynamic). Static fields are used directly; dynamic
@@ -214,6 +216,11 @@ pub struct EquivocationVoteReport {
 /// Number of vote types a validator can cast per round ([`VoteType::Prevote`] and
 /// [`VoteType::Precommit`]). Used to bound the future-vote cache.
 const NUM_VOTE_TYPES: usize = 2;
+
+/// If the network tip (from the trusted central source) is more than this many blocks above the
+/// node's current height, the node is considered far behind: it keeps syncing rather than running
+/// live consensus / proposing. Replaced by a validated dynamic config value in a follow-up.
+const FAR_BEHIND_PROPOSAL_THRESHOLD: u64 = 30;
 
 /// Manages votes and proposals for future heights.
 #[derive(Debug)]
@@ -629,6 +636,24 @@ impl<ContextT: ConsensusContext> MultiHeightManager<ContextT> {
         } else if context.try_sync(height).await {
             return Some(RunHeightRes::Sync);
         }
+
+        // Sync did not deliver this height, so we are about to run live consensus. If the network
+        // tip (from the trusted central source) is far ahead of our current height, we are catching
+        // up: keep syncing instead of proposing at this stale height — this stops a far-behind node
+        // from self-electing as proposer and producing blocks the network has long since passed.
+        // Fail-open when the tip is unknown (e.g. no central source).
+        if let Some(network_tip) = context.network_tip().await {
+            let blocks_behind = network_tip.0.saturating_sub(height.0);
+            if blocks_behind > FAR_BEHIND_PROPOSAL_THRESHOLD {
+                warn!(
+                    "{SKIPPED_PROPOSER_FAR_BEHIND} (current height {height}, network tip \
+                     {network_tip}, {blocks_behind} blocks behind). Waiting for sync."
+                );
+                self.wait_until_sync_reaches_height(height, context).await;
+                return Some(RunHeightRes::Sync);
+            }
+        }
+
         None
     }
 

--- a/crates/apollo_consensus/src/manager_test.rs
+++ b/crates/apollo_consensus/src/manager_test.rs
@@ -42,8 +42,15 @@ use starknet_types_core::felt::Felt;
 use tokio::sync::Mutex;
 use tracing_test::traced_test;
 
-use super::{run_consensus, ConsensusCache, MultiHeightManager, RunHeightRes, NUM_VOTE_TYPES};
-use crate::manager::CONSENSUS_RUNNING_PAST_STOP_HEIGHT;
+use super::{
+    run_consensus,
+    ConsensusCache,
+    MultiHeightManager,
+    RunHeightRes,
+    FAR_BEHIND_PROPOSAL_THRESHOLD,
+    NUM_VOTE_TYPES,
+};
+use crate::manager::{CONSENSUS_RUNNING_PAST_STOP_HEIGHT, SKIPPED_PROPOSER_FAR_BEHIND};
 use crate::storage::MockHeightVotedStorageTrait;
 use crate::test_utils::{
     precommit,
@@ -204,6 +211,7 @@ async fn manager_multiple_heights_unordered(consensus_config: ConsensusConfig) {
     send(&mut sender, precommit(Some(Felt::ONE), HEIGHT_1, ROUND_0, *PROPOSER_ID)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     // Run the manager for height 1.
     context.expect_try_sync().returning(|_| false);
     expect_validate_proposal(&mut context, Felt::ONE, 1);
@@ -257,6 +265,7 @@ async fn manager_multiple_heights_unordered(consensus_config: ConsensusConfig) {
 async fn run_consensus_sync(consensus_config: ConsensusConfig) {
     // Set expectations.
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     let (decision_tx, decision_rx) = oneshot::channel();
 
     let (mut proposal_receiver_sender, proposal_receiver_receiver) = mpsc::channel(CHANNEL_SIZE);
@@ -331,6 +340,7 @@ async fn run_consensus_stop_at_height(consensus_config: ConsensusConfig) {
     send(&mut network_sender, precommit(Some(Felt::ONE), HEIGHT_1, ROUND_0, *PROPOSER_ID)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     expect_validate_proposal(&mut context, Felt::ONE, 1);
     context.expect_set_height_and_round().returning(move |_, _| Ok(()));
     context.expect_broadcast().returning(move |_| Ok(()));
@@ -389,6 +399,7 @@ async fn test_timeouts(consensus_config: ConsensusConfig) {
     send(&mut sender, precommit(None, HEIGHT_1, ROUND_0, *VALIDATOR_ID_3)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_set_height_and_round().returning(move |_, _| Ok(()));
     expect_validate_proposal(&mut context, Felt::ONE, 2);
     context.expect_try_sync().returning(|_| false);
@@ -459,6 +470,7 @@ async fn timely_message_handling(consensus_config: ConsensusConfig) {
     // TODO(matan): Make run_height more generic so don't need mock network?
     // Check that, even when sync is immediately ready, consensus still handles queued messages.
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_try_sync().returning(|_| true);
 
     // Send messages
@@ -548,6 +560,7 @@ async fn future_height_limit_caching_and_dropping(mut consensus_config: Consensu
     send(&mut sender, precommit(Some(Felt::ZERO), HEIGHT_0, ROUND_0, *PROPOSER_ID)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_try_sync().returning(|_| false);
     expect_validate_proposal(&mut context, Felt::ZERO, 1); // Height 0 validation
     expect_validate_proposal(&mut context, Felt::ONE, 1); // Height 1 validation
@@ -674,6 +687,7 @@ async fn current_height_round_limit_caching_and_dropping(mut consensus_config: C
     send(&mut sender, precommit(None, HEIGHT_1, ROUND_0, *PROPOSER_ID)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_try_sync().returning(|_| false);
     // Will be called twice for round 0 and 2 (will send the proposal when advancing to round 2).
     expect_validate_proposal(&mut context, Felt::ONE, 2);
@@ -777,6 +791,7 @@ async fn run_consensus_dynamic_client_updates_validator_between_heights(
 
     // Context: H1 we sync (try_sync returns true); at H2 we run consensus as the proposer.
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_set_height_and_round().returning(move |_, _| Ok(()));
     context.expect_try_sync().withf(move |h| *h == HEIGHT_1).times(1).returning(|_| true);
     context.expect_try_sync().returning(|_| false);
@@ -870,6 +885,7 @@ async fn manager_successfully_syncs_when_higher_than_last_voted_height(
         .returning(|| Ok(Some(LAST_VOTED_HEIGHT)));
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_try_sync().with(eq(CURRENT_HEIGHT)).times(1).returning(|_| true);
     let committee_provider =
         mock_committee_provider_with_members(vec![*PROPOSER_ID, *VALIDATOR_ID]);
@@ -892,6 +908,107 @@ async fn manager_successfully_syncs_when_higher_than_last_voted_height(
         .unwrap();
 
     assert_eq!(decision, RunHeightRes::Sync);
+}
+
+#[rstest]
+#[traced_test]
+#[tokio::test]
+async fn far_behind_node_syncs_instead_of_proposing(consensus_config: ConsensusConfig) {
+    // This node is the designated proposer for HEIGHT_1, but the network tip (from the central
+    // source) is far ahead, so it must keep syncing and must NOT build a proposal. No
+    // build_proposal expectation is set, so the test panics (via mockall) if the guard is bypassed.
+    let TestSubscriberChannels { mock_network: _mock_network, subscriber_channels } =
+        mock_register_broadcast_topic().unwrap();
+    let (_proposal_receiver_sender, mut proposal_receiver_receiver) = mpsc::channel(CHANNEL_SIZE);
+
+    let network_tip = BlockNumber(HEIGHT_1.0 + FAR_BEHIND_PROPOSAL_THRESHOLD + 1);
+    let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(move || Some(network_tip));
+    // try_sync first fails, so we fall past the sync checks and reach the guard; it then succeeds,
+    // so the guard's wait_until_sync_reaches_height completes (rather than looping forever).
+    context.expect_try_sync().times(1).returning(|_| false);
+    context.expect_try_sync().returning(|_| true);
+
+    // This node (VALIDATOR_ID) is the proposer, so a bypassed guard would call build_proposal.
+    let committee = mock_committee_with_members_and_proposer(vec![*VALIDATOR_ID], *VALIDATOR_ID);
+    let mut committee_provider = MockCommitteeProvider::new();
+    committee_provider
+        .expect_get_committee()
+        .returning(move |_| Box::pin(std::future::ready(Ok(Arc::clone(&committee)))));
+
+    let mut manager = MultiHeightManager::new(
+        consensus_config,
+        QuorumType::Byzantine,
+        Arc::new(Mutex::new(NoOpHeightVotedStorage)),
+        Arc::new(committee_provider),
+    )
+    .await;
+    let mut subscriber_channels = subscriber_channels.into();
+    let res = manager
+        .run_height(
+            &mut context,
+            HEIGHT_1,
+            &mut subscriber_channels,
+            &mut proposal_receiver_receiver,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res, RunHeightRes::Sync);
+    assert!(logs_contain(SKIPPED_PROPOSER_FAR_BEHIND));
+}
+
+#[rstest]
+#[tokio::test]
+async fn at_threshold_node_proposes_normally(consensus_config: ConsensusConfig) {
+    // The tip is exactly FAR_BEHIND_PROPOSAL_THRESHOLD ahead (gap == threshold, not > it), so the
+    // guard must NOT fire: the node (proposer) proceeds past the guard and builds a proposal.
+    let TestSubscriberChannels { mock_network, subscriber_channels } =
+        mock_register_broadcast_topic().unwrap();
+    let _vote_sender = mock_network.broadcasted_messages_sender;
+    let (_proposal_receiver_sender, proposal_receiver_receiver) = mpsc::channel(CHANNEL_SIZE);
+
+    let network_tip = BlockNumber(HEIGHT_1.0 + FAR_BEHIND_PROPOSAL_THRESHOLD);
+    let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(move || Some(network_tip));
+    context.expect_try_sync().returning(|_| false);
+    context.expect_set_height_and_round().returning(|_, _| Ok(()));
+    context.expect_broadcast().returning(|_| Ok(()));
+    let (proposed_tx, proposed_rx) = oneshot::channel();
+    context.expect_build_proposal().withf(|init, _| init.height == HEIGHT_1).return_once(
+        move |_, _| {
+            // Reaching build_proposal proves the guard did not short-circuit at the boundary.
+            proposed_tx.send(()).unwrap();
+            let (sender, receiver) = oneshot::channel();
+            sender.send(ProposalCommitment(Felt::ONE)).unwrap();
+            Ok(receiver)
+        },
+    );
+
+    let committee = mock_committee_with_members_and_proposer(vec![*VALIDATOR_ID], *VALIDATOR_ID);
+    let mut committee_provider = MockCommitteeProvider::new();
+    committee_provider
+        .expect_get_committee()
+        .returning(move |_| Box::pin(std::future::ready(Ok(Arc::clone(&committee)))));
+
+    let run_consensus_args = RunConsensusArguments {
+        start_active_height: HEIGHT_1,
+        consensus_config,
+        quorum_type: QuorumType::Byzantine,
+        config_manager_client: None,
+        last_voted_height_storage: Arc::new(Mutex::new(NoOpHeightVotedStorage)),
+        committee_provider: Arc::new(committee_provider),
+    };
+    tokio::spawn(async move {
+        let _ = run_consensus(
+            run_consensus_args,
+            context,
+            subscriber_channels.into(),
+            proposal_receiver_receiver,
+        )
+        .await;
+    });
+    proposed_rx.await.unwrap();
 }
 
 #[rstest]
@@ -931,6 +1048,7 @@ async fn manager_runs_normally_when_height_is_greater_than_last_voted_height(
     send(&mut sender, precommit(Some(Felt::ONE), CURRENT_HEIGHT, ROUND_0, *PROPOSER_ID)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     // Sync will never succeed so we will proceed to run consensus (during which try_sync is called
     // periodically regardless of last voted height functionality).
     context.expect_try_sync().with(eq(CURRENT_HEIGHT)).returning(|_| false);
@@ -991,6 +1109,7 @@ async fn manager_waits_until_height_passes_last_voted_height(consensus_config: C
     send(&mut sender, precommit(Some(Felt::ONE), LAST_VOTED_HEIGHT, ROUND_0, *PROPOSER_ID)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     // At the last voted height we expect the manager to halt until it can get the last voted height
     // from storage. We wait 3 retries to make sure it retries.
     context.expect_try_sync().with(eq(LAST_VOTED_HEIGHT)).times(3).returning(|_| false);
@@ -1040,6 +1159,7 @@ async fn writes_voted_height_to_storage(consensus_config: ConsensusConfig) {
         mpsc::channel(CHANNEL_SIZE);
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_set_height_and_round().returning(move |_, _| Ok(()));
     context.expect_try_sync().returning(|_| false);
 
@@ -1183,6 +1303,7 @@ async fn manager_fallback_to_sync_on_height_level_errors(consensus_config: Conse
         mpsc::channel(CHANNEL_SIZE);
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
 
     // Sync should first fail, so consensus will try to run.
     context.expect_try_sync().times(1).returning(|_| false);
@@ -1250,6 +1371,7 @@ async fn cache_future_vote_deduplication(consensus_config: ConsensusConfig) {
     send(&mut sender, precommit(Some(Felt::ZERO), HEIGHT_0, ROUND_0, *PROPOSER_ID)).await;
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_try_sync().returning(|_| false);
     expect_validate_proposal(&mut context, Felt::ZERO, 1);
     context.expect_set_height_and_round().returning(move |_, _| Ok(()));
@@ -1342,6 +1464,7 @@ async fn manager_ignores_invalid_network_messages(consensus_config: ConsensusCon
         mpsc::channel(CHANNEL_SIZE);
 
     let mut context = MockTestContext::new();
+    context.expect_network_tip().returning(|| None);
     context.expect_try_sync().returning(|_| false);
 
     // Send proposal with no content.

--- a/crates/apollo_consensus/src/test_utils.rs
+++ b/crates/apollo_consensus/src/test_utils.rs
@@ -117,6 +117,8 @@ mock! {
 
         async fn try_sync(&mut self, height: BlockNumber) -> bool;
 
+        async fn network_tip(&self) -> Option<BlockNumber>;
+
         async fn set_height_and_round(&mut self, height: BlockNumber, round: Round) -> Result<(), ConsensusError>;
     }
 }

--- a/crates/apollo_consensus/src/types.rs
+++ b/crates/apollo_consensus/src/types.rs
@@ -105,6 +105,11 @@ pub trait ConsensusContext {
     /// Returns true if a decision was learned so consensus can proceed.
     async fn try_sync(&mut self, height: BlockNumber) -> bool;
 
+    /// The latest block number known from the central source (the feeder gateway) — the chain tip
+    /// the node is syncing toward — or `None` if unknown (e.g. no central source). Used to avoid
+    /// proposing while far behind the tip.
+    async fn network_tip(&self) -> Option<BlockNumber>;
+
     /// Update the context with the current height and round.
     /// Must be called at the beginning of each height.
     async fn set_height_and_round(

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -75,7 +75,7 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tracing::{error, error_span, info, instrument, trace, warn, Instrument};
+use tracing::{debug, error, error_span, info, instrument, trace, warn, Instrument};
 
 use crate::build_proposal::{build_proposal, BuildProposalError, ProposalBuildArguments};
 #[cfg(feature = "os_input")]
@@ -1094,6 +1094,16 @@ impl ConsensusContext for SequencerConsensusContext {
         }
 
         true
+    }
+
+    async fn network_tip(&self) -> Option<BlockNumber> {
+        // Fail-open: on error, report an unknown tip so consensus proceeds as usual. Logged at
+        // debug (not error) because this is queried every height and a transient miss is benign;
+        // a persistently unknown tip shows up as repeated lines worth investigating.
+        self.deps.state_sync_client.get_highest_block_number().await.unwrap_or_else(|err| {
+            debug!("Failed to fetch network tip from state sync: {err}");
+            None
+        })
     }
 
     async fn set_height_and_round(


### PR DESCRIPTION
A node catching up must not run live consensus / propose at its stale current height —
otherwise a far-behind node can self-elect as proposer and produce blocks the network
has long passed. Add ConsensusContext::network_tip() (backed by the state-sync feeder
tip) and, in check_and_wait_for_sync, keep syncing instead of proposing when
network_tip - current_height exceeds FAR_BEHIND_PROPOSAL_THRESHOLD (const 30 for now).
Fails open when the tip is unknown. Logs a warning when proposing is suppressed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>