### PR TITLE
starknet_transaction_prover: reject request limits exceeding semaphore capacity

### DIFF
--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -10,6 +10,7 @@ use blockifier::bouncer::BouncerConfig;
 use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ChainId, ContractAddress};
+use tokio::sync::Semaphore;
 use tracing::info;
 
 use crate::config::ProverConfig;
@@ -387,9 +388,22 @@ impl ServiceConfig {
                 "max_connections must be at least 1".to_string(),
             ));
         }
+        // max_concurrent_requests + max_queued_requests sizes the admission semaphore, which
+        // panics if built with more than `Semaphore::MAX_PERMITS`. Reject an oversized or
+        // overflowing sum with a clean error instead of crashing at startup.
+        let max_in_flight = config
+            .max_concurrent_requests
+            .checked_add(config.max_queued_requests)
+            .filter(|&total| total <= Semaphore::MAX_PERMITS)
+            .ok_or_else(|| {
+                ConfigError::InvalidArgument(format!(
+                    "max_concurrent_requests ({}) + max_queued_requests ({}) must not exceed {}",
+                    config.max_concurrent_requests,
+                    config.max_queued_requests,
+                    Semaphore::MAX_PERMITS,
+                ))
+            })?;
         // Waiting requests hold a connection, so queue depth is capped by max_connections.
-        let max_in_flight =
-            config.max_concurrent_requests.saturating_add(config.max_queued_requests);
         if max_in_flight > usize::try_from(config.max_connections).unwrap_or(usize::MAX) {
             info!(
                 "max_concurrent_requests ({}) + max_queued_requests ({}) exceeds max_connections \

--- a/crates/starknet_transaction_prover/src/server/config_test.rs
+++ b/crates/starknet_transaction_prover/src/server/config_test.rs
@@ -65,6 +65,18 @@ fn base_args() -> CliArgs {
     }
 }
 
+#[test]
+fn rejects_request_limits_exceeding_semaphore_capacity() {
+    // The sum sizes the admission semaphore; tokio's Semaphore panics above MAX_PERMITS, so an
+    // oversized config must surface as a clean error rather than a startup crash.
+    let mut args = base_args();
+    args.max_queued_requests = Some(tokio::sync::Semaphore::MAX_PERMITS);
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    assert!(matches!(error, ConfigError::InvalidArgument(_)));
+}
+
 /// Happy-path cases: input origins -> expected normalized output.
 #[rstest]
 #[case::disabled(vec![], vec![])]


### PR DESCRIPTION
max_concurrent_requests + max_queued_requests sizes the admission semaphore, and
tokio's Semaphore panics when constructed with more than MAX_PERMITS. Validate
the sum in from_args (via checked_add + MAX_PERMITS bound) and return a clean
ConfigError instead of crashing at startup on an oversized or overflowing config.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>