### PR TITLE
apollo_config: delete dead code (unsure, review carefully)

### DIFF
--- a/crates/apollo_config/src/secrets.rs
+++ b/crates/apollo_config/src/secrets.rs
@@ -12,7 +12,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize, Serializer};
-use url::Url;
 
 #[cfg(test)]
 #[path = "secrets_test.rs"]
@@ -126,14 +125,5 @@ impl<T> fmt::Display for Sensitive<T> {
 impl<T> Serialize for Sensitive<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_str(&self.redact())
-    }
-}
-
-impl Sensitive<Url> {
-    /// Appends a route to a sensitive url.
-    pub fn append_route(&mut self, suffix: &str) {
-        self.modify_in_place(|url: &mut Url| {
-            *url = url.join(suffix).expect("Failed to construct URL")
-        });
     }
 }


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

This PR removes the unused `Sensitive<Url>::append_route` method (and the now-orphaned `use url::Url;` import) from `apollo_config::secrets`.

**Why it appears dead**
- `append_route` has **zero references anywhere in the sequencer workspace** (a whole-word grep across `crates/` matches only its own definition), including tests and benches.
- It also has **zero references in either sibling repo** (`starkware-industries/sequencer-devops`, `starkware-industries/starkware`).
- It was introduced in #10527 ("apollo_config: add append_route method to sensitive url") but no caller was ever wired up.

**What a human must verify**
- `apollo_config` is `pub`, so this method is part of the crate's public surface. Confirm no consumer outside the three repos checked above depends on `Sensitive<Url>::append_route` (e.g. a private/downstream repo), and that it is not imminently needed by planned work.

**Scope notes**
- `modify_in_place` (called by `append_route`) is retained — it has other live callers in the crate.
- The `url` crate dependency is retained — `url::Url` is still used in `apollo_config::converters`.

**Verification** (env: `RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)
- `cargo build -p apollo_config` and `cargo build -p apollo_config --tests`: zero `dead_code`/`unused_*` warnings.
- `cargo clippy -p apollo_config --all-targets`: clean.
- `SEED=0 cargo test -p apollo_config`: passes.

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133RaU2RMuqhEbNVtqBCWyR)_