### PR TITLE
apollo_consensus_orchestrator: consume txs in send_reproposal to avoid per-tx clones

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1300,7 +1300,7 @@ async fn send_reproposal(
     transaction_converter: Arc<dyn TransactionConverterTrait>,
 ) -> Result<(), ReproposeError> {
     stream_sender.send(ProposalPart::Init(init)).await?;
-    for batch in txs.into_iter() {
+    for batch in txs {
         let transactions = futures::future::join_all(batch.into_iter().map(|tx| {
             // transaction_converter is an external dependency (class manager) and so
             // we can't assume success on reproposal.

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1300,11 +1300,11 @@ async fn send_reproposal(
     transaction_converter: Arc<dyn TransactionConverterTrait>,
 ) -> Result<(), ReproposeError> {
     stream_sender.send(ProposalPart::Init(init)).await?;
-    for batch in txs.iter() {
-        let transactions = futures::future::join_all(batch.iter().map(|tx| {
+    for batch in txs.into_iter() {
+        let transactions = futures::future::join_all(batch.into_iter().map(|tx| {
             // transaction_converter is an external dependency (class manager) and so
             // we can't assume success on reproposal.
-            transaction_converter.convert_internal_consensus_tx_to_consensus_tx(tx.clone())
+            transaction_converter.convert_internal_consensus_tx_to_consensus_tx(tx)
         }))
         .await
         .into_iter()


### PR DESCRIPTION
## Summary

Performance follow-up to #14579.

`send_reproposal` accepts `txs: Vec<Vec<InternalConsensusTransaction>>` by **value** but then iterates over it with `txs.iter()`, cloning every transaction with `tx.clone()` before handing it to the converter:

```rust
// Before
for batch in txs.iter() {
    let transactions = join_all(batch.iter().map(|tx| {
        converter.convert_internal_consensus_tx_to_consensus_tx(tx.clone())
    })).await ...
}
```

Since `txs` is not referenced after the loop, switching to `into_iter()` lets us move each transaction directly — no clone needed:

```rust
// After
for batch in txs.into_iter() {
    let transactions = join_all(batch.into_iter().map(|tx| {
        converter.convert_internal_consensus_tx_to_consensus_tx(tx)
    })).await ...
}
```

**Savings**: O(N_txs) heap allocations per `repropose` call. For a dense block with thousands of transactions (each potentially carrying large calldata), this removes an entire redundant copy of the block's transaction data on the critical reproposal path.

## Test plan

- [ ] CI passes (existing `apollo_consensus_orchestrator` suite covers the repropose path, including the new `repropose_is_tracked_and_cancelled_on_round_change` test from #14579)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFzScVAFn5iZVZqqdfUJde

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFzScVAFn5iZVZqqdfUJde)_