### PR TITLE
echonet: run Starknet OS against replayed cende blobs

### DIFF
--- a/echonet/class_fetcher.py
+++ b/echonet/class_fetcher.py
@@ -1,0 +1,289 @@
+"""
+Resolve the CASM (and deprecated v0) classes the OS needs to run a block.
+
+The cende blob only carries *newly declared* contract classes (`compiled_classes`)
+for the block being run. The OS, however, executes against any class touched by
+the block — including pre-existing on-chain ones. We bridge the gap by fetching
+missing classes from the mainnet feeder gateway, caching them on the echonet
+PVC so subsequent blocks don't refetch the same class.
+
+Inputs:
+- `initial_reads.compiled_class_hashes`: `class_hash → compiled_class_hash` for
+  every Cairo 1+ class touched. The OS's `compiled_classes` map is keyed by
+  `compiled_class_hash`, so this map is exactly the fetch list.
+- `initial_reads.class_hashes`: `address → class_hash` for every accessed
+  contract. Any non-zero class_hash here that is NOT in `compiled_class_hashes`
+  is a Cairo 0 (deprecated) class — needs `deprecated_compiled_classes` keyed
+  by class_hash. (`class_hash = 0x0` represents uninitialized accounts.)
+- `blob["compiled_classes"]`: newly declared CASM for this block, already in the
+  shape the OS expects — passed through without refetching.
+
+The fetched JSON from `feeder_gateway/get_compiled_class_by_class_hash` matches
+`CasmContractClass` (keys: bytecode, entry_points_by_type, hints, prime,
+pythonic_hints, compiler_version) — drop-in for the OS input.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Set, Tuple
+
+from echonet.echonet_types import CONFIG, JsonObject
+from echonet.logger import get_logger
+
+logger = get_logger("echonet.class_fetcher")
+
+_CASM_CACHE_SUBDIR = "cairo1"
+_DEPRECATED_CACHE_SUBDIR = "cairo0"
+_FETCH_PARALLELISM = 8
+_FETCH_TIMEOUT_SECONDS = 30
+_ZERO_CLASS_HASH = "0x0"
+
+
+def _is_sierra_shape(class_json: JsonObject) -> bool:
+    """
+    A class_by_hash response can be either a Cairo 0 deprecated class
+    (`program` + offset-keyed entry_points) OR — for some pre-existing
+    Cairo 1 classes that the sequencer didn't include in
+    `initial_reads.compiled_class_hashes` — a Cairo 1 Sierra class (mainnet's
+    v0 endpoint is permissive and returns Sierra anyway). The two shapes are
+    structurally distinct: only Sierra carries `sierra_program`.
+    """
+    return "sierra_program" in class_json
+
+
+def _is_zero_felt(felt_hex: str) -> bool:
+    if not felt_hex.startswith("0x"):
+        return False
+    return all(c == "0" for c in felt_hex[2:]) or felt_hex == "0x"
+
+
+class ClassFetchError(RuntimeError):
+    """Raised when a required class cannot be fetched from the feeder."""
+
+
+def resolve_classes_for_os(
+    blob: JsonObject, *, cache_root: Path
+) -> Tuple[Dict[str, JsonObject], Dict[str, JsonObject], int, int]:
+    """
+    Resolve all classes the OS will execute when replaying this block.
+
+    Returns:
+      compiled_classes:           `compiled_class_hash` → CASM (Cairo 1+)
+      deprecated_compiled_classes: `class_hash` → ContractClass v0 (Cairo 0)
+      fetched_count:              count of classes fetched from the feeder
+      cached_count:               count of classes served from the disk cache
+
+    Newly declared classes (from `blob["compiled_classes"]`) are merged in as-is
+    without refetching.
+    """
+    initial_reads = blob.get("initial_reads") or {}
+    compiled_class_hashes: Mapping[str, str] = initial_reads.get("compiled_class_hashes") or {}
+    address_to_class_hash: Mapping[str, str] = initial_reads.get("class_hashes") or {}
+
+    # The sequencer's `get_os_initial_reads` (cached_state.rs) force-reads
+    # `get_compiled_class_hash` for every accessed class — which per the
+    # `StateReader` contract returns `CompiledClassHash::default()` (= felt 0)
+    # for Cairo 0 classes. So a class_hash present in `compiled_class_hashes`
+    # with value 0 is the sentinel for "this is a Cairo 0 class", not a Cairo 1
+    # one. Route those to the v0 endpoint, not the CASM endpoint.
+    cairo1_compiled_class_hashes: Dict[str, str] = {
+        class_hash: compiled_class_hash
+        for class_hash, compiled_class_hash in compiled_class_hashes.items()
+        if not _is_zero_felt(compiled_class_hash)
+    }
+    cairo0_from_sentinels: Set[str] = {
+        class_hash
+        for class_hash, compiled_class_hash in compiled_class_hashes.items()
+        if _is_zero_felt(compiled_class_hash)
+    }
+    cairo1_class_hashes: Set[str] = set(cairo1_compiled_class_hashes.keys())
+    cairo0_class_hashes: Set[str] = cairo0_from_sentinels | {
+        class_hash
+        for class_hash in address_to_class_hash.values()
+        if class_hash != _ZERO_CLASS_HASH and class_hash not in cairo1_class_hashes
+    }
+
+    blob_compiled: Dict[str, JsonObject] = {}
+    for entry in blob.get("compiled_classes") or []:
+        compiled_class_hash = entry[0]
+        casm = entry[1].get("compiled_class") if isinstance(entry[1], dict) else None
+        if casm is None:
+            raise ClassFetchError(
+                f"blob compiled_classes entry for {compiled_class_hash} missing 'compiled_class'"
+            )
+        blob_compiled[compiled_class_hash] = casm
+
+    casm_cache_dir = cache_root / _CASM_CACHE_SUBDIR
+    deprecated_cache_dir = cache_root / _DEPRECATED_CACHE_SUBDIR
+    casm_cache_dir.mkdir(parents=True, exist_ok=True)
+    deprecated_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    compiled_classes: Dict[str, JsonObject] = {}
+    deprecated_compiled_classes: Dict[str, JsonObject] = {}
+    fetched_count = 0
+    cached_count = 0
+
+    for class_hash, compiled_class_hash in cairo1_compiled_class_hashes.items():
+        if compiled_class_hash in compiled_classes:
+            continue
+        if compiled_class_hash in blob_compiled:
+            compiled_classes[compiled_class_hash] = blob_compiled[compiled_class_hash]
+            continue
+        cached = _read_cache(casm_cache_dir, compiled_class_hash)
+        if cached is not None:
+            compiled_classes[compiled_class_hash] = cached
+            cached_count += 1
+
+    missing_cairo1 = [
+        (class_hash, compiled_class_hash)
+        for class_hash, compiled_class_hash in cairo1_compiled_class_hashes.items()
+        if compiled_class_hash not in compiled_classes
+    ]
+    if missing_cairo1:
+        for compiled_class_hash, casm in _fetch_casm_parallel(missing_cairo1).items():
+            compiled_classes[compiled_class_hash] = casm
+            _write_cache(casm_cache_dir, compiled_class_hash, casm)
+            fetched_count += 1
+
+    for compiled_class_hash, casm in blob_compiled.items():
+        compiled_classes.setdefault(compiled_class_hash, casm)
+
+    missing_cairo0: List[str] = []
+    for class_hash in cairo0_class_hashes:
+        cached = _read_cache(deprecated_cache_dir, class_hash)
+        if cached is None:
+            missing_cairo0.append(class_hash)
+            continue
+        # Stale cache from the pre-fix behavior may hold a Sierra (Cairo 1)
+        # body under the deprecated cache. Force a refetch so the new
+        # classification path routes it correctly.
+        if _is_sierra_shape(cached):
+            missing_cairo0.append(class_hash)
+            continue
+        deprecated_compiled_classes[class_hash] = cached
+        cached_count += 1
+    if missing_cairo0:
+        # The v0 endpoint is permissive — for a class that's actually Cairo 1
+        # but absent from `initial_reads.compiled_class_hashes`, it still
+        # returns the Sierra body. We can't reuse that body: the FGW's
+        # cairo-lang Python serialization of CASM differs from the Rust
+        # `CasmContractClass` schema (e.g. `pythonic_hints` is dict vs
+        # sequence-of-pairs), so injecting the raw FGW response would just
+        # move the deserialization failure. Skip the class — the OS only
+        # actually needs its code if it's invoked by some tx in this block;
+        # if so, we'll see a cleaner downstream error rather than the
+        # opaque "missing field offset" at JSON load.
+        for class_hash, deprecated_class in _fetch_deprecated_parallel(missing_cairo0).items():
+            if _is_sierra_shape(deprecated_class):
+                logger.warning(
+                    f"Skipping class {class_hash}: address-only reference, "
+                    "v0 endpoint returned Sierra (Cairo 1) but schema mismatch "
+                    "blocks using it; OS run will fail only if the class is "
+                    "actually invoked in this block."
+                )
+                continue
+            deprecated_compiled_classes[class_hash] = deprecated_class
+            _write_cache(deprecated_cache_dir, class_hash, deprecated_class)
+            fetched_count += 1
+
+    return compiled_classes, deprecated_compiled_classes, fetched_count, cached_count
+
+
+def _read_cache(cache_dir: Path, key: str) -> JsonObject | None:
+    path = cache_dir / f"{key}.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        return None
+
+
+def _write_cache(cache_dir: Path, key: str, value: JsonObject) -> None:
+    path = cache_dir / f"{key}.json"
+    tmp_path = cache_dir / f".{key}.json.{os.getpid()}.tmp"
+    try:
+        tmp_path.write_text(json.dumps(value), encoding="utf-8")
+        tmp_path.replace(path)
+    except OSError:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+
+
+def _fetch_casm_parallel(
+    pairs: Iterable[Tuple[str, str]],
+) -> Dict[str, JsonObject]:
+    """
+    `pairs` is `(class_hash, compiled_class_hash)`. Returns `compiled_class_hash → CASM`.
+    Class_hash is what the feeder needs as the request param; compiled_class_hash is
+    the key the OS will look up by.
+    """
+    pair_list = list(pairs)
+    if not pair_list:
+        return {}
+    result: Dict[str, JsonObject] = {}
+    errors: List[str] = []
+    with ThreadPoolExecutor(max_workers=_FETCH_PARALLELISM) as pool:
+        future_to_pair = {
+            pool.submit(_fetch_one_casm, class_hash): (class_hash, compiled_class_hash)
+            for class_hash, compiled_class_hash in pair_list
+        }
+        for fut in as_completed(future_to_pair):
+            class_hash, compiled_class_hash = future_to_pair[fut]
+            try:
+                result[compiled_class_hash] = fut.result()
+            except Exception as exc:
+                errors.append(f"{class_hash}: {exc}")
+    if errors:
+        raise ClassFetchError(f"feeder fetch failures: {errors}")
+    return result
+
+
+def _fetch_deprecated_parallel(class_hashes: Iterable[str]) -> Dict[str, JsonObject]:
+    class_hashes_list = list(class_hashes)
+    if not class_hashes_list:
+        return {}
+    result: Dict[str, JsonObject] = {}
+    errors: List[str] = []
+    with ThreadPoolExecutor(max_workers=_FETCH_PARALLELISM) as pool:
+        future_to_class = {
+            pool.submit(_fetch_one_deprecated, class_hash): class_hash
+            for class_hash in class_hashes_list
+        }
+        for fut in as_completed(future_to_class):
+            class_hash = future_to_class[fut]
+            try:
+                result[class_hash] = fut.result()
+            except Exception as exc:
+                errors.append(f"{class_hash}: {exc}")
+    if errors:
+        raise ClassFetchError(f"feeder fetch failures: {errors}")
+    return result
+
+
+def _fetch_one_casm(class_hash: str) -> JsonObject:
+    path = CONFIG.feeder.endpoints.get_compiled_class_by_class_hash
+    return _http_get_json(path, {"classHash": class_hash})
+
+
+def _fetch_one_deprecated(class_hash: str) -> JsonObject:
+    path = CONFIG.feeder.endpoints.get_class_by_hash
+    return _http_get_json(path, {"classHash": class_hash})
+
+
+def _http_get_json(path: str, params: Mapping[str, Any]) -> JsonObject:
+    base = CONFIG.feeder.base_url.rstrip("/")
+    url = f"{base}{path}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url)
+    for header, value in CONFIG.feeder.headers.items():
+        req.add_header(header, value)
+    with urllib.request.urlopen(req, timeout=_FETCH_TIMEOUT_SECONDS) as resp:
+        return json.loads(resp.read())

--- a/echonet/deploy_echonet.py
+++ b/echonet/deploy_echonet.py
@@ -220,6 +220,41 @@ def _install_block_hash_cli_into_pod(
     raise RuntimeError("Timed out waiting for echonet pod before copying block-hash CLI.")
 
 
+def _scale_down_existing_echonet_deployments(namespace_args: list[str]) -> None:
+    proc = subprocess.run(
+        [
+            "kubectl",
+            *namespace_args,
+            "get",
+            "deployments",
+            "-l",
+            "app.kubernetes.io/name=echonet",
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        logger.warning(
+            f"Failed to list echonet deployments (exit {proc.returncode}): "
+            f"{proc.stderr.strip() or '<no stderr>'}; skipping pre-scale-down."
+        )
+        return
+
+    deployment_names = proc.stdout.split()
+    if not deployment_names:
+        logger.info("No existing echonet deployments to scale down.")
+        return
+
+    for deployment_name in deployment_names:
+        logger.info(f"Scaling down deployment/{deployment_name} to 0 replicas...")
+        _run(["kubectl", *namespace_args, "scale", "deployment", deployment_name, "--replicas=0"])
+        logger.info(f"Waiting for rollout status deployment/{deployment_name}...")
+        _run(["kubectl", *namespace_args, "rollout", "status", f"deployment/{deployment_name}"])
+
+
 def _copy_generated_keys(keys_in_repo: Path, generated_path: Path) -> None:
     """
     Copy the non-secret echonet keys JSON into the kustomize generated/ directory.
@@ -308,6 +343,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.delete_first:
         logger.info("Deleting existing resources...")
         _run(["kubectl", *namespace_args, "delete", "-k", str(kustomize_dir), "--ignore-not-found"])
+
+    # Scale any existing echonet deployments to 0 first so the new pod doesn't
+    # come up while an old one still holds the PVC (Multi-Attach error). Belt
+    # and braces alongside the deployment's `strategy: Recreate`; useful when
+    # an unrelated/old echonet deployment is hanging around in the namespace.
+    _scale_down_existing_echonet_deployments(namespace_args)
 
     # Ensure the sequencer is scaled down before deploying/updating echonet.
     logger.info("Scaling down statefulset/sequencer-node-statefulset to 0 replicas...")

--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -2,11 +2,38 @@ import base64
 import json
 import logging
 import os
+import queue
 import subprocess
+import sys
 import tempfile
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
+
+# Bounded backlog of OS-run tasks fed to the background worker thread. With
+# blocks arriving ~1/s and each OS run taking several seconds, this lets a few
+# blocks queue up; anything beyond it is dropped (logged) so the Flask handler
+# never blocks blob storage.
+_OS_RUN_QUEUE_SIZE = 30
+# Number of OS-runner worker threads draining the queue in parallel. Each
+# worker spawns its own `committer-and-os-cli` subprocess per task. Per-worker
+# capacity ≈ 5/min (mean OS run ~12s); mainnet arrives at ~26/min, so we need
+# ≥6 workers to clear the queue. Sized at 8 (not 6) so the pod's `limits.cpu:
+# "8"` headroom over `requests.cpu: "6"` gets actually consumed under burst —
+# with 6 workers each pegging ~1 core, active CPU tops out near request; with
+# 8 the burst can reach the limit before drops start. Memory budget (post
+# cende-commitment-delta: p99 blob ~20 MB, typical subprocess ~300 MB, p99
+# ~2 GB): 8 workers worst-case ≈ 16 GiB + flask + cache ≈ 20 GiB, still
+# comfortably under the 32 GiB limit on an n4-standard-8.
+_OS_RUN_PARALLELISM = 8
+# Width of the `recent_state_commitment_infos` vector each blob carries — the
+# sequencer fills it with up to N_BLOCK_HASHES_BACK_IN_BLOB (= 10) prior blocks
+# plus the current one. A block's commit info therefore stays reachable from
+# blobs at most this many heights newer; older deferred lookups are dropped.
+_RECENT_STATE_COMMITMENT_WINDOW = 10
+
 
 import flask  # pyright: ignore[reportMissingImports]
 import requests
@@ -17,6 +44,7 @@ from echonet.feeder_client import FeederClient
 from echonet.helpers import format_hex
 from echonet.l1_logic.l1_manager import L1Manager
 from echonet.logger import get_logger
+from echonet.os_input_builder import OsInputBuildError, pick_state_commitment_infos
 from echonet.reports import (
     RevertClassifier,
     RevertComparisonTextReport,
@@ -32,6 +60,24 @@ BlockNumberParam = Union[int, Literal["latest"]]
 
 flask_logger = get_logger("flask")
 logger = get_logger("echo_center")
+
+
+def _os_run_error_text(exc: BaseException) -> str:
+    """
+    Build the per-failure `error` payload for the report — the exception's
+    message followed by the worker subprocess's stderr verbatim if present
+    (CalledProcessError carries it on `.stderr`). Recorded into the report's
+    `recent_failures` list and truncated at the storage layer; the full text
+    survives in pod logs.
+    """
+    parts = [str(exc)]
+    stderr_bytes = getattr(exc, "stderr", None)
+    if stderr_bytes:
+        if isinstance(stderr_bytes, bytes):
+            parts.append(stderr_bytes.decode(errors="replace"))
+        else:
+            parts.append(str(stderr_bytes))
+    return "\n".join(parts)
 
 
 def _static_file_b64(filename: str) -> str:
@@ -388,6 +434,109 @@ class BlobTransformer:
                 raise
             return json.loads(output_path.read_text(encoding="utf-8"))
 
+    def write_os_runner_input_file(
+        self,
+        blob_body: bytes,
+        block_document: JsonObject,
+        block_number: int,
+        state_commitment_infos: JsonObject,
+        block_commitments: JsonObject,
+    ) -> Path:
+        """
+        Serialize the worker input to a tempfile and return its path. The caller
+        is responsible for `unlink`ing it.
+
+        `blob_body` is the raw JSON bytes received from the sequencer (stored
+        verbatim in the BlockStore — see `_BlockStore.store_block` for the
+        rationale: storing the parsed Python dict balloons memory ~5-8× and
+        OOMs the pod). We splice the bytes directly into the output file's
+        `"blob"` field instead of parsing→re-serializing.
+
+        `block_commitments` was computed once at ingest (`transform_block`) and
+        stashed alongside the block in the store, so no re-parse or re-CLI-call
+        is needed here — under 6 concurrent workers that spike used to add up
+        to hundreds of MB of transient parsed-dict memory.
+        """
+        repo_root = Path(__file__).resolve().parent.parent
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=f"echonet_os_in_{block_number}_",
+            suffix=".json",
+            dir=repo_root,
+            delete=False,
+        ) as input_file:
+            # Hand-assemble the outer JSON object so we can splice the raw
+            # blob_body bytes in verbatim without going through a Python
+            # dict (which would re-create the ~30-50 MB parsed-dict heap
+            # spike we're trying to avoid).
+            input_file.write(b'{"blob":')
+            input_file.write(blob_body)
+            input_file.write(b',"state_commitment_infos":')
+            input_file.write(json.dumps(state_commitment_infos).encode("utf-8"))
+            input_file.write(b',"block_document":')
+            input_file.write(
+                json.dumps(
+                    {
+                        "parent_block_hash": block_document["parent_block_hash"],
+                        "block_hash": block_document["block_hash"],
+                    }
+                ).encode("utf-8")
+            )
+            input_file.write(f',"block_number":{int(block_number)}'.encode("utf-8"))
+            input_file.write(b',"block_hash_commitments_payload":')
+            input_file.write(json.dumps(block_commitments).encode("utf-8"))
+            input_file.write(b"}")
+            return Path(input_file.name)
+
+    def run_os_subprocess(self, input_path: Path, block_number: int) -> None:
+        """
+        Block on `echonet.os_runner_worker --input-path <input_path>`. The caller
+        must own `input_path`'s lifetime (write it via `write_os_runner_input_file`,
+        unlink after).
+
+        Stdio capture: the inner committer-and-os-cli writes a final JSON metric
+        blob to stdout without a trailing newline (e.g.
+        `{"da_segment_len": 26, "unused_hints_count": 58}`). If we let stdio
+        inherit, that blob gets glued to flask's next log line — and GCP Cloud
+        Logging auto-parses any line starting with `{` as structured JSON, so
+        the trailing text (the actual "OS run completed for block N" message)
+        gets dropped from the indexed payload. Capture and discard stdout on
+        success; on failure, surface stderr in the error log so we don't lose
+        diagnostic information when the worker fails.
+        """
+        repo_root = Path(__file__).resolve().parent.parent
+        timeout = CONFIG.os_runner.cli_timeout_secs + 30
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "echonet.os_runner_worker",
+                    "--input-path",
+                    str(input_path),
+                ],
+                cwd=repo_root,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                check=True,
+                timeout=timeout,
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr_tail = (exc.stderr or b"").decode(errors="replace")[-4096:]
+            self._logger.error(
+                f"OS runner worker for block {block_number} exited {exc.returncode}\n"
+                f"stderr (last 4KB):\n{stderr_tail}"
+            )
+            raise
+        except subprocess.TimeoutExpired as exc:
+            stderr_tail = (exc.stderr or b"").decode(errors="replace")[-4096:] if exc.stderr else ""
+            self._logger.error(
+                f"OS runner worker for block {block_number} timed out after {timeout}s\n"
+                f"stderr (last 4KB):\n{stderr_tail}"
+            )
+            raise
+
     @staticmethod
     def _build_thin_state_diff(blob: JsonObject) -> JsonObject:
         state_diff = blob["state_diff"]
@@ -588,7 +737,7 @@ class BlobTransformer:
         )
         return str(result)
 
-    def transform_block(self, blob: JsonObject) -> JsonObject:
+    def transform_block(self, blob: JsonObject) -> tuple[JsonObject, JsonObject]:
         """
         Build the stored "block" document from an incoming blob.
 
@@ -596,6 +745,13 @@ class BlobTransformer:
         - transactions + receipts (minimal schema expected by downstream consumers)
         - block hash computed from real commitments and block header fields
         - fee market metadata (timestamp + gas prices)
+
+        Returns `(block_document, block_commitments)`. The commitments dict is
+        the full 5-felt `BlockHeaderCommitments` (transaction / event / receipt /
+        state_diff / concatenated_counts) as returned by the block-hash CLI —
+        block_document only keeps the first four as strings, so we hand back the
+        raw dict too so downstream (OS runner) can reuse it without re-parsing
+        the blob to recompute the same values.
         """
         block_number = int(blob["block_number"])
         tx_entries = blob["transactions"]
