### PR TITLE
starknet_transaction_prover: reject zero queue_wait_timeout when a queue is configured

### DIFF
--- a/crates/starknet_transaction_prover/src/server/config.rs
+++ b/crates/starknet_transaction_prover/src/server/config.rs
@@ -402,6 +402,14 @@ impl ServiceConfig {
                 "max_request_body_size must be at least 1".to_string(),
             ));
         }
+        // A zero backstop makes an admitted request time out immediately instead of waiting for a
+        // worker slot, silently defeating the queue. Reject it when a queue is configured.
+        if config.queue_wait_timeout_millis == 0 && config.max_queued_requests > 0 {
+            return Err(ConfigError::InvalidArgument(
+                "queue_wait_timeout_millis must be at least 1 when max_queued_requests > 0"
+                    .to_string(),
+            ));
+        }
         let transport = TransportMode::new(config.tls_cert_file, config.tls_key_file)?;
         let cors_allow_origin = normalize_cors_allow_origins(config.cors_allow_origin)?;
         if cors_allow_origin == ["*"] {

--- a/crates/starknet_transaction_prover/src/server/config_test.rs
+++ b/crates/starknet_transaction_prover/src/server/config_test.rs
@@ -160,6 +160,27 @@ fn cors_allow_origin_rejects_non_array_in_config_file() {
     assert!(matches!(error, ConfigError::ConfigFileError(_)));
 }
 
+#[test]
+fn rejects_zero_queue_wait_timeout_with_a_queue() {
+    let mut args = base_args();
+    args.max_queued_requests = Some(1);
+    args.queue_wait_timeout_millis = Some(0);
+
+    let error = ServiceConfig::from_args(args).unwrap_err();
+
+    assert!(matches!(error, ConfigError::InvalidArgument(_)));
+}
+
+#[test]
+fn allows_zero_queue_wait_timeout_without_a_queue() {
+    // With no queue, a request never waits, so a zero backstop is harmless.
+    let mut args = base_args();
+    args.max_queued_requests = Some(0);
+    args.queue_wait_timeout_millis = Some(0);
+
+    ServiceConfig::from_args(args).unwrap();
+}
+
 /// TLS configuration validation: partial TLS config is rejected, complete config is accepted.
 #[rstest]
 #[case::cert_without_key(


### PR DESCRIPTION
A zero queue_wait_timeout_millis makes an admitted request time out immediately
instead of waiting for a worker slot, silently defeating the queue. Reject it in
from_args when max_queued_requests > 0; a zero timeout remains valid when no queue
is configured (a request never waits).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>