### PR TITLE
avi/privacy/screening v2 over old tag

### DIFF
--- a/crates/starknet_transaction_prover/src/blocking_check.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check.rs
@@ -5,6 +5,7 @@
 
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use starknet_api::rpc_transaction::RpcTransaction;
 use tracing::warn;
 use url::Url;
@@ -19,8 +20,11 @@ const BLOCKED_ERROR_CODE: i32 = 10000;
 /// Result of a blocking check call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BlockingCheckResult {
-    /// External service returned success — transaction is allowed.
-    Allowed,
+    /// External service returned success — transaction is allowed. Carries the
+    /// opaque `additional_data` object the prover relays verbatim on the prove
+    /// response (the prover does not interpret its contents); `None` when the
+    /// allow response carried no `additional_data`.
+    Allowed(Option<Map<String, Value>>),
     /// External service returned error code 10000 — transaction is blocked.
     Blocked,
     /// Any other outcome (network error, non-10000 error, deserialization failure).
@@ -53,10 +57,24 @@ struct CheckTransactionParams {
 }
 
 /// JSON-RPC response envelope (only the fields we need).
+///
+/// `additional_data` is required to be a JSON object: a non-object value fails
+/// envelope deserialization and is treated as `Inconclusive` (deferring to the
+/// fail-open policy). Its contents are otherwise opaque — the prover relays
+/// them verbatim without interpreting any keys.
 #[derive(Deserialize)]
 struct JsonRpcResponse {
     #[serde(default)]
+    result: Option<CheckTransactionResult>,
+    #[serde(default)]
     error: Option<JsonRpcError>,
+}
+
+/// Allow-response payload (only the fields we need).
+#[derive(Deserialize)]
+struct CheckTransactionResult {
+    #[serde(default)]
+    additional_data: Option<Map<String, Value>>,
 }
 
 /// JSON-RPC error object (only the code field is needed for decision logic).
