### PR TITLE
apollo_consensus_orchestrator: bound concurrent tx conversions to mitigate proposal DoS

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -28,6 +28,7 @@ use apollo_protobuf::consensus::{
 };
 use apollo_time::time::{Clock, DateTime};
 use apollo_transaction_converter::TransactionConverterError;
+use futures::StreamExt;
 use starknet_api::block::GasPrice;
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ContractAddress;
@@ -81,6 +82,7 @@ pub(crate) struct ProposalBuildArguments {
     pub fee_proposal: GasPrice,
     /// Current fee_actual from the sliding window.
     pub fee_actual: Option<GasPrice>,
+    pub max_concurrent_tx_conversions: usize,
 }
 
 type BuildProposalResult<T> = Result<T, BuildProposalError>;
@@ -250,11 +252,14 @@ async fn get_proposal_content(
                     "Sending transaction batch with {} txs.",
                     txs.len()
                 );
-                let transactions = futures::future::join_all(txs.into_iter().map(|tx| {
+                // Bound concurrency to cap the fan-out of class-manager requests per batch.
+                let transactions = futures::stream::iter(txs.into_iter().map(|tx| {
                     args.deps
                         .transaction_converter
                         .convert_internal_consensus_tx_to_consensus_tx(tx)
                 }))
+                .buffered(args.max_concurrent_tx_conversions)
+                .collect::<Vec<_>>()
                 .await
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()?;

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -53,7 +53,7 @@ use apollo_versioned_constants::VersionedConstants;
 use async_trait::async_trait;
 use futures::channel::mpsc::SendError;
 use futures::channel::{mpsc, oneshot};
-use futures::SinkExt;
+use futures::{SinkExt, StreamExt};
 use starknet_api::block::{
     BlockHashAndNumber,
     BlockHeaderWithoutHash,
@@ -761,6 +761,7 @@ impl ConsensusContext for SequencerConsensusContext {
             l2_gas_price,
             // TODO(Asmaa): Get it from committee once we have it.
             builder_address: self.config.static_config.builder_address,
+            max_concurrent_tx_conversions: self.config.static_config.max_concurrent_tx_conversions,
             cancel_token,
             previous_proposal_init: self.previous_proposal_init.clone(),
             proposal_round: self.current_round,
@@ -884,6 +885,7 @@ impl ConsensusContext for SequencerConsensusContext {
         let next_l2_gas_price =
             self.calculate_next_l2_gas_price(init.height, finished_info.l2_gas_used);
         let transaction_converter = self.deps.transaction_converter.clone();
+        let max_concurrent_tx_conversions = self.config.static_config.max_concurrent_tx_conversions;
         let mut stream_sender =
             self.start_stream(HeightAndRound(height.0, build_param.round)).await;
         let handle = tokio::spawn(
@@ -896,6 +898,7 @@ impl ConsensusContext for SequencerConsensusContext {
                     next_l2_gas_price,
                     &mut stream_sender,
                     transaction_converter,
+                    max_concurrent_tx_conversions,
                 )
                 .await;
                 match res {
@@ -1173,6 +1176,7 @@ impl SequencerConsensusContext {
                 .config
                 .dynamic_config
                 .compare_retrospective_block_hash,
+            max_concurrent_tx_conversions: self.config.static_config.max_concurrent_tx_conversions,
         };
 
         let handle = tokio::spawn(
@@ -1232,6 +1236,7 @@ async fn validate_and_send(
     Ok(proposal_commitment)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn send_reproposal(
     proposal_commitment: ProposalCommitment,
     init: ProposalInit,
@@ -1240,14 +1245,18 @@ async fn send_reproposal(
     next_l2_gas_price: GasPrice,
     stream_sender: &mut StreamSender,
     transaction_converter: Arc<dyn TransactionConverterTrait>,
+    max_concurrent_tx_conversions: usize,
 ) -> Result<(), ReproposeError> {
     stream_sender.send(ProposalPart::Init(init)).await?;
-    for batch in txs.iter() {
-        let transactions = futures::future::join_all(batch.iter().map(|tx| {
+    for batch in txs {
+        // Bound concurrency to cap the fan-out of class-manager requests per batch.
+        let transactions = futures::stream::iter(batch.into_iter().map(|tx| {
             // transaction_converter is an external dependency (class manager) and so
             // we can't assume success on reproposal.
-            transaction_converter.convert_internal_consensus_tx_to_consensus_tx(tx.clone())
+            transaction_converter.convert_internal_consensus_tx_to_consensus_tx(tx)
         }))
+        .buffered(max_concurrent_tx_conversions)
+        .collect::<Vec<_>>()
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -519,6 +519,9 @@ impl From<TestProposalBuildArguments> for ProposalBuildArguments {
             compare_retrospective_block_hash: args.compare_retrospective_block_hash,
             fee_proposal: GasPrice::default(),
             fee_actual: None,
+            max_concurrent_tx_conversions: ContextConfig::default()
+                .static_config
+                .max_concurrent_tx_conversions,
         }
     }
 }

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -67,6 +67,7 @@ pub(crate) struct ProposalValidateArguments {
     pub gas_price_params: GasPriceParams,
     pub cancel_token: CancellationToken,
     pub compare_retrospective_block_hash: bool,
+    pub max_concurrent_tx_conversions: usize,
 }
 
 // Contains parameters required for validating ProposalInit.
@@ -202,6 +203,7 @@ pub(crate) async fn validate_proposal(
                     args.deps.transaction_converter.clone(),
                     &deadline_params,
                     args.init.fee_proposal_fri,
+                    args.max_concurrent_tx_conversions,
                 ).await {
                     HandledProposalPart::Finished(built_block, received_fin, finished_info) => {
                         break (built_block, received_fin, finished_info);
@@ -472,6 +474,7 @@ async fn handle_proposal_part(
     transaction_converter: Arc<dyn TransactionConverterTrait>,
     deadline_params: &ProposalDeadlineParams,
     fee_proposal: Option<GasPrice>,
+    max_concurrent_tx_conversions: usize,
 ) -> HandledProposalPart {
     match proposal_part {
         None => {
@@ -564,10 +567,14 @@ async fn handle_proposal_part(
             // TODO(guyn): check that the length of txs and the number of batches we receive is not
             // so big it would fill up the memory (in case of a malicious proposal)
             debug!("Received transaction batch with {} txs", txs.len());
+            // Bound concurrency: a proposer-controlled batch must not fan out unbounded
+            // conversions.
             let conversion_results =
-                futures::future::join_all(txs.into_iter().map(|tx| {
+                futures::stream::iter(txs.into_iter().map(|tx| {
                     transaction_converter.convert_consensus_tx_to_internal_consensus_tx(tx)
                 }))
+                .buffered(max_concurrent_tx_conversions)
+                .collect::<Vec<_>>()
                 .await
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>();

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
@@ -92,6 +92,9 @@ impl From<TestProposalValidateArguments> for ProposalValidateArguments {
             gas_price_params: args.gas_price_params,
             cancel_token: args.cancel_token,
             compare_retrospective_block_hash: args.compare_retrospective_block_hash,
+            max_concurrent_tx_conversions: ContextConfig::default()
+                .static_config
+                .max_concurrent_tx_conversions,
         }
     }
 }

--- a/crates/apollo_consensus_orchestrator_config/src/config.rs
+++ b/crates/apollo_consensus_orchestrator_config/src/config.rs
@@ -88,6 +88,11 @@ pub const DEFAULT_SNIP35_TARGET_ATTO_USD_PER_L2_GAS: u128 = 880_000_000;
 // This matches the min_gas_price in orchestrator_versioned_constants_0_14_1.json (0x1dcd65000).
 const MIN_ALLOWED_GAS_PRICE: u128 = 8_000_000_000;
 
+// Per-transaction conversion fans out work to the class manager, hashing, and proof-task spawning.
+// Batch size is proposer-controlled, so bound concurrency to stop one oversized batch from flooding
+// the class manager and saturating CPU. The whole batch is still converted, just this many at once.
+const DEFAULT_MAX_CONCURRENT_TX_CONVERSIONS: usize = 10;
+
 /// Represents a minimum gas price that applies starting from a specific block height.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PricePerHeight {
@@ -176,6 +181,10 @@ pub struct ContextStaticConfig {
     /// The interval between retrospective block hash retries.
     #[serde(deserialize_with = "deserialize_milliseconds_to_duration")]
     pub retrospective_block_hash_retry_interval_millis: Duration,
+    /// Caps how many transaction conversions in a single batch run concurrently (build and
+    /// validate paths). The whole batch is still converted.
+    #[validate(range(min = 1))]
+    pub max_concurrent_tx_conversions: usize,
     pub behavior_mode: BehaviorMode,
 }
 
@@ -234,6 +243,13 @@ impl SerializeConfig for ContextStaticConfig {
                 "The interval between retrospective block hash retries.",
                 ParamPrivacyInput::Public,
             ),
+            ser_param(
+                "max_concurrent_tx_conversions",
+                &self.max_concurrent_tx_conversions,
+                "Maximum number of transaction conversions in a single batch allowed to run \
+                 concurrently.",
+                ParamPrivacyInput::Public,
+            ),
         ]);
         dump.extend([ser_param(
             "behavior_mode",
@@ -256,6 +272,7 @@ impl Default for ContextStaticConfig {
             validate_proposal_margin_millis: Duration::from_millis(10_000),
             build_proposal_time_ratio_for_retrospective_block_hash: 0.7,
             retrospective_block_hash_retry_interval_millis: Duration::from_millis(500),
+            max_concurrent_tx_conversions: DEFAULT_MAX_CONCURRENT_TX_CONVERSIONS,
             behavior_mode: BehaviorMode::default(),
         }
     }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2769,6 +2769,11 @@
     "privacy": "Public",
     "value": true
   },
+  "consensus_manager_config.context_config.static_config.max_concurrent_tx_conversions": {
+    "description": "Maximum number of transaction conversions in a single batch allowed to run concurrently.",
+    "privacy": "Public",
+    "value": 10
+  },
   "consensus_manager_config.context_config.static_config.proposal_buffer_size": {
     "description": "The buffer size for streaming outbound proposals.",
     "privacy": "Public",


### PR DESCRIPTION
A proposer-controlled transaction batch was converted with unbounded
concurrency via futures::future::join_all on both the validate and
build/repropose paths. Each conversion fans out work to the class manager
(declare add_class plus Sierra-to-CASM compilation), transaction-hash
computation, and proof-task spawning, so a single oversized batch could flood
the class-manager client and saturate CPU (audit finding M-26).

Replace join_all with futures::stream::iter(...).buffered(K), which bounds the
number of in-flight conversions to K while preserving result order. K is
configurable via the new ContextStaticConfig::max_concurrent_tx_conversions
(default 10). The whole batch is still converted, just K at a time.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>