### PR TITLE
apollo_propeller: O(1) incremental size check in create_message_batch

### DIFF
--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -239,6 +239,10 @@ impl Handler {
     }
 
     /// Create a batch of messages from the send queue that fits within max_wire_message_size.
+    ///
+    /// `max_wire_message_size` bounds the protobuf body (i.e. `ProtoBatch::encoded_len()`),
+    /// matching the codec's length check. The framed wire bytes are up to ~5 bytes larger due
+    /// to the length delimiter prepended by `PropellerCodec::encode`.
     fn create_message_batch(
         send_queue: &mut VecDeque<ProtoUnit>,
         max_wire_message_size: usize,

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -18,12 +18,17 @@ use libp2p::swarm::handler::{
     StreamUpgradeError,
 };
 use libp2p::swarm::{Stream, SubstreamProtocol};
+use prost::encoding::encoded_len_varint;
 use prost::Message;
 use tracing::{error, trace, warn};
 
 use crate::config::Config;
 use crate::protocol::{PropellerCodec, PropellerProtocol};
 use crate::PropellerUnit;
+
+#[cfg(test)]
+#[path = "handler_test.rs"]
+mod handler_test;
 
 /// Events that the handler can send to the behaviour.
 #[derive(Debug)]
@@ -242,19 +247,27 @@ impl Handler {
             return ProtoBatch { batch: Vec::new() };
         }
 
-        let mut batch = ProtoBatch { batch: vec![send_queue.pop_front().unwrap()] };
-        if batch.encoded_len() > max_wire_message_size {
+        let first = send_queue.pop_front().unwrap();
+        let mut batch = ProtoBatch { batch: vec![first] };
+        let mut batch_encoded_len = batch.encoded_len();
+        if batch_encoded_len > max_wire_message_size {
             warn!("Propeller unit size exceeds max wire message size, sending will fail");
         }
 
         while let Some(msg) = send_queue.front() {
-            batch.batch.push(msg.clone());
-            if batch.encoded_len() <= max_wire_message_size {
-                send_queue.pop_front();
-            } else {
-                batch.batch.pop();
+            let msg_encoded_len = msg.encoded_len();
+            // Per-item cost in a protobuf `repeated` message field: 1-byte tag (field 1,
+            // LEN wire type = 0x0A) + varint-encoded length prefix + the message bytes.
+            // Tracking this incrementally avoids re-encoding the entire batch on every
+            // iteration, dropping the loop from O(N²) to O(N).
+            let msg_encoded_len_u64 =
+                u64::try_from(msg_encoded_len).expect("message encoded length fits in u64");
+            let item_len = 1 + encoded_len_varint(msg_encoded_len_u64) + msg_encoded_len;
+            if batch_encoded_len + item_len > max_wire_message_size {
                 break;
             }
+            batch_encoded_len += item_len;
+            batch.batch.push(send_queue.pop_front().unwrap());
         }
 
         batch
@@ -550,7 +563,11 @@ impl ConnectionHandler for Handler {
     > {
         let result = self.poll_inner(cx);
         // Store the waker so on_behaviour_event / on_connection_event can wake us.
-        self.waker = Some(cx.waker().clone());
+        // Skip the clone when the stored waker already refers to the same task — avoids
+        // an atomic increment on every poll in the common steady-state case.
+        if self.waker.as_ref().is_none_or(|w| !w.will_wake(cx.waker())) {
+            self.waker = Some(cx.waker().clone());
+        }
         result
     }
 

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -502,9 +502,12 @@ impl Handler {
         }
 
         // Read from the wire only when the unsent buffer is empty (the previous batch has been
-        // fully delivered).
-        for inbound_substream in self.inbound_substream.iter_mut() {
-            Self::poll_single_inbound_substream(inbound_substream, &mut self.unsent_units, cx);
+        // fully delivered). This prevents unbounded accumulation: a malicious peer cannot force
+        // memory growth by sending batches faster than the engine drains the channel.
+        if self.unsent_units.is_empty() {
+            for inbound_substream in self.inbound_substream.iter_mut() {
+                Self::poll_single_inbound_substream(inbound_substream, &mut self.unsent_units, cx);
+            }
         }
 
         // Send newly-decoded units to the engine channel.

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -247,16 +247,8 @@ impl Handler {
         send_queue: &mut VecDeque<ProtoUnit>,
         max_wire_message_size: usize,
     ) -> ProtoBatch {
-        if send_queue.is_empty() {
-            return ProtoBatch { batch: Vec::new() };
-        }
-
-        let first = send_queue.pop_front().unwrap();
-        let mut batch = ProtoBatch { batch: vec![first] };
-        let mut batch_encoded_len = batch.encoded_len();
-        if batch_encoded_len > max_wire_message_size {
-            warn!("Propeller unit size exceeds max wire message size, sending will fail");
-        }
+        let mut batch = ProtoBatch { batch: Vec::new() };
+        let mut batch_encoded_len = 0;
 
         while let Some(msg) = send_queue.front() {
             let msg_encoded_len = msg.encoded_len();
@@ -268,7 +260,12 @@ impl Handler {
                 u64::try_from(msg_encoded_len).expect("message encoded length fits in u64");
             let item_len = 1 + encoded_len_varint(msg_encoded_len_u64) + msg_encoded_len;
             if batch_encoded_len + item_len > max_wire_message_size {
-                break;
+                // An empty batch means this is the first unit: include it regardless, otherwise
+                // an oversized unit would block the queue forever. The send itself will fail.
+                if !batch.batch.is_empty() {
+                    break;
+                }
+                warn!("Propeller unit size exceeds max wire message size, sending will fail");
             }
             batch_encoded_len += item_len;
             batch.batch.push(send_queue.pop_front().unwrap());

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -243,6 +243,11 @@ impl Handler {
     /// `max_wire_message_size` bounds the protobuf body (i.e. `ProtoBatch::encoded_len()`),
     /// matching the codec's length check. The framed wire bytes are up to ~5 bytes larger due
     /// to the length delimiter prepended by `PropellerCodec::encode`.
+    // TODO(Shahak): consider counting the frame's length delimiter against the budget. Appending a
+    // unit can widen that delimiter's varint -- a body crossing 127 -> 128 bytes takes it from 1 to
+    // 2 bytes -- so the framed message can exceed max_wire_message_size by up to 5 bytes. Harmless
+    // today, since ProtoCodec applies the limit to the body on both encode and decode, but it does
+    // mean the limit doesn't bound what actually goes on the wire.
     fn create_message_batch(
         send_queue: &mut VecDeque<ProtoUnit>,
         max_wire_message_size: usize,

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -1,0 +1,126 @@
+use std::collections::VecDeque;
+
+use apollo_protobuf::protobuf::PropellerUnit as ProtoUnit;
+use prost::Message;
+
+use super::Handler;
+
+/// Build a `ProtoUnit` whose `signature` field is `payload_bytes` bytes long, giving
+/// predictable and controllable encoded sizes.
+fn make_proto_unit(payload_bytes: usize) -> ProtoUnit {
+    ProtoUnit { signature: vec![0u8; payload_bytes], ..Default::default() }
+}
+
+/// Return the incremental cost of adding one more item to a `ProtoBatch`.
+/// Matches the formula used in `create_message_batch`.
+fn item_batch_cost(unit: &ProtoUnit) -> usize {
+    let unit_encoded_len = unit.encoded_len();
+    let unit_encoded_len_u64 =
+        u64::try_from(unit_encoded_len).expect("encoded length fits in u64");
+    1 + prost::encoding::encoded_len_varint(unit_encoded_len_u64) + unit_encoded_len
+}
+
+#[test]
+fn test_create_message_batch_empty_queue() {
+    let mut queue: VecDeque<ProtoUnit> = VecDeque::new();
+    let batch = Handler::create_message_batch(&mut queue, 1024);
+    assert!(batch.batch.is_empty());
+    assert!(queue.is_empty());
+}
+
+#[test]
+fn test_create_message_batch_single_item_fits() {
+    let unit = make_proto_unit(10);
+    let unit_cost = item_batch_cost(&unit);
+    let mut queue = VecDeque::from([unit]);
+    let batch = Handler::create_message_batch(&mut queue, unit_cost + 100);
+    assert_eq!(batch.batch.len(), 1);
+    assert!(queue.is_empty());
+    assert!(batch.encoded_len() <= unit_cost + 100);
+}
+
+#[test]
+fn test_create_message_batch_single_item_over_limit_still_included() {
+    // The first item is always included (the oversized warning is purely advisory).
+    let unit = make_proto_unit(200);
+    let mut queue = VecDeque::from([unit]);
+    let batch = Handler::create_message_batch(&mut queue, 1);
+    assert_eq!(batch.batch.len(), 1);
+    assert!(queue.is_empty());
+}
+
+#[test]
+fn test_create_message_batch_all_items_fit() {
+    let num_items = 5;
+    let unit = make_proto_unit(10);
+    let total_cost: usize = (0..num_items).map(|_| item_batch_cost(&unit)).sum();
+    let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
+
+    let batch = Handler::create_message_batch(&mut queue, total_cost + 100);
+
+    assert_eq!(batch.batch.len(), num_items);
+    assert!(queue.is_empty());
+    assert!(batch.encoded_len() <= total_cost + 100);
+}
+
+#[test]
+fn test_create_message_batch_stops_at_size_limit() {
+    // Make items whose individual cost is known, then cap the batch at exactly 2 items.
+    let unit = make_proto_unit(20);
+    let single_item_cost = item_batch_cost(&unit);
+    let max_size = 2 * single_item_cost; // fits exactly 2
+
+    let num_items = 5usize;
+    let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
+
+    let batch = Handler::create_message_batch(&mut queue, max_size);
+
+    assert_eq!(batch.batch.len(), 2, "should pack exactly 2 items");
+    assert_eq!(queue.len(), 3, "3 items should remain in the queue");
+    assert!(batch.encoded_len() <= max_size);
+}
+
+#[test]
+fn test_create_message_batch_packed_maximally() {
+    // Verify that we include as many items as possible (no premature stops).
+    let unit = make_proto_unit(8);
+    let single_cost = item_batch_cost(&unit);
+    let num_items = 10usize;
+
+    for limit in (single_cost..=num_items * single_cost).step_by(single_cost) {
+        let expected = limit / single_cost;
+        let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
+        let batch = Handler::create_message_batch(&mut queue, limit);
+        assert_eq!(
+            batch.batch.len(),
+            expected,
+            "limit={limit}: expected {expected} items, got {}",
+            batch.batch.len()
+        );
+        assert!(batch.encoded_len() <= limit);
+    }
+}
+
+#[test]
+fn test_create_message_batch_encoded_len_matches_proto() {
+    // The incremental size tracking must agree with prost's own encoded_len at every step.
+    let unit = make_proto_unit(15);
+    let num_items = 6usize;
+    let large_limit = usize::MAX;
+    let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
+
+    let batch = Handler::create_message_batch(&mut queue, large_limit);
+
+    assert_eq!(batch.batch.len(), num_items);
+    // Confirm the batch's actual encoded length is what prost reports (invariant check).
+    let expected_len: usize = batch
+        .batch
+        .iter()
+        .map(|u| {
+            let enc_len = u.encoded_len();
+            let enc_len_u64 = u64::try_from(enc_len).expect("encoded length fits in u64");
+            1 + prost::encoding::encoded_len_varint(enc_len_u64) + enc_len
+        })
+        .sum();
+    assert_eq!(batch.encoded_len(), expected_len);
+}

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -102,6 +102,33 @@ fn test_create_message_batch_packed_maximally() {
 }
 
 #[test]
+fn test_create_message_batch_tight_boundary() {
+    // Verify via prost's own encoded_len() that the batch fits and that the first excluded
+    // item would in fact push it over the limit — independent of the test helper formula.
+    let unit = make_proto_unit(25);
+    let single_cost = item_batch_cost(&unit);
+    let num_items = 4usize;
+    let max_size = 3 * single_cost; // fits exactly 3, 4th would exceed
+
+    let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
+    let batch = Handler::create_message_batch(&mut queue, max_size);
+
+    assert_eq!(batch.batch.len(), 3);
+    // Independent check: prost's encoded_len must be within budget.
+    assert!(batch.encoded_len() <= max_size, "batch overflows max_size");
+    // Independent check: adding the next item would exceed the budget.
+    let next_unit_encoded = queue.front().unwrap().encoded_len();
+    let next_unit_encoded_u64 =
+        u64::try_from(next_unit_encoded).expect("encoded length fits in u64");
+    let next_item_len =
+        1 + prost::encoding::encoded_len_varint(next_unit_encoded_u64) + next_unit_encoded;
+    assert!(
+        batch.encoded_len() + next_item_len > max_size,
+        "next item should not fit"
+    );
+}
+
+#[test]
 fn test_create_message_batch_encoded_len_matches_proto() {
     // The incremental size tracking must agree with prost's own encoded_len at every step.
     let unit = make_proto_unit(15);

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -15,8 +15,7 @@ fn make_proto_unit(payload_bytes: usize) -> ProtoUnit {
 /// Matches the formula used in `create_message_batch`.
 fn item_batch_cost(unit: &ProtoUnit) -> usize {
     let unit_encoded_len = unit.encoded_len();
-    let unit_encoded_len_u64 =
-        u64::try_from(unit_encoded_len).expect("encoded length fits in u64");
+    let unit_encoded_len_u64 = u64::try_from(unit_encoded_len).expect("encoded length fits in u64");
     1 + prost::encoding::encoded_len_varint(unit_encoded_len_u64) + unit_encoded_len
 }
 
@@ -122,10 +121,7 @@ fn test_create_message_batch_tight_boundary() {
         u64::try_from(next_unit_encoded).expect("encoded length fits in u64");
     let next_item_len =
         1 + prost::encoding::encoded_len_varint(next_unit_encoded_u64) + next_unit_encoded;
-    assert!(
-        batch.encoded_len() + next_item_len > max_size,
-        "next item should not fit"
-    );
+    assert!(batch.encoded_len() + next_item_len > max_size, "next item should not fit");
 }
 
 #[test]

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use apollo_protobuf::protobuf::PropellerUnit as ProtoUnit;
+use prost::encoding::encoded_len_varint;
 use prost::Message;
 
 use super::Handler;
@@ -17,7 +18,7 @@ fn item_batch_cost(unit: &ProtoUnit) -> usize {
     let unit_encoded_len = unit.encoded_len();
     let unit_encoded_len_u64 = u64::try_from(unit_encoded_len).expect("encoded length fits in u64");
     // 1-byte tag (field 1, LEN wire type 0x0A) + varint-encoded item length + item bytes.
-    1 + prost::encoding::encoded_len_varint(unit_encoded_len_u64) + unit_encoded_len
+    1 + encoded_len_varint(unit_encoded_len_u64) + unit_encoded_len
 }
 
 #[test]
@@ -78,30 +79,6 @@ fn test_create_message_batch_stops_at_size_limit() {
     assert_eq!(batch.batch.len(), 2, "should pack exactly 2 items");
     assert_eq!(queue.len(), 3, "3 items should remain in the queue");
     assert!(batch.encoded_len() <= max_size);
-}
-
-#[test]
-fn test_create_message_batch_encoded_len_matches_proto() {
-    // The incremental size tracking must agree with prost's own encoded_len at every step.
-    let unit = make_proto_unit(15);
-    let num_items = 6usize;
-    let large_limit = usize::MAX;
-    let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
-
-    let batch = Handler::create_message_batch(&mut queue, large_limit);
-
-    assert_eq!(batch.batch.len(), num_items);
-    // Confirm the batch's actual encoded length is what prost reports (invariant check).
-    let expected_len: usize = batch
-        .batch
-        .iter()
-        .map(|u| {
-            let enc_len = u.encoded_len();
-            let enc_len_u64 = u64::try_from(enc_len).expect("encoded length fits in u64");
-            1 + prost::encoding::encoded_len_varint(enc_len_u64) + enc_len
-        })
-        .sum();
-    assert_eq!(batch.encoded_len(), expected_len);
 }
 
 #[test]

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -80,36 +80,3 @@ fn test_create_message_batch_stops_at_size_limit() {
     assert_eq!(queue.len(), 3, "3 items should remain in the queue");
     assert!(batch.encoded_len() <= max_size);
 }
-
-#[test]
-fn test_create_message_batch_varint_boundary() {
-    // PropellerUnit.signature is field 6 (bytes, 1-byte tag 0x32).
-    // make_proto_unit(n).encoded_len() = 1 (tag) + varint_len(n) + n for n < 128.
-    // At the encoded_len 127->128 boundary, the per-item length varint grows from 1 to 2 bytes:
-    //   encoded_len = 127: item_batch_cost = 1 + 1 + 127 = 129
-    //   encoded_len = 128: item_batch_cost = 1 + 2 + 128 = 131
-    // Verify that the unit at the boundary is excluded when the budget fits a 129-byte item
-    // but not a 131-byte one.
-    let first_unit = make_proto_unit(10);
-    let below_boundary_unit = make_proto_unit(125); // encoded_len = 127, 1-byte varint
-    let at_boundary_unit = make_proto_unit(126); // encoded_len = 128, 2-byte varint
-
-    assert_eq!(below_boundary_unit.encoded_len(), 127);
-    assert_eq!(at_boundary_unit.encoded_len(), 128);
-
-    let first_cost = item_batch_cost(&first_unit);
-    let below_boundary_cost = item_batch_cost(&below_boundary_unit); // 129
-    let at_boundary_cost = item_batch_cost(&at_boundary_unit); // 131
-
-    // Budget: fits first_unit + a below-boundary item (129 bytes), but not first_unit +
-    // at_boundary_unit (131 bytes — 2 bytes more due to the 2-byte varint).
-    let max_size = first_cost + below_boundary_cost;
-    assert!(max_size < first_cost + at_boundary_cost, "at_boundary_unit must not fit");
-
-    let mut queue = VecDeque::from([first_unit, at_boundary_unit]);
-    let batch = Handler::create_message_batch(&mut queue, max_size);
-
-    assert_eq!(batch.batch.len(), 1, "2-byte varint causes at_boundary_unit to exceed budget");
-    assert_eq!(queue.len(), 1, "at_boundary_unit remains in queue");
-    assert!(batch.encoded_len() <= max_size);
-}

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -16,6 +16,7 @@ fn make_proto_unit(payload_bytes: usize) -> ProtoUnit {
 fn item_batch_cost(unit: &ProtoUnit) -> usize {
     let unit_encoded_len = unit.encoded_len();
     let unit_encoded_len_u64 = u64::try_from(unit_encoded_len).expect("encoded length fits in u64");
+    // 1-byte tag (field 1, LEN wire type 0x0A) + varint-encoded item length + item bytes.
     1 + prost::encoding::encoded_len_varint(unit_encoded_len_u64) + unit_encoded_len
 }
 
@@ -64,10 +65,10 @@ fn test_create_message_batch_all_items_fit() {
 
 #[test]
 fn test_create_message_batch_stops_at_size_limit() {
-    // Make items whose individual cost is known, then cap the batch at exactly 2 items.
+    // Make items whose individual cost is known, then cap the batch to fit exactly 2.
     let unit = make_proto_unit(20);
     let single_item_cost = item_batch_cost(&unit);
-    let max_size = 2 * single_item_cost; // fits exactly 2
+    let max_size = 2 * single_item_cost + 1; // fits exactly 2, 3rd would exceed
 
     let num_items = 5usize;
     let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
@@ -77,51 +78,6 @@ fn test_create_message_batch_stops_at_size_limit() {
     assert_eq!(batch.batch.len(), 2, "should pack exactly 2 items");
     assert_eq!(queue.len(), 3, "3 items should remain in the queue");
     assert!(batch.encoded_len() <= max_size);
-}
-
-#[test]
-fn test_create_message_batch_packed_maximally() {
-    // Verify that we include as many items as possible (no premature stops).
-    let unit = make_proto_unit(8);
-    let single_cost = item_batch_cost(&unit);
-    let num_items = 10usize;
-
-    for limit in (single_cost..=num_items * single_cost).step_by(single_cost) {
-        let expected = limit / single_cost;
-        let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
-        let batch = Handler::create_message_batch(&mut queue, limit);
-        assert_eq!(
-            batch.batch.len(),
-            expected,
-            "limit={limit}: expected {expected} items, got {}",
-            batch.batch.len()
-        );
-        assert!(batch.encoded_len() <= limit);
-    }
-}
-
-#[test]
-fn test_create_message_batch_tight_boundary() {
-    // Verify via prost's own encoded_len() that the batch fits and that the first excluded
-    // item would in fact push it over the limit — independent of the test helper formula.
-    let unit = make_proto_unit(25);
-    let single_cost = item_batch_cost(&unit);
-    let num_items = 4usize;
-    let max_size = 3 * single_cost; // fits exactly 3, 4th would exceed
-
-    let mut queue: VecDeque<ProtoUnit> = (0..num_items).map(|_| unit.clone()).collect();
-    let batch = Handler::create_message_batch(&mut queue, max_size);
-
-    assert_eq!(batch.batch.len(), 3);
-    // Independent check: prost's encoded_len must be within budget.
-    assert!(batch.encoded_len() <= max_size, "batch overflows max_size");
-    // Independent check: adding the next item would exceed the budget.
-    let next_unit_encoded = queue.front().unwrap().encoded_len();
-    let next_unit_encoded_u64 =
-        u64::try_from(next_unit_encoded).expect("encoded length fits in u64");
-    let next_item_len =
-        1 + prost::encoding::encoded_len_varint(next_unit_encoded_u64) + next_unit_encoded;
-    assert!(batch.encoded_len() + next_item_len > max_size, "next item should not fit");
 }
 
 #[test]
@@ -146,4 +102,37 @@ fn test_create_message_batch_encoded_len_matches_proto() {
         })
         .sum();
     assert_eq!(batch.encoded_len(), expected_len);
+}
+
+#[test]
+fn test_create_message_batch_varint_boundary() {
+    // PropellerUnit.signature is field 6 (bytes, 1-byte tag 0x32).
+    // make_proto_unit(n).encoded_len() = 1 (tag) + varint_len(n) + n for n < 128.
+    // At the encoded_len 127->128 boundary, the per-item length varint grows from 1 to 2 bytes:
+    //   encoded_len = 127: item_batch_cost = 1 + 1 + 127 = 129
+    //   encoded_len = 128: item_batch_cost = 1 + 2 + 128 = 131
+    // Verify that the unit at the boundary is excluded when the budget fits a 129-byte item
+    // but not a 131-byte one.
+    let first_unit = make_proto_unit(10);
+    let below_boundary_unit = make_proto_unit(125); // encoded_len = 127, 1-byte varint
+    let at_boundary_unit = make_proto_unit(126); // encoded_len = 128, 2-byte varint
+
+    assert_eq!(below_boundary_unit.encoded_len(), 127);
+    assert_eq!(at_boundary_unit.encoded_len(), 128);
+
+    let first_cost = item_batch_cost(&first_unit);
+    let below_boundary_cost = item_batch_cost(&below_boundary_unit); // 129
+    let at_boundary_cost = item_batch_cost(&at_boundary_unit); // 131
+
+    // Budget: fits first_unit + a below-boundary item (129 bytes), but not first_unit +
+    // at_boundary_unit (131 bytes — 2 bytes more due to the 2-byte varint).
+    let max_size = first_cost + below_boundary_cost;
+    assert!(max_size < first_cost + at_boundary_cost, "at_boundary_unit must not fit");
+
+    let mut queue = VecDeque::from([first_unit, at_boundary_unit]);
+    let batch = Handler::create_message_batch(&mut queue, max_size);
+
+    assert_eq!(batch.batch.len(), 1, "2-byte varint causes at_boundary_unit to exceed budget");
+    assert_eq!(queue.len(), 1, "at_boundary_unit remains in queue");
+    assert!(batch.encoded_len() <= max_size);
 }


### PR DESCRIPTION
## What

Performance follow-up to #14533 on the `apollo_propeller` connection handler.

`create_message_batch` called `batch.encoded_len()` — which traverses the entire batch — inside its fill loop, making outbound batch assembly **O(N²)** in the number of units per batch. It also cloned each candidate unit before deciding whether it fits, discarding the clone on rejection.

## Change

### 1. O(1) incremental size check (`create_message_batch`)

Replace the repeated `encoded_len()` calls with an **O(1) incremental running total**: compute each candidate's protobuf overhead before touching the queue, update the counter on acceptance, and `break` without any clone on rejection. Batch assembly is now **O(N)**.

`PropellerUnitBatch` is a single `repeated PropellerUnit batch = 1` field, which proto3 encodes as one independent record per element:

```
1 byte (tag 0x0A)  +  varint_len(unit.encoded_len())  +  unit.encoded_len()
```

There is no element-count prefix, so appending a unit never changes the cost of the units already in the batch — which is what makes the running total exact. The increment is computed via `prost::encoding::encoded_len_varint` and matches `ProtoBatch::encoded_len()` exactly.

Units are moved out of the queue with `pop_front()` on acceptance rather than cloned-then-maybe-discarded, and every unit is handled uniformly by the loop: the first unit is identified by `batch.batch.is_empty()` rather than being popped and measured separately before the loop. An oversized first unit is still included (with the advisory `warn!`), since dropping it would block the queue forever.

### 2. Bound inbound buffering

`poll_inner` carried a comment saying it reads from the wire "only when the unsent buffer is empty", but had no such check — it polled the inbound substreams unconditionally. Added the missing `unsent_units.is_empty()` guard, so a peer sending batches faster than the engine drains the bounded channel from #14533 can no longer grow `unsent_units` without bound.

### 3. Waker clone elision

Skip the `Waker::clone()` in `poll` when the stored waker already refers to the same task (`will_wake`), avoiding an unnecessary atomic increment on every steady-state poll.

## Impact

- Outbound batch creation: O(N²) → O(N) in units-per-batch
- Eliminates O(N) unnecessary deep clones per batch-fill cycle
- Inbound buffering is now actually bounded by the engine channel, as the code always claimed
- Waker path: one atomic refcount saved per `poll` call under steady state

## Tests

5 unit tests in `handler_test.rs` covering `create_message_batch`:

- Empty queue
- Single unit fits
- Single unit over the limit (still included, advisory warn only)
- All units fit
- Batch stops at the size limit, with the queue remainder preserved

A `varint_boundary` test was added and then removed: it exercised a single unit whose own length prefix crosses 127→128, which is not the case that was asked about. The unit count itself is never encoded, so appending a unit never widens a shared varint inside the budget. The varint that *does* grow with the unit count is the length delimiter `PropellerCodec::encode` prepends to the whole batch, and that sits outside `max_wire_message_size` — `ProtoCodec` compares the limit against the body on both encode and decode. `create_message_batch` now carries a `TODO(Shahak)` recording that gap.

All existing tests continue to pass: 166 unit tests + 4 e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
