### PR TITLE
apollo_transaction_converter: verify sierra/executable consistency in tx conversion (M-33)

### DIFF
--- a/crates/apollo_gateway/src/errors.rs
+++ b/crates/apollo_gateway/src/errors.rs
@@ -340,6 +340,22 @@ pub fn transaction_converter_err_to_deprecated_gw_err(
         TransactionConverterError::ProofNotFound { .. } => {
             StarknetError::internal_with_signature_logging("Proof not found", tx_signature, err)
         }
+        // Internal error: the class manager returned artifacts that are inconsistent with the
+        // requested class (e.g. stale cache or partial write), not a fault in the user's tx.
+        TransactionConverterError::SierraClassHashMismatch { .. } => {
+            StarknetError::internal_with_signature_logging(
+                "Inconsistent Sierra class hash",
+                tx_signature,
+                err,
+            )
+        }
+        TransactionConverterError::UnexpectedCairo0Executable { .. } => {
+            StarknetError::internal_with_signature_logging(
+                "Unexpected Cairo 0 executable",
+                tx_signature,
+                err,
+            )
+        }
         TransactionConverterError::StarknetApiError(err) => convert_sn_api_error(err),
     }
 }

--- a/crates/apollo_gateway/src/errors.rs
+++ b/crates/apollo_gateway/src/errors.rs
@@ -356,6 +356,15 @@ pub fn transaction_converter_err_to_deprecated_gw_err(
                 err,
             )
         }
+        // Internal error: the tx's compiled class hash was already validated during ingestion, so a
+        // mismatch here means the class manager returned an executable inconsistent with the class.
+        TransactionConverterError::CompiledClassHashMismatch { .. } => {
+            StarknetError::internal_with_signature_logging(
+                "Inconsistent compiled class hash",
+                tx_signature,
+                err,
+            )
+        }
         TransactionConverterError::StarknetApiError(err) => convert_sn_api_error(err),
     }
 }

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -47,6 +47,16 @@ pub enum TransactionConverterError {
     ClassManagerClientError(#[from] ClassManagerClientError),
     #[error("Class of hash: {class_hash} not found")]
     ClassNotFound { class_hash: ClassHash },
+    #[error(
+        "Executable fetched for class hash {class_hash} is inconsistent with the tx: computed \
+         compiled class hash {computed_compiled_class_hash} from the fetched executable does not \
+         match the tx's compiled class hash {compiled_class_hash}"
+    )]
+    CompiledClassHashMismatch {
+        class_hash: ClassHash,
+        compiled_class_hash: CompiledClassHash,
+        computed_compiled_class_hash: CompiledClassHash,
+    },
     #[error("Proof for proof facts hash: {facts_hash} not found.")]
     ProofNotFound { facts_hash: Felt },
     #[error(transparent)]
