### PR TITLE
apollo_staking: binary search for weighted proposer selection

### DIFF
--- a/crates/apollo_staking/src/staking_manager.rs
+++ b/crates/apollo_staking/src/staking_manager.rs
@@ -96,7 +96,11 @@ impl Epoch {
 
     fn within_next_epoch_min_bounds(&self, height: BlockNumber) -> bool {
         let next_epoch_start_block = BlockNumber(self.start_block.0 + self.epoch_length);
-        range_contains(height, next_epoch_start_block, MIN_EPOCH_LENGTH)
+        // Only heights guaranteed to fall within the next epoch may resolve to `epoch_id + 1`.
+        // The next epoch's length is unknown until it starts, so bound the window by the
+        // smallest known lower bound on epoch length.
+        let next_epoch_min_length = MIN_EPOCH_LENGTH.min(self.epoch_length);
+        range_contains(height, next_epoch_start_block, next_epoch_min_length)
     }
 }
 

--- a/crates/apollo_staking/src/staking_manager.rs
+++ b/crates/apollo_staking/src/staking_manager.rs
@@ -570,26 +570,24 @@ impl Committee {
             "Invalid random value {random}: exceeds total weight limit of {total_weight}."
         );
 
-        // Iterates over stakers and selects staker `i` if `random < cumulative_weights[i]`.
-        // Each staker occupies a range of values proportional to their weight, defined as:
-        //     [cumulative_weights[i - 1], cumulative_weights[i])
-        // Since we iterate in order, the first staker whose cumulative weight exceeds `random`
-        // is the one whose range contains it.
-        for (i, cum_weight) in self.cumulative_weights.iter().enumerate() {
-            if random < *cum_weight {
-                return self
-                    .committee_members
-                    .get(i)
-                    .expect(
-                        "Inconsistent committee data; cumulative_weights and committee_members \
-                         are not the same length.",
-                    )
-                    .address;
-            }
-        }
+        // Selects staker `proposer_index`, the first index with `random <
+        // cumulative_weights[proposer_index]`. Each staker occupies a range of values
+        // proportional to their weight: staker `i`'s range is
+        // `[cumulative_weights[i - 1], cumulative_weights[i])`.
+        // `cumulative_weights` is sorted ascending (all staker weights are positive), so binary
+        // search via `partition_point` finds this index in O(log n) instead of a linear scan.
+        let proposer_index =
+            self.cumulative_weights.partition_point(|cum_weight| *cum_weight <= random);
 
-        // We should never reach this point.
-        panic!("Inconsistent committee data; cumulative_weights inconsistent with total weight.")
+        self.committee_members
+            .get(proposer_index)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Inconsistent committee data: no committee member at index {proposer_index}, \
+                     random value {random}, total weight {total_weight}."
+                )
+            })
+            .address
     }
 }
 

