### PR TITLE
apollo_class_manager: eliminate redundant path computation and create_dir_all in write hot path

### DIFF
--- a/crates/apollo_class_manager/src/class_storage.rs
+++ b/crates/apollo_class_manager/src/class_storage.rs
@@ -479,10 +479,17 @@ impl FsClassStorage {
         persistent_dir: PathBuf,
     ) -> FsClassStorageResult<()> {
         if let Err(rename_error) = std::fs::rename(&tmp_dir, &persistent_dir) {
-            if rename_error.kind() == std::io::ErrorKind::DirectoryNotEmpty {
+            // POSIX permits both ENOTEMPTY and EEXIST for a non-empty destination directory;
+            // different kernels and filesystems can return either. Recover from both.
+            if matches!(
+                rename_error.kind(),
+                std::io::ErrorKind::DirectoryNotEmpty | std::io::ErrorKind::AlreadyExists
+            ) {
                 warn!(
                     "Recovering orphaned class dir from a prior partial write: {persistent_dir:?}"
                 );
+                // Safe to remove: the directory is named by class hash, so an existing
+                // directory holds the same class content (content-addressing invariant).
                 std::fs::remove_dir_all(&persistent_dir)?;
                 std::fs::rename(tmp_dir, persistent_dir)?;
             } else {

--- a/crates/apollo_class_manager/src/class_storage.rs
+++ b/crates/apollo_class_manager/src/class_storage.rs
@@ -394,15 +394,6 @@ impl FsClassStorage {
         self.persistent_root.join(self.get_class_dir(class_id))
     }
 
-    fn get_persistent_dir_with_create(&self, class_id: ClassId) -> FsClassStorageResult<PathBuf> {
-        let path = self.get_persistent_dir(class_id);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        Ok(path)
-    }
-
     fn get_sierra_path(&self, class_id: ClassId) -> PathBuf {
         concat_sierra_filename(&self.get_persistent_dir(class_id))
     }
@@ -418,7 +409,7 @@ impl FsClassStorage {
     fn create_tmp_dir(
         &self,
         class_id: ClassId,
-    ) -> FsClassStorageResult<(tempfile::TempDir, PathBuf)> {
+    ) -> FsClassStorageResult<(tempfile::TempDir, PathBuf, PathBuf)> {
         // Compute the final persistent directory for this `class_id`
         let persistent_dir = self.get_persistent_dir(class_id);
         let parent_dir = persistent_dir
@@ -435,7 +426,7 @@ impl FsClassStorage {
         let tmp_dir = tmp_root.path().join(leaf);
         // Returning `TempDir` since without it the handle would drop immediately and the temp
         // directory would be removed before writes/rename.
-        Ok((tmp_root, tmp_dir))
+        Ok((tmp_root, tmp_dir, persistent_dir))
     }
 
     fn mark_class_id_as_existent(
@@ -455,11 +446,11 @@ impl FsClassStorage {
         executable_class: RawExecutableClass,
     ) -> FsClassStorageResult<()> {
         // Write classes to a temporary directory.
-        let (_tmp_root, tmp_dir) = self.create_tmp_dir(class_id)?;
+        let (_tmp_root, tmp_dir, persistent_dir) = self.create_tmp_dir(class_id)?;
         class.write_to_file(concat_sierra_filename(&tmp_dir))?;
         executable_class.write_to_file(concat_executable_filename(&tmp_dir))?;
 
-        self.rename_to_persistent_dir(tmp_dir, class_id)
+        self.rename_to_persistent_dir(tmp_dir, persistent_dir)
     }
 
     fn write_deprecated_class_atomically(
@@ -468,34 +459,36 @@ impl FsClassStorage {
         class: RawExecutableClass,
     ) -> FsClassStorageResult<()> {
         // Write class to a temporary directory.
-        let (_tmp_root, tmp_dir) = self.create_tmp_dir(class_id)?;
+        let (_tmp_root, tmp_dir, persistent_dir) = self.create_tmp_dir(class_id)?;
         class.write_to_file(concat_deprecated_executable_filename(&tmp_dir))?;
 
-        self.rename_to_persistent_dir(tmp_dir, class_id)
+        self.rename_to_persistent_dir(tmp_dir, persistent_dir)
     }
 
-    /// Atomically moves the staged class directory `tmp_dir` into its content-addressed persistent
-    /// directory.
+    /// Atomically moves the staged class directory into its content-addressed persistent directory.
     ///
-    /// Recovers from a previous partial write: a crash between this rename and committing the
-    /// existence marker (see `FsClassStorage::set_class`) can leave an orphaned, non-empty
-    /// persistent directory. `std::fs::rename` refuses to replace a non-empty directory and fails
-    /// with `ENOTEMPTY`, which permanently wedges sync on the class. Callers reach this only when
-    /// the existence marker is absent, and the directory is named by the class hash, so an existing
-    /// directory holds the same class; removing it lets the rename proceed and the marker get
-    /// written, restoring filesystem/marker consistency.
+    /// The parent directory is guaranteed to exist: `create_tmp_dir` creates it before this is
+    /// called. The rename is attempted optimistically; `ENOTEMPTY` means a prior crash left an
+    /// orphaned non-empty directory at `persistent_dir`. Since the directory is named by class hash
+    /// it holds the same class content — removing it lets the rename proceed and the existence
+    /// marker get committed, restoring filesystem/marker consistency. Any other error is surfaced
+    /// immediately.
     fn rename_to_persistent_dir(
         &self,
         tmp_dir: PathBuf,
-        class_id: ClassId,
+        persistent_dir: PathBuf,
     ) -> FsClassStorageResult<()> {
-        let persistent_dir = self.get_persistent_dir_with_create(class_id)?;
-        if persistent_dir.exists() {
-            warn!("Recovering orphaned class dir from a prior partial write: {persistent_dir:?}");
-            std::fs::remove_dir_all(&persistent_dir)?;
+        if let Err(rename_error) = std::fs::rename(&tmp_dir, &persistent_dir) {
+            if rename_error.kind() == std::io::ErrorKind::DirectoryNotEmpty {
+                warn!(
+                    "Recovering orphaned class dir from a prior partial write: {persistent_dir:?}"
+                );
+                std::fs::remove_dir_all(&persistent_dir)?;
+                std::fs::rename(tmp_dir, persistent_dir)?;
+            } else {
+                return Err(rename_error.into());
+            }
         }
-        std::fs::rename(tmp_dir, persistent_dir)?;
-
         Ok(())
     }
 }


### PR DESCRIPTION
## Performance follow-up to #14666

### What

In `rename_to_persistent_dir` (called once per class write — on every new class declaration during block production and on every class encountered during state sync), the previous code did redundant work on the common (non-recovery) path:

1. **Redundant path computation**: `rename_to_persistent_dir` called `get_persistent_dir_with_create(class_id)` which re-ran `hex::encode(class_id.to_bytes_be())` + several path joins — all already computed by `create_tmp_dir` moments earlier.
2. **Redundant `create_dir_all`**: `get_persistent_dir_with_create` called `std::fs::create_dir_all` on the parent directory, which `create_tmp_dir` had already created. For an existing directory this is a no-op, but it still issues ~3 stat syscalls to walk the path components.
3. **`exists()` stat on every write**: The defensive `if persistent_dir.exists()` check issued a stat syscall on every write, even though orphaned directories are only possible after a crash (extremely rare in production).

### Fix

- `create_tmp_dir` now returns the already-computed `persistent_dir: PathBuf` as the third element of its tuple; callers thread it through rather than recomputing it.
- `rename_to_persistent_dir` is updated to accept `persistent_dir: PathBuf` directly — `get_persistent_dir_with_create` and its redundant `create_dir_all` are removed.
- The orphan recovery logic switches from a defensive *check-then-act* to an **optimistic rename-first** pattern: attempt `rename` immediately; on `ENOTEMPTY` (the only error that indicates an orphaned directory), emit the warning, remove the orphan, and retry. On any other error, surface it immediately. This removes the `exists()` stat from the common path entirely.

### Per-write savings (common path)

| Removed | Why |
|---------|-----|
| 1 `hex::encode` call + heap allocation | `persistent_dir` already computed in `create_tmp_dir` |
| 1 `create_dir_all` (~3 stat syscalls) | parent dir already created in `create_tmp_dir` |
| 1 `exists()` stat syscall | replaced by optimistic rename |

Recovery behavior is unchanged: `ENOTEMPTY` → warn + `remove_dir_all` + retry rename. All 15 existing tests pass, including both orphaned-dir recovery tests added in #14666.

### Verification

- `cargo build -p apollo_class_manager` ✅
- `cargo test -p apollo_class_manager`: **15 passed, 0 failed** (1 pre-existing ignored) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVVfTBjypX4mCpSdzi8NvP)_