### PR TITLE
apollo_consensus_manager: delete dead code (unsure, review carefully)

### DIFF
--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -397,31 +397,6 @@ pub fn create_committee_provider(
     Arc::new(staking_manager)
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn create_consensus_manager(
-    config: ConsensusManagerConfig,
-    batcher_client: SharedBatcherClient,
-    state_sync_client: SharedStateSyncClient,
-    class_manager_client: SharedClassManagerClient,
-    proof_manager_client: SharedProofManagerClient,
-    signature_manager_client: SharedSignatureManagerClient,
-    config_manager_client: SharedConfigManagerClient,
-    l1_gas_price_provider: Arc<dyn L1GasPriceProviderClient>,
-    committee_provider: Arc<dyn CommitteeProvider>,
-) -> ConsensusManager {
-    ConsensusManager::new(ConsensusManagerArgs {
-        config,
-        batcher_client,
-        state_sync_client,
-        class_manager_client,
-        proof_manager_client,
-        signature_manager_client,
-        config_manager_client,
-        l1_gas_price_provider,
-        committee_provider,
-    })
-}
-
 #[async_trait]
 impl ComponentStarter for ConsensusManager {
     async fn start(&mut self) {


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

This PR removes the unused free function `create_consensus_manager` from `apollo_consensus_manager::consensus_manager`.

**Why it appears dead**
- `create_consensus_manager` has **zero references anywhere in the sequencer workspace** (a whole-word grep across `crates/` matches only its definition), including tests and benches.
- **Zero references in either sibling repo** (`starkware-industries/sequencer-devops`, `starkware-industries/starkware`).
- It is a thin convenience wrapper whose entire body is `ConsensusManager::new(ConsensusManagerArgs { .. })`. The node builds the manager directly via `ConsensusManager::new(ConsensusManagerArgs { .. })` in `apollo_node/src/components.rs`, so this wrapper is superseded and uncalled.

**What a human must verify**
- `create_consensus_manager` is `pub`. Confirm no consumer outside the three repos checked above calls it, and that it is not intended as the canonical construction entry point for planned work (the direct `ConsensusManager::new` call site suggests not).

**Scope notes**
- No imports are orphaned: every type in the removed signature (`ConsensusManagerArgs`, the `Shared*Client` aliases, `L1GasPriceProviderClient`, `CommitteeProvider`) still has other live uses in the file.
- `ConsensusManager::new` and the sibling `create_committee_provider` are retained (both live).

**Verification** (env: `RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)
- `cargo build -p apollo_consensus_manager` and `... --tests`: zero `dead_code`/`unused_*` warnings.
- `cargo clippy -p apollo_consensus_manager --all-targets`: clean.
- `SEED=0 cargo test -p apollo_consensus_manager`: passes (3 tests).

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133RaU2RMuqhEbNVtqBCWyR)_