### PR TITLE
apollo_l1_events_types: delete dead code (unsure, review carefully)

### DIFF
--- a/crates/apollo_l1_events_types/src/errors.rs
+++ b/crates/apollo_l1_events_types/src/errors.rs
@@ -18,14 +18,6 @@ pub enum L1EventsProviderError {
     UnexpectedHeight { expected_height: BlockNumber, got: BlockNumber },
     #[error("Unexpected provider state: {expected}, got: {found}")]
     UnexpectedProviderState { expected: ProviderState, found: ProviderState },
-    #[error("Cannot transition from {from} to {to}")]
-    UnexpectedProviderStateTransition { from: String, to: String },
-}
-
-impl L1EventsProviderError {
-    pub fn unexpected_transition(from: impl ToString, to: impl ToString) -> Self {
-        Self::UnexpectedProviderStateTransition { from: from.to_string(), to: to.to_string() }
-    }
 }
 
 #[derive(Clone, Debug, Error)]


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

This PR removes the unused `L1EventsProviderError::UnexpectedProviderStateTransition` variant and its sole constructor `L1EventsProviderError::unexpected_transition`.

**Why it appears dead**
- `unexpected_transition` and `UnexpectedProviderStateTransition` each have **zero references anywhere in the sequencer workspace** (whole-word grep across `crates/` matches only their definitions), including tests and benches.
- Both have **zero references in either sibling repo** (`starkware-industries/sequencer-devops`, `starkware-industries/starkware`).
- The variant is constructed **exclusively** by `unexpected_transition`, so with that method removed the variant can never be produced.

**What a human must verify**
- `L1EventsProviderError` is a `pub` error enum. Confirm no consumer outside the three repos checked above matches on or constructs `UnexpectedProviderStateTransition`, and that this state-transition error is not scaffolding for imminent work.

The other variants (`Uninitialized`, `UnexpectedHeight`, `UnexpectedProviderState`) are retained and still used.

**Verification** (env: `RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)
- `cargo build -p apollo_l1_events_types` and `... --tests`: zero `dead_code`/`unused_*` warnings.
- `cargo clippy -p apollo_l1_events_types --all-targets`: clean.
- `SEED=0 cargo test -p apollo_l1_events_types`: passes.

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133RaU2RMuqhEbNVtqBCWyR)_