### PR TITLE
apollo_central_sync,apollo_central_sync_config: bound in-memory class-download backlog (M-10)

### DIFF
--- a/crates/apollo_central_sync/src/sources/central.rs
+++ b/crates/apollo_central_sync/src/sources/central.rs
@@ -371,6 +371,7 @@ impl CentralSource {
                 max_state_updates_to_download: config.max_state_updates_to_download,
                 max_state_updates_to_store_in_memory: config.max_state_updates_to_store_in_memory,
                 max_classes_to_download: config.max_classes_to_download,
+                max_classes_to_store_in_memory: config.max_classes_to_store_in_memory,
             },
             class_cache: Arc::from(Mutex::new(LruCache::new(
                 NonZeroUsize::new(config.class_cache_size)

--- a/crates/apollo_central_sync/src/sources/central/state_update_stream.rs
+++ b/crates/apollo_central_sync/src/sources/central/state_update_stream.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[path = "state_update_stream_test.rs"]
+mod state_update_stream_test;
+
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -27,6 +31,7 @@ pub struct StateUpdateStreamConfig {
     pub max_state_updates_to_download: usize,
     pub max_state_updates_to_store_in_memory: usize,
     pub max_classes_to_download: usize,
+    pub max_classes_to_store_in_memory: usize,
 }
 
 pub(crate) struct StateUpdateStream<TStarknetClient: StarknetReader + Send + 'static> {
@@ -102,13 +107,9 @@ impl<TStarknetClient: StarknetReader + Send + Sync + 'static> StateUpdateStream<
             downloaded_state_updates: VecDeque::with_capacity(
                 config.max_state_updates_to_store_in_memory,
             ),
-            classes_to_download: VecDeque::with_capacity(
-                config.max_state_updates_to_store_in_memory * 5,
-            ),
+            classes_to_download: VecDeque::with_capacity(config.max_classes_to_store_in_memory),
             download_class_tasks: futures::stream::FuturesOrdered::new(),
-            downloaded_classes: VecDeque::with_capacity(
-                config.max_state_updates_to_store_in_memory * 5,
-            ),
+            downloaded_classes: VecDeque::with_capacity(config.max_classes_to_store_in_memory),
             config,
             class_cache,
         }
@@ -211,14 +212,25 @@ impl<TStarknetClient: StarknetReader + Send + Sync + 'static> StateUpdateStream<
         }
     }
 
