### PR TITLE
starknet_patricia: track new-hash count per subtree in updated skeleton nodes

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -177,7 +177,7 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
     {
         let node = updated_skeleton.get_node(index)?;
         match node {
-            UpdatedSkeletonNode::Binary => {
+            UpdatedSkeletonNode::Binary { n_new_hashes: _ } => {
                 let left_index = index * 2.into();
                 let right_index = left_index + NodeIndex::ROOT;
 
@@ -209,7 +209,7 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
                 )?;
                 Ok(hash)
             }
-            UpdatedSkeletonNode::Edge(path_to_bottom) => {
+            UpdatedSkeletonNode::Edge { path_to_bottom, n_new_hashes: _ } => {
                 let bottom_node_index = NodeIndex::compute_bottom_index(index, path_to_bottom);
                 let bottom_hash = Self::compute_filled_tree_rec::<TH>(
                     Arc::clone(&updated_skeleton),

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree_test.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree_test.rs
@@ -171,7 +171,7 @@ async fn test_leaf_computation_error() {
     let leaf_input_map =
         HashMap::from([(first_leaf_index, 1_u128.into()), (second_leaf_index, Felt::MAX)]);
     let skeleton_tree = HashMap::from([
-        (NodeIndex::ROOT, UpdatedSkeletonNode::Binary),
+        (NodeIndex::ROOT, UpdatedSkeletonNode::Binary { n_new_hashes: 1 }),
         (first_leaf_index, UpdatedSkeletonNode::Leaf),
         (second_leaf_index, UpdatedSkeletonNode::Leaf),
     ]);
@@ -330,7 +330,7 @@ fn get_small_tree_expected_filled_tree_map_and_root_hash()
 fn create_binary_updated_skeleton_node_for_testing(
     index: u128,
 ) -> (NodeIndex, UpdatedSkeletonNode) {
-    (NodeIndex::from(index), UpdatedSkeletonNode::Binary)
+    (NodeIndex::from(index), UpdatedSkeletonNode::Binary { n_new_hashes: 0 })
 }
 
 fn create_path_to_bottom_edge_updated_skeleton_node_for_testing(
@@ -340,9 +340,11 @@ fn create_path_to_bottom_edge_updated_skeleton_node_for_testing(
 ) -> (NodeIndex, UpdatedSkeletonNode) {
     (
         NodeIndex::from(index),
-        UpdatedSkeletonNode::Edge(
-            PathToBottom::new(path.into(), EdgePathLength::new(length).unwrap()).unwrap(),
-        ),
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::new(path.into(), EdgePathLength::new(length).unwrap())
+                .unwrap(),
+            n_new_hashes: 0,
+        },
     )
 }
 

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
@@ -30,14 +30,26 @@ pub(crate) enum TempSkeletonNode {
     Empty,
     // A new/modified leaf.
     Leaf,
-    OriginalBinary,
-    OriginalEdge { path: PathToBottom },
+    // `n_new_hashes` is the number of hashes that must be computed for the subtree rooted at this
+    // node.
+    OriginalBinary { n_new_hashes: usize },
+    OriginalEdge { path: PathToBottom, n_new_hashes: usize },
     OriginalUnmodified { hash: HashOutput },
 }
 
 impl TempSkeletonNode {
     fn is_empty(&self) -> bool {
         *self == Self::Empty
+    }
+
+    /// The number of node hashes that must be (re)computed for the subtree rooted at this node.
+    fn n_new_hashes(&self) -> usize {
+        match self {
+            Self::Empty | Self::Leaf | Self::OriginalUnmodified { .. } => 0,
+            Self::OriginalBinary { n_new_hashes } | Self::OriginalEdge { n_new_hashes, .. } => {
+                *n_new_hashes
+            }
+        }
     }
 }
 
@@ -172,19 +184,20 @@ impl UpdatedSkeletonTreeImpl {
             .unwrap_or_else(|| panic!("Node {root_index:?} not found."));
 
         if leaf_indices.is_empty() {
-            match original_node {
+            return match original_node {
                 OriginalSkeletonNode::Binary => unreachable!(
                     "Index {root_index:?} is an original Binary node without leaf modifications -
                     it should be an unmodified subtree instead."
                 ),
+                // An unmodified edge node's hash is still recomputed during the filled-tree pass.
                 OriginalSkeletonNode::Edge(path) => {
-                    return TempSkeletonNode::OriginalEdge { path };
+                    TempSkeletonNode::OriginalEdge { path, n_new_hashes: 1 }
                 }
                 OriginalSkeletonNode::UnmodifiedSubTree(hash) => {
-                    return TempSkeletonNode::OriginalUnmodified { hash };
+                    TempSkeletonNode::OriginalUnmodified { hash }
                 }
-            }
-        };
+            };
+        }
 
         match original_node {
             OriginalSkeletonNode::UnmodifiedSubTree(_) => {
@@ -230,7 +243,9 @@ impl UpdatedSkeletonTreeImpl {
             self.finalize_binary_child(left_index, left);
             self.finalize_binary_child(right_index, right);
 
-            return TempSkeletonNode::OriginalBinary;
+            return TempSkeletonNode::OriginalBinary {
+                n_new_hashes: 1 + left.n_new_hashes() + right.n_new_hashes(),
+            };
         }
 
         // At least one of the children is empty.
@@ -247,11 +262,18 @@ impl UpdatedSkeletonTreeImpl {
     /// so they are only sanity-checked, not inserted.
     fn finalize_binary_child(&mut self, index: NodeIndex, child: &TempSkeletonNode) {
         match child {
-            TempSkeletonNode::OriginalBinary => {
-                self.skeleton_tree.insert(index, UpdatedSkeletonNode::Binary);
+            TempSkeletonNode::OriginalBinary { n_new_hashes } => {
+                self.skeleton_tree
+                    .insert(index, UpdatedSkeletonNode::Binary { n_new_hashes: *n_new_hashes });
             }
-            TempSkeletonNode::OriginalEdge { path } => {
-                self.skeleton_tree.insert(index, UpdatedSkeletonNode::Edge(*path));
+            TempSkeletonNode::OriginalEdge { path, n_new_hashes } => {
+                self.skeleton_tree.insert(
+                    index,
+                    UpdatedSkeletonNode::Edge {
+                        path_to_bottom: *path,
+                        n_new_hashes: *n_new_hashes,
+                    },
+                );
             }
             TempSkeletonNode::OriginalUnmodified { .. } | TempSkeletonNode::Leaf => {
                 assert!(
@@ -274,13 +296,21 @@ impl UpdatedSkeletonTreeImpl {
     ) -> TempSkeletonNode {
         match bottom {
             TempSkeletonNode::Empty => TempSkeletonNode::Empty,
-            TempSkeletonNode::OriginalEdge { path: bottom_path } => {
-                TempSkeletonNode::OriginalEdge { path: path.concat_paths(*bottom_path) }
+            TempSkeletonNode::OriginalEdge { path: bottom_path, n_new_hashes } => {
+                // The new edge unifies with the bottom edge into a single edge node, so the bottom
+                // edge's hash count already includes this node - no additional hash.
+                TempSkeletonNode::OriginalEdge {
+                    path: path.concat_paths(*bottom_path),
+                    n_new_hashes: *n_new_hashes,
+                }
             }
-            TempSkeletonNode::OriginalBinary => {
+            TempSkeletonNode::OriginalBinary { n_new_hashes } => {
                 // Finalize bottom - a binary descendant cannot change form.
-                self.skeleton_tree.insert(*bottom_index, UpdatedSkeletonNode::Binary);
-                TempSkeletonNode::OriginalEdge { path: *path }
+                self.skeleton_tree.insert(
+                    *bottom_index,
+                    UpdatedSkeletonNode::Binary { n_new_hashes: *n_new_hashes },
+                );
+                TempSkeletonNode::OriginalEdge { path: *path, n_new_hashes: 1 + *n_new_hashes }
             }
             TempSkeletonNode::OriginalUnmodified { .. } | TempSkeletonNode::Leaf => {
                 // Leaves and unmodified subtrees are finalized in the initial phase of updated
@@ -289,7 +319,7 @@ impl UpdatedSkeletonTreeImpl {
                     self.skeleton_tree.contains_key(bottom_index),
                     "bottom {bottom_index:?} doesn't appear in the skeleton."
                 );
-                TempSkeletonNode::OriginalEdge { path: *path }
+                TempSkeletonNode::OriginalEdge { path: *path, n_new_hashes: 1 }
             }
         }
     }

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
@@ -165,7 +165,7 @@ fn test_get_path_to_lca(
     &TempSkeletonNode::Leaf,
     &TempSkeletonNode::Empty,
     &[(NodeIndex::from(2), 1), (NodeIndex::from(3), 0)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD, n_new_hashes: 1 },
     &[]
 )]
 #[case::two_leaves(
@@ -173,27 +173,27 @@ fn test_get_path_to_lca(
     &TempSkeletonNode::Leaf,
     &TempSkeletonNode::Leaf,
     &[(NodeIndex::from(10),1), (NodeIndex::from(11),1)],
-    TempSkeletonNode::OriginalBinary,
+    TempSkeletonNode::OriginalBinary { n_new_hashes: 1 },
     &[]
 )]
 #[case::two_nodes(
     &NodeIndex::from(5),
-    &TempSkeletonNode::OriginalBinary,
-    &TempSkeletonNode::OriginalBinary,
+    &TempSkeletonNode::OriginalBinary { n_new_hashes: 1 },
+    &TempSkeletonNode::OriginalBinary { n_new_hashes: 2 },
     &[],
-    TempSkeletonNode::OriginalBinary,
+    TempSkeletonNode::OriginalBinary { n_new_hashes: 4 },
     &[
-        (NodeIndex::from(10),UpdatedSkeletonNode::Binary),
-        (NodeIndex::from(11), UpdatedSkeletonNode::Binary
-    )]
+        (NodeIndex::from(10), UpdatedSkeletonNode::Binary { n_new_hashes: 1 }),
+        (NodeIndex::from(11), UpdatedSkeletonNode::Binary { n_new_hashes: 2 }),
+    ]
 )]
 #[case::deleted_left_child(
     &NodeIndex::from(5),
     &TempSkeletonNode::Empty,
-    &TempSkeletonNode::OriginalBinary,
+    &TempSkeletonNode::OriginalBinary { n_new_hashes: 1 },
     &[(NodeIndex::from(20), 0)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
-    &[(NodeIndex::from(11),UpdatedSkeletonNode::Binary)]
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD, n_new_hashes: 2 },
+    &[(NodeIndex::from(11), UpdatedSkeletonNode::Binary { n_new_hashes: 1 })]
 )]
 #[case::deleted_two_children(
     &NodeIndex::from(5),
@@ -205,10 +205,10 @@ fn test_get_path_to_lca(
 )]
 #[case::left_edge_right_deleted(
     &NodeIndex::from(5),
-    &TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
+    &TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD, n_new_hashes: 1 },
     &TempSkeletonNode::Empty,
     &[(NodeIndex::from(22), 0)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("01") },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("01"), n_new_hashes: 1 },
     &[]
 )]
 fn test_node_from_binary_data(
@@ -240,11 +240,12 @@ fn test_node_from_binary_data(
     &PathToBottom::from("00"),
     (
         &NodeIndex::from(4),
-        &TempSkeletonNode::OriginalEdge { path: PathToBottom::from("11") },
+        &TempSkeletonNode::OriginalEdge { path: PathToBottom::from("11"), n_new_hashes: 1 },
     ),
     &[],
     &[],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("0011") },
+    // The new edge unifies with the bottom edge into a single node, so the count is unchanged.
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("0011"), n_new_hashes: 1 },
     &[],
 )]
 #[case::to_unmodified_bottom(
@@ -256,23 +257,26 @@ fn test_node_from_binary_data(
    &[],
     // The unmodified subtree is finalized in the initial phase, so it appears in the skeleton.
     &[(NodeIndex::from(5), OriginalSkeletonNode::UnmodifiedSubTree(HashOutput::ROOT_OF_EMPTY_TREE))],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("101") },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("101"), n_new_hashes: 1 },
     &[],
 )]
 #[case::to_binary(
     &PathToBottom::RIGHT_CHILD,
