### PR TITLE
apollo_http_server,starknet_api: fix unredacted signature/calldata leaked into logs

### DIFF
--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -129,10 +129,22 @@ impl fmt::Debug for TransactionSignature {
 }
 
 /// The calldata of a transaction.
-#[derive(
-    Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf,
-)]
+#[derive(Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf)]
 pub struct Calldata(pub Arc<Vec<Felt>>);
+
+// Calldata is embedded in `RpcTransaction`, which is logged via `{:?}` at debug level (transaction
+// ingestion, gateway processing); redact the felts so user-supplied calldata never ends up
+// unredacted in logs, mirroring `TransactionSignature`'s `Debug` impl above.
+impl fmt::Debug for Calldata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.0.len();
+        if len == 0 {
+            write!(f, "Calldata([])")
+        } else {
+            write!(f, "Calldata(<{len} elements redacted>)")
+        }
+    }
+}
 
 impl From<Vec<Felt>> for Calldata {
     fn from(value: Vec<Felt>) -> Self {

--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -112,10 +112,21 @@ pub struct ContractAddressSalt(pub StarkHash);
 /// A transaction signature, wrapped in `Arc` for efficient cloning and safe sharing across threads.
 /// `Rc` is avoided due to its lack of thread safety, and `Mutex` is unnecessary as the signature
 /// vector is immutable and never modified.
-#[derive(
-    Debug, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf,
-)]
+#[derive(Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, SizeOf)]
 pub struct TransactionSignature(pub Arc<Vec<Felt>>);
+
+// Signatures are logged (e.g. transaction ingestion, gateway processing) at debug level; redact
+// the felts so they never end up unredacted in logs, mirroring `Proof`'s `Debug` impl below.
+impl fmt::Debug for TransactionSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.0.len();
+        if len == 0 {
+            write!(f, "TransactionSignature([])")
+        } else {
+            write!(f, "TransactionSignature(<{len} elements redacted>)")
+        }
+    }
+}
 
 /// The calldata of a transaction.
 #[derive(

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -84,3 +84,25 @@ fn transaction_signature_debug_does_not_leak_felts() {
 fn transaction_signature_debug_empty() {
     assert_eq!(format!("{:?}", TransactionSignature::default()), "TransactionSignature([])");
 }
+
+// Same log-exposure concern as the signature: `Calldata` is embedded in every `RpcTransaction`
+// variant, which is logged via `{:?}`. A plain derived `Debug` would dump every raw calldata
+// felt, leaking user-supplied calldata into logs.
+#[test]
+fn calldata_debug_does_not_leak_felts() {
+    let secret_looking_felt = Felt::from_hex_unchecked("0xDEADBEEF");
+    let calldata = Calldata(Arc::new(vec![secret_looking_felt]));
+
+    let debug = format!("{calldata:?}");
+
+    assert!(
+        !debug.contains("deadbeef") && !debug.contains("DEADBEEF"),
+        "calldata felt leaked into Debug output: {debug}"
+    );
+    assert_eq!(debug, "Calldata(<1 elements redacted>)");
+}
+
+#[test]
+fn calldata_debug_empty() {
+    assert_eq!(format!("{:?}", Calldata::default()), "Calldata([])");
+}

--- a/crates/starknet_api/src/transaction/fields_test.rs
+++ b/crates/starknet_api/src/transaction/fields_test.rs
@@ -61,3 +61,26 @@ fn proof_facts_debug_falls_back_for_unparseable() {
     let facts = ProofFacts(Arc::new(vec![Felt::from_hex_unchecked("0xDEAD")]));
     assert_eq!(format!("{:?}", facts), "ProofFacts([<1 elements>])");
 }
+
+// Regression test for a log-exposure bug: transaction handlers (e.g. the HTTP server's ingest
+// path and the gateway's `add_tx`) log the request via `{:?}`, expecting the signature to be
+// redacted. Before this fix, `TransactionSignature` derived a plain `Debug` that dumped every
+// raw felt, so the signature ended up unredacted in logs.
+#[test]
+fn transaction_signature_debug_does_not_leak_felts() {
+    let secret_looking_felt = Felt::from_hex_unchecked("0xDEADBEEF");
+    let signature = TransactionSignature(Arc::new(vec![secret_looking_felt]));
+
+    let debug = format!("{signature:?}");
+
+    assert!(
+        !debug.contains("deadbeef") && !debug.contains("DEADBEEF"),
+        "signature felt leaked into Debug output: {debug}"
+    );
+    assert_eq!(debug, "TransactionSignature(<1 elements redacted>)");
+}
+
+#[test]
+fn transaction_signature_debug_empty() {
+    assert_eq!(format!("{:?}", TransactionSignature::default()), "TransactionSignature([])");
+}


### PR DESCRIPTION
## Summary

Automated security scan of #14662 ("apollo_http_server: log tx once redacted at ingest, drop raw body from span"), which was just merged to `main-v0.14.3`.

**Finding:** #14662's stated intent was to log the ingested transaction "once redacted." In practice, `add_tx_inner` added:

```rust
debug!("Received transaction: {tx:?}");
```

`RpcTransaction`'s `Debug` is a plain derive with no redaction. It recurses into `TransactionSignature` and `Calldata` (both `crates/starknet_api/src/transaction/fields.rs`), which also derived plain `Debug` and printed every raw felt. So the new debug line — and the pre-existing `apollo_gateway::add_tx` debug logs, which log `&tx` and `&tx_signature` under the same assumption — write the full, unredacted transaction signature *and* user-supplied calldata to logs on every request. This is an information-disclosure issue (OWASP A09 — sensitive/pre-confirmation data lands in logs that may be shipped to less-trusted aggregators/retention systems), and it's worse than having no redaction claim at all: reviewers and future readers will trust the "redacted" label and not notice the gap.

This repo already has an established redaction pattern for exactly this situation: `Proof` and `ProofFacts` (same file, landed in #14598 by the same author) implement a custom `Debug` that reports element counts instead of dumping raw felts.

## Fix

Apply the same pattern to both `TransactionSignature` and `Calldata`: drop the derived `Debug` and add a custom impl that reports `<Type>(<N elements redacted>)` (or `<Type>([])` when empty) instead of the raw felt values. This closes the gap in the new `apollo_http_server` debug log and the existing `apollo_gateway::add_tx` debug logs, with no call-site changes needed — every logging path that Debug-formats an `RpcTransaction` now routes through the redacted output.

## Test

Added regression tests in `fields_test.rs` for both types: each builds the type from a recognizable felt and asserts the felt's hex value never appears in the `Debug` output (it would, before this fix), plus an empty-case test — mirroring the existing `Proof`/`ProofFacts` debug tests in the same file.

## Verification

- `cargo test -p starknet_api --lib`: 99 passed, 0 failed (includes 4 new tests).
- `cargo check -p starknet_api -p apollo_http_server -p apollo_gateway`: clean.
- `cargo clippy -p starknet_api --lib`: clean.
- `scripts/rust_fmt.sh`: no diffs.

Independently reviewed by an Opus pass, which caught the `Calldata` gap in addition to the initial `TransactionSignature` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