-    // Checks for finished state update downloading tasks.
-    // Checks for finished class downloading tasks and adds the result to `downloaded_classes`.
+    // Checks for finished state update downloading tasks and adds the result to
+    // `downloaded_state_updates`, queuing its class hashes in `classes_to_download`.
     fn handle_downloaded_state_updates(
         self: &mut std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
         should_poll_again: &mut bool,
     ) -> CentralResult<()> {
         if self.downloaded_state_updates.len() >= self.config.max_state_updates_to_store_in_memory {
+            return Ok(());
+        }
+
+        // Backpressure on the class backlog: a state diff can declare an arbitrary (feeder-
+        // supplied) number of classes, so bound the total held in `classes_to_download` +
+        // `downloaded_classes` instead of only bounding the number of state updates. Checked
+        // before polling the task so a completed state update isn't consumed (and its class
+        // hashes dropped) until there's room to hold them; hashes must never be dropped, since
+        // that would desync sync.
+        let num_pending_classes = self.classes_to_download.len() + self.downloaded_classes.len();
+        if num_pending_classes >= self.config.max_classes_to_store_in_memory {
             return Ok(());
         }
 

--- a/crates/apollo_central_sync/src/sources/central/state_update_stream_test.rs
+++ b/crates/apollo_central_sync/src/sources/central/state_update_stream_test.rs
@@ -1,0 +1,164 @@
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+
+use apollo_starknet_client::reader::{GenericContractClass, MockStarknetReader};
+use apollo_storage::test_utils::get_test_storage;
+use futures_util::StreamExt;
+use mockall::predicate;
+use starknet_api::block::{BlockHash, BlockNumber};
+use starknet_api::class_hash;
+use starknet_api::core::{ClassHash, GlobalRoot};
+use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
+
+use super::{StateUpdateStream, StateUpdateStreamConfig};
+
+fn test_config(max_classes_to_store_in_memory: usize) -> StateUpdateStreamConfig {
+    StateUpdateStreamConfig {
+        max_state_updates_to_download: 100,
+        max_state_updates_to_store_in_memory: 100,
+        max_classes_to_download: 100,
+        max_classes_to_store_in_memory,
+    }
+}
+
+fn state_update_with_classes(
+    class_hashes: Vec<ClassHash>,
+) -> apollo_starknet_client::reader::StateUpdate {
+    apollo_starknet_client::reader::StateUpdate {
+        block_hash: BlockHash::default(),
+        new_root: GlobalRoot::default(),
+        old_root: GlobalRoot::default(),
+        state_diff: apollo_starknet_client::reader::StateDiff {
+            old_declared_contracts: class_hashes,
+            ..Default::default()
+        },
+    }
+}
+
+// Whitebox test of the backpressure gate added to `handle_downloaded_state_updates`: it must
+// hold a fully-downloaded state update (and its class hashes) back rather than admit it (or drop
+// its hashes) once the class backlog reached the configured bound, and must resume admitting
+// state updates once the backlog drains.
+#[test]
+fn class_backlog_backpressure_blocks_and_recovers() {
+    let ((storage_reader, _storage_writer), _temp_dir) = get_test_storage();
+    let class_cache = std::sync::Arc::new(std::sync::Mutex::new(lru::LruCache::new(
+        NonZeroUsize::new(2).unwrap(),
+    )));
+    let apollo_starknet_client = std::sync::Arc::new(MockStarknetReader::new());
+
+    // max_classes_to_store_in_memory == 3: exactly the size of the first update's class list.
+    let mut stream = StateUpdateStream::new(
+        BlockNumber(0),
+        BlockNumber(0),
+        apollo_starknet_client,
+        storage_reader,
+        test_config(3),
+        class_cache,
+    );
+    let mut pinned_stream = Pin::new(&mut stream);
+
+    let waker = futures::task::noop_waker_ref();
+    let mut cx = std::task::Context::from_waker(waker);
+    let mut should_poll_again = false;
+
+    let first_update =
+        state_update_with_classes(vec![class_hash!("0x1"), class_hash!("0x2"), class_hash!("0x3")]);
+    pinned_stream
+        .download_state_update_tasks
+        .push_back(Box::pin(async move { (BlockNumber(0), Ok(Some(first_update))) }));
+    pinned_stream.handle_downloaded_state_updates(&mut cx, &mut should_poll_again).unwrap();
+    assert_eq!(pinned_stream.downloaded_state_updates.len(), 1);
+    assert_eq!(pinned_stream.classes_to_download.len(), 3);
+
+    // A second, fully-downloaded state update arrives while the backlog is already at the bound.
+    // Backpressure must hold it back instead of admitting it (which would grow the backlog
+    // unboundedly) or dropping its class hashes (which would desync sync).
+    let second_update =
+        state_update_with_classes(vec![class_hash!("0x4"), class_hash!("0x5"), class_hash!("0x6")]);
+    pinned_stream
+        .download_state_update_tasks
+        .push_back(Box::pin(async move { (BlockNumber(1), Ok(Some(second_update))) }));
+    pinned_stream.handle_downloaded_state_updates(&mut cx, &mut should_poll_again).unwrap();
+    assert_eq!(
+        pinned_stream.downloaded_state_updates.len(),
+        1,
+        "second state update should be held back by backpressure"
+    );
+    assert_eq!(
+        pinned_stream.classes_to_download.len(),
+        3,
+        "no new hashes should be appended while the backlog is at its bound"
+    );
+    assert_eq!(
+        pinned_stream.download_state_update_tasks.len(),
+        1,
+        "the held-back task must remain queued, not dropped"
+    );
+
+    // Draining the backlog (as scheduling class downloads normally would) makes room again.
+    pinned_stream.classes_to_download.clear();
+    pinned_stream.handle_downloaded_state_updates(&mut cx, &mut should_poll_again).unwrap();
+    assert_eq!(
+        pinned_stream.downloaded_state_updates.len(),
+        2,
+        "backpressure should release once the backlog drains"
+    );
+    assert_eq!(pinned_stream.classes_to_download.len(), 3);
+}
+
+// End-to-end test that a class backlog spanning multiple state updates never causes hashes to be
+// dropped or the stream to deadlock, even with a small `max_classes_to_store_in_memory`.
+#[tokio::test]
+async fn class_backlog_backpressure_does_not_drop_or_deadlock() {
+    let class_hashes = [
+        class_hash!("0x1"),
+        class_hash!("0x2"),
+        class_hash!("0x3"),
+        class_hash!("0x4"),
+        class_hash!("0x5"),
+        class_hash!("0x6"),
+    ];
+
+    let mut mock = MockStarknetReader::new();
+    for (block_number, chunk) in class_hashes.chunks(2).enumerate() {
+        let state_update = state_update_with_classes(chunk.to_vec());
+        mock.expect_state_update()
+            .with(predicate::eq(BlockNumber(u64::try_from(block_number).unwrap())))
+            .times(1)
+            .returning(move |_| Ok(Some(state_update.clone())));
+    }
+    for class_hash in class_hashes {
+        mock.expect_class_by_hash().with(predicate::eq(class_hash)).times(1).returning(|_| {
+            Ok(Some(GenericContractClass::Cairo0ContractClass(DeprecatedContractClass::default())))
+        });
+    }
+
+    let ((storage_reader, _storage_writer), _temp_dir) = get_test_storage();
+    let class_cache = std::sync::Arc::new(std::sync::Mutex::new(lru::LruCache::new(
+        NonZeroUsize::new(2).unwrap(),
+    )));
+
+    // Only 2 classes may be held in memory at a time, forcing backpressure across all 3 blocks.
+    let stream = StateUpdateStream::new(
+        BlockNumber(0),
+        BlockNumber(3),
+        std::sync::Arc::new(mock),
+        storage_reader,
+        test_config(2),
+        class_cache,
+    );
+    futures_util::pin_mut!(stream);
+
+    for expected_block_number in 0..3u64 {
+        let central_state_update = stream
+            .next()
+            .await
+            .unwrap_or_else(|| panic!("stream ended early at block {expected_block_number}"))
+            .unwrap_or_else(|err| {
+                panic!("unexpected error at block {expected_block_number}: {err:?}")
+            });
+        assert_eq!(central_state_update.0, BlockNumber(expected_block_number));
+    }
+    assert!(stream.next().await.is_none(), "stream should be exhausted after 3 blocks");
+}

--- a/crates/apollo_central_sync/src/sources/central_test.rs
+++ b/crates/apollo_central_sync/src/sources/central_test.rs
@@ -681,6 +681,7 @@ fn state_update_stream_config_for_test() -> StateUpdateStreamConfig {
         max_state_updates_to_download: 10,
         max_state_updates_to_store_in_memory: 10,
         max_classes_to_download: 10,
+        max_classes_to_store_in_memory: 10,
     }
 }
 

