### PR TITLE
deployment: upgrade jsii to 1.138.0 in lockfiles

### DIFF
--- a/deployments/anvil/Pipfile.lock
+++ b/deployments/anvil/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/dummy_eth2strk_oracle/Pipfile.lock
+++ b/deployments/dummy_eth2strk_oracle/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/dummy_recorder/Pipfile.lock
+++ b/deployments/dummy_recorder/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/sequencer/Pipfile.lock
+++ b/deployments/sequencer/Pipfile.lock
@@ -167,11 +167,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "jsonschema": {
             "hashes": [

--- a/deployments/sequencer_simulator/Pipfile.lock
+++ b/deployments/sequencer_simulator/Pipfile.lock
@@ -60,11 +60,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [


### PR DESCRIPTION
## Problem

Every `system_test_hybrid` and `sequencer_cdk8s-test` run fails since 2026-07-02 ~14:20 UTC with:

```
ImportError: cannot import name 'cached_type_hints' from 'jsii._type_checking'
```

CI resolves the jsii codegen toolchain unpinned at run time (`npm install -g cdk8s-cli` — and even the pinned `cdk8s-cli@2.198.334` workflow pulls `jsii-pacmak`/`codemaker` through open semver ranges). `jsii-pacmak` 1.138.0, published 2026-07-02 13:42 UTC, generates bindings that import `cached_type_hints`, which only exists in the jsii **1.138.0** Python runtime — while all deployment `Pipfile.lock`s pin jsii **1.134.0**. Last green run 11:54Z, first red 14:21Z; no code change involved. Same failure class as #14386.

## Fix

Bump the locked jsii to 1.138.0 (version + PyPI sha256 hashes; `requires_python` marker unchanged) in all five deployment lockfiles: `dummy_recorder`, `dummy_eth2strk_oracle`, `sequencer_simulator`, `anvil`, `sequencer`.

## Validation

- `jsii==1.134.0` reproduces the exact ImportError locally; `1.138.0` imports fine.
- Full CI repro with the refreshed lock: fresh `pipenv sync` (hash-verified) + `npx cdk8s-cli@2.207.34 import && synth` in `deployments/dummy_recorder` — regenerates bindings with the new codegen and synthesizes the manifests successfully.

Note: this unblocks CI now, but the underlying exposure remains — codegen resolves unpinned at CI time, so the next incompatible jsii release will break again until the toolchain is pinned end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)