@@ -195,14 +205,18 @@ impl TransactionConverter {
         if matches!(contract_class, ContractClass::V0(_)) {
             return Err(TransactionConverterError::UnexpectedCairo0Executable { class_hash });
         }
+        // The tx's `compiled_class_hash` was already validated against the freshly compiled class
+        // during ingestion (`convert_rpc_tx_to_internal`), so a mismatch here is not a user fault
+        // but an inconsistency between the two independent class-manager reads (like the checks
+        // above). Report it as an internal error rather than reusing the client-facing
+        // `ValidateCompiledClassHashError`.
         let computed_compiled_class_hash = contract_class.compiled_class_hash();
         if computed_compiled_class_hash != compiled_class_hash {
-            return Err(TransactionConverterError::ValidateCompiledClassHashError(
-                ValidateCompiledClassHashError::CompiledClassHashMismatch {
-                    computed_class_hash: computed_compiled_class_hash,
-                    supplied_class_hash: compiled_class_hash,
-                },
-            ));
+            return Err(TransactionConverterError::CompiledClassHashMismatch {
+                class_hash,
+                compiled_class_hash,
+                computed_compiled_class_hash,
+            });
         }
 
         Ok(())

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use mockall::automock;
 use starknet_api::consensus_transaction::{ConsensusTransaction, InternalConsensusTransaction};
 use starknet_api::contract_class::{ClassInfo, ContractClass, SierraVersion};
-use starknet_api::core::{ChainId, ClassHash};
+use starknet_api::core::{ChainId, ClassHash, CompiledClassHash};
 use starknet_api::executable_transaction::{
     AccountTransaction,
     Transaction as ExecutableTransaction,
@@ -53,8 +53,17 @@ pub enum TransactionConverterError {
     ProofManagerClientError(#[from] ProofManagerClientError),
     #[error(transparent)]
     ProofVerificationError(#[from] VerifyProofError),
+    #[error(
+        "Sierra fetched for class hash {class_hash} is inconsistent with it: computed class hash \
+         {computed_class_hash} from the fetched Sierra program"
+    )]
+    SierraClassHashMismatch { class_hash: ClassHash, computed_class_hash: ClassHash },
     #[error(transparent)]
     StarknetApiError(#[from] StarknetApiError),
+    #[error(
+        "Expected a Cairo 1 (Sierra-compiled) executable for class {class_hash}, found Cairo 0"
+    )]
+    UnexpectedCairo0Executable { class_hash: ClassHash },
     #[error(transparent)]
     ValidateCompiledClassHashError(#[from] ValidateCompiledClassHashError),
 }
@@ -161,6 +170,42 @@ impl TransactionConverter {
             .get_executable(class_hash)
             .await?
             .ok_or(TransactionConverterError::ClassNotFound { class_hash })
+    }
+
+    /// `get_sierra` and `get_executable` are two independent class-manager reads; nothing
+    /// guarantees the class manager returned artifacts for the same compiled class (e.g. a
+    /// stale cache entry or a partial write could pair them incorrectly). The Sierra-derived
+    /// lengths and version are later trusted as authoritative billing/version-gating metadata
+    /// for the (separately fetched) executable, so verify both artifacts are actually keyed to
+    /// `class_hash`/`compiled_class_hash` before using them together.
+    fn verify_class_consistency(
+        class_hash: ClassHash,
+        compiled_class_hash: CompiledClassHash,
+        sierra: &SierraContractClass,
+        contract_class: &ContractClass,
+    ) -> TransactionConverterResult<()> {
+        let computed_class_hash = sierra.calculate_class_hash();
+        if computed_class_hash != class_hash {
+            return Err(TransactionConverterError::SierraClassHashMismatch {
+                class_hash,
+                computed_class_hash,
+            });
+        }
+
+        if matches!(contract_class, ContractClass::V0(_)) {
+            return Err(TransactionConverterError::UnexpectedCairo0Executable { class_hash });
+        }
+        let computed_compiled_class_hash = contract_class.compiled_class_hash();
+        if computed_compiled_class_hash != compiled_class_hash {
+            return Err(TransactionConverterError::ValidateCompiledClassHashError(
+                ValidateCompiledClassHashError::CompiledClassHashMismatch {
+                    computed_class_hash: computed_compiled_class_hash,
+                    supplied_class_hash: compiled_class_hash,
+                },
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -279,6 +324,12 @@ impl TransactionConverterTrait for TransactionConverter {
                 let (sierra, contract_class) = tokio::try_join!(
                     self.get_sierra(tx.class_hash),
                     self.get_executable(tx.class_hash)
+                )?;
+                Self::verify_class_consistency(
+                    tx.class_hash,
+                    tx.compiled_class_hash,
+                    &sierra,
+                    &contract_class,
                 )?;
                 let class_info = ClassInfo {
                     contract_class,

--- a/crates/apollo_transaction_converter/src/transaction_converter_test.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter_test.rs
@@ -336,11 +336,10 @@ async fn test_convert_internal_rpc_tx_to_executable_tx_declare_compiled_class_ha
 
     assert_eq!(
         err,
-        TransactionConverterError::ValidateCompiledClassHashError(
-            ValidateCompiledClassHashError::CompiledClassHashMismatch {
-                computed_class_hash: computed_compiled_class_hash,
-                supplied_class_hash: compiled_class_hash,
-            }
-        )
+        TransactionConverterError::CompiledClassHashMismatch {
+            class_hash,
+            compiled_class_hash,
+            computed_compiled_class_hash,
+        }
     );
 }

--- a/crates/apollo_transaction_converter/src/transaction_converter_test.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter_test.rs
@@ -12,12 +12,16 @@ use mempool_test_utils::starknet_api_test_utils::{
 };
 use mockall::predicate::eq;
 use rstest::{fixture, rstest};
-use starknet_api::compiled_class_hash;
 use starknet_api::consensus_transaction::ConsensusTransaction;
-use starknet_api::executable_transaction::ValidateCompiledClassHashError;
+use starknet_api::contract_class::ContractClass;
+use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::executable_transaction::{AccountTransaction, ValidateCompiledClassHashError};
 use starknet_api::rpc_transaction::{RpcDeclareTransaction, RpcTransaction};
+use starknet_api::state::SierraContractClass;
+use starknet_api::test_utils::declare::{default_compiled_contract_class, internal_rpc_declare_tx};
 use starknet_api::test_utils::{path_in_resources, read_json_file};
 use starknet_api::transaction::fields::{Proof, ProofFacts};
+use starknet_api::{compiled_class_hash, declare_tx_args};
 
 use crate::transaction_converter::{
     TransactionConverter,
@@ -230,4 +234,113 @@ async fn test_convert_internal_rpc_tx_to_rpc_tx_with_proof(proof_facts: ProofFac
         transaction_converter.convert_internal_rpc_tx_to_rpc_tx(internal_tx).await.unwrap();
 
     assert_eq!(rpc_tx, rpc_tx_from_internal);
+}
+
+/// Sets up a mock class manager returning `sierra`/`contract_class` for `class_hash`, and
+/// converts an internal declare tx (with the given `class_hash`/`compiled_class_hash`) to an
+/// executable tx.
+async fn convert_declare_tx_to_executable(
+    class_hash: ClassHash,
+    compiled_class_hash: CompiledClassHash,
+    sierra: SierraContractClass,
+    contract_class: ContractClass,
+) -> Result<AccountTransaction, TransactionConverterError> {
+    let internal_tx =
+        internal_rpc_declare_tx(declare_tx_args!(class_hash: class_hash, compiled_class_hash));
+
+    let mut mock_class_manager_client = MockClassManagerClient::new();
+    mock_class_manager_client
+        .expect_get_sierra()
+        .with(eq(class_hash))
+        .return_once(move |_| Ok(Some(sierra)));
+    mock_class_manager_client
+        .expect_get_executable()
+        .with(eq(class_hash))
+        .return_once(move |_| Ok(Some(contract_class)));
+
+    let transaction_converter = TransactionConverter::new(
+        Arc::new(mock_class_manager_client),
+        Arc::new(MockProofManagerClient::new()),
+        ChainInfo::create_for_testing().chain_id,
+    );
+
+    transaction_converter.convert_internal_rpc_tx_to_executable_tx(internal_tx).await
+}
+
+/// A consistent Sierra/executable pair (both keyed to the same class/compiled-class hash)
+/// converts successfully.
+#[rstest]
+#[tokio::test]
+async fn test_convert_internal_rpc_tx_to_executable_tx_declare_consistent_classes() {
+    let sierra = SierraContractClass::default();
+    let class_hash = sierra.calculate_class_hash();
+    let contract_class = default_compiled_contract_class();
+    let compiled_class_hash = contract_class.compiled_class_hash();
+
+    let account_tx = convert_declare_tx_to_executable(
+        class_hash,
+        compiled_class_hash,
+        sierra.clone(),
+        contract_class.clone(),
+    )
+    .await
+    .unwrap();
+
+    let class_info = assert_matches!(account_tx, AccountTransaction::Declare(tx) => tx.class_info);
+    assert_eq!(class_info.contract_class, contract_class);
+    assert_eq!(class_info.sierra_program_length, sierra.sierra_program.len());
+    assert_eq!(class_info.abi_length, sierra.abi.len());
+}
+
+/// If the class manager returns a Sierra that doesn't hash to the requested class hash (e.g. a
+/// stale cache entry for a different class), the conversion fails instead of silently deriving
+/// billing metadata from the wrong Sierra.
+#[rstest]
+#[tokio::test]
+async fn test_convert_internal_rpc_tx_to_executable_tx_declare_sierra_class_hash_mismatch() {
+    let sierra = SierraContractClass::default();
+    let computed_class_hash = sierra.calculate_class_hash();
+    let class_hash = ClassHash::default();
+    assert_ne!(class_hash, computed_class_hash);
+    let contract_class = default_compiled_contract_class();
+    let compiled_class_hash = contract_class.compiled_class_hash();
+
+    let err =
+        convert_declare_tx_to_executable(class_hash, compiled_class_hash, sierra, contract_class)
+            .await
+            .unwrap_err();
+
+    assert_eq!(
+        err,
+        TransactionConverterError::SierraClassHashMismatch { class_hash, computed_class_hash }
+    );
+}
+
+/// If the class manager returns an executable whose compiled class hash doesn't match the
+/// declare tx's `compiled_class_hash` (e.g. a stale/incorrect compilation for the same class),
+/// the conversion fails instead of pairing it with the fetched Sierra.
+#[rstest]
+#[tokio::test]
+async fn test_convert_internal_rpc_tx_to_executable_tx_declare_compiled_class_hash_mismatch() {
+    let sierra = SierraContractClass::default();
+    let class_hash = sierra.calculate_class_hash();
+    let contract_class = default_compiled_contract_class();
+    let computed_compiled_class_hash = contract_class.compiled_class_hash();
+    let compiled_class_hash = compiled_class_hash!(999_u16);
+    assert_ne!(compiled_class_hash, computed_compiled_class_hash);
+
+    let err =
+        convert_declare_tx_to_executable(class_hash, compiled_class_hash, sierra, contract_class)
+            .await
+            .unwrap_err();
+
+    assert_eq!(
+        err,
+        TransactionConverterError::ValidateCompiledClassHashError(
+            ValidateCompiledClassHashError::CompiledClassHashMismatch {
+                computed_class_hash: computed_compiled_class_hash,
+                supplied_class_hash: compiled_class_hash,
+            }
+        )
+    );
 }


### PR DESCRIPTION
## Finding
M-33 (Medium, Mempool) — Sequencer Security Report v1.0. `convert_internal_rpc_tx_to_executable_tx` derived Sierra version, program length, and ABI length from class-manager output without consistency checks against the stored compiled class.

## Change
`get_sierra` and `get_executable` are two independent class-manager reads; nothing guarantees they returned artifacts for the same compiled class, yet the Sierra-derived lengths and version are then trusted as authoritative billing / version-gating metadata for the separately-fetched executable.

- Add `verify_class_consistency`: recompute the class hash from the fetched Sierra and the compiled-class hash from the fetched executable, and confirm both are keyed to the tx's `class_hash` / `compiled_class_hash` before building `ClassInfo`. Return a descriptive error on mismatch (never panic).

This is defense-in-depth: under content-addressing + atomic writes a mismatch is not externally attacker-inducible today (it would require a compiler bug or storage corruption), but the check fails closed rather than admitting inconsistent metadata.

## Testing
- New tests: consistent pair converts successfully; Sierra-hash mismatch and compiled-class-hash mismatch each return the expected error.
- `SEED=0 cargo test -p apollo_transaction_converter` → 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