@@ -606,7 +762,7 @@ class BlobTransformer:
         execution_infos = blob["execution_infos"]
         assert len(execution_infos) == len(
             transformed_txs
-        ), f"The number of transactions in the blob does not match the number of execution infos."
+        ), "The number of transactions in the blob does not match the number of execution infos."
         for idx, (tx, execution_info) in enumerate(zip(transformed_txs, execution_infos)):
             receipts.append(
                 self._transform_receipt_from_execution_info(
@@ -669,7 +825,7 @@ class BlobTransformer:
             source_block=source_block,
         )
 
-        return block_document
+        return block_document, block_commitments
 
     def transform_state_update(
         self, blob: JsonObject, block_number: int, block_hash: str
@@ -776,6 +932,77 @@ class EchoCenterService:
             logger_obj=self.logger,
         )
 
+        # Background OS-run pipeline: blob-handlers enqueue tasks and return
+        # immediately; this thread drains the queue one at a time, spawning a
+        # fresh `echonet.os_runner_worker` subprocess per task. A bounded
+        # `maxsize` provides natural backpressure — if blobs arrive faster than
+        # OS runs complete, the excess are dropped (logged) so Flask never
+        # blocks blob storage.
+        self._os_run_queue: queue.Queue = queue.Queue(maxsize=_OS_RUN_QUEUE_SIZE)
+        # Block numbers whose `state_commitment_infos` were missing in their
+        # N+1 blob's vector (race in the sequencer's
+        # `collect_recent_state_commitment_infos`: the loop breaks on first
+        # NotFound, so if block N-1's commit task hasn't completed when block N
+        # is being proposed, N-1 is absent from N's vector). When a later blob
+        # arrives, retry the lookup against its vector. Anything older than
+        # the vector window (`_RECENT_STATE_COMMITMENT_WINDOW`) is permanently
+        # unreachable and dropped.
+        self._deferred_os_blocks: set[int] = set()
+        self._os_run_threads: list[threading.Thread] = []
+        for i in range(_OS_RUN_PARALLELISM):
+            t = threading.Thread(target=self._os_run_worker, name=f"os-runner-{i}", daemon=True)
+            t.start()
+            self._os_run_threads.append(t)
+
+    def _os_run_worker(self) -> None:
+        """
+        Drain `self._os_run_queue` serially, one OS run at a time.
+
+        Memory discipline: write the worker input tempfile FIRST, drop every
+        reference to the blob and other multi-MB task fields BEFORE waiting on
+        the OS subprocess. Otherwise the blob lives in this thread's heap for
+        the full ~10s OS run, and concurrent queue slots compound the cost.
+        """
+        while True:
+            task = self._os_run_queue.get()
+            block_number = task["block_number"]
+            wait_s = time.monotonic() - task["queued_at"]
+            start = time.monotonic()
+            input_path: Optional[Path] = None
+            try:
+                input_path = self._transformer.write_os_runner_input_file(
+                    blob_body=task["blob_body"],
+                    block_document=task["block_document"],
+                    block_number=block_number,
+                    state_commitment_infos=task["state_commitment_infos"],
+                    block_commitments=task["block_commitments"],
+                )
+                # Release every multi-MB reference before waiting on the
+                # subprocess. The blob/state_commitment_infos/block_document
+                # are now persisted in `input_path`; we no longer need them in
+                # memory.
+                task.clear()
+                del task
+                self._transformer.run_os_subprocess(input_path, block_number)
+                run_s = time.monotonic() - start
+                self.shared.record_os_run_completed()
+                self.flask_logger.info(
+                    f"OS run completed for block {block_number} "
+                    f"(wait={wait_s:.2f}s, run={run_s:.2f}s, queue={self._os_run_queue.qsize()}/"
+                    f"{_OS_RUN_QUEUE_SIZE})"
+                )
+            except Exception as exc:
+                run_s = time.monotonic() - start
+                self.shared.record_os_run_failed(block_number, _os_run_error_text(exc))
+                self.flask_logger.exception(
+                    f"OS run failed for block {block_number} "
+                    f"(wait={wait_s:.2f}s, run={run_s:.2f}s, queue={self._os_run_queue.qsize()}/"
+                    f"{_OS_RUN_QUEUE_SIZE})"
+                )
+            finally:
+                if input_path is not None:
+                    input_path.unlink(missing_ok=True)
+
     def _check_l2_gas_mismatches(self, stored_block: JsonObject, echo_block_number: int) -> None:
         txs = stored_block.get("transactions", [])
         receipts = stored_block.get("transaction_receipts", [])
@@ -859,10 +1086,17 @@ class EchoCenterService:
             self.flask_logger.info(f"Duplicate WRITE_BLOB for block {block_number}; no-op")
             return self._empty_response(requests.codes.ok)
 
+        # Persist this blob's state_commitment_infos vector. Two reasons:
+        # (1) the OS runner needs each block's commit later (the cende-delta
+        # optimization on the sequencer side means a future blob may not carry
+        # it); (2) the cende-recorder `get_last_stored_commitment_height` query
+        # reads `last_stored_commitment_height` derived from this store.
+        self.shared.record_commits_from_blob(blob)
+
         self.shared.set_last_block(block_number)
         self.flask_logger.info(f"last_block={block_number}")
 
-        to_store = self._transformer.transform_block(blob)
+        to_store, block_commitments = self._transformer.transform_block(blob)
         state_update = self._transformer.transform_state_update(
             blob, block_number, to_store["block_hash"]
         )
@@ -870,7 +1104,11 @@ class EchoCenterService:
         self._check_l2_gas_mismatches(to_store, echo_block_number=block_number)
 
         self.shared.store_block(
-            block_number, blob=blob, fgw_block=to_store, state_update=state_update
+            block_number,
+            blob_body=body,
+            fgw_block=to_store,
+            state_update=state_update,
+            block_commitments=block_commitments,
         )
         self.flask_logger.info(
             f"block {block_number} tx hashes: {' '.join(self._transformer.get_blob_tx_hashes(blob))}"
@@ -878,7 +1116,128 @@ class EchoCenterService:
 
         self._update_tx_tracking_and_reverts(blob, block_number)
 
+        self._maybe_run_os(blob, block_number)
+
         return self._empty_response(requests.codes.ok)
+
+    def _maybe_run_os(self, blob: JsonObject, block_number: int) -> None:
+        """
+        Opt-in OS run, **lagged by one block** and **fire-and-forget**. When the
+        blob for block N+1 arrives we want to run the OS over block N — its
+        `StateCommitmentInfos` are inside N+1's `recent_state_commitment_infos`
+        (the cende blob's vector slides by one and does not contain its own
+        block's entry; see `pick_state_commitment_infos`).
+
+        If block N's commit info is missing from N+1's vector (sequencer race —
+        the batcher's commit for N may not have completed by the time N+1 is
+        proposed), the target block is deferred and retried against subsequent
+        blobs' vectors until it falls outside `_RECENT_STATE_COMMITMENT_WINDOW`
+        heights — at which point it's permanently unreachable.
+
+        This method only validates inputs and enqueues; the heavy lifting happens
+        on the dedicated `os-runner` thread. The Flask request returns
+        immediately. If the queue is full (OS runs can't keep up with blob
+        arrival), the task is dropped and logged — block/state_update storage is
+        unaffected either way.
+        """
+        if not CONFIG.os_runner.enabled:
+            return
+        previous_block_number = block_number - 1
+        if previous_block_number < 0:
+            return
+
+        oldest_reachable = block_number - _RECENT_STATE_COMMITMENT_WINDOW
+        for stale_block in [b for b in self._deferred_os_blocks if b < oldest_reachable]:
+            self._deferred_os_blocks.discard(stale_block)
+            self.shared.record_os_run_abandoned()
+            self.flask_logger.warning(
+                f"OS run permanently abandoned for block {stale_block}: "
+                f"state_commitment_infos no longer reachable from any blob "
+                f"(current blob={block_number}, window={_RECENT_STATE_COMMITMENT_WINDOW})"
+            )
+
+        candidate_blocks = sorted(self._deferred_os_blocks | {previous_block_number})
+        for target_block in candidate_blocks:
+            self._try_enqueue_os_run(blob, block_number, target_block)
+
+        # Refresh report's live queue/defer state with the post-enqueue counts.
+        self.shared.set_os_run_live_state(
+            queue_depth=self._os_run_queue.qsize(),
+            queue_max=_OS_RUN_QUEUE_SIZE,
+            deferred_count=len(self._deferred_os_blocks),
+        )
+
+    def _try_enqueue_os_run(self, blob: JsonObject, current_block: int, target_block: int) -> None:
+        """
+        Look up `target_block`'s `state_commitment_infos` in `blob`'s vector
+        (where `blob` is for height `current_block`) and enqueue the OS run.
+        On miss, defer for retry against a future blob.
+        """
+        # Blob bodies are evicted from RAM aggressively (separate cap from the
+        # block-doc retention used by the tx sender), so fall back to the
+        # on-disk archive — the worker is fine with either source.
+        target_blob_body = self.shared.get_blob_body_with_disk_fallback(target_block)
+        if target_blob_body is None:
+            self._deferred_os_blocks.discard(target_block)
+            self.shared.record_os_run_skipped()
+            self.flask_logger.info(
+                f"OS run skipped: target blob (block {target_block}) not in cache or archive."
+            )
+            return
+        target_block_document = self.shared.get_block_field(target_block, "block")
+        if target_block_document is None:
+            self._deferred_os_blocks.discard(target_block)
+            self.shared.record_os_run_skipped()
+            self.flask_logger.info(
+                f"OS run skipped: target block document (block {target_block}) not in cache."
+            )
+            return
+        target_block_commitments = self.shared.get_block_field(target_block, "block_commitments")
+        if target_block_commitments is None:
+            self._deferred_os_blocks.discard(target_block)
+            self.shared.record_os_run_skipped()
+            self.flask_logger.info(
+                f"OS run skipped: target block_commitments (block {target_block}) not in cache."
+            )
+            return
+        # Prefer the persistent commit store (populated from every blob's
+        # `recent_state_commitment_infos` vector at handle_write_blob time).
+        # Falls back to extracting from the current blob for backwards
+        # compatibility with pre-cende-commitment-delta sequencer images that
+        # still ship a contiguous 10-block window.
+        state_commitment_infos = self.shared.get_state_commitment_infos(target_block)
+        if state_commitment_infos is None:
+            try:
+                state_commitment_infos = pick_state_commitment_infos(blob, target_block)
+            except OsInputBuildError:
+                self._deferred_os_blocks.add(target_block)
+                self.shared.record_os_run_deferred()
+                self.flask_logger.info(
+                    f"OS run deferred for block {target_block}: state_commitment_infos "
+                    f"not in store yet and missing from blob {current_block}; "
+                    "will retry with next blob."
+                )
+                return
+
+        task = {
+            "blob_body": target_blob_body,
+            "block_document": target_block_document,
+            "block_commitments": target_block_commitments,
+            "block_number": target_block,
+            "state_commitment_infos": state_commitment_infos,
+            "queued_at": time.monotonic(),
+        }
+        try:
+            self._os_run_queue.put_nowait(task)
+            self._deferred_os_blocks.discard(target_block)
+        except queue.Full:
+            self._deferred_os_blocks.discard(target_block)
+            self.shared.record_os_run_dropped()
+            self.flask_logger.warning(
+                f"OS run dropped for block {target_block}: queue full "
+                f"({self._os_run_queue.qsize()}/{_OS_RUN_QUEUE_SIZE}) — runner can't "
+                "keep up with blob arrival rate."
+            )
 
     def handle_write_pre_confirmed_block(self) -> flask.Response:
         self.flask_logger.debug("Received pre-confirmed block")
@@ -894,6 +1253,20 @@ class EchoCenterService:
             - 1
         )
         return self._json_response({"block_number": block_number}, requests.codes.ok)
+
+    def handle_get_last_stored_commitment_height(self) -> flask.Response:
+        """
+        GET /cende_recorder/get_last_stored_commitment_height
+
+        Returns the highest `block_number` whose state-commitment-info we've
+        observed in any incoming blob's `recent_state_commitment_infos` vector,
+        or `null` if we've seen none yet. The sequencer (post
+        cende-commitment-delta in `sequencer_consensus_context.rs`) bounds the
+        commitment-info window's lower end to `last_stored + 1`, so the blob
+        only carries commits we're still missing.
+        """
+        last = self.shared.get_last_stored_commitment_height()
+        return self._json_response({"block_number": last}, requests.codes.ok)
 
     def handle_report_snapshot(self) -> flask.Response:
         """Return current in-memory tx tracking snapshot."""
@@ -1019,6 +1392,14 @@ class EchoCenterService:
                 {"error": f"Invalid kind: {kind_raw}"}, requests.codes.bad_request
             )
 
+        # The blob is stored as raw JSON bytes (memory optimization — see
+        # `_BlockStore.store_block`); serve it back as-is. Other kinds are
+        # still Python objects.
+        if kind is BlockDumpKind.BLOB:
+            payload_bytes = self.shared.get_blob_body_with_disk_fallback(bn)
+            if payload_bytes is None:
+                return self._empty_response(requests.codes.not_found)
+            return flask.Response(payload_bytes, mimetype="application/json")
         payload = self.shared.get_block_field_with_disk_fallback(bn, kind.value)
         if payload is None:
             return self._empty_response(requests.codes.not_found)
@@ -1176,6 +1557,7 @@ class EchoCenterService:
 
 app = flask.Flask(__name__)
 feeder_client = FeederClient()
