### PR TITLE
apollo_consensus_orchestrator: avoid cloning txs in send_reproposal

### DIFF
--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -82,6 +82,7 @@ rand.workspace = true
 rand_chacha.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
+shared_execution_objects = { workspace = true, features = ["deserialize", "testing"] }
 starknet_committer = { workspace = true, features = ["testing"] }
 
 [lints]

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1300,11 +1300,11 @@ async fn send_reproposal(
     transaction_converter: Arc<dyn TransactionConverterTrait>,
 ) -> Result<(), ReproposeError> {
     stream_sender.send(ProposalPart::Init(init)).await?;
-    for batch in txs.iter() {
-        let transactions = futures::future::join_all(batch.iter().map(|tx| {
+    for batch in txs.into_iter() {
+        let transactions = futures::future::join_all(batch.into_iter().map(|tx| {
             // transaction_converter is an external dependency (class manager) and so
             // we can't assume success on reproposal.
-            transaction_converter.convert_internal_consensus_tx_to_consensus_tx(tx.clone())
+            transaction_converter.convert_internal_consensus_tx_to_consensus_tx(tx)
         }))
         .await
         .into_iter()


### PR DESCRIPTION
## What

Performance follow-up to #14579 on the reproposal path.

`send_reproposal` took `txs: Vec<Vec<InternalConsensusTransaction>>` by value but iterated with `iter()` and cloned every transaction (`tx.clone()`) before handing it to the converter. Since `txs` is not referenced after the loop, switching to `into_iter()` lets each transaction move directly into `convert_internal_consensus_tx_to_consensus_tx`, dropping the clone.

**Savings:** O(N_txs) heap allocations per repropose call — an entire redundant copy of the block's transaction data (each tx potentially carrying large calldata) on the critical reproposal path.

## Also: test-build fix

`cargo test -p apollo_consensus_orchestrator` (the command in CLAUDE.md) failed to compile without `--features testing`: the `cende` structs derive `Deserialize`/`PartialEq` under `cfg(test)`, but the `CentralTransactionExecutionInfo` impls they depend on live in `shared_execution_objects` behind its `deserialize`/`testing` features — only enabled via this crate's own `testing` feature. Added `shared_execution_objects` to `[dev-dependencies]` with those features, matching how every other testing-gated dependency is already declared.

## Verification

- `cargo test -p apollo_consensus_orchestrator` (plain): 166 passed, 0 failed
- The 4 `repropose` tests pass
- rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)