### PR TITLE
apollo_l1_gas_price,apollo_l1_gas_price_types: bound stale rate fallback, checked arithmetic (L-4)

### DIFF
--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use apollo_config::secrets::Sensitive;
 use apollo_l1_gas_price_config::config::ExchangeRateOracleConfig;
@@ -59,7 +59,10 @@ pub struct ExchangeRateOracleClient {
     index: Arc<AtomicUsize>,
     url_header_list: Arc<Vec<UrlAndHeaderMap>>,
     client: reqwest::Client,
-    cached_prices: Arc<Mutex<LruCache<u64, u128>>>,
+    // Value is `(rate, cached_at)`, where `cached_at` is the wall-clock time the rate was
+    // fetched. This lets the previous-quantum fallback in `fetch_rate` bound how stale a
+    // substituted rate may be, instead of relying solely on LRU eviction.
+    cached_prices: Arc<Mutex<LruCache<u64, (u128, Instant)>>>,
     queries: Arc<Mutex<LruCache<u64, PriceQuery>>>,
     metrics: ExchangeRateOracleMetrics,
 }
@@ -104,7 +107,7 @@ impl ExchangeRateOracleClient {
             self.config.lag_interval_seconds > 0,
             "lag_interval_seconds should be greater than 0"
         );
-        let adjusted_timestamp = quantized_timestamp * self.config.lag_interval_seconds;
+        let lag_interval_seconds = self.config.lag_interval_seconds;
         let query_timeout_sec = self.config.query_timeout_sec;
         let client = self.client.clone();
         let index_clone = self.index.clone();
