### PR TITLE
echonet: recreate deployment strategy and pre-scale-down to avoid PVC multi-attach

### DIFF
--- a/echonet/deploy_echonet.py
+++ b/echonet/deploy_echonet.py
@@ -220,6 +220,41 @@ def _install_block_hash_cli_into_pod(
     raise RuntimeError("Timed out waiting for echonet pod before copying block-hash CLI.")
 
 
+def _scale_down_existing_echonet_deployments(namespace_args: list[str]) -> None:
+    proc = subprocess.run(
+        [
+            "kubectl",
+            *namespace_args,
+            "get",
+            "deployments",
+            "-l",
+            "app.kubernetes.io/name=echonet",
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        logger.warning(
+            f"Failed to list echonet deployments (exit {proc.returncode}): "
+            f"{proc.stderr.strip() or '<no stderr>'}; skipping pre-scale-down."
+        )
+        return
+
+    deployment_names = proc.stdout.split()
+    if not deployment_names:
+        logger.info("No existing echonet deployments to scale down.")
+        return
+
+    for deployment_name in deployment_names:
+        logger.info(f"Scaling down deployment/{deployment_name} to 0 replicas...")
+        _run(["kubectl", *namespace_args, "scale", "deployment", deployment_name, "--replicas=0"])
+        logger.info(f"Waiting for rollout status deployment/{deployment_name}...")
+        _run(["kubectl", *namespace_args, "rollout", "status", f"deployment/{deployment_name}"])
+
+
 def _copy_generated_keys(keys_in_repo: Path, generated_path: Path) -> None:
     """
     Copy the non-secret echonet keys JSON into the kustomize generated/ directory.
@@ -308,6 +343,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.delete_first:
         logger.info("Deleting existing resources...")
         _run(["kubectl", *namespace_args, "delete", "-k", str(kustomize_dir), "--ignore-not-found"])
+
+    # Scale existing echonet deployments to 0 so a stale one doesn't hold the
+    # PVC while the new pod tries to attach it.
+    _scale_down_existing_echonet_deployments(namespace_args)
 
     # Ensure the sequencer is scaled down before deploying/updating echonet.
     logger.info("Scaling down statefulset/sequencer-node-statefulset to 0 replicas...")

--- a/echonet/k8s/echonet/deployment.yaml
+++ b/echonet/k8s/echonet/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     app.kubernetes.io/component: api
 spec:
   replicas: 1
+  # Kill the old pod before starting the new one: the PVC has node affinity,
+  # so under RollingUpdate the new pod hangs on a Multi-Attach error.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       # NOTE: Deployment selectors are immutable once created.


### PR DESCRIPTION
The echonet PVC has node affinity, so under the default RollingUpdate
strategy a redeploy leaves the new pod Pending on a Multi-Attach error
until the old pod releases the volume — which it never does, since the
rollout waits for the new pod. Switch to Recreate, and additionally
scale any existing echonet deployments to 0 in deploy_echonet.py before
applying, covering stale deployments left in the namespace.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>