### PR TITLE
deployment: add hybrid common native override layer + lockstep test

### DIFF
--- a/deployments/sequencer/configs/overlays/hybrid/common/sequencer_config.jsonnet
+++ b/deployments/sequencer/configs/overlays/hybrid/common/sequencer_config.jsonnet
@@ -1,0 +1,109 @@
+// Base nested-overrides layer for the `hybrid` layout (env-independent commons only).
+{
+  eth_fee_token_address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
+  strk_fee_token_address: '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
+  versioned_constants_overrides: null,
+
+  batcher_config: {
+    dynamic_config: {
+      proposer_idle_detection_delay_millis: 1500,
+    },
+    static_config: {
+      block_builder_config: {
+        bouncer_config: {
+          block_max_capacity: {
+            n_events: 5000,
+            receipt_l2_gas: 5800000000,
+          },
+        },
+      },
+    },
+  },
+  class_manager_config: {
+    static_config: {
+      class_manager_config: {
+        max_compiled_contract_class_object_size: 4089446,
+      },
+    },
+  },
+  committer_config: {
+    storage_config: {
+      inner_storage_config: {
+        cache_size: 8589934592,
+      },
+    },
+    verify_state_diff_hash: true,
+  },
+  consensus_manager_config: {
+    consensus_manager_config: {
+      dynamic_config: {
+        require_virtual_proposer_vote: false,
+        timeouts: {
+          proposal: {
+            base: 9.1,
+            max: 9.1,
+          },
+        },
+      },
+    },
+    context_config: {
+      dynamic_config: {
+        build_proposal_margin_millis: 1000,
+        compare_retrospective_block_hash: true,
+        override_eth_to_fri_rate: null,
+        override_l1_data_gas_price_fri: null,
+        override_l1_gas_price_fri: null,
+        override_l2_gas_price_fri: null,
+      },
+    },
+    network_config: {
+      port: 53080,
+    },
+    staking_manager_config: {
+      dynamic_config: {
+        override_committee: null,
+      },
+    },
+  },
+  gateway_config: {
+    static_config: {
+      authorized_declarer_accounts: null,
+      stateful_tx_validator_config: {
+        max_allowed_nonce_gap: 200,
+      },
+      stateless_tx_validator_config: {
+        max_contract_bytecode_size: 81920,
+        min_gas_price: 8000000000,
+      },
+    },
+  },
+  http_server_config: {
+    static_config: {
+      port: 8080,
+    },
+  },
+  mempool_config: {
+    dynamic_config: {
+      transaction_ttl: 300,
+    },
+  },
+  mempool_p2p_config: {
+    network_config: {
+      port: 53200,
+    },
+  },
+  monitoring_endpoint_config: {
+    port: 8082,
+  },
+  sierra_compiler_config: {
+    max_bytecode_size: 81920,
+  },
+  state_sync_config: {
+    static_config: {
+      p2p_sync_client_config: null,
+      rpc_config: {
+        port: 8090,
+      },
+    },
+  },
+}

--- a/deployments/sequencer/test/test_native_config.py
+++ b/deployments/sequencer/test/test_native_config.py
@@ -1,14 +1,27 @@
-"""Tests for the native (nested) node-config generation machinery.
+"""Tests for the native (nested) node-config generation path.
 