--- a/crates/apollo_central_sync_config/src/config.rs
+++ b/crates/apollo_central_sync_config/src/config.rs
@@ -25,6 +25,7 @@ pub struct CentralSourceConfig {
     pub max_state_updates_to_download: usize,
     pub max_state_updates_to_store_in_memory: usize,
     pub max_classes_to_download: usize,
+    pub max_classes_to_store_in_memory: usize,
     #[validate(range(min = 1))]
     pub class_cache_size: usize,
     pub retry_config: RetryConfig,
@@ -40,6 +41,7 @@ impl Default for CentralSourceConfig {
             max_state_updates_to_download: 20,
             max_state_updates_to_store_in_memory: 20,
             max_classes_to_download: 20,
+            max_classes_to_store_in_memory: 1000,
             class_cache_size: 100,
             retry_config: RetryConfig {
                 retry_base_millis: 30,
@@ -88,6 +90,13 @@ impl SerializeConfig for CentralSourceConfig {
                 "max_classes_to_download",
                 &self.max_classes_to_download,
                 "Maximum number of classes to download at a given time.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "max_classes_to_store_in_memory",
+                &self.max_classes_to_store_in_memory,
+                "Maximum number of classes (downloaded or pending download) to hold in memory at \
+                 a given time, bounding the class backlog of a single state diff.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3744,6 +3744,11 @@
     "privacy": "Public",
     "value": 20
   },
+  "state_sync_config.static_config.central_sync_client_config.central_source_config.max_classes_to_store_in_memory": {
+    "description": "Maximum number of classes (downloaded or pending download) to hold in memory at a given time, bounding the class backlog of a single state diff.",
+    "privacy": "Public",
+    "value": 1000
+  },
   "state_sync_config.static_config.central_sync_client_config.central_source_config.max_state_updates_to_download": {
     "description": "Maximum number of state updates to download at a given time.",
     "privacy": "Public",


### PR DESCRIPTION
## Finding
M-10 (Medium, DoS/Resource) — Sequencer Security Report v1.0. Central-sync class-download backlog (`classes_to_download`) was unbounded, allowing memory growth from oversized state diffs.

## Change
A feeder-supplied state diff can declare an arbitrary number of classes, so `classes_to_download` / `downloaded_classes` could grow without bound (the only existing backpressure caps the *number of buffered state updates*, not the class count per update).

- Add `max_classes_to_store_in_memory` to `CentralSourceConfig` (default 1000).
- In `StateUpdateStream::handle_downloaded_state_updates`, hold back admitting a fully-downloaded state update once the class backlog (`classes_to_download` + `downloaded_classes`) reaches the bound — rather than dropping its class hashes, which would desync sync.
- Regenerated `config_schema.json` for the new field.

## Testing
- New whitebox test (backpressure blocks a state update and recovers once the backlog drains, never dropping hashes) and an end-to-end no-deadlock test across multiple blocks with a small bound.
- `SEED=0 cargo test -p apollo_central_sync` → 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
