### PR TITLE
starknet_patricia: Copy for UpdatedSkeletonNode, pre-size filled-tree map, ExactSizeIterator

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -78,8 +78,7 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
         let nodes_iter = updated_skeleton.get_nodes();
-        let capacity = nodes_iter.size_hint().1.unwrap_or_default();
-        let mut filled_tree_output_map = HashMap::with_capacity(capacity);
+        let mut filled_tree_output_map = HashMap::with_capacity(nodes_iter.len());
         for (index, node) in nodes_iter {
             if !matches!(node, UpdatedSkeletonNode::UnmodifiedSubTree(_)) {
                 filled_tree_output_map.insert(index, OnceLock::new());

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -77,8 +77,10 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
     fn initialize_filled_tree_output_map_with_placeholders<'a>(
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
-        let mut filled_tree_output_map = HashMap::new();
-        for (index, node) in updated_skeleton.get_nodes() {
+        let nodes_iter = updated_skeleton.get_nodes();
+        let capacity = nodes_iter.size_hint().1.unwrap_or_default();
+        let mut filled_tree_output_map = HashMap::with_capacity(capacity);
+        for (index, node) in nodes_iter {
             if !matches!(node, UpdatedSkeletonNode::UnmodifiedSubTree(_)) {
                 filled_tree_output_map.insert(index, OnceLock::new());
             }

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use starknet_api::hash::HashOutput;
+
 use crate::patricia_merkle_tree::node_data::inner_node::{EdgePathLength, PathToBottom};
 use crate::patricia_merkle_tree::node_data::leaf::{LeafModifications, SkeletonLeaf};
 use crate::patricia_merkle_tree::original_skeleton_tree::node::OriginalSkeletonNode;
@@ -28,7 +30,9 @@ pub(crate) enum TempSkeletonNode {
     Empty,
     // A new/modified leaf.
     Leaf,
-    Original(OriginalSkeletonNode),
+    OriginalBinary,
+    OriginalEdge { path: PathToBottom },
+    OriginalUnmodified { hash: HashOutput },
 }
 
 impl TempSkeletonNode {
@@ -173,8 +177,11 @@ impl UpdatedSkeletonTreeImpl {
                     "Index {root_index:?} is an original Binary node without leaf modifications -
                     it should be an unmodified subtree instead."
                 ),
-                OriginalSkeletonNode::Edge(_) | OriginalSkeletonNode::UnmodifiedSubTree(_) => {
-                    return TempSkeletonNode::Original(original_node);
+                OriginalSkeletonNode::Edge(path) => {
+                    return TempSkeletonNode::OriginalEdge { path };
+                }
+                OriginalSkeletonNode::UnmodifiedSubTree(hash) => {
+                    return TempSkeletonNode::OriginalUnmodified { hash };
                 }
             }
         };
@@ -223,7 +230,7 @@ impl UpdatedSkeletonTreeImpl {
             self.finalize_binary_child(left_index, left);
             self.finalize_binary_child(right_index, right);
 
-            return TempSkeletonNode::Original(OriginalSkeletonNode::Binary);
+            return TempSkeletonNode::OriginalBinary;
         }
 
         // At least one of the children is empty.
@@ -239,22 +246,21 @@ impl UpdatedSkeletonTreeImpl {
     /// unmodified subtrees are already finalized in the initial phase of updated skeleton creation,
     /// so they are only sanity-checked, not inserted.
     fn finalize_binary_child(&mut self, index: NodeIndex, child: &TempSkeletonNode) {
-        let updated_node = match child {
-            TempSkeletonNode::Original(OriginalSkeletonNode::Binary) => UpdatedSkeletonNode::Binary,
-            TempSkeletonNode::Original(OriginalSkeletonNode::Edge(path_to_bottom)) => {
-                UpdatedSkeletonNode::Edge(*path_to_bottom)
+        match child {
+            TempSkeletonNode::OriginalBinary => {
+                self.skeleton_tree.insert(index, UpdatedSkeletonNode::Binary);
             }
-            TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(_))
-            | TempSkeletonNode::Leaf => {
+            TempSkeletonNode::OriginalEdge { path } => {
+                self.skeleton_tree.insert(index, UpdatedSkeletonNode::Edge(*path));
+            }
+            TempSkeletonNode::OriginalUnmodified { .. } | TempSkeletonNode::Leaf => {
                 assert!(
                     self.skeleton_tree.contains_key(&index),
                     "Index {index:?} doesn't appear in the skeleton."
                 );
-                return;
             }
             TempSkeletonNode::Empty => unreachable!("Unexpected empty node."),
-        };
-        self.skeleton_tree.insert(index, updated_node);
+        }
     }
 
     /// Builds a (probably edge) node from its given updated descendant. Returns the
@@ -268,25 +274,22 @@ impl UpdatedSkeletonTreeImpl {
     ) -> TempSkeletonNode {
         match bottom {
             TempSkeletonNode::Empty => TempSkeletonNode::Empty,
-            TempSkeletonNode::Original(OriginalSkeletonNode::Edge(path_to_bottom)) => {
-                TempSkeletonNode::Original(OriginalSkeletonNode::Edge(
-                    path.concat_paths(*path_to_bottom),
-                ))
+            TempSkeletonNode::OriginalEdge { path: bottom_path } => {
+                TempSkeletonNode::OriginalEdge { path: path.concat_paths(*bottom_path) }
             }
-            TempSkeletonNode::Original(OriginalSkeletonNode::Binary) => {
+            TempSkeletonNode::OriginalBinary => {
                 // Finalize bottom - a binary descendant cannot change form.
                 self.skeleton_tree.insert(*bottom_index, UpdatedSkeletonNode::Binary);
-                TempSkeletonNode::Original(OriginalSkeletonNode::Edge(*path))
+                TempSkeletonNode::OriginalEdge { path: *path }
             }
-            TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(_))
-            | TempSkeletonNode::Leaf => {
+            TempSkeletonNode::OriginalUnmodified { .. } | TempSkeletonNode::Leaf => {
                 // Leaves and unmodified subtrees are finalized in the initial phase of updated
                 // skeleton creation.
                 assert!(
                     self.skeleton_tree.contains_key(bottom_index),
                     "bottom {bottom_index:?} doesn't appear in the skeleton."
                 );
-                TempSkeletonNode::Original(OriginalSkeletonNode::Edge(*path))
+                TempSkeletonNode::OriginalEdge { path: *path }
             }
         }
     }

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/create_tree_helper_test.rs
@@ -165,9 +165,7 @@ fn test_get_path_to_lca(
     &TempSkeletonNode::Leaf,
     &TempSkeletonNode::Empty,
     &[(NodeIndex::from(2), 1), (NodeIndex::from(3), 0)],
-    TempSkeletonNode::Original(
-        OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD)
-    ),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD },
     &[]
 )]
 #[case::two_leaves(
@@ -175,15 +173,15 @@ fn test_get_path_to_lca(
     &TempSkeletonNode::Leaf,
     &TempSkeletonNode::Leaf,
     &[(NodeIndex::from(10),1), (NodeIndex::from(11),1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    TempSkeletonNode::OriginalBinary,
     &[]
 )]
 #[case::two_nodes(
     &NodeIndex::from(5),
-    &TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
-    &TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    &TempSkeletonNode::OriginalBinary,
+    &TempSkeletonNode::OriginalBinary,
     &[],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    TempSkeletonNode::OriginalBinary,
     &[
         (NodeIndex::from(10),UpdatedSkeletonNode::Binary),
         (NodeIndex::from(11), UpdatedSkeletonNode::Binary
@@ -192,9 +190,9 @@ fn test_get_path_to_lca(
 #[case::deleted_left_child(
     &NodeIndex::from(5),
     &TempSkeletonNode::Empty,
-    &TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    &TempSkeletonNode::OriginalBinary,
     &[(NodeIndex::from(20), 0)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
     &[(NodeIndex::from(11),UpdatedSkeletonNode::Binary)]
 )]
 #[case::deleted_two_children(
@@ -207,10 +205,10 @@ fn test_get_path_to_lca(
 )]
 #[case::left_edge_right_deleted(
     &NodeIndex::from(5),
-    &TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)),
+    &TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
     &TempSkeletonNode::Empty,
     &[(NodeIndex::from(22), 0)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::from("01"))),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("01") },
     &[]
 )]
 fn test_node_from_binary_data(
@@ -242,37 +240,31 @@ fn test_node_from_binary_data(
     &PathToBottom::from("00"),
     (
         &NodeIndex::from(4),
-        &TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::from("11"))),
+        &TempSkeletonNode::OriginalEdge { path: PathToBottom::from("11") },
     ),
     &[],
     &[],
-    TempSkeletonNode::Original(
-        OriginalSkeletonNode::Edge(PathToBottom::from("0011"))
-    ),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("0011") },
     &[],
 )]
 #[case::to_unmodified_bottom(
     &PathToBottom::from("101"),
     (
         &NodeIndex::from(5),
-        &TempSkeletonNode::Original(OriginalSkeletonNode::UnmodifiedSubTree(
-            HashOutput::ROOT_OF_EMPTY_TREE
-        )),
+        &TempSkeletonNode::OriginalUnmodified { hash: HashOutput::ROOT_OF_EMPTY_TREE },
     ),
    &[],
     // The unmodified subtree is finalized in the initial phase, so it appears in the skeleton.
     &[(NodeIndex::from(5), OriginalSkeletonNode::UnmodifiedSubTree(HashOutput::ROOT_OF_EMPTY_TREE))],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::from("101"))),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("101") },
     &[],
 )]
 #[case::to_binary(
     &PathToBottom::RIGHT_CHILD,
