### PR TITLE
apollo_mempool: stop FIFO get_txs from draining past a block boundary on shared timestamps

### DIFF
--- a/crates/apollo_mempool/src/fifo_mempool_test.rs
+++ b/crates/apollo_mempool/src/fifo_mempool_test.rs
@@ -337,6 +337,29 @@ fn test_get_txs_pauses_once_on_block_number_gap(mut mempool: Mempool) {
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input4.tx, input5.tx]);
 }
 
+// Consecutive mainnet blocks can share a wall-clock timestamp; a single get_txs call must not
+// drain across the block boundary in that case.
+#[rstest]
+fn test_get_txs_stops_at_block_boundary_on_shared_timestamp(mut mempool: Mempool) {
+    let block_9_tx = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let block_10_tx = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
+
+    // Blocks 9 and 10 share the same timestamp.
+    mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(1000, 9));
+    mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(1000, 10));
+
+    add_tx(&mut mempool, &block_9_tx);
+    add_tx(&mut mempool, &block_10_tx);
+
+    // First proposal builds block 9 — it must contain only block 9's tx.
+    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![block_9_tx.tx]);
+
+    // Second proposal builds block 10 with its tx.
+    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![block_10_tx.tx]);
+}
+
 #[rstest]
 fn test_get_txs_returns_empty_result_with_gaps(mut mempool: Mempool) {
     let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);

--- a/crates/apollo_mempool/src/fifo_transaction_queue.rs
+++ b/crates/apollo_mempool/src/fifo_transaction_queue.rs
@@ -46,7 +46,9 @@ impl CurrentProposalState {
             .expected_block_number
             .next()
             .expect("Block number overflow while advancing expected block after pop.");
-        self.emit_empty_block = false;
+        // Consecutive blocks can share a timestamp, so gate further pops until the next
+        // resolve_timestamp call re-syncs the state to the queue head.
+        self.emit_empty_block = true;
     }
 }
 


### PR DESCRIPTION
In FIFO (Echonet) mode, `advance_block_if_drained` cleared `emit_empty_block` after advancing `expected_block_number`, so when two consecutive mainnet blocks share a wall-clock timestamp (production occurrence: blocks 9188909 and 9188910), a single `get_txs` call kept popping past the block boundary and pulled the next block's tx into the current proposal, causing a transaction-commitment mismatch with mainnet.

Setting the flag gates further pops until the next `resolve_batch_timestamp` call, which clears it when syncing to the new queue head.

The regression test was verified to fail with the fix reverted. No effect outside Echonet mode — the FIFO queue is only instantiated under `BehaviorMode::Echonet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)