### PR TITLE
apollo_dashboard: add strk_to_usd oracle success and error alerts

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -2147,6 +2147,58 @@
       "severity": "p2"
     },
     {
+      "name": "strk_to_usd_error_count",
+      "title": "Strk to Usd error count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(sum(increase(snip35_strk_usd_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              10.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "1m",
+      "severity": "p5"
+    },
+    {
+      "name": "strk_to_usd_success_count",
+      "title": "Strk to Usd success count",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(sum(increase(snip35_strk_usd_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "$$$strk_to_usd_success_count-severity$$$"
+    },
+    {
       "name": "sync_storage_open_read_transactions",
       "title": "sync - High number of open read transactions",
       "ruleGroup": "evaluation_rate_default",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -74,6 +74,8 @@ use crate::alert_scenarios::l1_gas_prices::{
     get_eth_to_strk_success_count_alert,
     get_l1_gas_price_provider_insufficient_history_alert,
     get_l1_gas_price_scraper_success_count_alert,
+    get_strk_to_usd_error_count_alert,
+    get_strk_to_usd_success_count_alert,
 };
 use crate::alert_scenarios::l1_handlers::{
     get_l1_handler_transaction_waiting_in_l1_alert,
@@ -605,6 +607,7 @@ pub fn get_apollo_alerts() -> Alerts {
         get_consensus_round_above_zero(),
         get_consensus_votes_num_sent_messages_alert(),
         get_eth_to_strk_error_count_alert(),
+        get_strk_to_usd_error_count_alert(),
         get_gateway_add_tx_idle(),
         get_gateway_proof_archive_write_failure(),
         get_general_pod_state_not_ready(),
@@ -636,6 +639,7 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_consensus_round_above_zero_multiple_times());
     alerts.push(get_consensus_round_high());
     alerts.push(get_eth_to_strk_success_count_alert());
+    alerts.push(get_strk_to_usd_success_count_alert());
     alerts.append(&mut get_general_pod_memory_utilization_vec());
     alerts.append(&mut get_general_pod_disk_utilization_vec());
     alerts.push(get_http_server_avg_add_tx_latency_alert());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -3,6 +3,8 @@ use apollo_l1_gas_price::metrics::{
     ETH_TO_STRK_SUCCESS_COUNT,
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT,
+    SNIP35_STRK_USD_ERROR_COUNT,
+    SNIP35_STRK_USD_SUCCESS_COUNT,
 };
 use apollo_metrics::metrics::MetricQueryName;
 
@@ -34,6 +36,25 @@ pub(crate) fn get_eth_to_strk_error_count_alert() -> Alert {
         "eth_to_strk_error_count",
         "Eth to Strk error count",
         &ETH_TO_STRK_ERROR_COUNT,
+        AlertSeverity::Informational,
+    )
+}
+
+pub(crate) fn get_strk_to_usd_success_count_alert() -> Alert {
+    const ALERT_NAME: &str = "strk_to_usd_success_count";
+    oracle_success_count_alert(
+        ALERT_NAME,
+        "Strk to Usd success count",
+        &SNIP35_STRK_USD_SUCCESS_COUNT,
+        SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+    )
+}
+
+pub(crate) fn get_strk_to_usd_error_count_alert() -> Alert {
+    oracle_error_count_alert(
+        "strk_to_usd_error_count",
+        "Strk to Usd error count",
+        &SNIP35_STRK_USD_ERROR_COUNT,
         AlertSeverity::Informational,
     )
 }


### PR DESCRIPTION
## What
Add alert coverage for the `strk_to_usd` (SNIP-35 / Pragma STRK→USD) oracle, mirroring `eth_to_strk`:
- `snip35_strk_usd_success_count` — fires when the oracle has **no successful query in 1h** (per-env placeholder severity).
- `snip35_strk_usd_error_count` — fires on **>10 errors / 1h** (concrete `p5`).

Both are built via the shared helpers from the previous PR and registered in `get_apollo_alerts()`.

## Why
The `strk_to_usd` oracle had **no alerts**, while `eth_to_strk` has two. On Testnet the `strk_to_usd` query is currently failing **100%** (Pragma returns `404 Missing data for routing on pair: STRK/USD`), and that total outage was completely silent. This brings `strk_to_usd` to parity with `eth_to_strk`.

## Notes
- Regenerated `dev_grafana_alerts.json` gains exactly these two alerts; `eth_to_strk` output is unchanged.
- Alert names follow the oracle-pair convention (`strk_to_usd_*`, like `eth_to_strk_*`); the exprs query the `snip35_strk_usd_*` metrics.
- `strk_to_usd_success_count` uses a **per-env placeholder** severity (`$$$strk_to_usd_success_count-severity$$$`). Each deploying env's alert-override config — managed in the monitoring/infra side, **outside this repo** — must define `strk_to_usd_success_count-severity` before these alerts deploy, or `alert_builder.py` aborts (bidirectional placeholder validation). Suggested: **Testnet = paging**, **Mainnet = `p5`/silent** (strk_to_usd isn't deployed there yet, so the success-floor would otherwise sit on no-data), **other envs = `p5`**. `strk_to_usd_error_count` uses a concrete `p5` and needs no override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