-    (&NodeIndex::from(7), &TempSkeletonNode::OriginalBinary),
+    (
+        &NodeIndex::from(7),
+        &TempSkeletonNode::OriginalBinary { n_new_hashes: 1 },
+    ),
     &[],
     &[],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
-    &[(NodeIndex::from(7), UpdatedSkeletonNode::Binary)]
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD, n_new_hashes: 2 },
+    &[(NodeIndex::from(7), UpdatedSkeletonNode::Binary { n_new_hashes: 1 })]
 )]
 #[case::to_non_empty_leaf(
     &PathToBottom::RIGHT_CHILD,
     (&NodeIndex::from(7), &TempSkeletonNode::Leaf),
     &[(NodeIndex::from(7), 1)],
     &[],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD, n_new_hashes: 1 },
     &[]
 )]
 fn test_node_from_edge_data(
@@ -297,7 +301,7 @@ fn test_node_from_edge_data(
 #[case::one_leaf(
     &NodeIndex::ROOT,
     &[(NodeIndex::FIRST_LEAF, 1)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("0".repeat(251).as_str()) },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("0".repeat(251).as_str()), n_new_hashes: 1 },
     &[],
 )]
 // Note: the root is only finalized in the outer (create) function, so it doesn't appear in the
@@ -305,12 +309,18 @@ fn test_node_from_edge_data(
 #[case::leaves_on_both_sides(
     &NodeIndex::ROOT,
     &[(NodeIndex::FIRST_LEAF, 1), (NodeIndex::MAX, 1)],
-    TempSkeletonNode::OriginalBinary,
+    TempSkeletonNode::OriginalBinary { n_new_hashes: 3 },
     &[
         (NodeIndex::from(2),
-        UpdatedSkeletonNode::Edge(PathToBottom::from("0".repeat(250).as_str()))),
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::from("0".repeat(250).as_str()),
+            n_new_hashes: 1,
+        }),
         (NodeIndex::from(3),
-        UpdatedSkeletonNode::Edge(PathToBottom::from("1".repeat(250).as_str())))],
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::from("1".repeat(250).as_str()),
+            n_new_hashes: 1,
+        })],
 )]
 #[case::root_is_a_leaf(
     &NodeIndex::FIRST_LEAF,