-Covers the pure building blocks of the native config builder (`src/config/native.py`):
-  - the null-preserving deep-merge.
-
-The override-layer data (the per-layer `sequencer_config.jsonnet` files) and the data-validation
-tests that exercise it end-to-end — the AUTHORITATIVE PARITY test (native vs folded/filtered preset)
-and the "jsonnet mirrors combined YAML" layer tests — land together with those layers in a follow-up.
+Covers:
+  - the null-preserving deep-merge,
+  - the per-layer lockstep test: the common base `sequencer_config.jsonnet` mirrors the combined
+    `config.sequencerConfig` of the common-layer YAMLs (folded).
 """
 
-from src.config.native import deep_merge_preserving_null
+import json
+from pathlib import Path
+
+import _jsonnet
+import yaml
+from src.config.native import JSONNET_DIR, deep_merge_preserving_null
+
+DEPLOYMENTS_SEQUENCER = Path(__file__).resolve().parents[1]
+
+LAYOUT = "hybrid"
+
+# Per-layer override-file dirs: the base/common layer holds a `sequencer_config.jsonnet` that must
+# mirror the combined `config.sequencerConfig` of the YAMLs in the same dir (see
+# `_assert_layer_jsonnet_mirrors_combined_yaml`).
+HYBRID_OVERLAYS_DIR = DEPLOYMENTS_SEQUENCER / "configs" / "overlays" / LAYOUT
+COMMON_LAYER_DIR = HYBRID_OVERLAYS_DIR / "common"
 
 
 def test_deep_merge_preserves_explicit_null():
@@ -38,3 +51,118 @@ def test_deep_merge_does_not_mutate_inputs():
     deep_merge_preserving_null(base, overlay)
     assert base == {"a": {"x": 1}}  # Verify base is not mutated.
     assert overlay == {"a": {"y": 2}}  # Verify overlay is not mutated.
+
+
+def _flatten(nested: dict, prefix: str = "") -> dict:
+    """Flatten a nested config to dotted keys. Lists and null are leaf values (not recursed)."""
+    flat = {}
+    for key, value in nested.items():
+        dotted = f"{prefix}{key}"
+        if isinstance(value, dict):
+            flat.update(_flatten(value, prefix=f"{dotted}."))
+        else:
+            flat[dotted] = value
+    return flat
+
+
+def _is_under(prefix: str, dotted_key: str) -> bool:
+    """True if `dotted_key` equals `prefix` or is nested under it (segment-aligned)."""
+    return dotted_key == prefix or dotted_key.startswith(prefix + ".")
+
+
+def _combined_layer_sequencer_config(layer_dir: Path) -> dict:
+    """Merge the flat-dotted `config.sequencerConfig` across one overlay layer's YAMLs.
+
+    Mirrors what the preset path merges for a single layer: `<layer>/common.yaml` first, then each
+    `<layer>/services/*.yaml` in sorted order (last wins). Returns the merged flat dotted-key dict
+    (still carrying `.#is_none` markers and `components.*`; fold/drop them with
+    `_fold_is_none_drop_components`).
+    """
+    merged: dict = {}
+    files = []
+    common_yaml = layer_dir / "common.yaml"
+    if common_yaml.exists():
+        files.append(common_yaml)
+    services_dir = layer_dir / "services"
+    if services_dir.is_dir():
+        files.extend(sorted(services_dir.glob("*.yaml")))
+    for yaml_file in files:
+        document = yaml.safe_load(yaml_file.read_text()) or {}
+        merged.update((document.get("config") or {}).get("sequencerConfig") or {})
+    return merged
+
+
+def _fold_is_none_drop_components(flat: dict) -> dict:
+    """Apply the same transform the jsonnet override layers encode, to a flat YAML sequencerConfig.
+
+    - drop every `components.*` key (the layout supplies components);
+    - `<path>.#is_none: true`  -> `<path>: null` and drop the whole `<path>.*` subtree;
+    - `<path>.#is_none: false` -> drop only the marker, keep the real sub-keys.
+    Returns a flat dotted dict directly comparable to the flattened jsonnet layer.
+    """
+    none_true_roots = [
+        key[: -len(".#is_none")]
+        for key, value in flat.items()
+        if key.endswith(".#is_none") and value is True
+    ]
+    folded = {}
+    for key, value in flat.items():
+        if key.split(".", 1)[0] == "components":
+            continue
+        if key.endswith(".#is_none"):
+            continue  # drop all markers (true and false)
+        if any(_is_under(root, key) for root in none_true_roots):
+            continue  # drop the subtree of a None-folded option
+        folded[key] = value
+    for root in none_true_roots:
+        if root.split(".", 1)[0] != "components":
+            folded[root] = None  # the option itself folds to null
+    return folded
+
+
+def _eval_layer_jsonnet(layer_dir: Path) -> dict:
+    """Evaluate `<layer>/sequencer_config.jsonnet` to a nested Python dict."""
+    path = layer_dir / "sequencer_config.jsonnet"
+    return json.loads(_jsonnet.evaluate_file(str(path), jpathdir=[str(JSONNET_DIR)]))
+
+
+def _assert_layer_jsonnet_mirrors_combined_yaml(layer_dir: Path):
+    """Shared assertion for the per-layer regression tests.
+
+    Asserts the layer's `sequencer_config.jsonnet` (flattened to dotted keys) has EXACTLY the keys
+    of, and equal values to, the combined `config.sequencerConfig` of that layer's YAMLs (folded:
+    `#is_none` applied, `components.*` dropped). This keeps the native override layers in lockstep
+    with the YAML overlays the preset path consumes, so the two generation paths cannot silently
+    drift. (The storage-reader ports are not a special case: they are fixed infra constants, baked
+    into the app_configs and `applicative_config.libsonnet`, and absent from BOTH the YAMLs and the
+    jsonnet layers.)
+    """
+    jsonnet_flat = _flatten(_eval_layer_jsonnet(layer_dir))
+    expected = _fold_is_none_drop_components(_combined_layer_sequencer_config(layer_dir))
+
+    missing_in_jsonnet = sorted(set(expected) - set(jsonnet_flat))
+    extra_in_jsonnet = sorted(set(jsonnet_flat) - set(expected))
+    value_diffs = sorted(
+        key for key in set(jsonnet_flat) & set(expected) if jsonnet_flat[key] != expected[key]
+    )
+
+    assert not (missing_in_jsonnet or extra_in_jsonnet or value_diffs), (
+        f"{layer_dir.name}/sequencer_config.jsonnet diverges from the combined "
+        f"config.sequencerConfig of its YAMLs (folded):\n"
+        f"  missing in jsonnet ({len(missing_in_jsonnet)}): {missing_in_jsonnet}\n"
+        f"  extra in jsonnet ({len(extra_in_jsonnet)}): {extra_in_jsonnet}\n"
+        f"  value diffs ({len(value_diffs)}):\n    "
+        + "\n    ".join(
+            f"{key}: jsonnet={jsonnet_flat[key]!r} yaml={expected[key]!r}" for key in value_diffs
+        )
+    )
+
+
+def test_common_layer_jsonnet_mirrors_combined_yaml():
+    """REGRESSION: the common base `sequencer_config.jsonnet` equals the combined common-layer
+    `config.sequencerConfig` (folded), exactly.
+
+    Catches drift in either direction: a common-YAML override not transcribed into the base jsonnet,
+    a stale/extra key in the jsonnet, or a value mismatch.
+    """
+    _assert_layer_jsonnet_mirrors_combined_yaml(COMMON_LAYER_DIR)


### PR DESCRIPTION
Add the base (common) hybrid sequencer_config.jsonnet override layer consumed by the native config builder, plus the durable per-layer regression test that keeps it in lockstep with the YAML overlays: the common layer's jsonnet, flattened to dotted keys, must exactly match the combined config.sequencerConfig of the common-layer YAMLs (with #is_none folded and components.* dropped). This prevents the native and preset generation paths from silently drifting.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>