### PR TITLE
echonet: stash block-hash commitments alongside each stored block

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -588,7 +588,7 @@ class BlobTransformer:
         )
         return str(result)
 
-    def transform_block(self, blob: JsonObject) -> JsonObject:
+    def transform_block(self, blob: JsonObject) -> tuple[JsonObject, JsonObject]:
         """
         Build the stored "block" document from an incoming blob.
 
@@ -596,6 +596,10 @@ class BlobTransformer:
         - transactions + receipts (minimal schema expected by downstream consumers)
         - block hash computed from real commitments and block header fields
         - fee market metadata (timestamp + gas prices)
+
+        Returns `(block_document, block_commitments)` — the raw 5-felt
+        `BlockHeaderCommitments` dict is handed back for downstream reuse
+        (block_document only keeps four of them, stringified).
         """
         block_number = int(blob["block_number"])
         tx_entries = blob["transactions"]
@@ -606,7 +610,7 @@ class BlobTransformer:
         execution_infos = blob["execution_infos"]
         assert len(execution_infos) == len(
             transformed_txs
-        ), f"The number of transactions in the blob does not match the number of execution infos."
+        ), "The number of transactions in the blob does not match the number of execution infos."
         for idx, (tx, execution_info) in enumerate(zip(transformed_txs, execution_infos)):
             receipts.append(
                 self._transform_receipt_from_execution_info(
@@ -669,7 +673,7 @@ class BlobTransformer:
             source_block=source_block,
         )
 
-        return block_document
+        return block_document, block_commitments
 
     def transform_state_update(
         self, blob: JsonObject, block_number: int, block_hash: str
@@ -862,7 +866,7 @@ class EchoCenterService:
         self.shared.set_last_block(block_number)
         self.flask_logger.info(f"last_block={block_number}")
 
-        to_store = self._transformer.transform_block(blob)
+        to_store, block_commitments = self._transformer.transform_block(blob)
         state_update = self._transformer.transform_state_update(
             blob, block_number, to_store["block_hash"]
         )
@@ -874,6 +878,7 @@ class EchoCenterService:
             blob_body=body,
             fgw_block=to_store,
             state_update=state_update,
+            block_commitments=block_commitments,
         )
         self.flask_logger.info(
             f"block {block_number} tx hashes: {' '.join(self._transformer.get_blob_tx_hashes(blob))}"

--- a/echonet/shared_context.py
+++ b/echonet/shared_context.py
@@ -350,13 +350,17 @@ class _BlockStore:
         blob_body: bytes,
         fgw_block: JsonObject,
         state_update: JsonObject,
+        block_commitments: JsonObject,
     ) -> tuple[List[tuple[int, JsonObject]], List[tuple[int, bytes]]]:
         # Store the blob as raw JSON bytes, not a parsed dict: parsing costs
         # 5-8x the memory and OOMs the pod; consumers parse just-in-time.
+        # `block_commitments` (the 5-felt BlockHeaderCommitments from ingest)
+        # is stashed for downstream reuse without re-parsing blob_body.
         self.blocks[block_number] = {
             "blob_body": blob_body,
             "block": fgw_block,
             "state_update": state_update,
+            "block_commitments": block_commitments,
         }
         evicted_items = self._evict_old_items(self.blocks, current_block_number=block_number)
         evicted_blob_bodies = self._evict_old_blob_bodies(
@@ -660,6 +664,7 @@ class SharedContext:
         blob_body: bytes,
         fgw_block: JsonObject,
         state_update: JsonObject,
+        block_commitments: JsonObject,
     ) -> None:
         with self._lock:
             evicted_items, evicted_blob_bodies = self._blocks.store_block(
@@ -667,6 +672,7 @@ class SharedContext:
                 blob_body=blob_body,
                 fgw_block=fgw_block,
                 state_update=state_update,
+                block_commitments=block_commitments,
             )
         if evicted_items:
             _BlockStore.write_snapshot_items_to_disk(


### PR DESCRIPTION
transform_block already computes the full 5-felt BlockHeaderCommitments
via the block-hash CLI but only string-ifies four of them into the
block document. Return the raw dict too and keep it in the block store,
so the upcoming OS runner can reuse it instead of re-parsing the
multi-MB blob to recompute the same values.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>