@@ -364,7 +374,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Binary)
     ],
     &[(NodeIndex::FIRST_LEAF, 1)],
-    TempSkeletonNode::OriginalBinary,
+    TempSkeletonNode::OriginalBinary { n_new_hashes: 1 },
     &[],
 )]
 #[case::orig_binary_with_deleted_leaf(
@@ -375,7 +385,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Binary)
     ],
     &[(NodeIndex::FIRST_LEAF, 0)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD, n_new_hashes: 1 },
     &[],
 )]
 #[case::orig_binary_with_deleted_leaves(
@@ -398,10 +408,12 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF + 2, 1),
         (NodeIndex::FIRST_LEAF + 3, 1)
     ],
-    TempSkeletonNode::OriginalBinary,
+    TempSkeletonNode::OriginalBinary { n_new_hashes: 3 },
     &[
-        (NodeIndex::FIRST_LEAF >> 1, UpdatedSkeletonNode::Binary),
-        ((NodeIndex::FIRST_LEAF >> 1) + 1, UpdatedSkeletonNode::Binary)
+        (NodeIndex::FIRST_LEAF >> 1,
+        UpdatedSkeletonNode::Binary { n_new_hashes: 1 }),
+        ((NodeIndex::FIRST_LEAF >> 1) + 1,
+        UpdatedSkeletonNode::Binary { n_new_hashes: 1 })
     ],
 )]
 // The following cases test the `update_edge_node` function as well.