+
 service = EchoCenterService(
     feeder_client=feeder_client,
     shared_ctx=shared,
@@ -1198,6 +1580,11 @@ def write_pre_confirmed_block() -> flask.Response:
 @app.route("/cende_recorder/get_latest_received_block", methods=["GET"])
 def get_latest_received_block() -> flask.Response:
     return service.handle_get_latest_received_block()
+
+
+@app.route("/cende_recorder/get_last_stored_commitment_height", methods=["GET"])
+def get_last_stored_commitment_height() -> flask.Response:
+    return service.handle_get_last_stored_commitment_height()
 
 
 @app.route("/echonet/report", methods=["GET"])

--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -33,6 +33,13 @@ class BlockStoreTuning:
     """
 
     max_blocks_to_keep_in_memory: int = 100
+    # Raw cende blob bodies dominate memory (p95 ~80 MB, max ~110 MB) and only
+    # the OS runner consumes them — block doc + state_update are kept for the
+    # transaction sender's tx-confirmation window, which is what drives
+    # `max_blocks_to_keep_in_memory`. Cap blob_body in-memory retention much
+    # tighter; older blobs are archived to disk and read back via
+    # `get_blob_body_with_disk_fallback` on demand.
+    max_blob_bodies_to_keep_in_memory: int = 30
 
 
 class ResyncTriggerPayload(TypedDict):
@@ -161,6 +168,27 @@ class PathsConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class OsRunnerConfig:
+    """
+    Configuration for running the Starknet OS over each received blob.
+
+    The OS is invoked by shelling out to the same `starknet_committer_and_os_cli`
+    binary that backs the block-hash calculator, via its `OS run-os-stateless`
+    subcommand. The binary must be built with the `os_input` and `transaction_serde`
+    features for the cende blob to carry `recent_state_commitment_infos` and for the
+    OS input's `StateMaps` to deserialize.
+    """
+
+    enabled: bool = False
+    layout: str = "all_cairo"
+    cli_timeout_secs: int = 600
+    chain_id: str = "SN_MAIN"
+    strk_fee_token_address: str = (
+        "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class TxFilterConfig:
     """Transaction forwarding filter parameters."""
 
@@ -200,6 +228,7 @@ class EchonetConfig:
     block_store: BlockStoreTuning
     severity: SeverityConfig
     paths: PathsConfig
+    os_runner: OsRunnerConfig
     tx_filter: TxFilterConfig
     l1: L1Config
     gcp_logs: GcpLogsConfig
@@ -259,6 +288,21 @@ class EchonetConfig:
             ),
             severity=SeverityConfig(),
             paths=PathsConfig(),
+            os_runner=OsRunnerConfig(
+                enabled=bool(keys.get("os_runner_enabled", True)),
+                layout=str(keys.get("os_runner_layout", "all_cairo")),
+                cli_timeout_secs=int(keys.get("os_runner_cli_timeout_secs", 600)),
+                chain_id=str(keys.get("os_runner_chain_id", "SN_MAIN")),
+                # NOTE: `OsRunnerConfig.strk_fee_token_address` evaluates to a slot
+                # descriptor (`slots=True`), NOT the default value — inline the
+                # literal here so the keys.get() fallback resolves correctly.
+                strk_fee_token_address=str(
+                    keys.get(
+                        "os_runner_strk_fee_token_address",
+                        "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+                    )
+                ),
+            ),
             tx_filter=TxFilterConfig(
                 blocked_senders=helpers.parse_csv_to_lower_set(blocked_senders_csv),
             ),

--- a/echonet/k8s/echonet/deployment.yaml
+++ b/echonet/k8s/echonet/deployment.yaml
@@ -7,6 +7,13 @@ metadata:
     app.kubernetes.io/component: api
 spec:
   replicas: 1
+  # `Recreate` so old pod is killed BEFORE the new one starts. Avoids the
+  # two-pods-fighting-for-the-PVC trap caused by the default RollingUpdate
+  # strategy: the PVC has node-affinity, so the new pod sits Pending with
+  # `Multi-Attach error` until the old one releases the volume — and the
+  # deploy never finishes.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       # NOTE: Deployment selectors are immutable once created.
@@ -26,6 +33,22 @@ spec:
         karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: echonet
+
+      # Force the pod onto an n4-standard-8 (8 CPU / 32 GiB) from the
+      # `sequencer-n4` autoscaling node pool. ScaleOps's admission webhook
+      # mutates `requests` under the `cost` policy, which would otherwise
+      # pack us onto an n4-standard-4 (4 CPU / 16 GiB) — too small to run
+      # more than ~4 OS-runner workers usefully. nodeSelector is enforced
+      # by the kube scheduler downstream of the webhook, so it survives
+      # ScaleOps mutating resource values. The pool taints
+      # `role=sequencer:NoSchedule`, so we add the matching toleration.
+      nodeSelector:
+        node.kubernetes.io/instance-type: n4-standard-8
+      tolerations:
+        - key: role
+          operator: Equal
+          value: sequencer
+          effect: NoSchedule
 
       initContainers:
         - name: extract-echonet-src
@@ -80,17 +103,24 @@ spec:
             - >
               export PYTHONPATH=/app:${PYTHONPATH:-} &&
               python -m pip install --no-cache-dir --disable-pip-version-check
-              flask gunicorn requests aiohttp 'kubernetes<36' eth_abi &&
-              echo "[echonet] starting gunicorn on :80 (1 worker, 4 threads)" &&
-              gunicorn -w 1 --threads 4 -b 0.0.0.0:80 echonet.echo_center:app --timeout 60 --access-logfile -
+              flask gunicorn requests aiohttp 'kubernetes<36' eth_abi 'cairo-lang==0.14.0.1' zstandard &&
+              echo "[echonet] starting gunicorn on :80 (1 worker, 8 threads, 300s timeout)" &&
+              gunicorn -w 1 --threads 8 -b 0.0.0.0:80 echonet.echo_center:app --timeout 300 --access-logfile -
           workingDir: /app
           resources:
+            # `requests` drive scheduling — they must reflect what the pod
+            # actually consumes so kube picks a node with that much free. With
+            # 6 OS-runner workers + flask + transient blob parsing the working
+            # set is ~6 CPU / 12–14 GiB. Asking for 6/16 lands us on an
+            # n4-standard-8 (8 CPU / 32 GiB) instead of the n4-standard-4
+            # (4 CPU / 16 GiB) ScaleOps was packing us onto under the `cost`
+            # policy. `limits` are the runtime ceiling.
             requests:
-              cpu: 250m
-              memory: 1Gi
+              cpu: "6"
+              memory: 16Gi
             limits:
-              cpu: "2"
-              memory: 4Gi
+              cpu: "8"
+              memory: 32Gi
           volumeMounts:
             - { name: app-src, mountPath: /app }
             - { name: data-dir, mountPath: /data }

--- a/echonet/os_input_builder.py
+++ b/echonet/os_input_builder.py
@@ -1,0 +1,591 @@
+"""
+Build the JSON input (`OsCliInput`) for the Starknet OS runner from a cende blob.
+
+The Rust types are in `crates/starknet_committer_and_os_cli/src/os_cli/commands.rs`
+(`OsCliInput`) and `crates/starknet_os/src/io/os_input.rs` (`OsHints`,
+`StarknetOsInput`, `OsBlockInput`, `OsHintsConfig`). All structs use
+`serde(deny_unknown_fields)`, so every emitted key must match exactly.
+
+The cende blob (`AerospikeBlob` in
+`crates/apollo_consensus_orchestrator/src/cende/mod.rs`) is the single source of
+truth for OS inputs.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json as _json
+from typing import Any, Dict, List, Mapping, Optional
+
+import zstandard
+
+from echonet.echonet_types import JsonObject
+
+OS_DEFAULT_LAYOUT = "all_cairo"
+
+
+class OsInputBuildError(RuntimeError):
+    """Raised when the cende blob lacks a field required to assemble OsHints."""
+
+
+def decompress_state_commitment_infos(compressed: str) -> JsonObject:
+    """
+    Reverse of the committer's `base64(zstd(serde_json(StateCommitmentInfos)))`
+    pipeline (see `compress_state_commitment_infos` in
+    crates/apollo_committer/src/committer.rs). Blobs from sequencers built with
+    the compress-commitment-infos change carry each block's
+    `state_commitment_infos` as this compressed string instead of the raw dict;
+    every consumer downstream (`pick_state_commitment_infos`,
+    `SharedContext.record_commits_from_blob`) must decompress at ingest, since
+    `_build_os_block_input` accesses the inner fields directly.
+
+    Uses the streaming decompressor because the Rust committer emits its frame
+    via `zstd::encode_all`, which omits the pledged content size from the frame
+    header — `zstandard.decompress()` (the top-level function) rejects such
+    frames with "could not determine content size in frame header", whereas
+    `stream_reader` reads until end-of-frame.
+    """
+    if isinstance(compressed, dict):
+        # Backwards compat: pre-compression sequencers send the raw dict.
+        return compressed
+    if not isinstance(compressed, str):
+        raise OsInputBuildError(
+            f"unexpected state_commitment_infos type: {type(compressed).__name__}"
+        )
+    try:
+        raw = base64.b64decode(compressed)
+        decompressed = zstandard.ZstdDecompressor().stream_reader(io.BytesIO(raw)).read()
+        return _json.loads(decompressed)
+    except (ValueError, zstandard.ZstdError) as exc:
+        raise OsInputBuildError(
+            f"failed to decode compressed state_commitment_infos: {exc}"
+        ) from exc
+
+
+def build_os_cli_input(
+    blob: JsonObject,
+    *,
+    state_commitment_infos: JsonObject,
+    block_number: int,
+    prev_block_hash: str,
+    new_block_hash: str,
+    block_hash_commitments_payload: JsonObject,
+    chain_id: str,
+    strk_fee_token_address: str,
+    layout: str,
+    cairo_pie_zip_path: str,
+    raw_os_output_path: str,
+) -> JsonObject:
+    """
+    Assemble the `OsCliInput` JSON consumed by `committer-and-os-cli OS run-os-stateless`.
+
+    `state_commitment_infos` is pre-picked by the caller. The cende blob carries
+    `recent_state_commitment_infos` as a sliding window of the 10 *prior* blocks
+    (for SNOS proof_facts), so to run the OS on block N the caller must pull N's
+    entry from block N+1's blob — not block N's own blob. echo_center handles
+    that one-block lag externally and passes the right entry here.
+
+    `block_hash_commitments_payload` is the JSON returned by the existing
+    `block-hash-commitments` CLI invocation in echo_center.
+    """
+    os_block_input = _build_os_block_input(
+        blob=blob,
+        state_commitment_infos=state_commitment_infos,
+        block_number=block_number,
+        prev_block_hash=prev_block_hash,
+        new_block_hash=new_block_hash,
+        block_hash_commitments_payload=block_hash_commitments_payload,
+    )
+    os_input = {
+        "os_block_inputs": [os_block_input],
+        "deprecated_compiled_classes": {},
+        "compiled_classes": _compiled_classes_to_map(blob),
+    }
+    use_kzg_da = bool(blob["state_diff"]["block_info"].get("use_kzg_da", False))
+    os_hints_config = {
+        "debug_mode": False,
+        "full_output": False,
+        "use_kzg_da": use_kzg_da,
+        "chain_info": {
+            "chain_id": _chain_id_to_hex(chain_id),
+            "strk_fee_token_address": strk_fee_token_address,
+        },
+        "public_keys": None,
+        "rng_seed_salt": None,
+    }
+    return {
+        "layout": layout,
+        "os_hints": {"os_input": os_input, "os_hints_config": os_hints_config},
+        "cairo_pie_zip_path": cairo_pie_zip_path,
+        "raw_os_output_path": raw_os_output_path,
+    }
+
+
+def _build_os_block_input(
+    *,
+    blob: JsonObject,
+    state_commitment_infos: JsonObject,
+    block_number: int,
+    prev_block_hash: str,
+    new_block_hash: str,
+    block_hash_commitments_payload: JsonObject,
+) -> JsonObject:
+    sierra_by_class_hash = _sierra_by_class_hash(blob)
+    return {
+        "contract_state_commitment_info": state_commitment_infos["contracts_trie_commitment_info"],
+        "address_to_storage_commitment_info": state_commitment_infos[
+            "storage_tries_commitment_infos"
+        ],
+        "contract_class_commitment_info": state_commitment_infos["classes_trie_commitment_info"],
+        "transactions": [
+            _central_tx_to_executable(entry["tx"], sierra_by_class_hash)
+            for entry in blob["transactions"]
+        ],
+        "tx_execution_infos": blob["execution_infos"],
+        "declared_class_hash_to_component_hashes": _declared_class_hash_to_component_hashes(blob),
+        "block_info": _central_block_info_to_block_info(blob["state_diff"]["block_info"]),
+        "block_hash_commitments": _block_hash_commitments_from_payload(
+            block_hash_commitments_payload
+        ),
+        "prev_block_hash": prev_block_hash,
+        "new_block_hash": new_block_hash,
+        "old_block_number_and_hash": _old_block_number_and_hash(blob, block_number),
+        "class_hashes_to_migrate": _class_hashes_to_migrate(blob),
+        "initial_reads": _initial_reads_from_blob(blob),
+    }
+
+
+def pick_state_commitment_infos(blob: JsonObject, block_number: int) -> JsonObject:
+    """
+    Pull the `StateCommitmentInfos` matching `block_number` out of the blob's
+    `recent_state_commitment_infos: Vec<StateCommitmentInfosAndNumber>` (gated on
+    `os_input` in the cende crate; required for OS runs).
+
+    Note: the orchestrator's `collect_recent_state_commitment_infos` populates the
+    vector with the 10 *prior* committed blocks — the current block is not in its own
+    blob because the batcher's commit task races against the blob preparation.
+    So to get block N's `StateCommitmentInfos`, call this with **block N+1's blob**.
+    """
+    entries = blob.get("recent_state_commitment_infos")
+    if entries is None:
+        raise OsInputBuildError(
+            "blob missing 'recent_state_commitment_infos'; sequencer must be "
+            "built with --features os_input"
+        )
+    for entry in entries:
+        if int(entry["block_number"]) == int(block_number):
+            return decompress_state_commitment_infos(entry["state_commitment_infos"])
+    available = sorted(int(entry["block_number"]) for entry in entries)
+    raise OsInputBuildError(
+        f"no recent_state_commitment_infos entry for block_number {block_number}; "
+        f"vector contains {len(available)} entries for block_numbers={available}"
+    )
+
+
+def _central_block_info_to_block_info(central_block_info: JsonObject) -> JsonObject:
+    """
+    Map `CentralBlockInfo` → `starknet_api::block::BlockInfo`.
+
+    Central layout (separate `l1_gas_price` / `l1_data_gas_price` / `l2_gas_price`
+    objects, each `{price_in_wei, price_in_fri}`) is folded into BlockInfo's
+    `gas_prices: {eth_gas_prices, strk_gas_prices}` — eth ← price_in_wei,
+    strk ← price_in_fri. `GasPrice` serializes as 16-byte hex.
+    """
+    l1 = central_block_info["l1_gas_price"]
+    l1_data = central_block_info["l1_data_gas_price"]
+    l2 = central_block_info["l2_gas_price"]
+    return {
+        "block_number": int(central_block_info["block_number"]),
+        "block_timestamp": int(central_block_info["block_timestamp"]),
+        "starknet_version": str(central_block_info["starknet_version"]),
+        "sequencer_address": central_block_info["sequencer_address"],
+        "gas_prices": {
+            "eth_gas_prices": {
+                "l1_gas_price": _gas_price_to_hex16(l1["price_in_wei"]),
+                "l1_data_gas_price": _gas_price_to_hex16(l1_data["price_in_wei"]),
+                "l2_gas_price": _gas_price_to_hex16(l2["price_in_wei"]),
+            },
+            "strk_gas_prices": {
+                "l1_gas_price": _gas_price_to_hex16(l1["price_in_fri"]),
+                "l1_data_gas_price": _gas_price_to_hex16(l1_data["price_in_fri"]),
+                "l2_gas_price": _gas_price_to_hex16(l2["price_in_fri"]),
+            },
+        },
+        "use_kzg_da": bool(central_block_info.get("use_kzg_da", False)),
+    }
+
+
+def _central_tx_to_executable(
+    central_tx: JsonObject, sierra_by_class_hash: Mapping[str, JsonObject]
+) -> JsonObject:
+    """
+    Convert a `CentralTransaction` JSON object to the executable
+    `starknet_api::executable_transaction::Transaction` JSON.
+
+    The executable enum is externally tagged: `{"Account":{"Invoke":{...}}}` etc.
+    The inner versioned tx is also externally tagged (`{"V3": {...}}`).
+
+    All current mainnet account-txs are V3 (V0/V1/V2 are deprecated). L1_HANDLER
+    is unversioned (its `version` field is 0).
+
+    `sierra_by_class_hash` maps `class_hash → SierraContractClass` for any
+    classes declared in this block (from `blob["contract_classes"]`); only
+    DECLARE uses it.
+    """
+    tx_type = central_tx["type"]
+    if tx_type == "INVOKE_FUNCTION":
+        return {"Account": {"Invoke": _invoke_v3_to_executable(central_tx)}}
+    if tx_type == "DEPLOY_ACCOUNT":
+        return {"Account": {"DeployAccount": _deploy_account_v3_to_executable(central_tx)}}
+    if tx_type == "DECLARE":
+        return {"Account": {"Declare": _declare_v3_to_executable(central_tx, sierra_by_class_hash)}}
+    if tx_type == "L1_HANDLER":
+        return {"L1Handler": _l1_handler_to_executable(central_tx)}
+    raise OsInputBuildError(f"unknown transaction type {tx_type!r} in blob")
+
+
+def _invoke_v3_to_executable(central_tx: JsonObject) -> JsonObject:
+    inner = {
+        "resource_bounds": _resource_bounds_central_to_executable(central_tx["resource_bounds"]),
+        # `Tip(u64)` uses `PrefixedBytesAsHex<8>` — serializes as a `0x`-prefixed
+        # 8-byte hex string. The central blob already carries it in that exact form,
+        # so pass through (do NOT convert to int).
+        "tip": central_tx["tip"],
+        "signature": list(central_tx.get("signature", [])),
+        "nonce": central_tx["nonce"],
+        "sender_address": central_tx["sender_address"],
+        "calldata": list(central_tx.get("calldata", [])),
+        "nonce_data_availability_mode": _da_mode_to_str(central_tx["nonce_data_availability_mode"]),
+        "fee_data_availability_mode": _da_mode_to_str(central_tx["fee_data_availability_mode"]),
+        "paymaster_data": list(central_tx.get("paymaster_data", [])),
+        "account_deployment_data": list(central_tx.get("account_deployment_data", [])),
+    }
+    # SNIP-19 / SNOS proof-fact txs: non-empty `proof_facts` participates in
+    # the V3 invoke hash (see `transaction_hash.rs::get_invoke_transaction_v3_hash`
+    # — appended to the hash chain only when non-empty). The central blob
+    # serializes the field with `skip_serializing_if = "ProofFacts::is_empty"`,
+    # so it's absent for plain invokes; pass through when present.
+    proof_facts = central_tx.get("proof_facts")
+    if proof_facts:
+        inner["proof_facts"] = list(proof_facts)
+    return {"tx": {"V3": inner}, "tx_hash": central_tx["hash_value"]}
+
+
+def _deploy_account_v3_to_executable(central_tx: JsonObject) -> JsonObject:
+    """
+    Central `DEPLOY_ACCOUNT` V3 → executable `DeployAccountTransaction`. Central
+    carries `sender_address` (the deployed contract's address); the executable
+    wrapper exposes it as `contract_address` (sibling of `tx` / `tx_hash`).
+    See `crates/starknet_api/src/executable_transaction.rs::DeployAccountTransaction`.
+    """
+    inner = {
+        "resource_bounds": _resource_bounds_central_to_executable(central_tx["resource_bounds"]),
+        "tip": central_tx["tip"],
+        "signature": list(central_tx.get("signature", [])),
+        "nonce": central_tx["nonce"],
+        "class_hash": central_tx["class_hash"],
+        "contract_address_salt": central_tx["contract_address_salt"],
+        "constructor_calldata": list(central_tx.get("constructor_calldata", [])),
+        "nonce_data_availability_mode": _da_mode_to_str(central_tx["nonce_data_availability_mode"]),
+        "fee_data_availability_mode": _da_mode_to_str(central_tx["fee_data_availability_mode"]),
+        "paymaster_data": list(central_tx.get("paymaster_data", [])),
+    }
+    return {
+        "tx": {"V3": inner},
+        "tx_hash": central_tx["hash_value"],
+        "contract_address": central_tx["sender_address"],
+    }
+
+
+def _declare_v3_to_executable(
+    central_tx: JsonObject, sierra_by_class_hash: Mapping[str, JsonObject]
+) -> JsonObject:
+    """
+    Central `DECLARE` V3 → executable `DeclareTransaction`. The executable
+    wrapper adds `class_info` (the Sierra/CASM bundle) alongside `tx`/`tx_hash`;
+    the OS pulls bytecode/abi sizes + the Sierra version from there for fee
+    accounting. We assemble it from `blob["contract_classes"]` (Sierra, keyed
+    by `class_hash`) and the metadata the central tx already carries
+    (`sierra_program_size`, `abi_size`, `sierra_version`).
+    """
+    class_hash = central_tx["class_hash"]
+    sierra_class = sierra_by_class_hash.get(class_hash)
+    if sierra_class is None:
+        raise OsInputBuildError(
+            f"DECLARE tx references class_hash {class_hash} but it is not in "
+            f"blob['contract_classes']; available={list(sierra_by_class_hash)[:5]}..."
+        )
+
+    inner = {
+        "resource_bounds": _resource_bounds_central_to_executable(central_tx["resource_bounds"]),
+        "tip": central_tx["tip"],
+        "signature": list(central_tx.get("signature", [])),
+        "nonce": central_tx["nonce"],
+        "class_hash": class_hash,
+        "compiled_class_hash": central_tx["compiled_class_hash"],
+        "sender_address": central_tx["sender_address"],
+        "nonce_data_availability_mode": _da_mode_to_str(central_tx["nonce_data_availability_mode"]),
+        "fee_data_availability_mode": _da_mode_to_str(central_tx["fee_data_availability_mode"]),
+        "paymaster_data": list(central_tx.get("paymaster_data", [])),
+        "account_deployment_data": list(central_tx.get("account_deployment_data", [])),
+    }
+
+    sierra_version_tuple = central_tx.get("sierra_version")
+    if not isinstance(sierra_version_tuple, list) or len(sierra_version_tuple) != 3:
+        raise OsInputBuildError(
+            f"DECLARE tx missing/invalid sierra_version: {sierra_version_tuple!r}"
+        )
+    sierra_version = _sierra_version_to_executable(sierra_version_tuple)
+
+    # The OS deserializes class_info.contract_class as
+    # `ContractClass::V1((CasmContractClass, SierraVersion))` and asserts the
+    # `CasmContractClass` is a blank sentinel (prime = 0) — see
+    # `validate_single_input` in starknet_committer_and_os_cli. Passing the
+    # actual Sierra body here fails deserialization with
+    # `missing field 'offset'`, because Sierra entry points carry
+    # `function_idx` while `CasmContractEntryPoint` requires `offset`.
+    # Sierra/abi length + version are the only class_info fields the OS
+    # actually uses (for fee accounting); the CASM slot is a mandatory-shape
+    # placeholder.
+    blank_casm = {
+        "prime": "0x0",
+        "compiler_version": "",
+        "bytecode": [],
+        "hints": [],
+        "entry_points_by_type": {
+            "EXTERNAL": [],
+            "L1_HANDLER": [],
+            "CONSTRUCTOR": [],
+        },
+    }
+    class_info = {
+        "contract_class": {"V1": [blank_casm, sierra_version]},
+        "sierra_program_length": int(central_tx["sierra_program_size"]),
+        "abi_length": int(central_tx["abi_size"]),
+        "sierra_version": sierra_version,
+    }
+    return {
+        "tx": {"V3": inner},
+        "tx_hash": central_tx["hash_value"],
+        "class_info": class_info,
+    }
+
+
+def _l1_handler_to_executable(central_tx: JsonObject) -> JsonObject:
+    """
+    Central `L1_HANDLER` → executable `L1HandlerTransaction`. The inner
+    `L1HandlerTransaction` struct (from `starknet_api::transaction`) has a
+    `version` field that's always 0 (per `L1HandlerTransaction::VERSION`).
+    """
+    inner = {
+        "version": "0x0",
+        "nonce": central_tx["nonce"],
+        "contract_address": central_tx["contract_address"],
+        "entry_point_selector": central_tx["entry_point_selector"],
+        "calldata": list(central_tx.get("calldata", [])),
+    }
+    return {
+        "tx": inner,
+        "tx_hash": central_tx["hash_value"],
+        "paid_fee_on_l1": central_tx["paid_fee_on_l1"],
+    }
+
+
+def _sierra_version_to_executable(sierra_version_tuple: List[Any]) -> str:
+    """
+    Central serializes `SierraVersion` as a 3-tuple of `0x`-prefixed hex strings
+    (major, minor, patch — see `into_string_tuple` in cende's central_objects).
+    The executable `SierraVersion(semver::Version)` deserializes from a single
+    semver string, not a 3-tuple, so we join them: `"2.11.4"`.
+    """
+    major, minor, patch = (int(str(v), 16) for v in sierra_version_tuple[:3])
+    return f"{major}.{minor}.{patch}"
+
+
+def _resource_bounds_central_to_executable(central_rb: JsonObject) -> JsonObject:
+    """
+    Central uses `L1_GAS / L2_GAS / L1_DATA_GAS`; the executable
+    `ValidResourceBounds`'s serialized map uses `Resource` keys
+    `L1_GAS / L2_GAS / L1_DATA` (see `crates/starknet_api/src/transaction/fields.rs`,
+    `pub enum Resource` with `#[serde(rename = ...)]`).
+    """
+    return {
+        "L1_GAS": central_rb["L1_GAS"],
+        "L2_GAS": central_rb["L2_GAS"],
+        "L1_DATA": central_rb["L1_DATA_GAS"],
+    }
+
+
+def _da_mode_to_str(value: Any) -> str:
+    """Central tx encodes DataAvailabilityMode as u32 (0/1); executable expects 'L1'/'L2'."""
+    if isinstance(value, str):
+        if value in ("L1", "L2"):
+            return value
+        raise OsInputBuildError(f"unexpected DA mode string: {value!r}")
+    as_int = int(value)
+    if as_int == 0:
+        return "L1"
+    if as_int == 1:
+        return "L2"
+    raise OsInputBuildError(f"unexpected DA mode value: {value!r}")
+
+
+def _compiled_classes_to_map(blob: JsonObject) -> JsonObject:
+    """
+    `blob["compiled_classes"]` is `Vec<(CompiledClassHash, {compiled_class: CasmContractClass})>`
+    (each entry serialized as a `[hash, {"compiled_class": ...}]` JSON tuple).
+    The OS expects `BTreeMap<CompiledClassHash, CasmContractClass>` — an object keyed
+    by hex hash, value is the inner `CasmContractClass` (unwrap the `compiled_class` field).
+    """
+    out: Dict[str, JsonObject] = {}
+    for entry in blob.get("compiled_classes", []):
+        compiled_class_hash, wrapper = entry[0], entry[1]
+        out[str(compiled_class_hash)] = wrapper["compiled_class"]
+    return out
+
+
+def _sierra_by_class_hash(blob: JsonObject) -> Dict[str, JsonObject]:
+    """
+    `blob["contract_classes"]` is `Vec<(ClassHash, {contract_class: SierraContractClass})>`
+    — the Sierra classes newly declared in this block. Indexed by `class_hash` so
+    DECLARE-tx conversion can assemble each tx's `ClassInfo`.
+    """
+    out: Dict[str, JsonObject] = {}
+    for entry in blob.get("contract_classes", []) or []:
+        class_hash, wrapper = entry[0], entry[1]
+        out[str(class_hash)] = wrapper["contract_class"]
+    return out
+
+
+def _block_hash_commitments_from_payload(payload: JsonObject) -> JsonObject:
+    """
+    Reshape the block-hash CLI's `block-hash-commitments` response into
+    `BlockHeaderCommitments`. The CLI returns flat felt strings for each
+    commitment kind; concatenated_counts is a separate field.
+    """
+    return {
+        "transaction_commitment": str(payload["transaction_commitment"]),
+        "event_commitment": str(payload["event_commitment"]),
+        "receipt_commitment": str(payload["receipt_commitment"]),
+        "state_diff_commitment": str(payload["state_diff_commitment"]),
+        "concatenated_counts": str(payload["concatenated_counts"]),
+    }
+
+
+def _old_block_number_and_hash(blob: JsonObject, current_block_number: int) -> Optional[List[Any]]:
+    """
+    The OS uses `Option<(BlockNumber, BlockHash)>` for the
+    `(current - STORED_BLOCK_HASH_BUFFER)` block hash. The cende blob carries
+    `recent_block_hashes: Vec<{block_hash, block_number}>` — pick the oldest entry
+    (the buffer-back entry, by `N_BLOCK_HASHES_BACK_IN_BLOB = STORED_BLOCK_HASH_BUFFER`),
+    or `None` if the list is empty.
+
+    The serde shape of a Rust 2-tuple is a JSON array `[num, hash]`.
+    """
+    recent: List[JsonObject] = list(blob.get("recent_block_hashes", []))
+    if not recent:
+        return None
+    oldest = min(recent, key=lambda e: int(e["block_number"]))
+    return [int(oldest["block_number"]), str(oldest["block_hash"])]
+
+
+def _class_hashes_to_migrate(blob: JsonObject) -> List[List[str]]:
+    """
+    `blob["compiled_class_hashes_for_migration"]` is `Vec<(CompiledClassHash, CompiledClassHash)>`
+    (V2, V1 pair per the central type). The OS expects
+    `Vec<(ClassHash, CompiledClassHash)>` — we forward the pairs as-is. Their JSON
+    shape is `[[h1, h2], ...]`; confirm the central type when validating against a
+    real blob (TODO: verify the pair order matches the OS's `(class_hash, compiled_class_hash)`).
+    """
+    pairs = blob.get("compiled_class_hashes_for_migration", []) or []
+    return [[str(a), str(b)] for a, b in pairs]
+
+
+def _declared_class_hash_to_component_hashes(blob: JsonObject) -> JsonObject:
+    """
+    Map `{class_hash: ContractClassComponentHashes}` derived from each Sierra class in
+    `blob["contract_classes"]`. Uses cairo-lang's `py_hash_class_components` — the same
+    Poseidon-over-class-structure derivation as the Rust
+    `sierra_class.get_component_hashes()`. Cairo-lang is imported lazily and only when
+    there is at least one declared class, so echonet's module load does not require it
+    on blocks (or local dev runs) without declares.
+    """
+    entries = blob.get("contract_classes") or []
+    if not entries:
+        return {}
+
+    from starkware.starknet.core.os.contract_class.class_hash_utils import (
+        py_hash_class_components,
+    )
+    from starkware.starknet.services.api.contract_class.contract_class import ContractClass
+
+    out: Dict[str, JsonObject] = {}
+    for entry in entries:
+        class_hash, wrapper = entry[0], entry[1]
+        contract_class = ContractClass.load(wrapper["contract_class"])
+        component_hashes = py_hash_class_components(contract_class)
+        out[str(class_hash)] = {
+            "contract_class_version": _felt_hex(component_hashes.contract_class_version),
+            "external_functions_hash": _felt_hex(component_hashes.external_functions_hash),
+            "l1_handlers_hash": _felt_hex(component_hashes.l1_handlers_hash),
+            "constructors_hash": _felt_hex(component_hashes.constructors_hash),
+            "abi_hash": _felt_hex(component_hashes.abi_hash),
+            "sierra_program_hash": _felt_hex(component_hashes.sierra_program_hash),
+        }
+    return out
+
+
+def _felt_hex(value: int) -> str:
+    """`Felt` serializes as `0x{value:x}` (no zero-padding)."""
+    return f"0x{value:x}"
+
+
+def _initial_reads_from_blob(blob: JsonObject) -> JsonObject:
+    """
+    Pass `blob["initial_reads"]` through as `StateMaps` JSON.
+
+    The blob writer (`apollo_batcher::batcher::decision_reached` →
+    `cended_state::get_os_initial_reads`) populates this with the OS's pre-state reads
+    (back-filled with the trie leaves for accessed contracts and classes), then trims
+    to `accessed_keys` and clears `declared_contracts`. The serializer is blockifier's
+    `transaction_serde` — the same one `starknet_os` deserializes with — so the JSON
+    shape matches the OS expectation exactly:
+      - `storage` is nested `{addr: {key: value}}` (custom serializer).
+      - `nonces`, `class_hashes`, `compiled_class_hashes` are flat maps.
+      - `declared_contracts` is empty (OS `update_cache` asserts on this).
+    """
+    initial_reads = blob.get("initial_reads")
+    if initial_reads is None:
+        raise OsInputBuildError(
+            "blob is missing `initial_reads`; sequencer image must be built with "
+            "the `os_input` feature (added in PR #14593)"
+        )
+    return initial_reads
+
+
+def _chain_id_to_hex(chain_id: str) -> str:
+    """
+    `ChainId` is serialized as a `0x`-prefixed UTF-8 hex of the chain string
+    (e.g. 'SN_MAIN' → '0x534e5f4d41494e'). If the caller already provided a
+    hex-form chain id, pass it through.
+    """
+    if chain_id.startswith("0x"):
+        return chain_id
+    return "0x" + chain_id.encode("utf-8").hex()
+
+
+def _gas_price_to_hex16(value: Any) -> str:
+    """
+    `GasPrice` is `u128` serialized as a `0x`-prefixed 16-byte hex (32 hex chars,
+    zero-padded). Central `NonzeroGasPrice` is already a hex string; we just
+    normalize zero-padding/width.
+    """
+    if isinstance(value, int):
+        as_int = value
+    else:
+        s = str(value)
+        as_int = int(s, 16) if s.startswith("0x") else int(s)
+    if as_int < 0:
+        raise OsInputBuildError(f"negative gas price: {value!r}")
+    return "0x" + format(as_int, "032x")

--- a/echonet/os_runner_worker.py
+++ b/echonet/os_runner_worker.py
@@ -1,0 +1,172 @@
+"""
+Standalone CLI tool that runs the Starknet OS for one block.
+
+echo_center spawns this as a subprocess per OS run. The process loads CONFIG
+(from /data/echonet/echonet_keys.json), builds the `OsCliInput` JSON, invokes
+`committer-and-os-cli os run-os-stateless`, then exits — so all retained
+Python heap (captured CLI output, intermediate JSON dicts, cairo-lang imports
+for component-hash derivation) dies with this process. echo_center stays clean.
+
+Protocol:
+  argv:   --input-path <path>     # JSON file written by echo_center; see below
+  stdin:  unused (DEVNULL)
+  stdout: empty on success (any output is treated as log noise by echo_center)
+  stderr: human-readable log lines, inherited to echo_center's stderr
+  exit:   0 = success, non-zero = failure. On failure the failing OS CLI
+          `input.json` is dumped to /data/echonet/os_runs/block_<N>_failed/
+          (rolling retention of the most recent _MAX_FAILED_DUMPS dirs).
+
+Input file shape:
+  {
+    "blob":                          AerospikeBlob (from cende write_blob),
+    "state_commitment_infos":        StateCommitmentInfos for block_number,
+    "block_document":                {parent_block_hash, block_hash},
+    "block_number":                  int,
+    "block_hash_commitments_payload": JSON from block-hash CLI (computed in
+                                      echo_center; small payload — txs +
+                                      thin state diff, not the full blob)
+  }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from echonet.class_fetcher import resolve_classes_for_os
+from echonet.echonet_types import CONFIG
+from echonet.os_input_builder import build_os_cli_input
+
+_MAX_FAILED_DUMPS = 10
+_CLASS_CACHE_SUBDIR = "class_cache"
+
+
+def _prune_old_failed_dumps(dump_root: Path, *, keep: int) -> None:
+    """Keep at most `keep` most-recent `block_<N>_failed` directories; delete the rest."""
+    try:
+        entries = [
+            child
+            for child in dump_root.iterdir()
+            if child.is_dir() and child.name.startswith("block_") and child.name.endswith("_failed")
+        ]
+    except OSError:
+        return
+    if len(entries) <= keep:
+        return
+    entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    for stale in entries[keep:]:
+        shutil.rmtree(stale, ignore_errors=True)
+
+
+def _log(msg: str) -> None:
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-path", required=True, type=Path)
+    args = parser.parse_args()
+    with args.input_path.open("r", encoding="utf-8") as fp:
+        payload = json.load(fp)
+    blob = payload["blob"]
+    state_commitment_infos = payload["state_commitment_infos"]
+    block_document = payload["block_document"]
+    block_number = int(payload["block_number"])
+    block_hash_commitments_payload = payload["block_hash_commitments_payload"]
+
+    cli_path = CONFIG.paths.block_hash_cli_path
+    if not cli_path.exists():
+        _log(f"Missing committer-and-os-cli binary at: {cli_path}")
+        return 2
+    timeout = CONFIG.os_runner.cli_timeout_secs
+    repo_root = Path(__file__).resolve().parent.parent
+
+    with tempfile.TemporaryDirectory(prefix="echonet_os_", dir=repo_root) as tmp:
+        tmp_path = Path(tmp)
+        input_path = tmp_path / "input.json"
+        output_path = tmp_path / "output.json"
+        cairo_pie_zip_path = tmp_path / "pie.zip"
+        raw_os_output_path = tmp_path / "raw_os_output.json"
+        os_cli_input = build_os_cli_input(
+            blob,
+            state_commitment_infos=state_commitment_infos,
+            block_number=block_number,
+            prev_block_hash=block_document["parent_block_hash"],
+            new_block_hash=block_document["block_hash"],
+            block_hash_commitments_payload=block_hash_commitments_payload,
+            chain_id=CONFIG.os_runner.chain_id,
+            strk_fee_token_address=CONFIG.os_runner.strk_fee_token_address,
+            layout=CONFIG.os_runner.layout,
+            cairo_pie_zip_path=str(cairo_pie_zip_path),
+            raw_os_output_path=str(raw_os_output_path),
+        )
+        cache_root = CONFIG.paths.log_dir / _CLASS_CACHE_SUBDIR
+        (
+            compiled_classes,
+            deprecated_compiled_classes,
+            fetched_count,
+            cached_count,
+        ) = resolve_classes_for_os(blob, cache_root=cache_root)
+        os_input = os_cli_input["os_hints"]["os_input"]
+        os_input["compiled_classes"] = compiled_classes
+        os_input["deprecated_compiled_classes"] = deprecated_compiled_classes
+        _log(
+            f"block {block_number} classes: "
+            f"compiled={len(compiled_classes)} deprecated={len(deprecated_compiled_classes)} "
+            f"fetched={fetched_count} cached={cached_count}"
+        )
+        input_path.write_text(json.dumps(os_cli_input), encoding="utf-8")
+        try:
+            subprocess.run(
+                [
+                    str(cli_path),
+                    "os",
+                    "run-os-stateless",
+                    "--input-path",
+                    str(input_path),
+                    "--output-path",
+                    str(output_path),
+                ],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=timeout,
+            )
+        except subprocess.CalledProcessError as exc:
+            dump_root = CONFIG.paths.log_dir / "os_runs"
+            dump_dir = dump_root / f"block_{block_number}_failed"
+            try:
+                dump_dir.mkdir(parents=True, exist_ok=True)
+                (dump_dir / "input.json").write_bytes(input_path.read_bytes())
+                _prune_old_failed_dumps(dump_root, keep=_MAX_FAILED_DUMPS)
+            except Exception as dump_err:
+                _log(f"Failed to dump input.json: {dump_err}")
+            _log(
+                f"OS CLI run failed for block {block_number} (exit {exc.returncode}); "
+                f"input dumped at {dump_dir}/input.json\n"
+                f"stderr (last 2KB): {exc.stderr[-2048:]}"
+            )
+            return 1
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        da_segment = result.get("da_segment") or []
+        unused_hints = result.get("unused_hints") or []
+        json.dump(
+            {
+                "da_segment_len": len(da_segment),
+                "unused_hints_count": len(unused_hints),
+            },
+            sys.stdout,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/echonet/report_models.py
+++ b/echonet/report_models.py
@@ -46,6 +46,10 @@ class SnapshotModel:
     block_hash_mismatches: list[JsonObject]
     transaction_commitment_mismatches: list[JsonObject]
 
+    # OS-runner outcomes (cumulative counters + live queue/defer state — see
+    # `SharedContext.get_os_run_stats`).
+    os_run_stats: JsonObject
+
     def to_dict(self) -> JsonObject:
         """
         Convert to a JSON-serializable dict compatible with `/echonet/report`.
@@ -76,6 +80,7 @@ class SnapshotModel:
             "l2_gas_mismatches": self.l2_gas_mismatches,
             "block_hash_mismatches": self.block_hash_mismatches,
             "transaction_commitment_mismatches": self.transaction_commitment_mismatches,
+            "os_run_stats": self.os_run_stats,
         }
 
     @classmethod
@@ -103,4 +108,5 @@ class SnapshotModel:
             l2_gas_mismatches=data["l2_gas_mismatches"],
             block_hash_mismatches=data.get("block_hash_mismatches", []),
             transaction_commitment_mismatches=data.get("transaction_commitment_mismatches", []),
+            os_run_stats=data.get("os_run_stats", {}),
         )

--- a/echonet/reports.py
+++ b/echonet/reports.py
@@ -163,6 +163,55 @@ class SnapshotTextReport:
             ],
         )
 
+        os_stats = s.os_run_stats or {}
+        if os_stats:
+            completed = int(os_stats.get("completed", 0))
+            failed = int(os_stats.get("failed", 0))
+            dropped = int(os_stats.get("dropped", 0))
+            deferred_events = int(os_stats.get("deferred_events", 0))
+            abandoned = int(os_stats.get("abandoned", 0))
+            skipped = int(os_stats.get("skipped", 0))
+            total_attempts = completed + failed + dropped + abandoned + skipped
+            lines.append("")
+            lines.append("=== OS-runner outcomes ===")
+            append_key_value_lines(
+                lines,
+                [
+                    (
+                        "Completed",
+                        f"{completed} ({_format_percent(completed, total_attempts)})",
+                    ),
+                    ("Failed", f"{failed} ({_format_percent(failed, total_attempts)})"),
+                    (
+                        "Dropped (queue full)",
+                        f"{dropped} ({_format_percent(dropped, total_attempts)})",
+                    ),
+                    (
+                        "Abandoned (window expired)",
+                        f"{abandoned} ({_format_percent(abandoned, total_attempts)})",
+                    ),
+                    (
+                        "Skipped (cache miss)",
+                        f"{skipped} ({_format_percent(skipped, total_attempts)})",
+                    ),
+                    ("Deferred events (cumulative)", str(deferred_events)),
+                    (
+                        "Queue depth",
+                        f"{os_stats.get('queue_depth', 0)}/{os_stats.get('queue_max', 0)}",
+                    ),
+                    ("Currently deferred", str(os_stats.get("currently_deferred", 0))),
+                ],
+            )
+
+            recent_failures = os_stats.get("recent_failures") or []
+            if recent_failures:
+                lines.append("")
+                lines.append(f"=== OS-runner recent failures ({len(recent_failures)}) ===")
+                for entry in recent_failures:
+                    lines.append(f"block {entry.get('block_number', '?')} @ {entry.get('ts', '?')}")
+                    for err_line in str(entry.get("error", "")).splitlines():
+                        lines.append(f"  {err_line}")
+
         lines.append("")
         lines.append("=== Gateway errors (hash -> response) ===")
         if not s.gateway_errors:
@@ -546,6 +595,7 @@ class _SnapshotReportRollup:
     l2_gas_mismatches_count: int
     block_hash_mismatches_count: int
     transaction_commitment_mismatches_count: int
+    os_failed_count: int
 
     forward_rate: str
     echonet_revert_rate_pct: float
@@ -563,6 +613,7 @@ class _SnapshotReportRollup:
     l2_gas_mismatches_rows: list[dict[str, Any]]
     block_hash_mismatches_rows: list[dict[str, Any]]
     transaction_commitment_mismatches_rows: list[dict[str, Any]]
+    os_failures_rows: list[dict[str, Any]]
 
     @classmethod
     def from_snapshot(cls, s: SnapshotModel) -> "_SnapshotReportRollup":
@@ -583,6 +634,13 @@ class _SnapshotReportRollup:
         block_hash_mismatches_count = len(s.block_hash_mismatches)
         transaction_commitment_mismatches_count = len(s.transaction_commitment_mismatches)
 
+        os_stats_for_sev = s.os_run_stats or {}
+        os_completed_count = int(os_stats_for_sev.get("completed", 0))
+        os_failed_count = int(os_stats_for_sev.get("failed", 0))
+        os_dropped_count = int(os_stats_for_sev.get("dropped", 0))
+        os_abandoned_count = int(os_stats_for_sev.get("abandoned", 0))
+        os_skipped_count = int(os_stats_for_sev.get("skipped", 0))
+
         sev = {
             "pending": "neutral",
             "committed": ("ok" if committed > 0 else "neutral"),
@@ -596,6 +654,20 @@ class _SnapshotReportRollup:
             "transaction_commitment_mismatches": _severity_for_count(
                 transaction_commitment_mismatches_count
             ),
+            # OS-runner pill colors: completed → green when any have succeeded;
+            # failed/abandoned → red on ANY positive count (hard correctness
+            # signals — even one matters); dropped/skipped → warn-or-bad by
+            # threshold (throughput shortfalls, not correctness).
+            "os_completed": ("ok" if os_completed_count > 0 else "neutral"),
+            "os_failed": ("bad" if os_failed_count > 0 else "neutral"),
+            "os_dropped": _severity_for_count(os_dropped_count),
+            "os_abandoned": ("bad" if os_abandoned_count > 0 else "neutral"),
+            # Skipped is transient (target block wasn't in cache/archive at
+            # enqueue time — usually a race or a resync, self-heals). Don't
+            # color the tile at 1 or below.
+            "os_skipped": _severity_for_count(os_skipped_count)
+            if os_skipped_count > 1
+            else "neutral",
         }
 
         pending_txs = [(tx_hash, src_bn) for tx_hash, src_bn in s.sent_tx_hashes.items()]
@@ -626,6 +698,9 @@ class _SnapshotReportRollup:
         transaction_commitment_mismatches_rows = [
             dict(v) for v in s.transaction_commitment_mismatches
         ]
+        os_failures_rows = [
+            dict(entry) for entry in (os_stats_for_sev.get("recent_failures") or [])
+        ]
         forward_rate = _format_rate(total_sent, s.uptime_seconds, unit="TPS")
         echonet_revert_rate_pct = (
             (100.0 * reverts_echonet_count / total_sent) if total_sent > 0 else 0.0
@@ -646,6 +721,7 @@ class _SnapshotReportRollup:
             l2_gas_mismatches_count=l2_gas_mismatches_count,
             block_hash_mismatches_count=block_hash_mismatches_count,
             transaction_commitment_mismatches_count=transaction_commitment_mismatches_count,
+            os_failed_count=os_failed_count,
             forward_rate=forward_rate,
             echonet_revert_rate_pct=echonet_revert_rate_pct,
             echonet_revert_risk_0_1=echonet_revert_risk_0_1,
@@ -660,6 +736,7 @@ class _SnapshotReportRollup:
             l2_gas_mismatches_rows=l2_gas_mismatches_rows,
             block_hash_mismatches_rows=block_hash_mismatches_rows,
             transaction_commitment_mismatches_rows=transaction_commitment_mismatches_rows,
+            os_failures_rows=os_failures_rows,
         )
 
 
@@ -698,6 +775,7 @@ def build_report_view_model(
             "l2_gas_mismatches_count": r.l2_gas_mismatches_count,
             "block_hash_mismatches_count": r.block_hash_mismatches_count,
             "transaction_commitment_mismatches_count": r.transaction_commitment_mismatches_count,
+            "os_failed_count": r.os_failed_count,
             "committed_pct_of_pending_total": _format_percent(r.committed, r.pending_total),
             "pending_pct_of_pending_total": _format_percent(r.pending_commission, r.pending_total),
         },
