### PR TITLE
echonet: redesign the report UI with sidenav, alerts grid, and CSV export

### DIFF
--- a/echonet/static/report.css
+++ b/echonet/static/report.css
@@ -3,29 +3,34 @@
     --bg: #0b0d12;
     --panel: #121827;
     --panel2: #0f1422;
+    --panel3: #161d2f;
     --text: #e7eaf0;
     --muted: #a7b0c0;
     --border: rgba(255, 255, 255, 0.08);
+    --borderStrong: rgba(255, 255, 255, 0.14);
     --shadow: rgba(0, 0, 0, 0.35);
     --ok: #2ecc71;
     --warn: #f1c40f;
     --bad: #ff5d5d;
     --accent: #7aa2ff;
-    /* Secondary backdrop accent (keep neutral by default; "risk" theme will override). */
     --accent2: var(--accent);
     --link: var(--accent);
+    --topbarH: 78px;
+    --sideW: 248px;
+    --rowPadY: 9px;
     --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     --sans: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
 }
 
-/* Light theme variables (toggled via [data-theme="light"]) */
 html[data-theme="light"] {
     --bg: #f6f7fb;
     --panel: #ffffff;
     --panel2: #fbfbfe;
+    --panel3: #f0f2fa;
     --text: #111827;
     --muted: #5b6475;
     --border: rgba(17, 24, 39, 0.10);
+    --borderStrong: rgba(17, 24, 39, 0.18);
     --shadow: rgba(0, 0, 0, 0.10);
     --accent: #2457ff;
     --accent2: var(--accent);
@@ -46,9 +51,9 @@ body {
     font-family: var(--sans);
     background: var(--bg);
     color: var(--text);
+    -webkit-font-smoothing: antialiased;
 }
 
-/* Fixed soft glow backdrop (no hard band while scrolling). */
 body::before {
     content: "";
     position: fixed;
@@ -67,12 +72,6 @@ body::before {
             transparent 70%);
 }
 
-/* Make section anchors scroll nicely under sticky header. */
-section[id] {
-    scroll-margin-top: 86px;
-}
-
-/* In "risk" theme, make the glow a bit stronger. */
 html[data-theme="risk"] body::before {
     background:
         radial-gradient(1100px 680px at 18% -8%,
@@ -86,19 +85,8 @@ html[data-theme="risk"] body::before {
             transparent 70%);
 }
 
-.pillLink {
-    cursor: pointer;
-    user-select: none;
-}
-
-.pillLink:focus {
-    outline: none;
-    box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
-}
-
-/* Risk theme (accent is set dynamically by JS based on echonet-only revert rate). */
-html[data-theme="risk"] {
-    --link: var(--accent);
+section[id] {
+    scroll-margin-top: calc(var(--topbarH) + 12px);
 }
 
 a {
@@ -121,13 +109,40 @@ a:hover {
 .smallMuted {
     color: var(--muted);
     font-size: 12px;
-    margin-top: 10px;
-    line-height: 1.35;
+    line-height: 1.4;
 }
 
 .empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 24px 12px;
     color: var(--muted);
-    padding: 12px 0;
+    text-align: center;
+}
+
+.empty .emptyIcon {
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--muted) 16%, transparent);
+    color: var(--muted);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 18px;
+}
+
+.empty .emptyIcon.ok {
+    background: color-mix(in oklab, var(--ok) 18%, transparent);
+    color: var(--ok);
+}
+
+.empty .emptyText {
+    font-size: 13px;
 }
 
 .countPill {
@@ -144,37 +159,163 @@ a:hover {
     font-family: var(--mono);
 }
 
+/* ───────── Topbar ───────── */
+
 .topbar {
     position: sticky;
     top: 0;
     z-index: 50;
     display: flex;
     justify-content: space-between;
+    align-items: stretch;
     gap: 16px;
-    padding: 14px 16px;
+    padding: 12px 18px;
     border-bottom: 1px solid var(--border);
-    background: color-mix(in oklab, var(--panel) 88%, transparent);
-    backdrop-filter: blur(10px);
+    background: color-mix(in oklab, var(--panel) 90%, transparent);
+    backdrop-filter: blur(12px);
+}
+
+.topbarLeft {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.brandLogo {
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
+    background: linear-gradient(135deg,
+        color-mix(in oklab, var(--accent) 50%, transparent),
+        color-mix(in oklab, var(--accent2) 25%, transparent));
+    color: var(--text);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--borderStrong);
+    box-shadow: 0 6px 18px var(--shadow);
+}
+
+.brandText {
+    line-height: 1.1;
 }
 
 .brand .title {
     font-size: 16px;
-    font-weight: 650;
-    letter-spacing: 0.2px;
+    font-weight: 700;
+    letter-spacing: 0.15px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .brand .subtitle {
-    margin-top: 2px;
+    margin-top: 4px;
     font-size: 12px;
     color: var(--muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.agoChip {
+    padding: 1px 7px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 70%, transparent);
+    color: var(--muted);
+    font-size: 11px;
+}
+
+.healthDot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--ok);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--ok) 22%, transparent);
+    transition: background 200ms ease, box-shadow 200ms ease;
+}
+
+.healthDot.warn {
+    background: var(--warn);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--warn) 22%, transparent);
+}
+
+.healthDot.bad {
+    background: var(--bad);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--bad) 22%, transparent);
+    animation: healthPulse 2s ease-in-out infinite;
+}
+
+@keyframes healthPulse {
+    0%, 100% { box-shadow: 0 0 0 3px color-mix(in oklab, var(--bad) 22%, transparent); }
+    50%      { box-shadow: 0 0 0 6px color-mix(in oklab, var(--bad) 14%, transparent); }
+}
+
+.liveIndicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--muted) 50%, transparent);
+}
+
+.liveIndicator.live {
+    background: var(--ok);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--ok) 22%, transparent);
+    animation: livePulse 1.4s ease-in-out infinite;
+}
+
+@keyframes livePulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50%      { transform: scale(1.25); opacity: 0.7; }
 }
 
 .controls {
     display: flex;
-    gap: 10px;
+    gap: 8px;
     align-items: end;
     flex-wrap: wrap;
     justify-content: flex-end;
+}
+
+.btnGroup {
+    display: inline-flex;
+    align-items: stretch;
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: 11px;
+    overflow: hidden;
+    background: color-mix(in oklab, var(--panel2) 80%, transparent);
+    box-shadow: 0 6px 16px var(--shadow);
+}
+
+.btnGroup .btn {
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    background: transparent;
+    padding: 7px 10px;
+    border-right: 1px solid var(--border);
+}
+
+.btnGroup .btn:last-child {
+    border-right: none;
+}
+
+.btnGroup .btn:hover {
+    background: color-mix(in oklab, var(--link) 14%, transparent);
+}
+
+.btnGroup .btn[aria-pressed="true"] {
+    background: color-mix(in oklab, var(--link) 22%, transparent);
+    color: var(--text);
 }
 
 .inlineForm {
@@ -193,30 +334,38 @@ a:hover {
 
 .statusLine {
     color: var(--muted);
-    font-size: 12px;
+    font-size: 11px;
     padding: 6px 10px;
     border-radius: 999px;
     border: 1px solid var(--border);
     background: color-mix(in oklab, var(--panel2) 88%, transparent);
     font-family: var(--mono);
+    align-self: end;
 }
 
 .control {
     display: grid;
-    gap: 6px;
-    font-size: 12px;
+    gap: 4px;
+    font-size: 11px;
     color: var(--muted);
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
 }
 
 .control input,
 .control select {
     min-width: 220px;
-    padding: 8px 10px;
+    padding: 7px 10px;
     border-radius: 10px;
     border: 1px solid var(--border);
     background: var(--panel2);
     color: var(--text);
     outline: none;
+    font-family: var(--sans);
+    font-size: 13px;
+    text-transform: none;
+    letter-spacing: 0;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
 .noSpin[type="number"] {
@@ -224,7 +373,6 @@ a:hover {
     -moz-appearance: textfield;
 }
 
-/* Chrome, Safari, Edge */
 .noSpin[type="number"]::-webkit-outer-spin-button,
 .noSpin[type="number"]::-webkit-inner-spin-button {
     -webkit-appearance: none;
@@ -246,19 +394,33 @@ a:hover {
     border: 1px solid var(--border);
     background: linear-gradient(180deg, color-mix(in oklab, var(--panel) 92%, white 8%), var(--panel));
     color: var(--text);
-    padding: 8px 10px;
+    padding: 7px 11px;
     border-radius: 10px;
     cursor: pointer;
     font-size: 12px;
-    box-shadow: 0 8px 20px var(--shadow);
+    box-shadow: 0 6px 16px var(--shadow);
+    transition: filter 120ms ease, transform 60ms ease, box-shadow 120ms ease, background 120ms ease;
+    font-family: var(--sans);
 }
 
 .btn:hover {
-    filter: brightness(1.05);
+    filter: brightness(1.06);
 }
 
 .btn:active {
     transform: translateY(1px);
+}
+
+.btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--link) 28%, transparent);
+}
+
+.btnIcon {
+    width: 32px;
+    padding: 0;
+    text-align: center;
+    font-weight: 700;
 }
 
 .btnLink {
@@ -267,14 +429,15 @@ a:hover {
 }
 
 .btnSmall {
-    padding: 5px 7px;
-    border-radius: 9px;
+    padding: 4px 7px;
+    border-radius: 8px;
     box-shadow: none;
+    font-size: 11px;
 }
 
 .rowActions {
     display: flex;
-    gap: 5px;
+    gap: 4px;
     align-items: center;
     justify-content: flex-end;
     flex-wrap: nowrap;
@@ -290,10 +453,115 @@ a:hover {
     margin: -2px 0 10px;
 }
 
+/* ───────── Layout: sidenav + main ───────── */
+
+.layout {
+    display: grid;
+    grid-template-columns: var(--sideW) minmax(0, 1fr);
+    align-items: start;
+}
+
+.sidenav {
+    position: sticky;
+    top: var(--topbarH);
+    height: calc(100vh - var(--topbarH));
+    overflow-y: auto;
+    border-right: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel) 65%, transparent);
+    backdrop-filter: blur(10px);
+    padding: 18px 12px 30px;
+}
+
+.sidenavTitle {
+    color: var(--muted);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    margin: 4px 8px 8px;
+}
+
+.sidenavList {
+    display: grid;
+    gap: 2px;
+}
+
+.sidenavItem {
+    display: grid;
+    grid-template-columns: 12px 1fr auto;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 10px;
+    border-radius: 10px;
+    color: var(--text);
+    font-size: 13px;
+    cursor: pointer;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: background 120ms ease, border-color 120ms ease;
+}
+
+.sidenavItem:hover {
+    background: color-mix(in oklab, var(--link) 10%, transparent);
+    text-decoration: none;
+}
+
+.sidenavItem.active {
+    background: color-mix(in oklab, var(--link) 18%, transparent);
+    border-color: color-mix(in oklab, var(--link) 35%, transparent);
+}
+
+.sidenavItem .navLabel {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sidenavItem .navCount {
+    font-size: 11px;
+    color: var(--muted);
+    padding: 1px 7px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--panel2) 90%, transparent);
+}
+
+.navDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--muted) 40%, transparent);
+}
+
+.navDot.ok { background: var(--ok); }
+.navDot.warn { background: var(--warn); }
+.navDot.bad { background: var(--bad); box-shadow: 0 0 0 3px color-mix(in oklab, var(--bad) 18%, transparent); }
+.navDot.neutral { background: color-mix(in oklab, var(--muted) 50%, transparent); }
+
+.sidenavFooter {
+    margin-top: 18px;
+    padding: 12px 10px 6px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+}
+
+.sidenavFooter kbd,
+.shortcutsBody kbd {
+    display: inline-block;
+    padding: 1px 6px;
+    border: 1px solid var(--border);
+    border-bottom-width: 2px;
+    border-radius: 6px;
+    background: color-mix(in oklab, var(--panel2) 90%, transparent);
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--text);
+    margin: 0 2px;
+}
+
 .container {
     max-width: 1280px;
-    margin: 18px auto;
-    padding: 0 16px 30px;
+    margin: 16px auto;
+    padding: 0 18px 30px;
 }
 
 .stack {
@@ -302,51 +570,34 @@ a:hover {
     gap: 14px;
 }
 
-.row2 {
+.overviewGrid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 2fr 1fr 1fr;
     gap: 14px;
+    align-items: stretch;
 }
 
-.grid {
-    display: grid;
-    gap: 14px;
+.overviewGrid .span3 {
+    grid-row: span 1;
 }
 
-.kpis {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.span2 {
-    grid-column: span 2;
-}
-
-.twoCol {
+.alertsCard {
     margin-top: 14px;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-@media (max-width: 1050px) {
-    .kpis {
+@media (max-width: 1100px) {
+    .layout {
         grid-template-columns: 1fr;
     }
-
-    .span2 {
-        grid-column: auto;
+    .sidenav {
+        display: none;
     }
-
-    .twoCol {
+    .overviewGrid {
         grid-template-columns: 1fr;
-    }
-
-    .row2 {
-        grid-template-columns: 1fr;
-    }
-
-    .control input {
-        min-width: 180px;
     }
 }
+
+/* ───────── Cards ───────── */
 
 .card {
     background: linear-gradient(180deg, color-mix(in oklab, var(--panel) 92%, white 8%), var(--panel));
@@ -355,16 +606,41 @@ a:hover {
     padding: 14px 14px 12px;
     box-shadow: 0 16px 40px var(--shadow);
     min-width: 0;
-    /* allow shrinking in CSS grid */
+}
+
+.cardHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+}
+
+.cardHeaderRight {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
 }
 
 .cardTitle {
-    font-weight: 650;
-    letter-spacing: 0.2px;
-    margin-bottom: 10px;
+    font-weight: 700;
+    letter-spacing: 0.15px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
 }
 
-/* Collapsible section cards (page-level sections). */
+.cardTitle .icon {
+    width: 16px;
+    height: 16px;
+    color: color-mix(in oklab, var(--link) 75%, var(--text));
+    opacity: 0.9;
+}
+
+/* Collapsible section cards */
 .sectionDetails>summary {
     list-style: none;
     cursor: pointer;
@@ -378,17 +654,22 @@ a:hover {
 .sectionDetails>summary.sectionSummary {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
     gap: 10px;
-    font-weight: 650;
-    letter-spacing: 0.2px;
-    /* Override generic `.details summary` styling; match original `.cardTitle`. */
+    font-weight: 700;
+    letter-spacing: 0.15px;
     color: var(--text);
-    font-size: inherit;
+    font-size: 14px;
     position: relative;
-    padding-right: 18px;
-    /* room for chevron */
+    padding-right: 22px;
     margin: 0 0 10px;
+}
+
+.sectionSummary .icon {
+    width: 16px;
+    height: 16px;
+    color: color-mix(in oklab, var(--link) 75%, var(--text));
+    opacity: 0.9;
 }
 
 .sectionDetails:not([open])>summary.sectionSummary {
@@ -399,13 +680,14 @@ a:hover {
     min-width: 0;
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
 }
 
 .sectionSummaryRight {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
+    margin-right: 14px;
 }
 
 .sectionDetails>summary.sectionSummary::after {
@@ -429,11 +711,13 @@ a:hover {
     opacity: 0.95;
 }
 
-.sectionDetails>summary.sectionSummary:focus {
+.sectionDetails>summary.sectionSummary:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
     border-radius: 12px;
 }
+
+/* ───────── Progress / hero ───────── */
 
 .kpiProgress .cardTitle {
     margin-bottom: 8px;
@@ -442,20 +726,22 @@ a:hover {
 .progressHero {
     display: grid;
     grid-template-columns: 1.1fr 1fr;
-    gap: 12px 14px;
+    gap: 12px 18px;
     align-items: start;
 }
 
 .heroLabel {
     color: var(--muted);
-    font-size: 12px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
 }
 
 .heroValue {
-    font-size: 36px;
+    font-size: 34px;
     font-weight: 800;
     letter-spacing: -0.6px;
-    margin-top: 2px;
+    margin-top: 4px;
 }
 
 .heroRow {
@@ -475,12 +761,324 @@ a:hover {
     gap: 6px 10px;
 }
 
-.bigNumber {
-    font-size: 32px;
-    font-weight: 750;
-    letter-spacing: -0.3px;
+.progressBarWrap {
+    margin-top: 14px;
+}
+
+.progressBarTrack {
+    position: relative;
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+    border: 1px solid var(--border);
+    overflow: hidden;
+}
+
+.progressBarFill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0%;
+    background: linear-gradient(90deg,
+        color-mix(in oklab, var(--accent) 55%, transparent),
+        color-mix(in oklab, var(--accent2) 80%, transparent));
+    transition: width 600ms ease;
+}
+
+.progressBarLabels {
+    display: flex;
+    justify-content: space-between;
     margin-top: 4px;
 }
+
+/* ───────── Mini tiles (overview right column) ───────── */
+
+.tile {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.tileValue {
+    font-size: 30px;
+    font-weight: 750;
+    letter-spacing: -0.3px;
+}
+
+.tileSub {
+    font-size: 12px;
+}
+
+.stackedBar {
+    display: flex;
+    height: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+    border: 1px solid var(--border);
+    margin-top: 10px;
+}
+
+.stackedBarPart {
+    height: 100%;
+    transition: width 400ms ease;
+}
+
+.stackedOk {
+    background: color-mix(in oklab, var(--ok) 70%, transparent);
+}
+
+.stackedPending {
+    background: color-mix(in oklab, var(--warn) 55%, transparent);
+}
+
+.legendRow {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.legendDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--muted);
+}
+
+.legendDot.ok { background: var(--ok); }
+.legendDot.pending { background: var(--warn); }
+.legendDot.bad { background: var(--bad); }
+
+.riskGauge {
+    margin-top: 10px;
+}
+
+.riskGaugeTrack {
+    position: relative;
+    height: 10px;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: linear-gradient(90deg,
+        color-mix(in oklab, var(--ok) 55%, var(--panel2)),
+        color-mix(in oklab, var(--warn) 60%, var(--panel2)),
+        color-mix(in oklab, var(--bad) 65%, var(--panel2)));
+}
+
+.riskGaugeFill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0%;
+    background: color-mix(in oklab, white 6%, transparent);
+    backdrop-filter: blur(2px);
+}
+
+.riskGaugeMarker {
+    position: absolute;
+    top: -3px;
+    bottom: -3px;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--text);
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--panel) 85%, transparent);
+    left: 0%;
+    transition: left 600ms ease;
+}
+
+/* ───────── Alerts: metric grid ───────── */
+
+.metricGrid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.metricTile {
+    appearance: none;
+    text-align: left;
+    background: color-mix(in oklab, var(--panel2) 85%, transparent);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 10px 12px;
+    color: var(--text);
+    cursor: pointer;
+    display: grid;
+    gap: 4px;
+    transition: transform 80ms ease, border-color 120ms ease, background 120ms ease;
+    box-shadow: 0 8px 18px var(--shadow);
+}
+
+.metricTile:hover {
+    transform: translateY(-1px);
+    border-color: color-mix(in oklab, var(--link) 30%, var(--border));
+}
+
+.metricLabel {
+    font-size: 11px;
+    color: var(--muted);
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.metricValue {
+    font-size: 22px;
+    font-weight: 750;
+    letter-spacing: -0.2px;
+}
+
+.metricSub {
+    font-size: 11px;
+    color: var(--muted);
+}
+
+.metricTile.ok {
+    border-color: color-mix(in oklab, var(--ok) 30%, var(--border));
+    background: color-mix(in oklab, var(--ok) 8%, var(--panel2));
+}
+
+.metricTile.warn {
+    border-color: color-mix(in oklab, var(--warn) 45%, var(--border));
+    background: color-mix(in oklab, var(--warn) 10%, var(--panel2));
+}
+
+.metricTile.bad {
+    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
+    background: color-mix(in oklab, var(--bad) 11%, var(--panel2));
+}
+
+.metricTile.neutral .metricLabel {
+    color: var(--muted);
+}
+
+.metricTile.static {
+    cursor: default;
+    box-shadow: none;
+}
+
+.metricTile.static:hover {
+    transform: none;
+    border-color: var(--border);
+}
+
+.metricSubgroupDivider {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 16px 2px 10px 2px;
+    color: var(--muted);
+}
+
+.metricSubgroupDivider::before,
+.metricSubgroupDivider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+}
+
+.metricSubgroupLabel {
+    font-size: 11px;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+@media (max-width: 980px) {
+    .metricGrid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+/* ───────── Revert reasons summary ───────── */
+
+.revertSummaryGrid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    margin-top: 10px;
+}
+
+@media (max-width: 980px) {
+    .revertSummaryGrid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.revertSummaryTitle {
+    font-size: 12px;
+    color: var(--muted);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+}
+
+.barList {
+    display: grid;
+    gap: 6px;
+}
+
+.barRow {
+    appearance: none;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 6px 8px;
+    color: var(--text);
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: minmax(120px, 1.3fr) minmax(80px, 2fr) 60px 60px;
+    align-items: center;
+    gap: 10px;
+    text-align: left;
+    transition: background 120ms ease, border-color 120ms ease;
+}
+
+.barRow:hover {
+    background: color-mix(in oklab, var(--link) 8%, transparent);
+    border-color: color-mix(in oklab, var(--link) 25%, transparent);
+}
+
+.barName {
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.barTrack {
+    height: 8px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--panel2) 92%, transparent);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    position: relative;
+}
+
+.barFill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0%;
+    background: linear-gradient(90deg,
+        color-mix(in oklab, var(--warn) 55%, transparent),
+        color-mix(in oklab, var(--bad) 75%, transparent));
+    transition: width 500ms ease;
+}
+
+.barCount {
+    text-align: right;
+    font-size: 12px;
+}
+
+.barPct {
+    text-align: right;
+    font-size: 11px;
+}
+
+/* ───────── KV pairs ───────── */
 
 .kv {
     display: grid;
@@ -491,85 +1089,44 @@ a:hover {
 
 .kv .k {
     color: var(--muted);
-    font-size: 12px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
 }
 
 .kv .v {
     font-size: 13px;
 }
 
-.pillRow {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 10px;
-}
+/* ───────── Tables ───────── */
 
-.pill {
-    display: inline-flex;
-    gap: 6px;
-    align-items: center;
+.tableWrap {
+    overflow: auto;
+    border-radius: 14px;
     border: 1px solid var(--border);
-    padding: 6px 10px;
-    border-radius: 999px;
-    font-size: 12px;
-    background: color-mix(in oklab, var(--panel2) 88%, transparent);
-}
-
-.pill.neutral {
-    color: var(--muted);
-}
-
-.pill.ok {
-    border-color: color-mix(in oklab, var(--ok) 42%, var(--border));
-    background: color-mix(in oklab, var(--ok) 10%, var(--panel2));
-}
-
-.pill.warn {
-    border-color: color-mix(in oklab, var(--warn) 45%, var(--border));
-    background: color-mix(in oklab, var(--warn) 10%, var(--panel2));
-}
-
-.pill.bad {
-    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
-    background: color-mix(in oklab, var(--bad) 10%, var(--panel2));
-}
-
-.badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 28px;
-    padding: 2px 8px;
-    border-radius: 999px;
-    border: 1px solid var(--border);
-    font-size: 12px;
-    font-family: var(--mono);
-}
-
-.badge.bad {
-    border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
+    background: color-mix(in oklab, var(--panel2) 75%, transparent);
 }
 
 .table {
     width: 100%;
     border-collapse: separate;
     border-spacing: 0;
-    overflow: hidden;
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    background: color-mix(in oklab, var(--panel2) 75%, transparent);
     table-layout: fixed;
 }
 
 .table thead th {
     text-align: left;
-    font-size: 12px;
+    font-size: 11px;
     color: var(--muted);
     font-weight: 650;
     padding: 10px 10px;
     border-bottom: 1px solid var(--border);
-    background: color-mix(in oklab, var(--panel2) 88%, transparent);
+    background: color-mix(in oklab, var(--panel3) 92%, transparent);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
 }
 
 .table thead th.sortable {
@@ -581,14 +1138,14 @@ body[data-report-export="1"] .table thead th.sortable {
     cursor: default;
 }
 
-.table thead th.sortable:focus {
+.table thead th.sortable:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 14%, transparent);
-    border-radius: 10px;
+    border-radius: 6px;
 }
 
 .table thead th.sortable:hover {
-    color: color-mix(in oklab, var(--muted) 50%, var(--text));
+    color: color-mix(in oklab, var(--muted) 40%, var(--text));
 }
 
 .table thead th.sortable::after {
@@ -608,12 +1165,12 @@ body[data-report-export="1"] .table thead th.sortable {
 .table thead th.sortable[data-sort-dir="asc"]::after {
     border-top: 0;
     border-bottom: 6px solid color-mix(in oklab, var(--link) 70%, transparent);
-    opacity: 0.9;
+    opacity: 0.95;
 }
 
 .table thead th.sortable[data-sort-dir="desc"]::after {
     border-top: 6px solid color-mix(in oklab, var(--link) 70%, transparent);
-    opacity: 0.9;
+    opacity: 0.95;
 }
 
 body[data-report-export="1"] .table thead th.sortable::after {
@@ -621,11 +1178,15 @@ body[data-report-export="1"] .table thead th.sortable::after {
 }
 
 .table tbody td {
-    padding: 9px 10px;
+    padding: var(--rowPadY) 10px;
     border-bottom: 1px solid var(--border);
     vertical-align: top;
     font-size: 13px;
     overflow: hidden;
+}
+
+body[data-density="compact"] {
+    --rowPadY: 5px;
 }
 
 .table tbody tr:last-child td {
@@ -648,6 +1209,7 @@ body[data-report-export="1"] .table thead th.sortable::after {
     border-radius: 999px;
     border: 1px solid var(--border);
     background: color-mix(in oklab, var(--panel2) 85%, transparent);
+    font-size: 11px;
 }
 
 .status.ok {
@@ -660,14 +1222,6 @@ body[data-report-export="1"] .table thead th.sortable::after {
 
 .status.bad {
     border-color: color-mix(in oklab, var(--bad) 45%, var(--border));
-}
-
-tr.sev.bad td {
-    box-shadow: inset 3px 0 0 color-mix(in oklab, var(--bad) 75%, transparent);
-}
-
-tr.sev.warn td {
-    box-shadow: inset 3px 0 0 color-mix(in oklab, var(--warn) 70%, transparent);
 }
 
 .hash {
@@ -686,14 +1240,17 @@ body[data-report-export="1"] .hash {
     user-select: text;
 }
 
-.hash:focus {
+.hash:focus-visible {
     outline: none;
     box-shadow: 0 0 0 4px color-mix(in oklab, var(--link) 16%, transparent);
     border-radius: 8px;
 }
 
-body[data-report-export="1"] .hash:focus {
-    box-shadow: none;
+mark.matchHighlight {
+    background: color-mix(in oklab, var(--warn) 50%, transparent);
+    color: var(--text);
+    border-radius: 4px;
+    padding: 0 2px;
 }
 
 /* Column sizing (used via <colgroup>) */
@@ -717,7 +1274,7 @@ body[data-report-export="1"] .hash:focus {
     width: 280px;
 }
 
-@media (max-width: 1050px) {
+@media (max-width: 1100px) {
     .progressHero {
         grid-template-columns: 1fr;
     }
@@ -746,6 +1303,21 @@ body[data-report-export="1"] .hash:focus {
     margin-top: 6px;
 }
 
+.revertGroup {
+    margin-top: 8px;
+    padding: 4px 0;
+    border-radius: 10px;
+}
+
+details.revertGroup.flash {
+    animation: groupFlash 1.4s ease;
+}
+
+@keyframes groupFlash {
+    0%   { background: color-mix(in oklab, var(--link) 26%, transparent); }
+    100% { background: transparent; }
+}
+
 .pre {
     margin: 10px 0 0;
     padding: 10px;
@@ -758,13 +1330,13 @@ body[data-report-export="1"] .hash:focus {
     word-break: break-word;
     font-family: var(--mono);
     font-size: 12px;
-    line-height: 1.35;
+    line-height: 1.4;
 }
 
 .reason {
     font-family: var(--mono);
     font-size: 12px;
-    line-height: 1.35;
+    line-height: 1.4;
 }
 
 .footer {
@@ -779,3 +1351,114 @@ tr.isHidden,
 details.isHidden {
     display: none;
 }
+
+/* ───────── Shortcuts overlay ───────── */
+
+.shortcutsOverlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: color-mix(in oklab, black 50%, transparent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    backdrop-filter: blur(4px);
+    animation: fadeIn 120ms ease;
+}
+
+/* The `hidden` attribute must win over `display: flex` above. */
+.shortcutsOverlay[hidden] {
+    display: none;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.shortcutsCard {
+    width: min(520px, 100%);
+    border-radius: 16px;
+    border: 1px solid var(--borderStrong);
+    background: var(--panel);
+    box-shadow: 0 30px 80px var(--shadow);
+    padding: 16px 18px 18px;
+}
+
+.shortcutsHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}
+
+.shortcutsTitle {
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.15px;
+}
+
+.shortcutsBody {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 16px;
+}
+
+.shortcutRow {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 10px;
+    align-items: center;
+    font-size: 13px;
+    padding: 4px 0;
+    border-bottom: 1px dashed color-mix(in oklab, var(--border) 80%, transparent);
+}
+
+.shortcutRow:nth-last-child(-n+2) {
+    border-bottom: none;
+}
+
+@media (max-width: 600px) {
+    .shortcutsBody {
+        grid-template-columns: 1fr;
+    }
+    .shortcutRow {
+        border-bottom: 1px dashed color-mix(in oklab, var(--border) 80%, transparent);
+    }
+}
+
+/* ───────── Toast ───────── */
+
+#toast {
+    position: fixed;
+    bottom: 18px;
+    right: 18px;
+    padding: 9px 14px;
+    border-radius: 12px;
+    border: 1px solid var(--borderStrong);
+    background: color-mix(in oklab, var(--panel) 90%, transparent);
+    backdrop-filter: blur(10px);
+    color: var(--text);
+    font-size: 12px;
+    font-family: var(--sans);
+    box-shadow: 0 18px 40px var(--shadow);
+    z-index: 110;
+    opacity: 0;
+    transform: translateY(6px);
+    transition: opacity 140ms ease, transform 140ms ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#toast .toastDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--accent);
+}
+
+#toast.success .toastDot { background: var(--ok); }
+#toast.error .toastDot   { background: var(--bad); }
+#toast.info .toastDot    { background: var(--accent); }

--- a/echonet/static/report.js
+++ b/echonet/static/report.js
@@ -4,6 +4,9 @@
         theme: "echonet.report.theme",
         filter: "echonet.report.filter",
         scope: "echonet.report.filterScope",
+        density: "echonet.report.density",
+        hashMode: "echonet.report.hashMode",
+        sortPrefix: "echonet.report.sort.",
         blockDumpNumber: "echonet.report.blockDumpNumber",
         blockDumpKind: "echonet.report.blockDumpKind",
     };
@@ -24,8 +27,6 @@
             html.removeAttribute("data-theme");
         }
 
-        // "risk" sets --accent/--accent2 inline; clear when leaving it so dark/light
-        // revert to CSS defaults immediately (no refresh required).
         if (theme !== "risk") {
             html.style.removeProperty("--accent");
             html.style.removeProperty("--accent2");
@@ -33,12 +34,10 @@
     }
 
     function getDefaultTheme() {
-        // Default: risk (accent derived from echonet-only revert rate).
         return "risk";
     }
 
     function nextTheme(current) {
-        // Cycle: risk -> dark -> light -> risk
         if (current === "risk") return "dark";
         if (current === "dark") return "light";
         return "risk";
@@ -79,7 +78,6 @@
     }
 
     function updateTableMeta() {
-        // Tables (by data-table)
         document.querySelectorAll("[data-table-meta]").forEach((el) => {
             const name = el.getAttribute("data-table-meta");
             if (!name) return;
@@ -94,7 +92,6 @@
             el.textContent = total === 0 ? "" : `Showing ${visible}/${total} rows`;
         });
 
-        // Global stats (all rows)
         const stats = $("filterStats");
         if (stats) {
             const all = countVisibleRows(document);
@@ -102,17 +99,76 @@
         }
     }
 
+    // ───────── Filtering + match highlighting ─────────
+
+    function clearHighlightsIn(root) {
+        root.querySelectorAll("mark.matchHighlight").forEach((m) => {
+            const parent = m.parentNode;
+            if (!parent) return;
+            parent.replaceChild(document.createTextNode(m.textContent || ""), m);
+            parent.normalize();
+        });
+    }
+
+    function highlightMatchesIn(root, query) {
+        if (!query) return;
+        const q = query.toLowerCase();
+        const SKIP_TAGS = new Set(["script", "style", "mark", "pre", "code"]);
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+                const parent = node.parentNode;
+                if (!parent) return NodeFilter.FILTER_REJECT;
+                if (SKIP_TAGS.has((parent.nodeName || "").toLowerCase())) return NodeFilter.FILTER_REJECT;
+                if (parent.classList && parent.classList.contains("matchHighlight")) return NodeFilter.FILTER_REJECT;
+                if (!node.nodeValue) return NodeFilter.FILTER_REJECT;
+                return NodeFilter.FILTER_ACCEPT;
+            },
+        });
+
+        const targets = [];
+        let n;
+        while ((n = walker.nextNode())) {
+            const t = n.nodeValue || "";
+            if (!t.toLowerCase().includes(q)) continue;
+            targets.push(n);
+        }
+
+        for (const node of targets) {
+            const text = node.nodeValue || "";
+            const frag = document.createDocumentFragment();
+            const lower = text.toLowerCase();
+            let i = 0;
+            while (i < text.length) {
+                const idx = lower.indexOf(q, i);
+                if (idx < 0) {
+                    frag.appendChild(document.createTextNode(text.slice(i)));
+                    break;
+                }
+                if (idx > i) frag.appendChild(document.createTextNode(text.slice(i, idx)));
+                const mark = document.createElement("mark");
+                mark.className = "matchHighlight";
+                mark.textContent = text.slice(idx, idx + q.length);
+                frag.appendChild(mark);
+                i = idx + q.length;
+            }
+            node.parentNode.replaceChild(frag, node);
+        }
+    }
+
     function filterAll(query, scope) {
         const q = normalize(query);
-
         const activeScope = scope || "all";
 
-        // Filter each filterable container independently. If scope doesn't match, leave it unfiltered.
         const containers = document.querySelectorAll(".filterable[data-filter-scope]");
         containers.forEach((root) => {
+            // Always clear stale highlights — even when not filtering this scope —
+            // so flipping from "filter all" → "filter scope" doesn't leave orphans.
+            clearHighlightsIn(root);
+
             const rootScope = root.getAttribute("data-filter-scope") || "";
             const doFilter = activeScope === "all" || activeScope === rootScope;
             const rows = root.querySelectorAll("tr[data-search]");
+
             rows.forEach((tr) => {
                 if (!doFilter) {
                     setHidden(tr, false);
@@ -121,9 +177,9 @@
                 const hay = normalize(tr.getAttribute("data-search"));
                 const match = !q || hay.includes(q);
                 setHidden(tr, !match);
+                if (match && q) highlightMatchesIn(tr, q);
             });
 
-            // If root is a <details>, hide the entire group if it has no visible rows (only when filtering it).
             if (root.tagName && root.tagName.toLowerCase() === "details") {
                 if (!doFilter) {
                     setHidden(root, false);
@@ -138,8 +194,6 @@
     }
 
     function initSectionCollapsePersistence() {
-        // Persist section open/closed state across refreshes (like refresh dropdown).
-        // Keyed by the <section id="..."> that wraps a `details.sectionDetails`.
         try {
             const prefix = "echonet.report.sectionOpen.";
             document.querySelectorAll('details.sectionDetails[data-section-details="1"]').forEach((d) => {
@@ -152,7 +206,6 @@
                 if (saved === "1") d.open = true;
                 else if (saved === "0") d.open = false;
                 else {
-                    // Defaults: everything open except pending txs.
                     if (id === "pending-txs") d.open = false;
                 }
 
@@ -162,36 +215,24 @@
                     } catch (_) { }
                 });
             });
-        } catch (_) {
-            // If localStorage is unavailable, just fall back to HTML defaults.
-        }
+        } catch (_) { }
     }
 
-    function toast(msg) {
-        // Tiny toast without dependencies.
+    // ───────── Toast ─────────
+
+    function toast(msg, kind) {
         let el = document.getElementById("toast");
         if (!el) {
             el = document.createElement("div");
             el.id = "toast";
-            el.style.position = "fixed";
-            el.style.bottom = "14px";
-            el.style.right = "14px";
-            el.style.padding = "10px 12px";
-            el.style.borderRadius = "12px";
-            el.style.border = "1px solid rgba(255,255,255,0.12)";
-            el.style.background = "rgba(20, 24, 39, 0.92)";
-            el.style.backdropFilter = "blur(10px)";
-            el.style.color = "#e7eaf0";
-            el.style.fontSize = "12px";
-            el.style.fontFamily = "ui-sans-serif, system-ui";
-            el.style.boxShadow = "0 18px 40px rgba(0,0,0,0.35)";
-            el.style.zIndex = "999";
-            el.style.opacity = "0";
-            el.style.transform = "translateY(6px)";
-            el.style.transition = "opacity 120ms ease, transform 120ms ease";
+            el.innerHTML = '<span class="toastDot" aria-hidden="true"></span><span class="toastText"></span>';
             document.body.appendChild(el);
         }
-        el.textContent = msg;
+        el.className = "";
+        if (kind === "success" || kind === "error" || kind === "info") {
+            el.classList.add(kind);
+        }
+        el.querySelector(".toastText").textContent = msg;
         requestAnimationFrame(() => {
             el.style.opacity = "1";
             el.style.transform = "translateY(0)";
@@ -200,20 +241,17 @@
         el._t = window.setTimeout(() => {
             el.style.opacity = "0";
             el.style.transform = "translateY(6px)";
-        }, 1100);
+        }, 1300);
     }
 
-    async function copyText(text) {
+    async function copyText(text, { silent = false } = {}) {
         const t = (text || "").toString();
-        if (!t) return;
+        if (!t) return false;
         try {
             await navigator.clipboard.writeText(t);
-            toast("Copied");
-            return;
-        } catch (_) {
-            // fall through
-        }
-        // Fallback
+            if (!silent) toast("Copied", "success");
+            return true;
+        } catch (_) { }
         const ta = document.createElement("textarea");
         ta.value = t;
         ta.style.position = "fixed";
@@ -222,14 +260,17 @@
         document.body.appendChild(ta);
         ta.focus();
         ta.select();
+        let ok = false;
         try {
-            document.execCommand("copy");
-            toast("Copied");
+            ok = document.execCommand("copy");
+            if (ok && !silent) toast("Copied", "success");
+            else if (!silent) toast("Copy failed", "error");
         } catch (_) {
-            toast("Copy failed");
+            if (!silent) toast("Copy failed", "error");
         } finally {
             document.body.removeChild(ta);
         }
+        return ok;
     }
 
     function initCopyButtons() {
@@ -241,11 +282,10 @@
     function initHashClickToCopy() {
         document.querySelectorAll(".hash").forEach((el) => {
             el.addEventListener("click", (e) => {
-                // Avoid interfering with text selection.
                 if (window.getSelection && (window.getSelection().toString() || "").trim()) return;
                 e.preventDefault();
                 e.stopPropagation();
-                const t = el.getAttribute("title") || el.textContent || "";
+                const t = el.getAttribute("data-full-hash") || el.getAttribute("title") || el.textContent || "";
                 copyText(t.trim());
             });
             el.setAttribute("role", "button");
@@ -253,7 +293,7 @@
             el.addEventListener("keydown", (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    const t = el.getAttribute("title") || el.textContent || "";
+                    const t = el.getAttribute("data-full-hash") || el.getAttribute("title") || el.textContent || "";
                     copyText(t.trim());
                 }
             });
@@ -270,7 +310,6 @@
 
         const lines = [];
         lines.push('resource.type="k8s_container"');
-        // These labels are harmless even if they don't match (they narrow search).
         if (projectId) lines.push(`resource.labels.project_id="${projectId}"`);
         if (location) lines.push(`resource.labels.location="${location}"`);
         if (cluster) lines.push(`resource.labels.cluster_name="${cluster}"`);
@@ -278,7 +317,6 @@
 
         if (txHash) {
             const h = txHash.trim();
-            // A simple string search is good enough here.
             lines.push(`"${h}"`);
         }
 
@@ -293,13 +331,9 @@
     }
 
     function initLogsLinks() {
-        // Base namespace logs link.
         const base = $("logsBaseLink");
-        if (base) {
-            base.href = buildGcpLogsUrl();
-        }
+        if (base) base.href = buildGcpLogsUrl();
 
-        // Per-tx logs links.
         document.querySelectorAll("a.logsLink[data-logs-tx]").forEach((a) => {
             const txHash = a.getAttribute("data-logs-tx") || "";
             a.href = buildGcpLogsUrl({ txHash });
@@ -318,7 +352,6 @@
         const savedQ = localStorage.getItem(STORAGE.filter) || "";
         const savedScope = localStorage.getItem(STORAGE.scope) || "all";
 
-        // URL params win (shareable view), otherwise fall back to local storage.
         input.value = (urlQ != null ? urlQ : savedQ) || "";
         if (scopeSelect) scopeSelect.value = (urlScope != null ? urlScope : savedScope) || "all";
 
@@ -333,44 +366,17 @@
                 filterAll(input.value, scopeSelect.value);
             });
         }
-        // Preserve focus across auto-refresh reloads (best-effort).
+
         const focusKey = "echonet.report.filterFocused";
         input.addEventListener("focus", () => sessionStorage.setItem(focusKey, "1"));
         input.addEventListener("blur", () => sessionStorage.setItem(focusKey, "0"));
         if (sessionStorage.getItem(focusKey) === "1") {
-            // Defer to allow initial layout to settle.
             setTimeout(() => {
                 input.focus();
-                // Put caret at end.
                 const v = input.value || "";
                 input.setSelectionRange(v.length, v.length);
             }, 0);
         }
-
-        // Keyboard shortcuts:
-        // - "/" focuses filter (like many dashboards)
-        // - "Escape" clears filter
-        window.addEventListener("keydown", (e) => {
-            if (e.defaultPrevented) return;
-            const tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : "";
-            const inTypingContext = tag === "input" || tag === "textarea" || tag === "select";
-
-            if (!inTypingContext && e.key === "/") {
-                e.preventDefault();
-                input.focus();
-                input.select();
-                return;
-            }
-            if (e.key === "Escape") {
-                if (document.activeElement === input || input.value) {
-                    input.value = "";
-                    localStorage.setItem(STORAGE.filter, "");
-                    filterAll("", scopeSelect ? scopeSelect.value : "all");
-                    input.blur();
-                    toast("Filter cleared");
-                }
-            }
-        });
     }
 
     function initCopyVisibleHashes() {
@@ -381,7 +387,7 @@
         function collectHashesWithin(root) {
             const out = [];
             root.querySelectorAll("tr[data-search]:not(.isHidden) .hash").forEach((el) => {
-                const t = (el.getAttribute("title") || el.textContent || "").trim();
+                const t = (el.getAttribute("data-full-hash") || el.getAttribute("title") || el.textContent || "").trim();
                 if (t) out.push(t);
             });
             return out;
@@ -402,17 +408,18 @@
 
             const uniq = Array.from(new Set(hashes));
             if (!uniq.length) {
-                toast("No visible hashes");
+                toast("No visible hashes", "info");
                 return;
             }
-            copyText(uniq.join("\n"));
-            toast(`Copied ${uniq.length} hashes`);
+            copyText(uniq.join("\n"), { silent: true });
+            toast(`Copied ${uniq.length} hashes`, "success");
         });
     }
 
     function initRefresh() {
         const select = $("refreshSelect");
         const btn = $("refreshNowBtn");
+        const liveDot = $("liveIndicator");
         if (!select) return;
 
         const params = qs();
@@ -420,10 +427,18 @@
         const saved = localStorage.getItem(STORAGE.refresh) || "off";
         select.value = (urlRefresh != null ? urlRefresh : saved) || "off";
 
+        function applyLiveState(v) {
+            if (!liveDot) return;
+            if (v === "off") liveDot.classList.remove("live");
+            else liveDot.classList.add("live");
+        }
+        applyLiveState(select.value);
+
         let timer = null;
         function setTimer(v) {
             if (timer) window.clearInterval(timer);
             timer = null;
+            applyLiveState(v);
             if (v === "off") return;
             const secs = parseInt(v, 10);
             if (!Number.isFinite(secs) || secs <= 0) return;
@@ -445,7 +460,6 @@
         const params = qs();
         const urlTheme = params.get("theme");
         let saved = (urlTheme != null ? urlTheme : (localStorage.getItem(STORAGE.theme) || getDefaultTheme())) || getDefaultTheme();
-        // Migrate old "system" setting to the new default.
         if (saved === "system") {
             saved = getDefaultTheme();
             localStorage.setItem(STORAGE.theme, saved);
@@ -459,8 +473,75 @@
             localStorage.setItem(STORAGE.theme, nxt);
             applyTheme(nxt);
             if (nxt === "risk") applyRiskAccent();
-            toast(`Theme: ${nxt}`);
+            toast(`Theme: ${nxt}`, "info");
         });
+    }
+
+    function initDensityToggle() {
+        const btn = $("densityBtn");
+        if (!btn) return;
+        const saved = localStorage.getItem(STORAGE.density) || "comfortable";
+        function apply(mode) {
+            document.body.setAttribute("data-density", mode);
+            btn.setAttribute("aria-pressed", mode === "compact" ? "true" : "false");
+            btn.textContent = mode === "compact" ? "Comfortable" : "Compact";
+        }
+        apply(saved);
+        btn.addEventListener("click", () => {
+            const cur = document.body.getAttribute("data-density") || "comfortable";
+            const nxt = cur === "compact" ? "comfortable" : "compact";
+            localStorage.setItem(STORAGE.density, nxt);
+            apply(nxt);
+        });
+    }
+
+    function shortenHash(full) {
+        if (!full) return "";
+        if (full.length <= 18) return full;
+        return `${full.slice(0, 10)}…${full.slice(-8)}`;
+    }
+
+    function initHashModeToggle() {
+        const btn = $("hashModeBtn");
+        if (!btn) return;
+        const saved = localStorage.getItem(STORAGE.hashMode) || "full";
+        function apply(mode) {
+            document.body.setAttribute("data-hash-mode", mode);
+            btn.setAttribute("aria-pressed", mode === "short" ? "true" : "false");
+            btn.textContent = mode === "short" ? "Full hashes" : "Short hashes";
+            document.querySelectorAll(".hash[data-full-hash]").forEach((el) => {
+                const full = el.getAttribute("data-full-hash") || "";
+                if (!full) return;
+                el.textContent = mode === "short" ? shortenHash(full) : full;
+            });
+            // Re-run filter so highlights re-apply to new text content
+            const input = $("filterInput");
+            const scopeSelect = $("scopeSelect");
+            if (input) filterAll(input.value || "", scopeSelect ? scopeSelect.value : "all");
+        }
+        apply(saved);
+        btn.addEventListener("click", () => {
+            const cur = document.body.getAttribute("data-hash-mode") || "full";
+            const nxt = cur === "short" ? "full" : "short";
+            localStorage.setItem(STORAGE.hashMode, nxt);
+            apply(nxt);
+        });
+    }
+
+    function initExpandCollapseAll() {
+        const expandBtn = $("expandAllBtn");
+        const collapseBtn = $("collapseAllBtn");
+        const all = () => document.querySelectorAll('details.sectionDetails[data-section-details="1"]');
+        if (expandBtn) {
+            expandBtn.addEventListener("click", () => {
+                all().forEach((d) => { d.open = true; });
+            });
+        }
+        if (collapseBtn) {
+            collapseBtn.addEventListener("click", () => {
+                all().forEach((d) => { d.open = false; });
+            });
+        }
     }
 
     function initBlockDumpPersistence() {
@@ -468,7 +549,6 @@
         const kind = $("blockDumpKind");
         if (!num && !kind) return;
 
-        // Restore (localStorage wins; no URL param support needed here since the form opens in a new tab).
         try {
             if (num) {
                 const saved = localStorage.getItem(STORAGE.blockDumpNumber);
@@ -480,7 +560,6 @@
             }
         } catch (_) { }
 
-        // Preserve focus across auto-refresh reloads (best-effort), like filter input.
         if (num) {
             const focusKey = "echonet.report.blockDumpNumberFocused";
             num.addEventListener("focus", () => sessionStorage.setItem(focusKey, "1"));
@@ -493,19 +572,14 @@
             }
         }
 
-        // Persist changes.
         if (num) {
             num.addEventListener("input", () => {
-                try {
-                    localStorage.setItem(STORAGE.blockDumpNumber, num.value || "");
-                } catch (_) { }
+                try { localStorage.setItem(STORAGE.blockDumpNumber, num.value || ""); } catch (_) { }
             });
         }
         if (kind) {
             kind.addEventListener("change", () => {
-                try {
-                    localStorage.setItem(STORAGE.blockDumpKind, kind.value || "");
-                } catch (_) { }
+                try { localStorage.setItem(STORAGE.blockDumpKind, kind.value || ""); } catch (_) { }
             });
         }
     }
@@ -523,29 +597,159 @@
     }
 
     function applyRiskAccent() {
-        // Map echonet-only revert rate -> accent color.
-        // 0% => muted green; 1%+ => muted red.
         const risk = clamp01(document.body?.dataset?.echonetRevertRisk);
-
-        // Muted (non-neon) endpoints.
-        const green = { r: 52, g: 156, b: 98 }; // slightly stronger green
-        const red = { r: 196, g: 56, b: 56 };   // slightly stronger red
-
+        const green = { r: 52, g: 156, b: 98 };
+        const red = { r: 196, g: 56, b: 56 };
         const r = lerp(green.r, red.r, risk);
         const g = lerp(green.g, red.g, risk);
         const b = lerp(green.b, red.b, risk);
-
         const accent = `rgb(${r} ${g} ${b})`;
         document.documentElement.style.setProperty("--accent", accent);
-        // Keep any secondary glow aligned with the same accent (avoid hard banding).
         document.documentElement.style.setProperty("--accent2", accent);
+    }
+
+    function applyHealthDot() {
+        const dot = $("healthDot");
+        if (!dot) return;
+        const pct = Number(document.body?.dataset?.echonetRevertRatePct || "0");
+        // Severity: any non-empty bad metric tile turns the dot bad;
+        // any non-empty warn-only state shows warn; else ok.
+        const hasBad = document.querySelector(".metricTile.bad") != null;
+        const hasWarn = document.querySelector(".metricTile.warn") != null;
+        dot.classList.remove("ok", "warn", "bad");
+        if (hasBad || pct >= 1) dot.classList.add("bad");
+        else if (hasWarn || pct > 0) dot.classList.add("warn");
+        // Default visual is ok (set by CSS)
+        const title = hasBad || pct >= 1
+            ? `Critical · echonet revert ${pct}%`
+            : (hasWarn || pct > 0)
+                ? `Warning · echonet revert ${pct}%`
+                : `Healthy · echonet revert ${pct}%`;
+        dot.setAttribute("title", title);
+    }
+
+    function applyProgressBar() {
+        const fill = $("progressBarFill");
+        if (!fill) return;
+        const blocksText = document.querySelector('#progressNowLabel')?.textContent?.trim() || "";
+        const startText = document.querySelector('#progressStartLabel')?.textContent?.trim() || "";
+        const start = Number(startText);
+        const now = Number(blocksText);
+        if (!Number.isFinite(start) || !Number.isFinite(now) || start <= 0 || now <= 0) {
+            const wrap = $("progressBarWrap");
+            if (wrap) wrap.style.display = "none";
+            return;
+        }
+        if (now <= start) {
+            fill.style.width = "0%";
+            return;
+        }
+        // Show progress relative to a 200-block "window" so the bar moves visibly.
+        // (We don't have a target block number, so this is just a visual heartbeat.)
+        const span = Math.max(1, now - start);
+        const denom = Math.max(span, 200);
+        const pct = Math.min(100, (span / denom) * 100);
+        fill.style.width = `${pct.toFixed(1)}%`;
+
+        const meta = $("progressMeta");
+        if (meta) meta.textContent = `+${span} blocks since current start`;
+    }
+
+    function applyRiskGauge() {
+        const fill = $("riskGaugeFill");
+        const marker = $("riskGaugeMarker");
+        const value = $("revertRateValue");
+        if (!fill || !marker) return;
+        const pct = Number(document.body?.dataset?.echonetRevertRatePct || "0");
+        const clamped = Math.max(0, Math.min(100, pct));
+        // The gauge visualizes 0% .. 1% — anything >= 1% pegs the marker at the right.
+        const ratio = Math.min(1, clamped / 1.0);
+        marker.style.left = `${(ratio * 100).toFixed(2)}%`;
+        // Mask the unreached portion with a subtle overlay.
+        fill.style.width = `${100 - ratio * 100}%`;
+        fill.style.left = "auto";
+        fill.style.right = "0";
+        fill.style.inset = `0 0 0 auto`;
+        if (value) value.textContent = (Math.round(pct * 1000) / 1000).toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+    }
+
+    function applyStackedTxBar() {
+        const okEl = $("stackedCommitted");
+        const pendEl = $("stackedPending");
+        if (!okEl || !pendEl) return;
+        // Read totals out of the legend "mono" spans for robustness.
+        const tile = okEl.closest(".tile");
+        if (!tile) return;
+        const monos = tile.querySelectorAll(".legendRow .mono");
+        let committed = 0;
+        let pending = 0;
+        if (monos.length >= 2) {
+            committed = Number((monos[0].textContent || "").replace(/[^0-9.-]/g, "")) || 0;
+            pending = Number((monos[1].textContent || "").replace(/[^0-9.-]/g, "")) || 0;
+        }
+        const total = committed + pending;
+        if (total <= 0) {
+            okEl.style.width = "0%";
+            pendEl.style.width = "0%";
+            return;
+        }
+        okEl.style.width = `${(committed / total * 100).toFixed(2)}%`;
+        pendEl.style.width = `${(pending / total * 100).toFixed(2)}%`;
+    }
+
+    function applyBarChartFills() {
+        document.querySelectorAll("[data-bar-section]").forEach((section) => {
+            const fills = section.querySelectorAll("[data-bar-count]");
+            let max = 0;
+            fills.forEach((f) => {
+                const n = Number(f.getAttribute("data-bar-count") || "0");
+                if (n > max) max = n;
+            });
+            fills.forEach((f) => {
+                const n = Number(f.getAttribute("data-bar-count") || "0");
+                const pct = max > 0 ? (n / max) * 100 : 0;
+                f.style.width = `${pct.toFixed(1)}%`;
+            });
+        });
+    }
+
+    function initRevertBarRowClicks() {
+        document.querySelectorAll(".barRow[data-scroll-to]").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                const target = btn.getAttribute("data-scroll-to");
+                if (!target) return;
+                const el = document.getElementById(target);
+                if (!el) return;
+                openCollapsibleSection(el);
+                el.scrollIntoView({ behavior: "smooth", block: "start" });
+
+                // Briefly highlight the matching group inside the destination section.
+                const groupName = btn.getAttribute("data-filter-text") || "";
+                if (groupName) {
+                    const summaries = el.querySelectorAll("details.revertGroup summary .mono");
+                    summaries.forEach((s) => {
+                        if ((s.textContent || "").trim() === groupName) {
+                            const det = s.closest("details");
+                            if (det) {
+                                det.open = true;
+                                det.scrollIntoView({ behavior: "smooth", block: "center" });
+                                det.classList.remove("flash");
+                                // Restart the animation by forcing a reflow.
+                                // eslint-disable-next-line no-unused-expressions
+                                det.offsetWidth;
+                                det.classList.add("flash");
+                            }
+                        }
+                    });
+                }
+            });
+        });
     }
 
     function initScrollLinks() {
         function scrollToId(id) {
             const el = document.getElementById(id);
             if (!el) return;
-            // If the target section is collapsed, open it before scrolling.
             openCollapsibleSection(el);
             el.scrollIntoView({ behavior: "smooth", block: "start" });
         }
@@ -554,7 +758,12 @@
             const id = el.getAttribute("data-scroll-to");
             if (!id) return;
 
-            el.addEventListener("click", () => scrollToId(id));
+            el.addEventListener("click", (e) => {
+                // Allow internal handlers (e.g. revert bar rows) to also act.
+                if (el.classList.contains("barRow")) return;
+                e.preventDefault();
+                scrollToId(id);
+            });
             el.addEventListener("keydown", (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
@@ -571,9 +780,7 @@
             if (ticking) return;
             ticking = true;
             window.requestAnimationFrame(() => {
-                try {
-                    sessionStorage.setItem(key, String(window.scrollY || 0));
-                } catch (_) { }
+                try { sessionStorage.setItem(key, String(window.scrollY || 0)); } catch (_) { }
                 ticking = false;
             });
         });
@@ -594,7 +801,6 @@
         if (!section) return;
         const el = document.getElementById(section);
         if (el) {
-            // If the target section is collapsed, open it before scrolling.
             openCollapsibleSection(el);
             setTimeout(() => el.scrollIntoView({ behavior: "smooth", block: "start" }), 0);
         }
@@ -622,6 +828,40 @@
         return Number.isFinite(n) ? n : null;
     }
 
+    function tableSortKey(table) {
+        const cardSummary = table.closest("section[id]");
+        const groupSummary = table.closest("details.revertGroup")?.querySelector("summary .mono")?.textContent || "";
+        const sectionId = cardSummary ? cardSummary.id : "";
+        const tableName = table.getAttribute("data-table") || "";
+        return `${STORAGE.sortPrefix}${sectionId}::${tableName}::${groupSummary}`;
+    }
+
+    function sortRows(tbody, idx, type, dir) {
+        const rows = Array.from(tbody.querySelectorAll("tr"));
+        rows.sort((a, b) => {
+            const av = getCellValue(a, idx);
+            const bv = getCellValue(b, idx);
+            if (type === "num") {
+                const an = tryParseNumber(av);
+                const bn = tryParseNumber(bv);
+                const ax = an == null ? Number.NEGATIVE_INFINITY : an;
+                const bx = bn == null ? Number.NEGATIVE_INFINITY : bn;
+                return dir === "asc" ? ax - bx : bx - ax;
+            }
+            const an = tryParseNumber(av);
+            const bn = tryParseNumber(bv);
+            if (type === "auto" && an != null && bn != null) {
+                return dir === "asc" ? an - bn : bn - an;
+            }
+            const as = normalize(av);
+            const bs = normalize(bv);
+            if (as < bs) return dir === "asc" ? -1 : 1;
+            if (as > bs) return dir === "asc" ? 1 : -1;
+            return 0;
+        });
+        rows.forEach((tr) => tbody.appendChild(tr));
+    }
+
     function initSortableTables() {
         document.querySelectorAll("table").forEach((table) => {
             const thead = table.querySelector("thead");
@@ -630,54 +870,37 @@
             const headers = thead.querySelectorAll("th.sortable");
             if (!headers.length) return;
 
+            const storeKey = tableSortKey(table);
+            let restored = null;
+            try {
+                const raw = localStorage.getItem(storeKey);
+                if (raw) restored = JSON.parse(raw);
+            } catch (_) { }
+
             headers.forEach((th, idx) => {
                 th.setAttribute("role", "button");
                 th.setAttribute("tabindex", "0");
                 const sortType = th.getAttribute("data-sort") || "auto";
 
-                function doSort() {
-                    const cur = th.getAttribute("data-sort-dir") || "none";
-                    const next = cur === "asc" ? "desc" : "asc";
-
-                    // Reset siblings
+                function applyDir(dir) {
                     headers.forEach((h) => {
                         if (h !== th) {
                             h.removeAttribute("data-sort-dir");
                             h.removeAttribute("aria-sort");
                         }
                     });
+                    th.setAttribute("data-sort-dir", dir);
+                    th.setAttribute("aria-sort", dir === "asc" ? "ascending" : "descending");
+                    sortRows(tbody, idx, sortType, dir);
+                }
 
-                    th.setAttribute("data-sort-dir", next);
-                    th.setAttribute("aria-sort", next === "asc" ? "ascending" : "descending");
-
-                    const rows = Array.from(tbody.querySelectorAll("tr"));
-                    rows.sort((a, b) => {
-                        const av = getCellValue(a, idx);
-                        const bv = getCellValue(b, idx);
-
-                        if (sortType === "num") {
-                            const an = tryParseNumber(av);
-                            const bn = tryParseNumber(bv);
-                            const ax = an == null ? Number.NEGATIVE_INFINITY : an;
-                            const bx = bn == null ? Number.NEGATIVE_INFINITY : bn;
-                            return next === "asc" ? ax - bx : bx - ax;
-                        }
-
-                        // auto / str
-                        const an = tryParseNumber(av);
-                        const bn = tryParseNumber(bv);
-                        if (sortType === "auto" && an != null && bn != null) {
-                            return next === "asc" ? an - bn : bn - an;
-                        }
-
-                        const as = normalize(av);
-                        const bs = normalize(bv);
-                        if (as < bs) return next === "asc" ? -1 : 1;
-                        if (as > bs) return next === "asc" ? 1 : -1;
-                        return 0;
-                    });
-
-                    rows.forEach((tr) => tbody.appendChild(tr));
+                function doSort() {
+                    const cur = th.getAttribute("data-sort-dir") || "none";
+                    const next = cur === "asc" ? "desc" : "asc";
+                    applyDir(next);
+                    try {
+                        localStorage.setItem(storeKey, JSON.stringify({ idx, type: sortType, dir: next }));
+                    } catch (_) { }
                 }
 
                 th.addEventListener("click", doSort);
@@ -687,7 +910,353 @@
                         doSort();
                     }
                 });
+
+                if (restored && restored.idx === idx) {
+                    // Re-apply persisted sort to the header that matches by index.
+                    applyDir(restored.dir);
+                }
             });
+        });
+    }
+
+    // ───────── Sidenav scrollspy ─────────
+
+    function initSidenavScrollspy() {
+        const items = Array.from(document.querySelectorAll(".sidenavItem[data-nav]"));
+        if (!items.length) return;
+
+        // A plain href jump lands on a collapsed section (e.g. default-collapsed
+        // pending) with no table shown; open the target section on click too.
+        items.forEach((a) => {
+            a.addEventListener("click", () => {
+                const el = document.getElementById(a.getAttribute("data-nav"));
+                if (el) openCollapsibleSection(el);
+            });
+        });
+
+        // Sections in DOM (vertical) order — required for the linear scan below.
+        const sections = items
+            .map((a) => ({ id: a.getAttribute("data-nav"), a, el: document.getElementById(a.getAttribute("data-nav")) }))
+            .filter((x) => x.el);
+        if (!sections.length) return;
+
+        const setActive = (id) => {
+            items.forEach((a) => a.classList.toggle("active", a.getAttribute("data-nav") === id));
+        };
+
+        function activationLine() {
+            const raw = getComputedStyle(document.documentElement).getPropertyValue("--topbarH");
+            const h = parseInt(raw, 10);
+            return (Number.isFinite(h) ? h : 78) + 24;
+        }
+
+        let ticking = false;
+        function update() {
+            ticking = false;
+            const line = activationLine();
+
+            // The active section is the last one whose top has scrolled past the line.
+            let currentId = sections[0].id;
+            for (const s of sections) {
+                if (s.el.getBoundingClientRect().top - line <= 0) currentId = s.id;
+                else break;
+            }
+
+            // At the very bottom of the page, force-select the last section so
+            // short trailing sections can still become active.
+            const atBottom =
+                window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+            if (atBottom) currentId = sections[sections.length - 1].id;
+
+            setActive(currentId);
+        }
+
+        window.addEventListener(
+            "scroll",
+            () => {
+                if (ticking) return;
+                ticking = true;
+                window.requestAnimationFrame(update);
+            },
+            { passive: true }
+        );
+        window.addEventListener("resize", update);
+        // Instant feedback when a nav item is clicked (before the smooth scroll settles).
+        items.forEach((a) => a.addEventListener("click", () => setActive(a.getAttribute("data-nav"))));
+
+        update();
+    }
+
+    // ───────── CSV export per section ─────────
+
+    function csvEscape(value) {
+        const s = (value == null ? "" : String(value));
+        if (/[",\n\r]/.test(s)) {
+            return `"${s.replace(/"/g, '""')}"`;
+        }
+        return s;
+    }
+
+    function tableToCsv(table) {
+        const lines = [];
+        const headerCells = table.querySelectorAll("thead th");
+        const headers = Array.from(headerCells).map((th) => (th.textContent || "").trim());
+        if (headers.length && headers[headers.length - 1] === "") headers.pop();
+        lines.push(headers.map(csvEscape).join(","));
+
+        table.querySelectorAll("tbody tr:not(.isHidden)").forEach((tr) => {
+            const cols = Array.from(tr.children).slice(0, headers.length).map((td) => {
+                // Prefer the full hash from data attribute if present.
+                const hashEl = td.querySelector(".hash[data-full-hash]");
+                if (hashEl) return hashEl.getAttribute("data-full-hash") || (td.textContent || "").trim();
+                // Avoid copying nested <pre> blobs verbatim; collapse to one line.
+                return (td.textContent || "").trim().replace(/\s+/g, " ");
+            });
+            lines.push(cols.map(csvEscape).join(","));
+        });
+        return lines.join("\n");
+    }
+
+    function initSectionCsvExport() {
+        document.querySelectorAll(".sectionExportBtn[data-export-table]").forEach((btn) => {
+            btn.addEventListener("click", (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const name = btn.getAttribute("data-export-table");
+                const tables = document.querySelectorAll(`table[data-table="${CSS.escape(name)}"]`);
+                if (!tables.length) {
+                    toast("No data to export", "info");
+                    return;
+                }
+                const parts = [];
+                tables.forEach((t, i) => {
+                    if (i > 0) parts.push(""); // blank separator
+                    parts.push(tableToCsv(t));
+                });
+                const csv = parts.join("\n");
+                copyText(csv, { silent: true });
+                toast(`Copied ${name} as CSV`, "success");
+            });
+        });
+    }
+
+    // ───────── Generated-at "ago" timer ─────────
+
+    function parseGeneratedAt() {
+        const raw = (document.body?.dataset?.generatedAt || "").trim();
+        if (!raw) return null;
+        // Try ISO; if missing TZ, treat as UTC.
+        let s = raw;
+        if (!/Z|[+-]\d\d:?\d\d$/.test(s)) s = s + "Z";
+        const t = Date.parse(s);
+        if (!Number.isFinite(t)) return null;
+        return t;
+    }
+
+    function formatAgo(ms) {
+        if (ms < 0) ms = 0;
+        const sec = Math.floor(ms / 1000);
+        if (sec < 5) return "just now";
+        if (sec < 60) return `${sec}s ago`;
+        const min = Math.floor(sec / 60);
+        if (min < 60) return `${min}m ago`;
+        const hr = Math.floor(min / 60);
+        if (hr < 48) return `${hr}h ${min % 60}m ago`;
+        const day = Math.floor(hr / 24);
+        return `${day}d ${hr % 24}h ago`;
+    }
+
+    function initAgoTimer() {
+        const chip = $("agoChip");
+        if (!chip) return;
+        const t0 = parseGeneratedAt();
+        if (t0 == null) {
+            chip.style.display = "none";
+            return;
+        }
+        const tick = () => {
+            chip.textContent = formatAgo(Date.now() - t0);
+        };
+        tick();
+        window.setInterval(tick, 1000);
+    }
+
+    // ───────── Shortcuts overlay + keyboard ─────────
+
+    function initShortcutsOverlay() {
+        const overlay = $("shortcutsOverlay");
+        const open = $("shortcutsBtn");
+        const close = $("shortcutsClose");
+        if (!overlay) return;
+
+        const show = () => {
+            overlay.hidden = false;
+            (close || open)?.focus();
+        };
+        const hide = () => { overlay.hidden = true; };
+
+        if (open) open.addEventListener("click", show);
+        if (close) close.addEventListener("click", hide);
+        overlay.addEventListener("click", (e) => {
+            if (e.target === overlay) hide();
+        });
+        // Expose so other key handlers can dismiss it.
+        overlay._hide = hide;
+        overlay._show = show;
+        overlay._toggle = () => { overlay.hidden ? show() : hide(); };
+    }
+
+    function initKeyboard() {
+        const input = $("filterInput");
+        const scopeSelect = $("scopeSelect");
+        const overlay = $("shortcutsOverlay");
+
+        // "g" then a letter — jump shortcuts.
+        let gPending = false;
+        let gTimer = null;
+
+        function clearGPending() {
+            gPending = false;
+            if (gTimer) { window.clearTimeout(gTimer); gTimer = null; }
+        }
+
+        const JUMPS = {
+            o: "overview",
+            p: "pending-txs",
+            e: "gateway-errors",
+            r: "reverts-mainnet",
+            s: "resync-triggers",
+            l: "l2-gas-mismatches",
+            b: "block-hash-mismatches",
+            t: "tx-commitment-mismatches",
+        };
+
+        // Track double-r for "reverts-echonet".
+        let lastJump = null;
+        let lastJumpAt = 0;
+
+        function jumpToId(id) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            openCollapsibleSection(el);
+            el.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+
+        window.addEventListener("keydown", (e) => {
+            if (e.defaultPrevented) return;
+            const tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : "";
+            const inTypingContext = tag === "input" || tag === "textarea" || tag === "select";
+            const isMeta = e.ctrlKey || e.metaKey || e.altKey;
+
+            // Filter & overlay shortcuts work outside typing context (except Esc).
+            if (e.key === "Escape") {
+                if (overlay && !overlay.hidden) {
+                    e.preventDefault();
+                    overlay._hide && overlay._hide();
+                    return;
+                }
+                if (input && (document.activeElement === input || input.value)) {
+                    input.value = "";
+                    localStorage.setItem(STORAGE.filter, "");
+                    filterAll("", scopeSelect ? scopeSelect.value : "all");
+                    input.blur();
+                    toast("Filter cleared", "info");
+                }
+                return;
+            }
+
+            if (inTypingContext || isMeta) return;
+
+            if (e.key === "/") {
+                if (input) {
+                    e.preventDefault();
+                    input.focus();
+                    input.select();
+                }
+                clearGPending();
+                return;
+            }
+
+            if (e.key === "?" || (e.shiftKey && e.key === "/")) {
+                e.preventDefault();
+                overlay && overlay._toggle && overlay._toggle();
+                clearGPending();
+                return;
+            }
+
+            const k = e.key.toLowerCase();
+
+            if (gPending) {
+                clearGPending();
+                if (k === "r") {
+                    // Double-r within 600ms → echonet reverts.
+                    const now = Date.now();
+                    if (lastJump === "r" && now - lastJumpAt < 600) {
+                        jumpToId("reverts-echonet");
+                        lastJump = null;
+                        return;
+                    }
+                    lastJump = "r";
+                    lastJumpAt = now;
+                }
+                const target = JUMPS[k];
+                if (target) {
+                    e.preventDefault();
+                    jumpToId(target);
+                }
+                return;
+            }
+
+            if (k === "g") {
+                gPending = true;
+                gTimer = window.setTimeout(clearGPending, 800);
+                e.preventDefault();
+                return;
+            }
+
+            if (k === "r") {
+                // Second tap of the "G R R" chord jumps to echonet reverts;
+                // it must not fall through to the refresh (page reload).
+                const now = Date.now();
+                if (lastJump === "r" && now - lastJumpAt < 600) {
+                    e.preventDefault();
+                    jumpToId("reverts-echonet");
+                    lastJump = null;
+                    return;
+                }
+                const btn = $("refreshNowBtn");
+                if (btn) {
+                    e.preventDefault();
+                    btn.click();
+                }
+                return;
+            }
+
+            if (k === "e") {
+                const btn = $("expandAllBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "c") {
+                const btn = $("collapseAllBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "d") {
+                const btn = $("densityBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "h") {
+                const btn = $("hashModeBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
+            if (k === "t") {
+                const btn = $("themeToggleBtn");
+                if (btn) { e.preventDefault(); btn.click(); }
+                return;
+            }
         });
     }
 
@@ -699,6 +1268,9 @@
         initCopyVisibleHashes();
         initRefresh();
         initThemeToggle();
+        initDensityToggle();
+        initHashModeToggle();
+        initExpandCollapseAll();
         initBlockDumpPersistence();
         initSectionCollapsePersistence();
         initScrollLinks();
@@ -706,6 +1278,20 @@
         initSectionParamScroll();
         initHashOpen();
         initRestoreScrollPosition();
+        initSidenavScrollspy();
+        initRevertBarRowClicks();
+        initSectionCsvExport();
+        initAgoTimer();
+        initShortcutsOverlay();
+        initKeyboard();
+
+        // Visualizations (rely on data already on the page).
+        applyHealthDot();
+        applyProgressBar();
+        applyRiskGauge();
+        applyStackedTxBar();
+        applyBarChartFills();
+
         updateTableMeta();
     }
 

--- a/echonet/templates/report.html
+++ b/echonet/templates/report.html
@@ -16,15 +16,34 @@
 </head>
 
 <body data-echonet-revert-rate-pct="{{ meta.echonet_revert_rate_pct }}"
-  data-echonet-revert-risk="{{ meta.echonet_revert_risk_0_1 }}" data-report-export="{{ 1 if export else 0 }}"
-  data-gcp-project-id="{{ logs.gcp_project_id }}" data-gcp-location="{{ logs.gcp_location }}"
-  data-gke-cluster-name="{{ logs.gke_cluster_name }}" data-k8s-namespace="{{ logs.k8s_namespace }}"
+  data-echonet-revert-risk="{{ meta.echonet_revert_risk_0_1 }}"
+  data-report-export="{{ 1 if export else 0 }}"
+  data-generated-at="{{ meta.generated_at_utc }}"
+  data-gcp-project-id="{{ logs.gcp_project_id }}"
+  data-gcp-location="{{ logs.gcp_location }}"
+  data-gke-cluster-name="{{ logs.gke_cluster_name }}"
+  data-k8s-namespace="{{ logs.k8s_namespace }}"
   data-gcp-logs-duration="{{ logs.duration }}">
+
   <header class="topbar">
-    <div class="brand">
-      <div class="title">Echonet Report</div>
-      <div class="subtitle">
-        Generated <span class="mono">{{ meta.generated_at_utc }}</span>
+    <div class="topbarLeft">
+      <div class="brand">
+        <div class="brandLogo" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 12 7 6l4 12 4-10 3 7h4" />
+          </svg>
+        </div>
+        <div class="brandText">
+          <div class="title">Echonet Report
+            <span class="healthDot" id="healthDot" title="Overall health"></span>
+          </div>
+          <div class="subtitle">
+            <span class="liveIndicator" id="liveIndicator" aria-hidden="true"></span>
+            Generated <span class="mono" id="generatedAtLabel">{{ meta.generated_at_utc }}</span>
+            <span class="agoChip mono" id="agoChip" title="Time since this snapshot was generated">just now</span>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -57,684 +76,1197 @@
         </select>
       </label>
 
-      <button class="btn" id="refreshNowBtn" type="button">Refresh</button>
+      <button class="btn" id="refreshNowBtn" type="button" title="Reload (R)">Refresh</button>
       {% endif %}
-      <button class="btn" id="copyVisibleBtn" type="button" title="Copy visible tx hashes (respects scope)">Copy
-        visible</button>
-      <a class="btn btnLink" id="logsBaseLink" href="#" target="_blank" rel="noopener"
-        title="Open GCP Logs Explorer for this namespace">Logs</a>
-      <button class="btn" id="themeToggleBtn" type="button" title="Toggle theme">Theme</button>
-      {% if not export %}
-      <a class="btn btnLink" href="/echonet/report/ui/download" title="Download static HTML snapshot">Download</a>
-      <a class="btn btnLink" href="/echonet/report" title="Raw JSON snapshot">JSON</a>
-      <a class="btn btnLink" href="/echonet/report/text" title="Text snapshot (plain text)">Text</a>
-      {% endif %}
+
+      <div class="btnGroup" role="group" aria-label="View controls">
+        <button class="btn" id="copyVisibleBtn" type="button" title="Copy visible tx hashes (respects scope)">Copy
+          hashes</button>
+        <button class="btn" id="expandAllBtn" type="button" title="Expand all sections (E)">Expand</button>
+        <button class="btn" id="collapseAllBtn" type="button" title="Collapse all sections (C)">Collapse</button>
+        <button class="btn" id="densityBtn" type="button" title="Toggle row density (D)"
+          aria-pressed="false">Compact</button>
+        <button class="btn" id="hashModeBtn" type="button" title="Toggle hash display: full ↔ truncated (H)"
+          aria-pressed="false">Hashes</button>
+      </div>
+
+      <div class="btnGroup" role="group" aria-label="Links">
+        <a class="btn btnLink" id="logsBaseLink" href="#" target="_blank" rel="noopener"
+          title="Open GCP Logs Explorer for this namespace">Logs</a>
+        {% if not export %}
+        <a class="btn btnLink" href="/echonet/report/ui/download" title="Download static HTML snapshot">Download</a>
+        <a class="btn btnLink" href="/echonet/report" title="Raw JSON snapshot">JSON</a>
+        <a class="btn btnLink" href="/echonet/report/text" title="Text snapshot (plain text)">Text</a>
+        {% endif %}
+        <button class="btn" id="themeToggleBtn" type="button" title="Cycle theme (T)">Theme</button>
+        <button class="btn btnIcon" id="shortcutsBtn" type="button" title="Keyboard shortcuts (?)"
+          aria-label="Keyboard shortcuts">?</button>
+      </div>
+
       <div class="statusLine" id="filterStats" aria-live="polite"></div>
     </div>
   </header>
 
-  <main class="container">
-    <div class="stack">
-      <section>
-        <div class="card kpiProgress">
-          <div class="cardTitle">Progress</div>
-          <div class="progressHero">
-            <div>
-              {% set blocks_unknown = progress.blocks_processed == "(unknown)" %}
-              {% set current_unknown = progress.current_block == "(unknown)" %}
-              {% if blocks_unknown and current_unknown %}
-              <div class="heroRow">
+  <div class="layout">
+    <aside class="sidenav" id="sidenav" aria-label="Section navigation">
+      <div class="sidenavTitle">Sections</div>
+      <nav class="sidenavList" id="sidenavList">
+        <a class="sidenavItem" data-nav="overview" href="#overview">
+          <span class="navDot"></span><span class="navLabel">Overview</span>
+        </a>
+        <a class="sidenavItem" data-nav="reverts-summary" href="#reverts-summary">
+          <span class="navDot"></span><span class="navLabel">Top revert reasons</span>
+        </a>
+        <a class="sidenavItem" data-nav="pending-txs" href="#pending-txs">
+          <span class="navDot {{ severity.pending }}"></span>
+          <span class="navLabel">Pending</span>
+          <span class="navCount mono">{{ kpis.pending_commission_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="gateway-errors" href="#gateway-errors">
+          <span class="navDot {{ severity.gateway_errors }}"></span>
+          <span class="navLabel">Gateway errors</span>
+          <span class="navCount mono">{{ kpis.gateway_errors_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="reverts-mainnet" href="#reverts-mainnet">
+          <span class="navDot {{ severity.reverts_mainnet }}"></span>
+          <span class="navLabel">Reverts (mainnet)</span>
+          <span class="navCount mono">{{ kpis.reverts_mainnet_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="reverts-echonet" href="#reverts-echonet">
+          <span class="navDot {{ severity.reverts_echonet }}"></span>
+          <span class="navLabel">Reverts (echonet)</span>
+          <span class="navCount mono">{{ kpis.reverts_echonet_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="resync-triggers" href="#resync-triggers">
+          <span class="navDot {{ severity.resync_causes }}"></span>
+          <span class="navLabel">Resync triggers</span>
+          <span class="navCount mono">{{ kpis.resync_causes_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="certain-failures" href="#certain-failures">
+          <span class="navDot {{ severity.certain_failures }}"></span>
+          <span class="navLabel">Certain failures</span>
+          <span class="navCount mono">{{ kpis.certain_failures_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="l2-gas-mismatches" href="#l2-gas-mismatches">
+          <span class="navDot {{ severity.l2_gas_mismatches }}"></span>
+          <span class="navLabel">L2 gas mismatches</span>
+          <span class="navCount mono">{{ kpis.l2_gas_mismatches_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="block-hash-mismatches" href="#block-hash-mismatches">
+          <span class="navDot {{ severity.block_hash_mismatches }}"></span>
+          <span class="navLabel">Block hash mismatches</span>
+          <span class="navCount mono">{{ kpis.block_hash_mismatches_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="tx-commitment-mismatches" href="#tx-commitment-mismatches">
+          <span class="navDot {{ severity.transaction_commitment_mismatches }}"></span>
+          <span class="navLabel">Tx commitment mismatches</span>
+          <span class="navCount mono">{{ kpis.transaction_commitment_mismatches_count }}</span>
+        </a>
+        <a class="sidenavItem" data-nav="os-run-failures" href="#os-run-failures">
+          <span class="navDot {{ severity.os_failed }}"></span>
+          <span class="navLabel">OS run failures</span>
+          <span class="navCount mono">{{ kpis.os_failed_count }}</span>
+        </a>
+        {% if not export %}
+        <a class="sidenavItem" data-nav="block-dump" href="#block-dump">
+          <span class="navDot"></span><span class="navLabel">Block dump</span>
+        </a>
+        {% endif %}
+      </nav>
+
+      <div class="sidenavFooter smallMuted">
+        Press <kbd>?</kbd> for shortcuts.
+      </div>
+    </aside>
+
+    <main class="container">
+      <div class="stack">
+
+        <section id="overview">
+          <div class="overviewGrid">
+            <div class="card kpiProgress span3">
+              <div class="cardHeader">
+                <div class="cardTitle">
+                  <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 20V10M6 20V4M18 20v-7" />
+                  </svg>
+                  Progress
+                </div>
+                <div class="cardHeaderRight smallMuted mono" id="progressMeta"></div>
+              </div>
+              <div class="progressHero">
                 <div>
-                  <div class="heroValue mono">Starting...</div>
+                  {% set blocks_unknown = progress.blocks_processed == "(unknown)" %}
+                  {% set current_unknown = progress.current_block == "(unknown)" %}
+                  {% if blocks_unknown and current_unknown %}
+                  <div class="heroRow">
+                    <div>
+                      <div class="heroValue mono">Starting…</div>
+                      <div class="heroSub">Waiting for first block to be processed.</div>
+                    </div>
+                  </div>
+                  {% else %}
+                  <div class="heroRow">
+                    <div>
+                      <div class="heroLabel">Blocks processed</div>
+                      <div class="heroValue mono">{{ progress.blocks_processed }}</div>
+                    </div>
+                    <div>
+                      <div class="heroLabel">Current block</div>
+                      <div class="heroValue mono">
+                        {% if current_unknown %}Resyncing…{% else %}{{ progress.current_block }}{% endif %}
+                      </div>
+                    </div>
+                  </div>
+                  {% endif %}
+                  <div class="progressBarWrap" id="progressBarWrap" aria-hidden="true">
+                    <div class="progressBarTrack">
+                      <div class="progressBarFill" id="progressBarFill"></div>
+                    </div>
+                    <div class="progressBarLabels smallMuted mono">
+                      <span id="progressStartLabel">{{ progress.current_start_block }}</span>
+                      <span id="progressNowLabel">{{ progress.current_block }}</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="kv kvTight">
+                  <div class="k">Initial start</div>
+                  <div class="v mono">{{ progress.initial_start_block }}</div>
+                  <div class="k">Current start</div>
+                  <div class="v mono">{{ progress.current_start_block }}</div>
+                  <div class="k">First timestamp</div>
+                  <div class="v mono">{{ meta.first_block_timestamp_iso }}</div>
+                  <div class="k">Latest timestamp</div>
+                  <div class="v mono">{{ meta.latest_block_timestamp_iso }}</div>
+                  <div class="k">Span</div>
+                  <div class="v mono">{{ meta.span_human }}</div>
+                  <div class="k">Forward rate</div>
+                  <div class="v mono">{{ meta.forward_rate }}</div>
                 </div>
               </div>
-              {% else %}
-              <div class="heroRow">
-                <div>
-                  <div class="heroLabel">Blocks processed</div>
-                  <div class="heroValue mono">{{ progress.blocks_processed }}</div>
-                </div>
-                <div>
-                  <div class="heroLabel">Current block</div>
-                  <div class="heroValue mono">
-                    {% if current_unknown %}Resyncing...{% else %}{{ progress.current_block }}{% endif %}
-                  </div>
+            </div>
+
+            <div class="card tile tileTx">
+              <div class="cardHeader">
+                <div class="cardTitle">
+                  <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="m3 7 4 4-4 4M14 7h7M3 17h11M14 13l4-4 4 4" />
+                  </svg>
+                  Transactions
                 </div>
               </div>
-              {% endif %}
+              <div class="tileValue mono">{{ kpis.total_sent_tx_count }}</div>
+              <div class="tileSub smallMuted">Total forwarded</div>
+              <div class="stackedBar" title="Committed vs pending">
+                <div class="stackedBarPart stackedOk" id="stackedCommitted"></div>
+                <div class="stackedBarPart stackedPending" id="stackedPending"></div>
+              </div>
+              <div class="legendRow smallMuted">
+                <span class="legendDot ok"></span>
+                <span>Committed <span class="mono">{{ kpis.committed_count }}</span>
+                  ({{ kpis.committed_pct_of_pending_total }})</span>
+                <span class="legendDot pending"></span>
+                <span>Pending <span class="mono">{{ kpis.pending_commission_count }}</span>
+                  ({{ kpis.pending_pct_of_pending_total }})</span>
+              </div>
             </div>
-            <div class="kv kvTight">
-              <div class="k">Initial start</div>
-              <div class="v mono">{{ progress.initial_start_block }}</div>
-              <div class="k">Current start</div>
-              <div class="v mono">{{ progress.current_start_block }}</div>
-              <div class="k">First timestamp</div>
-              <div class="v mono">{{ meta.first_block_timestamp_iso }}</div>
-              <div class="k">Latest timestamp</div>
-              <div class="v mono">{{ meta.latest_block_timestamp_iso }}</div>
-              <div class="k">Span</div>
-              <div class="v mono">{{ meta.span_human }}</div>
-              <div class="k">Forward rate</div>
-              <div class="v mono">{{ meta.forward_rate }}</div>
+
+            <div class="card tile tileRisk">
+              <div class="cardHeader">
+                <div class="cardTitle">
+                  <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 2 2 22h20L12 2zM12 9v6M12 18h.01" />
+                  </svg>
+                  Echonet-only revert rate
+                </div>
+              </div>
+              <div class="tileValue mono"><span id="revertRateValue">{{ meta.echonet_revert_rate_pct }}</span>%</div>
+              <div class="tileSub smallMuted">Reverts only on Echonet ÷ total forwarded</div>
+              <div class="riskGauge">
+                <div class="riskGaugeTrack">
+                  <div class="riskGaugeFill" id="riskGaugeFill"></div>
+                  <div class="riskGaugeMarker" id="riskGaugeMarker"></div>
+                </div>
+                <div class="legendRow smallMuted">
+                  <span>0%</span><span style="flex:1"></span><span>1%+</span>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </section>
 
-      <section class="row2">
-        <div class="card">
-          <div class="cardTitle">Transactions</div>
-          <div class="bigNumber mono">{{ kpis.total_sent_tx_count }}</div>
-          <div class="smallMuted">Total forwarded</div>
-          <div class="pillRow">
-            <span class="pill {{ severity.committed }}">Committed: <span class="mono">{{ kpis.committed_count }}</span>
-              ({{ kpis.committed_pct_of_pending_total }})</span>
-            <span class="pill {{ severity.pending }}">Pending: <span class="mono">{{ kpis.pending_commission_count
-                }}</span> ({{ kpis.pending_pct_of_pending_total }})</span>
-          </div>
-        </div>
+          <div class="card alertsCard">
+            <div class="cardHeader">
+              <div class="cardTitle">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 2v6m0 0 4-2m-4 2-4-2M5 22h14a2 2 0 0 0 2-2v-8a9 9 0 0 0-18 0v8a2 2 0 0 0 2 2z" />
+                </svg>
+                Alerts
+              </div>
+              <div class="cardHeaderRight smallMuted">
+                Click a tile to jump to its section · press <span class="mono">/</span> to focus filter
+              </div>
+            </div>
+            <div class="metricGrid">
+              <button class="metricTile {{ severity.gateway_errors }}" type="button" data-scroll-to="gateway-errors">
+                <div class="metricLabel">Gateway errors</div>
+                <div class="metricValue mono">{{ kpis.gateway_errors_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.reverts_mainnet }}" type="button" data-scroll-to="reverts-mainnet">
+                <div class="metricLabel">Reverts (mainnet-only)</div>
+                <div class="metricValue mono">{{ kpis.reverts_mainnet_count }}</div>
+                <div class="metricSub mono">{{ reverts.mainnet_only.pct_of_total_sent }}</div>
+              </button>
+              <button class="metricTile {{ severity.reverts_echonet }}" type="button" data-scroll-to="reverts-echonet">
+                <div class="metricLabel">Reverts (echonet-only)</div>
+                <div class="metricValue mono">{{ kpis.reverts_echonet_count }}</div>
+                <div class="metricSub mono">{{ reverts.echonet_only.pct_of_total_sent }}</div>
+              </button>
+              <button class="metricTile {{ severity.resync_causes }}" type="button" data-scroll-to="resync-triggers">
+                <div class="metricLabel">Resync triggers</div>
+                <div class="metricValue mono">{{ kpis.resync_causes_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.certain_failures }}" type="button"
+                data-scroll-to="certain-failures">
+                <div class="metricLabel">Certain failures</div>
+                <div class="metricValue mono">{{ kpis.certain_failures_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.l2_gas_mismatches }}" type="button"
+                data-scroll-to="l2-gas-mismatches">
+                <div class="metricLabel">L2 gas mismatches</div>
+                <div class="metricValue mono">{{ kpis.l2_gas_mismatches_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.block_hash_mismatches }}" type="button"
+                data-scroll-to="block-hash-mismatches">
+                <div class="metricLabel">Block hash mismatches</div>
+                <div class="metricValue mono">{{ kpis.block_hash_mismatches_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.transaction_commitment_mismatches }}" type="button"
+                data-scroll-to="tx-commitment-mismatches">
+                <div class="metricLabel">Tx commitment mismatches</div>
+                <div class="metricValue mono">{{ kpis.transaction_commitment_mismatches_count }}</div>
+              </button>
+              <button class="metricTile {{ severity.os_failed }}" type="button" data-scroll-to="os-run-failures">
+                <div class="metricLabel">OS run failures</div>
+                <div class="metricValue mono">{{ kpis.os_failed_count }}</div>
+              </button>
+            </div>
 
-        <div class="card">
-          <div class="cardTitle">Alerts</div>
-          <div class="pillRow">
-            <span class="pill pillLink {{ severity.gateway_errors }}" role="button" tabindex="0"
-              data-scroll-to="gateway-errors">Gateway errors:
-              <span class="mono">{{ kpis.gateway_errors_count }}</span></span>
-            <span class="pill pillLink {{ severity.reverts_mainnet }}" role="button" tabindex="0"
-              data-scroll-to="reverts-mainnet">Reverts
-              (mainnet-only): <span class="mono">{{ kpis.reverts_mainnet_count }}</span>
-              <span class="mono">({{ reverts.mainnet_only.pct_of_total_sent }})</span></span>
-            <span class="pill pillLink {{ severity.reverts_echonet }}" role="button" tabindex="0"
-              data-scroll-to="reverts-echonet">Reverts
-              (echonet-only): <span class="mono">{{ kpis.reverts_echonet_count }}</span>
-              <span class="mono">({{ reverts.echonet_only.pct_of_total_sent }})</span></span>
+            <div class="metricSubgroupDivider">
+              <span class="metricSubgroupLabel">OS runner</span>
+            </div>
+            <div class="metricGrid">
+              <div class="metricTile static {{ severity.os_completed }}">
+                <div class="metricLabel">Completed</div>
+                <div class="metricValue mono">{{ os_run_stats.completed | default(0) }}</div>
+              </div>
+              <div class="metricTile static {{ severity.os_dropped }}">
+                <div class="metricLabel">Dropped (queue full)</div>
+                <div class="metricValue mono">{{ os_run_stats.dropped | default(0) }}</div>
+              </div>
+              <div class="metricTile static {{ severity.os_abandoned }}">
+                <div class="metricLabel">Abandoned (window expired)</div>
+                <div class="metricValue mono">{{ os_run_stats.abandoned | default(0) }}</div>
+              </div>
+              <div class="metricTile static {{ severity.os_skipped }}">
+                <div class="metricLabel">Skipped (cache miss)</div>
+                <div class="metricValue mono">{{ os_run_stats.skipped | default(0) }}</div>
+              </div>
+              <div class="metricTile static">
+                <div class="metricLabel">Queue depth</div>
+                <div class="metricValue mono">{{ os_run_stats.queue_depth | default(0) }}</div>
+                <div class="metricSub mono">of {{ os_run_stats.queue_max | default(0) }}</div>
+              </div>
+              <div class="metricTile static">
+                <div class="metricLabel">Currently deferred</div>
+                <div class="metricValue mono">{{ os_run_stats.currently_deferred | default(0) }}</div>
+              </div>
+              <div class="metricTile static">
+                <div class="metricLabel">Deferred events (cumulative)</div>
+                <div class="metricValue mono">{{ os_run_stats.deferred_events | default(0) }}</div>
+              </div>
+            </div>
           </div>
-          <div class="pillRow">
-            <span class="pill pillLink {{ severity.resync_causes }}" role="button" tabindex="0"
-              data-scroll-to="resync-triggers">Resync triggers:
-              <span class="mono">{{ kpis.resync_causes_count }}</span></span>
-            <span class="pill pillLink {{ severity.certain_failures }}" role="button" tabindex="0"
-              data-scroll-to="certain-failures">Certain failures:
-              <span class="mono">{{ kpis.certain_failures_count }}</span></span>
-            <span class="pill pillLink {{ severity.l2_gas_mismatches }}" role="button" tabindex="0"
-              data-scroll-to="l2-gas-mismatches">L2 gas
-              mismatches: <span class="mono">{{ kpis.l2_gas_mismatches_count }}</span></span>
-          </div>
-          <div class="pillRow">
-            <span class="pill pillLink {{ severity.block_hash_mismatches }}" role="button" tabindex="0"
-              data-scroll-to="block-hash-mismatches">Block hash mismatches:
-              <span class="mono">{{ kpis.block_hash_mismatches_count }}</span></span>
-            <span class="pill pillLink {{ severity.transaction_commitment_mismatches }}" role="button" tabindex="0"
-              data-scroll-to="tx-commitment-mismatches">Tx commitment mismatches:
-              <span class="mono">{{ kpis.transaction_commitment_mismatches_count }}</span></span>
-          </div>
-          <div class="smallMuted">
-            Tip: press <span class="mono">/</span> to focus filter; <span class="mono">Esc</span> clears it.
-          </div>
-        </div>
-      </section>
+        </section>
 
-      <section id="pending-txs">
-        <details class="card details sectionDetails" data-section-details="1">
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Non-committed tx hashes (pending)</span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="pending"></div>
-          {% if not pending_txs_total %}
-          <div class="empty">(none)</div>
-          {% else %}
-          {% if pending_txs_total > 10 %}
-          <div class="smallMuted">Showing first 10 of {{ pending_txs_total }}</div>
-          {% endif %}
-          <table class="table filterable" data-filter-scope="pending" data-table="pending">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colHash" />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Source block</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for tx_hash, src_bn in pending_txs %}
-              <tr data-search="{{ tx_hash }} {{ src_bn }}">
-                <td class="mono">{{ src_bn }}</td>
-                <td class="mono">
-                  <span class="hash" title="{{ tx_hash }}">{{ tx_hash }}</span>
-                </td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ src_bn }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ src_bn }}"
-                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="gateway-errors">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Gateway errors <span class="countPill">{{ kpis.gateway_errors_count
-                }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="gateway"></div>
-          {% if not gateway_errors %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="gateway" data-table="gateway">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colStatus" />
-              <col class="colHash" />
-              <col />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Status</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th>Response</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in gateway_errors %}
-              <tr class="sev {{ severity.gateway_errors }}"
-                data-search="{{ row.tx_hash }} {{ row.status }} {{ row.block_number }} {{ row.response }}">
-                <td class="mono">{{ row.block_number }}</td>
-                <td class="mono"><span class="status {{ severity.gateway_errors }}">{{ row.status }}</span></td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">
-                  <details class="details">
-                    <summary>Show</summary>
-                    <pre class="pre">{{ row.response }}</pre>
-                  </details>
-                </td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
-                      target="_blank" rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="reverts-mainnet">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Reverted only on Mainnet <span class="countPill">{{
-                reverts.mainnet_only.total }} ({{ reverts.mainnet_only.pct_of_total_sent
-                }})</span></span>
-          </summary>
-          {% if reverts.mainnet_only.total == 0 %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <div class="smallMuted">Use the filter box to narrow down.</div>
-          {% for group in reverts.mainnet_only.groups %}
-          <details class="details filterable" data-filter-scope="reverts" open>
-            <summary>
-              <span class="badge bad">{{ group.count }}</span>
-              <span class="mono">{{ group.name }}</span>
-              <span class="countPill">{{ group.pct_of_section }}</span>
+        {% if kpis.reverts_mainnet_count > 0 or kpis.reverts_echonet_count > 0 %}
+        <section id="reverts-summary">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M3 12h4l3-9 4 18 3-9h4" />
+                </svg>
+                Top revert reasons
+              </span>
             </summary>
-            <table class="table" data-table="reverts">
-              <colgroup>
-                <col class="colBn" />
-                <col class="colHash" />
-                <col />
-                <col class="colActions" />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th class="sortable" data-sort="num">Source block</th>
-                  <th class="sortable" data-sort="str">Tx hash</th>
-                  <th>Reason (shortened)</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for row in group.rows %}
-                <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
-                  <td class="mono">{{ row.block_number }}</td>
-                  <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                  <td>
-                    <div class="reason">{{ row.reason }}</div>
-                    {% if row.raw_error and row.raw_error != row.reason %}
-                    <details class="details nested">
-                      <summary>Raw</summary>
-                      <pre class="pre">{{ row.raw_error }}</pre>
-                    </details>
-                    {% endif %}
-                  </td>
-                  <td class="right">
-                    <div class="rowActions">
-                      <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                      <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                        rel="noopener" title="Open in Voyager">Voyager</a>
-                      <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                        data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
-                        target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
-                        target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                    </div>
-                  </td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </details>
-          {% endfor %}
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="reverts-echonet">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Reverted only on Echonet <span class="countPill">{{
-                reverts.echonet_only.total }} ({{ reverts.echonet_only.pct_of_total_sent
-                }})</span></span>
-          </summary>
-          {% if reverts.echonet_only.total == 0 %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <div class="smallMuted">Use the filter box to narrow down.</div>
-          {% for group in reverts.echonet_only.groups %}
-          <details class="details filterable" data-filter-scope="reverts" open>
-            <summary>
-              <span class="badge bad">{{ group.count }}</span>
-              <span class="mono">{{ group.name }}</span>
-              <span class="countPill">{{ group.pct_of_section }}</span>
-            </summary>
-            <table class="table" data-table="reverts">
-              <colgroup>
-                <col class="colBn" />
-                <col class="colHash" />
-                <col />
-                <col class="colActions" />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th class="sortable" data-sort="num">Source block</th>
-                  <th class="sortable" data-sort="str">Tx hash</th>
-                  <th>Reason (shortened)</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for row in group.rows %}
-                <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
-                  <td class="mono">{{ row.block_number }}</td>
-                  <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                  <td>
-                    <div class="reason">{{ row.reason }}</div>
-                    {% if row.raw_error and row.raw_error != row.reason %}
-                    <details class="details nested">
-                      <summary>Raw</summary>
-                      <pre class="pre">{{ row.raw_error }}</pre>
-                    </details>
-                    {% endif %}
-                  </td>
-                  <td class="right">
-                    <div class="rowActions">
-                      <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                      <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                        rel="noopener" title="Open in Voyager">Voyager</a>
-                      <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                        data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
-                        target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                      <a class="btn btnSmall btnLink"
-                        href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
-                        target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                    </div>
-                  </td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </details>
-          {% endfor %}
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="resync-triggers">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Resync triggers (first failures) <span class="countPill">{{
-                kpis.resync_causes_count }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="resync"></div>
-          {% if not resync.causes %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="resync" data-table="resync">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colCount" />
-              <col class="colHash" />
-              <col />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="num">Count</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th class="sortable" data-sort="str">Reason</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in resync.causes %}
-              <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
-                <td class="mono">{{ row.failure_block_number }}</td>
-                <td class="mono">{{ row.count }}</td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">{{ row.reason }}</td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
-                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="certain-failures">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Certain failures (repeated triggers) <span class="countPill">{{
-                kpis.certain_failures_count }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="certain"></div>
-          {% if not resync.certain_failures %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="resync" data-table="certain">
-            <colgroup>
-              <col class="colCount" />
-              <col class="colBn" />
-              <col class="colHash" />
-              <col />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Count</th>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th class="sortable" data-sort="str">Reason</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in resync.certain_failures %}
-              <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
-                <td class="mono">{{ row.count }}</td>
-                <td class="mono">{{ row.failure_block_number }}</td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">{{ row.reason }}</td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
-                      target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="l2-gas-mismatches">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">L2 gas used mismatches <span class="countPill">{{ l2_gas_mismatches |
-                length }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="diag"></div>
-          {% if not l2_gas_mismatches %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <div class="smallMuted">
-            Showing all L2 gas used mismatches.
-          </div>
-          <table class="table filterable" data-filter-scope="diag" data-table="diag">
-            <colgroup>
-              <col class="colBn" />
-              <col class="colBn" />
-              <col class="colHash" />
-              <col class="colCount" />
-              <col class="colCount" />
-              <col class="colActions" />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Echo block</th>
-                <th class="sortable" data-sort="num">Source block</th>
-                <th class="sortable" data-sort="str">Tx hash</th>
-                <th class="sortable" data-sort="num">Blob L2 gas</th>
-                <th class="sortable" data-sort="num">FGW L2 gas</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in l2_gas_mismatches %}
-              <tr
-                data-search="{{ row.tx_hash }} {{ row.echo_block }} {{ row.source_block }} {{ row.blob_total_gas_l2 }} {{ row.fgw_total_gas_consumed_l2 }}">
-                <td class="mono">{{ row.echo_block }}</td>
-                <td class="mono">{{ row.source_block }}</td>
-                <td class="mono"><span class="hash" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
-                <td class="mono">{{ row.blob_total_gas_l2 }}</td>
-                <td class="mono">{{ row.fgw_total_gas_consumed_l2 }}</td>
-                <td class="right">
-                  <div class="rowActions">
-                    <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
-                    <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
-                      rel="noopener" title="Open in Voyager">Voyager</a>
-                    <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
-                      data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
-                    {% if not export %}
-                    <a class="btn btnSmall btnLink"
-                      href="/echonet/block_dump?blockNumber={{ row.echo_block }}&kind=blob" target="_blank"
-                      rel="noopener" title="Open echonet blob dump JSON (echo block)">Echo&nbsp;blob</a>
-                    {% endif %}
-                    <a class="btn btnSmall btnLink"
-                      href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.source_block }}&withFeeMarketInfo=true"
-                      target="_blank" rel="noopener"
-                      title="Open source block JSON (upstream feeder)">Source&nbsp;block</a>
-                  </div>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="block-hash-mismatches">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Block hash mismatches <span class="countPill">{{ block_hash_mismatches |
-                length }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="block-hash-mismatches"></div>
-          {% if not block_hash_mismatches %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="diag" data-table="block-hash-mismatches">
-            <colgroup>
-              <col class="colBn" />
-              <col />
-              <col />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Echonet</th>
-                <th class="sortable" data-sort="str">Mainnet</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in block_hash_mismatches %}
-              <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
-                <td class="mono">{{ row.block_number }}</td>
-                <td class="mono">{{ row.echonet }}</td>
-                <td class="mono">{{ row.mainnet }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      <section id="tx-commitment-mismatches">
-        <details class="card details sectionDetails" data-section-details="1" open>
-          <summary class="sectionSummary">
-            <span class="sectionSummaryLeft">Transaction commitment mismatches <span class="countPill">{{
-                transaction_commitment_mismatches | length }}</span></span>
-          </summary>
-          <div class="tableMeta smallMuted" data-table-meta="tx-commitment-mismatches"></div>
-          {% if not transaction_commitment_mismatches %}
-          <div class="empty">(none)</div>
-          {% else %}
-          <table class="table filterable" data-filter-scope="diag" data-table="tx-commitment-mismatches">
-            <colgroup>
-              <col class="colBn" />
-              <col />
-              <col />
-            </colgroup>
-            <thead>
-              <tr>
-                <th class="sortable" data-sort="num">Block</th>
-                <th class="sortable" data-sort="str">Echonet</th>
-                <th class="sortable" data-sort="str">Mainnet</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for row in transaction_commitment_mismatches %}
-              <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
-                <td class="mono">{{ row.block_number }}</td>
-                <td class="mono">{{ row.echonet }}</td>
-                <td class="mono">{{ row.mainnet }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-          {% endif %}
-        </details>
-      </section>
-
-      {% if not export %}
-      <section id="block-dump">
-        <div class="card">
-          <div class="cardTitle">Echonet Blocks</div>
-          <div class="smallMuted">
-            Fetch a stored payload from Echonet via <span class="mono">/echonet/block_dump</span>.
-          </div>
-          <form class="inlineForm" action="/echonet/block_dump" method="get" target="_blank" rel="noopener">
-            <label class="control">
-              <span>Block number</span>
-              <input id="blockDumpNumber" name="blockNumber" type="number" inputmode="numeric" min="0"
-                placeholder="e.g. 123456" required class="noSpin" />
-            </label>
-            <label class="control">
-              <span>Kind</span>
-              <select id="blockDumpKind" name="kind" required>
-                <option value="blob">blob</option>
-                <option value="block">block</option>
-                <option value="state_update">state_update</option>
-              </select>
-            </label>
-            <div class="formActions">
-              <button class="btn" id="blockDumpOpenBtn" type="submit">Open</button>
+            <div class="smallMuted">Largest revert categories. Click a row to jump to that reason's group
+              in the reverts section.</div>
+            <div class="revertSummaryGrid">
+              <div class="revertSummaryCol">
+                <div class="revertSummaryTitle">Mainnet-only</div>
+                {% if not reverts.mainnet_only.groups %}
+                <div class="empty">(none)</div>
+                {% else %}
+                <div class="barList" data-bar-section="mainnet">
+                  {% for group in reverts.mainnet_only.groups[:8] %}
+                  <button class="barRow" type="button" data-filter-text="{{ group.name }}" data-scroll-to="reverts-mainnet">
+                    <span class="barName mono" title="{{ group.name }}">{{ group.name }}</span>
+                    <span class="barTrack"><span class="barFill bad" data-bar-count="{{ group.count }}"></span></span>
+                    <span class="barCount mono">{{ group.count }}</span>
+                    <span class="barPct smallMuted mono">{{ group.pct_of_section }}</span>
+                  </button>
+                  {% endfor %}
+                </div>
+                {% endif %}
+              </div>
+              <div class="revertSummaryCol">
+                <div class="revertSummaryTitle">Echonet-only</div>
+                {% if not reverts.echonet_only.groups %}
+                <div class="empty">(none)</div>
+                {% else %}
+                <div class="barList" data-bar-section="echonet">
+                  {% for group in reverts.echonet_only.groups[:8] %}
+                  <button class="barRow" type="button" data-filter-text="{{ group.name }}" data-scroll-to="reverts-echonet">
+                    <span class="barName mono" title="{{ group.name }}">{{ group.name }}</span>
+                    <span class="barTrack"><span class="barFill bad" data-bar-count="{{ group.count }}"></span></span>
+                    <span class="barCount mono">{{ group.count }}</span>
+                    <span class="barPct smallMuted mono">{{ group.pct_of_section }}</span>
+                  </button>
+                  {% endfor %}
+                </div>
+                {% endif %}
+              </div>
             </div>
-          </form>
-        </div>
-      </section>
-      {% endif %}
-    </div>
+          </details>
+        </section>
+        {% endif %}
 
-    <footer class="footer">
-      <div>
-        {% if export %}
-        Static snapshot: filter/scope, copy, logs links, theme, and feeder links are enabled.
-        {% else %}
-        Endpoints:
-        <a href="/echonet/report/ui">UI</a>,
-        <a href="/echonet/report">JSON</a>,
-        <a href="/echonet/report/text">Text</a>,
-        <a href="/echonet/block_dump?blockNumber=0&kind=blob">Block dump</a>
+        <section id="pending-txs">
+          <details class="card details sectionDetails" data-section-details="1">
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="M12 7v5l3 2" />
+                </svg>
+                Non-committed tx hashes (pending)
+                <span class="countPill" data-section-count="{{ pending_txs_total }}">{{ pending_txs_total }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="pending" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="pending"></div>
+            {% if not pending_txs_total %}
+            <div class="empty">
+              <div class="emptyIcon" aria-hidden="true">✓</div>
+              <div class="emptyText">All forwarded transactions have been committed.</div>
+            </div>
+            {% else %}
+            {% if pending_txs_total > 10 %}
+            <div class="smallMuted">Showing first 10 of {{ pending_txs_total }}</div>
+            {% endif %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="pending" data-table="pending">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colHash" />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Source block</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for tx_hash, src_bn in pending_txs %}
+                  <tr data-search="{{ tx_hash }} {{ src_bn }}">
+                    <td class="mono">{{ src_bn }}</td>
+                    <td class="mono">
+                      <span class="hash" data-full-hash="{{ tx_hash }}" title="{{ tx_hash }}">{{ tx_hash }}</span>
+                    </td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ src_bn }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ src_bn }}"
+                          target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+
+        {% if kpis.gateway_errors_count > 0 %}
+        <section id="gateway-errors">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="M12 8v4M12 16h.01" />
+                </svg>
+                Gateway errors
+                <span class="countPill" data-section-count="{{ kpis.gateway_errors_count }}">{{ kpis.gateway_errors_count }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="gateway" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="gateway"></div>
+            {% if not gateway_errors %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No gateway errors recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="gateway" data-table="gateway">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colStatus" />
+                  <col class="colHash" />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Status</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th>Response</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in gateway_errors %}
+                  <tr data-search="{{ row.tx_hash }} {{ row.status }} {{ row.block_number }} {{ row.response }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono"><span class="status {{ severity.gateway_errors }}">{{ row.status }}</span></td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">
+                      <details class="details">
+                        <summary>Show</summary>
+                        <pre class="pre">{{ row.response }}</pre>
+                      </details>
+                    </td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                          target="_blank" rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.reverts_mainnet_count > 0 %}
+        <section id="reverts-mainnet">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M9 12 4 7l5-5M4 7h12a4 4 0 0 1 4 4v10" />
+                </svg>
+                Reverted only on Mainnet
+                <span class="countPill" data-section-count="{{ reverts.mainnet_only.total }}">
+                  {{ reverts.mainnet_only.total }} ({{ reverts.mainnet_only.pct_of_total_sent }})
+                </span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="reverts-mainnet" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            {% if reverts.mainnet_only.total == 0 %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No transactions reverted only on Mainnet.</div>
+            </div>
+            {% else %}
+            <div class="smallMuted">Use the filter box to narrow down.</div>
+            {% for group in reverts.mainnet_only.groups %}
+            <details class="details filterable revertGroup" data-filter-scope="reverts" open>
+              <summary>
+                <span class="countPill">{{ group.count }}</span>
+                <span class="mono">{{ group.name }}</span>
+                <span class="countPill">{{ group.pct_of_section }}</span>
+              </summary>
+              <div class="tableWrap">
+                <table class="table" data-table="reverts-mainnet">
+                  <colgroup>
+                    <col class="colBn" />
+                    <col class="colHash" />
+                    <col />
+                    <col class="colActions" />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th class="sortable" data-sort="num">Source block</th>
+                      <th class="sortable" data-sort="str">Tx hash</th>
+                      <th>Reason (shortened)</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in group.rows %}
+                    <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
+                      <td class="mono">{{ row.block_number }}</td>
+                      <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                      <td>
+                        <div class="reason">{{ row.reason }}</div>
+                        {% if row.raw_error and row.raw_error != row.reason %}
+                        <details class="details nested">
+                          <summary>Raw</summary>
+                          <pre class="pre">{{ row.raw_error }}</pre>
+                        </details>
+                        {% endif %}
+                      </td>
+                      <td class="right">
+                        <div class="rowActions">
+                          <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                          <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                            rel="noopener" title="Open in Voyager">Voyager</a>
+                          <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                            data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                            target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                            target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                        </div>
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+            {% endfor %}
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.reverts_echonet_count > 0 %}
+        <section id="reverts-echonet">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m15 12 5-5-5-5M20 7H8a4 4 0 0 0-4 4v10" />
+                </svg>
+                Reverted only on Echonet
+                <span class="countPill" data-section-count="{{ reverts.echonet_only.total }}">
+                  {{ reverts.echonet_only.total }} ({{ reverts.echonet_only.pct_of_total_sent }})
+                </span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="reverts-echonet" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            {% if reverts.echonet_only.total == 0 %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No transactions reverted only on Echonet.</div>
+            </div>
+            {% else %}
+            <div class="smallMuted">Use the filter box to narrow down.</div>
+            {% for group in reverts.echonet_only.groups %}
+            <details class="details filterable revertGroup" data-filter-scope="reverts" open>
+              <summary>
+                <span class="countPill">{{ group.count }}</span>
+                <span class="mono">{{ group.name }}</span>
+                <span class="countPill">{{ group.pct_of_section }}</span>
+              </summary>
+              <div class="tableWrap">
+                <table class="table" data-table="reverts-echonet">
+                  <colgroup>
+                    <col class="colBn" />
+                    <col class="colHash" />
+                    <col />
+                    <col class="colActions" />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th class="sortable" data-sort="num">Source block</th>
+                      <th class="sortable" data-sort="str">Tx hash</th>
+                      <th>Reason (shortened)</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in group.rows %}
+                    <tr data-search="{{ row.tx_hash }} {{ row.block_number }} {{ row.reason }} {{ row.raw_error }}">
+                      <td class="mono">{{ row.block_number }}</td>
+                      <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                      <td>
+                        <div class="reason">{{ row.reason }}</div>
+                        {% if row.raw_error and row.raw_error != row.reason %}
+                        <details class="details nested">
+                          <summary>Raw</summary>
+                          <pre class="pre">{{ row.raw_error }}</pre>
+                        </details>
+                        {% endif %}
+                      </td>
+                      <td class="right">
+                        <div class="rowActions">
+                          <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                          <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                            rel="noopener" title="Open in Voyager">Voyager</a>
+                          <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                            data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                            target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                          <a class="btn btnSmall btnLink"
+                            href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                            target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                        </div>
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+            {% endfor %}
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.resync_causes_count > 0 %}
+        <section id="resync-triggers">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M21 12a9 9 0 1 1-3-6.7M21 4v5h-5" />
+                </svg>
+                Resync triggers (first failures)
+                <span class="countPill" data-section-count="{{ kpis.resync_causes_count }}">{{ kpis.resync_causes_count }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="resync" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="resync"></div>
+            {% if not resync.causes %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No resync triggers recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="resync" data-table="resync">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colCount" />
+                  <col class="colHash" />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="num">Count</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th class="sortable" data-sort="str">Reason</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in resync.causes %}
+                  <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
+                    <td class="mono">{{ row.failure_block_number }}</td>
+                    <td class="mono">{{ row.count }}</td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">{{ row.reason }}</td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
+                          target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.certain_failures_count > 0 %}
+        <section id="certain-failures">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9" />
+                  <path d="m9 9 6 6M15 9l-6 6" />
+                </svg>
+                Certain failures (repeated triggers)
+                <span class="countPill" data-section-count="{{ kpis.certain_failures_count }}">{{ kpis.certain_failures_count }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="certain" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="certain"></div>
+            {% if not resync.certain_failures %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No certain failures recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="resync" data-table="certain">
+                <colgroup>
+                  <col class="colCount" />
+                  <col class="colBn" />
+                  <col class="colHash" />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Count</th>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th class="sortable" data-sort="str">Reason</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in resync.certain_failures %}
+                  <tr data-search="{{ row.tx_hash }} {{ row.failure_block_number }} {{ row.reason }} {{ row.count }}">
+                    <td class="mono">{{ row.count }}</td>
+                    <td class="mono">{{ row.failure_block_number }}</td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">{{ row.reason }}</td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.failure_block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open source block JSON (upstream feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.failure_block_number }}"
+                          target="_blank" rel="noopener" title="Open source state update JSON (upstream feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.l2_gas_mismatches_count > 0 %}
+        <section id="l2-gas-mismatches">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 22V6l6-4 6 4v16M5 11h12M9 18h4" />
+                </svg>
+                L2 gas used mismatches
+                <span class="countPill" data-section-count="{{ l2_gas_mismatches | length }}">{{ l2_gas_mismatches | length }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="diag" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="diag"></div>
+            {% if not l2_gas_mismatches %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">L2 gas matches the upstream feeder.</div>
+            </div>
+            {% else %}
+            <div class="smallMuted">Showing all L2 gas used mismatches.</div>
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="diag">
+                <colgroup>
+                  <col class="colBn" />
+                  <col class="colBn" />
+                  <col class="colHash" />
+                  <col class="colCount" />
+                  <col class="colCount" />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Echo block</th>
+                    <th class="sortable" data-sort="num">Source block</th>
+                    <th class="sortable" data-sort="str">Tx hash</th>
+                    <th class="sortable" data-sort="num">Blob L2 gas</th>
+                    <th class="sortable" data-sort="num">FGW L2 gas</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in l2_gas_mismatches %}
+                  <tr
+                    data-search="{{ row.tx_hash }} {{ row.echo_block }} {{ row.source_block }} {{ row.blob_total_gas_l2 }} {{ row.fgw_total_gas_consumed_l2 }}">
+                    <td class="mono">{{ row.echo_block }}</td>
+                    <td class="mono">{{ row.source_block }}</td>
+                    <td class="mono"><span class="hash" data-full-hash="{{ row.tx_hash }}" title="{{ row.tx_hash }}">{{ row.tx_hash }}</span></td>
+                    <td class="mono">{{ row.blob_total_gas_l2 }}</td>
+                    <td class="mono">{{ row.fgw_total_gas_consumed_l2 }}</td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <button class="btn btnSmall copyBtn" type="button" data-copy="{{ row.tx_hash }}">Copy</button>
+                        <a class="btn btnSmall btnLink" href="https://voyager.online/tx/{{ row.tx_hash }}" target="_blank"
+                          rel="noopener" title="Open in Voyager">Voyager</a>
+                        <a class="btn btnSmall btnLink logsLink" href="#" target="_blank" rel="noopener"
+                          data-logs-tx="{{ row.tx_hash }}" title="Open logs filtered by this tx hash">Logs</a>
+                        {% if not export %}
+                        <a class="btn btnSmall btnLink"
+                          href="/echonet/block_dump?blockNumber={{ row.echo_block }}&kind=blob" target="_blank"
+                          rel="noopener" title="Open echonet blob dump JSON (echo block)">Echo&nbsp;blob</a>
+                        {% endif %}
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.source_block }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener"
+                          title="Open source block JSON (upstream feeder)">Source&nbsp;block</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.block_hash_mismatches_count > 0 %}
+        <section id="block-hash-mismatches">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m4 7 8-4 8 4M4 7v10l8 4 8-4V7M4 7l8 4 8-4M12 11v10" />
+                </svg>
+                Block hash mismatches
+                <span class="countPill" data-section-count="{{ block_hash_mismatches | length }}">{{ block_hash_mismatches | length }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="block-hash-mismatches" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="block-hash-mismatches"></div>
+            {% if not block_hash_mismatches %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">Block hashes match mainnet.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="block-hash-mismatches">
+                <colgroup>
+                  <col class="colBn" />
+                  <col />
+                  <col />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Echonet</th>
+                    <th class="sortable" data-sort="str">Mainnet</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in block_hash_mismatches %}
+                  <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono">{{ row.echonet }}</td>
+                    <td class="mono">{{ row.mainnet }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.transaction_commitment_mismatches_count > 0 %}
+        <section id="tx-commitment-mismatches">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M9 12 11 14l4-4M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" />
+                </svg>
+                Transaction commitment mismatches
+                <span class="countPill" data-section-count="{{ transaction_commitment_mismatches | length }}">{{ transaction_commitment_mismatches | length }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="tx-commitment-mismatches"
+                  type="button" title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="tx-commitment-mismatches"></div>
+            {% if not transaction_commitment_mismatches %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">Transaction commitments match mainnet.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="tx-commitment-mismatches">
+                <colgroup>
+                  <col class="colBn" />
+                  <col />
+                  <col />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Echonet</th>
+                    <th class="sortable" data-sort="str">Mainnet</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in transaction_commitment_mismatches %}
+                  <tr data-search="{{ row.block_number }} {{ row.echonet }} {{ row.mainnet }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono">{{ row.echonet }}</td>
+                    <td class="mono">{{ row.mainnet }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if kpis.os_failed_count > 0 %}
+        <section id="os-run-failures">
+          <details class="card details sectionDetails" data-section-details="1" open>
+            <summary class="sectionSummary">
+              <span class="sectionSummaryLeft">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 3l9 15H3zM12 9v4M12 17h.01" />
+                </svg>
+                OS run failures
+                <span class="countPill" data-section-count="{{ kpis.os_failed_count }}">{{ kpis.os_failed_count }}</span>
+              </span>
+              <span class="sectionSummaryRight">
+                <button class="btn btnSmall sectionExportBtn" data-export-table="os-run-failures" type="button"
+                  title="Copy visible rows as CSV">CSV</button>
+              </span>
+            </summary>
+            <div class="tableMeta smallMuted" data-table-meta="os-run-failures"></div>
+            {% if not os_run_failures %}
+            <div class="empty">
+              <div class="emptyIcon ok" aria-hidden="true">✓</div>
+              <div class="emptyText">No OS run failures recorded.</div>
+            </div>
+            {% else %}
+            <div class="tableWrap">
+              <table class="table filterable" data-filter-scope="diag" data-table="os-run-failures">
+                <colgroup>
+                  <col class="colBn" />
+                  <col />
+                  <col />
+                  <col class="colActions" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th class="sortable" data-sort="num">Block</th>
+                    <th class="sortable" data-sort="str">Timestamp</th>
+                    <th>Error</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in os_run_failures %}
+                  <tr data-search="{{ row.block_number }} {{ row.ts }} {{ row.error }}">
+                    <td class="mono">{{ row.block_number }}</td>
+                    <td class="mono">{{ row.ts }}</td>
+                    <td class="mono">
+                      <details class="details">
+                        <summary>Show</summary>
+                        <pre class="pre">{{ row.error }}</pre>
+                      </details>
+                    </td>
+                    <td class="right">
+                      <div class="rowActions">
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_block?blockNumber={{ row.block_number }}&withFeeMarketInfo=true"
+                          target="_blank" rel="noopener" title="Open block JSON (upstream/stored feeder)">Block</a>
+                        <a class="btn btnSmall btnLink"
+                          href="{{ feeder_base_url }}/feeder_gateway/get_state_update?blockNumber={{ row.block_number }}"
+                          target="_blank" rel="noopener" title="Open state update JSON (upstream/stored feeder)">State</a>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% endif %}
+          </details>
+        </section>
+        {% endif %}
+
+        {% if not export %}
+        <section id="block-dump">
+          <div class="card">
+            <div class="cardHeader">
+              <div class="cardTitle">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
+                </svg>
+                Echonet block dump
+              </div>
+            </div>
+            <div class="smallMuted">
+              Fetch a stored payload from Echonet via <span class="mono">/echonet/block_dump</span>.
+            </div>
+            <form class="inlineForm" action="/echonet/block_dump" method="get" target="_blank" rel="noopener">
+              <label class="control">
+                <span>Block number</span>
+                <input id="blockDumpNumber" name="blockNumber" type="number" inputmode="numeric" min="0"
+                  placeholder="e.g. 123456" required class="noSpin" />
+              </label>
+              <label class="control">
+                <span>Kind</span>
+                <select id="blockDumpKind" name="kind" required>
+                  <option value="blob">blob</option>
+                  <option value="block">block</option>
+                  <option value="state_update">state_update</option>
+                </select>
+              </label>
+              <div class="formActions">
+                <button class="btn" id="blockDumpOpenBtn" type="submit">Open</button>
+              </div>
+            </form>
+          </div>
+        </section>
         {% endif %}
       </div>
-    </footer>
-  </main>
+
+      <footer class="footer">
+        <div>
+          {% if export %}
+          Static snapshot: filter/scope, copy, logs links, theme, and feeder links are enabled.
+          {% else %}
+          Endpoints:
+          <a href="/echonet/report/ui">UI</a>,
+          <a href="/echonet/report">JSON</a>,
+          <a href="/echonet/report/text">Text</a>,
+          <a href="/echonet/block_dump?blockNumber=0&kind=blob">Block dump</a>
+          {% endif %}
+        </div>
+      </footer>
+    </main>
+  </div>
+
+  <div class="shortcutsOverlay" id="shortcutsOverlay" hidden role="dialog" aria-modal="true"
+    aria-labelledby="shortcutsTitle">
+    <div class="shortcutsCard" role="document">
+      <div class="shortcutsHeader">
+        <div id="shortcutsTitle" class="shortcutsTitle">Keyboard shortcuts</div>
+        <button class="btn btnSmall" type="button" id="shortcutsClose" aria-label="Close">Esc</button>
+      </div>
+      <div class="shortcutsBody">
+        <div class="shortcutRow"><kbd>/</kbd><span>Focus the filter</span></div>
+        <div class="shortcutRow"><kbd>Esc</kbd><span>Clear the filter / close overlay</span></div>
+        <div class="shortcutRow"><kbd>R</kbd><span>Refresh now</span></div>
+        <div class="shortcutRow"><kbd>E</kbd><span>Expand all sections</span></div>
+        <div class="shortcutRow"><kbd>C</kbd><span>Collapse all sections</span></div>
+        <div class="shortcutRow"><kbd>D</kbd><span>Toggle row density</span></div>
+        <div class="shortcutRow"><kbd>H</kbd><span>Toggle hash display (full ↔ truncated)</span></div>
+        <div class="shortcutRow"><kbd>T</kbd><span>Cycle theme (risk → dark → light)</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>P</kbd><span>Jump to pending</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>E</kbd><span>Jump to gateway errors</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>R</kbd><span>Jump to reverts (mainnet)</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>R</kbd> <kbd>R</kbd><span>Jump to reverts (echonet)</span></div>
+        <div class="shortcutRow"><kbd>G</kbd> <kbd>O</kbd><span>Jump to overview</span></div>
+        <div class="shortcutRow"><kbd>?</kbd><span>Show / hide this help</span></div>
+      </div>
+    </div>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
Rebased UI overhaul: sticky sidenav with per-section severity pills, a
metric-tile Alerts grid (with a divider'd OS-runner subgroup showing
completed/failed/dropped/abandoned/skipped and live queue/deferred
state), per-section CSV export, section-collapse and sort persistence,
scroll restore, keyboard navigation, and an OS run failures section.
Diagnostic sections only render when their count is positive.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>