### PR TITLE
starknet_patricia_storage: delete dead code (unsure, review carefully)

### DIFF
--- a/crates/starknet_patricia_storage/src/map_storage.rs
+++ b/crates/starknet_patricia_storage/src/map_storage.rs
@@ -37,11 +37,6 @@ const DEFAULT_CACHE_SIZE: usize = 10000000;
 #[derive(Debug, Default, PartialEq, Serialize)]
 pub struct MapStorage(pub DbHashMap);
 
-#[derive(Serialize, Debug)]
-pub struct BorrowedStorage<'a, S: Storage> {
-    pub storage: &'a mut S,
-}
-
 impl ImmutableReadOnlyStorage for MapStorage {
     async fn get(&self, key: &DbKey) -> PatriciaStorageResult<Option<DbValue>> {
         Ok(self.0.get(key).cloned())


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

This PR removes the unused struct `BorrowedStorage<'a, S: Storage>` from `starknet_patricia_storage::map_storage`.

**Why it appears dead**
- `BorrowedStorage` has **zero references anywhere in the sequencer workspace** (a whole-word grep across `crates/` matches only its definition), including tests and benches. It has **no `impl` blocks** and is **never constructed**.
- **Zero references in either sibling repo** (`starkware-industries/sequencer-devops`, `starkware-industries/starkware`).
- It is a `#[derive(Serialize)]` wrapper around `&mut S: Storage` that was never wired up (contrast `MapStorage`, the used type in the same module).

**What a human must verify**
- The struct is `pub`. Confirm no consumer outside the three repos checked above uses it, and that it is not scaffolding for a planned "serialize a borrowed storage" path.

**Scope notes**
- No imports are orphaned: `Storage` and `Serialize` remain used by other items in the module (`MapStorage` and the storage-trait impls).

**Verification** (env: `RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)
- `cargo build -p starknet_patricia_storage` and `cargo build -p starknet_patricia_storage --tests`: zero `dead_code`/`unused_*` warnings.
- `cargo clippy -p starknet_patricia_storage --all-targets`: clean.
- `SEED=0 cargo test -p starknet_patricia_storage`: passes (8 tests).

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133RaU2RMuqhEbNVtqBCWyR)_