### PR TITLE
apollo_consensus_orchestrator: send only the commitment-info delta the recorder is missing

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -128,6 +128,10 @@ pub trait CendeContext: Send + Sync {
         &self,
         blob_parameters: BlobParameters,
     ) -> CendeAmbassadorResult<()>;
+
+    /// Highest block whose state commitment info the recorder stored, or `None` on query failure.
+    #[cfg(feature = "os_input")]
+    async fn query_last_stored_commitment_height(&self) -> Option<BlockNumber>;
 }
 
 #[derive(Clone)]
@@ -138,6 +142,8 @@ pub struct CendeAmbassador {
     prev_height_blob: Arc<Mutex<Option<Arc<AerospikeBlob>>>>,
     write_blob_url: Url,
     get_latest_received_block_url: Url,
+    #[cfg(feature = "os_input")]
+    get_last_stored_commitment_height_url: Url,
     client: ClientWithMiddleware,
     class_manager: SharedClassManagerClient,
 }
@@ -148,9 +154,18 @@ pub const RECORDER_WRITE_BLOB_PATH: &str = "/cende_recorder/write_blob";
 /// to DB. returns null when no blocks exist).
 pub const RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH: &str =
     "/cende_recorder/get_latest_received_block";
+#[cfg(feature = "os_input")]
+pub const RECORDER_GET_LAST_STORED_COMMITMENT_HEIGHT_PATH: &str =
+    "/cende_recorder/get_last_stored_commitment_height";
 
 #[derive(Debug, Deserialize)]
 struct GetLatestReceivedBlockResponse {
+    block_number: Option<u64>,
+}
+
+#[cfg(feature = "os_input")]
+#[derive(Debug, Deserialize)]
+struct GetLastStoredCommitmentHeightResponse {
     block_number: Option<u64>,
 }
 
@@ -171,6 +186,11 @@ impl CendeAmbassador {
                 .recorder_url
                 .join(RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH)
                 .expect("Failed to construct get latest received block URL"),
+            #[cfg(feature = "os_input")]
+            get_last_stored_commitment_height_url: cende_config
+                .recorder_url
+                .join(RECORDER_GET_LAST_STORED_COMMITMENT_HEIGHT_PATH)
+                .expect("Failed to construct get last stored commitment height URL"),
             // Bound each attempt by the max retry interval. Without a per-attempt timeout
             // `RetryTransientMiddleware` only retries attempts that *return* a transient error, so
             // a request that hangs against a slow recorder would block until the build deadline
@@ -265,6 +285,43 @@ async fn fetch_latest_received_block(
     }
 }
 