@@ -730,4 +808,6 @@ def build_report_view_model(
         "l2_gas_mismatches": r.l2_gas_mismatches_rows,
         "block_hash_mismatches": r.block_hash_mismatches_rows,
         "transaction_commitment_mismatches": r.transaction_commitment_mismatches_rows,
+        "os_run_failures": r.os_failures_rows,
+        "os_run_stats": snapshot.os_run_stats or {},
     }

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -20,6 +20,7 @@ from echonet.echonet_types import (
 from echonet.l1_logic.l1_client import L1Client
 from echonet.l1_logic.l1_manager import L1Manager
 from echonet.logger import get_logger
+from echonet.os_input_builder import decompress_state_commitment_infos
 from echonet.report_models import SnapshotModel
 
 logger = get_logger("shared_context")
@@ -333,16 +334,58 @@ class _BlockStore:
         evict_bns = [bn for bn in store.keys() if bn < cutoff]
         return [(bn, store.pop(bn)) for bn in sorted(evict_bns)]
 
+    def _evict_old_blob_bodies(self, current_block_number: int) -> List[tuple[int, bytes]]:
+        """
+        Drop in-memory `blob_body` for entries older than the blob retention
+        window (the entry itself stays — block doc + state_update remain
+        available for the tx sender). Returns the (block_number, blob_bytes)
+        pairs that were dropped so the caller can archive them.
+        """
+        cutoff = current_block_number - CONFIG.block_store.max_blob_bodies_to_keep_in_memory
+        evicted: List[tuple[int, bytes]] = []
+        for bn, entry in self.blocks.items():
+            if bn >= cutoff:
+                continue
+            blob_body = entry.get("blob_body")
+            if blob_body is None:
+                continue
+            evicted.append((bn, blob_body))
+            entry["blob_body"] = None
+        return evicted
+
     # --- Block store API ---
     def store_block(
-        self, block_number: int, blob: JsonObject, fgw_block: JsonObject, state_update: JsonObject
-    ) -> List[tuple[int, JsonObject]]:
+        self,
+        block_number: int,
+        blob_body: bytes,
+        fgw_block: JsonObject,
+        state_update: JsonObject,
+        block_commitments: JsonObject,
+    ) -> tuple[List[tuple[int, JsonObject]], List[tuple[int, bytes]]]:
+        # MEMORY: store the blob as raw JSON bytes, not the parsed Python
+        # dict. A 6 MB blob parses to 30-50 MB of Python heap (millions of
+        # tiny dict/list/str/int objects, each with ~85 byte CPython
+        # overhead) which glibc then backs with 4-6× that in arena pages.
+        # At max_blocks_to_keep_in_memory=250 the parsed-dict variant
+        # reliably OOMs the pod above 16 GiB. Bytes give a 5-8× reduction
+        # without losing any information — consumers parse just-in-time.
+        #
+        # `block_commitments` is the 5-felt `BlockHeaderCommitments` dict
+        # (returned by the block-hash CLI at ingest); stashed here so the
+        # OS runner worker can splice it into its input without re-parsing
+        # `blob_body` just to recompute the same values.
         self.blocks[block_number] = {
-            "blob": blob,
+            "blob_body": blob_body,
             "block": fgw_block,
             "state_update": state_update,
+            "block_commitments": block_commitments,
         }
-        return self._evict_old_items(self.blocks, current_block_number=block_number)
+        evicted_items = self._evict_old_items(self.blocks, current_block_number=block_number)
+        # Blob-body retention is tighter than block retention; drop in-memory
+        # blob_body for entries that have aged past `max_blob_bodies_to_keep_in_memory`
+        # but are still within `max_blocks_to_keep_in_memory`.
+        evicted_blob_bodies = self._evict_old_blob_bodies(current_block_number=block_number)
+        return evicted_items, evicted_blob_bodies
 
     def store_fgw_block(self, block_number: int, block_obj: JsonObject) -> None:
         self.fgw_blocks[block_number] = block_obj
@@ -373,10 +416,9 @@ class _BlockStore:
     ) -> None:
         try:
             for bn, entry in snapshot_items:
-                (base_dir / f"blob_{bn}.json").write_text(
-                    json.dumps(entry["blob"], ensure_ascii=False),
-                    encoding="utf-8",
-                )
+                blob_body = entry.get("blob_body")
+                if blob_body is not None:
+                    (base_dir / f"blob_{bn}.json").write_bytes(blob_body)
                 (base_dir / f"block_{bn}.json").write_text(
                     json.dumps(entry["block"], ensure_ascii=False),
                     encoding="utf-8",
@@ -388,6 +430,53 @@ class _BlockStore:
             _BlockStore._enforce_blocks_archives_size_cap()
         except Exception as e:
             logger.error(f"Failed to snapshot blocks to disk: {e}")
+
+    @staticmethod
+    def write_blob_bodies_to_disk(blob_body_items: List[tuple[int, bytes]], base_dir: Path) -> None:
+        """
+        Archive blob bodies that were evicted from memory while their parent
+        entry (block doc + state_update) stays cached. The OS runner reads them
+        back via `get_blob_body_with_disk_fallback`.
+        """
+        try:
+            for bn, blob_body in blob_body_items:
+                (base_dir / f"blob_{bn}.json").write_bytes(blob_body)
+            _BlockStore._enforce_blocks_archives_size_cap()
+        except Exception as e:
+            logger.error(f"Failed to archive evicted blob bodies to disk: {e}")
+
+
+@dataclass(slots=True)
+class _OsRunStats:
+    """
+    Cumulative counters for OS-runner outcomes, surfaced in the echonet report.
+    Match the log-line categories emitted from `echo_center._maybe_run_os` /
+    `_try_enqueue_os_run` / `_os_run_worker`.
+
+    `recent_failures` is a rolling list of `{block_number, ts, error}` entries
+    for the last N hard failures — exposed in the report so a quick read can
+    map a failure count to actual blocks + the panic line that caused them.
+    """
+
+    completed: int
+    failed: int
+    dropped: int
+    deferred_events: int
+    abandoned: int
+    skipped: int
+    recent_failures: List[JsonObject]
+
+    @classmethod
+    def empty(cls) -> "_OsRunStats":
+        return cls(
+            completed=0,
+            failed=0,
+            dropped=0,
+            deferred_events=0,
+            abandoned=0,
+            skipped=0,
+            recent_failures=[],
+        )
 
 
 @dataclass(slots=True)
@@ -475,6 +564,25 @@ class SharedContext:
         self._hash_mismatches = _BlockHashMismatchTracker.empty()
         self._blocks = _BlockStore.empty()
         self._progress = _ProgressMarkers.empty()
+        self._os_runs = _OsRunStats.empty()
+        self._os_run_live = {"queue_depth": 0, "queue_max": 0, "deferred_count": 0}
+        # State-commitment-info store, populated from every incoming blob's
+        # `recent_state_commitment_infos` vector. Two purposes:
+        #
+        # 1. OS-run input building: with the sequencer's cende-commitment-delta
+        #    optimization, blob N+1 may no longer carry N's commit (since we
+        #    told the sequencer we already have it). So we keep our own copy
+        #    instead of re-extracting from the blob at OS-run time.
+        # 2. The `last_stored_commitment_height` query — the sequencer skips
+        #    every commit at-or-below the height we return, so we must report
+        #    the highest *contiguous* block we hold (no internal gaps), else
+        #    the missing block's commit is dropped forever from the wire.
+        #
+        # Cap the dict so it doesn't grow unbounded; trim oldest entries beyond
+        # `_COMMITS_RETENTION` heights. Not persisted across pod restart — the
+        # sequencer falls back to its full window when we return null/None.
+        self._commits_by_block: Dict[int, JsonObject] = {}
+        self._last_stored_commitment_height: Optional[int] = None
         self._epoch = 0
 
     def get_uptime_seconds(self) -> int:
@@ -483,6 +591,137 @@ class SharedContext:
     def get_epoch(self) -> int:
         with self._lock:
             return self._epoch
+
+    # --- OS-runner stats ---
+    def record_os_run_completed(self) -> None:
+        with self._lock:
+            self._os_runs.completed += 1
+
+    # Cap on per-block-failure entries kept for the report. Older entries get
+    # dropped FIFO; the report shows "most recent N failures" — enough to spot
+    # patterns without growing unbounded.
+    _OS_RUN_FAILURES_RETENTION: int = 50
+
+    def record_os_run_failed(self, block_number: int, error: str) -> None:
+        # `error` is the exception message + worker subprocess stderr; capped
+        # generously so a full Cairo traceback fits but the report stays
+        # bounded. Full text always survives in pod logs.
+        entry = {
+            "block_number": int(block_number),
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "error": error[:4096],
+        }
+        with self._lock:
+            self._os_runs.failed += 1
+            self._os_runs.recent_failures.append(entry)
+            overflow = len(self._os_runs.recent_failures) - SharedContext._OS_RUN_FAILURES_RETENTION
+            if overflow > 0:
+                del self._os_runs.recent_failures[:overflow]
+
+    def record_os_run_dropped(self) -> None:
+        with self._lock:
+            self._os_runs.dropped += 1
+
+    def record_os_run_deferred(self) -> None:
+        with self._lock:
+            self._os_runs.deferred_events += 1
+
+    def record_os_run_abandoned(self) -> None:
+        with self._lock:
+            self._os_runs.abandoned += 1
+
+    def record_os_run_skipped(self) -> None:
+        with self._lock:
+            self._os_runs.skipped += 1
+
+    def set_os_run_live_state(self, queue_depth: int, queue_max: int, deferred_count: int) -> None:
+        with self._lock:
+            self._os_run_live["queue_depth"] = queue_depth
+            self._os_run_live["queue_max"] = queue_max
+            self._os_run_live["deferred_count"] = deferred_count
+
+    def _os_run_stats_dict_locked(self) -> JsonObject:
+        """Caller must hold `self._lock`. Shape mirrored by
+        `get_report_snapshot`'s `os_run_stats` field — keep in sync."""
+        return {
+            "completed": self._os_runs.completed,
+            "failed": self._os_runs.failed,
+            "dropped": self._os_runs.dropped,
+            "deferred_events": self._os_runs.deferred_events,
+            "abandoned": self._os_runs.abandoned,
+            "skipped": self._os_runs.skipped,
+            "queue_depth": self._os_run_live["queue_depth"],
+            "queue_max": self._os_run_live["queue_max"],
+            "currently_deferred": self._os_run_live["deferred_count"],
+            "recent_failures": list(self._os_runs.recent_failures),
+        }
+
+    def get_os_run_stats(self) -> JsonObject:
+        with self._lock:
+            return self._os_run_stats_dict_locked()
+
+    # --- Cende-recorder commitment-info tracking ---
+    # Retain just the deferred-retry window's worth of commits. Once a block
+    # ages past `_RECENT_STATE_COMMITMENT_WINDOW` (10) heights it's permanently
+    # abandoned for OS runs (see `_maybe_run_os` in echo_center), so older
+    # commits are dead weight. Workers hold their task's commit directly after
+    # enqueue, so the store doesn't need to span the OS-run duration either.
+    _COMMITS_RETENTION: int = 10
+
+    def get_last_stored_commitment_height(self) -> Optional[int]:
+        with self._lock:
+            return self._last_stored_commitment_height
+
+    def get_state_commitment_infos(self, block_number: int) -> Optional[JsonObject]:
+        """Return the stored `state_commitment_infos` for `block_number`, or None."""
+        with self._lock:
+            return self._commits_by_block.get(int(block_number))
+
+    def record_commits_from_blob(self, blob: JsonObject) -> None:
+        """
+        Persist every `state_commitment_infos` entry in `blob`'s
+        `recent_state_commitment_infos` vector so OS-runs can look them up
+        directly (instead of re-extracting from the blob, which post
+        cende-commitment-delta may not carry them anymore).
+
+        Also bumps `last_stored_commitment_height` only by *contiguous*
+        extension — never claiming a height beyond which we have a gap. The
+        sequencer skips every commit at-or-below the returned height, so
+        announcing a non-contiguous max would permanently lose any held-back
+        commit in the gap.
+        """
+        entries = blob.get("recent_state_commitment_infos") or []
+        if not entries:
+            return
+        with self._lock:
+            # Store every entry we don't already have. Blob-side entries are
+            # compressed strings (base64(zstd(json))) as of the committer's
+            # compress-commitment-infos change — decompress once at ingest so
+            # every downstream consumer sees the raw dict.
+            for entry in entries:
+                bn = int(entry["block_number"])
+                if bn in self._commits_by_block:
+                    continue
+                self._commits_by_block[bn] = decompress_state_commitment_infos(
+                    entry["state_commitment_infos"]
+                )
+
+            # Bump the contiguous-stored-height by extending forward block by
+            # block while present in the dict. First-time path: anchor at the
+            # min block_number we just inserted.
+            if self._last_stored_commitment_height is None:
+                self._last_stored_commitment_height = min(self._commits_by_block) - 1
+            while (self._last_stored_commitment_height + 1) in self._commits_by_block:
+                self._last_stored_commitment_height += 1
+
+            # Trim entries we no longer need (older than the contiguous head by
+            # `_COMMITS_RETENTION`). We never trim above the head — that's the
+            # window the OS-runner actually consumes.
+            if len(self._commits_by_block) > SharedContext._COMMITS_RETENTION:
+                cutoff = self._last_stored_commitment_height - SharedContext._COMMITS_RETENTION
+                stale = [bn for bn in self._commits_by_block if bn < cutoff]
+                for bn in stale:
+                    self._commits_by_block.pop(bn, None)
 
     # --- Tx lifecycle ---
     def record_sent_tx(self, tx_hash: str, source_block_number: int) -> None:
@@ -589,6 +828,13 @@ class SharedContext:
             self._hash_mismatches.clear_pending_mismatch()
             self._progress.last_echo_center_block = None
             self._progress.sender_current_block = None
+            # Stale commit map + contiguous-height marker would otherwise let
+            # `get_last_stored_commitment_height` announce a pre-resync height
+            # (sequencer omits commits at-or-below it) while `record_commits_from_blob`
+            # short-circuits on "already stored" — OS runs on replayed blocks would
+            # then see stale StateCommitmentInfos.
+            self._commits_by_block.clear()
+            self._last_stored_commitment_height = None
         _BlockStore.write_snapshot_items_to_disk(snapshot_items, base_dir=archive_dir)
         l1_manager.clear_stored_blocks()
 
@@ -626,15 +872,28 @@ class SharedContext:
 
     # --- Block storage (echo_center output + raw FGW blocks) ---
     def store_block(
-        self, block_number: int, blob: JsonObject, fgw_block: JsonObject, state_update: JsonObject
+        self,
+        block_number: int,
+        blob_body: bytes,
+        fgw_block: JsonObject,
+        state_update: JsonObject,
+        block_commitments: JsonObject,
     ) -> None:
         with self._lock:
-            evicted_items = self._blocks.store_block(
-                block_number, blob=blob, fgw_block=fgw_block, state_update=state_update
+            evicted_items, evicted_blob_bodies = self._blocks.store_block(
+                block_number,
+                blob_body=blob_body,
+                fgw_block=fgw_block,
+                state_update=state_update,
+                block_commitments=block_commitments,
             )
         if evicted_items:
             _BlockStore.write_snapshot_items_to_disk(
                 evicted_items, base_dir=self._blocks._ensure_archive_dir()
+            )
+        if evicted_blob_bodies:
+            _BlockStore.write_blob_bodies_to_disk(
+                evicted_blob_bodies, base_dir=self._blocks._ensure_archive_dir()
             )
 
     def store_fgw_block(self, block_number: int, block_obj: JsonObject) -> None:
@@ -668,6 +927,26 @@ class SharedContext:
             return json.loads(path.read_text(encoding="utf-8"))
         except Exception as e:
             logger.warning(f"Failed reading archived block dump {path}: {e}")
+            return None
+
+    def get_blob_body_with_disk_fallback(self, block_number: int) -> Optional[bytes]:
+        """
+        Return the raw blob bytes for `block_number` — from memory if cached,
+        else from the on-disk archive (`blob_<N>.json`, which contains the
+        JSON body verbatim per `_BlockStore.write_snapshot_items_to_disk`).
+        """
+        in_mem = self.get_block_field(block_number, "blob_body")
+        if in_mem is not None:
+            if isinstance(in_mem, str):
+                return in_mem.encode("utf-8")
+            return in_mem
+        path = _find_archived_block_path(block_number=block_number, field="blob")
+        if not path:
+            return None
+        try:
+            return path.read_bytes()
+        except Exception as e:
+            logger.warning(f"Failed reading archived blob {path}: {e}")
             return None
 
     def get_latest_block_number(self) -> Optional[int]:
@@ -724,6 +1003,7 @@ class SharedContext:
                 transaction_commitment_mismatches=list(
                     self._hash_mismatches.transaction_commitment_mismatches
                 ),
+                os_run_stats=self._os_run_stats_dict_locked(),
             )
 
     # --- Progress markers ---

--- a/echonet/static/report.css
+++ b/echonet/static/report.css
@@ -3,29 +3,34 @@
     --bg: #0b0d12;
     --panel: #121827;
     --panel2: #0f1422;
+    --panel3: #161d2f;
     --text: #e7eaf0;
     --muted: #a7b0c0;
     --border: rgba(255, 255, 255, 0.08);
+    --borderStrong: rgba(255, 255, 255, 0.14);
     --shadow: rgba(0, 0, 0, 0.35);
     --ok: #2ecc71;
     --warn: #f1c40f;
     --bad: #ff5d5d;
     --accent: #7aa2ff;
-    /* Secondary backdrop accent (keep neutral by default; "risk" theme will override). */
     --accent2: var(--accent);
     --link: var(--accent);
+    --topbarH: 78px;
+    --sideW: 248px;
+    --rowPadY: 9px;
     --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     --sans: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
 }
 
