### PR TITLE
apollo_consensus,apollo_consensus_config: make far-behind propose threshold a validated config

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -217,11 +217,6 @@ pub struct EquivocationVoteReport {
 /// [`VoteType::Precommit`]). Used to bound the future-vote cache.
 const NUM_VOTE_TYPES: usize = 2;
 
-/// If the network tip (from the trusted central source) is more than this many blocks above the
-/// node's current height, the node is considered far behind: it keeps syncing rather than running
-/// live consensus / proposing. Replaced by a validated dynamic config value in a follow-up.
-const FAR_BEHIND_PROPOSAL_THRESHOLD: u64 = 30;
-
 /// Manages votes and proposals for future heights.
 #[derive(Debug)]
 struct ConsensusCache<ContextT: ConsensusContext> {
@@ -644,7 +639,7 @@ impl<ContextT: ConsensusContext> MultiHeightManager<ContextT> {
         // Fail-open when the tip is unknown (e.g. no central source).
         if let Some(network_tip) = context.network_tip().await {
             let blocks_behind = network_tip.0.saturating_sub(height.0);
-            if blocks_behind > FAR_BEHIND_PROPOSAL_THRESHOLD {
+            if blocks_behind > self.consensus_config.dynamic_config.far_behind_proposal_threshold {
                 warn!(
                     "{SKIPPED_PROPOSER_FAR_BEHIND} (current height {height}, network tip \
                      {network_tip}, {blocks_behind} blocks behind). Waiting for sync."

--- a/crates/apollo_consensus/src/manager_test.rs
+++ b/crates/apollo_consensus/src/manager_test.rs
@@ -42,14 +42,7 @@ use starknet_types_core::felt::Felt;
 use tokio::sync::Mutex;
 use tracing_test::traced_test;
 
-use super::{
-    run_consensus,
-    ConsensusCache,
-    MultiHeightManager,
-    RunHeightRes,
-    FAR_BEHIND_PROPOSAL_THRESHOLD,
-    NUM_VOTE_TYPES,
-};
+use super::{run_consensus, ConsensusCache, MultiHeightManager, RunHeightRes, NUM_VOTE_TYPES};
 use crate::manager::{CONSENSUS_RUNNING_PAST_STOP_HEIGHT, SKIPPED_PROPOSER_FAR_BEHIND};
 use crate::storage::MockHeightVotedStorageTrait;
 use crate::test_utils::{
@@ -134,6 +127,7 @@ fn consensus_config() -> ConsensusConfig {
             timeouts: TIMEOUTS.clone(),
             sync_retry_interval: SYNC_RETRY_INTERVAL,
             future_msg_limit: FutureMsgLimitsConfig::default(),
+            far_behind_proposal_threshold: 30,
             require_virtual_proposer_vote: true,
             stop_at_height: None,
         },
@@ -921,7 +915,8 @@ async fn far_behind_node_syncs_instead_of_proposing(consensus_config: ConsensusC
         mock_register_broadcast_topic().unwrap();
     let (_proposal_receiver_sender, mut proposal_receiver_receiver) = mpsc::channel(CHANNEL_SIZE);
 
-    let network_tip = BlockNumber(HEIGHT_1.0 + FAR_BEHIND_PROPOSAL_THRESHOLD + 1);
+    let network_tip =
+        BlockNumber(HEIGHT_1.0 + consensus_config.dynamic_config.far_behind_proposal_threshold + 1);
     let mut context = MockTestContext::new();
     context.expect_network_tip().returning(move || Some(network_tip));
     // try_sync first fails, so we fall past the sync checks and reach the guard; it then succeeds,
@@ -961,14 +956,15 @@ async fn far_behind_node_syncs_instead_of_proposing(consensus_config: ConsensusC
 #[rstest]
 #[tokio::test]
 async fn at_threshold_node_proposes_normally(consensus_config: ConsensusConfig) {
-    // The tip is exactly FAR_BEHIND_PROPOSAL_THRESHOLD ahead (gap == threshold, not > it), so the
+    // The tip is exactly far_behind_proposal_threshold ahead (gap == threshold, not > it), so the
     // guard must NOT fire: the node (proposer) proceeds past the guard and builds a proposal.
     let TestSubscriberChannels { mock_network, subscriber_channels } =
         mock_register_broadcast_topic().unwrap();
     let _vote_sender = mock_network.broadcasted_messages_sender;
     let (_proposal_receiver_sender, proposal_receiver_receiver) = mpsc::channel(CHANNEL_SIZE);
 
-    let network_tip = BlockNumber(HEIGHT_1.0 + FAR_BEHIND_PROPOSAL_THRESHOLD);
+    let network_tip =
+        BlockNumber(HEIGHT_1.0 + consensus_config.dynamic_config.far_behind_proposal_threshold);
     let mut context = MockTestContext::new();
     context.expect_network_tip().returning(move || Some(network_tip));
     context.expect_try_sync().returning(|_| false);

--- a/crates/apollo_consensus_config/src/config.rs
+++ b/crates/apollo_consensus_config/src/config.rs
@@ -25,6 +25,10 @@ use validator::Validate;
 
 use crate::ValidatorId;
 
+#[cfg(test)]
+#[path = "config_test.rs"]
+mod config_test;
+
 /// Dynamic configuration for consensus that can change at runtime.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Validate)]
 pub struct ConsensusDynamicConfig {
@@ -37,6 +41,11 @@ pub struct ConsensusDynamicConfig {
     pub sync_retry_interval: Duration,
     /// Future message limits configuration.
     pub future_msg_limit: FutureMsgLimitsConfig,
+    /// If the network tip is more than this many blocks above the node's current height, the node
+    /// is considered far behind and keeps syncing instead of proposing. Must be in the range
+    /// [5, 1000].
+    #[validate(range(min = 5, max = 1000))]
+    pub far_behind_proposal_threshold: u64,
     /// When true, require the virtual proposer to have voted in favor before reaching a decision.
     pub require_virtual_proposer_vote: bool,
     /// If set, the node participates in consensus up to and including this height, then stops.
@@ -85,6 +94,14 @@ impl SerializeConfig for ConsensusDynamicConfig {
                 &self.require_virtual_proposer_vote,
                 "When true, require the virtual proposer to have voted in favor before reaching a \
                  decision.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "far_behind_proposal_threshold",
+                &self.far_behind_proposal_threshold,
+                "If the network tip exceeds the node's current height by more than this many \
+                 blocks, the node keeps syncing instead of proposing. Must be in the range [5, \
+                 1000].",
                 ParamPrivacyInput::Public,
             ),
         ]);
@@ -138,6 +155,7 @@ impl Default for ConsensusDynamicConfig {
             timeouts: TimeoutsConfig::default(),
             sync_retry_interval: Duration::from_secs_f64(1.0),
             future_msg_limit: FutureMsgLimitsConfig::default(),
+            far_behind_proposal_threshold: 30,
             require_virtual_proposer_vote: false,
             stop_at_height: None,
         }

--- a/crates/apollo_consensus_config/src/config_test.rs
+++ b/crates/apollo_consensus_config/src/config_test.rs
@@ -1,0 +1,25 @@
+use validator::Validate;
+
+use super::ConsensusDynamicConfig;
+
+#[test]
+fn far_behind_proposal_threshold_default_is_valid() {
+    let config = ConsensusDynamicConfig::default();
+    assert_eq!(config.far_behind_proposal_threshold, 30);
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn far_behind_proposal_threshold_must_be_in_range_5_to_1000() {
+    // Must be at least 5 and at most 1000 (inclusive bounds).
+    for valid in [5, 30, 1000] {
+        let config =
+            ConsensusDynamicConfig { far_behind_proposal_threshold: valid, ..Default::default() };
+        assert!(config.validate().is_ok(), "{valid} should be accepted");
+    }
+    for invalid in [4, 1001] {
+        let config =
+            ConsensusDynamicConfig { far_behind_proposal_threshold: invalid, ..Default::default() };
+        assert!(config.validate().is_err(), "{invalid} should be rejected");
+    }
+}

--- a/crates/apollo_consensus_manager_config/src/config.rs
+++ b/crates/apollo_consensus_manager_config/src/config.rs
@@ -10,9 +10,14 @@ use apollo_staking_config::config::StakingManagerConfig;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
+#[cfg(test)]
+#[path = "config_test.rs"]
+mod config_test;
+
 /// The consensus manager related configuration.
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
 pub struct ConsensusManagerConfig {
+    #[validate(nested)]
     pub consensus_manager_config: ConsensusConfig,
     #[validate(nested)]
     pub context_config: ContextConfig,

--- a/crates/apollo_consensus_manager_config/src/config_test.rs
+++ b/crates/apollo_consensus_manager_config/src/config_test.rs
@@ -1,0 +1,20 @@
+use validator::Validate;
+
+use super::ConsensusManagerConfig;
+
+// Regression guard for the `#[validate(nested)]` on `consensus_manager_config`: without it,
+// validator_derive does not recurse into `ConsensusConfig`, so the nested
+// `far_behind_proposal_threshold` range check (and every other nested rule under it) is silently
+// skipped on config load. This test exercises the full nested chain, and also confirms the default
+// config still validates once nested validation is enabled.
+#[test]
+fn nested_consensus_config_validation_is_enforced() {
+    let mut config = ConsensusManagerConfig::default();
+    assert!(config.validate().is_ok(), "default config should be valid");
+
+    config.consensus_manager_config.dynamic_config.far_behind_proposal_threshold = 0;
+    assert!(
+        config.validate().is_err(),
+        "an out-of-range far_behind_proposal_threshold must fail validation via the nested chain"
+    );
+}

--- a/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
@@ -4,6 +4,7 @@
   "consensus_manager_config.cende_config.max_retry_duration_secs": 3,
   "consensus_manager_config.cende_config.max_retry_interval_ms": 1000,
   "consensus_manager_config.cende_config.min_retry_interval_ms": 50,
+  "consensus_manager_config.consensus_manager_config.dynamic_config.far_behind_proposal_threshold": 30,
   "consensus_manager_config.consensus_manager_config.dynamic_config.future_msg_limit.future_height_limit": 20,
   "consensus_manager_config.consensus_manager_config.dynamic_config.future_msg_limit.future_height_round_limit": 5,
   "consensus_manager_config.consensus_manager_config.dynamic_config.future_msg_limit.future_round_limit": 20,

--- a/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
@@ -4,6 +4,7 @@
   "consensus_manager_config.cende_config.max_retry_duration_secs": 3,
   "consensus_manager_config.cende_config.max_retry_interval_ms": 1000,
   "consensus_manager_config.cende_config.min_retry_interval_ms": 50,
+  "consensus_manager_config.consensus_manager_config.dynamic_config.far_behind_proposal_threshold": 30,
   "consensus_manager_config.consensus_manager_config.dynamic_config.future_msg_limit.future_height_limit": 20,
   "consensus_manager_config.consensus_manager_config.dynamic_config.future_msg_limit.future_height_round_limit": 5,
   "consensus_manager_config.consensus_manager_config.dynamic_config.future_msg_limit.future_round_limit": 20,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2524,6 +2524,11 @@
     "pointer_target": "recorder_url",
     "privacy": "Public"
   },
+  "consensus_manager_config.consensus_manager_config.dynamic_config.far_behind_proposal_threshold": {
+    "description": "If the network tip exceeds the node's current height by more than this many blocks, the node keeps syncing instead of proposing. Must be in the range [5, 1000].",
+    "privacy": "Public",
+    "value": 30
+  },
   "consensus_manager_config.consensus_manager_config.dynamic_config.future_msg_limit.future_height_limit": {
     "description": "How many heights in the future should we cache.",
     "privacy": "Public",


### PR DESCRIPTION
Replace the const FAR_BEHIND_PROPOSAL_THRESHOLD with far_behind_proposal_threshold on
ConsensusDynamicConfig (default 30), validated to be greater than 5 and less than 1000.
The guard reads the threshold from config; regenerated config_schema.json accordingly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>