### PR TITLE
apollo_batcher: avoid redundant tx clone in add_txs_to_executor

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -512,17 +512,23 @@ impl BlockBuilder {
         }
 
         let n_txs = next_txs.len();
+        let block_txs_start = self.block_txs.len();
         debug!(
             "Got {} transactions from the transaction provider (aggregated: {}).",
             n_txs,
-            self.block_txs.len() + n_txs
+            block_txs_start + n_txs
         );
 
-        self.block_txs.extend(next_txs.iter().cloned());
+        // Move next_txs into block_txs instead of cloning. Conversion and (in propose mode)
+        // forwarding to validators each require one clone per tx — but those clones can be taken
+        // directly from block_txs, so the initial extend no longer needs to clone.
+        // Savings: N heap allocations per batch on the validate path; same count on the propose
+        // path (the clone previously done for the extend is now done for the send instead).
+        self.block_txs.extend(next_txs);
 
-        let tx_convert_futures = next_txs.iter().map(|tx| async {
-            convert_to_executable_blockifier_tx(&self.transaction_converter, tx.clone()).await
-        });
+        let tx_convert_futures = self.block_txs[block_txs_start..]
+            .iter()
+            .map(|tx| convert_to_executable_blockifier_tx(&self.transaction_converter, tx.clone()));
         let executor_input_chunk = futures::future::try_join_all(tx_convert_futures).await?;
 
         // Start the execution of the transactions on the worker pool.
@@ -537,8 +543,8 @@ impl BlockBuilder {
         if let Some(output_content_sender) = &self.output_content_sender {
             // Send the transactions to the validators.
             // Only reached in proposal flow.
-            for tx in next_txs.into_iter() {
-                output_content_sender.send(tx).map_err(Box::new)?;
+            for tx in &self.block_txs[block_txs_start..] {
+                output_content_sender.send(tx.clone()).map_err(Box::new)?;
             }
         }
 

--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -519,11 +519,6 @@ impl BlockBuilder {
             block_txs_start + n_txs
         );
 
-        // Move next_txs into block_txs instead of cloning. Conversion and (in propose mode)
-        // forwarding to validators each require one clone per tx — but those clones can be taken
-        // directly from block_txs, so the initial extend no longer needs to clone.
-        // Savings: N heap allocations per batch on the validate path; same count on the propose
-        // path (the clone previously done for the extend is now done for the send instead).
         self.block_txs.extend(next_txs);
 
         let tx_convert_futures = self.block_txs[block_txs_start..]


### PR DESCRIPTION
## Performance follow-up to #14633

### What

In `add_txs_to_executor` (the hot inner loop of `build_block_inner`), each batch of N transactions was cloned **twice**:

1. `self.block_txs.extend(next_txs.iter().cloned())` — one clone to populate `block_txs`
2. `tx.clone()` inside the async conversion closure — a second clone for `convert_to_executable_blockifier_tx`

### Fix

Move `next_txs` into `block_txs` (zero-copy extend), then take the single required clone for conversion directly from `block_txs[block_txs_start..]`. In propose mode, forwarding to validators previously consumed `next_txs` directly (0 extra clones); it now clones from `block_txs` instead — same total clone count.

| Mode | Before | After |
|------|--------|-------|
| Validate | 2N clones | **N clones** |
| Propose  | 2N clones | 2N clones |

### Impact

`n_concurrent_txs = 100` by default, so this saves up to **100 full `InternalConsensusTransaction` heap copies per iteration** on the validate path. `InternalConsensusTransaction` carries calldata and other variable-length fields, so each saved clone avoids at least one heap allocation and copy of calldata bytes.

The validate path is the one #14633 just optimised for latency (10 ms polling interval). This change compounds that improvement by reducing per-iteration work.

### Verification

- `cargo build -p apollo_batcher` ✅
- `cargo test -p apollo_batcher`: **114 passed, 0 failed** ✅
- `scripts/rust_fmt.sh --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYhBtpaCKQy3fSMU9tHYrv)_