### PR TITLE
starknet_transaction_prover: default blocking-check to fail-closed (10000ms, fail_open=false)

### DIFF
--- a/crates/starknet_transaction_prover/src/config.rs
+++ b/crates/starknet_transaction_prover/src/config.rs
@@ -45,7 +45,7 @@ impl Default for ProverConfig {
             validate_zero_fee_fields: true,
             blocking_check_url: None,
             blocking_check_timeout_millis: 10000,
-            blocking_check_fail_open: true,
+            blocking_check_fail_open: false,
         }
     }
 }

--- a/crates/starknet_transaction_prover/src/config.rs
+++ b/crates/starknet_transaction_prover/src/config.rs
@@ -44,7 +44,7 @@ impl Default for ProverConfig {
             strk_fee_token_address: None,
             validate_zero_fee_fields: true,
             blocking_check_url: None,
-            blocking_check_timeout_millis: 2000,
+            blocking_check_timeout_millis: 10000,
             blocking_check_fail_open: true,
         }
     }

--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -125,7 +125,7 @@ impl Default for RawServiceConfig {
             tls_key_file: None,
             blocking_check_url: None,
             blocking_check_timeout_millis: 10000,
-            blocking_check_fail_open: true,
+            blocking_check_fail_open: false,
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             ohttp_enabled: false,
             ohttp_key_cache_max_age_secs: DEFAULT_OHTTP_KEY_CACHE_MAX_AGE_SECS,
@@ -643,7 +643,7 @@ pub struct CliArgs {
     #[arg(long, value_name = "MILLIS", env = "BLOCKING_CHECK_TIMEOUT_MILLIS")]
     pub blocking_check_timeout_millis: Option<u64>,
 
-    /// Fail-open when blocking check is inconclusive (default: true). Set to false for
+    /// Fail-open when blocking check is inconclusive (default: false). Set to false for
     /// fail-close.
     #[arg(long, env = "BLOCKING_CHECK_FAIL_OPEN")]
     pub blocking_check_fail_open: Option<bool>,

--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -124,7 +124,7 @@ impl Default for RawServiceConfig {
             tls_cert_file: None,
             tls_key_file: None,
             blocking_check_url: None,
-            blocking_check_timeout_millis: 2000,
+            blocking_check_timeout_millis: 10000,
             blocking_check_fail_open: true,
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             ohttp_enabled: false,
@@ -639,7 +639,7 @@ pub struct CliArgs {
     pub blocking_check_url: Option<String>,
 
     /// Milliseconds to wait for the blocking check response before applying the
-    /// fail-open/fail-close policy (default: 2000).
+    /// fail-open/fail-close policy (default: 10000).
     #[arg(long, value_name = "MILLIS", env = "BLOCKING_CHECK_TIMEOUT_MILLIS")]
     pub blocking_check_timeout_millis: Option<u64>,
 


### PR DESCRIPTION
Fail-closed-by-default for the external blocking (screening) check:
- `blocking_check_timeout_millis` default 2000 → 10000 ms
- `blocking_check_fail_open` default true → false

Both defaults live in `ProverConfig::default()` and `RawServiceConfig::default()` (+ CLI-arg docs). Deployments that set these explicitly (config.json / env) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)