### PR TITLE
bench_tools: delete dead code (unsure, review carefully)

### DIFF
--- a/crates/bench_tools/src/types/benchmark_config.rs
+++ b/crates/bench_tools/src/types/benchmark_config.rs
@@ -14,11 +14,6 @@ pub struct BenchmarkConfig {
 }
 
 impl BenchmarkConfig {
-    /// Get the full cargo bench command as owned strings.
-    pub fn cmd_args_owned(&self) -> Vec<String> {
-        self.cmd_args.iter().map(|s| s.to_string()).collect()
-    }
-
     /// Check if this benchmark requires input files.
     pub fn needs_inputs(&self) -> bool {
         self.input_dir.is_some()


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

This PR removes the unused method `BenchmarkConfig::cmd_args_owned` from `bench_tools`.

**Why it appears dead**
- `cmd_args_owned` has **zero references anywhere in the sequencer workspace** (a whole-word grep across `crates/` matches only its definition), including the crate's own `main.rs`, `runner.rs`, tests and benches.
- **Zero references in either sibling repo** (`starkware-industries/sequencer-devops`, `starkware-industries/starkware`).

**What a human must verify**
- The method is `pub`. Confirm no consumer outside the three repos checked above calls it (bench_tools is internal tooling, so external use is unlikely, but I cannot fully rule it out).

**Scope notes**
- The `cmd_args` field it read is retained — used directly elsewhere (`bench.cmd_args.join(..)` in `main.rs`, `.args(bench.cmd_args)` in `runner.rs`).
- The sibling method `needs_inputs` is retained (it has live callers).

**Verification** (env: `RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)
- `cargo build -p bench_tools` and `cargo build -p bench_tools --tests`: zero `dead_code`/`unused_*` warnings.
- `cargo clippy -p bench_tools --all-targets`: clean.
- `SEED=0 cargo test -p bench_tools`: passes.

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133RaU2RMuqhEbNVtqBCWyR)_