-/* Light theme variables (toggled via [data-theme="light"]) */
 html[data-theme="light"] {
     --bg: #f6f7fb;
     --panel: #ffffff;
     --panel2: #fbfbfe;
+    --panel3: #f0f2fa;
     --text: #111827;
     --muted: #5b6475;
     --border: rgba(17, 24, 39, 0.10);
+    --borderStrong: rgba(17, 24, 39, 0.18);
     --shadow: rgba(0, 0, 0, 0.10);
     --accent: #2457ff;
     --accent2: var(--accent);
@@ -46,9 +51,9 @@ body {
     font-family: var(--sans);
     background: var(--bg);
     color: var(--text);
+    -webkit-font-smoothing: antialiased;
 }
 
-/* Fixed soft glow backdrop (no hard band while scrolling). */
 body::before {
     content: "";
     position: fixed;
@@ -67,12 +72,6 @@ body::before {
             transparent 70%);
 }
 
-/* Make section anchors scroll nicely under sticky header. */
-section[id] {
-    scroll-margin-top: 86px;
-}
-
-/* In "risk" theme, make the glow a bit stronger. */
 html[data-theme="risk"] body::before {
     background:
         radial-gradient(1100px 680px at 18% -8%,
@@ -86,19 +85,8 @@ html[data-theme="risk"] body::before {
             transparent 70%);
 }
 
-.pillLink {
-    cursor: pointer;
-    user-select: none;
-}
-
-.pillLink:focus {
-    outline: none;
-    box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
-}
-
-/* Risk theme (accent is set dynamically by JS based on echonet-only revert rate). */
-html[data-theme="risk"] {
-    --link: var(--accent);
+section[id] {
+    scroll-margin-top: calc(var(--topbarH) + 12px);
 }
 
 a {
@@ -121,13 +109,40 @@ a:hover {
 .smallMuted {
     color: var(--muted);
     font-size: 12px;
-    margin-top: 10px;
-    line-height: 1.35;
+    line-height: 1.4;
 }
 
 .empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 24px 12px;
     color: var(--muted);
-    padding: 12px 0;
+    text-align: center;
+}
+
+.empty .emptyIcon {
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--muted) 16%, transparent);
+    color: var(--muted);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 18px;
+}
+
+.empty .emptyIcon.ok {
+    background: color-mix(in oklab, var(--ok) 18%, transparent);
+    color: var(--ok);
+}
+
+.empty .emptyText {
+    font-size: 13px;
 }
 
 .countPill {
@@ -144,37 +159,163 @@ a:hover {
     font-family: var(--mono);
 }
 
+/* ───────── Topbar ───────── */
+
 .topbar {
     position: sticky;
     top: 0;
     z-index: 50;
     display: flex;
     justify-content: space-between;
+    align-items: stretch;
     gap: 16px;
-    padding: 14px 16px;
+    padding: 12px 18px;
     border-bottom: 1px solid var(--border);
-    background: color-mix(in oklab, var(--panel) 88%, transparent);
-    backdrop-filter: blur(10px);
+    background: color-mix(in oklab, var(--panel) 90%, transparent);
+    backdrop-filter: blur(12px);
+}
+
+.topbarLeft {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.brandLogo {
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
+    background: linear-gradient(135deg,
+        color-mix(in oklab, var(--accent) 50%, transparent),
+        color-mix(in oklab, var(--accent2) 25%, transparent));
+    color: var(--text);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--borderStrong);
+    box-shadow: 0 6px 18px var(--shadow);
+}
+
+.brandText {
+    line-height: 1.1;
 }
 
 .brand .title {
     font-size: 16px;
-    font-weight: 650;
-    letter-spacing: 0.2px;
+    font-weight: 700;
+    letter-spacing: 0.15px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .brand .subtitle {
-    margin-top: 2px;
+    margin-top: 4px;
     font-size: 12px;
     color: var(--muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.agoChip {
+    padding: 1px 7px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 70%, transparent);
+    color: var(--muted);
+    font-size: 11px;
+}
+
+.healthDot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--ok);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--ok) 22%, transparent);
+    transition: background 200ms ease, box-shadow 200ms ease;
+}
+
+.healthDot.warn {
+    background: var(--warn);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--warn) 22%, transparent);
+}
+
+.healthDot.bad {
+    background: var(--bad);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--bad) 22%, transparent);
+    animation: healthPulse 2s ease-in-out infinite;
+}
+
+@keyframes healthPulse {
+    0%, 100% { box-shadow: 0 0 0 3px color-mix(in oklab, var(--bad) 22%, transparent); }
+    50%      { box-shadow: 0 0 0 6px color-mix(in oklab, var(--bad) 14%, transparent); }
+}
+
+.liveIndicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--muted) 50%, transparent);
+}
+
+.liveIndicator.live {
+    background: var(--ok);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--ok) 22%, transparent);
+    animation: livePulse 1.4s ease-in-out infinite;
+}
+
+@keyframes livePulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50%      { transform: scale(1.25); opacity: 0.7; }
 }
 
 .controls {
     display: flex;
-    gap: 10px;
+    gap: 8px;
     align-items: end;
     flex-wrap: wrap;
     justify-content: flex-end;
+}
+
+.btnGroup {
+    display: inline-flex;
+    align-items: stretch;
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: 11px;
+    overflow: hidden;
+    background: color-mix(in oklab, var(--panel2) 80%, transparent);
+    box-shadow: 0 6px 16px var(--shadow);
+}
+
+.btnGroup .btn {
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    background: transparent;
+    padding: 7px 10px;
+    border-right: 1px solid var(--border);
+}
+
+.btnGroup .btn:last-child {
+    border-right: none;
+}
+
+.btnGroup .btn:hover {
+    background: color-mix(in oklab, var(--link) 14%, transparent);
+}
+
+.btnGroup .btn[aria-pressed="true"] {
+    background: color-mix(in oklab, var(--link) 22%, transparent);
+    color: var(--text);
 }
 
 .inlineForm {
@@ -193,30 +334,38 @@ a:hover {
 
 .statusLine {
     color: var(--muted);
-    font-size: 12px;
+    font-size: 11px;
     padding: 6px 10px;
     border-radius: 999px;
     border: 1px solid var(--border);
     background: color-mix(in oklab, var(--panel2) 88%, transparent);
     font-family: var(--mono);
+    align-self: end;
 }
 
 .control {
     display: grid;
-    gap: 6px;
-    font-size: 12px;
+    gap: 4px;
+    font-size: 11px;
     color: var(--muted);
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
 }
 
 .control input,
 .control select {
     min-width: 220px;
-    padding: 8px 10px;
+    padding: 7px 10px;
     border-radius: 10px;
     border: 1px solid var(--border);
     background: var(--panel2);
     color: var(--text);
     outline: none;
+    font-family: var(--sans);
+    font-size: 13px;
+    text-transform: none;
+    letter-spacing: 0;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
 .noSpin[type="number"] {
@@ -224,7 +373,6 @@ a:hover {
     -moz-appearance: textfield;
 }
 
-/* Chrome, Safari, Edge */
 .noSpin[type="number"]::-webkit-outer-spin-button,
 .noSpin[type="number"]::-webkit-inner-spin-button {
     -webkit-appearance: none;
@@ -246,19 +394,33 @@ a:hover {
     border: 1px solid var(--border);
     background: linear-gradient(180deg, color-mix(in oklab, var(--panel) 92%, white 8%), var(--panel));
     color: var(--text);
-    padding: 8px 10px;
+    padding: 7px 11px;
     border-radius: 10px;
     cursor: pointer;
     font-size: 12px;
-    box-shadow: 0 8px 20px var(--shadow);
+    box-shadow: 0 6px 16px var(--shadow);
+    transition: filter 120ms ease, transform 60ms ease, box-shadow 120ms ease, background 120ms ease;
+    font-family: var(--sans);
 }
 
 .btn:hover {
-    filter: brightness(1.05);
+    filter: brightness(1.06);
 }
 
 .btn:active {
     transform: translateY(1px);
+}
+
+.btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--link) 28%, transparent);
+}
+
+.btnIcon {
+    width: 32px;
+    padding: 0;
+    text-align: center;
+    font-weight: 700;
 }
 
 .btnLink {
@@ -267,14 +429,15 @@ a:hover {
 }
 
 .btnSmall {
-    padding: 5px 7px;
-    border-radius: 9px;
+    padding: 4px 7px;
+    border-radius: 8px;
     box-shadow: none;
+    font-size: 11px;
 }
 
 .rowActions {
     display: flex;
-    gap: 5px;
+    gap: 4px;
     align-items: center;
     justify-content: flex-end;
     flex-wrap: nowrap;
@@ -290,10 +453,115 @@ a:hover {
     margin: -2px 0 10px;
 }
 
+/* ───────── Layout: sidenav + main ───────── */
+
+.layout {
+    display: grid;
+    grid-template-columns: var(--sideW) minmax(0, 1fr);
+    align-items: start;
+}
+
+.sidenav {
+    position: sticky;
+    top: var(--topbarH);
+    height: calc(100vh - var(--topbarH));
+    overflow-y: auto;
+    border-right: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel) 65%, transparent);
+    backdrop-filter: blur(10px);
+    padding: 18px 12px 30px;
+}
+
+.sidenavTitle {
+    color: var(--muted);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    margin: 4px 8px 8px;
+}
+
+.sidenavList {
+    display: grid;
+    gap: 2px;
+}
+
+.sidenavItem {
+    display: grid;
+    grid-template-columns: 12px 1fr auto;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 10px;
+    border-radius: 10px;
+    color: var(--text);
+    font-size: 13px;
+    cursor: pointer;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: background 120ms ease, border-color 120ms ease;
+}
+
+.sidenavItem:hover {
+    background: color-mix(in oklab, var(--link) 10%, transparent);
+    text-decoration: none;
+}
+
+.sidenavItem.active {
+    background: color-mix(in oklab, var(--link) 18%, transparent);
+    border-color: color-mix(in oklab, var(--link) 35%, transparent);
+}
+
+.sidenavItem .navLabel {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sidenavItem .navCount {
+    font-size: 11px;
+    color: var(--muted);
+    padding: 1px 7px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 90%, transparent);
+}
+
+.navDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--muted) 40%, transparent);
+}
+
+.navDot.ok { background: var(--ok); }
+.navDot.warn { background: var(--warn); }
+.navDot.bad { background: var(--bad); box-shadow: 0 0 0 3px color-mix(in oklab, var(--bad) 18%, transparent); }
+.navDot.neutral { background: color-mix(in oklab, var(--muted) 50%, transparent); }
+
+.sidenavFooter {
+    margin-top: 18px;
+    padding: 12px 10px 6px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+}
+
+.sidenavFooter kbd,
+.shortcutsBody kbd {
+    display: inline-block;
+    padding: 1px 6px;
+    border: 1px solid var(--border);
+    border-bottom-width: 2px;
+    border-radius: 6px;
+    background: color-mix(in oklab, var(--panel2) 90%, transparent);
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--text);
+    margin: 0 2px;
+}
+
 .container {
     max-width: 1280px;
-    margin: 18px auto;
-    padding: 0 16px 30px;
+    margin: 16px auto;
+    padding: 0 18px 30px;
 }
 
 .stack {
@@ -302,51 +570,34 @@ a:hover {
     gap: 14px;
 }
 
-.row2 {
+.overviewGrid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 2fr 1fr 1fr;
     gap: 14px;
+    align-items: stretch;
 }
 
-.grid {
-    display: grid;
-    gap: 14px;
+.overviewGrid .span3 {
+    grid-row: span 1;
 }
 
-.kpis {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.span2 {
-    grid-column: span 2;
-}
-
-.twoCol {
+.alertsCard {
     margin-top: 14px;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-@media (max-width: 1050px) {
-    .kpis {
+@media (max-width: 1100px) {
+    .layout {
         grid-template-columns: 1fr;
     }
-
-    .span2 {
-        grid-column: auto;
+    .sidenav {
+        display: none;
     }
-
-    .twoCol {
+    .overviewGrid {
         grid-template-columns: 1fr;
-    }
-
-    .row2 {
-        grid-template-columns: 1fr;
-    }
-
-    .control input {
-        min-width: 180px;
     }
 }
+
+/* ───────── Cards ───────── */
 
 .card {
     background: linear-gradient(180deg, color-mix(in oklab, var(--panel) 92%, white 8%), var(--panel));
@@ -355,16 +606,41 @@ a:hover {
     padding: 14px 14px 12px;
     box-shadow: 0 16px 40px var(--shadow);
     min-width: 0;
-    /* allow shrinking in CSS grid */
+}
+
+.cardHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+}
+
+.cardHeaderRight {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
 }
 
 .cardTitle {
-    font-weight: 650;
-    letter-spacing: 0.2px;
-    margin-bottom: 10px;
+    font-weight: 700;
+    letter-spacing: 0.15px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
 }
 
-/* Collapsible section cards (page-level sections). */
+.cardTitle .icon {
+    width: 16px;
+    height: 16px;
+    color: color-mix(in oklab, var(--link) 75%, var(--text));
+    opacity: 0.9;
+}
+
+/* Collapsible section cards */
 .sectionDetails>summary {
     list-style: none;
     cursor: pointer;
@@ -378,17 +654,22 @@ a:hover {
 .sectionDetails>summary.sectionSummary {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
     gap: 10px;
-    font-weight: 650;
-    letter-spacing: 0.2px;
-    /* Override generic `.details summary` styling; match original `.cardTitle`. */
+    font-weight: 700;
+    letter-spacing: 0.15px;
     color: var(--text);
-    font-size: inherit;
+    font-size: 14px;
     position: relative;
-    padding-right: 18px;
-    /* room for chevron */
+    padding-right: 22px;
     margin: 0 0 10px;
+}
+
+.sectionSummary .icon {
+    width: 16px;
+    height: 16px;
+    color: color-mix(in oklab, var(--link) 75%, var(--text));
+    opacity: 0.9;
 }
 
 .sectionDetails:not([open])>summary.sectionSummary {
@@ -399,13 +680,14 @@ a:hover {
     min-width: 0;
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
 }
 
 .sectionSummaryRight {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
+    margin-right: 14px;
 }
 
 .sectionDetails>summary.sectionSummary::after {
@@ -429,11 +711,13 @@ a:hover {
     opacity: 0.95;
 }
 
-.sectionDetails>summary.sectionSummary:focus {
+.sectionDetails>summary.sectionSummary:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
     border-radius: 12px;
 }
+
+/* ───────── Progress / hero ───────── */
 
 .kpiProgress .cardTitle {
     margin-bottom: 8px;
@@ -442,20 +726,22 @@ a:hover {
 .progressHero {
     display: grid;
     grid-template-columns: 1.1fr 1fr;
-    gap: 12px 14px;
+    gap: 12px 18px;
     align-items: start;
 }
 
 .heroLabel {
     color: var(--muted);
-    font-size: 12px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
 }
 
 .heroValue {
-    font-size: 36px;
+    font-size: 34px;
     font-weight: 800;
     letter-spacing: -0.6px;
-    margin-top: 2px;
+    margin-top: 4px;
 }
 
 .heroRow {
@@ -475,12 +761,324 @@ a:hover {
     gap: 6px 10px;
 }
 
-.bigNumber {
-    font-size: 32px;
-    font-weight: 750;
-    letter-spacing: -0.3px;
+.progressBarWrap {
+    margin-top: 14px;
+}
+
+.progressBarTrack {
+    position: relative;
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+    border: 1px solid var(--border);
+    overflow: hidden;
+}
+
+.progressBarFill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0%;
+    background: linear-gradient(90deg,
+        color-mix(in oklab, var(--accent) 55%, transparent),
+        color-mix(in oklab, var(--accent2) 80%, transparent));
+    transition: width 600ms ease;
+}
+
+.progressBarLabels {
+    display: flex;
+    justify-content: space-between;
     margin-top: 4px;
 }
+
+/* ───────── Mini tiles (overview right column) ───────── */
+
+.tile {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.tileValue {
+    font-size: 30px;
+    font-weight: 750;
+    letter-spacing: -0.3px;
+}
+
+.tileSub {
+    font-size: 12px;
+}
+
+.stackedBar {
+    display: flex;
+    height: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+    border: 1px solid var(--border);
+    margin-top: 10px;
+}
+
+.stackedBarPart {
+    height: 100%;
+    transition: width 400ms ease;
+}
+
+.stackedOk {
+    background: color-mix(in oklab, var(--ok) 70%, transparent);
+}
+
+.stackedPending {
+    background: color-mix(in oklab, var(--warn) 55%, transparent);
+}
+
+.legendRow {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.legendDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--muted);
+}
+
+.legendDot.ok { background: var(--ok); }
+.legendDot.pending { background: var(--warn); }
+.legendDot.bad { background: var(--bad); }
+
+.riskGauge {
+    margin-top: 10px;
+}
+
+.riskGaugeTrack {
+    position: relative;
+    height: 10px;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: linear-gradient(90deg,
+        color-mix(in oklab, var(--ok) 55%, var(--panel2)),
+        color-mix(in oklab, var(--warn) 60%, var(--panel2)),
+        color-mix(in oklab, var(--bad) 65%, var(--panel2)));
+}
+
+.riskGaugeFill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0%;
+    background: color-mix(in oklab, white 6%, transparent);
+    backdrop-filter: blur(2px);
+}
+
+.riskGaugeMarker {
+    position: absolute;
+    top: -3px;
+    bottom: -3px;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--text);
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--panel) 85%, transparent);
+    left: 0%;
+    transition: left 600ms ease;
+}
+
+/* ───────── Alerts: metric grid ───────── */
+
+.metricGrid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.metricTile {
+    appearance: none;
+    text-align: left;
+    background: color-mix(in oklab, var(--panel2) 85%, transparent);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 10px 12px;
+    color: var(--text);
+    cursor: pointer;
+    display: grid;
+    gap: 4px;
+    transition: transform 80ms ease, border-color 120ms ease, background 120ms ease;
+    box-shadow: 0 8px 18px var(--shadow);
+}
+
+.metricTile:hover {
+    transform: translateY(-1px);
+    border-color: color-mix(in oklab, var(--link) 30%, var(--border));
+}
+
+.metricLabel {
+    font-size: 11px;
+    color: var(--muted);
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.metricValue {
+    font-size: 22px;
+    font-weight: 750;
+    letter-spacing: -0.2px;
+}
+
+.metricSub {
+    font-size: 11px;
+    color: var(--muted);
+}
+
+.metricTile.ok {
+    border-color: color-mix(in oklab, var(--ok) 30%, var(--border));
+    background: color-mix(in oklab, var(--ok) 8%, var(--panel2));
+}
+
+.metricTile.warn {
+    border-color: color-mix(in oklab, var(--warn) 45%, var(--border));
+    background: color-mix(in oklab, var(--warn) 10%, var(--panel2));
+}
+
+.metricTile.bad {
+    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
+    background: color-mix(in oklab, var(--bad) 11%, var(--panel2));
+}
+
+.metricTile.neutral .metricLabel {
+    color: var(--muted);
+}
+
+.metricTile.static {
+    cursor: default;
+    box-shadow: none;
+}
+
+.metricTile.static:hover {
+    transform: none;
+    border-color: var(--border);
+}
+
+.metricSubgroupDivider {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 16px 2px 10px 2px;
+    color: var(--muted);
+}
+
+.metricSubgroupDivider::before,
+.metricSubgroupDivider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+}
+
+.metricSubgroupLabel {
+    font-size: 11px;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+@media (max-width: 980px) {
+    .metricGrid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+/* ───────── Revert reasons summary ───────── */
+
+.revertSummaryGrid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    margin-top: 10px;
+}
+
+@media (max-width: 980px) {
+    .revertSummaryGrid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.revertSummaryTitle {
+    font-size: 12px;
+    color: var(--muted);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+}
+
+.barList {
+    display: grid;
+    gap: 6px;
+}
+
+.barRow {
+    appearance: none;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 6px 8px;
+    color: var(--text);
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: minmax(120px, 1.3fr) minmax(80px, 2fr) 60px 60px;
+    align-items: center;
+    gap: 10px;
+    text-align: left;
+    transition: background 120ms ease, border-color 120ms ease;
+}
+
+.barRow:hover {
+    background: color-mix(in oklab, var(--link) 8%, transparent);
+    border-color: color-mix(in oklab, var(--link) 25%, transparent);
+}
+
+.barName {
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.barTrack {
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--panel2) 92%, transparent);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    position: relative;
+}
+
+.barFill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0%;
+    background: linear-gradient(90deg,
+        color-mix(in oklab, var(--warn) 55%, transparent),
+        color-mix(in oklab, var(--bad) 75%, transparent));
+    transition: width 500ms ease;
+}
+
+.barCount {
+    text-align: right;
+    font-size: 12px;
+}
+
+.barPct {
+    text-align: right;
+    font-size: 11px;
+}
+
+/* ───────── KV pairs ───────── */
 
 .kv {
     display: grid;
@@ -491,85 +1089,44 @@ a:hover {
 
 .kv .k {
     color: var(--muted);
-    font-size: 12px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
 }
 
 .kv .v {
     font-size: 13px;
 }
 
-.pillRow {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 10px;
-}
+/* ───────── Tables ───────── */
 
-.pill {
-    display: inline-flex;
-    gap: 6px;
-    align-items: center;
+.tableWrap {
+    overflow: auto;
+    border-radius: 14px;
     border: 1px solid var(--border);
-    padding: 6px 10px;
-    border-radius: 999px;
-    font-size: 12px;
-    background: color-mix(in oklab, var(--panel2) 88%, transparent);
-}
-
-.pill.neutral {
-    color: var(--muted);
-}
-
-.pill.ok {
-    border-color: color-mix(in oklab, var(--ok) 42%, var(--border));
-    background: color-mix(in oklab, var(--ok) 10%, var(--panel2));
-}
-
-.pill.warn {
-    border-color: color-mix(in oklab, var(--warn) 45%, var(--border));
-    background: color-mix(in oklab, var(--warn) 10%, var(--panel2));
-}
-
-.pill.bad {
-    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
-    background: color-mix(in oklab, var(--bad) 10%, var(--panel2));
-}
-
-.badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 28px;
-    padding: 2px 8px;
-    border-radius: 999px;
-    border: 1px solid var(--border);
-    font-size: 12px;
-    font-family: var(--mono);
-}
-
-.badge.bad {
-    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
+    background: color-mix(in oklab, var(--panel2) 75%, transparent);
 }
 
 .table {
     width: 100%;
     border-collapse: separate;
     border-spacing: 0;
-    overflow: hidden;
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    background: color-mix(in oklab, var(--panel2) 75%, transparent);
     table-layout: fixed;
 }
 
 .table thead th {
     text-align: left;
-    font-size: 12px;
+    font-size: 11px;
     color: var(--muted);
     font-weight: 650;
     padding: 10px 10px;
     border-bottom: 1px solid var(--border);
-    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+    background: color-mix(in oklab, var(--panel3) 92%, transparent);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
 }
 
 .table thead th.sortable {
@@ -581,14 +1138,14 @@ body[data-report-export="1"] .table thead th.sortable {
     cursor: default;
 }
 
-.table thead th.sortable:focus {
+.table thead th.sortable:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 14%, transparent);
-    border-radius: 10px;
+    border-radius: 6px;
 }
 
 .table thead th.sortable:hover {
-    color: color-mix(in oklab, var(--muted) 50%, var(--text));
+    color: color-mix(in oklab, var(--muted) 40%, var(--text));
 }
 
 .table thead th.sortable::after {
@@ -608,12 +1165,12 @@ body[data-report-export="1"] .table thead th.sortable {
 .table thead th.sortable[data-sort-dir="asc"]::after {
     border-top: 0;
     border-bottom: 6px solid color-mix(in oklab, var(--link) 70%, transparent);
-    opacity: 0.9;
+    opacity: 0.95;
 }
 
 .table thead th.sortable[data-sort-dir="desc"]::after {
     border-top: 6px solid color-mix(in oklab, var(--link) 70%, transparent);
-    opacity: 0.9;
+    opacity: 0.95;
 }
 
 body[data-report-export="1"] .table thead th.sortable::after {
@@ -621,11 +1178,15 @@ body[data-report-export="1"] .table thead th.sortable::after {
 }
 
 .table tbody td {
-    padding: 9px 10px;
+    padding: var(--rowPadY) 10px;
     border-bottom: 1px solid var(--border);
     vertical-align: top;
     font-size: 13px;
     overflow: hidden;
+}
+
+body[data-density="compact"] {
+    --rowPadY: 5px;
 }
 
 .table tbody tr:last-child td {
@@ -648,6 +1209,7 @@ body[data-report-export="1"] .table thead th.sortable::after {
     border-radius: 999px;
     border: 1px solid var(--border);
     background: color-mix(in oklab, var(--panel2) 85%, transparent);
+    font-size: 11px;
 }
 
 .status.ok {
@@ -686,14 +1248,17 @@ body[data-report-export="1"] .hash {
     user-select: text;
 }
 
-.hash:focus {
+.hash:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
     border-radius: 8px;
 }
 
-body[data-report-export="1"] .hash:focus {
-    box-shadow: none;
+mark.matchHighlight {
+    background: color-mix(in oklab, var(--warn) 50%, transparent);
+    color: var(--text);
+    border-radius: 4px;
+    padding: 0 2px;
 }
 
 /* Column sizing (used via <colgroup>) */
@@ -717,7 +1282,7 @@ body[data-report-export="1"] .hash:focus {
     width: 280px;
 }
 
-@media (max-width: 1050px) {
+@media (max-width: 1100px) {
     .progressHero {
         grid-template-columns: 1fr;
     }
@@ -746,6 +1311,21 @@ body[data-report-export="1"] .hash:focus {
     margin-top: 6px;
 }
 
+.revertGroup {
+    margin-top: 8px;
+    padding: 4px 0;
+    border-radius: 10px;
+}
+
+details.revertGroup.flash {
+    animation: groupFlash 1.4s ease;
+}
+
+@keyframes groupFlash {
+    0%   { background: color-mix(in oklab, var(--link) 26%, transparent); }
+    100% { background: transparent; }
+}
+
 .pre {
     margin: 10px 0 0;
     padding: 10px;
@@ -758,13 +1338,13 @@ body[data-report-export="1"] .hash:focus {
     word-break: break-word;
     font-family: var(--mono);
     font-size: 12px;
-    line-height: 1.35;
+    line-height: 1.4;
 }
 
 .reason {
     font-family: var(--mono);
     font-size: 12px;
-    line-height: 1.35;
+    line-height: 1.4;
 }
 
 .footer {
@@ -779,3 +1359,114 @@ tr.isHidden,
 details.isHidden {
     display: none;
 }
+
+/* ───────── Shortcuts overlay ───────── */
+
+.shortcutsOverlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: color-mix(in oklab, black 50%, transparent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    backdrop-filter: blur(4px);
+    animation: fadeIn 120ms ease;
+}
+
+/* The `hidden` attribute must win over `display: flex` above. */
+.shortcutsOverlay[hidden] {
+    display: none;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.shortcutsCard {
+    width: min(520px, 100%);
+    border-radius: 16px;
+    border: 1px solid var(--borderStrong);
+    background: var(--panel);
+    box-shadow: 0 30px 80px var(--shadow);
+    padding: 16px 18px 18px;
+}
+
+.shortcutsHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}
+
+.shortcutsTitle {
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.15px;
+}
+
+.shortcutsBody {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 16px;
+}
+
+.shortcutRow {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 10px;
+    align-items: center;
+    font-size: 13px;
+    padding: 4px 0;
+    border-bottom: 1px dashed color-mix(in oklab, var(--border) 80%, transparent);
+}
+
+.shortcutRow:nth-last-child(-n+2) {
+    border-bottom: none;
+}
+
+@media (max-width: 600px) {
+    .shortcutsBody {
+        grid-template-columns: 1fr;
+    }
+    .shortcutRow {
+        border-bottom: 1px dashed color-mix(in oklab, var(--border) 80%, transparent);
+    }
+}
+
+/* ───────── Toast ───────── */
+
+#toast {
+    position: fixed;
+    bottom: 18px;
+    right: 18px;
+    padding: 9px 14px;
+    border-radius: 12px;
+    border: 1px solid var(--borderStrong);
+    background: color-mix(in oklab, var(--panel) 90%, transparent);
+    backdrop-filter: blur(10px);
+    color: var(--text);
+    font-size: 12px;
+    font-family: var(--sans);
+    box-shadow: 0 18px 40px var(--shadow);
+    z-index: 110;
+    opacity: 0;
+    transform: translateY(6px);
+    transition: opacity 140ms ease, transform 140ms ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#toast .toastDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--accent);
+}
+
+#toast.success .toastDot { background: var(--ok); }
+#toast.error .toastDot   { background: var(--bad); }
+#toast.info .toastDot    { background: var(--accent); }

--- a/echonet/static/report.js
+++ b/echonet/static/report.js
@@ -4,6 +4,9 @@
         theme: "echonet.report.theme",
         filter: "echonet.report.filter",
         scope: "echonet.report.filterScope",
+        density: "echonet.report.density",
+        hashMode: "echonet.report.hashMode",
+        sortPrefix: "echonet.report.sort.",
         blockDumpNumber: "echonet.report.blockDumpNumber",
         blockDumpKind: "echonet.report.blockDumpKind",
     };
@@ -24,8 +27,6 @@
             html.removeAttribute("data-theme");
         }
 
-        // "risk" sets --accent/--accent2 inline; clear when leaving it so dark/light
-        // revert to CSS defaults immediately (no refresh required).
         if (theme !== "risk") {
             html.style.removeProperty("--accent");
             html.style.removeProperty("--accent2");
@@ -33,12 +34,10 @@
     }
 
     function getDefaultTheme() {
-        // Default: risk (accent derived from echonet-only revert rate).
         return "risk";
     }
 
     function nextTheme(current) {
-        // Cycle: risk -> dark -> light -> risk
         if (current === "risk") return "dark";
         if (current === "dark") return "light";
         return "risk";
@@ -79,7 +78,6 @@
     }
 
     function updateTableMeta() {
-        // Tables (by data-table)
         document.querySelectorAll("[data-table-meta]").forEach((el) => {
             const name = el.getAttribute("data-table-meta");
             if (!name) return;
@@ -94,7 +92,6 @@
             el.textContent = total === 0 ? "" : `Showing ${visible}/${total} rows`;
         });
 
-        // Global stats (all rows)
         const stats = $("filterStats");
         if (stats) {
             const all = countVisibleRows(document);
@@ -102,17 +99,76 @@
         }
     }
 
+    // ───────── Filtering + match highlighting ─────────
+
+    function clearHighlightsIn(root) {
+        root.querySelectorAll("mark.matchHighlight").forEach((m) => {
+            const parent = m.parentNode;
+            if (!parent) return;
+            parent.replaceChild(document.createTextNode(m.textContent || ""), m);
+            parent.normalize();
+        });
+    }
+
+    function highlightMatchesIn(root, query) {
+        if (!query) return;
+        const q = query.toLowerCase();
+        const SKIP_TAGS = new Set(["script", "style", "mark", "pre", "code"]);
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+                const parent = node.parentNode;
+                if (!parent) return NodeFilter.FILTER_REJECT;
+                if (SKIP_TAGS.has((parent.nodeName || "").toLowerCase())) return NodeFilter.FILTER_REJECT;
+                if (parent.classList && parent.classList.contains("matchHighlight")) return NodeFilter.FILTER_REJECT;
+                if (!node.nodeValue) return NodeFilter.FILTER_REJECT;
+                return NodeFilter.FILTER_ACCEPT;
+            },
+        });
+
+        const targets = [];
+        let n;
+        while ((n = walker.nextNode())) {
+            const t = n.nodeValue || "";
+            if (!t.toLowerCase().includes(q)) continue;
+            targets.push(n);
+        }
+
+        for (const node of targets) {
+            const text = node.nodeValue || "";
+            const frag = document.createDocumentFragment();
+            const lower = text.toLowerCase();
+            let i = 0;
+            while (i < text.length) {
+                const idx = lower.indexOf(q, i);
+                if (idx < 0) {
+                    frag.appendChild(document.createTextNode(text.slice(i)));
+                    break;
+                }
+                if (idx > i) frag.appendChild(document.createTextNode(text.slice(i, idx)));
+                const mark = document.createElement("mark");
+                mark.className = "matchHighlight";
+                mark.textContent = text.slice(idx, idx + q.length);
+                frag.appendChild(mark);
+                i = idx + q.length;
+            }
+            node.parentNode.replaceChild(frag, node);
+        }
+    }
+
     function filterAll(query, scope) {
         const q = normalize(query);
-
         const activeScope = scope || "all";
 
-        // Filter each filterable container independently. If scope doesn't match, leave it unfiltered.
         const containers = document.querySelectorAll(".filterable[data-filter-scope]");
         containers.forEach((root) => {
+            // Always clear stale highlights — even when not filtering this scope —
+            // so flipping from "filter all" → "filter scope" doesn't leave orphans.
+            clearHighlightsIn(root);
+
             const rootScope = root.getAttribute("data-filter-scope") || "";
             const doFilter = activeScope === "all" || activeScope === rootScope;
             const rows = root.querySelectorAll("tr[data-search]");
+
             rows.forEach((tr) => {
                 if (!doFilter) {
                     setHidden(tr, false);
@@ -121,9 +177,9 @@
                 const hay = normalize(tr.getAttribute("data-search"));
                 const match = !q || hay.includes(q);
                 setHidden(tr, !match);
+                if (match && q) highlightMatchesIn(tr, q);
             });
 
-            // If root is a <details>, hide the entire group if it has no visible rows (only when filtering it).
             if (root.tagName && root.tagName.toLowerCase() === "details") {
                 if (!doFilter) {
                     setHidden(root, false);
@@ -138,8 +194,6 @@
     }
 
     function initSectionCollapsePersistence() {
-        // Persist section open/closed state across refreshes (like refresh dropdown).
-        // Keyed by the <section id="..."> that wraps a `details.sectionDetails`.
         try {
             const prefix = "echonet.report.sectionOpen.";
             document.querySelectorAll('details.sectionDetails[data-section-details="1"]').forEach((d) => {
@@ -152,7 +206,6 @@
                 if (saved === "1") d.open = true;
                 else if (saved === "0") d.open = false;
                 else {
-                    // Defaults: everything open except pending txs.
                     if (id === "pending-txs") d.open = false;
                 }
 
@@ -162,36 +215,24 @@
                     } catch (_) { }
                 });
             });
-        } catch (_) {
-            // If localStorage is unavailable, just fall back to HTML defaults.
-        }
+        } catch (_) { }
     }
 
-    function toast(msg) {
-        // Tiny toast without dependencies.
+    // ───────── Toast ─────────
+
+    function toast(msg, kind) {
         let el = document.getElementById("toast");
         if (!el) {
             el = document.createElement("div");
             el.id = "toast";
-            el.style.position = "fixed";
-            el.style.bottom = "14px";
-            el.style.right = "14px";
-            el.style.padding = "10px 12px";
-            el.style.borderRadius = "12px";
-            el.style.border = "1px solid rgba(255,255,255,0.12)";
-            el.style.background = "rgba(20, 24, 39, 0.92)";
-            el.style.backdropFilter = "blur(10px)";
-            el.style.color = "#e7eaf0";
-            el.style.fontSize = "12px";
-            el.style.fontFamily = "ui-sans-serif, system-ui";
-            el.style.boxShadow = "0 18px 40px rgba(0,0,0,0.35)";
-            el.style.zIndex = "999";
-            el.style.opacity = "0";
-            el.style.transform = "translateY(6px)";
-            el.style.transition = "opacity 120ms ease, transform 120ms ease";
+            el.innerHTML = '<span class="toastDot" aria-hidden="true"></span><span class="toastText"></span>';
             document.body.appendChild(el);
         }
-        el.textContent = msg;
+        el.className = "";
+        if (kind === "success" || kind === "error" || kind === "info") {
+            el.classList.add(kind);
+        }
+        el.querySelector(".toastText").textContent = msg;
         requestAnimationFrame(() => {
             el.style.opacity = "1";
             el.style.transform = "translateY(0)";
@@ -200,20 +241,17 @@
         el._t = window.setTimeout(() => {
             el.style.opacity = "0";
             el.style.transform = "translateY(6px)";
-        }, 1100);
+        }, 1300);
     }
 
-    async function copyText(text) {
+    async function copyText(text, { silent = false } = {}) {
         const t = (text || "").toString();
-        if (!t) return;
+        if (!t) return false;
         try {
             await navigator.clipboard.writeText(t);
-            toast("Copied");
-            return;
-        } catch (_) {
-            // fall through
-        }
-        // Fallback
+            if (!silent) toast("Copied", "success");
+            return true;
+        } catch (_) { }
         const ta = document.createElement("textarea");
         ta.value = t;
         ta.style.position = "fixed";
@@ -222,14 +260,17 @@
         document.body.appendChild(ta);
         ta.focus();
         ta.select();
+        let ok = false;
         try {
-            document.execCommand("copy");
-            toast("Copied");
+            ok = document.execCommand("copy");
+            if (ok && !silent) toast("Copied", "success");
+            else if (!silent) toast("Copy failed", "error");
         } catch (_) {
-            toast("Copy failed");
+            if (!silent) toast("Copy failed", "error");
         } finally {
             document.body.removeChild(ta);
         }
+        return ok;
     }
 
     function initCopyButtons() {
@@ -241,11 +282,10 @@
     function initHashClickToCopy() {
         document.querySelectorAll(".hash").forEach((el) => {
             el.addEventListener("click", (e) => {
-                // Avoid interfering with text selection.
                 if (window.getSelection && (window.getSelection().toString() || "").trim()) return;
                 e.preventDefault();
                 e.stopPropagation();
-                const t = el.getAttribute("title") || el.textContent || "";
+                const t = el.getAttribute("data-full-hash") || el.getAttribute("title") || el.textContent || "";
                 copyText(t.trim());
             });
             el.setAttribute("role", "button");
@@ -253,7 +293,7 @@
             el.addEventListener("keydown", (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    const t = el.getAttribute("title") || el.textContent || "";
+                    const t = el.getAttribute("data-full-hash") || el.getAttribute("title") || el.textContent || "";
                     copyText(t.trim());
                 }
             });
@@ -270,7 +310,6 @@
 
         const lines = [];
         lines.push('resource.type="k8s_container"');
-        // These labels are harmless even if they don't match (they narrow search).
         if (projectId) lines.push(`resource.labels.project_id="${projectId}"`);
         if (location) lines.push(`resource.labels.location="${location}"`);
         if (cluster) lines.push(`resource.labels.cluster_name="${cluster}"`);
@@ -278,7 +317,6 @@
 
         if (txHash) {
             const h = txHash.trim();
-            // A simple string search is good enough here.
             lines.push(`"${h}"`);
         }
 
@@ -293,13 +331,9 @@
     }
 
     function initLogsLinks() {
-        // Base namespace logs link.
         const base = $("logsBaseLink");
-        if (base) {
-            base.href = buildGcpLogsUrl();
-        }
+        if (base) base.href = buildGcpLogsUrl();
 
-        // Per-tx logs links.
         document.querySelectorAll("a.logsLink[data-logs-tx]").forEach((a) => {
             const txHash = a.getAttribute("data-logs-tx") || "";
             a.href = buildGcpLogsUrl({ txHash });
@@ -318,7 +352,6 @@
         const savedQ = localStorage.getItem(STORAGE.filter) || "";
         const savedScope = localStorage.getItem(STORAGE.scope) || "all";
 
-        // URL params win (shareable view), otherwise fall back to local storage.
         input.value = (urlQ != null ? urlQ : savedQ) || "";
         if (scopeSelect) scopeSelect.value = (urlScope != null ? urlScope : savedScope) || "all";
 
@@ -333,44 +366,33 @@
                 filterAll(input.value, scopeSelect.value);
             });
         }
-        // Preserve focus across auto-refresh reloads (best-effort).
+
         const focusKey = "echonet.report.filterFocused";
         input.addEventListener("focus", () => sessionStorage.setItem(focusKey, "1"));
         input.addEventListener("blur", () => sessionStorage.setItem(focusKey, "0"));
         if (sessionStorage.getItem(focusKey) === "1") {
-            // Defer to allow initial layout to settle.
             setTimeout(() => {
                 input.focus();
-                // Put caret at end.
                 const v = input.value || "";
                 input.setSelectionRange(v.length, v.length);
             }, 0);
         }
+    }
 
-        // Keyboard shortcuts:
-        // - "/" focuses filter (like many dashboards)
-        // - "Escape" clears filter
-        window.addEventListener("keydown", (e) => {
-            if (e.defaultPrevented) return;
-            const tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : "";
-            const inTypingContext = tag === "input" || tag === "textarea" || tag === "select";
-
-            if (!inTypingContext && e.key === "/") {
-                e.preventDefault();
-                input.focus();
-                input.select();
-                return;
+    function setFilter(text, { scrollToId } = {}) {
+        const input = $("filterInput");
+        const scopeSelect = $("scopeSelect");
+        if (!input) return;
+        input.value = text || "";
+        localStorage.setItem(STORAGE.filter, input.value);
+        filterAll(input.value, scopeSelect ? scopeSelect.value : "all");
+        if (scrollToId) {
+            const el = document.getElementById(scrollToId);
+            if (el) {
+                openCollapsibleSection(el);
+                el.scrollIntoView({ behavior: "smooth", block: "start" });
             }
-            if (e.key === "Escape") {
-                if (document.activeElement === input || input.value) {
-                    input.value = "";
-                    localStorage.setItem(STORAGE.filter, "");
-                    filterAll("", scopeSelect ? scopeSelect.value : "all");
-                    input.blur();
-                    toast("Filter cleared");
-                }
-            }
-        });
+        }
     }
 
     function initCopyVisibleHashes() {
@@ -381,7 +403,7 @@
         function collectHashesWithin(root) {
             const out = [];
             root.querySelectorAll("tr[data-search]:not(.isHidden) .hash").forEach((el) => {
-                const t = (el.getAttribute("title") || el.textContent || "").trim();
+                const t = (el.getAttribute("data-full-hash") || el.getAttribute("title") || el.textContent || "").trim();
                 if (t) out.push(t);
             });
             return out;
@@ -402,17 +424,18 @@
 
             const uniq = Array.from(new Set(hashes));
             if (!uniq.length) {
-                toast("No visible hashes");
+                toast("No visible hashes", "info");
                 return;
             }
-            copyText(uniq.join("\n"));
-            toast(`Copied ${uniq.length} hashes`);
+            copyText(uniq.join("\n"), { silent: true });
+            toast(`Copied ${uniq.length} hashes`, "success");
         });
     }
 
     function initRefresh() {
         const select = $("refreshSelect");
         const btn = $("refreshNowBtn");
+        const liveDot = $("liveIndicator");
         if (!select) return;
 
         const params = qs();
@@ -420,10 +443,18 @@
         const saved = localStorage.getItem(STORAGE.refresh) || "off";
         select.value = (urlRefresh != null ? urlRefresh : saved) || "off";
 
+        function applyLiveState(v) {
+            if (!liveDot) return;
+            if (v === "off") liveDot.classList.remove("live");
+            else liveDot.classList.add("live");
+        }
+        applyLiveState(select.value);
+
         let timer = null;
         function setTimer(v) {
             if (timer) window.clearInterval(timer);
             timer = null;
+            applyLiveState(v);
             if (v === "off") return;
             const secs = parseInt(v, 10);
             if (!Number.isFinite(secs) || secs <= 0) return;
@@ -445,7 +476,6 @@
         const params = qs();
         const urlTheme = params.get("theme");
         let saved = (urlTheme != null ? urlTheme : (localStorage.getItem(STORAGE.theme) || getDefaultTheme())) || getDefaultTheme();
-        // Migrate old "system" setting to the new default.
         if (saved === "system") {
             saved = getDefaultTheme();
             localStorage.setItem(STORAGE.theme, saved);
@@ -459,8 +489,75 @@
             localStorage.setItem(STORAGE.theme, nxt);
             applyTheme(nxt);
             if (nxt === "risk") applyRiskAccent();
-            toast(`Theme: ${nxt}`);
+            toast(`Theme: ${nxt}`, "info");
         });
+    }
+
+    function initDensityToggle() {
+        const btn = $("densityBtn");
+        if (!btn) return;
+        const saved = localStorage.getItem(STORAGE.density) || "comfortable";
+        function apply(mode) {
+            document.body.setAttribute("data-density", mode);
+            btn.setAttribute("aria-pressed", mode === "compact" ? "true" : "false");
+            btn.textContent = mode === "compact" ? "Comfortable" : "Compact";
+        }
+        apply(saved);
+        btn.addEventListener("click", () => {
+            const cur = document.body.getAttribute("data-density") || "comfortable";
+            const nxt = cur === "compact" ? "comfortable" : "compact";
+            localStorage.setItem(STORAGE.density, nxt);
+            apply(nxt);
+        });
+    }
+
+    function shortenHash(full) {
+        if (!full) return "";
+        if (full.length <= 18) return full;
+        return `${full.slice(0, 10)}…${full.slice(-8)}`;
+    }
+
+    function initHashModeToggle() {
+        const btn = $("hashModeBtn");
+        if (!btn) return;
+        const saved = localStorage.getItem(STORAGE.hashMode) || "full";
+        function apply(mode) {
+            document.body.setAttribute("data-hash-mode", mode);
+            btn.setAttribute("aria-pressed", mode === "short" ? "true" : "false");
+            btn.textContent = mode === "short" ? "Full hashes" : "Short hashes";
+            document.querySelectorAll(".hash[data-full-hash]").forEach((el) => {
+                const full = el.getAttribute("data-full-hash") || "";
+                if (!full) return;
+                el.textContent = mode === "short" ? shortenHash(full) : full;
+            });
+            // Re-run filter so highlights re-apply to new text content
+            const input = $("filterInput");
+            const scopeSelect = $("scopeSelect");
+            if (input) filterAll(input.value || "", scopeSelect ? scopeSelect.value : "all");
+        }
+        apply(saved);
+        btn.addEventListener("click", () => {
+            const cur = document.body.getAttribute("data-hash-mode") || "full";
+            const nxt = cur === "short" ? "full" : "short";
+            localStorage.setItem(STORAGE.hashMode, nxt);
+            apply(nxt);
+        });
+    }
+
+    function initExpandCollapseAll() {
+        const expandBtn = $("expandAllBtn");
+        const collapseBtn = $("collapseAllBtn");
+        const all = () => document.querySelectorAll('details.sectionDetails[data-section-details="1"]');
+        if (expandBtn) {
+            expandBtn.addEventListener("click", () => {
+                all().forEach((d) => { d.open = true; });
+            });
+        }
+        if (collapseBtn) {
+            collapseBtn.addEventListener("click", () => {
+                all().forEach((d) => { d.open = false; });
+            });
+        }
     }
 
     function initBlockDumpPersistence() {
@@ -468,7 +565,6 @@
         const kind = $("blockDumpKind");
         if (!num && !kind) return;
 
-        // Restore (localStorage wins; no URL param support needed here since the form opens in a new tab).
         try {
             if (num) {
                 const saved = localStorage.getItem(STORAGE.blockDumpNumber);
@@ -480,7 +576,6 @@
             }
         } catch (_) { }
 
-        // Preserve focus across auto-refresh reloads (best-effort), like filter input.
         if (num) {
             const focusKey = "echonet.report.blockDumpNumberFocused";
             num.addEventListener("focus", () => sessionStorage.setItem(focusKey, "1"));
@@ -493,19 +588,14 @@
             }
         }
 
-        // Persist changes.
         if (num) {
             num.addEventListener("input", () => {
-                try {
-                    localStorage.setItem(STORAGE.blockDumpNumber, num.value || "");
-                } catch (_) { }
+                try { localStorage.setItem(STORAGE.blockDumpNumber, num.value || ""); } catch (_) { }
             });
         }
         if (kind) {
             kind.addEventListener("change", () => {
-                try {
-                    localStorage.setItem(STORAGE.blockDumpKind, kind.value || "");
-                } catch (_) { }
+                try { localStorage.setItem(STORAGE.blockDumpKind, kind.value || ""); } catch (_) { }
             });
         }
     }
@@ -523,29 +613,159 @@
     }
 
     function applyRiskAccent() {
-        // Map echonet-only revert rate -> accent color.
-        // 0% => muted green; 1%+ => muted red.
         const risk = clamp01(document.body?.dataset?.echonetRevertRisk);
-
-        // Muted (non-neon) endpoints.
-        const green = { r: 52, g: 156, b: 98 }; // slightly stronger green
-        const red = { r: 196, g: 56, b: 56 };   // slightly stronger red
-
+        const green = { r: 52, g: 156, b: 98 };
+        const red = { r: 196, g: 56, b: 56 };
         const r = lerp(green.r, red.r, risk);
         const g = lerp(green.g, red.g, risk);
         const b = lerp(green.b, red.b, risk);
-
         const accent = `rgb(${r} ${g} ${b})`;
         document.documentElement.style.setProperty("--accent", accent);
-        // Keep any secondary glow aligned with the same accent (avoid hard banding).
         document.documentElement.style.setProperty("--accent2", accent);
+    }
+
+    function applyHealthDot() {
+        const dot = $("healthDot");
+        if (!dot) return;
+        const pct = Number(document.body?.dataset?.echonetRevertRatePct || "0");
+        // Severity: any non-empty bad metric tile turns the dot bad;
+        // any non-empty warn-only state shows warn; else ok.
+        const hasBad = document.querySelector(".metricTile.bad") != null;
+        const hasWarn = document.querySelector(".metricTile.warn") != null;
+        dot.classList.remove("ok", "warn", "bad");
+        if (hasBad || pct >= 1) dot.classList.add("bad");
+        else if (hasWarn || pct > 0) dot.classList.add("warn");
+        // Default visual is ok (set by CSS)
+        const title = hasBad || pct >= 1
+            ? `Critical · echonet revert ${pct}%`
+            : (hasWarn || pct > 0)
+                ? `Warning · echonet revert ${pct}%`
+                : `Healthy · echonet revert ${pct}%`;
+        dot.setAttribute("title", title);
+    }
+
+    function applyProgressBar() {
+        const fill = $("progressBarFill");
+        if (!fill) return;
+        const blocksText = document.querySelector('#progressNowLabel')?.textContent?.trim() || "";
+        const startText = document.querySelector('#progressStartLabel')?.textContent?.trim() || "";
+        const start = Number(startText);
+        const now = Number(blocksText);
+        if (!Number.isFinite(start) || !Number.isFinite(now) || start <= 0 || now <= 0) {
+            const wrap = $("progressBarWrap");
+            if (wrap) wrap.style.display = "none";
+            return;
+        }
+        if (now <= start) {
+            fill.style.width = "0%";
+            return;
+        }
+        // Show progress relative to a 200-block "window" so the bar moves visibly.
+        // (We don't have a target block number, so this is just a visual heartbeat.)
+        const span = Math.max(1, now - start);
+        const denom = Math.max(span, 200);
+        const pct = Math.min(100, (span / denom) * 100);
+        fill.style.width = `${pct.toFixed(1)}%`;
+
+        const meta = $("progressMeta");
+        if (meta) meta.textContent = `+${span} blocks since current start`;
+    }
+
+    function applyRiskGauge() {
+        const fill = $("riskGaugeFill");
+        const marker = $("riskGaugeMarker");
+        const value = $("revertRateValue");
+        if (!fill || !marker) return;
+        const pct = Number(document.body?.dataset?.echonetRevertRatePct || "0");
+        const clamped = Math.max(0, Math.min(100, pct));
+        // The gauge visualizes 0% .. 1% — anything >= 1% pegs the marker at the right.
+        const ratio = Math.min(1, clamped / 1.0);
+        marker.style.left = `${(ratio * 100).toFixed(2)}%`;
+        // Mask the unreached portion with a subtle overlay.
+        fill.style.width = `${100 - ratio * 100}%`;
+        fill.style.left = "auto";
+        fill.style.right = "0";
+        fill.style.inset = `0 0 0 auto`;
+        if (value) value.textContent = (Math.round(pct * 1000) / 1000).toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+    }
+
+    function applyStackedTxBar() {
+        const okEl = $("stackedCommitted");
+        const pendEl = $("stackedPending");
+        if (!okEl || !pendEl) return;
+        // Read totals out of the legend "mono" spans for robustness.
+        const tile = okEl.closest(".tile");
+        if (!tile) return;
+        const monos = tile.querySelectorAll(".legendRow .mono");
+        let committed = 0;
+        let pending = 0;
+        if (monos.length >= 2) {
+            committed = Number((monos[0].textContent || "").replace(/[^0-9.-]/g, "")) || 0;
+            pending = Number((monos[1].textContent || "").replace(/[^0-9.-]/g, "")) || 0;
+        }
+        const total = committed + pending;
+        if (total <= 0) {
+            okEl.style.width = "0%";
+            pendEl.style.width = "0%";
+            return;
+        }
+        okEl.style.width = `${(committed / total * 100).toFixed(2)}%`;
+        pendEl.style.width = `${(pending / total * 100).toFixed(2)}%`;
+    }
+
+    function applyBarChartFills() {
+        document.querySelectorAll("[data-bar-section]").forEach((section) => {
+            const fills = section.querySelectorAll("[data-bar-count]");
+            let max = 0;
+            fills.forEach((f) => {
+                const n = Number(f.getAttribute("data-bar-count") || "0");
+                if (n > max) max = n;
+            });
+            fills.forEach((f) => {
+                const n = Number(f.getAttribute("data-bar-count") || "0");
+                const pct = max > 0 ? (n / max) * 100 : 0;
+                f.style.width = `${pct.toFixed(1)}%`;
+            });
+        });
+    }
+
+    function initRevertBarRowClicks() {
+        document.querySelectorAll(".barRow[data-scroll-to]").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                const target = btn.getAttribute("data-scroll-to");
+                if (!target) return;
+                const el = document.getElementById(target);
+                if (!el) return;
+                openCollapsibleSection(el);
+                el.scrollIntoView({ behavior: "smooth", block: "start" });
+
+                // Briefly highlight the matching group inside the destination section.
+                const groupName = btn.getAttribute("data-filter-text") || "";
+                if (groupName) {
+                    const summaries = el.querySelectorAll("details.revertGroup summary .mono");
+                    summaries.forEach((s) => {
+                        if ((s.textContent || "").trim() === groupName) {
+                            const det = s.closest("details");
+                            if (det) {
+                                det.open = true;
+                                det.scrollIntoView({ behavior: "smooth", block: "center" });
+                                det.classList.remove("flash");
+                                // Restart the animation by forcing a reflow.
+                                // eslint-disable-next-line no-unused-expressions
+                                det.offsetWidth;
+                                det.classList.add("flash");
+                            }
+                        }
+                    });
+                }
+            });
+        });
     }
 
     function initScrollLinks() {
         function scrollToId(id) {
             const el = document.getElementById(id);
             if (!el) return;
-            // If the target section is collapsed, open it before scrolling.
             openCollapsibleSection(el);
             el.scrollIntoView({ behavior: "smooth", block: "start" });
         }
@@ -554,7 +774,12 @@
             const id = el.getAttribute("data-scroll-to");
             if (!id) return;
 
-            el.addEventListener("click", () => scrollToId(id));
+            el.addEventListener("click", (e) => {
+                // Allow internal handlers (e.g. revert bar rows) to also act.
+                if (el.classList.contains("barRow")) return;
+                e.preventDefault();
+                scrollToId(id);
+            });
             el.addEventListener("keydown", (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
@@ -571,9 +796,7 @@
             if (ticking) return;
             ticking = true;
             window.requestAnimationFrame(() => {
-                try {
-                    sessionStorage.setItem(key, String(window.scrollY || 0));
-                } catch (_) { }
+                try { sessionStorage.setItem(key, String(window.scrollY || 0)); } catch (_) { }
                 ticking = false;
             });
         });
@@ -594,7 +817,6 @@
         if (!section) return;
         const el = document.getElementById(section);
         if (el) {
-            // If the target section is collapsed, open it before scrolling.
             openCollapsibleSection(el);
             setTimeout(() => el.scrollIntoView({ behavior: "smooth", block: "start" }), 0);
         }
@@ -622,6 +844,40 @@
         return Number.isFinite(n) ? n : null;
     }
 
+    function tableSortKey(table) {
+        const cardSummary = table.closest("section[id]");
+        const groupSummary = table.closest("details.revertGroup")?.querySelector("summary .mono")?.textContent || "";
+        const sectionId = cardSummary ? cardSummary.id : "";
+        const tableName = table.getAttribute("data-table") || "";
+        return `${STORAGE.sortPrefix}${sectionId}::${tableName}::${groupSummary}`;
+    }
+
+    function sortRows(tbody, idx, type, dir) {
+        const rows = Array.from(tbody.querySelectorAll("tr"));
+        rows.sort((a, b) => {
+            const av = getCellValue(a, idx);
+            const bv = getCellValue(b, idx);
+            if (type === "num") {
+                const an = tryParseNumber(av);
+                const bn = tryParseNumber(bv);
+                const ax = an == null ? Number.NEGATIVE_INFINITY : an;
+                const bx = bn == null ? Number.NEGATIVE_INFINITY : bn;
+                return dir === "asc" ? ax - bx : bx - ax;
+            }
+            const an = tryParseNumber(av);
+            const bn = tryParseNumber(bv);
+            if (type === "auto" && an != null && bn != null) {
+                return dir === "asc" ? an - bn : bn - an;
+            }
+            const as = normalize(av);
+            const bs = normalize(bv);
+            if (as < bs) return dir === "asc" ? -1 : 1;
+            if (as > bs) return dir === "asc" ? 1 : -1;
+            return 0;
+        });
+        rows.forEach((tr) => tbody.appendChild(tr));
+    }
+
     function initSortableTables() {
         document.querySelectorAll("table").forEach((table) => {
             const thead = table.querySelector("thead");
@@ -630,54 +886,37 @@
             const headers = thead.querySelectorAll("th.sortable");
             if (!headers.length) return;
 
+            const storeKey = tableSortKey(table);
+            let restored = null;
+            try {
+                const raw = localStorage.getItem(storeKey);
+                if (raw) restored = JSON.parse(raw);
+            } catch (_) { }
+
             headers.forEach((th, idx) => {
                 th.setAttribute("role", "button");
                 th.setAttribute("tabindex", "0");
                 const sortType = th.getAttribute("data-sort") || "auto";
 
-                function doSort() {
-                    const cur = th.getAttribute("data-sort-dir") || "none";
-                    const next = cur === "asc" ? "desc" : "asc";
-
-                    // Reset siblings
+                function applyDir(dir) {
                     headers.forEach((h) => {
                         if (h !== th) {
                             h.removeAttribute("data-sort-dir");
                             h.removeAttribute("aria-sort");
                         }
                     });
+                    th.setAttribute("data-sort-dir", dir);
+                    th.setAttribute("aria-sort", dir === "asc" ? "ascending" : "descending");
+                    sortRows(tbody, idx, sortType, dir);
+                }
 
-                    th.setAttribute("data-sort-dir", next);
-                    th.setAttribute("aria-sort", next === "asc" ? "ascending" : "descending");
-
-                    const rows = Array.from(tbody.querySelectorAll("tr"));
-                    rows.sort((a, b) => {
-                        const av = getCellValue(a, idx);
-                        const bv = getCellValue(b, idx);
-
-                        if (sortType === "num") {
-                            const an = tryParseNumber(av);
-                            const bn = tryParseNumber(bv);
-                            const ax = an == null ? Number.NEGATIVE_INFINITY : an;
-                            const bx = bn == null ? Number.NEGATIVE_INFINITY : bn;
-                            return next === "asc" ? ax - bx : bx - ax;
-                        }
-
-                        // auto / str
-                        const an = tryParseNumber(av);
-                        const bn = tryParseNumber(bv);
-                        if (sortType === "auto" && an != null && bn != null) {
-                            return next === "asc" ? an - bn : bn - an;
-                        }
-
-                        const as = normalize(av);
-                        const bs = normalize(bv);
-                        if (as < bs) return next === "asc" ? -1 : 1;
-                        if (as > bs) return next === "asc" ? 1 : -1;
-                        return 0;
-                    });
-
-                    rows.forEach((tr) => tbody.appendChild(tr));
+                function doSort() {
+                    const cur = th.getAttribute("data-sort-dir") || "none";
+                    const next = cur === "asc" ? "desc" : "asc";
+                    applyDir(next);
+                    try {
+                        localStorage.setItem(storeKey, JSON.stringify({ idx, type: sortType, dir: next }));
+                    } catch (_) { }
                 }
 
                 th.addEventListener("click", doSort);
@@ -687,7 +926,335 @@
                         doSort();
                     }
                 });
+
+                if (restored && restored.idx === idx) {
+                    // Re-apply persisted sort to the header that matches by index.
+                    applyDir(restored.dir);
+                }
             });
+        });
+    }
+
+    // ───────── Sidenav scrollspy ─────────
+
+    function initSidenavScrollspy() {
+        const items = Array.from(document.querySelectorAll(".sidenavItem[data-nav]"));
+        if (!items.length) return;
+
+        // Sections in DOM (vertical) order — required for the linear scan below.
+        const sections = items
+            .map((a) => ({ id: a.getAttribute("data-nav"), a, el: document.getElementById(a.getAttribute("data-nav")) }))
+            .filter((x) => x.el);
+        if (!sections.length) return;
+
+        const setActive = (id) => {
+            items.forEach((a) => a.classList.toggle("active", a.getAttribute("data-nav") === id));
+        };
+
+        function activationLine() {
+            const raw = getComputedStyle(document.documentElement).getPropertyValue("--topbarH");
+            const h = parseInt(raw, 10);
+            return (Number.isFinite(h) ? h : 78) + 24;
+        }
+
+        let ticking = false;
+        function update() {
+            ticking = false;
+            const line = activationLine();
+
+            // The active section is the last one whose top has scrolled past the line.
+            let currentId = sections[0].id;
+            for (const s of sections) {
+                if (s.el.getBoundingClientRect().top - line <= 0) currentId = s.id;
+                else break;
+            }
+
+            // At the very bottom of the page, force-select the last section so
+            // short trailing sections can still become active.
+            const atBottom =
+                window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+            if (atBottom) currentId = sections[sections.length - 1].id;
+
+            setActive(currentId);
+        }
+
+        window.addEventListener(
+            "scroll",
+            () => {
+                if (ticking) return;
+                ticking = true;
+                window.requestAnimationFrame(update);
+            },
+            { passive: true }
+        );
+        window.addEventListener("resize", update);
+        // Instant feedback when a nav item is clicked (before the smooth scroll settles).
+        items.forEach((a) => a.addEventListener("click", () => setActive(a.getAttribute("data-nav"))));
+
+        update();
+    }
+
+    // ───────── CSV export per section ─────────
+
+    function csvEscape(value) {
+        const s = (value == null ? "" : String(value));
+        if (/[",\n\r]/.test(s)) {
+            return `"${s.replace(/"/g, '""')}"`;
+        }
+        return s;
+    }
+
+    function tableToCsv(table) {
+        const lines = [];
+        const headerCells = table.querySelectorAll("thead th");
+        const headers = Array.from(headerCells).map((th) => (th.textContent || "").trim());
+        if (headers.length && headers[headers.length - 1] === "") headers.pop();
+        lines.push(headers.map(csvEscape).join(","));
+
+        table.querySelectorAll("tbody tr:not(.isHidden)").forEach((tr) => {
+            const cols = Array.from(tr.children).slice(0, headers.length).map((td) => {
+                // Prefer the full hash from data attribute if present.
+                const hashEl = td.querySelector(".hash[data-full-hash]");
+                if (hashEl) return hashEl.getAttribute("data-full-hash") || (td.textContent || "").trim();
+                // Avoid copying nested <pre> blobs verbatim; collapse to one line.
+                return (td.textContent || "").trim().replace(/\s+/g, " ");
+            });
+            lines.push(cols.map(csvEscape).join(","));
+        });
+        return lines.join("\n");
+    }
+
+    function initSectionCsvExport() {
+        document.querySelectorAll(".sectionExportBtn[data-export-table]").forEach((btn) => {
+            btn.addEventListener("click", (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const name = btn.getAttribute("data-export-table");
+                const tables = document.querySelectorAll(`table[data-table="${CSS.escape(name)}"]`);
+                if (!tables.length) {
+                    toast("No data to export", "info");
+                    return;
+                }
+                const parts = [];
+                tables.forEach((t, i) => {
+                    if (i > 0) parts.push(""); // blank separator
+                    parts.push(tableToCsv(t));
+                });
+                const csv = parts.join("\n");
+                copyText(csv, { silent: true });
+                toast(`Copied ${name} as CSV`, "success");
+            });
+        });
+    }
+
+    // ───────── Generated-at "ago" timer ─────────
+
+    function parseGeneratedAt() {
+        const raw = (document.body?.dataset?.generatedAt || "").trim();
+        if (!raw) return null;
+        // Try ISO; if missing TZ, treat as UTC.
+        let s = raw;
+        if (!/Z|[+-]\d\d:?\d\d$/.test(s)) s = s + "Z";
+        const t = Date.parse(s);
+        if (!Number.isFinite(t)) return null;
+        return t;
+    }
+
+    function formatAgo(ms) {
+        if (ms < 0) ms = 0;
+        const sec = Math.floor(ms / 1000);
+        if (sec < 5) return "just now";
+        if (sec < 60) return `${sec}s ago`;
+        const min = Math.floor(sec / 60);
+        if (min < 60) return `${min}m ago`;
+        const hr = Math.floor(min / 60);
+        if (hr < 48) return `${hr}h ${min % 60}m ago`;
+        const day = Math.floor(hr / 24);
+        return `${day}d ${hr % 24}h ago`;
+    }
+
+    function initAgoTimer() {
+        const chip = $("agoChip");
+        if (!chip) return;
+        const t0 = parseGeneratedAt();
+        if (t0 == null) {
+            chip.style.display = "none";
+            return;
+        }
+        const tick = () => {
+            chip.textContent = formatAgo(Date.now() - t0);
+        };
+        tick();
+        window.setInterval(tick, 1000);
+    }
+
+    // ───────── Shortcuts overlay + keyboard ─────────
+
+    function initShortcutsOverlay() {
+        const overlay = $("shortcutsOverlay");
+        const open = $("shortcutsBtn");
+        const close = $("shortcutsClose");
+        if (!overlay) return;
+
+        const show = () => {
+            overlay.hidden = false;
+            (close || open)?.focus();
+        };
+        const hide = () => { overlay.hidden = true; };
+
+        if (open) open.addEventListener("click", show);
+        if (close) close.addEventListener("click", hide);
+        overlay.addEventListener("click", (e) => {
+            if (e.target === overlay) hide();
+        });
+        // Expose so other key handlers can dismiss it.
+        overlay._hide = hide;
+        overlay._show = show;
+        overlay._toggle = () => { overlay.hidden ? show() : hide(); };
+    }
+
+    function initKeyboard() {
+        const input = $("filterInput");
+        const scopeSelect = $("scopeSelect");
+        const overlay = $("shortcutsOverlay");
+
+        // "g" then a letter — jump shortcuts.
+        let gPending = false;
+        let gTimer = null;
+
+        function clearGPending() {
+            gPending = false;
+            if (gTimer) { window.clearTimeout(gTimer); gTimer = null; }
+        }
+
+        const JUMPS = {
+            o: "overview",
+            p: "pending-txs",
+            e: "gateway-errors",
+            r: "reverts-mainnet",
+            s: "resync-triggers",
+            l: "l2-gas-mismatches",
+            b: "block-hash-mismatches",
+            t: "tx-commitment-mismatches",
+        };
+
+        // Track double-r for "reverts-echonet".
+        let lastJump = null;
+        let lastJumpAt = 0;
+
+        function jumpToId(id) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            openCollapsibleSection(el);
+            el.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+
+        window.addEventListener("keydown", (e) => {
+            if (e.defaultPrevented) return;
+            const tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : "";
+            const inTypingContext = tag === "input" || tag === "textarea" || tag === "select";
+            const isMeta = e.ctrlKey || e.metaKey || e.altKey;
+
+            // Filter & overlay shortcuts work outside typing context (except Esc).
+            if (e.key === "Escape") {
+                if (overlay && !overlay.hidden) {
+                    e.preventDefault();
+                    overlay._hide && overlay._hide();
+                    return;
+                }
+                if (input && (document.activeElement === input || input.value)) {
+                    input.value = "";
+                    localStorage.setItem(STORAGE.filter, "");
+                    filterAll("", scopeSelect ? scopeSelect.value : "all");
+                    input.blur();
+                    toast("Filter cleared", "info");
+                }
+                return;
+            }
+
+            if (inTypingContext || isMeta) return;
+
+            if (e.key === "/") {
+                if (input) {
+                    e.preventDefault();
+                    input.focus();
+                    input.select();
+                }
+                clearGPending();
+                return;
+            }
+
+            if (e.key === "?" || (e.shiftKey && e.key === "/")) {
+                e.preventDefault();
+                overlay && overlay._toggle && overlay._toggle();
+                clearGPending();
+                return;
+            }
+
+            const k = e.key.toLowerCase();
+
+            if (gPending) {
+                clearGPending();
+                if (k === "r") {
+                    // Double-r within 600ms → echonet reverts.
+                    const now = Date.now();
+                    if (lastJump === "r" && now - lastJumpAt < 600) {
+                        jumpToId("reverts-echonet");
+                        lastJump = null;
+                        return;
+                    }
+                    lastJump = "r";
+                    lastJumpAt = now;
+                }
+                const target = JUMPS[k];
+                if (target) {
+                    e.preventDefault();
+                    jumpToId(target);
+                }
+                return;
+            }
+
+            if (k === "g") {
+                gPending = true;
+                gTimer = window.setTimeout(clearGPending, 800);
+                e.preventDefault();
+                return;
+            }
+
+            if (k === "r") {
+                const btn = $("refreshNowBtn");
+                if (btn) {
+                    e.preventDefault();
+                    btn.click();
+                }
+                return;
+            }
+
+            if (k === "e") {
+                const btn = $("expandAllBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "c") {
+                const btn = $("collapseAllBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "d") {
+                const btn = $("densityBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "h") {
+                const btn = $("hashModeBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "t") {
+                const btn = $("themeToggleBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
         });
     }
 
@@ -699,6 +1266,9 @@
         initCopyVisibleHashes();
         initRefresh();
         initThemeToggle();
+        initDensityToggle();
+        initHashModeToggle();
+        initExpandCollapseAll();
         initBlockDumpPersistence();
         initSectionCollapsePersistence();
         initScrollLinks();
@@ -706,6 +1276,20 @@
         initSectionParamScroll();
         initHashOpen();
         initRestoreScrollPosition();
+        initSidenavScrollspy();
+        initRevertBarRowClicks();
+        initSectionCsvExport();
+        initAgoTimer();
+        initShortcutsOverlay();
+        initKeyboard();
+
+        // Visualizations (rely on data already on the page).
+        applyHealthDot();
+        applyProgressBar();
+        applyRiskGauge();
+        applyStackedTxBar();
+        applyBarChartFills();
+
         updateTableMeta();
     }
 

--- a/echonet/templates/report.html
+++ b/echonet/templates/report.html
@@ -16,15 +16,34 @@
 </head>
 
 <body data-echonet-revert-rate-pct="{{ meta.echonet_revert_rate_pct }}"
-  data-echonet-revert-risk="{{ meta.echonet_revert_risk_0_1 }}" data-report-export="{{ 1 if export else 0 }}"
-  data-gcp-project-id="{{ logs.gcp_project_id }}" data-gcp-location="{{ logs.gcp_location }}"
-  data-gke-cluster-name="{{ logs.gke_cluster_name }}" data-k8s-namespace="{{ logs.k8s_namespace }}"
+  data-echonet-revert-risk="{{ meta.echonet_revert_risk_0_1 }}"
+  data-report-export="{{ 1 if export else 0 }}"
+  data-generated-at="{{ meta.generated_at_utc }}"
+  data-gcp-project-id="{{ logs.gcp_project_id }}"
+  data-gcp-location="{{ logs.gcp_location }}"
+  data-gke-cluster-name="{{ logs.gke_cluster_name }}"
+  data-k8s-namespace="{{ logs.k8s_namespace }}"
   data-gcp-logs-duration="{{ logs.duration }}">
+
   <header class="topbar">
-    <div class="brand">
-      <div class="title">Echonet Report</div>
-      <div class="subtitle">
-        Generated <span class="mono">{{ meta.generated_at_utc }}</span>
+    <div class="topbarLeft">
+      <div class="brand">
+        <div class="brandLogo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 12 7 6l4 12 4-10 3 7h4" />
+          </svg>
+        </div>
+        <div class="brandText">
+          <div class="title">Echonet Report
+            <span class="healthDot" id="healthDot" title="Overall health"></span>
+          </div>
+          <div class="subtitle">
+            <span class="liveIndicator" id="liveIndicator" aria-hidden="true"></span>
+            Generated <span class="mono" id="generatedAtLabel">{{ meta.generated_at_utc }}</span>
+            <span class="agoChip mono" id="agoChip" title="Time since this snapshot was generated">just now</span>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -57,684 +76,1199 @@
         </select>
       </label>
 
-      <button class="btn" id="refreshNowBtn" type="button">Refresh</button>
+      <button class="btn" id="refreshNowBtn" type="button" title="Reload (R)">Refresh</button>
       {% endif %}
-      <button class="btn" id="copyVisibleBtn" type="button" title="Copy visible tx hashes (respects scope)">Copy
-        visible</button>
-      <a class="btn btnLink" id="logsBaseLink" href="#" target="_blank" rel="noopener"
-        title="Open GCP Logs Explorer for this namespace">Logs</a>
-      <button class="btn" id="themeToggleBtn" type="button" title="Toggle theme">Theme</button>
-      {% if not export %}
-      <a class="btn btnLink" href="/echonet/report/ui/download" title="Download static HTML snapshot">Download</a>
-      <a class="btn btnLink" href="/echonet/report" title="Raw JSON snapshot">JSON</a>
-      <a class="btn btnLink" href="/echonet/report/text" title="Text snapshot (plain text)">Text</a>
-      {% endif %}
+
+      <div class="btnGroup" role="group" aria-label="View controls">
+        <button class="btn" id="copyVisibleBtn" type="button" title="Copy visible tx hashes (respects scope)">Copy
+          hashes</button>
+        <button class="btn" id="expandAllBtn" type="button" title="Expand all sections (E)">Expand</button>
+        <button class="btn" id="collapseAllBtn" type="button" title="Collapse all sections (C)">Collapse</button>
+        <button class="btn" id="densityBtn" type="button" title="Toggle row density (D)"
+          aria-pressed="false">Compact</button>
+        <button class="btn" id="hashModeBtn" type="button" title="Toggle hash display: full ↔ truncated (H)"
+          aria-pressed="false">Hashes</button>
+      </div>
+
+      <div class="btnGroup" role="group" aria-label="Links">
+        <a class="btn btnLink" id="logsBaseLink" href="#" target="_blank" rel="noopener"
+          title="Open GCP Logs Explorer for this namespace">Logs</a>
+        {% if not export %}
+        <a class="btn btnLink" href="/echonet/report/ui/download" title="Download static HTML snapshot">Download</a>
+        <a class="btn btnLink" href="/echonet/report" title="Raw JSON snapshot">JSON</a>
+        <a class="btn btnLink" href="/echonet/report/text" title="Text snapshot (plain text)">Text</a>
+        {% endif %}
+        <button class="btn" id="themeToggleBtn" type="button" title="Cycle theme (T)">Theme</button>
+        <button class="btn btnIcon" id="shortcutsBtn" type="button" title="Keyboard shortcuts (?)"
+          aria-label="Keyboard shortcuts">?</button>
+      </div>
+
       <div class="statusLine" id="filterStats" aria-live="polite"></div>
     </div>
   </header>
 
-  <main class="container">
-    <div class="stack">
-      <section>
-        <div class="card kpiProgress">
-          <div class="cardTitle">Progress</div>
-          <div class="progressHero">
-            <div>
-              {% set blocks_unknown = progress.blocks_processed == "(unknown)" %}
-              {% set current_unknown = progress.current_block == "(unknown)" %}
-              {% if blocks_unknown and current_unknown %}
-              <div class="heroRow">
+  <div class="layout">
+    <aside class="sidenav" id="sidenav" aria-label="Section navigation">
+      <div class="sidenavTitle">Sections</div>
+      <nav class="sidenavList" id="sidenavList">
+        <a class="sidenavItem" data-nav="overview" href="#overview">
+          <span class="navDot"></span><span class="navLabel">Overview</span>
+        </a>
+        <a class="sidenavItem" data-nav="reverts-summary" href="#reverts-summary">
+          <span class="navDot"></span><span class="navLabel">Top revert reasons</span>
+        </a>
+        <a class="sidenavItem" data-nav="pending-txs" href="#pending-txs">
+          <span class="navDot {{ severity.pending }}"></span>
+          <span class="navLabel">Pending</span>
+          <span class="navCount mono">{{ kpis.pending_commission_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="gateway-errors" href="#gateway-errors">
+          <span class="navDot {{ severity.gateway_errors }}"></span>
+          <span class="navLabel">Gateway errors</span>
+          <span class="navCount mono">{{ kpis.gateway_errors_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="reverts-mainnet" href="#reverts-mainnet">
+          <span class="navDot {{ severity.reverts_mainnet }}"></span>
+          <span class="navLabel">Reverts (mainnet)</span>
+          <span class="navCount mono">{{ kpis.reverts_mainnet_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="reverts-echonet" href="#reverts-echonet">
+          <span class="navDot {{ severity.reverts_echonet }}"></span>
+          <span class="navLabel">Reverts (echonet)</span>
+          <span class="navCount mono">{{ kpis.reverts_echonet_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="resync-triggers" href="#resync-triggers">
+          <span class="navDot {{ severity.resync_causes }}"></span>
+          <span class="navLabel">Resync triggers</span>
+          <span class="navCount mono">{{ kpis.resync_causes_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="certain-failures" href="#certain-failures">
+          <span class="navDot {{ severity.certain_failures }}"></span>
+          <span class="navLabel">Certain failures</span>
+          <span class="navCount mono">{{ kpis.certain_failures_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="l2-gas-mismatches" href="#l2-gas-mismatches">
+          <span class="navDot {{ severity.l2_gas_mismatches }}"></span>
+          <span class="navLabel">L2 gas mismatches</span>
+          <span class="navCount mono">{{ kpis.l2_gas_mismatches_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="block-hash-mismatches" href="#block-hash-mismatches">
+          <span class="navDot {{ severity.block_hash_mismatches }}"></span>
+          <span class="navLabel">Block hash mismatches</span>
+          <span class="navCount mono">{{ kpis.block_hash_mismatches_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="tx-commitment-mismatches" href="#tx-commitment-mismatches">
+          <span class="navDot {{ severity.transaction_commitment_mismatches }}"></span>
+          <span class="navLabel">Tx commitment mismatches</span>
+          <span class="navCount mono">{{ kpis.transaction_commitment_mismatches_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="os-run-failures" href="#os-run-failures">
+          <span class="navDot {{ severity.os_failed }}"></span>
+          <span class="navLabel">OS run failures</span>
+          <span class="navCount mono">{{ kpis.os_failed_count }}</span>
+        </a>
+        {% if not export %}
+        <a class="sidenavItem" data-nav="block-dump" href="#block-dump">
+          <span class="navDot"></span><span class="navLabel">Block dump</span>
+        </a>
+        {% endif %}
+      </nav>
+
+      <div class="sidenavFooter smallMuted">
+        Press <kbd>?</kbd> for shortcuts.
+      </div>
+    </aside>
+
+    <main class="container">
+      <div class="stack">
+
+        <section id="overview">
+          <div class="overviewGrid">
+            <div class="card kpiProgress span3">
+              <div class="cardHeader">
+                <div class="cardTitle">
+                  <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 20V10M6 20V4M18 20v-7" />
+                  </svg>
+                  Progress
+                </div>
+                <div class="cardHeaderRight smallMuted mono" id="progressMeta"></div>
+              </div>
+              <div class="progressHero">
                 <div>
-                  <div class="heroValue mono">Starting...</div>
+                  {% set blocks_unknown = progress.blocks_processed == "(unknown)" %}
+                  {% set current_unknown = progress.current_block == "(unknown)" %}
+                  {% if blocks_unknown and current_unknown %}
+                  <div class="heroRow">
+                    <div>
+                      <div class="heroValue mono">Starting…</div>
+                      <div class="heroSub">Waiting for first block to be processed.</div>
+                    </div>
+                  </div>
+                  {% else %}
+                  <div class="heroRow">
+                    <div>
+                      <div class="heroLabel">Blocks processed</div>
+                      <div class="heroValue mono">{{ progress.blocks_processed }}</div>
+                    </div>
+                    <div>
+                      <div class="heroLabel">Current block</div>
+                      <div class="heroValue mono">
+                        {% if current_unknown %}Resyncing…{% else %}{{ progress.current_block }}{% endif %}
+                      </div>
+                    </div>
+                  </div>
+                  {% endif %}
+                  <div class="progressBarWrap" id="progressBarWrap" aria-hidden="true">
+                    <div class="progressBarTrack">
+                      <div class="progressBarFill" id="progressBarFill"></div>
+                    </div>
+                    <div class="progressBarLabels smallMuted mono">
+                      <span id="progressStartLabel">{{ progress.current_start_block }}</span>
+                      <span id="progressNowLabel">{{ progress.current_block }}</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="kv kvTight">
+                  <div class="k">Initial start</div>
+                  <div class="v mono">{{ progress.initial_start_block }}</div>
+                  <div class="k">Current start</div>
+                  <div class="v mono">{{ progress.current_start_block }}</div>
+                  <div class="k">First timestamp</div>
+                  <div class="v mono">{{ meta.first_block_timestamp_iso }}</div>
+                  <div class="k">Latest timestamp</div>
+                  <div class="v mono">{{ meta.latest_block_timestamp_iso }}</div>
+                  <div class="k">Span</div>
+                  <div class="v mono">{{ meta.span_human }}</div>
+                  <div class="k">Forward rate</div>
+                  <div class="v mono">{{ meta.forward_rate }}</div>
                 </div>
               </div>
-              {% else %}
-              <div class="heroRow">
-                <div>
-                  <div class="heroLabel">Blocks processed</div>
-                  <div class="heroValue mono">{{ progress.blocks_processed }}</div>
-                </div>
-                <div>
-                  <div class="heroLabel">Current block</div>
-                  <div class="heroValue mono">
-                    {% if current_unknown %}Resyncing...{% else %}{{ progress.current_block }}{% endif %}
-                  </div>
+            </div>
+
+            <div class="card tile tileTx">
+              <div class="cardHeader">
+                <div class="cardTitle">
+                  <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="m3 7 4 4-4 4M14 7h7M3 17h11M14 13l4-4 4 4" />
+                  </svg>
+                  Transactions
                 </div>
               </div>
-              {% endif %}
+              <div class="tileValue mono">{{ kpis.total_sent_tx_count }}</div>
+              <div class="tileSub smallMuted">Total forwarded</div>
+              <div class="stackedBar" title="Committed vs pending">
+                <div class="stackedBarPart stackedOk" id="stackedCommitted"></div>
+                <div class="stackedBarPart stackedPending" id="stackedPending"></div>
+              </div>
+              <div class="legendRow smallMuted">
+                <span class="legendDot ok"></span>
+                <span>Committed <span class="mono">{{ kpis.committed_count }}</span>
+                  ({{ kpis.committed_pct_of_pending_total }})</span>
+                <span class="legendDot pending"></span>
+                <span>Pending <span class="mono">{{ kpis.pending_commission_count }}</span>
+                  ({{ kpis.pending_pct_of_pending_total }})</span>
+              </div>
             </div>
-            <div class="kv kvTight">
-              <div class="k">Initial start</div>
-              <div class="v mono">{{ progress.initial_start_block }}</div>
-              <div class="k">Current start</div>
-              <div class="v mono">{{ progress.current_start_block }}</div>
-              <div class="k">First timestamp</div>
-              <div class="v mono">{{ meta.first_block_timestamp_iso }}</div>
-              <div class="k">Latest timestamp</div>
-              <div class="v mono">{{ meta.latest_block_timestamp_iso }}</div>
-              <div class="k">Span</div>
-              <div class="v mono">{{ meta.span_human }}</div>
-              <div class="k">Forward rate</div>
-              <div class="v mono">{{ meta.forward_rate }}</div>
+
+            <div class="card tile tileRisk">
+              <div class="cardHeader">
+                <div class="cardTitle">
+                  <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 2 2 22h20L12 2zM12 9v6M12 18h.01" />
+                  </svg>
+                  Echonet-only revert rate
+                </div>
+              </div>
+              <div class="tileValue mono"><span id="revertRateValue">{{ meta.echonet_revert_rate_pct }}</span>%</div>
+              <div class="tileSub smallMuted">Reverts only on Echonet ÷ total forwarded</div>
+              <div class="riskGauge">
+                <div class="riskGaugeTrack">
+                  <div class="riskGaugeFill" id="riskGaugeFill"></div>
+                  <div class="riskGaugeMarker" id="riskGaugeMarker"></div>
+                </div>
+                <div class="legendRow smallMuted">
+                  <span>0%</span><span style="flex:1"></span><span>1%+</span>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </section>
 
-      <section class="row2">
-        <div class="card">
-          <div class="cardTitle">Transactions</div>
-          <div class="bigNumber mono">{{ kpis.total_sent_tx_count }}</div>
-          <div class="smallMuted">Total forwarded</div>
-          <div class="pillRow">
-            <span class="pill {{ severity.committed }}">Committed: <span class="mono">{{ kpis.committed_count }}</span>
-              ({{ kpis.committed_pct_of_pending_total }})</span>
-            <span class="pill {{ severity.pending }}">Pending: <span class="mono">{{ kpis.pending_commission_count
-                }}</span> ({{ kpis.pending_pct_of_pending_total }})</span>
-          </div>
-        </div>
+          <div class="card alertsCard">
+            <div class="cardHeader">
+              <div class="cardTitle">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 2v6m0 0 4-2m-4 2-4-2M5 22h14a2 2 0 0 0 2-2v-8a9 9 0 0 0-18 0v8a2 2 0 0 0 2 2z" />
+                </svg>
+                Alerts
+              </div>
+              <div class="cardHeaderRight smallMuted">
+                Click a tile to jump to its section · press <span class="mono">/</span> to focus filter
+              </div>
+            </div>
+            <div class="metricGrid">
+              <button class="metricTile {{ severity.gateway_errors }}" type="button" data-scroll-to="gateway-errors">
+                <div class="metricLabel">Gateway errors</div>
+                <div class="metricValue mono">{{ kpis.gateway_errors_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.reverts_mainnet }}" type="button" data-scroll-to="reverts-mainnet">
+                <div class="metricLabel">Reverts (mainnet-only)</div>
+                <div class="metricValue mono">{{ kpis.reverts_mainnet_count }}</div>
+                <div class="metricSub mono">{{ reverts.mainnet_only.pct_of_total_sent }}</div>
+              </button>
+              <button class="metricTile {{ severity.reverts_echonet }}" type="button" data-scroll-to="reverts-echonet">
+                <div class="metricLabel">Reverts (echonet-only)</div>
+                <div class="metricValue mono">{{ kpis.reverts_echonet_count }}</div>
+                <div class="metricSub mono">{{ reverts.echonet_only.pct_of_total_sent }}</div>
+              </button>
+              <button class="metricTile {{ severity.resync_causes }}" type="button" data-scroll-to="resync-triggers">
+                <div class="metricLabel">Resync triggers</div>
+                <div class="metricValue mono">{{ kpis.resync_causes_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.certain_failures }}" type="button"
+                data-scroll-to="certain-failures">
+                <div class="metricLabel">Certain failures</div>
+                <div class="metricValue mono">{{ kpis.certain_failures_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.l2_gas_mismatches }}" type="button"
+                data-scroll-to="l2-gas-mismatches">
+                <div class="metricLabel">L2 gas mismatches</div>
+                <div class="metricValue mono">{{ kpis.l2_gas_mismatches_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.block_hash_mismatches }}" type="button"
+                data-scroll-to="block-hash-mismatches">
+                <div class="metricLabel">Block hash mismatches</div>
+                <div class="metricValue mono">{{ kpis.block_hash_mismatches_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.transaction_commitment_mismatches }}" type="button"
+                data-scroll-to="tx-commitment-mismatches">
+                <div class="metricLabel">Tx commitment mismatches</div>
+                <div class="metricValue mono">{{ kpis.transaction_commitment_mismatches_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.os_failed }}" type="button" data-scroll-to="os-run-failures">
+                <div class="metricLabel">OS run failures</div>
+                <div class="metricValue mono">{{ kpis.os_failed_count }}</div>
+              </button>
+            </div>
 
-        <div class="card">
-          <div class="cardTitle">Alerts</div>
-          <div class="pillRow">
-            <span class="pill pillLink {{ severity.gateway_errors }}" role="button" tabindex="0"
-              data-scroll-to="gateway-errors">Gateway errors:
-              <span class="mono">{{ kpis.gateway_errors_count }}</span></span>
-            <span class="pill pillLink {{ severity.reverts_mainnet }}" role="button" tabindex="0"
-              data-scroll-to="reverts-mainnet">Reverts
-              (mainnet-only): <span class="mono">{{ kpis.reverts_mainnet_count }}</span>
-              <span class="mono">({{ reverts.mainnet_only.pct_of_total_sent }})</span></span>
-            <span class="pill pillLink {{ severity.reverts_echonet }}" role="button" tabindex="0"
-              data-scroll-to="reverts-echonet">Reverts
-              (echonet-only): <span class="mono">{{ kpis.reverts_echonet_count }}</span>
-              <span class="mono">({{ reverts.echonet_only.pct_of_total_sent }})</span></span>
+            <div class="metricSubgroupDivider">
+              <span class="metricSubgroupLabel">OS runner</span>
+            </div>
+            <div class="metricGrid">
+              <div class="metricTile static {{ severity.os_completed }}">
+                <div class="metricLabel">Completed</div>
+                <div class="metricValue mono">{{ os_run_stats.completed | default(0) }}</div>
+              </div>
+              <div class="metricTile static {{ severity.os_dropped }}">
+                <div class="metricLabel">Dropped (queue full)</div>
+                <div class="metricValue mono">{{ os_run_stats.dropped | default(0) }}</div>
+              </div>
+              <div class="metricTile static {{ severity.os_abandoned }}">
+                <div class="metricLabel">Abandoned (window expired)</div>
+                <div class="metricValue mono">{{ os_run_stats.abandoned | default(0) }}</div>
+              </div>
+              <div class="metricTile static {{ severity.os_skipped }}">
+                <div class="metricLabel">Skipped (cache miss)</div>
+                <div class="metricValue mono">{{ os_run_stats.skipped | default(0) }}</div>
+              </div>
+              <div class="metricTile static">
+                <div class="metricLabel">Queue depth</div>
+                <div class="metricValue mono">{{ os_run_stats.queue_depth | default(0) }}</div>
+                <div class="metricSub mono">of {{ os_run_stats.queue_max | default(0) }}</div>
+              </div>
+              <div class="metricTile static">
+                <div class="metricLabel">Currently deferred</div>
+                <div class="metricValue mono">{{ os_run_stats.currently_deferred | default(0) }}</div>
+              </div>
+              <div class="metricTile static">
+                <div class="metricLabel">Deferred events (cumulative)</div>
+                <div class="metricValue mono">{{ os_run_stats.deferred_events | default(0) }}</div>
+              </div>
+            </div>
           </div>
-          <div class="pillRow">
-            <span class="pill pillLink {{ severity.resync_causes }}" role="button" tabindex="0"
-              data-scroll-to="resync-triggers">Resync triggers:
-              <span class="mono">{{ kpis.resync_causes_count }}</span></span>
-            <span class="pill pillLink {{ severity.certain_failures }}" role="button" tabindex="0"
-              data-scroll-to="certain-failures">Certain failures:
-              <span class="mono">{{ kpis.certain_failures_count }}</span></span>
-            <span class="pill pillLink {{ severity.l2_gas_mismatches }}" role="button" tabindex="0"
-              data-scroll-to="l2-gas-mismatches">L2 gas
-              mismatches: <span class="mono">{{ kpis.l2_gas_mismatches_count }}</span></span>
-          </div>
-          <div class="pillRow">
-            <span class="pill pillLink {{ severity.block_hash_mismatches }}" role="button" tabindex="0"
-              data-scroll-to="block-hash-mismatches">Block hash mismatches:
-              <span class="mono">{{ kpis.block_hash_mismatches_count }}</span></span>
-            <span class="pill pillLink {{ severity.transaction_commitment_mismatches }}" role="button" tabindex="0"
-              data-scroll-to="tx-commitment-mismatches">Tx commitment mismatches:
-              <span class="mono">{{ kpis.transaction_commitment_mismatches_count }}</span></span>
-          </div>
-          <div class="smallMuted">
-            Tip: press <span class="mono">/</span> to focus filter; <span class="mono">Esc</span> clears it.
-          </div>
-        </div>
-      </section>
+        </section>
 
-      <section id="pending-txs">
-        <details class="card details sectionDetails" data-section-details="1">
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Non-committed tx hashes (pending)</span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="pending"></div>
-          {% if not pending_txs_total %}
-          <div class="empty">(none)</div>
-          {% else %}
-          {% if pending_txs_total > 10 %}
-          <div class="smallMuted">Showing first 10 of {{ pending_txs_total }}</div>
-          {% endif %}
-          <table class="table filterable" data-filter-scope="pending" data-table="pending">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colHash" />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Source block</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for tx_hash, src_bn in pending_txs %}
-              <tr data-search="{{ tx_hash }} {{ src_bn }}">
-                <td class="mono">{{ src_bn }}</td>
-                <td class="mono">
-                  <span class="hash" title="{{ tx_hash }}">{{ tx_hash }}</span>
-                </td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ src_bn }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ src_bn }}"
-                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="gateway-errors">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Gateway errors <span class="countPill">{{ kpis.gateway_errors_count
-                }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="gateway"></div>
-          {% if not gateway_errors %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="gateway" data-table="gateway">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colStatus" />
-              <col class="colHash" />
-              <col />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Status</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th>Response</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in gateway_errors %}
-              <tr class="sev {{ severity.gateway_errors }}"
-                data-search="{{ row.tx_hash }} {{ row.status }} {{ row.block_number }} {{ row.response }}">
-                <td class="mono">{{ row.block_number }}</td>
-                <td class="mono"><span class="status {{ severity.gateway_errors }}">{{ row.status }}</span></td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">
-                  <details class="details">
-                    <summary>Show</summary>
-                    <pre class="pre">{{ row.response }}</pre>
-                  </details>
-                </td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
-                      target="_blank" rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="reverts-mainnet">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Reverted only on Mainnet <span class="countPill">{{
-                reverts.mainnet_only.total }} ({{ reverts.mainnet_only.pct_of_total_sent
-                }})</span></span>
-          </summary>
-          {% if reverts.mainnet_only.total == 0 %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <div class="smallMuted">Use the filter box to narrow down.</div>
-          {% for group in reverts.mainnet_only.groups %}
-          <details class="details filterable" data-filter-scope="reverts" open>
-            <summary>
-              <span class="badge bad">{{ group.count }}</span>
-              <span class="mono">{{ group.name }}</span>
-              <span class="countPill">{{ group.pct_of_section }}</span>
+        {% if kpis.reverts_mainnet_count > 0 or kpis.reverts_echonet_count > 0 %}
+        <section id="reverts-summary">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M3 12h4l3-9 4 18 3-9h4" />
+                </svg>
+                Top revert reasons
+              </span>
             </summary>
-            <table class="table" data-table="reverts">
-              <colgroup>
-                <col class="colBn" />
-                <col class="colHash" />
-                <col />
-                <col class="colActions" />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th class="sortable" data-sort="num">Source block</th>
-                  <th class="sortable" data-sort="str">Tx hash</th>
-                  <th>Reason (shortened)</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for row in group.rows %}
-                <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
-                  <td class="mono">{{ row.block_number }}</td>
-                  <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                  <td>
-                    <div class="reason">{{ row.reason }}</div>
-                    {% if row.raw_error and row.raw_error != row.reason %}
-                    <details class="details nested">
-                      <summary>Raw</summary>
-                      <pre class="pre">{{ row.raw_error }}</pre>
-                    </details>
-                    {% endif %}
-                  </td>
-                  <td class="right">
-                    <div class="rowActions">
-                      <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                      <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                        rel="noopener" title="Open in Voyager">Voyager</a>
-                      <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                        data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
-                        target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
-                        target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                    </div>
-                  </td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </details>
-          {% endfor %}
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="reverts-echonet">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Reverted only on Echonet <span class="countPill">{{
-                reverts.echonet_only.total }} ({{ reverts.echonet_only.pct_of_total_sent
-                }})</span></span>
-          </summary>
-          {% if reverts.echonet_only.total == 0 %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <div class="smallMuted">Use the filter box to narrow down.</div>
-          {% for group in reverts.echonet_only.groups %}
-          <details class="details filterable" data-filter-scope="reverts" open>
-            <summary>
-              <span class="badge bad">{{ group.count }}</span>
-              <span class="mono">{{ group.name }}</span>
-              <span class="countPill">{{ group.pct_of_section }}</span>
-            </summary>
-            <table class="table" data-table="reverts">
-              <colgroup>
-                <col class="colBn" />
-                <col class="colHash" />
-                <col />
-                <col class="colActions" />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th class="sortable" data-sort="num">Source block</th>
-                  <th class="sortable" data-sort="str">Tx hash</th>
-                  <th>Reason (shortened)</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for row in group.rows %}
-                <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
-                  <td class="mono">{{ row.block_number }}</td>
-                  <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                  <td>
-                    <div class="reason">{{ row.reason }}</div>
-                    {% if row.raw_error and row.raw_error != row.reason %}
-                    <details class="details nested">
-                      <summary>Raw</summary>
-                      <pre class="pre">{{ row.raw_error }}</pre>
-                    </details>
-                    {% endif %}
-                  </td>
-                  <td class="right">
-                    <div class="rowActions">
-                      <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                      <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                        rel="noopener" title="Open in Voyager">Voyager</a>
-                      <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                        data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
-                        target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
-                        target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                    </div>
-                  </td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </details>
-          {% endfor %}
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="resync-triggers">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Resync triggers (first failures) <span class="countPill">{{
-                kpis.resync_causes_count }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="resync"></div>
-          {% if not resync.causes %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="resync" data-table="resync">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colCount" />
-              <col class="colHash" />
-              <col />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="num">Count</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th class="sortable" data-sort="str">Reason</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in resync.causes %}
-              <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
-                <td class="mono">{{ row.failure_block_number }}</td>
-                <td class="mono">{{ row.count }}</td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">{{ row.reason }}</td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
-                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="certain-failures">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Certain failures (repeated triggers) <span class="countPill">{{
-                kpis.certain_failures_count }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="certain"></div>
-          {% if not resync.certain_failures %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="resync" data-table="certain">
-            <colgroup>
-              <col class="colCount" />
-              <col class="colBn" />
-              <col class="colHash" />
-              <col />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Count</th>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th class="sortable" data-sort="str">Reason</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in resync.certain_failures %}
-              <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
-                <td class="mono">{{ row.count }}</td>
-                <td class="mono">{{ row.failure_block_number }}</td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">{{ row.reason }}</td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
-                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="l2-gas-mismatches">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">L2 gas used mismatches <span class="countPill">{{ l2_gas_mismatches |
-                length }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="diag"></div>
-          {% if not l2_gas_mismatches %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <div class="smallMuted">
-            Showing all L2 gas used mismatches.
-          </div>
-          <table class="table filterable" data-filter-scope="diag" data-table="diag">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colBn" />
-              <col class="colHash" />
-              <col class="colCount" />
-              <col class="colCount" />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Echo block</th>
-                <th class="sortable" data-sort="num">Source block</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th class="sortable" data-sort="num">Blob L2 gas</th>
-                <th class="sortable" data-sort="num">FGW L2 gas</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in l2_gas_mismatches %}
-              <tr
-                data-search="{{ row.tx_hash }} {{ row.echo_block }} {{ row.source_block }} {{ row.blob_total_gas_l2 }} {{ row.fgw_total_gas_consumed_l2 }}">
-                <td class="mono">{{ row.echo_block }}</td>
-                <td class="mono">{{ row.source_block }}</td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">{{ row.blob_total_gas_l2 }}</td>
-                <td class="mono">{{ row.fgw_total_gas_consumed_l2 }}</td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    {% if not export %}
-                    <a class="btn btnSmall btnLink"
-                      href="/echonet/block_dump?blockNumber={{ row.echo_block }}&kind=blob" target="_blank"
-                      rel="noopener" title="Open echonet blob dump JSON (echo block)">Echo&nbsp;blob</a>
-                    {% endif %}
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.source_block }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener"
-                      title="Open source block JSON (upstream feeder)">Source&nbsp;block</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="block-hash-mismatches">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Block hash mismatches <span class="countPill">{{ block_hash_mismatches |
-                length }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="block-hash-mismatches"></div>
-          {% if not block_hash_mismatches %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="diag" data-table="block-hash-mismatches">
-            <colgroup>
-              <col class="colBn" />
-              <col />
-              <col />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Echonet</th>
-                <th class="sortable" data-sort="str">Mainnet</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in block_hash_mismatches %}
-              <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
-                <td class="mono">{{ row.block_number }}</td>
-                <td class="mono">{{ row.echonet }}</td>
-                <td class="mono">{{ row.mainnet }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="tx-commitment-mismatches">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Transaction commitment mismatches <span class="countPill">{{
-                transaction_commitment_mismatches | length }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="tx-commitment-mismatches"></div>
-          {% if not transaction_commitment_mismatches %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="diag" data-table="tx-commitment-mismatches">
-            <colgroup>
-              <col class="colBn" />
-              <col />
-              <col />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Echonet</th>
-                <th class="sortable" data-sort="str">Mainnet</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in transaction_commitment_mismatches %}
-              <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
-                <td class="mono">{{ row.block_number }}</td>
-                <td class="mono">{{ row.echonet }}</td>
-                <td class="mono">{{ row.mainnet }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      {% if not export %}
-      <section id="block-dump">
-        <div class="card">
-          <div class="cardTitle">Echonet Blocks</div>
-          <div class="smallMuted">
-            Fetch a stored payload from Echonet via <span class="mono">/echonet/block_dump</span>.
-          </div>
-          <form class="inlineForm" action="/echonet/block_dump" method="get" target="_blank" rel="noopener">
-            <label class="control">
-              <span>Block number</span>
-              <input id="blockDumpNumber" name="blockNumber" type="number" inputmode="numeric" min="0"
-                placeholder="e.g. 123456" required class="noSpin" />
-            </label>
-            <label class="control">
-              <span>Kind</span>
-              <select id="blockDumpKind" name="kind" required>
-                <option value="blob">blob</option>
-                <option value="block">block</option>
-                <option value="state_update">state_update</option>
-              </select>
-            </label>
-            <div class="formActions">
-              <button class="btn" id="blockDumpOpenBtn" type="submit">Open</button>
+            <div class="smallMuted">Largest revert categories. Click a row to filter the dashboard by that
+              reason.</div>
+            <div class="revertSummaryGrid">
+              <div class="revertSummaryCol">
+                <div class="revertSummaryTitle">Mainnet-only</div>
+                {% if not reverts.mainnet_only.groups %}
+                <div class="empty">(none)</div>
+                {% else %}
+                <div class="barList" data-bar-section="mainnet">
+                  {% for group in reverts.mainnet_only.groups[:8] %}
+                  <button class="barRow" type="button" data-filter-text="{{ group.name }}" data-scroll-to="reverts-mainnet">
+                    <span class="barName mono" title="{{ group.name }}">{{ group.name }}</span>
+                    <span class="barTrack"><span class="barFill bad" data-bar-count="{{ group.count }}"></span></span>
+                    <span class="barCount mono">{{ group.count }}</span>
+                    <span class="barPct smallMuted mono">{{ group.pct_of_section }}</span>
+                  </button>
+                  {% endfor %}
+                </div>
+                {% endif %}
+              </div>
+              <div class="revertSummaryCol">
+                <div class="revertSummaryTitle">Echonet-only</div>
+                {% if not reverts.echonet_only.groups %}
+                <div class="empty">(none)</div>
+                {% else %}
+                <div class="barList" data-bar-section="echonet">
+                  {% for group in reverts.echonet_only.groups[:8] %}
+                  <button class="barRow" type="button" data-filter-text="{{ group.name }}" data-scroll-to="reverts-echonet">
+                    <span class="barName mono" title="{{ group.name }}">{{ group.name }}</span>
+                    <span class="barTrack"><span class="barFill bad" data-bar-count="{{ group.count }}"></span></span>
+                    <span class="barCount mono">{{ group.count }}</span>
+                    <span class="barPct smallMuted mono">{{ group.pct_of_section }}</span>
+                  </button>
+                  {% endfor %}
+                </div>
+                {% endif %}
+              </div>
             </div>
-          </form>
-        </div>
-      </section>
-      {% endif %}
-    </div>
+          </details>
+        </section>
+        {% endif %}
 
-    <footer class="footer">
-      <div>
-        {% if export %}
-        Static snapshot: filter/scope, copy, logs links, theme, and feeder links are enabled.
-        {% else %}
-        Endpoints:
-        <a href="/echonet/report/ui">UI</a>,
-        <a href="/echonet/report">JSON</a>,
-        <a href="/echonet/report/text">Text</a>,
-        <a href="/echonet/block_dump?blockNumber=0&kind=blob">Block dump</a>
+        <section id="pending-txs">
+          <details class="card details sectionDetails" data-section-details="1">
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="M12 7v5l3 2" />
+                </svg>
+                Non-committed tx hashes (pending)
+                <span class="countPill" data-section-count="{{ pending_txs_total }}">{{ pending_txs_total }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="pending" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="pending"></div>
+            {% if not pending_txs_total %}
+            <div class="empty">
+              <div class="emptyIcon" aria-hidden="true">✓</div>
+              <div class="emptyText">All forwarded transactions have been committed.</div>
+            </div>
+            {% else %}
+            {% if pending_txs_total > 10 %}
+            <div class="smallMuted">Showing first 10 of {{ pending_txs_total }}</div>
+            {% endif %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="pending" data-table="pending">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colHash" />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Source block</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for tx_hash, src_bn in pending_txs %}
+                  <tr data-search="{{ tx_hash }} {{ src_bn }}">
+                    <td class="mono">{{ src_bn }}</td>
+                    <td class="mono">
+                      <span class="hash" data-full-hash="{{ tx_hash }}" title="{{ tx_hash }}">{{ tx_hash }}</span>
+                    </td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ src_bn }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ src_bn }}"
+                          target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+
+        {% if kpis.gateway_errors_count > 0 %}
+        <section id="gateway-errors">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="M12 8v4M12 16h.01" />
+                </svg>
+                Gateway errors
+                <span class="countPill" data-section-count="{{ kpis.gateway_errors_count }}">{{ kpis.gateway_errors_count }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="gateway" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="gateway"></div>
+            {% if not gateway_errors %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No gateway errors recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="gateway" data-table="gateway">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colStatus" />
+                  <col class="colHash" />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Status</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th>Response</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in gateway_errors %}
+                  <tr class="sev {{ severity.gateway_errors }}"
+                    data-search="{{ row.tx_hash }} {{ row.status }} {{ row.block_number }} {{ row.response }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono"><span class="status {{ severity.gateway_errors }}">{{ row.status }}</span></td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">
+                      <details class="details">
+                        <summary>Show</summary>
+                        <pre class="pre">{{ row.response }}</pre>
+                      </details>
+                    </td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                          target="_blank" rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.reverts_mainnet_count > 0 %}
+        <section id="reverts-mainnet">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M9 12 4 7l5-5M4 7h12a4 4 0 0 1 4 4v10" />
+                </svg>
+                Reverted only on Mainnet
+                <span class="countPill" data-section-count="{{ reverts.mainnet_only.total }}">
+                  {{ reverts.mainnet_only.total }} ({{ reverts.mainnet_only.pct_of_total_sent }})
+                </span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="reverts-mainnet" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            {% if reverts.mainnet_only.total == 0 %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No transactions reverted only on Mainnet.</div>
+            </div>
+            {% else %}
+            <div class="smallMuted">Use the filter box to narrow down.</div>
+            {% for group in reverts.mainnet_only.groups %}
+            <details class="details filterable revertGroup" data-filter-scope="reverts" open>
+              <summary>
+                <span class="badge bad">{{ group.count }}</span>
+                <span class="mono">{{ group.name }}</span>
+                <span class="countPill">{{ group.pct_of_section }}</span>
+              </summary>
+              <div class="tableWrap">
+                <table class="table" data-table="reverts-mainnet">
+                  <colgroup>
+                    <col class="colBn" />
+                    <col class="colHash" />
+                    <col />
+                    <col class="colActions" />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th class="sortable" data-sort="num">Source block</th>
+                      <th class="sortable" data-sort="str">Tx hash</th>
+                      <th>Reason (shortened)</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in group.rows %}
+                    <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
+                      <td class="mono">{{ row.block_number }}</td>
+                      <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                      <td>
+                        <div class="reason">{{ row.reason }}</div>
+                        {% if row.raw_error and row.raw_error != row.reason %}
+                        <details class="details nested">
+                          <summary>Raw</summary>
+                          <pre class="pre">{{ row.raw_error }}</pre>
+                        </details>
+                        {% endif %}
+                      </td>
+                      <td class="right">
+                        <div class="rowActions">
+                          <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                          <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                            rel="noopener" title="Open in Voyager">Voyager</a>
+                          <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                            data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                            target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                            target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                        </div>
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+            {% endfor %}
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.reverts_echonet_count > 0 %}
+        <section id="reverts-echonet">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m15 12 5-5-5-5M20 7H8a4 4 0 0 0-4 4v10" />
+                </svg>
+                Reverted only on Echonet
+                <span class="countPill" data-section-count="{{ reverts.echonet_only.total }}">
+                  {{ reverts.echonet_only.total }} ({{ reverts.echonet_only.pct_of_total_sent }})
+                </span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="reverts-echonet" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            {% if reverts.echonet_only.total == 0 %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No transactions reverted only on Echonet.</div>
+            </div>
+            {% else %}
+            <div class="smallMuted">Use the filter box to narrow down.</div>
+            {% for group in reverts.echonet_only.groups %}
+            <details class="details filterable revertGroup" data-filter-scope="reverts" open>
+              <summary>
+                <span class="badge bad">{{ group.count }}</span>
+                <span class="mono">{{ group.name }}</span>
+                <span class="countPill">{{ group.pct_of_section }}</span>
+              </summary>
+              <div class="tableWrap">
+                <table class="table" data-table="reverts-echonet">
+                  <colgroup>
+                    <col class="colBn" />
+                    <col class="colHash" />
+                    <col />
+                    <col class="colActions" />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th class="sortable" data-sort="num">Source block</th>
+                      <th class="sortable" data-sort="str">Tx hash</th>
+                      <th>Reason (shortened)</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in group.rows %}
+                    <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
+                      <td class="mono">{{ row.block_number }}</td>
+                      <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                      <td>
+                        <div class="reason">{{ row.reason }}</div>
+                        {% if row.raw_error and row.raw_error != row.reason %}
+                        <details class="details nested">
+                          <summary>Raw</summary>
+                          <pre class="pre">{{ row.raw_error }}</pre>
+                        </details>
+                        {% endif %}
+                      </td>
+                      <td class="right">
+                        <div class="rowActions">
+                          <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                          <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                            rel="noopener" title="Open in Voyager">Voyager</a>
+                          <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                            data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                            target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                            target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                        </div>
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+            {% endfor %}
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.resync_causes_count > 0 %}
+        <section id="resync-triggers">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M21 12a9 9 0 1 1-3-6.7M21 4v5h-5" />
+                </svg>
+                Resync triggers (first failures)
+                <span class="countPill" data-section-count="{{ kpis.resync_causes_count }}">{{ kpis.resync_causes_count }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="resync" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="resync"></div>
+            {% if not resync.causes %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No resync triggers recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="resync" data-table="resync">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colCount" />
+                  <col class="colHash" />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="num">Count</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th class="sortable" data-sort="str">Reason</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in resync.causes %}
+                  <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
+                    <td class="mono">{{ row.failure_block_number }}</td>
+                    <td class="mono">{{ row.count }}</td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">{{ row.reason }}</td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
+                          target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.certain_failures_count > 0 %}
+        <section id="certain-failures">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="m9 9 6 6M15 9l-6 6" />
+                </svg>
+                Certain failures (repeated triggers)
+                <span class="countPill" data-section-count="{{ kpis.certain_failures_count }}">{{ kpis.certain_failures_count }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="certain" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="certain"></div>
+            {% if not resync.certain_failures %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No certain failures recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="resync" data-table="certain">
+                <colgroup>
+                  <col class="colCount" />
+                  <col class="colBn" />
+                  <col class="colHash" />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Count</th>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th class="sortable" data-sort="str">Reason</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in resync.certain_failures %}
+                  <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
+                    <td class="mono">{{ row.count }}</td>
+                    <td class="mono">{{ row.failure_block_number }}</td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">{{ row.reason }}</td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
+                          target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.l2_gas_mismatches_count > 0 %}
+        <section id="l2-gas-mismatches">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 22V6l6-4 6 4v16M5 11h12M9 18h4" />
+                </svg>
+                L2 gas used mismatches
+                <span class="countPill" data-section-count="{{ l2_gas_mismatches | length }}">{{ l2_gas_mismatches | length }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="diag" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="diag"></div>
+            {% if not l2_gas_mismatches %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">L2 gas matches the upstream feeder.</div>
+            </div>
+            {% else %}
+            <div class="smallMuted">Showing all L2 gas used mismatches.</div>
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="diag">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colBn" />
+                  <col class="colHash" />
+                  <col class="colCount" />
+                  <col class="colCount" />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Echo block</th>
+                    <th class="sortable" data-sort="num">Source block</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th class="sortable" data-sort="num">Blob L2 gas</th>
+                    <th class="sortable" data-sort="num">FGW L2 gas</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in l2_gas_mismatches %}
+                  <tr
+                    data-search="{{ row.tx_hash }} {{ row.echo_block }} {{ row.source_block }} {{ row.blob_total_gas_l2 }} {{ row.fgw_total_gas_consumed_l2 }}">
+                    <td class="mono">{{ row.echo_block }}</td>
+                    <td class="mono">{{ row.source_block }}</td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">{{ row.blob_total_gas_l2 }}</td>
+                    <td class="mono">{{ row.fgw_total_gas_consumed_l2 }}</td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        {% if not export %}
+                        <a class="btn btnSmall btnLink"
+                          href="/echonet/block_dump?blockNumber={{ row.echo_block }}&kind=blob" target="_blank"
+                          rel="noopener" title="Open echonet blob dump JSON (echo block)">Echo&nbsp;blob</a>
+                        {% endif %}
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.source_block }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener"
+                          title="Open source block JSON (upstream feeder)">Source&nbsp;block</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.block_hash_mismatches_count > 0 %}
+        <section id="block-hash-mismatches">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m4 7 8-4 8 4M4 7v10l8 4 8-4V7M4 7l8 4 8-4M12 11v10" />
+                </svg>
+                Block hash mismatches
+                <span class="countPill" data-section-count="{{ block_hash_mismatches | length }}">{{ block_hash_mismatches | length }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="block-hash-mismatches" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="block-hash-mismatches"></div>
+            {% if not block_hash_mismatches %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">Block hashes match mainnet.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="block-hash-mismatches">
+                <colgroup>
+                  <col class="colBn" />
+                  <col />
+                  <col />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Echonet</th>
+                    <th class="sortable" data-sort="str">Mainnet</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in block_hash_mismatches %}
+                  <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono">{{ row.echonet }}</td>
+                    <td class="mono">{{ row.mainnet }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.transaction_commitment_mismatches_count > 0 %}
+        <section id="tx-commitment-mismatches">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M9 12 11 14l4-4M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" />
+                </svg>
+                Transaction commitment mismatches
+                <span class="countPill" data-section-count="{{ transaction_commitment_mismatches | length }}">{{ transaction_commitment_mismatches | length }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="tx-commitment-mismatches"
+                  type="button" title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="tx-commitment-mismatches"></div>
+            {% if not transaction_commitment_mismatches %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">Transaction commitments match mainnet.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="tx-commitment-mismatches">
+                <colgroup>
+                  <col class="colBn" />
+                  <col />
+                  <col />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Echonet</th>
+                    <th class="sortable" data-sort="str">Mainnet</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in transaction_commitment_mismatches %}
+                  <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono">{{ row.echonet }}</td>
+                    <td class="mono">{{ row.mainnet }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.os_failed_count > 0 %}
+        <section id="os-run-failures">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 3l9 15H3zM12 9v4M12 17h.01" />
+                </svg>
+                OS run failures
+                <span class="countPill" data-section-count="{{ os_run_failures | length }}">{{ os_run_failures | length }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="os-run-failures" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="os-run-failures"></div>
+            {% if not os_run_failures %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No OS run failures recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="os-run-failures">
+                <colgroup>
+                  <col class="colBn" />
+                  <col />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Timestamp</th>
+                    <th>Error</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in os_run_failures %}
+                  <tr class="sev {{ severity.os_failed }}"
+                    data-search="{{ row.block_number }} {{ row.ts }} {{ row.error }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono">{{ row.ts }}</td>
+                    <td class="mono">
+                      <details class="details">
+                        <summary>Show</summary>
+                        <pre class="pre">{{ row.error }}</pre>
+                      </details>
+                    </td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                          target="_blank" rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if not export %}
+        <section id="block-dump">
+          <div class="card">
+            <div class="cardHeader">
+              <div class="cardTitle">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
+                </svg>
+                Echonet block dump
+              </div>
+            </div>
+            <div class="smallMuted">
+              Fetch a stored payload from Echonet via <span class="mono">/echonet/block_dump</span>.
+            </div>
+            <form class="inlineForm" action="/echonet/block_dump" method="get" target="_blank" rel="noopener">
+              <label class="control">
+                <span>Block number</span>
+                <input id="blockDumpNumber" name="blockNumber" type="number" inputmode="numeric" min="0"
+                  placeholder="e.g. 123456" required class="noSpin" />
+              </label>
+              <label class="control">
+                <span>Kind</span>
+                <select id="blockDumpKind" name="kind" required>
+                  <option value="blob">blob</option>
+                  <option value="block">block</option>
+                  <option value="state_update">state_update</option>
+                </select>
+              </label>
+              <div class="formActions">
+                <button class="btn" id="blockDumpOpenBtn" type="submit">Open</button>
+              </div>
+            </form>
+          </div>
+        </section>
         {% endif %}
       </div>
-    </footer>
-  </main>
+
+      <footer class="footer">
+        <div>
+          {% if export %}
+          Static snapshot: filter/scope, copy, logs links, theme, and feeder links are enabled.
+          {% else %}
+          Endpoints:
+          <a href="/echonet/report/ui">UI</a>,
+          <a href="/echonet/report">JSON</a>,
+          <a href="/echonet/report/text">Text</a>,
+          <a href="/echonet/block_dump?blockNumber=0&kind=blob">Block dump</a>
+          {% endif %}
+        </div>
+      </footer>
+    </main>
+  </div>
+
+  <div class="shortcutsOverlay" id="shortcutsOverlay" hidden role="dialog" aria-modal="true"
+    aria-labelledby="shortcutsTitle">
+    <div class="shortcutsCard" role="document">
+      <div class="shortcutsHeader">
+        <div id="shortcutsTitle" class="shortcutsTitle">Keyboard shortcuts</div>
+        <button class="btn btnSmall" type="button" id="shortcutsClose" aria-label="Close">Esc</button>
+      </div>
+      <div class="shortcutsBody">
+        <div class="shortcutRow"><kbd>/</kbd><span>Focus the filter</span></div>
+        <div class="shortcutRow"><kbd>Esc</kbd><span>Clear the filter / close overlay</span></div>
+        <div class="shortcutRow"><kbd>R</kbd><span>Refresh now</span></div>
+        <div class="shortcutRow"><kbd>E</kbd><span>Expand all sections</span></div>
+        <div class="shortcutRow"><kbd>C</kbd><span>Collapse all sections</span></div>
+        <div class="shortcutRow"><kbd>D</kbd><span>Toggle row density</span></div>
+        <div class="shortcutRow"><kbd>H</kbd><span>Toggle hash display (full ↔ truncated)</span></div>
+        <div class="shortcutRow"><kbd>T</kbd><span>Cycle theme (risk → dark → light)</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>P</kbd><span>Jump to pending</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>E</kbd><span>Jump to gateway errors</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>R</kbd><span>Jump to reverts (mainnet)</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>R</kbd> <kbd>R</kbd><span>Jump to reverts (echonet)</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>O</kbd><span>Jump to overview</span></div>
+        <div class="shortcutRow"><kbd>?</kbd><span>Show / hide this help</span></div>
+      </div>
+    </div>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
Add an OS-runner background pipeline: for each blob received, defer-and-enqueue an OS execution over the previous block (whose state_commitment_infos live in the next blob's sliding window). Six worker threads drain a bounded queue, shelling out to committer-and-os-cli's `os run-os-stateless`. Blob bodies stay as raw JSON bytes in memory; a new class_fetcher resolves missing CASM from the mainnet FGW with an on-PVC cache. block_commitments computed once at ingest is threaded through the queue task so workers don't re-parse the multi-MB blob.

Report UI is redesigned around a sidenav + metric-tile Alerts grid + per-section CSV export (rebased from earlier UI-overhaul work). Diagnostic sections only render when their count > 0. Adds an OS run failures section + a divider'd OS-runner subgroup in Alerts showing completed/dropped/abandoned/skipped counts and queue/deferred state.

Deploy: force onto n4-standard-8 via nodeSelector so ScaleOps doesn't downsize into an n4-standard-4; Recreate strategy so the old pod releases the PVC before the new one attaches; --block-hash-cli-binary flag now accepts a path.

The associated Rust-side changes (pin syscall gas costs to 0.14.2 and set the OS's effective Starknet version from block_info) live outside this branch.