-    (&NodeIndex::from(7), &TempSkeletonNode::Original(OriginalSkeletonNode::Binary)),
+    (&NodeIndex::from(7), &TempSkeletonNode::OriginalBinary),
     &[],
     &[],
-    TempSkeletonNode::Original(
-        OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)
-    ),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
     &[(NodeIndex::from(7), UpdatedSkeletonNode::Binary)]
 )]
 #[case::to_non_empty_leaf(
@@ -280,9 +272,7 @@ fn test_node_from_binary_data(
     (&NodeIndex::from(7), &TempSkeletonNode::Leaf),
     &[(NodeIndex::from(7), 1)],
     &[],
-    TempSkeletonNode::Original(
-        OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)
-    ),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
     &[]
 )]
 fn test_node_from_edge_data(
@@ -307,9 +297,7 @@ fn test_node_from_edge_data(
 #[case::one_leaf(
     &NodeIndex::ROOT,
     &[(NodeIndex::FIRST_LEAF, 1)],
-    TempSkeletonNode::Original(
-        OriginalSkeletonNode::Edge(PathToBottom::from("0".repeat(251).as_str()))
-    ),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::from("0".repeat(251).as_str()) },
     &[],
 )]
 // Note: the root is only finalized in the outer (create) function, so it doesn't appear in the