--- a/crates/apollo_staking/src/staking_manager_test.rs
+++ b/crates/apollo_staking/src/staking_manager_test.rs
@@ -73,10 +73,24 @@ const EPOCH_1: Epoch = Epoch { epoch_id: 1, start_block: BlockNumber(1), epoch_l
 const EPOCH_2: Epoch = Epoch { epoch_id: 2, start_block: BlockNumber(1001), epoch_length: 1000 };
 const EPOCH_3: Epoch = Epoch { epoch_id: 3, start_block: BlockNumber(2001), epoch_length: 1000 };
 
+// Epochs shorter than MIN_EPOCH_LENGTH, matching the config-backed mock contract's epochs.
+const SHORT_EPOCH_LENGTH: u64 = 30;
+const SHORT_EPOCH_4: Epoch =
+    Epoch { epoch_id: 4, start_block: BlockNumber(120), epoch_length: SHORT_EPOCH_LENGTH };
+const SHORT_EPOCH_5: Epoch =
+    Epoch { epoch_id: 5, start_block: BlockNumber(150), epoch_length: SHORT_EPOCH_LENGTH };
+const SHORT_EPOCH_6: Epoch =
+    Epoch { epoch_id: 6, start_block: BlockNumber(180), epoch_length: SHORT_EPOCH_LENGTH };
+const SHORT_EPOCH_7: Epoch =
+    Epoch { epoch_id: 7, start_block: BlockNumber(210), epoch_length: SHORT_EPOCH_LENGTH };
+
 const E1_H1: BlockNumber = EPOCH_1.start_block;
 const E1_H2: BlockNumber = BlockNumber(EPOCH_1.start_block.0 + EPOCH_1.epoch_length - 1);
 const E2_H1: BlockNumber = EPOCH_2.start_block;
-const E2_H2: BlockNumber = BlockNumber(EPOCH_2.start_block.0 + MIN_EPOCH_LENGTH + 1);
+// The last height within the next epoch's min bounds, and the first height past them.
+const E2_H_LAST_WITHIN_MIN_BOUNDS: BlockNumber =
+    BlockNumber(EPOCH_2.start_block.0 + MIN_EPOCH_LENGTH - 1);
+const E2_H2: BlockNumber = BlockNumber(EPOCH_2.start_block.0 + MIN_EPOCH_LENGTH);
 const E3_H1: BlockNumber = EPOCH_3.start_block;
 
 fn test_config_with_committee_size(committee_size: usize) -> StakingManagerDynamicConfig {
@@ -362,7 +376,10 @@ async fn get_committee_for_next_epoch(
     let committee = committee_manager.get_committee(E2_H1).await.unwrap().members().clone();
     assert_eq!(committee.into_iter().collect::<HashSet<_>>(), HashSet::from([STAKER_1, STAKER_2]));
 
-    // 2. Invalid Query: E2_H2 exceeds the min bounds of the next epoch.
+    // 2. Valid Query: the last height within the next epoch's min bounds.
+    assert!(committee_manager.get_committee(E2_H_LAST_WITHIN_MIN_BOUNDS).await.is_ok());
+
+    // 3. Invalid Query: E2_H2 exceeds the min bounds of the next epoch.
     // Since the next epoch's length is not known at this point, we cannot know if this height
     // belongs to Epoch 2 or a future Epoch > 2.
     let err = committee_manager.get_committee(E2_H2).await.err().unwrap();
@@ -935,4 +952,62 @@ async fn get_actual_proposer_invalid_height(
 
     let err = committee_manager.get_committee(E2_H2).await.err().unwrap();
     assert_matches!(err, CommitteeProviderError::InvalidHeight { .. });
+}
+
+#[rstest]
+#[tokio::test]
+async fn get_committee_short_epochs_override_activates_at_start_epoch(
+    default_config: StakingManagerConfig,
+    mut contract: MockStakingContract,
+) {
+    // Regression test: with epochs shorter than MIN_EPOCH_LENGTH, a node whose epoch cache
+    // was synced a few epochs before an override's start_epoch must still apply the override
+    // exactly from the override's first height, rather than serving the default committee
+    // under a stale epoch ID.
+    set_current_epoch(&mut contract, SHORT_EPOCH_5);
+    set_current_epoch(&mut contract, SHORT_EPOCH_6);
+    set_previous_epoch(&mut contract, Some(SHORT_EPOCH_4));
+    set_stakers(&mut contract, SHORT_EPOCH_6, vec![STAKER_1, STAKER_2, STAKER_3]);
+    set_stakers(&mut contract, SHORT_EPOCH_7, vec![STAKER_1, STAKER_2, STAKER_3]);
+
+    let default_committee = CommitteeConfig {
+        start_epoch: 0,
+        committee_size: 3,
+        stakers: vec![
+            create_configured_staker(&STAKER_1, true),
+            create_configured_staker(&STAKER_2, true),
+            create_configured_staker(&STAKER_3, true),
+        ],
+    };
+    // Shrink the committee to 2 members starting at epoch 7.
+    let override_committee = Some(CommitteeConfig {
+        start_epoch: SHORT_EPOCH_7.epoch_id,
+        committee_size: 2,
+        stakers: vec![
+            create_configured_staker(&STAKER_2, true),
+            create_configured_staker(&STAKER_3, true),
+        ],
+    });
+
+    let committee_manager = StakingManager::new(
+        Arc::new(contract),
+        Arc::new(create_batcher_client_with_block_hash()),
+        Arc::new(create_state_sync_client_with_block_hash()),
+        Arc::new(make_generator_factory(0)),
+        StakingManagerConfig {
+            dynamic_config: StakingManagerDynamicConfig { default_committee, override_committee },
+            ..default_config
+        },
+        None,
+    );
+
+    // The last height of epoch 6 primes the epoch cache at epoch 5 and still gets the
+    // default committee.
+    let last_height_before_override = BlockNumber(SHORT_EPOCH_7.start_block.0 - 1);
+    let committee = committee_manager.get_committee(last_height_before_override).await.unwrap();
+    assert_eq!(*committee.members(), vec![STAKER_3, STAKER_2, STAKER_1]);
+
+    // The first height of epoch 7 must already get the override committee.
+    let committee = committee_manager.get_committee(SHORT_EPOCH_7.start_block).await.unwrap();
+    assert_eq!(*committee.members(), vec![STAKER_3, STAKER_2]);
 }


### PR DESCRIPTION
## Context

Follow-up performance review after #14689 (`apollo_staking: bound next-epoch resolution window by the epoch length`) was merged, which touched `crates/apollo_staking/src/staking_manager.rs`.

## Problem

`Committee::choose_proposer` linearly scans `cumulative_weights: Vec<u128>` to find the staker whose weight range contains the generated random value. This runs on `get_proposer`, called on every consensus round (a per-block hot path), with an O(n) scan over the committee (typically ~100 members, configurable via `committee_size`).

## Fix

`cumulative_weights` is strictly increasing — `validate_stakers` filters out all zero-weight stakers before a `Committee` is built, so no two cumulative sums can tie. This makes the array binary-searchable: replaced the linear scan with `slice::partition_point`, turning the lookup into O(log n).

Panic/error behavior on inconsistent internal data is preserved (now via `unwrap_or_else` instead of a fallthrough `panic!`), and the guarantee that `random < total_weight` (enforced by the existing `assert!`) ensures `partition_point` always resolves to a valid index for valid input.

## Testing

- `cargo build -p apollo_staking` — succeeds.
- `SEED=0 cargo test -p apollo_staking --lib staking_manager` — 55 passed, 0 failed (including `get_proposer_success` weighted-selection cases and the `get_proposer_random_value_exceeds_total_weight` panic case).
- `cargo clippy -p apollo_staking --all-targets` — clean.
- Reviewed by an independent Opus pass for correctness (binary search result equivalence to the original scan across edge cases) and style; one style nit (single-letter variable) was addressed.

Note: the crate's `cairo_staking_contract` tests fail both with and without this change in this sandbox (pre-existing/environment issue unrelated to this diff, verified via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01177vEtzcpVYnXi7FPu4hHd)_