### PR TITLE
apollo_dashboard: fall back to vector(1) so no-data doesn't fire consensus_block_number_stuck

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -382,7 +382,7 @@
       "name": "consensus_block_number_stuck",
       "title": "Consensus Block Number Stuck",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -408,7 +408,7 @@
       "name": "consensus_block_number_stuck_long_time",
       "title": "Consensus Block Number Stuck Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
@@ -30,8 +30,13 @@ fn get_consensus_block_number_stuck(
     alert_severity: impl Into<SeverityValueOrPlaceholder>,
 ) -> Alert {
     let name = title.to_lowercase().replace(' ', "_");
+    // Fall back to `vector(1)`, not `vector(0)`, when the metric has no samples: an absent/late
+    // series (e.g. transient query-time gaps for a remote-region node) must not read as a halt.
+    // A real halt keeps the gauge present, so `increase` yields a present `0` and still fires;
+    // a dead pod is caught by the `pod_state_not_ready` / `pod_state_crashloopbackoff` alerts.
+    // The fallback must stay `>=` the stuck threshold (`< 1`).
     let expr_template_string = format!(
-        "sum(increase({}[{{}}s])) or vector(0)",
+        "sum(increase({}[{{}}s])) or vector(1)",
         CONSENSUS_BLOCK_NUMBER.get_name_with_filter()
     );
     Alert::new(


### PR DESCRIPTION
## What
Change the `consensus_block_number_stuck` no-data fallback `or vector(0)` → `or vector(1)` (both the `stuck` and `stuck_long_time` variants) in `get_consensus_block_number_stuck`.

## Why
On 2026-07-06 this alert paged **p1** and flapped on `apollo-mainnet-0` while the node was fully healthy (`up`=1, ~24 blocks/min, 0 restarts, committing throughout). Grafana state history showed `A=0.000000` at each fire and `A≈47` when healthy — including a ~9-min continuous Alerting stretch on a healthy chain.

Root cause: the rule is `(sum(increase(consensus_block_number[120s])) or vector(0)) and on() (is_observer==0) < 1`. At Grafana's real-time evaluation, `increase([120s])` intermittently returned an **empty** result — it needs ≥2 fresh samples in the trailing 120s, and node-0 is the lone **us-west1** node (nodes 1–5 are us-east1), so its freshest samples are occasionally not yet queryable via the central Grafana/GMP query path (the *stored* series is complete, which is why the raw metric never "drops"). `or vector(0)` converts that empty into a hard `0`, so `0 < 1` → false page. The pattern is chronic and fleet-wide (testnet flaps identically).

## Fix
Use `or vector(1)`. PromQL `or` is a set operator on series *presence* (not boolean on values), so:

| Case | `or vector(0)` (before) | `or vector(1)` (after) | fires (`< 1`)? |
|---|---|---|---|
| Healthy chain | 48 | 48 | no → no |
| Real halt (present `0`) | 0 | 0 | **yes → yes** (unchanged, no added latency) |
| Absent series (query no-data) | 0 | 1 | **yes (false) → no** (the fix) |

A real halt keeps the gauge present, so `increase` yields a present `0` and still fires immediately. A genuinely dead pod remains covered by the `pod_state_not_ready` / `pod_state_crashloopbackoff` alerts.

## Verification
- `cargo build -p apollo_dashboard`; `cargo run --bin sequencer_dashboard_generator -q` (regenerated `dev_grafana_alerts.json`); `SEED=0 cargo test -p apollo_dashboard` (16 pass, incl. the `dashboard_definitions` fixture check); rustfmt clean.
- Live check against GMP: healthy `… or vector(1)` = 48 (no fire); forced present-0 `(…*0) or vector(1)` = 0 (fires); absent `… or vector(1)` = 1 (no fire).
- Diff is exactly the two `consensus_block_number_stuck*` exprs; no other alert changed; no new placeholders.

## Follow-up (not in this PR)
The same `or vector(0)` + `LessThan` pattern exists in 7 other alerts (incl. p1 `mempool_add_tx_idle_p2p_rpc`, p2 `gateway_add_tx_idle_p2p_rpc`, same-metric `consensus_block_number_progress_is_slow`, and the `consensus_decisions_reached_by_consensus_ratio` ratio), left for a separate change. The 22 `GreaterThan` `or vector(0)` alerts are correct as-is.

## Note
Monitoring-config only — no sequencer runtime code. Takes effect after the alert config is redeployed (deployment pipeline → grafana-operator → `grafana10`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