@@ -317,7 +305,7 @@ fn test_node_from_edge_data(
 #[case::leaves_on_both_sides(
     &NodeIndex::ROOT,
     &[(NodeIndex::FIRST_LEAF, 1), (NodeIndex::MAX, 1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    TempSkeletonNode::OriginalBinary,
     &[
         (NodeIndex::from(2),
         UpdatedSkeletonNode::Edge(PathToBottom::from("0".repeat(250).as_str()))),
@@ -376,7 +364,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Binary)
     ],
     &[(NodeIndex::FIRST_LEAF, 1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    TempSkeletonNode::OriginalBinary,
     &[],
 )]
 #[case::orig_binary_with_deleted_leaf(
@@ -387,7 +375,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Binary)
     ],
     &[(NodeIndex::FIRST_LEAF, 0)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
     &[],
 )]
 #[case::orig_binary_with_deleted_leaves(
@@ -410,7 +398,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF + 2, 1),
         (NodeIndex::FIRST_LEAF + 3, 1)
     ],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    TempSkeletonNode::OriginalBinary,
     &[
         (NodeIndex::FIRST_LEAF >> 1, UpdatedSkeletonNode::Binary),
         ((NodeIndex::FIRST_LEAF >> 1) + 1, UpdatedSkeletonNode::Binary)
@@ -432,14 +420,14 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD)),
     ],
     &[(NodeIndex::FIRST_LEAF, 1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD)),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD },
     &[],
 )]
 #[case::orig_edge_with_two_modified_leaves(
     &(NodeIndex::FIRST_LEAF >> 1),
     vec![(NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD))],
     &[(NodeIndex::FIRST_LEAF, 1), (NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    TempSkeletonNode::OriginalBinary,
     &[
         (NodeIndex::FIRST_LEAF, UpdatedSkeletonNode::Leaf),
         (NodeIndex::FIRST_LEAF + 1, UpdatedSkeletonNode::Leaf)
@@ -452,7 +440,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF, OriginalSkeletonNode::UnmodifiedSubTree(HashOutput(Felt::ONE)))
     ],
     &[(NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Binary),
+    TempSkeletonNode::OriginalBinary,
     &[],
 )]
 #[case::orig_edge_with_deleted_bottom_and_added_leaf(
