### PR TITLE
apollo_committer,apollo_batcher: compress state commitment infos at the committer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,6 @@ dependencies = [
  "serde_json",
  "starknet-types-core",
  "starknet_api",
- "starknet_committer",
  "strum",
  "thiserror 1.0.69",
  "tokio",
@@ -1095,13 +1094,16 @@ dependencies = [
  "apollo_metrics",
  "assert_matches",
  "async-trait",
+ "base64 0.13.1",
  "indexmap 2.14.0",
+ "serde_json",
  "starknet_api",
  "starknet_committer",
  "starknet_patricia",
  "starknet_patricia_storage",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -1454,7 +1456,6 @@ dependencies = [
  "shared_execution_objects",
  "starknet-types-core",
  "starknet_api",
- "starknet_committer",
  "strum",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,6 @@ dependencies = [
  "serde",
  "starknet-types-core",
  "starknet_api",
- "starknet_committer",
  "strum",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/apollo_batcher/Cargo.toml
+++ b/crates/apollo_batcher/Cargo.toml
@@ -14,7 +14,6 @@ os_input = [
   "apollo_reverts/os_input",
   "apollo_storage/os_input",
   "blockifier/os_input",
-  "dep:starknet_committer",
 ]
 testing = []
 
@@ -50,7 +49,6 @@ lru.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true
 starknet_api.workspace = true
-starknet_committer = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio.workspace = true
@@ -85,5 +83,4 @@ pretty_assertions.workspace = true
 rstest.workspace = true
 starknet-types-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
-starknet_committer = { workspace = true, features = ["testing"] }
 tempfile.workspace = true

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -66,10 +66,8 @@ use apollo_storage::partial_block_hash::{
 };
 use apollo_storage::state::{StateStorageReader, StateStorageWriter};
 #[cfg(feature = "os_input")]
-use apollo_storage::state_commitment_infos::StateCommitmentInfosStorageReader;
-#[cfg(feature = "os_input")]
 use apollo_storage::state_commitment_infos::{
-    StateCommitmentInfos,
+    StateCommitmentInfosStorageReader,
     StateCommitmentInfosStorageWriter,
 };
 use apollo_storage::storage_reader_server::{
@@ -1526,10 +1524,7 @@ impl Batcher {
     }
 
     #[cfg(feature = "os_input")]
-    pub fn get_state_commitment_infos(
-        &self,
-        block_number: BlockNumber,
-    ) -> BatcherResult<StateCommitmentInfos> {
+    pub fn get_state_commitment_infos(&self, block_number: BlockNumber) -> BatcherResult<String> {
         self.storage_reader
             .get_state_commitment_infos(block_number)
             .map_err(|err| {
@@ -1739,10 +1734,7 @@ pub trait BatcherStorageReader: Send + Sync {
     fn get_block_hash(&self, height: BlockNumber) -> StorageResult<Option<BlockHash>>;
 
     #[cfg(feature = "os_input")]
-    fn get_state_commitment_infos(
-        &self,
-        height: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>>;
+    fn get_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<Option<String>>;
 
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
@@ -1839,10 +1831,7 @@ impl BatcherStorageReader for StorageReader {
     }
 
     #[cfg(feature = "os_input")]
-    fn get_state_commitment_infos(
-        &self,
-        height: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>> {
+    fn get_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<Option<String>> {
         self.begin_ro_txn()?.get_state_commitment_infos(height)
     }
 
@@ -1908,7 +1897,7 @@ pub trait BatcherStorageWriter: Send + Sync {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
-        state_commitment_infos: Option<StateCommitmentInfos>,
+        state_commitment_infos: Option<String>,
     ) -> StorageResult<()>;
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()>;
@@ -1954,7 +1943,7 @@ impl BatcherStorageWriter for StorageWriter {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
-        #[cfg(feature = "os_input")] state_commitment_infos: Option<StateCommitmentInfos>,
+        #[cfg(feature = "os_input")] state_commitment_infos: Option<String>,
     ) -> StorageResult<()> {
         #[cfg(not(feature = "os_input"))]
         info!(
@@ -1964,10 +1953,10 @@ impl BatcherStorageWriter for StorageWriter {
         #[cfg(feature = "os_input")]
         info!(
             "Setting global root and block hash for height {height}. Root: {global_root:?}, Block \
-             hash: {block_hash:?}, number of storage-trie commitment infos: {:?}.",
-            state_commitment_infos.as_ref().map(|state_commitment_infos| state_commitment_infos
-                .storage_tries_commitment_infos
-                .len())
+             hash: {block_hash:?}, compressed commitment infos byte length: {:?}.",
+            state_commitment_infos
+                .as_ref()
+                .map(|state_commitment_infos| state_commitment_infos.len())
         );
         let mut txn = self
             .begin_rw_txn()?

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -66,10 +66,9 @@ use apollo_storage::partial_block_hash::{
 };
 use apollo_storage::state::{StateStorageReader, StateStorageWriter};
 #[cfg(feature = "os_input")]
-use apollo_storage::state_commitment_infos::StateCommitmentInfosStorageReader;
-#[cfg(feature = "os_input")]
 use apollo_storage::state_commitment_infos::{
-    StateCommitmentInfos,
+    CompressedStateCommitmentInfos,
+    StateCommitmentInfosStorageReader,
     StateCommitmentInfosStorageWriter,
 };
 use apollo_storage::storage_reader_server::{
@@ -1529,7 +1528,7 @@ impl Batcher {
     pub fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherResult<StateCommitmentInfos> {
+    ) -> BatcherResult<CompressedStateCommitmentInfos> {
         self.storage_reader
             .get_state_commitment_infos(block_number)
             .map_err(|err| {
@@ -1742,7 +1741,7 @@ pub trait BatcherStorageReader: Send + Sync {
     fn get_state_commitment_infos(
         &self,
         height: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>>;
+    ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
 
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
@@ -1842,7 +1841,7 @@ impl BatcherStorageReader for StorageReader {
     fn get_state_commitment_infos(
         &self,
         height: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>> {
+    ) -> StorageResult<Option<CompressedStateCommitmentInfos>> {
         self.begin_ro_txn()?.get_state_commitment_infos(height)
     }
 
@@ -1908,7 +1907,7 @@ pub trait BatcherStorageWriter: Send + Sync {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
-        state_commitment_infos: Option<StateCommitmentInfos>,
+        state_commitment_infos: Option<CompressedStateCommitmentInfos>,
     ) -> StorageResult<()>;
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()>;
@@ -1954,7 +1953,7 @@ impl BatcherStorageWriter for StorageWriter {
         height: BlockNumber,
         global_root: GlobalRoot,
         block_hash: Option<BlockHash>,
-        #[cfg(feature = "os_input")] state_commitment_infos: Option<StateCommitmentInfos>,
+        #[cfg(feature = "os_input")] state_commitment_infos: Option<CompressedStateCommitmentInfos>,
     ) -> StorageResult<()> {
         #[cfg(not(feature = "os_input"))]
         info!(
@@ -1964,10 +1963,10 @@ impl BatcherStorageWriter for StorageWriter {
         #[cfg(feature = "os_input")]
         info!(
             "Setting global root and block hash for height {height}. Root: {global_root:?}, Block \
-             hash: {block_hash:?}, number of storage-trie commitment infos: {:?}.",
-            state_commitment_infos.as_ref().map(|state_commitment_infos| state_commitment_infos
-                .storage_tries_commitment_infos
-                .len())
+             hash: {block_hash:?}, compressed commitment infos byte length: {:?}.",
+            state_commitment_infos
+                .as_ref()
+                .map(|state_commitment_infos| state_commitment_infos.0.len())
         );
         let mut txn = self
             .begin_rw_txn()?

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
@@ -20,8 +20,6 @@ use rstest::{fixture, rstest};
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::block_hash::block_hash_calculator::PartialBlockHashComponents;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::batcher::{MockBatcherStorageReader, MockBatcherStorageWriter};
@@ -70,7 +68,7 @@ fn mock_dependencies() -> MockDependencies {
         Box::pin(async {
             Ok(ReadPathsAndCommitBlockResponse {
                 global_root: GlobalRoot::default(),
-                state_commitment_infos: StateCommitmentInfos::default(),
+                state_commitment_infos: String::new(),
             })
         })
     });

--- a/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
+++ b/crates/apollo_batcher/src/commitment_manager/commitment_manager_test.rs
@@ -13,6 +13,8 @@ use apollo_committer_types::committer_types::{CommitBlockResponse, RevertBlockRe
 use apollo_committer_types::communication::MockCommitterClient;
 #[cfg(feature = "os_input")]
 use apollo_storage::accessed_keys::AccessedKeys;
+#[cfg(feature = "os_input")]
+use apollo_storage::state_commitment_infos::CompressedStateCommitmentInfos;
 use apollo_storage::StorageResult;
 use assert_matches::assert_matches;
 use mockall::predicate::eq;
@@ -20,8 +22,6 @@ use rstest::{fixture, rstest};
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::block_hash::block_hash_calculator::PartialBlockHashComponents;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::batcher::{MockBatcherStorageReader, MockBatcherStorageWriter};
@@ -70,7 +70,7 @@ fn mock_dependencies() -> MockDependencies {
         Box::pin(async {
             Ok(ReadPathsAndCommitBlockResponse {
                 global_root: GlobalRoot::default(),
-                state_commitment_infos: StateCommitmentInfos::default(),
+                state_commitment_infos: CompressedStateCommitmentInfos(Vec::new()),
             })
         })
     });

--- a/crates/apollo_batcher/src/commitment_manager/types.rs
+++ b/crates/apollo_batcher/src/commitment_manager/types.rs
@@ -13,8 +13,6 @@ use apollo_committer_types::committer_types::{
     RevertBlockResponse,
 };
 use apollo_committer_types::communication::CommitterRequestLabelValue;
-#[cfg(feature = "os_input")]
-use apollo_storage::state_commitment_infos::StateCommitmentInfos;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::GlobalRoot;
 use tracing::warn;
@@ -76,10 +74,10 @@ impl Display for CommitterTaskInput {
 pub(crate) struct CommitmentTaskOutput {
     pub(crate) response: CommitBlockResponse,
     pub(crate) height: BlockNumber,
-    // The commitment infos derived from the committer output. `None` when the block was committed
-    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    // Compressed commitment infos from the committer. `None` when the block was committed via
+    // `CommitBlock` (no accessed keys to request the Patricia witnesses).
     #[cfg(feature = "os_input")]
-    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
+    pub(crate) state_commitment_infos: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -131,10 +129,10 @@ pub(crate) struct FinalBlockCommitment {
     // cannot be finalized.
     pub(crate) block_hash: Option<BlockHash>,
     pub(crate) global_root: GlobalRoot,
-    // The commitment infos derived from the committer output. `None` when the block was committed
-    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    // Compressed commitment infos from the committer. `None` when the block was committed via
+    // `CommitBlock` (no accessed keys to request the Patricia witnesses).
     #[cfg(feature = "os_input")]
-    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
+    pub(crate) state_commitment_infos: Option<String>,
 }
 
 pub(crate) struct TaskTimer {

--- a/crates/apollo_batcher/src/commitment_manager/types.rs
+++ b/crates/apollo_batcher/src/commitment_manager/types.rs
@@ -14,7 +14,7 @@ use apollo_committer_types::committer_types::{
 };
 use apollo_committer_types::communication::CommitterRequestLabelValue;
 #[cfg(feature = "os_input")]
-use apollo_storage::state_commitment_infos::StateCommitmentInfos;
+use apollo_storage::state_commitment_infos::CompressedStateCommitmentInfos;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::GlobalRoot;
 use tracing::warn;
@@ -76,10 +76,10 @@ impl Display for CommitterTaskInput {
 pub(crate) struct CommitmentTaskOutput {
     pub(crate) response: CommitBlockResponse,
     pub(crate) height: BlockNumber,
-    // The commitment infos derived from the committer output. `None` when the block was committed
-    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    // Compressed commitment infos from the committer. `None` when the block was committed via
+    // `CommitBlock` (no accessed keys to request the Patricia witnesses).
     #[cfg(feature = "os_input")]
-    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
+    pub(crate) state_commitment_infos: Option<CompressedStateCommitmentInfos>,
 }
 
 #[derive(Clone, Debug)]
@@ -131,10 +131,10 @@ pub(crate) struct FinalBlockCommitment {
     // cannot be finalized.
     pub(crate) block_hash: Option<BlockHash>,
     pub(crate) global_root: GlobalRoot,
-    // The commitment infos derived from the committer output. `None` when the block was committed
-    // via `CommitBlock` (no accessed keys were available to request the Patricia witnesses).
+    // Compressed commitment infos from the committer. `None` when the block was committed via
+    // `CommitBlock` (no accessed keys to request the Patricia witnesses).
     #[cfg(feature = "os_input")]
-    pub(crate) state_commitment_infos: Option<StateCommitmentInfos>,
+    pub(crate) state_commitment_infos: Option<CompressedStateCommitmentInfos>,
 }
 
 pub(crate) struct TaskTimer {

--- a/crates/apollo_batcher/src/test_utils.rs
+++ b/crates/apollo_batcher/src/test_utils.rs
@@ -45,8 +45,6 @@ use starknet_api::test_utils::l1_handler::{executable_l1_handler_tx, L1HandlerTx
 use starknet_api::transaction::fields::{Fee, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{class_hash, contract_address, nonce, tx_hash};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::{Receiver, Sender, UnboundedSender};
 use tokio::time::sleep;
@@ -309,7 +307,7 @@ impl Default for MockClients {
             Box::pin(async {
                 Ok(ReadPathsAndCommitBlockResponse {
                     global_root: GlobalRoot::default(),
-                    state_commitment_infos: StateCommitmentInfos::default(),
+                    state_commitment_infos: String::new(),
                 })
             })
         });

--- a/crates/apollo_batcher/src/test_utils.rs
+++ b/crates/apollo_batcher/src/test_utils.rs
@@ -18,6 +18,8 @@ use apollo_mempool_types::communication::MockMempoolClient;
 use apollo_mempool_types::mempool_types::CommitBlockArgs;
 #[cfg(feature = "os_input")]
 use apollo_storage::accessed_keys::AccessedKeys;
+#[cfg(feature = "os_input")]
+use apollo_storage::state_commitment_infos::CompressedStateCommitmentInfos;
 use async_trait::async_trait;
 use blockifier::blockifier::transaction_executor::BlockExecutionSummary;
 use blockifier::bouncer::{BouncerWeights, CasmHashComputationData};
@@ -45,8 +47,6 @@ use starknet_api::test_utils::l1_handler::{executable_l1_handler_tx, L1HandlerTx
 use starknet_api::transaction::fields::{Fee, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{class_hash, contract_address, nonce, tx_hash};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::{Receiver, Sender, UnboundedSender};
 use tokio::time::sleep;
@@ -309,7 +309,7 @@ impl Default for MockClients {
             Box::pin(async {
                 Ok(ReadPathsAndCommitBlockResponse {
                     global_root: GlobalRoot::default(),
-                    state_commitment_infos: StateCommitmentInfos::default(),
+                    state_commitment_infos: CompressedStateCommitmentInfos(Vec::new()),
                 })
             })
         });

--- a/crates/apollo_batcher_types/Cargo.toml
+++ b/crates/apollo_batcher_types/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Type definitions and interfaces for the Apollo batcher component."
 
 [features]
-os_input = ["dep:starknet_committer"]
+os_input = []
 testing = ["mockall"]
 
 [lints]
@@ -26,7 +26,6 @@ mockall = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 starknet-types-core.workspace = true
 starknet_api.workspace = true
-starknet_committer = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -15,8 +15,6 @@ use async_trait::async_trait;
 use mockall::automock;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockNumber, UnixTimestamp};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use thiserror::Error;
 
@@ -56,11 +54,12 @@ pub trait BatcherClient: Send + Sync {
     async fn propose_block(&self, input: ProposeBlockInput) -> BatcherClientResult<()>;
     /// Gets the block hash for a given block number.
     async fn get_block_hash(&self, block_number: BlockNumber) -> BatcherClientResult<BlockHash>;
+    /// Gets the compressed (`base64(zstd(serde_json(..)))`) state commitment infos for a block.
     #[cfg(feature = "os_input")]
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<StateCommitmentInfos>;
+    ) -> BatcherClientResult<String>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -146,7 +145,7 @@ pub enum BatcherResponse {
     ProposeBlock(BatcherResult<()>),
     GetBlockHash(BatcherResult<BlockHash>),
     #[cfg(feature = "os_input")]
-    GetStateCommitmentInfos(BatcherResult<StateCommitmentInfos>),
+    GetStateCommitmentInfos(BatcherResult<String>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -205,7 +204,7 @@ where
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<StateCommitmentInfos> {
+    ) -> BatcherClientResult<String> {
         let request = BatcherRequest::GetStateCommitmentInfos(block_number);
         handle_all_response_variants!(
             self,

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -16,7 +16,7 @@ use mockall::automock;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockNumber, UnixTimestamp};
 #[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use thiserror::Error;
 
@@ -56,11 +56,12 @@ pub trait BatcherClient: Send + Sync {
     async fn propose_block(&self, input: ProposeBlockInput) -> BatcherClientResult<()>;
     /// Gets the block hash for a given block number.
     async fn get_block_hash(&self, block_number: BlockNumber) -> BatcherClientResult<BlockHash>;
+    /// Gets the compressed state commitment infos for a block.
     #[cfg(feature = "os_input")]
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<StateCommitmentInfos>;
+    ) -> BatcherClientResult<CompressedStateCommitmentInfos>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -146,7 +147,7 @@ pub enum BatcherResponse {
     ProposeBlock(BatcherResult<()>),
     GetBlockHash(BatcherResult<BlockHash>),
     #[cfg(feature = "os_input")]
-    GetStateCommitmentInfos(BatcherResult<StateCommitmentInfos>),
+    GetStateCommitmentInfos(BatcherResult<CompressedStateCommitmentInfos>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -205,7 +206,7 @@ where
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<StateCommitmentInfos> {
+    ) -> BatcherClientResult<CompressedStateCommitmentInfos> {
         let request = BatcherRequest::GetStateCommitmentInfos(block_number);
         handle_all_response_variants!(
             self,

--- a/crates/apollo_committer/Cargo.toml
+++ b/crates/apollo_committer/Cargo.toml
@@ -7,7 +7,12 @@ license.workspace = true
 description = "State root commitment computation component for the Starknet sequencer."
 
 [features]
-os_input = ["apollo_committer_types/os_input", "starknet_committer/os_input"]
+os_input = [
+  "apollo_committer_types/os_input",
+  "dep:base64",
+  "dep:zstd",
+  "starknet_committer/os_input",
+]
 testing = []
 
 [dependencies]
@@ -16,10 +21,13 @@ apollo_committer_types.workspace = true
 apollo_infra.workspace = true
 apollo_metrics.workspace = true
 async-trait.workspace = true
+base64 = { workspace = true, optional = true }
+serde_json.workspace = true
 starknet_api.workspace = true
 starknet_committer.workspace = true
 starknet_patricia_storage = { workspace = true, features = ["rocksdb_storage"] }
 tracing.workspace = true
+zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -61,6 +61,8 @@ use starknet_committer::forest::filled_forest::FilledForest;
 #[cfg(feature = "os_input")]
 use starknet_committer::patricia_merkle_tree::tree::LeavesRequest;
 #[cfg(feature = "os_input")]
+use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+#[cfg(feature = "os_input")]
 use starknet_patricia_storage::errors::SerializationError;
 use starknet_patricia_storage::map_storage::CachedStorage;
 use starknet_patricia_storage::rocksdb_storage::RocksDbStorage;
@@ -147,6 +149,21 @@ fn commit_tip_metadata_bundle(
         next_offset,
     )
 }
+
+/// Compresses the state commitment infos to `base64(zstd(serde_json(..)))`, once at the source, so
+/// the witness stays compact across the committer->batcher RPC (which has an 8 MB response cap),
+/// batcher storage, and the cende blob.
+#[cfg(feature = "os_input")]
+fn compress_state_commitment_infos(infos: &StateCommitmentInfos) -> CommitterResult<String> {
+    let json = serde_json::to_vec(infos)
+        .map_err(|err| CommitterError::StateCommitmentInfosSerialization(err.to_string()))?;
+    let compressed = zstd::encode_all(json.as_slice(), STATE_COMMITMENT_INFOS_ZSTD_LEVEL)
+        .map_err(|err| CommitterError::StateCommitmentInfosCompression(err.to_string()))?;
+    Ok(base64::encode(compressed))
+}
+
+#[cfg(feature = "os_input")]
+const STATE_COMMITMENT_INFOS_ZSTD_LEVEL: i32 = 3;
 
 /// Apollo committer. Maintains the Starknet state tries in persistent storage.
 pub struct Committer<S: Storage, ForestDB>
@@ -540,7 +557,12 @@ where
                     .await
                     .map_err(|error| self.map_internal_error_at_height(height, error))?
                     .ok_or(CommitterError::MissingPatriciaPaths { height })?;
-                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
+                Ok(ReadPathsAndCommitBlockResponse {
+                    global_root,
+                    state_commitment_infos: compress_state_commitment_infos(
+                        &state_commitment_infos,
+                    )?,
+                })
             }
             // Flow overview:
             // 1. Fetch patricia paths for the accessed keys.
@@ -603,7 +625,12 @@ where
                 block_measurements.attempt_to_stop_measurement(Action::EndToEnd, 0).ok();
                 update_metrics(height, &block_measurements.block_measurement);
                 self.update_offset(next_offset);
-                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
+                Ok(ReadPathsAndCommitBlockResponse {
+                    global_root,
+                    state_commitment_infos: compress_state_commitment_infos(
+                        &state_commitment_infos,
+                    )?,
+                })
             }
         }
     }

--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -540,7 +540,10 @@ where
                     .await
                     .map_err(|error| self.map_internal_error_at_height(height, error))?
                     .ok_or(CommitterError::MissingPatriciaPaths { height })?;
-                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
+                Ok(ReadPathsAndCommitBlockResponse {
+                    global_root,
+                    state_commitment_infos: state_commitment_infos.compress()?,
+                })
             }
             // Flow overview:
             // 1. Fetch patricia paths for the accessed keys.
@@ -603,7 +606,10 @@ where
                 block_measurements.attempt_to_stop_measurement(Action::EndToEnd, 0).ok();
                 update_metrics(height, &block_measurements.block_measurement);
                 self.update_offset(next_offset);
-                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
+                Ok(ReadPathsAndCommitBlockResponse {
+                    global_root,
+                    state_commitment_infos: state_commitment_infos.compress()?,
+                })
             }
         }
     }

--- a/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
+++ b/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
@@ -162,6 +162,17 @@ static BLOCK_1_REVERSED_STATE_DIFF: LazyLock<ThinStateDiff> = LazyLock::new(|| T
     ..Default::default()
 });
 
+/// Decompresses the response witness (`base64(zstd(serde_json(..)))`) so the assertions below can
+/// inspect the trie commitment infos.
+fn decompress_response_commitment_infos(
+    response: &ReadPathsAndCommitBlockResponse,
+) -> StateCommitmentInfos {
+    let compressed =
+        base64::decode(&response.state_commitment_infos).expect("response witness is valid base64");
+    let json = zstd::decode_all(compressed.as_slice()).expect("response witness is valid zstd");
+    serde_json::from_slice(&json).expect("response witness deserializes into StateCommitmentInfos")
+}
+
 fn read_paths_and_commit_block_request(
     state_diff: ThinStateDiff,
     state_diff_commitment: Option<StateDiffCommitment>,
@@ -330,11 +341,11 @@ async fn read_paths_and_commit_block_happy_flow() {
 
     let response = committer.read_paths_and_commit_block(request.clone()).await.unwrap();
     assert_eq!(committer.offset, BlockNumber(height + 1));
+    let commitment_infos = decompress_response_commitment_infos(&response);
     // The commitment infos don't retain the contract-trie leaves, so reconstruct the expected
     // contract states for the accessed contracts: storage root from the commitment infos, class
     // hash from the block-0 deployment, and the default (zero) nonce.
-    let contract_leaves: HashMap<ContractAddress, ContractState> = response
-        .state_commitment_infos
+    let contract_leaves: HashMap<ContractAddress, ContractState> = commitment_infos
         .storage_tries_commitment_infos
         .iter()
         .map(|(address, storage_info)| {
@@ -349,7 +360,7 @@ async fn read_paths_and_commit_block_happy_flow() {
         })
         .collect();
     verify_witness_patricia_paths(
-        &response.state_commitment_infos,
+        &commitment_infos,
         &accessed_keys,
         &ACCESSED_CLASS_LEAVES,
         &contract_leaves,
@@ -362,13 +373,12 @@ async fn read_paths_and_commit_block_happy_flow() {
 
     let replay_response = committer.read_paths_and_commit_block(request).await.unwrap();
     assert_eq!(response.global_root, replay_response.global_root);
-    assert_eq!(response.state_commitment_infos, replay_response.state_commitment_infos);
-    assert_witnesses_and_digest_present(
-        &mut committer,
-        BlockNumber(height),
-        &response.state_commitment_infos,
-    )
-    .await;
+    // Compare the decompressed witnesses, not the compressed strings: `StateCommitmentInfos`
+    // contains `HashMap`s whose JSON serialization order is not stable, so two equal witnesses can
+    // compress to different byte strings.
+    assert_eq!(commitment_infos, decompress_response_commitment_infos(&replay_response));
+    assert_witnesses_and_digest_present(&mut committer, BlockNumber(height), &commitment_infos)
+        .await;
 }
 
 /// Flow overview:
@@ -397,7 +407,7 @@ async fn revert_removes_witnesses_and_digest() {
     assert_witnesses_and_digest_present(
         &mut committer,
         BlockNumber(height_1),
-        &block_1_response.state_commitment_infos,
+        &decompress_response_commitment_infos(&block_1_response),
     )
     .await;
 
@@ -485,8 +495,7 @@ async fn test_bottom_of_new_edge_to_an_unmoidifed_subtree_is_present() {
     // This in turn also proves that G is not an edge node, as it's the bottom of an old
     // edge node, without explicitly requesting an opening of E.
     assert!(
-        response
-            .state_commitment_infos
+        decompress_response_commitment_infos(&response)
             .classes_trie_commitment_info
             .commitment_facts
             .contains_key(&node_g_hash),
@@ -558,8 +567,7 @@ async fn test_bottom_of_new_edge_which_was_not_bottom_of_an_old_edge_is_present(
     }));
 
     assert!(
-        response
-            .state_commitment_infos
+        decompress_response_commitment_infos(&response)
             .classes_trie_commitment_info
             .commitment_facts
             .contains_key(&node_e_hash),

--- a/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
+++ b/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
@@ -162,6 +162,15 @@ static BLOCK_1_REVERSED_STATE_DIFF: LazyLock<ThinStateDiff> = LazyLock::new(|| T
     ..Default::default()
 });
 
+fn decompress_response_commitment_infos(
+    response: &ReadPathsAndCommitBlockResponse,
+) -> StateCommitmentInfos {
+    response
+        .state_commitment_infos
+        .decompress()
+        .expect("response witness decompresses into StateCommitmentInfos")
+}
+
 fn read_paths_and_commit_block_request(
     state_diff: ThinStateDiff,
     state_diff_commitment: Option<StateDiffCommitment>,
@@ -330,11 +339,11 @@ async fn read_paths_and_commit_block_happy_flow() {
 
     let response = committer.read_paths_and_commit_block(request.clone()).await.unwrap();
     assert_eq!(committer.offset, BlockNumber(height + 1));
+    let commitment_infos = decompress_response_commitment_infos(&response);
     // The commitment infos don't retain the contract-trie leaves, so reconstruct the expected
     // contract states for the accessed contracts: storage root from the commitment infos, class
     // hash from the block-0 deployment, and the default (zero) nonce.
-    let contract_leaves: HashMap<ContractAddress, ContractState> = response
-        .state_commitment_infos
+    let contract_leaves: HashMap<ContractAddress, ContractState> = commitment_infos
         .storage_tries_commitment_infos
         .iter()
         .map(|(address, storage_info)| {
@@ -349,7 +358,7 @@ async fn read_paths_and_commit_block_happy_flow() {
         })
         .collect();
     verify_witness_patricia_paths(
-        &response.state_commitment_infos,
+        &commitment_infos,
         &accessed_keys,
         &ACCESSED_CLASS_LEAVES,
         &contract_leaves,
@@ -362,13 +371,9 @@ async fn read_paths_and_commit_block_happy_flow() {
 
     let replay_response = committer.read_paths_and_commit_block(request).await.unwrap();
     assert_eq!(response.global_root, replay_response.global_root);
-    assert_eq!(response.state_commitment_infos, replay_response.state_commitment_infos);
-    assert_witnesses_and_digest_present(
-        &mut committer,
-        BlockNumber(height),
-        &response.state_commitment_infos,
-    )
-    .await;
+    assert_eq!(commitment_infos, decompress_response_commitment_infos(&replay_response));
+    assert_witnesses_and_digest_present(&mut committer, BlockNumber(height), &commitment_infos)
+        .await;
 }
 
 /// Flow overview:
@@ -397,7 +402,7 @@ async fn revert_removes_witnesses_and_digest() {
     assert_witnesses_and_digest_present(
         &mut committer,
         BlockNumber(height_1),
-        &block_1_response.state_commitment_infos,
+        &decompress_response_commitment_infos(&block_1_response),
     )
     .await;
 
@@ -485,8 +490,7 @@ async fn test_bottom_of_new_edge_to_an_unmoidifed_subtree_is_present() {
     // This in turn also proves that G is not an edge node, as it's the bottom of an old
     // edge node, without explicitly requesting an opening of E.
     assert!(
-        response
-            .state_commitment_infos
+        decompress_response_commitment_infos(&response)
             .classes_trie_commitment_info
             .commitment_facts
             .contains_key(&node_g_hash),
@@ -558,8 +562,7 @@ async fn test_bottom_of_new_edge_which_was_not_bottom_of_an_old_edge_is_present(
     }));
 
     assert!(
-        response
-            .state_commitment_infos
+        decompress_response_commitment_infos(&response)
             .classes_trie_commitment_info
             .commitment_facts
             .contains_key(&node_e_hash),

--- a/crates/apollo_committer_types/src/committer_types.rs
+++ b/crates/apollo_committer_types/src/committer_types.rs
@@ -4,8 +4,6 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
 use starknet_api::state::ThinStateDiff;
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommitBlockRequest {
@@ -50,5 +48,7 @@ pub struct ReadPathsAndCommitBlockRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReadPathsAndCommitBlockResponse {
     pub global_root: GlobalRoot,
-    pub state_commitment_infos: StateCommitmentInfos,
+    /// The OS-input commitment infos, compressed by the committer into a
+    /// `base64(zstd(serde_json(StateCommitmentInfos)))` string (kept compact across this RPC).
+    pub state_commitment_infos: String,
 }

--- a/crates/apollo_committer_types/src/committer_types.rs
+++ b/crates/apollo_committer_types/src/committer_types.rs
@@ -5,7 +5,7 @@ use starknet_api::block::BlockNumber;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
 use starknet_api::state::ThinStateDiff;
 #[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommitBlockRequest {
@@ -50,5 +50,5 @@ pub struct ReadPathsAndCommitBlockRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReadPathsAndCommitBlockResponse {
     pub global_root: GlobalRoot,
-    pub state_commitment_infos: StateCommitmentInfos,
+    pub state_commitment_infos: CompressedStateCommitmentInfos,
 }

--- a/crates/apollo_committer_types/src/errors.rs
+++ b/crates/apollo_committer_types/src/errors.rs
@@ -62,6 +62,16 @@ pub enum CommitterError {
     #[cfg(feature = "os_input")]
     #[error("Missing Patricia paths for block {height}")]
     MissingPatriciaPaths { height: BlockNumber },
+    // Holds the error message rather than `#[from] serde_json::Error` because `CommitterError`
+    // crosses the RPC boundary and must stay `Clone`/`Serialize`/`Deserialize`.
+    #[cfg(feature = "os_input")]
+    #[error("Failed to serialize state commitment infos: {0}")]
+    StateCommitmentInfosSerialization(String),
+    // Holds the error message rather than `#[from] std::io::Error` for the same reason as
+    // `StateCommitmentInfosSerialization`.
+    #[cfg(feature = "os_input")]
+    #[error("Failed to compress state commitment infos: {0}")]
+    StateCommitmentInfosCompression(String),
 }
 
 pub type CommitterResult<T> = Result<T, CommitterError>;

--- a/crates/apollo_committer_types/src/errors.rs
+++ b/crates/apollo_committer_types/src/errors.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{GlobalRoot, StateDiffCommitment};
 use starknet_committer::db::forest_trait::ForestMetadataType;
+#[cfg(feature = "os_input")]
+use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfosCodecError;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Deserialize, Error, Serialize)]
@@ -62,6 +64,16 @@ pub enum CommitterError {
     #[cfg(feature = "os_input")]
     #[error("Missing Patricia paths for block {height}")]
     MissingPatriciaPaths { height: BlockNumber },
+    #[cfg(feature = "os_input")]
+    #[error("Failed to compress state commitment infos: {0}")]
+    StateCommitmentInfosCompression(String),
+}
+
+#[cfg(feature = "os_input")]
+impl From<StateCommitmentInfosCodecError> for CommitterError {
+    fn from(error: StateCommitmentInfosCodecError) -> Self {
+        CommitterError::StateCommitmentInfosCompression(error.to_string())
+    }
 }
 
 pub type CommitterResult<T> = Result<T, CommitterError>;

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -42,7 +42,6 @@ serde_json = { workspace = true, features = ["arbitrary_precision"] }
 shared_execution_objects.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
-starknet_committer = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
@@ -83,11 +82,10 @@ rand_chacha.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 shared_execution_objects = { workspace = true, features = ["deserialize", "testing"] }
-starknet_committer = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true
 
 [features]
-os_input = ["apollo_batcher/os_input", "dep:starknet_committer"]
+os_input = ["apollo_batcher/os_input"]
 testing = ["shared_execution_objects/deserialize", "shared_execution_objects/testing"]

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -84,7 +84,6 @@ rand_chacha.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 shared_execution_objects = { workspace = true, features = ["deserialize", "testing"] }
-starknet_committer = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -133,8 +133,6 @@ use starknet_api::transaction::{
     TransactionVersion,
 };
 use starknet_api::{contract_address, felt, nonce, storage_key};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 use starknet_types_core::felt::Felt;
 
 use super::{
@@ -744,11 +742,7 @@ fn recent_state_commitment_infos() -> Vec<StateCommitmentInfosAndNumber> {
     [BlockNumber(1), BlockNumber(2)]
         .into_iter()
         .map(|block_number| StateCommitmentInfosAndNumber {
-            state_commitment_infos: StateCommitmentInfos {
-                contracts_trie_commitment_info: CommitmentInfo::default(),
-                classes_trie_commitment_info: CommitmentInfo::default(),
-                storage_tries_commitment_infos: HashMap::new(),
-            },
+            state_commitment_infos: format!("compressed-state-commitment-infos-{block_number}"),
             block_number,
         })
         .collect()

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -134,7 +134,7 @@ use starknet_api::transaction::{
 };
 use starknet_api::{contract_address, felt, nonce, storage_key};
 #[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
+use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 use starknet_types_core::felt::Felt;
 
 use super::{
@@ -744,11 +744,9 @@ fn recent_state_commitment_infos() -> Vec<StateCommitmentInfosAndNumber> {
     [BlockNumber(1), BlockNumber(2)]
         .into_iter()
         .map(|block_number| StateCommitmentInfosAndNumber {
-            state_commitment_infos: StateCommitmentInfos {
-                contracts_trie_commitment_info: CommitmentInfo::default(),
-                classes_trie_commitment_info: CommitmentInfo::default(),
-                storage_tries_commitment_infos: HashMap::new(),
-            },
+            state_commitment_infos: CompressedStateCommitmentInfos(
+                format!("compressed-state-commitment-infos-{block_number}").into_bytes(),
+            ),
             block_number,
         })
         .collect()

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -44,8 +44,6 @@ use starknet_api::block::{BlockHashAndNumber, BlockInfo, BlockNumber, StarknetVe
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ClassHash;
 use starknet_api::state::ThinStateDiff;
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
 use tokio::sync::Mutex;
 use tokio::task::{self, JoinHandle};
 use tracing::{info, warn, Instrument};
@@ -80,7 +78,9 @@ pub type CendeAmbassadorResult<T> = Result<T, CendeAmbassadorError>;
 #[cfg(feature = "os_input")]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StateCommitmentInfosAndNumber {
-    pub state_commitment_infos: StateCommitmentInfos,
+    /// Compressed (`base64(zstd(serde_json(..)))`) commitment infos from the committer, forwarded
+    /// as-is into the cende blob.
+    pub state_commitment_infos: String,
     pub block_number: BlockNumber,
 }
 

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -46,7 +46,7 @@ use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ClassHash;
 use starknet_api::state::ThinStateDiff;
 #[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
+use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 use tokio::sync::Mutex;
 use tokio::task::{self, JoinHandle};
 use tracing::{info, warn, Instrument};
@@ -83,7 +83,7 @@ pub type CendeAmbassadorResult<T> = Result<T, CendeAmbassadorError>;
 #[cfg(feature = "os_input")]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StateCommitmentInfosAndNumber {
-    pub state_commitment_infos: StateCommitmentInfos,
+    pub state_commitment_infos: CompressedStateCommitmentInfos,
     pub block_number: BlockNumber,
 }
 

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeMap;
-#[cfg(feature = "os_input")]
-use std::collections::HashMap;
 use std::future::ready;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
@@ -63,8 +61,6 @@ use starknet_api::execution_resources::GasAmount;
 use starknet_api::hash::StarkHash;
 use starknet_api::state::ThinStateDiff;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 
 #[cfg(feature = "os_input")]
 use crate::cende::StateCommitmentInfosAndNumber;
@@ -920,11 +916,8 @@ async fn blob_parent_proposal_commitment_binds_parent_fee_proposal() {
 async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let (mut deps, _network) = create_test_and_network_deps();
 
-    let state_commitment_infos = StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    };
+    // The batcher serves the compressed witness string; the orchestrator forwards it verbatim.
+    let state_commitment_infos = "compressed-state-commitment-infos".to_string();
 
     let returned_infos = state_commitment_infos.clone();
     deps.batcher
@@ -958,12 +951,8 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
 }
 
 #[cfg(feature = "os_input")]
-fn default_state_commitment_infos() -> StateCommitmentInfos {
-    StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    }
+fn default_state_commitment_infos() -> String {
+    "compressed-state-commitment-infos".to_string()
 }
 
 /// Returns the block numbers `collect_recent_state_commitment_infos` sends for `height` when the

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeMap;
-#[cfg(feature = "os_input")]
-use std::collections::HashMap;
 use std::future::ready;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
@@ -64,7 +62,7 @@ use starknet_api::hash::StarkHash;
 use starknet_api::state::ThinStateDiff;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 #[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
+use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 
 #[cfg(feature = "os_input")]
 use crate::cende::StateCommitmentInfosAndNumber;
@@ -920,11 +918,9 @@ async fn blob_parent_proposal_commitment_binds_parent_fee_proposal() {
 async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let (mut deps, _network) = create_test_and_network_deps();
 
-    let state_commitment_infos = StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    };
+    // The batcher serves the compressed witness; the orchestrator forwards it verbatim.
+    let state_commitment_infos =
+        CompressedStateCommitmentInfos(b"compressed-state-commitment-infos".to_vec());
 
     let returned_infos = state_commitment_infos.clone();
     deps.batcher

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -188,8 +188,6 @@ use crate::header::StorageBlockHeader;
 use crate::metrics::{register_metrics, STORAGE_COMMIT_LATENCY};
 use crate::mmap_file::MMapFileStats;
 use crate::state::data::IndexedDeprecatedContractClass;
-#[cfg(feature = "os_input")]
-use crate::state_commitment_infos::StateCommitmentInfos;
 use crate::storage_reader_server::{
     create_storage_reader_server,
     ServerConfig,
@@ -1173,7 +1171,7 @@ struct FileHandlers<Mode: TransactionKind> {
     #[cfg(feature = "os_input")]
     accessed_keys: FileHandler<VersionZeroWrapper<AccessedKeys>, Mode>,
     #[cfg(feature = "os_input")]
-    state_commitment_infos: FileHandler<VersionZeroWrapper<StateCommitmentInfos>, Mode>,
+    state_commitment_infos: FileHandler<VersionZeroWrapper<String>, Mode>,
 }
 
 impl FileHandlers<RW> {
@@ -1216,11 +1214,11 @@ impl FileHandlers<RW> {
         self.clone().accessed_keys.append(accessed_keys)
     }
 
+    // Takes `&String` (not `&str`) because the mmap file handler appends `&V::Value`, i.e.
+    // `&String`.
     #[cfg(feature = "os_input")]
-    fn append_state_commitment_infos(
-        &self,
-        state_commitment_infos: &StateCommitmentInfos,
-    ) -> LocationInFile {
+    #[allow(clippy::ptr_arg)]
+    fn append_state_commitment_infos(&self, state_commitment_infos: &String) -> LocationInFile {
         self.clone().state_commitment_infos.append(state_commitment_infos)
     }
 
@@ -1326,11 +1324,11 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
     }
 
     #[cfg(feature = "os_input")]
-    // Returns the commitment infos at the given location or an error in case they don't exist.
+    // Returns the compressed commitment infos at the given location.
     pub(crate) fn get_state_commitment_infos_unchecked(
         &self,
         location: LocationInFile,
-    ) -> StorageResult<StateCommitmentInfos> {
+    ) -> StorageResult<String> {
         self.state_commitment_infos.get(location)?.ok_or(StorageError::DBInconsistency {
             msg: format!("StateCommitmentInfos at location {location:?} not found."),
         })

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -189,7 +189,7 @@ use crate::metrics::{register_metrics, STORAGE_COMMIT_LATENCY};
 use crate::mmap_file::MMapFileStats;
 use crate::state::data::IndexedDeprecatedContractClass;
 #[cfg(feature = "os_input")]
-use crate::state_commitment_infos::StateCommitmentInfos;
+use crate::state_commitment_infos::CompressedStateCommitmentInfos;
 use crate::storage_reader_server::{
     create_storage_reader_server,
     ServerConfig,
@@ -1173,7 +1173,7 @@ struct FileHandlers<Mode: TransactionKind> {
     #[cfg(feature = "os_input")]
     accessed_keys: FileHandler<VersionZeroWrapper<AccessedKeys>, Mode>,
     #[cfg(feature = "os_input")]
-    state_commitment_infos: FileHandler<VersionZeroWrapper<StateCommitmentInfos>, Mode>,
+    state_commitment_infos: FileHandler<VersionZeroWrapper<CompressedStateCommitmentInfos>, Mode>,
 }
 
 impl FileHandlers<RW> {
@@ -1219,7 +1219,7 @@ impl FileHandlers<RW> {
     #[cfg(feature = "os_input")]
     fn append_state_commitment_infos(
         &self,
-        state_commitment_infos: &StateCommitmentInfos,
+        state_commitment_infos: &CompressedStateCommitmentInfos,
     ) -> LocationInFile {
         self.clone().state_commitment_infos.append(state_commitment_infos)
     }
@@ -1326,11 +1326,12 @@ impl<Mode: TransactionKind> FileHandlers<Mode> {
     }
 
     #[cfg(feature = "os_input")]
-    // Returns the commitment infos at the given location or an error in case they don't exist.
+    // Returns the compressed commitment infos at the given location or an error in case they don't
+    // exist.
     pub(crate) fn get_state_commitment_infos_unchecked(
         &self,
         location: LocationInFile,
-    ) -> StorageResult<StateCommitmentInfos> {
+    ) -> StorageResult<CompressedStateCommitmentInfos> {
         self.state_commitment_infos.get(location)?.ok_or(StorageError::DBInconsistency {
             msg: format!("StateCommitmentInfos at location {location:?} not found."),
         })

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -1,49 +1,25 @@
 //! Storage for the per-block OS-input commitment infos (state-trie commitment data for the OS).
+//!
+//! Stored as the already-compressed string (`base64(zstd(serde_json(..)))`) the committer produces,
+//! so this path persists the witness verbatim without (de)serializing `StateCommitmentInfos`.
 
 use starknet_api::block::BlockNumber;
-pub use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfosCodecError;
 
 #[cfg(test)]
 #[path = "state_commitment_infos_test.rs"]
 mod state_commitment_infos_test;
 
-use crate::db::serialization::{StorageSerde, StorageSerdeError};
 use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
 use crate::{OffsetKind, StorageResult, StorageTransaction};
 
-// Encoded with bincode (not serde_json): this is hash/`Felt`-heavy data, where bincode's fixed
-// binary encoding is markedly more compact than JSON's hex-string encoding. The trade-off is that
-// bincode is positional and not schema-evolution tolerant, which is acceptable here.
-impl StorageSerde for StateCommitmentInfos {
-    fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
-        let compressed = self.compress()?;
-        compressed.serialize_into(res)
-    }
-
-    fn deserialize_from(bytes: &mut impl std::io::Read) -> Option<Self> {
-        let compressed = Vec::<u8>::deserialize_from(bytes)?;
-        Self::decompress(&compressed).ok()
-    }
-}
-
-impl From<StateCommitmentInfosCodecError> for StorageSerdeError {
-    fn from(error: StateCommitmentInfosCodecError) -> Self {
-        match error {
-            StateCommitmentInfosCodecError::Bincode(error) => StorageSerdeError::Bincode(error),
-            StateCommitmentInfosCodecError::Io(error) => StorageSerdeError::Io(error),
-        }
-    }
-}
-
 /// Interface for reading the OS-input commitment infos from storage.
 pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
-    /// Returns the commitment infos for the given block, or `None` if not stored.
+    /// Returns the compressed commitment infos for the given block, or `None` if not stored.
     fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>>;
+    ) -> StorageResult<Option<String>>;
 }
 
 /// Interface for writing the OS-input commitment infos to storage.
@@ -51,11 +27,14 @@ pub trait StateCommitmentInfosStorageWriter
 where
     Self: Sized,
 {
-    /// Appends the commitment infos for the given block to storage.
+    /// Appends the compressed commitment infos for the given block to storage.
+    // Takes `&String` (not `&str`) because the mmap file handler appends `&V::Value`; `&str` would
+    // force an extra copy of the (potentially multi-MB) compressed witness.
+    #[allow(clippy::ptr_arg)]
     fn append_state_commitment_infos(
         self,
         block_number: BlockNumber,
-        state_commitment_infos: &StateCommitmentInfos,
+        state_commitment_infos: &String,
     ) -> StorageResult<Self>;
 
     /// Removes the commitment infos for the given block from storage.
@@ -69,7 +48,7 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
     fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>> {
+    ) -> StorageResult<Option<String>> {
         let table = self.open_table(&self.tables().state_commitment_infos)?;
         let Some(location) = table.get(self.txn(), &block_number)? else {
             return Ok(None);
@@ -79,10 +58,11 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
 }
 
 impl<T: StorageTransaction<Mode = RW>> StateCommitmentInfosStorageWriter for T {
+    #[allow(clippy::ptr_arg)]
     fn append_state_commitment_infos(
         self,
         block_number: BlockNumber,
-        state_commitment_infos: &StateCommitmentInfos,
+        state_commitment_infos: &String,
     ) -> StorageResult<Self> {
         let file_offset_table = self.open_table(&self.tables().file_offsets)?;
         let state_commitment_infos_table =

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -1,8 +1,9 @@
 //! Storage for the per-block OS-input commitment infos (state-trie commitment data for the OS).
+//!
+//! Persists the already-compressed `CompressedStateCommitmentInfos` the committer produces.
 
 use starknet_api::block::BlockNumber;
-pub use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfos;
-use starknet_committer::patricia_merkle_tree::types::StateCommitmentInfosCodecError;
+pub use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 
 #[cfg(test)]
 #[path = "state_commitment_infos_test.rs"]
@@ -13,37 +14,24 @@ use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
 use crate::{OffsetKind, StorageResult, StorageTransaction};
 
-// Encoded with bincode (not serde_json): this is hash/`Felt`-heavy data, where bincode's fixed
-// binary encoding is markedly more compact than JSON's hex-string encoding. The trade-off is that
-// bincode is positional and not schema-evolution tolerant, which is acceptable here.
-impl StorageSerde for StateCommitmentInfos {
+// Stores the raw compressed bytes.
+impl StorageSerde for CompressedStateCommitmentInfos {
     fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
-        let compressed = self.compress()?;
-        compressed.serialize_into(res)
+        self.0.serialize_into(res)
     }
 
     fn deserialize_from(bytes: &mut impl std::io::Read) -> Option<Self> {
-        let compressed = Vec::<u8>::deserialize_from(bytes)?;
-        Self::decompress(&compressed).ok()
-    }
-}
-
-impl From<StateCommitmentInfosCodecError> for StorageSerdeError {
-    fn from(error: StateCommitmentInfosCodecError) -> Self {
-        match error {
-            StateCommitmentInfosCodecError::Bincode(error) => StorageSerdeError::Bincode(error),
-            StateCommitmentInfosCodecError::Io(error) => StorageSerdeError::Io(error),
-        }
+        Some(Self(Vec::<u8>::deserialize_from(bytes)?))
     }
 }
 
 /// Interface for reading the OS-input commitment infos from storage.
 pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
-    /// Returns the commitment infos for the given block, or `None` if not stored.
+    /// Returns the compressed commitment infos for the given block, or `None` if not stored.
     fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>>;
+    ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
 }
 
 /// Interface for writing the OS-input commitment infos to storage.
@@ -51,11 +39,11 @@ pub trait StateCommitmentInfosStorageWriter
 where
     Self: Sized,
 {
-    /// Appends the commitment infos for the given block to storage.
+    /// Appends the compressed commitment infos for the given block to storage.
     fn append_state_commitment_infos(
         self,
         block_number: BlockNumber,
-        state_commitment_infos: &StateCommitmentInfos,
+        state_commitment_infos: &CompressedStateCommitmentInfos,
     ) -> StorageResult<Self>;
 
     /// Removes the commitment infos for the given block from storage.
@@ -69,7 +57,7 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
     fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> StorageResult<Option<StateCommitmentInfos>> {
+    ) -> StorageResult<Option<CompressedStateCommitmentInfos>> {
         let table = self.open_table(&self.tables().state_commitment_infos)?;
         let Some(location) = table.get(self.txn(), &block_number)? else {
             return Ok(None);
@@ -82,7 +70,7 @@ impl<T: StorageTransaction<Mode = RW>> StateCommitmentInfosStorageWriter for T {
     fn append_state_commitment_infos(
         self,
         block_number: BlockNumber,
-        state_commitment_infos: &StateCommitmentInfos,
+        state_commitment_infos: &CompressedStateCommitmentInfos,
     ) -> StorageResult<Self> {
         let file_offset_table = self.open_table(&self.tables().file_offsets)?;
         let state_commitment_infos_table =

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-
 use starknet_api::block::BlockNumber;
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 
 use crate::state_commitment_infos::{
     StateCommitmentInfosStorageReader,
@@ -9,12 +6,9 @@ use crate::state_commitment_infos::{
 };
 use crate::test_utils::get_test_storage;
 
-fn sample_state_commitment_infos() -> StateCommitmentInfos {
-    StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    }
+// Storage persists the witness verbatim, so a plain string stands in for the real payload.
+fn sample_state_commitment_infos() -> String {
+    "compressed-state-commitment-infos".to_string()
 }
 
 #[test]

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -1,27 +1,21 @@
-use std::collections::HashMap;
-
 use starknet_api::block::BlockNumber;
-use starknet_committer::patricia_merkle_tree::types::{CommitmentInfo, StateCommitmentInfos};
 
 use crate::state_commitment_infos::{
+    CompressedStateCommitmentInfos,
     StateCommitmentInfosStorageReader,
     StateCommitmentInfosStorageWriter,
 };
 use crate::test_utils::get_test_storage;
 
-fn sample_state_commitment_infos() -> StateCommitmentInfos {
-    StateCommitmentInfos {
-        contracts_trie_commitment_info: CommitmentInfo::default(),
-        classes_trie_commitment_info: CommitmentInfo::default(),
-        storage_tries_commitment_infos: HashMap::new(),
-    }
+fn dummy_state_commitment_infos() -> CompressedStateCommitmentInfos {
+    CompressedStateCommitmentInfos(b"compressed-state-commitment-infos".to_vec())
 }
 
 #[test]
 fn append_and_get_state_commitment_infos() {
     let (reader, mut writer) = get_test_storage().0;
     let height = BlockNumber(5);
-    let state_commitment_infos = sample_state_commitment_infos();
+    let state_commitment_infos = dummy_state_commitment_infos();
 
     // No infos stored for the height yet.
     assert_eq!(reader.begin_ro_txn().unwrap().get_state_commitment_infos(height).unwrap(), None);
@@ -53,7 +47,7 @@ fn revert_state_commitment_infos() {
     writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_commitment_infos(height, &sample_state_commitment_infos())
+        .append_state_commitment_infos(height, &dummy_state_commitment_infos())
         .unwrap()
         .revert_state_commitment_infos(height)
         .unwrap()

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -84,7 +84,11 @@ use crate::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 use crate::patricia_merkle_tree::tree::{fetch_all_patricia_paths, SortedLeafIndices};
 use crate::patricia_merkle_tree::types::CompiledClassHash;
 #[cfg(feature = "os_input")]
-use crate::patricia_merkle_tree::types::{StarknetForestProofs, StateCommitmentInfos};
+use crate::patricia_merkle_tree::types::{
+    CompressedStateCommitmentInfos,
+    StarknetForestProofs,
+    StateCommitmentInfos,
+};
 
 /// Set to 2^251 + 1 to avoid collisions with contract addresses prefixes.
 pub(crate) static FIRST_AVAILABLE_PREFIX_FELT: LazyLock<Felt> =
@@ -378,7 +382,7 @@ impl<S: Storage + ImmutableReadOnlyStorage + Sync + Send + 'static> ForestReader
         Ok(match self.get_from_storage(db_key).await? {
             None => None,
             Some(DbValue(bytes)) => {
-                Some(StateCommitmentInfos::decompress(&bytes).map_err(|e| {
+                Some(CompressedStateCommitmentInfos(bytes).decompress().map_err(|e| {
                     ForestError::PatriciaStorage(PatriciaStorageError::Deserialization(
                         DeserializationError::ValueError(Box::new(e)),
                     ))
@@ -459,7 +463,7 @@ impl<S: Storage + Send> ForestWriterWithMetadataAndWitnesses for IndexDb<S> {
                 keys_digest,
                 commitment_infos,
             }) => {
-                let encoded = DbValue(commitment_infos.compress()?);
+                let encoded = DbValue(commitment_infos.compress()?.0);
                 operations.insert(
                     Self::metadata_key(ForestMetadataType::AccessedKeysDigest(DbBlockNumber(
                         block_number,

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -118,19 +118,30 @@ impl From<StateCommitmentInfosCodecError> for SerializationError {
     }
 }
 
-impl StateCommitmentInfos {
-    /// Bincode-serializes and zstd-compresses the commitment infos into a byte vector.
-    #[cfg(feature = "os_input")]
-    pub fn compress(&self) -> Result<Vec<u8>, StateCommitmentInfosCodecError> {
-        let bincode_payload = bincode::serialize(self)?;
-        Ok(zstd::encode_all(bincode_payload.as_slice(), zstd::DEFAULT_COMPRESSION_LEVEL)?)
-    }
+/// The compressed form of [`StateCommitmentInfos`].
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct CompressedStateCommitmentInfos(pub Vec<u8>);
 
+#[cfg(feature = "os_input")]
+impl CompressedStateCommitmentInfos {
     /// Reverses [`StateCommitmentInfos::compress`]: zstd-decompresses then bincode-deserializes.
-    #[cfg(feature = "os_input")]
-    pub fn decompress(data: &[u8]) -> Result<Self, StateCommitmentInfosCodecError> {
-        let bincode_payload = zstd::decode_all(data)?;
+    pub fn decompress(&self) -> Result<StateCommitmentInfos, StateCommitmentInfosCodecError> {
+        let bincode_payload = zstd::decode_all(self.0.as_slice())?;
         Ok(bincode::deserialize(&bincode_payload)?)
+    }
+}
+
+impl StateCommitmentInfos {
+    /// Bincode-serializes and zstd-compresses the commitment infos.
+    #[cfg(feature = "os_input")]
+    pub fn compress(
+        &self,
+    ) -> Result<CompressedStateCommitmentInfos, StateCommitmentInfosCodecError> {
+        let bincode_payload = bincode::serialize(self)?;
+        Ok(CompressedStateCommitmentInfos(zstd::encode_all(
+            bincode_payload.as_slice(),
+            zstd::DEFAULT_COMPRESSION_LEVEL,
+        )?))
     }
 
     /// Builds the commitment infos directly from the pre- and post-commit state roots and the


### PR DESCRIPTION
Compress each block's StateCommitmentInfos to a base64(zstd) String at the committer (in ReadPathsAndCommitBlockResponse) instead of at the consensus orchestrator, so the witness travels compressed across the committer->batcher RPC (capped at 8MB max_response_body_bytes, which wedged the chain on large state diffs), storage, and cende. The compressed String propagates end-to-end; the orchestrator- and storage-layer compression are removed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>