### PR TITLE
papyrus_base_layer: bisect L1 log range on oversized or timed-out getLogs queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9990,6 +9990,7 @@ dependencies = [
  "strum",
  "thiserror 1.0.69",
  "tokio",
+ "tower",
  "tracing",
  "url",
  "validator",

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -42,3 +42,4 @@ rstest.workspace = true
 starknet-types-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 tokio = { workspace = true, features = ["test-util"] }
+tower.workspace = true

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -8,11 +8,12 @@ use alloy::eips::eip7840;
 use alloy::network::Ethereum;
 use alloy::primitives::{Address, U256};
 use alloy::providers::{Provider, ProviderBuilder, RootProvider};
-use alloy::rpc::json_rpc::RpcError;
+use alloy::rpc::json_rpc::{ErrorPayload, RpcError};
 use alloy::rpc::types::eth::Filter as EthEventFilter;
+use alloy::rpc::types::Log;
 use alloy::sol;
 use alloy::sol_types::sol_data;
-use alloy::transports::TransportErrorKind;
+use alloy::transports::{HttpError, TransportErrorKind};
 use apollo_config::converters::{
     deserialize_milliseconds_to_duration,
     deserialize_seconds_to_duration,
@@ -132,6 +133,99 @@ impl EthereumBaseLayerContract {
         let contract = Starknet::new(starknet_contract_address, provider);
         Self { url_iterator, contract, config, node_url }
     }
+
+    /// Runs a single getLogs query for the given range, subject to the configured timeout.
+    async fn get_logs_in_range(
+        &self,
+        block_range: RangeInclusive<u64>,
+        event_types_to_filter: &[&str],
+    ) -> EthereumBaseLayerResult<Vec<Log>> {
+        let filter = EthEventFilter::new()
+            .select(block_range)
+            .events(event_types_to_filter)
+            .address(self.config.starknet_contract_address);
+
+        Ok(tokio::time::timeout(
+            self.config.timeout_millis,
+            self.contract.provider().get_logs(&filter),
+        )
+        .await??)
+    }
+
+    /// Fetches all logs in `block_range`, bisecting the range whenever a sub-query fails with an
+    /// oversized-response / timeout error and retrying each half. Returns the logs in ascending
+    /// block order (sub-ranges are fetched low-half-before-high-half). Any non-range error, or a
+    /// range error that persists down to a single block, is propagated unchanged.
+    async fn get_logs_bisected(
+        &self,
+        block_range: RangeInclusive<u64>,
+        event_types_to_filter: &[&str],
+    ) -> EthereumBaseLayerResult<Vec<Log>> {
+        let mut all_logs: Vec<Log> = Vec::new();
+        // Explicit LIFO stack instead of async recursion. On a split we push the high half then the
+        // low half, so the low half is popped (and fetched) first, keeping `all_logs` ascending.
+        let mut ranges_to_fetch = vec![block_range];
+        while let Some(range) = ranges_to_fetch.pop() {
+            let (start, end) = (*range.start(), *range.end());
+            match self.get_logs_in_range(range, event_types_to_filter).await {
+                Ok(mut logs) => all_logs.append(&mut logs),
+                Err(error) if is_range_too_large_error(&error) => {
+                    // Single-block floor: can't split further, surface the failure.
+                    if start == end {
+                        return Err(error);
+                    }
+                    let mid = start + (end - start) / 2;
+                    ranges_to_fetch.push((mid + 1)..=end);
+                    ranges_to_fetch.push(start..=mid);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(all_logs)
+    }
+}
+
+/// Classifies whether an error from a getLogs query indicates the queried block range was too large
+/// (or too slow) and should be bisected. Whitelists the oversized / timeout error class only;
+/// auth, rate-limit, connection and decoding errors return false so they propagate to the caller
+/// (and, for endpoint-down cases, the cyclic wrapper's failover) rather than triggering bisection.
+pub(crate) fn is_range_too_large_error(error: &EthereumBaseLayerError) -> bool {
+    match error {
+        // A window that times out is treated as too big/slow and bisected.
+        EthereumBaseLayerError::ProviderTimeout(_) => true,
+        EthereumBaseLayerError::RpcError(RpcError::ErrorResp(payload)) => {
+            is_oversized_error_payload(payload)
+        }
+        EthereumBaseLayerError::RpcError(RpcError::Transport(TransportErrorKind::HttpError(
+            HttpError { status, body },
+        ))) => {
+            // 413 Payload Too Large: the response exceeded the provider/proxy size limit.
+            *status == 413 || {
+                let body = body.to_lowercase();
+                body.contains("response size") || body.contains("too large")
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Matches a JSON-RPC error payload against known provider phrasings for oversized-range /
+/// too-many-results responses. Codes alone are not sufficient (`-32000` / `-32602` are overloaded);
+/// they only count when paired with a matching message.
+fn is_oversized_error_payload(payload: &ErrorPayload) -> bool {
+    let message = payload.message.to_lowercase();
+    let too_many_results = (message.contains("more than") && message.contains("results"))
+        || message.contains("query returned more than");
+    let response_too_large = message.contains("response size exceeded");
+    let query_too_slow = message.contains("query timeout") || message.contains("took too long");
+    let range_too_large = message.contains("block range is too large")
+        || message.contains("range too large")
+        || message.contains("exceed maximum block range");
+    // "limit exceeded" is overloaded, so only treat it as oversized alongside a block-range
+    // context.
+    let block_range_limit = message.contains("limit exceeded") && message.contains("block range");
+
+    too_many_results || response_too_large || query_too_slow || range_too_large || block_range_limit
 }
 
 #[async_trait]
@@ -172,16 +266,9 @@ impl BaseLayerContract for EthereumBaseLayerContract {
         // Don't actually need mutability here, and using mut self doesn't work with async move in
         // the loop below.
         let immutable_self = &*self;
-        let filter = EthEventFilter::new()
-            .select(block_range.clone())
-            .events(event_types_to_filter)
-            .address(immutable_self.config.starknet_contract_address);
 
-        let matching_logs = tokio::time::timeout(
-            immutable_self.config.timeout_millis,
-            immutable_self.contract.provider().get_logs(&filter),
-        )
-        .await??;
+        let matching_logs =
+            immutable_self.get_logs_bisected(block_range.clone(), event_types_to_filter).await?;
 
         // Debugging.
         let hashes: Vec<_> = matching_logs.iter().filter_map(|log| log.transaction_hash).collect();

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract_test.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract_test.rs
@@ -1,9 +1,100 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
+use alloy::providers::mock::{Asserter, MockTransport};
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::client::RpcClient;
+use alloy::rpc::json_rpc::{ErrorPayload, RequestPacket, ResponsePacket, RpcError};
+use alloy::rpc::types::Log;
+use alloy::transports::{HttpError, TransportErrorKind, TransportFut};
+use tokio::time::error::Elapsed;
+use tower::Service;
 use url::Url;
 
-use crate::ethereum_base_layer_contract::{EthereumBaseLayerConfig, EthereumBaseLayerContract};
+use crate::ethereum_base_layer_contract::{
+    is_range_too_large_error,
+    EthereumBaseLayerConfig,
+    EthereumBaseLayerContract,
+    EthereumBaseLayerError,
+};
 use crate::BaseLayerContract;
+
+fn base_layer_with_mocked_provider() -> (EthereumBaseLayerContract, Asserter) {
+    // The Asserter is a FIFO queue of mocked responses (success or failure).
+    let asserter = Asserter::new();
+    let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone()).root().clone();
+    let base_layer =
+        EthereumBaseLayerContract::new_with_provider(EthereumBaseLayerConfig::default(), provider);
+    (base_layer, asserter)
+}
+
+/// Transport whose first request hangs past the configured timeout (so the production
+/// `tokio::time::timeout` fires a real `Elapsed`, exercising the timeout-triggered bisection path);
+/// every later request delegates to the wrapped `Asserter` queue immediately.
+#[derive(Clone)]
+struct HangOnFirstRequestTransport {
+    inner: MockTransport,
+    first_request_seen: Arc<AtomicBool>,
+}
+
+impl Service<RequestPacket> for HangOnFirstRequestTransport {
+    type Response = ResponsePacket;
+    type Error = alloy::transports::TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: RequestPacket) -> Self::Future {
+        let is_first_request = !self.first_request_seen.swap(true, Ordering::SeqCst);
+        let mut inner = self.inner.clone();
+        Box::pin(async move {
+            // Hang so the outer timeout elapses; the future is then dropped without touching the
+            // Asserter queue, leaving the half-range responses for the retries.
+            if is_first_request {
+                std::future::pending::<()>().await;
+            }
+            inner.call(request).await
+        })
+    }
+}
+
+// Timeout short enough to fire promptly against the hanging first request, but long enough that the
+// immediate half-range retries never race it.
+const HANGING_PROVIDER_TIMEOUT: Duration = Duration::from_millis(50);
+
+fn base_layer_hanging_on_first_request() -> (EthereumBaseLayerContract, Asserter) {
+    let asserter = Asserter::new();
+    let transport = HangOnFirstRequestTransport {
+        inner: MockTransport::new(asserter.clone()),
+        first_request_seen: Arc::new(AtomicBool::new(false)),
+    };
+    let provider =
+        ProviderBuilder::new().connect_client(RpcClient::new(transport, true)).root().clone();
+    let config =
+        EthereumBaseLayerConfig { timeout_millis: HANGING_PROVIDER_TIMEOUT, ..Default::default() };
+    let base_layer = EthereumBaseLayerContract::new_with_provider(config, provider);
+    (base_layer, asserter)
+}
+
+fn too_many_results_error() -> ErrorPayload {
+    ErrorPayload {
+        code: -32005,
+        message: "query returned more than 10000 results".into(),
+        data: None,
+    }
+}
+
+async fn make_elapsed() -> Elapsed {
+    tokio::time::timeout(Duration::ZERO, std::future::pending::<()>()).await.unwrap_err()
+}
+
+fn log_at_block(block_number: u64) -> Log {
+    Log { block_number: Some(block_number), ..Default::default() }
+}
 
 #[tokio::test]
 #[ignore = "This test uses external dependencies, like Infura. But still it is a good \
@@ -81,4 +172,172 @@ async fn fusaka_blob_fee_sanity_check() {
         .expect("expected call to get block header to succeed")
         .expect("expected block header to be found");
     assert!(block_header.blob_fee * 1000 < base_fee_from_blobscan);
+}
+
+#[tokio::test]
+async fn events_single_call_success_is_unaffected() {
+    let (mut base_layer, asserter) = base_layer_with_mocked_provider();
+    asserter.push_success(&Vec::<Log>::new());
+
+    let events = base_layer.events(1..=100, &[]).await.unwrap();
+
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn events_bisects_on_too_many_results_and_drains_queue() {
+    let (mut base_layer, asserter) = base_layer_with_mocked_provider();
+    // Full range fails as oversized, then each half returns empty logs.
+    asserter.push_failure(too_many_results_error());
+    asserter.push_success(&Vec::<Log>::new());
+    asserter.push_success(&Vec::<Log>::new());
+
+    let events = base_layer.events(1..=4, &[]).await.unwrap();
+
+    assert!(events.is_empty());
+    // 1 failed full-range call + 2 successful half-range calls must have drained the queue; a
+    // fourth call would panic on the empty asserter, proving exactly two halves were fetched.
+    asserter.push_success(&Vec::<Log>::new());
+    base_layer.events(1..=1, &[]).await.unwrap();
+}
+
+#[tokio::test]
+async fn events_recursively_bisects_down_to_single_blocks() {
+    let (mut base_layer, asserter) = base_layer_with_mocked_provider();
+    // 1..=4 fails -> [1..=2, 3..=4]. 1..=2 fails -> [1..=1, 2..=2] (both empty). 3..=4 fails ->
+    // [3..=3, 4..=4] (both empty). Low-before-high traversal fixes this exact response order.
+    asserter.push_failure(too_many_results_error());
+    asserter.push_failure(too_many_results_error());
+    asserter.push_success(&Vec::<Log>::new());
+    asserter.push_success(&Vec::<Log>::new());
+    asserter.push_failure(too_many_results_error());
+    asserter.push_success(&Vec::<Log>::new());
+    asserter.push_success(&Vec::<Log>::new());
+
+    let events = base_layer.events(1..=4, &[]).await.unwrap();
+
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn bisection_returns_all_logs_in_ascending_block_order() {
+    let (base_layer, asserter) = base_layer_with_mocked_provider();
+    // Full range fails as oversized -> [1..=2, 3..=4]; the low half is fetched first, so its logs
+    // (blocks 1, 2) must precede the high half's logs (blocks 3, 4) in the concatenated result.
+    asserter.push_failure(too_many_results_error());
+    asserter.push_success(&vec![log_at_block(1), log_at_block(2)]);
+    asserter.push_success(&vec![log_at_block(3), log_at_block(4)]);
+
+    let logs = base_layer.get_logs_bisected(1..=4, &[]).await.unwrap();
+
+    let block_numbers: Vec<_> = logs.iter().map(|log| log.block_number).collect();
+    assert_eq!(block_numbers, vec![Some(1), Some(2), Some(3), Some(4)]);
+}
+
+#[tokio::test]
+async fn bisection_on_timeout_returns_all_logs_in_ascending_block_order() {
+    let (base_layer, asserter) = base_layer_hanging_on_first_request();
+    // The wide-range query hangs and times out (classified as range-too-large) -> [1..=2, 3..=4];
+    // the low half is fetched first, so its logs (blocks 1, 2) must precede the high half's logs
+    // (blocks 3, 4) in the concatenated result.
+    asserter.push_success(&vec![log_at_block(1), log_at_block(2)]);
+    asserter.push_success(&vec![log_at_block(3), log_at_block(4)]);
+
+    let logs = base_layer.get_logs_bisected(1..=4, &[]).await.unwrap();
+
+    let block_numbers: Vec<_> = logs.iter().map(|log| log.block_number).collect();
+    assert_eq!(block_numbers, vec![Some(1), Some(2), Some(3), Some(4)]);
+}
+
+#[tokio::test]
+async fn events_single_block_floor_still_failing_propagates() {
+    let (mut base_layer, asserter) = base_layer_with_mocked_provider();
+    asserter.push_failure(too_many_results_error());
+
+    let error = base_layer.events(5..=5, &[]).await.unwrap_err();
+
+    assert_eq!(
+        error,
+        EthereumBaseLayerError::RpcError(RpcError::ErrorResp(too_many_results_error()))
+    );
+}
+
+#[tokio::test]
+async fn events_propagates_non_range_error_without_bisecting() {
+    let (mut base_layer, asserter) = base_layer_with_mocked_provider();
+    let auth_error = ErrorPayload { code: -32000, message: "unauthorized".into(), data: None };
+    asserter.push_failure(auth_error.clone());
+
+    let error = base_layer.events(1..=100, &[]).await.unwrap_err();
+
+    assert_eq!(error, EthereumBaseLayerError::RpcError(RpcError::ErrorResp(auth_error)));
+    // No bisection was attempted: the queue is empty, so a follow-up single-block success is the
+    // very next response (would panic if the previous call had popped extra half-range requests).
+    asserter.push_success(&Vec::<Log>::new());
+    base_layer.events(1..=1, &[]).await.unwrap();
+}
+
+#[tokio::test]
+async fn is_range_too_large_error_classification() {
+    let oversized_messages = [
+        "query returned more than 10000 results",
+        "Query returned more than 10000 results",
+        "response size exceeded the limit",
+        "query timeout exceeded",
+        "the query took too long",
+        "block range is too large",
+        "range too large",
+        "query exceed maximum block range",
+        "block range limit exceeded",
+    ];
+    for message in oversized_messages {
+        let error = EthereumBaseLayerError::RpcError(RpcError::ErrorResp(ErrorPayload {
+            code: -32000,
+            message: message.into(),
+            data: None,
+        }));
+        assert!(is_range_too_large_error(&error), "expected oversized for message: {message}");
+    }
+
+    // HTTP 413 and matching body -> true.
+    assert!(is_range_too_large_error(&http_error(413, "payload too large")));
+    assert!(is_range_too_large_error(&http_error(200, "response size exceeded")));
+
+    // Timeout -> true.
+    assert!(is_range_too_large_error(&EthereumBaseLayerError::ProviderTimeout(
+        make_elapsed().await
+    )));
+
+    // Auth / rate-limit / server / connection errors -> false.
+    for status in [401, 403, 429, 500, 503] {
+        assert!(
+            !is_range_too_large_error(&http_error(status, "")),
+            "expected non-oversized for status: {status}"
+        );
+    }
+    let not_oversized_messages =
+        ["unauthorized", "limit exceeded", "rate limited", "invalid params"];
+    for message in not_oversized_messages {
+        let error = EthereumBaseLayerError::RpcError(RpcError::ErrorResp(ErrorPayload {
+            code: -32000,
+            message: message.into(),
+            data: None,
+        }));
+        assert!(!is_range_too_large_error(&error), "expected non-oversized for message: {message}");
+    }
+    assert!(!is_range_too_large_error(&EthereumBaseLayerError::RpcError(RpcError::Transport(
+        TransportErrorKind::BackendGone
+    ))));
+    assert!(!is_range_too_large_error(&EthereumBaseLayerError::RpcError(
+        TransportErrorKind::custom_str("connection refused")
+    )));
+    assert!(!is_range_too_large_error(&EthereumBaseLayerError::CalldataValueOutOfRange(
+        alloy::primitives::U256::from(1_u8)
+    )));
+}
+
+fn http_error(status: u16, body: &str) -> EthereumBaseLayerError {
+    EthereumBaseLayerError::RpcError(RpcError::Transport(TransportErrorKind::HttpError(
+        HttpError { status, body: body.to_string() },
+    )))
 }

--- a/crates/papyrus_base_layer/src/lib.rs
+++ b/crates/papyrus_base_layer/src/lib.rs
@@ -74,6 +74,11 @@ pub trait BaseLayerContract {
     ) -> Result<Option<L1BlockReference>, Self::Error>;
 
     /// Get specific events from the Starknet base contract between two L1 block numbers.
+    ///
+    /// Returns all matching events for the entire `block_range`. An implementation may split the
+    /// range internally (for example when a provider rejects an oversized query or times out), but
+    /// must return the complete set for the range with no events dropped. Callers may rely on this
+    /// completeness, so no separate upstream event-count cap is required.
     async fn events<'a>(
         &'a mut self,
         block_range: RangeInclusive<L1BlockNumber>,


### PR DESCRIPTION
## What
Make `EthereumBaseLayerContract::events()` adaptively bisect its block range when a `getLogs` query fails because the range is too large (or too slow) for the provider. `events()` delegates the raw log fetch to a new `get_logs_bisected` helper: on an oversized/timeout error it splits the range in half and retries each half, down to a single-block floor. The existing per-log header-fetch + `parse_event` step is unchanged and runs once on the concatenated logs.

## Why
Public RPC providers cap `getLogs` responses (e.g. "query returned more than 10000 results", response-size limits, block-range limits, HTTP 413) or time out on wide windows. Previously a wide window that tripped such a cap failed every poll with no way to make progress — the scraper would retry the same window forever. Adaptive bisection lets the same window succeed by fetching it in smaller pieces. This is the base-layer follow-up to the review on #14602 (getLogs range chunking): it addresses the "bisect the window before backing off" and "bound event volume" points, which belong at the base-layer boundary where the oversized/timeout error can actually be classified.

## Behavior
- **Returns all events, in order.** Bisection is iterative (explicit stack, no async recursion) and always fetches the low half before the high half, so concatenated logs stay in ascending block order — identical to today's single-call ordering. No events are dropped; the `CalldataValueOutOfRange`-skip semantics are unchanged.
- **Only bisects the oversized/timeout class.** Classification is a whitelist over the *typed* error (`ErrorPayload.message` substrings for the major providers, provider codes only when paired with a range/results message, and HTTP 413), plus provider timeouts. Auth / rate-limit / connection / decoding errors are propagated unchanged (they are the cyclic-wrapper's or the caller's concern, never bisected).
- **Single-block floor.** If a single-block range still fails with an oversized/timeout error, the error is propagated verbatim (never a truncated/partial result), so the scraper's existing retry and the cyclic wrapper's failover behave exactly as before.

## Tests
Offline (`Asserter`-mocked provider): error classification (whitelist vs excluded variants); bisection split structure and single-block-floor propagation; and `bisection_returns_all_logs_in_ascending_block_order` — real non-empty logs across the split boundary asserting all are returned in ascending block order (completeness + ordering, not just drain counts).

`papyrus_base_layer`: 43 tests pass, clippy clean. Trait signature unchanged, so the scraper and cyclic wrapper are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