@@ -112,6 +115,15 @@ impl ExchangeRateOracleClient {
         let list_len = url_header_list.len();
         let metrics = self.metrics;
         let future = async move {
+            // Computed inside the task (rather than before spawning) so an overflow surfaces as
+            // a query error instead of panicking the caller's thread.
+            let adjusted_timestamp =
+                quantized_timestamp.checked_mul(lag_interval_seconds).ok_or_else(|| {
+                    ExchangeRateOracleClientError::InvalidTimestampError(format!(
+                        "Overflow computing adjusted timestamp: quantized_timestamp \
+                         ({quantized_timestamp}) * lag_interval_seconds ({lag_interval_seconds})"
+                    ))
+                })?;
             let initial_index = index_clone.load(Ordering::SeqCst);
             for (i, url_and_headers) in
                 url_header_list.iter().cycle().skip(initial_index).take(list_len).enumerate()
@@ -220,13 +232,24 @@ impl ExchangeRateOracleClientTrait for ExchangeRateOracleClient {
     #[instrument(skip(self))]
     async fn fetch_rate(&self, timestamp: u64) -> Result<u128, ExchangeRateOracleClientError> {
         const NUMBER_OF_TIMESTAMPS_BACK: u64 = 1;
-        let quantized_timestamp = (timestamp - self.config.lag_interval_seconds)
+        // A previous-quantum rate substituted for the current quantum (see below) is only
+        // trusted if it was fetched within this long ago; otherwise it's treated as too stale
+        // to silently pass off as current.
+        let max_fallback_rate_age = Duration::from_secs(self.config.lag_interval_seconds);
+        let quantized_timestamp = timestamp
+            .checked_sub(self.config.lag_interval_seconds)
+            .ok_or_else(|| {
+                ExchangeRateOracleClientError::InvalidTimestampError(format!(
+                    "timestamp ({timestamp}) is smaller than lag_interval_seconds ({})",
+                    self.config.lag_interval_seconds
+                ))
+            })?
             .checked_div(self.config.lag_interval_seconds)
             .expect("lag_interval_seconds should be non-zero");
 
         let mut cache = self.cached_prices.lock().unwrap();
 
-        if let Some(rate) = cache.get(&quantized_timestamp) {
+        if let Some((rate, _)) = cache.get(&quantized_timestamp) {
             debug!("Cached conversion rate for timestamp {timestamp} is {rate}");
             return Ok(*rate);
         }
@@ -238,15 +261,27 @@ impl ExchangeRateOracleClientTrait for ExchangeRateOracleClient {
         // If the query is not finished, return an error.
         if !handle.is_finished() {
             debug!("Query not yet resolved: timestamp={timestamp}");
-            // If the previous quantized timestamp is in the cache, use it.
-            if let Some(rate) = cache.get(&(quantized_timestamp - NUMBER_OF_TIMESTAMPS_BACK)) {
-                debug!(
-                    "Query not yet resolved: timestamp={timestamp}, using previous rate {rate} \
-                     from quantized timestamp={}",
-                    (quantized_timestamp - NUMBER_OF_TIMESTAMPS_BACK)
-                        * self.config.lag_interval_seconds
-                );
-                return Ok(*rate);
+            // If the previous quantized timestamp is in the cache and still fresh enough, use
+            // it as a bounded-staleness substitute.
+            if let Some(previous_quantized_timestamp) =
+                quantized_timestamp.checked_sub(NUMBER_OF_TIMESTAMPS_BACK)
+            {
+                if let Some((rate, cached_at)) = cache.get(&previous_quantized_timestamp) {
+                    let rate_age = cached_at.elapsed();
+                    if rate_age <= max_fallback_rate_age {
+                        debug!(
+                            "Query not yet resolved: timestamp={timestamp}, using previous rate \
+                             {rate} from quantized timestamp={} (age={rate_age:?})",
+                            previous_quantized_timestamp
+                                .saturating_mul(self.config.lag_interval_seconds)
+                        );
+                        return Ok(*rate);
+                    }
+                    debug!(
+                        "Previous rate from quantized timestamp={previous_quantized_timestamp} is \
+                         too stale to substitute (age={rate_age:?})"
+                    );
+                }
             }
             // If not, return a query not ready error.
             return Err(ExchangeRateOracleClientError::QueryNotReadyError(timestamp));
@@ -270,7 +305,7 @@ impl ExchangeRateOracleClientTrait for ExchangeRateOracleClient {
         };
 
         // Make sure to cache the result.
-        cache.put(quantized_timestamp, rate);
+        cache.put(quantized_timestamp, (rate, Instant::now()));
         // We don't need to come back to this query since we have the result in cache.
         queries.pop(&quantized_timestamp);
         debug!("Caching conversion rate for timestamp {timestamp}, with rate {rate}");

--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle_test.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle_test.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use apollo_config::converters::UrlAndHeaders;
 use apollo_l1_gas_price_types::errors::ExchangeRateOracleClientError;
@@ -297,4 +297,74 @@ async fn eth_to_fri_rate_non_success_status_code() {
         }
         tokio::task::yield_now().await;
     }
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_timestamp_below_lag_interval_errors() {
+    const LAG_INTERVAL_SECONDS: u64 = 60;
+
+    let url_and_headers = UrlAndHeaders {
+        url: Url::parse("http://localhost:1234").unwrap(),
+        headers: BTreeMap::new(),
+    };
+    let config = ExchangeRateOracleConfig {
+        url_header_list: Some(vec![url_and_headers.into()]),
+        lag_interval_seconds: LAG_INTERVAL_SECONDS,
+        ..Default::default()
+    };
+    let client = ExchangeRateOracleClient::new(config, ETH_TO_STRK_ORACLE_METRICS);
+
+    // A timestamp smaller than lag_interval_seconds would underflow the quantization
+    // subtraction; it must surface as an error rather than panic.
+    assert!(matches!(
+        client.fetch_rate(LAG_INTERVAL_SECONDS - 1).await,
+        Err(ExchangeRateOracleClientError::InvalidTimestampError(_))
+    ));
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_stale_prev_cache_not_substituted() {
+    const EXPECTED_RATE: u128 = 123456;
+    let expected_rate_hex = format!("0x{EXPECTED_RATE:x}");
+    const LAG_INTERVAL_SECONDS: u64 = 60;
+    const TIMESTAMP1: u64 = 1234567890;
+    // Next quantized bucket, so its not-ready fallback looks one bucket back at TIMESTAMP1's rate.
+    const TIMESTAMP2: u64 = TIMESTAMP1 + LAG_INTERVAL_SECONDS;
+
+    let quantized_timestamp1 = (TIMESTAMP1 - LAG_INTERVAL_SECONDS) / LAG_INTERVAL_SECONDS;
+
+    let mut server = mockito::Server::new_async().await;
+    let _mock_response =
+        make_server(&mut server, json!({"price": expected_rate_hex, "decimals": 18})).await;
+    let url_and_headers =
+        UrlAndHeaders { url: Url::parse(&server.url()).unwrap(), headers: BTreeMap::new() };
+    let config = ExchangeRateOracleConfig {
+        url_header_list: Some(vec![url_and_headers.into()]),
+        lag_interval_seconds: LAG_INTERVAL_SECONDS,
+        ..Default::default()
+    };
+    let client = ExchangeRateOracleClient::new(config, ETH_TO_STRK_ORACLE_METRICS);
+
+    // Resolve and cache the rate for the first quantized bucket.
+    while client.fetch_rate(TIMESTAMP1).await.is_err() {
+        tokio::task::yield_now().await;
+    }
+
+    // Age the cached entry past the freshness bound (max_fallback_rate_age ==
+    // lag_interval_seconds), so it is no longer a valid substitute for the next bucket.
+    {
+        let mut cache = client.cached_prices.lock().unwrap();
+        let (rate, _) = *cache.get(&quantized_timestamp1).expect("first bucket should be cached");
+        let stale_cached_at = Instant::now()
+            .checked_sub(Duration::from_secs(LAG_INTERVAL_SECONDS * 10))
+            .expect("stale instant");
+        cache.put(quantized_timestamp1, (rate, stale_cached_at));
+    }
+
+    // The next bucket's query is still pending, and the only prior rate is now too stale to
+    // substitute, so fetch_rate must report the query as not ready rather than serve a stale rate.
+    assert!(matches!(
+        client.fetch_rate(TIMESTAMP2).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    ));
 }

--- a/crates/apollo_l1_gas_price_types/src/errors.rs
+++ b/crates/apollo_l1_gas_price_types/src/errors.rs
@@ -49,6 +49,8 @@ pub enum ExchangeRateOracleClientError {
     AllUrlsFailedError(u64, usize),
     #[error("Invalid rate from oracle: {0}")]
     InvalidRateError(String),
+    #[error("Invalid timestamp arithmetic: {0}")]
+    InvalidTimestampError(String),
 }
 
 impl From<reqwest::Error> for ExchangeRateOracleClientError {


### PR DESCRIPTION
## Finding
L-4 (Low, Gas/Oracle) — Sequencer Security Report v1.0. The exchange-rate oracle treated a stale prior-quantum rate as a live substitute without freshness bounds.

## Change
When the current quantum's query is not yet ready, the oracle substituted the previous quantum's cached rate with no staleness check, so an arbitrarily old rate could be served as if current.

- Store the wall-clock fetch time alongside each cached rate (`LruCache<u64, (u128, Instant)>`) and only substitute the previous quantum's rate when it is within one lag interval old; otherwise report the query as not ready.
- Replace the unchecked timestamp subtraction/multiplication (which could underflow/overflow-panic) with checked arithmetic, surfaced as a new `InvalidTimestampError`.

## Testing
- New tests: a timestamp below `lag_interval_seconds` returns `InvalidTimestampError` instead of panicking; a prior-quantum rate aged past the freshness bound is not substituted (returns `QueryNotReadyError`).
- `SEED=0 cargo test -p apollo_l1_gas_price exchange_rate` → 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
