### PR TITLE
apollo_http_server: skip headers in add_rpc_tx/add_tx instrument spans

### DIFF
--- a/crates/apollo_http_server/src/http_server.rs
+++ b/crates/apollo_http_server/src/http_server.rs
@@ -164,7 +164,7 @@ impl HttpServer {
 
 // HttpServer handlers.
 
-#[instrument(skip(app_state, tx))]
+#[instrument(skip(app_state, headers, tx))]
 async fn add_rpc_tx(
     Extension(app_state): Extension<AppState>,
     headers: HeaderMap,
@@ -180,7 +180,7 @@ async fn add_rpc_tx(
     add_tx_inner(app_state, headers, tx).await
 }
 
-#[instrument(skip(app_state, tx))]
+#[instrument(skip(app_state, headers, tx))]
 #[sequencer_latency_histogram(HTTP_SERVER_ADD_TX_LATENCY, true)]
 async fn add_tx(
     Extension(app_state): Extension<AppState>,


### PR DESCRIPTION
## What

Performance follow-up to #14662.

#14662 changed `#[instrument(skip(app_state))]` to `#[instrument(skip(app_state, tx))]` on the `add_rpc_tx`/`add_tx` HTTP handlers, to stop `tracing`'s `#[instrument]` macro from eagerly `Debug`-formatting the entire transaction on every request — an expensive operation on the tx-ingestion hot path (called once per incoming transaction, i.e. O(N) per block).

The same two handlers also take a `headers: HeaderMap` parameter that was left un-skipped, so it still gets `Debug`-formatted (iterating and decoding every header) on every request whenever the span is enabled — the exact same class of overhead #14662 just fixed for `tx`, just not extended to `headers`.

## Why it's safe

- `headers` is only ever forwarded to `add_tx_inner` in both handlers; it's never read for tracing/logging in `add_rpc_tx`/`add_tx` themselves.
- The one header value that *is* meaningful for observability (client region, via `CLIENT_REGION_HEADER`) is extracted and logged explicitly in `record_added_transactions` — independent of the parent span's fields — so no observability is lost.
- `skip(...)` only omits a field from span recording; it does not change the argument's availability or the function's behavior.

## Change

```diff
-#[instrument(skip(app_state, tx))]
+#[instrument(skip(app_state, headers, tx))]
 async fn add_rpc_tx(...)

-#[instrument(skip(app_state, tx))]
+#[instrument(skip(app_state, headers, tx))]
 #[sequencer_latency_histogram(HTTP_SERVER_ADD_TX_LATENCY, true)]
 async fn add_tx(...)
```

Two-line diff, no behavior change.

## Verification

- `cargo build -p apollo_http_server` ✅
- `cargo test -p apollo_http_server`: 37 passed, 0 failed ✅
- Reviewed by an independent Opus pass: no blocking issues found, confirmed `headers` is unused for tracing purposes in both handlers and that the existing multi-arg `skip(...)` pattern is already established elsewhere in the codebase (e.g. `apollo_mempool`, `apollo_batcher`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcrLbp6DhRkqCri83SHi8c)_