+#[cfg(feature = "os_input")]
+async fn fetch_last_stored_commitment_height(
+    client: &ClientWithMiddleware,
+    url: &Url,
+) -> Option<BlockNumber> {
+    match client.get(url.as_str()).send().await {
+        Ok(response) if response.status().is_success() => {
+            match response.json::<GetLastStoredCommitmentHeightResponse>().await {
+                Ok(resp) => resp.block_number.map(BlockNumber),
+                Err(e) => {
+                    warn!(
+                        "Failed to parse recorder get_last_stored_commitment_height response: \
+                         {e}. Sending all blocks in the window."
+                    );
+                    None
+                }
+            }
+        }
+        Ok(response) => {
+            warn!(
+                "Recorder get_last_stored_commitment_height returned error status {}: {}. Sending \
+                 all blocks in the window.",
+                response.status(),
+                response.text().await.unwrap_or_else(|_| "unparseable".to_string())
+            );
+            None
+        }
+        Err(e) => {
+            warn!(
+                "Failed to request recorder get_last_stored_commitment_height: {e}. Sending all \
+                 blocks in the window."
+            );
+            None
+        }
+    }
+}
+
 #[async_trait]
 impl CendeContext for CendeAmbassador {
     fn write_prev_height_blob(&self, current_height: BlockNumber) -> JoinHandle<bool> {
@@ -334,6 +391,15 @@ impl CendeContext for CendeAmbassador {
         info!("Blob for block number {block_number} is ready.");
         CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER.set_lossy(block_number.0);
         Ok(())
+    }
+
+    #[cfg(feature = "os_input")]
+    async fn query_last_stored_commitment_height(&self) -> Option<BlockNumber> {
+        fetch_last_stored_commitment_height(
+            &self.client,
+            &self.get_last_stored_commitment_height_url,
+        )
+        .await
     }
 }
 

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -702,7 +702,15 @@ impl SequencerConsensusContext {
                 .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
                 + 1,
         );
-        let lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
+        // Send only the delta the recorder hasn't stored yet, bounded above by the fixed window.
+        let fixed_window_lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
+        let lowest_height =
+            match self.deps.cende_ambassador.query_last_stored_commitment_height().await {
+                Some(last_stored_height) => {
+                    fixed_window_lowest_height.max(last_stored_height.0.saturating_add(1))
+                }
+                None => fixed_window_lowest_height,
+            };
         for height in lowest_height..=height.0 {
             let block_number = BlockNumber(height);
             match self.deps.batcher.get_state_commitment_infos(block_number).await {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -957,6 +957,82 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     context.decision_reached(HEIGHT_0, ROUND_0, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
 }
 
+#[cfg(feature = "os_input")]
+fn default_state_commitment_infos() -> StateCommitmentInfos {
+    StateCommitmentInfos {
+        contracts_trie_commitment_info: CommitmentInfo::default(),
+        classes_trie_commitment_info: CommitmentInfo::default(),
+        storage_tries_commitment_infos: HashMap::new(),
+    }
+}
+
+/// Returns the block numbers `collect_recent_state_commitment_infos` sends for `height` when the
+/// recorder reports `last_stored_height`.
+#[cfg(feature = "os_input")]
+async fn collected_heights_for(
+    height: BlockNumber,
+    last_stored_height: Option<BlockNumber>,
+) -> Vec<u64> {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.batcher
+        .expect_get_state_commitment_infos()
+        .returning(|_| Ok(default_state_commitment_infos()));
+    deps.cende_ambassador
+        .expect_query_last_stored_commitment_height()
+        .times(1)
+        .return_once(move || last_stored_height);
+
+    let context = deps.build_context();
+    context
+        .collect_recent_state_commitment_infos(height)
+        .await
+        .iter()
+        .map(|info| info.block_number.0)
+        .collect()
+}
+
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_sends_only_delta_above_recorder() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(97))).await;
+    assert_eq!(heights, vec![98, 99, 100]);
+}
+
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_sends_single_block_when_recorder_caught_up() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(99))).await;
+    assert_eq!(heights, vec![100]);
+}
+
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_caps_delta_at_fixed_window() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(50))).await;
+    let expected: Vec<u64> = (100 - N_BLOCK_HASHES_BACK_IN_BLOB..=100).collect();
+    assert_eq!(heights, expected);
+}
+
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_falls_back_to_full_window_on_query_failure() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, None).await;
+    let expected: Vec<u64> = (100 - N_BLOCK_HASHES_BACK_IN_BLOB..=100).collect();
+    assert_eq!(heights, expected);
+}
+
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_sends_nothing_when_recorder_at_height() {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, Some(BlockNumber(100))).await;
+    assert!(heights.is_empty(), "expected empty delta, got {heights:?}");
+}
+
 /// Verify that when `stop_at_height` is set and decision is reached at that height:
 /// 1. `wait_for_block_hash` retries until the batcher has computed the hash.
 /// 2. The blob contains the block hash of that height.

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -318,6 +318,9 @@ impl TestDeps {
         self.cende_ambassador
             .expect_write_prev_height_blob()
             .return_once(|_height| tokio::spawn(ready(true)));
+        // Default: recorder reports nothing stored → full window sent. Delta tests override this.
+        #[cfg(feature = "os_input")]
+        self.cende_ambassador.expect_query_last_stored_commitment_height().returning(|| None);
     }
 
     pub(crate) fn setup_default_gas_price_provider(&mut self) {


### PR DESCRIPTION
Query the recorder's get_last_stored_commitment_height and bound collect_recent_state_commitment_infos' lower end to max(height - N, last_stored + 1), so the blob carries only the commitment infos the recorder has not stored yet instead of the full fixed window. Falls back to the full window when the query fails/returns nothing, so correctness never depends on the optimization. os_input-gated.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>