### PR TITLE
apollo_dashboard: alert on frozen exchange-rate oracle (eth_to_strk, strk_to_usd)

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -899,6 +899,32 @@
       "severity": "p5"
     },
     {
+      "name": "eth_to_strk_rate_frozen",
+      "title": "Eth to Strk rate frozen",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(changes(eth_to_strk_rate{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "$$$eth_to_strk_rate_frozen-severity$$$"
+    },
+    {
       "name": "eth_to_strk_success_count",
       "title": "Eth to Strk success count",
       "ruleGroup": "evaluation_rate_default",
@@ -2171,6 +2197,32 @@
       ],
       "for": "1m",
       "severity": "p5"
+    },
+    {
+      "name": "strk_to_usd_rate_frozen",
+      "title": "Strk to Usd rate frozen",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(changes(snip35_strk_usd_rate{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              1.0
+            ],
+            "type": "lt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "$$$strk_to_usd_rate_frozen-severity$$$"
     },
     {
       "name": "strk_to_usd_success_count",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -71,10 +71,12 @@ use crate::alert_scenarios::infra_alerts::{
 use crate::alert_scenarios::l1_endpoints::get_primary_l1_endpoint_down_too_long_alerts;
 use crate::alert_scenarios::l1_gas_prices::{
     get_eth_to_strk_error_count_alert,
+    get_eth_to_strk_rate_frozen_alert,
     get_eth_to_strk_success_count_alert,
     get_l1_gas_price_provider_insufficient_history_alert,
     get_l1_gas_price_scraper_success_count_alert,
     get_strk_to_usd_error_count_alert,
+    get_strk_to_usd_rate_frozen_alert,
     get_strk_to_usd_success_count_alert,
 };
 use crate::alert_scenarios::l1_handlers::{
@@ -640,6 +642,8 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_consensus_round_high());
     alerts.push(get_eth_to_strk_success_count_alert());
     alerts.push(get_strk_to_usd_success_count_alert());
+    alerts.push(get_eth_to_strk_rate_frozen_alert());
+    alerts.push(get_strk_to_usd_rate_frozen_alert());
     alerts.append(&mut get_general_pod_memory_utilization_vec());
     alerts.append(&mut get_general_pod_disk_utilization_vec());
     alerts.push(get_http_server_avg_add_tx_latency_alert());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -1,9 +1,11 @@
 use apollo_l1_gas_price::metrics::{
     ETH_TO_STRK_ERROR_COUNT,
+    ETH_TO_STRK_RATE,
     ETH_TO_STRK_SUCCESS_COUNT,
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT,
     SNIP35_STRK_USD_ERROR_COUNT,
+    SNIP35_STRK_USD_RATE,
     SNIP35_STRK_USD_SUCCESS_COUNT,
 };
 use apollo_metrics::metrics::MetricQueryName;
@@ -56,6 +58,26 @@ pub(crate) fn get_strk_to_usd_error_count_alert() -> Alert {
         "Strk to Usd error count",
         &SNIP35_STRK_USD_ERROR_COUNT,
         AlertSeverity::Informational,
+    )
+}
+
+pub(crate) fn get_eth_to_strk_rate_frozen_alert() -> Alert {
+    const ALERT_NAME: &str = "eth_to_strk_rate_frozen";
+    oracle_rate_frozen_alert(
+        ALERT_NAME,
+        "Eth to Strk rate frozen",
+        &ETH_TO_STRK_RATE,
+        SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+    )
+}
+
+pub(crate) fn get_strk_to_usd_rate_frozen_alert() -> Alert {
+    const ALERT_NAME: &str = "strk_to_usd_rate_frozen";
+    oracle_rate_frozen_alert(
+        ALERT_NAME,
+        "Strk to Usd rate frozen",
+        &SNIP35_STRK_USD_RATE,
+        SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
     )
 }
 
@@ -136,5 +158,34 @@ fn oracle_error_count_alert(
         "1m",
         severity,
         ObserverApplicability::NotApplicable,
+    )
+}
+
+/// Alert if an exchange-rate oracle's rate gauge has not changed at all in the last hour.
+///
+/// Detects a *frozen feed*: the oracle keeps resolving successfully (so the success count and
+/// last-success timestamp stay healthy) while serving a stale, unchanging price. `changes` over 1h
+/// is 0 only when the value never moved across the ~4 update buckets in that window — effectively
+/// impossible for a live 18-decimal rate. Unlike the error-count alert there is deliberately no
+/// `or vector(0)`: an absent gauge must stay no-data (so an oracle that never resolves doesn't look
+/// "frozen"); only a present-but-flat gauge trips this.
+///
+/// Applies to observers too: a frozen upstream feed is env-wide and observer nodes run the same
+/// oracle client, so the alert should fire regardless of node role.
+fn oracle_rate_frozen_alert(
+    name: &str,
+    title: &str,
+    rate_metric: &dyn MetricQueryName,
+    severity: impl Into<SeverityValueOrPlaceholder>,
+) -> Alert {
+    Alert::new(
+        name,
+        title,
+        EvaluationRate::Default,
+        format!("sum(changes({}[1h]))", rate_metric.get_name_with_filter()),
+        vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
+        PENDING_DURATION_DEFAULT,
+        severity,
+        ObserverApplicability::Applicable,
     )
 }


### PR DESCRIPTION
## What
Add a **frozen-rate** alert for both exchange-rate oracles, via a shared `oracle_rate_frozen_alert` helper (alongside the existing success/error helpers):
- `eth_to_strk_rate_frozen`
- `strk_to_usd_rate_frozen`

Signal: `sum(changes(<rate>[1h])) < 1` — fires only when the rate gauge hasn't changed at all across the ~4 update buckets in the window. Per-env **placeholder** severity; **applicable to observers** (a frozen upstream feed is env-wide and observer nodes run the same oracle client).

## Why
Confirmed in prod: the `eth_to_strk` rate has been frozen at `53419983883964544721998` since **~2026-07-02 12:30 UTC (~5 days)**, byte-identical on Mainnet and Testnet (shared Pragma upstream went stale). This is invisible to every existing alert — fresh resolves keep happening, so `eth_to_strk_success_count` climbs and `eth_to_strk_last_success_timestamp_seconds` stays current while the price is 5 days stale. The sequencer is pricing L1 gas from a frozen ETH→STRK rate.

## Notes
- Deliberately **no `or vector(0)`** (unlike the error-count alert): an absent gauge stays no-data so `strk_to_usd` (currently never set — Pragma STRK/USD 404s / not deployed on mainnet) doesn't false-fire; only a present-but-flat gauge trips.
- `sum(changes[…])` fires only on a *total* freeze (all pods stuck) — the real upstream case; a single-pod glitch won't trip it.
- **Action outside this repo:** both alerts use placeholder severities, so the real per-env alert-override configs must define `eth_to_strk_rate_frozen-severity` and `strk_to_usd_rate_frozen-severity` before deploy (bidirectional validation). Suggested: eth_to_strk = paging (it's genuinely frozen now), strk_to_usd = `p5`/silent until its feed is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