@@ -420,14 +432,14 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD)),
     ],
     &[(NodeIndex::FIRST_LEAF, 1)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD, n_new_hashes: 1 },
     &[],
 )]
 #[case::orig_edge_with_two_modified_leaves(
     &(NodeIndex::FIRST_LEAF >> 1),
     vec![(NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD))],
     &[(NodeIndex::FIRST_LEAF, 1), (NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::OriginalBinary,
+    TempSkeletonNode::OriginalBinary { n_new_hashes: 1 },
     &[
         (NodeIndex::FIRST_LEAF, UpdatedSkeletonNode::Leaf),
         (NodeIndex::FIRST_LEAF + 1, UpdatedSkeletonNode::Leaf)
@@ -440,7 +452,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF, OriginalSkeletonNode::UnmodifiedSubTree(HashOutput(Felt::ONE)))
     ],
     &[(NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::OriginalBinary,
+    TempSkeletonNode::OriginalBinary { n_new_hashes: 1 },
     &[],
 )]
 #[case::orig_edge_with_deleted_bottom_and_added_leaf(
@@ -449,7 +461,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD)),
     ],
     &[(NodeIndex::FIRST_LEAF, 0), (NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD, n_new_hashes: 1 },
     &[],
 )]
 #[case::orig_edge_with_modified_leaves_beneath_bottom(