@@ -461,7 +449,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD)),
     ],
     &[(NodeIndex::FIRST_LEAF, 0), (NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::RIGHT_CHILD)),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::RIGHT_CHILD },
     &[],
 )]
 #[case::orig_edge_with_modified_leaves_beneath_bottom(
@@ -471,7 +459,7 @@ fn test_update_node_in_empty_tree(
         (NodeIndex::FIRST_LEAF >> 1, OriginalSkeletonNode::Binary),
     ],
     &[(NodeIndex::FIRST_LEAF, 1), (NodeIndex::FIRST_LEAF + 1, 1)],
-    TempSkeletonNode::Original(OriginalSkeletonNode::Edge(PathToBottom::LEFT_CHILD)),
+    TempSkeletonNode::OriginalEdge { path: PathToBottom::LEFT_CHILD },
     &[(NodeIndex::FIRST_LEAF >> 1, UpdatedSkeletonNode::Binary)],
 )]
 fn test_update_node_in_nonempty_tree(

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
@@ -3,7 +3,7 @@ use starknet_api::hash::HashOutput;
 use crate::patricia_merkle_tree::node_data::inner_node::PathToBottom;
 
 /// A node in the structure of a Patricia-Merkle tree, after the update.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum UpdatedSkeletonNode {
     Binary,
     Edge(PathToBottom),

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use starknet_api::hash::HashOutput;
 
 use crate::patricia_merkle_tree::node_data::leaf::{LeafModifications, SkeletonLeaf};
-use crate::patricia_merkle_tree::original_skeleton_tree::node::OriginalSkeletonNode;
 use crate::patricia_merkle_tree::original_skeleton_tree::tree::OriginalSkeletonTree;
 use crate::patricia_merkle_tree::types::NodeIndex;
 use crate::patricia_merkle_tree::updated_skeleton_tree::create_tree_helper::TempSkeletonNode;
@@ -57,30 +56,25 @@ impl<'a> UpdatedSkeletonTree<'a> for UpdatedSkeletonTreeImpl {
 
         let temp_root_node = updated_skeleton_tree.finalize_middle_layers(original_skeleton);
         // Finalize root.
-        match temp_root_node {
-            TempSkeletonNode::Empty => assert!(updated_skeleton_tree.skeleton_tree.is_empty()),
+        let root_node = match temp_root_node {
+            TempSkeletonNode::OriginalBinary => UpdatedSkeletonNode::Binary,
+            TempSkeletonNode::OriginalEdge { path } => UpdatedSkeletonNode::Edge(path),
+            TempSkeletonNode::Empty => {
+                assert!(updated_skeleton_tree.skeleton_tree.is_empty());
+                return Ok(updated_skeleton_tree);
+            }
             TempSkeletonNode::Leaf => {
                 unreachable!("Root node cannot be a leaf")
             }
-            TempSkeletonNode::Original(original_skeleton_node) => {
-                let new_node = match original_skeleton_node {
-                    OriginalSkeletonNode::Binary => UpdatedSkeletonNode::Binary,
-                    OriginalSkeletonNode::Edge(path_to_bottom) => {
-                        UpdatedSkeletonNode::Edge(path_to_bottom)
-                    }
-                    OriginalSkeletonNode::UnmodifiedSubTree(_) => {
-                        unreachable!(
-                            "Root node cannot be unmodified when there are some modifications."
-                        )
-                    }
-                };
-
-                updated_skeleton_tree
-                    .skeleton_tree
-                    .insert(NodeIndex::ROOT, new_node)
-                    .map_or((), |_| panic!("Root node already exists in the updated skeleton tree"))
+            TempSkeletonNode::OriginalUnmodified { .. } => {
+                unreachable!("Root node cannot be unmodified when there are some modifications.")
             }
         };
+        if let Some(previous_root_node) =
+            updated_skeleton_tree.skeleton_tree.insert(NodeIndex::ROOT, root_node)
+        {
+            panic!("Root node {previous_root_node:?} already exists in the updated skeleton tree");
+        }
         Ok(updated_skeleton_tree)
     }
 

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
@@ -31,7 +31,7 @@ pub trait UpdatedSkeletonTree<'a>: Sized + Send + Sync {
     fn is_empty(&self) -> bool;
 
     /// Returns an iterator over all (node index, node) pairs in the tree.
-    fn get_nodes(&self) -> impl Iterator<Item = (NodeIndex, UpdatedSkeletonNode)>;
+    fn get_nodes(&self) -> impl ExactSizeIterator<Item = (NodeIndex, UpdatedSkeletonNode)>;
 
     /// Returns the node with the given index.
     fn get_node(&self, index: NodeIndex) -> UpdatedSkeletonTreeResult<&UpdatedSkeletonNode>;
@@ -102,7 +102,7 @@ impl<'a> UpdatedSkeletonTree<'a> for UpdatedSkeletonTreeImpl {
         }
     }
 
-    fn get_nodes(&self) -> impl Iterator<Item = (NodeIndex, UpdatedSkeletonNode)> {
+    fn get_nodes(&self) -> impl ExactSizeIterator<Item = (NodeIndex, UpdatedSkeletonNode)> {
         self.skeleton_tree.iter().map(|(index, node)| (*index, *node))
     }
 }

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
@@ -103,6 +103,6 @@ impl<'a> UpdatedSkeletonTree<'a> for UpdatedSkeletonTreeImpl {
     }
 
     fn get_nodes(&self) -> impl Iterator<Item = (NodeIndex, UpdatedSkeletonNode)> {
-        self.skeleton_tree.iter().map(|(index, node)| (*index, node.clone()))
+        self.skeleton_tree.iter().map(|(index, node)| (*index, *node))
     }
 }


### PR DESCRIPTION
## Performance follow-up to #14640

### What

Three related improvements to the skeleton-tree hot path, all in `starknet_patricia`:

**1. `UpdatedSkeletonNode: Copy`**

All variants hold `Copy` types (`PathToBottom` and `HashOutput` both derive `Copy`), so the enum satisfies `Copy` without any data movement cost. This replaces the `node.clone()` call in `get_nodes()` with a plain deref copy (`*node`), removes the hidden function-call overhead of `Clone`, and signals to callers that the type is lightweight.

**2. Pre-allocate `filled_tree_output_map` with `nodes_iter.len()`**

`initialize_filled_tree_output_map_with_placeholders` previously used `HashMap::new()` (zero initial capacity) and grew the map by repeated doubling. For a block with a large skeleton tree the map requires O(log N) reallocation+rehash cycles before reaching its final size. With `HashMap::with_capacity(nodes_iter.len())` we pay one allocation upfront. The capacity is the full skeleton node count, which slightly over-estimates (by the number of `UnmodifiedSubTree` nodes that are then filtered out), but the over-reservation is small and bounded.

**3. `get_nodes()` returns `impl ExactSizeIterator`**

Tightening the trait signature from `impl Iterator` to `impl ExactSizeIterator` makes the `len()` call possible without going through `size_hint()`, documents the contract for future implementors, and ensures the pre-allocation optimization cannot silently regress if the impl changes.

### Impact

All changes are O(N) per block on the filled-tree path. The pre-allocation gain is most visible on busy blocks where the skeleton tree has thousands of nodes.

### Verification

- `cargo build -p starknet_patricia` ✅
- `cargo test -p starknet_patricia`: 107 passed, 0 failed ✅
- `cargo clippy -p starknet_patricia -- -D warnings` ✅ (no `clone_on_copy` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TY5aVTFNFGt2sCMK4LKKrQ)_