### PR TITLE
starknet_api: redact signature, calldata, paymaster and deployment data from Debug

### DIFF
--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -112,16 +112,28 @@ pub struct ContractAddressSalt(pub StarkHash);
 /// A transaction signature, wrapped in `Arc` for efficient cloning and safe sharing across threads.
 /// `Rc` is avoided due to its lack of thread safety, and `Mutex` is unnecessary as the signature
 /// vector is immutable and never modified.
-#[derive(
-    Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf,
-)]
+#[derive(Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf)]
 pub struct TransactionSignature(pub Arc<Vec<Felt>>);
 
+// The signature is security-sensitive; hide its felts from logs (e.g. `debug!("{tx:?}")` at the
+// gateway ingest point) so it is never dumped in plaintext.
+impl fmt::Debug for TransactionSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TransactionSignature(<{} felts>)", self.0.len())
+    }
+}
+
 /// The calldata of a transaction.
-#[derive(
-    Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf,
-)]
+#[derive(Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf)]
 pub struct Calldata(pub Arc<Vec<Felt>>);
+
+// Calldata can carry unbounded, sensitive-looking user data; hide its felts from logs (e.g.
+// `debug!("{tx:?}")` at the gateway ingest point) so it is never dumped in plaintext.
+impl fmt::Debug for Calldata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Calldata(<{} felts>)", self.0.len())
+    }
+}
 
 impl From<Vec<Felt>> for Calldata {
     fn from(value: Vec<Felt>) -> Self {
@@ -607,10 +619,16 @@ impl TryFrom<DeprecatedResourceBoundsMapping> for ValidResourceBounds {
 }
 
 /// Paymaster-related data.
-#[derive(
-    Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, SizeOf,
-)]
+#[derive(Clone, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, SizeOf)]
 pub struct PaymasterData(pub Vec<Felt>);
+
+// Paymaster data is unbounded, user-controlled input; hide its felts from logs (e.g.
+// `debug!("{tx:?}")` at the gateway ingest point) so it is never dumped in plaintext.
+impl fmt::Debug for PaymasterData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PaymasterData(<{} felts>)", self.0.len())
+    }
+}
 
 impl PaymasterData {
     pub fn is_empty(&self) -> bool {
@@ -620,10 +638,16 @@ impl PaymasterData {
 
 /// If nonempty, will contain the required data for deploying and initializing an account contract:
 /// its class hash, address salt and constructor calldata.
-#[derive(
-    Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf,
-)]
+#[derive(Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf)]
 pub struct AccountDeploymentData(pub Vec<Felt>);
+
+// Account deployment data is unbounded, user-controlled input; hide its felts from logs (e.g.
+// `debug!("{tx:?}")` at the gateway ingest point) so it is never dumped in plaintext.
+impl fmt::Debug for AccountDeploymentData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AccountDeploymentData(<{} felts>)", self.0.len())
+    }
+}
 
 impl AccountDeploymentData {
     pub fn is_empty(&self) -> bool {

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -61,3 +61,39 @@ fn proof_facts_debug_falls_back_for_unparseable() {
     let facts = ProofFacts(Arc::new(vec![Felt::from_hex_unchecked("0xDEAD")]));
     assert_eq!(format!("{:?}", facts), "ProofFacts([<1 elements>])");
 }
+
+#[test]
+fn transaction_signature_debug_hides_felts() {
+    let signature =
+        TransactionSignature(Arc::new(vec![Felt::from_hex_unchecked("0xDEADBEEF"), Felt::TWO]));
+    let debug = format!("{signature:?}");
+    assert_eq!(debug, "TransactionSignature(<2 felts>)");
+    assert!(!debug.contains("deadbeef"), "raw signature felt leaked into Debug output: {debug}");
+}
+
+#[test]
+fn calldata_debug_hides_felts() {
+    let calldata = Calldata(Arc::new(vec![Felt::from_hex_unchecked("0xC0FFEE")]));
+    let debug = format!("{calldata:?}");
+    assert_eq!(debug, "Calldata(<1 felts>)");
+    assert!(!debug.contains("c0ffee"), "raw calldata felt leaked into Debug output: {debug}");
+}
+
+#[test]
+fn paymaster_data_debug_hides_felts() {
+    let paymaster_data = PaymasterData(vec![Felt::from_hex_unchecked("0xDEADBEEF"), Felt::TWO]);
+    let debug = format!("{paymaster_data:?}");
+    assert_eq!(debug, "PaymasterData(<2 felts>)");
+    assert!(!debug.contains("deadbeef"), "raw paymaster felt leaked into Debug output: {debug}");
+}
+
+#[test]
+fn account_deployment_data_debug_hides_felts() {
+    let account_deployment_data = AccountDeploymentData(vec![Felt::from_hex_unchecked("0xC0FFEE")]);
+    let debug = format!("{account_deployment_data:?}");
+    assert_eq!(debug, "AccountDeploymentData(<1 felts>)");
+    assert!(
+        !debug.contains("c0ffee"),
+        "raw account deployment felt leaked into Debug output: {debug}"
+    );
+}


### PR DESCRIPTION
## Problem

PR #14662 added `debug!("Received transaction: {tx:?}")` in `apollo_http_server`'s `add_tx_inner` to log a redacted transaction at ingest. But `RpcTransaction`'s derived `Debug` is **not** redacted — it transitively includes several user-controlled felt vectors that derived plain `Debug` and were dumped in plaintext whenever debug logging is enabled (several deployment overlays set `RUST_LOG=debug`). This is a CWE-532 sensitive-data-exposure bug:

- `TransactionSignature` — raw ECDSA signature felts (secret).
- `Calldata` / `constructor_calldata` — unbounded, sensitive-looking user data.
- `PaymasterData` — unbounded, user-controlled input (may carry paymaster signatures/secrets).
- `AccountDeploymentData` — unbounded, user-controlled input.

All four are reachable from the exact `RpcTransaction` value logged at the ingest point.

## Fix

In `crates/starknet_api/src/transaction/fields.rs`, remove `Debug` from the derive list of all four types and add manual `impl fmt::Debug` for each that prints only the felt count, e.g. `TransactionSignature(<2 felts>)`. This mirrors the existing `ProofFacts` precedent in the same file for hiding sensitive/unbounded fields from logs.

Added tests in `fields_test.rs` (`transaction_signature_debug_hides_felts`, `calldata_debug_hides_felts`, `paymaster_data_debug_hides_felts`, `account_deployment_data_debug_hides_felts`), each constructing a value with a distinctive felt and asserting the `Debug` output is exactly the redacted string and does not contain the raw felt. These fail against the pre-fix derived `Debug`.

## Notes / out of scope

- `RpcDeclareTransactionV3.contract_class: SierraContractClass` still derives plain `Debug` and would dump its full `sierra_program` via `{tx:?}`. This is a large but **non-secret** payload (log bloat, not sensitive-data exposure), so it is left as a documented follow-up rather than expanded here.
- Non-secret scalar fields reachable from `RpcTransaction` Debug (class hashes, nonces, addresses, resource bounds, tip, DA modes) are intentionally left unredacted.

## Verification

- `cargo test -p starknet_api debug_hides_felts` — 4 passed.
- `cargo build -p starknet_api -p apollo_http_server` — clean.
- `scripts/rust_fmt.sh` applied.
- No workspace snapshot/golden test captures the `Debug` format of these types (verified: the only `assert_debug_snapshot!` usage is in `apollo_propeller/merkle_test.rs`, unrelated to transactions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DLTRyXnsr8WqAGYg39MWi