### PR TITLE
starknet_patricia: compute binary children concurrently only above new-hash threshold

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -24,6 +24,11 @@ use crate::patricia_merkle_tree::updated_skeleton_tree::tree::UpdatedSkeletonTre
 pub mod tree_test;
 
 pub(crate) type FilledTreeResult<T> = Result<T, FilledTreeError>;
+
+/// Minimum number of new hashes in each child of a binary node to be computed concurrently. Below
+/// this threshold the children are computed sequentially.
+const MIN_NEW_HASHES_FOR_CONCURRENT_BINARY: usize = 16;
+
 /// Consider a Patricia-Merkle Tree which has been updated with new leaves.
 /// FilledTree consists of all nodes which were modified in the update, including their updated
 /// data and hashes.
@@ -181,25 +186,38 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
                 let left_index = index * 2.into();
                 let right_index = left_index + NodeIndex::ROOT;
 
-                let (left_hash, right_hash) = (
-                    tokio::spawn(Self::compute_filled_tree_rec::<TH>(
-                        Arc::clone(&updated_skeleton),
-                        left_index,
-                        Arc::clone(&leaf_source),
-                        Arc::clone(&filled_tree_output_map),
-                    )),
-                    tokio::spawn(Self::compute_filled_tree_rec::<TH>(
-                        Arc::clone(&updated_skeleton),
-                        right_index,
-                        Arc::clone(&leaf_source),
-                        Arc::clone(&filled_tree_output_map),
-                    )),
+                let left_task = Self::compute_filled_tree_rec::<TH>(
+                    Arc::clone(&updated_skeleton),
+                    left_index,
+                    Arc::clone(&leaf_source),
+                    Arc::clone(&filled_tree_output_map),
+                );
+                let right_task = Self::compute_filled_tree_rec::<TH>(
+                    Arc::clone(&updated_skeleton),
+                    right_index,
+                    Arc::clone(&leaf_source),
+                    Arc::clone(&filled_tree_output_map),
                 );
 
-                let data = NodeData::Binary(BinaryData {
-                    left_data: left_hash.await??,
-                    right_data: right_hash.await??,
-                });
+                // Spawn the children concurrently only when both subtrees are large enough to
+                // offset the task-spawning overhead, or whenever the leaves must be computed (which
+                // may be heavy); otherwise compute sequentially.
+                let both_children_heavy = updated_skeleton.get_node(left_index)?.n_new_hashes()
+                    >= MIN_NEW_HASHES_FOR_CONCURRENT_BINARY
+                    && updated_skeleton.get_node(right_index)?.n_new_hashes()
+                        >= MIN_NEW_HASHES_FOR_CONCURRENT_BINARY;
+
+                let (left_data, right_data) = if both_children_heavy
+                    || matches!(leaf_source.as_ref(), LeafSource::ComputeLeaves { .. })
+                {
+                    let (left_hash, right_hash) =
+                        (tokio::spawn(left_task), tokio::spawn(right_task));
+                    (left_hash.await??, right_hash.await??)
+                } else {
+                    (left_task.await?, right_task.await?)
+                };
+
+                let data = NodeData::Binary(BinaryData { left_data, right_data });
 
                 let hash = TH::compute_node_hash(&data);
                 Self::write_to_output_map(

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -24,6 +24,11 @@ use crate::patricia_merkle_tree::updated_skeleton_tree::tree::UpdatedSkeletonTre
 pub mod tree_test;
 
 pub(crate) type FilledTreeResult<T> = Result<T, FilledTreeError>;
+
+/// Minimum number of new hashes in each child of a binary node for its children to be computed
+/// concurrently. When either child is below this threshold the children are computed sequentially.
+const MIN_NEW_HASHES_FOR_CONCURRENT_BINARY: usize = 16;
+
 /// Consider a Patricia-Merkle Tree which has been updated with new leaves.
 /// FilledTree consists of all nodes which were modified in the update, including their updated
 /// data and hashes.
@@ -181,25 +186,38 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
                 let left_index = index * 2.into();
                 let right_index = left_index + NodeIndex::ROOT;
 
-                let (left_hash, right_hash) = (
-                    tokio::spawn(Self::compute_filled_tree_rec::<TH>(
-                        Arc::clone(&updated_skeleton),
-                        left_index,
-                        Arc::clone(&leaf_source),
-                        Arc::clone(&filled_tree_output_map),
-                    )),
-                    tokio::spawn(Self::compute_filled_tree_rec::<TH>(
-                        Arc::clone(&updated_skeleton),
-                        right_index,
-                        Arc::clone(&leaf_source),
-                        Arc::clone(&filled_tree_output_map),
-                    )),
+                let left_task = Self::compute_filled_tree_rec::<TH>(
+                    Arc::clone(&updated_skeleton),
+                    left_index,
+                    Arc::clone(&leaf_source),
+                    Arc::clone(&filled_tree_output_map),
+                );
+                let right_task = Self::compute_filled_tree_rec::<TH>(
+                    Arc::clone(&updated_skeleton),
+                    right_index,
+                    Arc::clone(&leaf_source),
+                    Arc::clone(&filled_tree_output_map),
                 );
 
-                let data = NodeData::Binary(BinaryData {
-                    left_data: left_hash.await??,
-                    right_data: right_hash.await??,
-                });
+                // Spawn the children concurrently when the leaves must be computed (which may be
+                // heavy regardless of the new-hash count), or when both subtrees are large enough
+                // to offset the task-spawning overhead; otherwise compute sequentially.
+                let spawn_children =
+                    matches!(leaf_source.as_ref(), LeafSource::ComputeLeaves { .. })
+                        || (updated_skeleton.get_node(left_index)?.n_new_hashes()
+                            >= MIN_NEW_HASHES_FOR_CONCURRENT_BINARY
+                            && updated_skeleton.get_node(right_index)?.n_new_hashes()
+                                >= MIN_NEW_HASHES_FOR_CONCURRENT_BINARY);
+
+                let (left_data, right_data) = if spawn_children {
+                    let (left_hash, right_hash) =
+                        (tokio::spawn(left_task), tokio::spawn(right_task));
+                    (left_hash.await??, right_hash.await??)
+                } else {
+                    (left_task.await?, right_task.await?)
+                };
+
+                let data = NodeData::Binary(BinaryData { left_data, right_data });
 
                 let hash = TH::compute_node_hash(&data);
                 Self::write_to_output_map(

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
@@ -42,7 +42,8 @@ impl TempSkeletonNode {
         *self == Self::Empty
     }
 
-    /// The number of node hashes that must be (re)computed for the subtree rooted at this node.
+    /// The number of node hashes that must be (re)computed for the subtree rooted at this node
+    /// during the filled-tree pass.
     fn n_new_hashes(&self) -> usize {
         match self {
             Self::Empty | Self::Leaf | Self::OriginalUnmodified { .. } => 0,

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
@@ -14,3 +14,14 @@ pub enum UpdatedSkeletonNode {
     UnmodifiedSubTree(HashOutput),
     Leaf,
 }
+
+impl UpdatedSkeletonNode {
+    /// The number of node hashes that must be (re)computed for the subtree rooted at this node
+    /// during the filled-tree pass.
+    pub fn n_new_hashes(&self) -> usize {
+        match self {
+            Self::Binary { n_new_hashes } | Self::Edge { n_new_hashes, .. } => *n_new_hashes,
+            Self::UnmodifiedSubTree(_) | Self::Leaf => 0,
+        }
+    }
+}


### PR DESCRIPTION
In compute_filled_tree_rec, spawn the two children of a binary node on separate
tasks only when its subtree has at least MIN_NEW_HASHES_FOR_CONCURRENT_BINARY (16)
new hashes to compute. For smaller subtrees the task-spawning overhead outweighs
the parallelism gain, so the children are computed sequentially.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>