@@ -459,8 +471,9 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Binary),
     ],
     &[(NodeIndex::FIRST_LEAF, 1), (NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD },
-    &[(NodeIndex::FIRST_LEAF >> 1, UpdatedSkeletonNode::Binary)],
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD, n_new_hashes: 2 },
+    &[(NodeIndex::FIRST_LEAF >> 1,
+    UpdatedSkeletonNode::Binary { n_new_hashes: 1 })],
 )]
 fn test_update_node_in_nonempty_tree(
     #[case] root_index: &NodeIndex,

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
@@ -3,10 +3,13 @@ use starknet_api::hash::HashOutput;
 use crate::patricia_merkle_tree::node_data::inner_node::PathToBottom;
 
 /// A node in the structure of a Patricia-Merkle tree, after the update.
+///
+/// `n_new_hashes` is the number of node hashes that must be computed for the
+/// subtree rooted at this node during the filled-tree pass.
 #[derive(Debug, Clone, PartialEq)]
 pub enum UpdatedSkeletonNode {
-    Binary,
-    Edge(PathToBottom),
+    Binary { n_new_hashes: usize },
+    Edge { path_to_bottom: PathToBottom, n_new_hashes: usize },
     // Represents a root of a subtree where none of it's descendants has changed.
     UnmodifiedSubTree(HashOutput),
     Leaf,

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
@@ -57,8 +57,12 @@ impl<'a> UpdatedSkeletonTree<'a> for UpdatedSkeletonTreeImpl {
         let temp_root_node = updated_skeleton_tree.finalize_middle_layers(original_skeleton);
         // Finalize root.
         let root_node = match temp_root_node {
-            TempSkeletonNode::OriginalBinary => UpdatedSkeletonNode::Binary,
-            TempSkeletonNode::OriginalEdge { path } => UpdatedSkeletonNode::Edge(path),
+            TempSkeletonNode::OriginalBinary { n_new_hashes } => {
+                UpdatedSkeletonNode::Binary { n_new_hashes }
+            }
+            TempSkeletonNode::OriginalEdge { path, n_new_hashes } => {
+                UpdatedSkeletonNode::Edge { path_to_bottom: path, n_new_hashes }
+            }
             TempSkeletonNode::Empty => {
                 assert!(updated_skeleton_tree.skeleton_tree.is_empty());
                 return Ok(updated_skeleton_tree);

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree_test.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree_test.rs
@@ -35,16 +35,23 @@ fn initial_updated_skeleton(
     &[(NodeIndex::FIRST_LEAF, 1)],
     &[
         (NodeIndex::ROOT,
-        UpdatedSkeletonNode::Edge(PathToBottom::from("0".repeat(TREE_HEIGHT).as_str())))
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::from("0".repeat(TREE_HEIGHT).as_str()),
+            n_new_hashes: 1,
+        })
     ],
 )]
 #[case::empty_to_binary(
     &[],
     &[(NodeIndex::FIRST_LEAF, 1), (NodeIndex::FIRST_LEAF + 1, 1)],
     &([
-        (NodeIndex::FIRST_LEAF >> 1, UpdatedSkeletonNode::Binary),
+        (NodeIndex::FIRST_LEAF >> 1,
+        UpdatedSkeletonNode::Binary { n_new_hashes: 1 }),
         (NodeIndex::ROOT,
-        UpdatedSkeletonNode::Edge(PathToBottom::from("0".repeat(TREE_HEIGHT - 1).as_str()))),
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::from("0".repeat(TREE_HEIGHT - 1).as_str()),
+            n_new_hashes: 2,
+        }),
     ]),
 )]
 #[case::nonempty_to_empty_tree(
