### PR TITLE
starknet_patricia: pre-size filled-tree output map using n_new_hashes

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -76,8 +76,15 @@ enum LeafSource<L: Leaf> {
 impl<L: Leaf + 'static> FilledTreeImpl<L> {
     fn initialize_filled_tree_output_map_with_placeholders<'a>(
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
+        num_leaves: usize,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
-        let mut filled_tree_output_map = HashMap::new();
+        // The root's n_new_hashes counts all Binary and Edge nodes that need hashing. Adding
+        // num_leaves gives the exact capacity for the placeholder map, avoiding rehashes.
+        let num_inner_nodes = updated_skeleton
+            .get_node(NodeIndex::ROOT)
+            .ok()
+            .map_or(0, |node| node.n_new_hashes());
+        let mut filled_tree_output_map = HashMap::with_capacity(num_inner_nodes + num_leaves);
         for (index, node) in updated_skeleton.get_nodes() {
             if !matches!(node, UpdatedSkeletonNode::UnmodifiedSubTree(_)) {
                 filled_tree_output_map.insert(index, OnceLock::new());
@@ -293,8 +300,12 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
         }
 
         // Wrap values in `OnceLock<T>` for write-once interior mutability.
-        let filled_tree_output_map =
-            Arc::new(Self::initialize_filled_tree_output_map_with_placeholders(&updated_skeleton));
+        let filled_tree_output_map = Arc::new(
+            Self::initialize_filled_tree_output_map_with_placeholders(
+                &updated_skeleton,
+                leaf_index_to_leaf_input.len(),
+            ),
+        );
         let leaf_index_to_leaf_output =
             Arc::new(Self::initialize_leaf_output_map_with_placeholders(&leaf_index_to_leaf_input));
         let leaf_source = Arc::new(LeafSource::ComputeLeaves {
@@ -339,8 +350,12 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
         }
 
         // Wrap values in `OnceLock<T>` for write-once interior mutability.
-        let filled_tree_output_map =
-            Arc::new(Self::initialize_filled_tree_output_map_with_placeholders(&updated_skeleton));
+        let filled_tree_output_map = Arc::new(
+            Self::initialize_filled_tree_output_map_with_placeholders(
+                &updated_skeleton,
+                leaf_modifications.len(),
+            ),
+        );
 
         // Compute the filled tree.
         let root_hash = Self::compute_filled_tree_rec::<TH>(

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -78,12 +78,13 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
         num_leaves: usize,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
-        // The root's n_new_hashes counts all Binary and Edge nodes that need hashing. Adding
-        // num_leaves gives the exact capacity for the placeholder map, avoiding rehashes.
+        // The root's n_new_hashes counts all Binary/Edge nodes; num_leaves is an upper bound on
+        // Leaf nodes (exact when there are no deletions). Together they give an upper bound — exact
+        // in the common case — on the capacity needed, avoiding HashMap rehashes.
         let num_inner_nodes = updated_skeleton
             .get_node(NodeIndex::ROOT)
-            .ok()
-            .map_or(0, |node| node.n_new_hashes());
+            .expect("root must exist after the empty-tree guard in the caller")
+            .n_new_hashes();
         let mut filled_tree_output_map = HashMap::with_capacity(num_inner_nodes + num_leaves);
         for (index, node) in updated_skeleton.get_nodes() {
             if !matches!(node, UpdatedSkeletonNode::UnmodifiedSubTree(_)) {
@@ -300,12 +301,11 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
         }
 
         // Wrap values in `OnceLock<T>` for write-once interior mutability.
-        let filled_tree_output_map = Arc::new(
-            Self::initialize_filled_tree_output_map_with_placeholders(
+        let filled_tree_output_map =
+            Arc::new(Self::initialize_filled_tree_output_map_with_placeholders(
                 &updated_skeleton,
                 leaf_index_to_leaf_input.len(),
-            ),
-        );
+            ));
         let leaf_index_to_leaf_output =
             Arc::new(Self::initialize_leaf_output_map_with_placeholders(&leaf_index_to_leaf_input));
         let leaf_source = Arc::new(LeafSource::ComputeLeaves {
@@ -350,12 +350,11 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
         }
 
         // Wrap values in `OnceLock<T>` for write-once interior mutability.
-        let filled_tree_output_map = Arc::new(
-            Self::initialize_filled_tree_output_map_with_placeholders(
+        let filled_tree_output_map =
+            Arc::new(Self::initialize_filled_tree_output_map_with_placeholders(
                 &updated_skeleton,
                 leaf_modifications.len(),
-            ),
-        );
+            ));
 
         // Compute the filled tree.
         let root_hash = Self::compute_filled_tree_rec::<TH>(

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/node.rs
@@ -14,3 +14,14 @@ pub enum UpdatedSkeletonNode {
     UnmodifiedSubTree(HashOutput),
     Leaf,
 }
+
+impl UpdatedSkeletonNode {
+    /// Returns the number of inner-node hashes that must be computed for the subtree rooted here.
+    /// Leaf and UnmodifiedSubTree nodes contribute zero.
+    pub fn n_new_hashes(&self) -> usize {
+        match self {
+            Self::Binary { n_new_hashes } | Self::Edge { n_new_hashes, .. } => *n_new_hashes,
+            Self::UnmodifiedSubTree(_) | Self::Leaf => 0,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR #14643 added `n_new_hashes` to `UpdatedSkeletonNode::Binary` and `::Edge` — accumulating, in O(1) per node, the exact count of inner nodes that will need hashing during the filled-tree pass. That count was computed but never consumed. This PR uses it.

- Adds `UpdatedSkeletonNode::n_new_hashes()` accessor method.
- Changes `initialize_filled_tree_output_map_with_placeholders` to call `HashMap::with_capacity(n_new_hashes(root) + num_leaves)` instead of `HashMap::new()`.
- Updates both callers (`create` and `create_with_existing_leaves`) to pass the leaf count.

**Why this matters:** `initialize_filled_tree_output_map_with_placeholders` is called once per block per modified storage trie. Without a capacity hint, the `HashMap` rehashes ⌈log₂ N⌉ times as it grows. With the exact capacity, zero rehashes occur. For a block modifying K distinct storage tries with an average of N nodes per trie, this saves K × ⌈log₂ N⌉ full table copies in the per-block critical path.

Closes #14643 follow-up: consuming `n_new_hashes` for allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0192EcWvHSzsXn1cBvCY2xYg)_