@@ -116,7 +134,9 @@ impl BlockingCheckClient {
         };
 
         match json_rpc_response.error {
-            None => BlockingCheckResult::Allowed,
+            None => BlockingCheckResult::Allowed(
+                json_rpc_response.result.and_then(|check_result| check_result.additional_data),
+            ),
             Some(err) if err.code == BLOCKED_ERROR_CODE => BlockingCheckResult::Blocked,
             Some(err) => {
                 warn!("Blocking check returned non-blocking error code: {}", err.code);

--- a/crates/starknet_transaction_prover/src/blocking_check.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check.rs
@@ -117,6 +117,15 @@ impl BlockingCheckClient {
                 }
             };
 
+        // Only a 2xx response carries a trustworthy decision. A non-success status (e.g. a 5xx
+        // from a broken upstream) may still return a body without an `error` field, which would
+        // otherwise deserialize to `Allowed` and bypass the operator's fail-close policy.
+        let status = response.status();
+        if !status.is_success() {
+            warn!("Blocking check returned non-success HTTP status: {status}");
+            return BlockingCheckResult::Inconclusive;
+        }
+
         let body = match response.text().await {
             Ok(text) => text,
             Err(err) => {

--- a/crates/starknet_transaction_prover/src/blocking_check_test.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check_test.rs
@@ -144,6 +144,25 @@ async fn test_network_error_returns_inconclusive() {
 }
 
 #[tokio::test]
+async fn test_non_success_status_without_error_field_returns_inconclusive() {
+    // A broken upstream may return a 5xx whose body lacks an `error` field. Without a status
+    // check this would deserialize to `Allowed` and bypass the operator's fail-close policy.
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(500)
+        .with_body(r#"{"jsonrpc":"2.0","id":1}"#)
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    assert_eq!(result, BlockingCheckResult::Inconclusive);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn test_malformed_response_returns_inconclusive() {
     let mut server = Server::new_async().await;
     let mock = server.mock("POST", "/").with_status(200).with_body("not json").create_async().await;

--- a/crates/starknet_transaction_prover/src/blocking_check_test.rs
+++ b/crates/starknet_transaction_prover/src/blocking_check_test.rs
@@ -1,12 +1,13 @@
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use mockito::{Matcher, Server};
+use serde_json::{json, Map, Value};
 use starknet_api::invoke_tx_args;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::test_utils::invoke::rpc_invoke_tx;
 use starknet_api::transaction::fields::{AllResourceBounds, ValidResourceBounds};
 use url::Url;
 
-use super::{BlockingCheckClient, BlockingCheckResult};
+use crate::blocking_check::{BlockingCheckClient, BlockingCheckResult};
 
 fn test_transaction() -> RpcTransaction {
     rpc_invoke_tx(invoke_tx_args!(
@@ -35,7 +36,65 @@ async fn test_success_response_returns_allowed() {
     let client = client_for_server(&server);
     let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
 
-    assert_eq!(result, BlockingCheckResult::Allowed);
+    assert_eq!(result, BlockingCheckResult::Allowed(None));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_allow_with_additional_data_relays_it_verbatim() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(200)
+        .with_body(
+            r#"{"jsonrpc":"2.0","result":{"allowed":true,"additional_data":{"signature":{"issued_at":1716579600,"sig_r":"0x6e6f63c8","sig_s":"0x58a68a71"}}},"id":1}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    // The contents are opaque to the client; it relays the object as-is.
+    let expected: Map<String, Value> = serde_json::from_value(json!({
+        "signature": { "issued_at": 1716579600, "sig_r": "0x6e6f63c8", "sig_s": "0x58a68a71" }
+    }))
+    .unwrap();
+    assert_eq!(result, BlockingCheckResult::Allowed(Some(expected)));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_allow_without_additional_data_returns_allowed_none() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(200)
+        .with_body(r#"{"jsonrpc":"2.0","result":{"allowed":true},"id":1}"#)
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    assert_eq!(result, BlockingCheckResult::Allowed(None));
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_allow_with_non_object_additional_data_returns_inconclusive() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/")
+        .with_status(200)
+        .with_body(r#"{"jsonrpc":"2.0","result":{"allowed":true,"additional_data":42},"id":1}"#)
+        .create_async()
+        .await;
+
+    let client = client_for_server(&server);
+    let result = client.check_transaction(BlockId::Latest, test_transaction()).await;
+
+    assert_eq!(result, BlockingCheckResult::Inconclusive);
     mock.assert_async().await;
 }
 

--- a/crates/starknet_transaction_prover/src/proving/blocking_check_integration_test.rs
+++ b/crates/starknet_transaction_prover/src/proving/blocking_check_integration_test.rs
@@ -11,6 +11,7 @@
 use async_trait::async_trait;
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use mockito::Server;
+use serde_json::{json, Map, Value};
 use starknet_api::invoke_tx_args;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::test_utils::invoke::rpc_invoke_tx;
@@ -18,9 +19,9 @@ use starknet_api::transaction::fields::ValidResourceBounds;
 use starknet_api::transaction::InvokeTransaction;
 use url::Url;
 
-use super::virtual_snos_prover::VirtualSnosProver;
 use crate::blocking_check::BlockingCheckClient;
 use crate::errors::{RunnerError, VirtualSnosProverError};
+use crate::proving::virtual_snos_prover::{ProveTransactionResult, VirtualSnosProver};
 use crate::running::runner::{RunnerOutput, VirtualSnosRunner};
 use crate::test_utils::resource_bounds_for_client_side_tx;
 
@@ -122,6 +123,74 @@ async fn test_check_allowed_proceeds_to_proving() {
 
     let result = prove(&prover).await;
     assert_runner_error(&result);
+}
+
+#[tokio::test]
+async fn test_check_allowed_with_additional_data_proceeds_to_proving() {
+    let mut server = Server::new_async().await;
+    let _mock = server
+        .mock("POST", "/")
+        .with_status(200)
+        .with_body(
+            r#"{"jsonrpc":"2.0","result":{"allowed":true,"additional_data":{"signature":{"issued_at":1716579600,"sig_r":"0x1","sig_s":"0x2"}}},"id":1}"#,
+        )
+        .create_async()
+        .await;
+
+    let url = Url::parse(&server.url()).unwrap();
+    let client = BlockingCheckClient::new(url, TEST_TIMEOUT_MILLIS, true);
+    let prover = build_prover(MockRunner, Some(client));
+
+    // The MockRunner errors before producing a result, so the verbatim relay is
+    // covered by the serde tests below; this confirms an allow carrying
+    // additional_data routes to proving rather than blocking.
+    let result = prove(&prover).await;
+    assert_runner_error(&result);
+}
+
+fn sample_additional_data() -> Map<String, Value> {
+    serde_json::from_value(json!({
+        "signature": { "issued_at": 1716579600, "sig_r": "0x6e6f63c8", "sig_s": "0x58a68a71" }
+    }))
+    .unwrap()
+}
+
+#[test]
+fn test_additional_data_relays_object_verbatim() {
+    // The prover does not interpret additional_data; an arbitrary object,
+    // including keys it has never heard of, round-trips unchanged.
+    let additional_data: Map<String, Value> =
+        serde_json::from_value(json!({ "signature": { "sig_r": "0x1" }, "future_key": [1, 2, 3] }))
+            .unwrap();
+    let fixture = include_str!("../../resources/mock_proving_rpc/prove_transaction_result.json");
+    let mut result: ProveTransactionResult = serde_json::from_str(fixture).unwrap();
+    result.additional_data = Some(additional_data.clone());
+
+    let json = serde_json::to_value(&result).unwrap();
+    assert_eq!(json["additional_data"], Value::Object(additional_data));
+}
+
+#[test]
+fn test_empty_additional_data_is_omitted_from_prove_result_json() {
+    // The committed mock fixture carries no additional_data; the field must
+    // deserialize to `None` and stay absent on re-serialization.
+    let fixture = include_str!("../../resources/mock_proving_rpc/prove_transaction_result.json");
+    let result: ProveTransactionResult = serde_json::from_str(fixture).unwrap();
+    assert!(result.additional_data.is_none());
+
+    let json = serde_json::to_value(&result).unwrap();
+    // Must be absent, not serialized as `null`: `contains_key` is true for an explicit null.
+    assert!(!json.as_object().unwrap().contains_key("additional_data"));
+}
+
+#[test]
+fn test_populated_additional_data_is_present_in_prove_result_json() {
+    let fixture = include_str!("../../resources/mock_proving_rpc/prove_transaction_result.json");
+    let mut result: ProveTransactionResult = serde_json::from_str(fixture).unwrap();
+    result.additional_data = Some(sample_additional_data());
+
+    let json = serde_json::to_value(&result).unwrap();
+    assert_eq!(json["additional_data"]["signature"]["sig_r"], "0x6e6f63c8");
 }
 
 #[tokio::test]

--- a/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
+++ b/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
@@ -320,6 +320,8 @@ impl<R: VirtualSnosRunner + 'static> VirtualSnosProver<R> {
             proof: prover_output.proof,
             proof_facts,
             l2_to_l1_messages: runner_output.l2_to_l1_messages,
+            // Populated by the caller from the blocking check's allow response.
+            additional_data: None,
         })
     }
 }

--- a/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
+++ b/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
@@ -11,7 +11,7 @@ use blockifier::state::contract_class_manager::ContractClassManager;
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use blockifier_reexecution::utils::get_chain_info;
 #[cfg(feature = "stwo_proving")]
-use privacy_prove::{RecursiveProverPrecomputes, prepare_recursive_prover_precomputes};
+use privacy_prove::{prepare_recursive_prover_precomputes, RecursiveProverPrecomputes};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use starknet_api::block::GasPrice;

--- a/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
+++ b/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
@@ -11,8 +11,9 @@ use blockifier::state::contract_class_manager::ContractClassManager;
 use blockifier_reexecution::state_reader::rpc_objects::BlockId;
 use blockifier_reexecution::utils::get_chain_info;
 #[cfg(feature = "stwo_proving")]
-use privacy_prove::{prepare_recursive_prover_precomputes, RecursiveProverPrecomputes};
+use privacy_prove::{RecursiveProverPrecomputes, prepare_recursive_prover_precomputes};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use starknet_api::block::GasPrice;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::{RpcInvokeTransaction, RpcInvokeTransactionV3, RpcTransaction};
@@ -37,6 +38,13 @@ pub struct ProveTransactionResult {
     pub proof_facts: ProofFacts,
     /// Messages sent from L2 to L1 during execution.
     pub l2_to_l1_messages: Vec<MessageToL1>,
+    /// Opaque side-channel relayed verbatim from the blocking check's allow
+    /// response; omitted from the JSON response when absent. The prover does not
+    /// interpret its contents (a screened deposit carries a screening signature
+    /// under `signature`, but that is the screening domain's concern, not the
+    /// prover's).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_data: Option<Map<String, Value>>,
 }
 
 /// Virtual SNOS prover for Starknet transactions.
@@ -241,22 +249,24 @@ impl<R: VirtualSnosRunner + 'static> VirtualSnosProver<R> {
             tokio::time::timeout(timeout_duration, client.check_transaction(block_id, transaction))
                 .await;
 
-        let allow = match check_outcome {
+        // A transaction allowed via the fail-open policy (inconclusive check or
+        // timeout) carries no additional_data.
+        let (allow, additional_data) = match check_outcome {
             Ok(BlockingCheckResult::Blocked) => {
                 info!("Transaction blocked by external check");
-                false
+                (false, None)
             }
-            Ok(BlockingCheckResult::Allowed(_)) => {
+            Ok(BlockingCheckResult::Allowed(additional_data)) => {
                 info!("Transaction allowed by external check");
-                true
+                (true, additional_data)
             }
             Ok(BlockingCheckResult::Inconclusive) => {
                 info!(fail_open = client.fail_open, "Blocking check inconclusive");
-                client.fail_open
+                (client.fail_open, None)
             }
             Err(_) => {
                 info!(fail_open = client.fail_open, "Blocking check timed out");
-                client.fail_open
+                (client.fail_open, None)
             }
         };
 
@@ -265,11 +275,13 @@ impl<R: VirtualSnosRunner + 'static> VirtualSnosProver<R> {
             return Err(VirtualSnosProverError::TransactionBlocked);
         }
 
-        match prove_handle.await {
-            Ok(result) => result,
+        let mut result = match prove_handle.await {
+            Ok(prove_result) => prove_result?,
             Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
             Err(err) => unreachable!("prove task cancelled unexpectedly: {err}"),
-        }
+        };
+        result.additional_data = additional_data;
+        Ok(result)
     }
 
     /// Proves a Virtual Starknet OS run from its output.

--- a/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
+++ b/crates/starknet_transaction_prover/src/proving/virtual_snos_prover.rs
@@ -246,7 +246,7 @@ impl<R: VirtualSnosRunner + 'static> VirtualSnosProver<R> {
                 info!("Transaction blocked by external check");
                 false
             }
-            Ok(BlockingCheckResult::Allowed) => {
+            Ok(BlockingCheckResult::Allowed(_)) => {
                 info!("Transaction allowed by external check");
                 true
             }


### PR DESCRIPTION
- **starknet_transaction_prover: relay opaque additional_data from check response (#14410)**
- **starknet_transaction_prover: relay opaque additional_data on proveTransaction response (#14411)**
- **starknet_transaction_prover: treat non-success blocking-check status as inconclusive (#14492)**