@@ -67,9 +74,13 @@ fn initial_updated_skeleton(
     &[
         (
             NodeIndex::ROOT,
-            UpdatedSkeletonNode::Edge(PathToBottom::from("0".repeat(TREE_HEIGHT - 1).as_str()))
+            UpdatedSkeletonNode::Edge {
+                path_to_bottom: PathToBottom::from("0".repeat(TREE_HEIGHT - 1).as_str()),
+                n_new_hashes: 2,
+            }
         ),
-        (NodeIndex::FIRST_LEAF >> 1, UpdatedSkeletonNode::Binary)
+        (NodeIndex::FIRST_LEAF >> 1,
+        UpdatedSkeletonNode::Binary { n_new_hashes: 1 })
     ]
 )]
 #[case::non_empty_replace_edge_bottom(
@@ -83,7 +94,10 @@ fn initial_updated_skeleton(
     ],
     &[
         (NodeIndex::ROOT,
-        UpdatedSkeletonNode::Edge(PathToBottom::from(("0".repeat(TREE_HEIGHT - 1) + "1").as_str())))
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::from(("0".repeat(TREE_HEIGHT - 1) + "1").as_str()),
+            n_new_hashes: 1,
+        })
     ]
 )]
 #[case::fake_modification(
@@ -96,7 +110,10 @@ fn initial_updated_skeleton(
     ],
     &[
         (NodeIndex::ROOT,
-        UpdatedSkeletonNode::Edge(PathToBottom::from(("0".repeat(TREE_HEIGHT)).as_str())))
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::from(("0".repeat(TREE_HEIGHT)).as_str()),
+            n_new_hashes: 1,
+        })
     ]
 )]
 #[case::fake_deletion(
@@ -111,7 +128,10 @@ fn initial_updated_skeleton(
     ],
     &[
         (NodeIndex::ROOT,
-        UpdatedSkeletonNode::Edge(PathToBottom::from(("0".repeat(TREE_HEIGHT)).as_str())))
+        UpdatedSkeletonNode::Edge {
+            path_to_bottom: PathToBottom::from(("0".repeat(TREE_HEIGHT)).as_str()),
+            n_new_hashes: 1,
+        })
     ]
 )]
 fn test_updated_skeleton_tree_impl_create(


### PR DESCRIPTION
Add an `n_new_hashes` field to the Binary and Edge variants of
UpdatedSkeletonNode, holding the number of node hashes that must be
(re)computed for the subtree rooted at that node. The count is accumulated
in O(1) per node while the updated skeleton is structured bottom-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>