### PR TITLE
apollo_staking,apollo_consensus_manager: read mock epoch height from batcher first

### DIFF
--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -382,6 +382,7 @@ pub fn create_committee_provider(
     let staking_manager_config = config.staking_manager_config.clone();
     // TODO(Asmaa/Dafna): Create StakingContract according to config.
     let mock_staking_contract = Arc::new(MockStakingContract::new(
+        batcher_client.clone(),
         state_sync_client.clone(),
         staking_manager_config.dynamic_config.clone(),
     ));

--- a/crates/apollo_staking/src/mock_staking_contract.rs
+++ b/crates/apollo_staking/src/mock_staking_contract.rs
@@ -1,3 +1,4 @@
+use apollo_batcher_types::communication::SharedBatcherClient;
 use apollo_staking_config::config::{
     get_config_for_epoch,
     ConfiguredStaker,
@@ -6,6 +7,7 @@ use apollo_staking_config::config::{
 use apollo_state_sync_types::communication::SharedStateSyncClient;
 use async_trait::async_trait;
 use starknet_api::block::BlockNumber;
+use tracing::warn;
 
 use crate::committee_provider::Staker;
 use crate::staking_contract::{StakingContract, StakingContractResult};
@@ -27,6 +29,7 @@ impl From<&ConfiguredStaker> for Staker {
 
 /// Mock implementation of the staking contract backed by static in-memory configuration.
 pub struct MockStakingContract {
+    batcher_client: SharedBatcherClient,
     state_sync_client: SharedStateSyncClient,
     // Default configuration used when no other configuration is provided.
     default_config: StakingManagerDynamicConfig,
@@ -37,10 +40,31 @@ impl MockStakingContract {
     pub const EPOCH_LENGTH: u64 = 30;
 
     pub fn new(
+        batcher_client: SharedBatcherClient,
         state_sync_client: SharedStateSyncClient,
         default_config: StakingManagerDynamicConfig,
     ) -> Self {
-        Self { state_sync_client, default_config }
+        Self { batcher_client, state_sync_client, default_config }
+    }
+
+    // Returns the latest committed block number, preferring the batcher and falling back to state
+    // sync on batcher error. The batcher's height marker tracks the commit tip, whereas state sync
+    // is a downstream reader that can lag it significantly; deriving the epoch from a lagging
+    // source can push the consensus height beyond the resolvable committee window and stall block
+    // production. `get_height` returns the next-to-build marker, so the latest committed block is
+    // one below it.
+    async fn latest_committed_block(&self) -> StakingContractResult<BlockNumber> {
+        match self.batcher_client.get_height().await {
+            Ok(response) => Ok(BlockNumber(response.height.0.saturating_sub(1))),
+            Err(batcher_error) => {
+                warn!("Batcher get_height failed, falling back to state sync: {batcher_error}");
+                Ok(self
+                    .state_sync_client
+                    .get_latest_block_number()
+                    .await?
+                    .unwrap_or(BlockNumber(0)))
+            }
+        }
     }
 }
 
@@ -61,8 +85,7 @@ impl StakingContract for MockStakingContract {
     }
 
     async fn get_current_epoch(&self) -> StakingContractResult<Epoch> {
-        let latest_block_number =
-            self.state_sync_client.get_latest_block_number().await?.unwrap_or(BlockNumber(0));
+        let latest_block_number = self.latest_committed_block().await?;
 
         let epoch_id = latest_block_number.0 / Self::EPOCH_LENGTH;
         let start_block = BlockNumber(epoch_id * Self::EPOCH_LENGTH);

--- a/crates/apollo_staking/src/mock_staking_contract_test.rs
+++ b/crates/apollo_staking/src/mock_staking_contract_test.rs
@@ -1,5 +1,12 @@
 use std::sync::Arc;
 
+use apollo_batcher_types::batcher_types::GetHeightResponse;
+use apollo_batcher_types::communication::{
+    BatcherClientError,
+    MockBatcherClient,
+    SharedBatcherClient,
+};
+use apollo_batcher_types::errors::BatcherError;
 use apollo_staking_config::config::{
     CommitteeConfig,
     ConfiguredStaker,
@@ -78,6 +85,31 @@ fn mock_client_with_latest(block: Option<BlockNumber>) -> SharedStateSyncClient 
     Arc::new(mock)
 }
 
+// A no-op batcher client for tests that never query the current height.
+fn no_batcher() -> SharedBatcherClient {
+    Arc::new(MockBatcherClient::new())
+}
+
+// A batcher whose next-to-build height marker is `marker`; the latest committed block is one below.
+fn mock_batcher_with_marker(marker: BlockNumber) -> SharedBatcherClient {
+    let mut mock = MockBatcherClient::new();
+    mock.expect_get_height().returning(move || Ok(GetHeightResponse { height: marker }));
+    Arc::new(mock)
+}
+
+// A batcher reporting `committed` as its latest committed block (marker = committed + 1).
+fn mock_batcher_with_committed(committed: BlockNumber) -> SharedBatcherClient {
+    mock_batcher_with_marker(BlockNumber(committed.0 + 1))
+}
+
+// A batcher whose height query always fails, forcing the state-sync fallback.
+fn mock_batcher_erroring() -> SharedBatcherClient {
+    let mut mock = MockBatcherClient::new();
+    mock.expect_get_height()
+        .returning(|| Err(BatcherClientError::BatcherError(BatcherError::InternalError)));
+    Arc::new(mock)
+}
+
 #[rstest]
 #[tokio::test]
 async fn get_stakers_with_config_picks_latest_config_for_epoch(
@@ -93,7 +125,8 @@ async fn get_stakers_with_config_picks_latest_config_for_epoch(
         ..default_config
     };
 
-    let contract = MockStakingContract::new(mock_state_sync_client, input_config.clone());
+    let contract =
+        MockStakingContract::new(no_batcher(), mock_state_sync_client, input_config.clone());
 
     // Epoch 1 < 3, so should use default (STAKER_1 only).
     let stakers = contract.get_stakers_with_config(1, &input_config).await.unwrap();
@@ -110,7 +143,7 @@ async fn get_stakers_uses_internal_default_config(
     mock_state_sync_client: SharedStateSyncClient,
     default_config: StakingManagerDynamicConfig,
 ) {
-    let contract = MockStakingContract::new(mock_state_sync_client, default_config);
+    let contract = MockStakingContract::new(no_batcher(), mock_state_sync_client, default_config);
 
     // get_stakers() should use the internal default_config.
     let stakers = contract.get_stakers(0).await.unwrap();
@@ -129,8 +162,11 @@ async fn get_current_epoch_success(
     #[case] expected_epoch: Epoch,
     default_config: StakingManagerDynamicConfig,
 ) {
-    let contract =
-        MockStakingContract::new(mock_client_with_latest(Some(block_number)), default_config);
+    let contract = MockStakingContract::new(
+        mock_batcher_with_committed(block_number),
+        Arc::new(MockStateSyncClient::new()),
+        default_config,
+    );
 
     let epoch = contract.get_current_epoch().await.unwrap();
     assert_eq!(epoch, expected_epoch);
@@ -141,7 +177,11 @@ async fn get_current_epoch_success(
 async fn get_current_epoch_defaults_to_epoch_zero_when_no_blocks(
     default_config: StakingManagerDynamicConfig,
 ) {
-    let contract = MockStakingContract::new(mock_client_with_latest(None), default_config);
+    let contract = MockStakingContract::new(
+        mock_batcher_with_marker(BlockNumber(0)),
+        Arc::new(MockStateSyncClient::new()),
+        default_config,
+    );
 
     let epoch = contract.get_current_epoch().await.unwrap();
     assert_eq!(epoch, EPOCH_0);
@@ -158,8 +198,11 @@ async fn get_previous_epoch_success(
     #[case] expected_previous_epoch: Option<Epoch>,
     default_config: StakingManagerDynamicConfig,
 ) {
-    let contract =
-        MockStakingContract::new(mock_client_with_latest(Some(block_number)), default_config);
+    let contract = MockStakingContract::new(
+        mock_batcher_with_committed(block_number),
+        Arc::new(MockStateSyncClient::new()),
+        default_config,
+    );
 
     let previous_epoch = contract.get_previous_epoch().await.unwrap();
     assert_eq!(previous_epoch, expected_previous_epoch);
@@ -170,8 +213,47 @@ async fn get_previous_epoch_success(
 async fn get_previous_epoch_returns_none_when_no_blocks(
     default_config: StakingManagerDynamicConfig,
 ) {
-    let contract = MockStakingContract::new(mock_client_with_latest(None), default_config);
+    let contract = MockStakingContract::new(
+        mock_batcher_with_marker(BlockNumber(0)),
+        Arc::new(MockStateSyncClient::new()),
+        default_config,
+    );
 
     let previous_epoch = contract.get_previous_epoch().await.unwrap();
     assert_eq!(previous_epoch, None);
+}
+
+// The batcher's `get_height` returns the next-to-build marker, so the latest committed block is
+// one below it. A marker at an epoch boundary must resolve to the previous epoch, not the next.
+#[rstest]
+#[tokio::test]
+async fn get_current_epoch_uses_committed_tip_not_marker(
+    default_config: StakingManagerDynamicConfig,
+) {
+    // Marker == EPOCH_LENGTH means the latest committed block is EPOCH_LENGTH - 1, still in epoch
+    // 0.
+    let contract = MockStakingContract::new(
+        mock_batcher_with_marker(BlockNumber(EPOCH_LENGTH)),
+        Arc::new(MockStateSyncClient::new()),
+        default_config,
+    );
+
+    let epoch = contract.get_current_epoch().await.unwrap();
+    assert_eq!(epoch, EPOCH_0);
+}
+
+// When the batcher height query fails, the epoch is derived from the state-sync latest block.
+#[rstest]
+#[tokio::test]
+async fn get_current_epoch_falls_back_to_state_sync_on_batcher_error(
+    default_config: StakingManagerDynamicConfig,
+) {
+    let contract = MockStakingContract::new(
+        mock_batcher_erroring(),
+        mock_client_with_latest(Some(E2_H1)),
+        default_config,
+    );
+
+    let epoch = contract.get_current_epoch().await.unwrap();
+    assert_eq!(epoch, EPOCH_2);
 }

--- a/crates/apollo_staking/src/staking_manager.rs
+++ b/crates/apollo_staking/src/staking_manager.rs
@@ -47,9 +47,10 @@ mod staking_manager_test;
 // The minimum number of blocks in an epoch. This is used to anticipate if a
 // height falls within the next epoch, even when the exact epoch length is unknown.
 //
-// CONSTRAINT: Must be ≥ `STORED_BLOCK_HASH_BUFFER` - the maximum StateSync lag.
-// A smaller value could cause the consensus tip to advance beyond our knowledge of the next epoch,
-// resulting in a failure to retrieve the committee.
+// CONSTRAINT: Must be ≥ `STORED_BLOCK_HASH_BUFFER` - the maximum lag between the consensus tip and
+// the height source used to resolve the current epoch (the batcher's committed height, falling
+// back to StateSync). A smaller value could cause the consensus tip to advance beyond our
+// knowledge of the next epoch, resulting in a failure to retrieve the committee.
 const MIN_EPOCH_LENGTH: u64 = 5 * 60 / 2; // Roughly 5 minutes in 2 seconds blocks.
 const_assert!(MIN_EPOCH_LENGTH >= STORED_BLOCK_HASH_BUFFER);
 


### PR DESCRIPTION
## Problem

The mock staking contract (`MockStakingContract`, currently the wired committee/epoch source in production) derives the current epoch from the chain's latest block number, which it read **solely from state sync**:

```rust
let latest_block_number = self.state_sync_client.get_latest_block_number().await?...;
let epoch_id = latest_block_number.0 / EPOCH_LENGTH;
```

State sync is a *downstream reader* of committed state and can lag the commit tip significantly. Committee resolution can only look ahead `MIN_EPOCH_LENGTH` (150) blocks past the epoch boundary implied by that height (see `EpochCache::try_resolve_epoch_id`). So when state sync lags the consensus height by ~150 blocks, the height consensus needs a committee for falls outside the resolvable window:

- `epoch_at_height` → `CommitteeProviderError::InvalidHeight`
- `get_committee` → `ConsensusError::CommitteeError`
- consensus `run_height` falls back to `wait_until_sync_reaches_height` — i.e. **stops producing blocks** until sync catches up.

This can be self-reinforcing: if enough proposers/validators stall, sync can't advance, so the committee never resolves.

## Fix

Read the current height from the **batcher first** (its storage marker `state_diff_height` tracks the commit tip and lags far less), falling back to state sync on error — mirroring the existing `get_block_hash_with_fallback` policy in `StakingManager`.

- `get_height` returns the *next-to-build* marker (`get_state_marker` = "the first block number that doesn't exist yet"), so the latest committed block is `marker - 1` (saturating).
- Epoch math is unchanged; only the height *source* moves closer to the tip, shrinking the input lag so the ±150 window is far less likely to be exceeded.
- Aligns the mock with `CairoStakingContract`, which already reads epoch data via the batcher.

Scope note: this does not touch `MIN_EPOCH_LENGTH` or the resolution window — a deeper fix is moot once `CairoStakingContract` replaces the mock.

## Tests

- Repointed the epoch-derivation tests to drive the batcher as the primary source (state-sync mocks now have no expectations, so any accidental state-sync read would panic).
- Added `get_current_epoch_uses_committed_tip_not_marker` (off-by-one: marker at an epoch boundary resolves to the previous epoch).
- Added `get_current_epoch_falls_back_to_state_sync_on_batcher_error`.

Verified: `cargo build`, `SEED=0 cargo test -p apollo_staking` (97 pass), `rust_fmt.sh`, `cargo clippy -p apollo_staking -p apollo_consensus_manager --all-targets` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)