### PR TITLE
apollo_mempool,apollo_batcher: realign FIFO proposal state on round start after an aborted round

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -724,11 +724,22 @@ impl Batcher {
     }
 
     #[instrument(skip(self), err)]
-    pub async fn get_batch_timestamp(&self) -> BatcherResult<UnixTimestamp> {
+    pub async fn get_batch_timestamp(&mut self) -> BatcherResult<UnixTimestamp> {
+        // This call starts a proposer round; the proposer flow has no other round-transition
+        // hook, so abort the previous round's proposal here.
+        self.abort_active_proposal().await;
+
         let mempool_client = self.mempool_client.as_ref().expect(
             "Mempool client must be present in non-validation-only mode. Unreachable code when \
              validation-only mode is enabled.",
         );
+        // Rewind any staged txs left behind by an aborted round, so the timestamp resolved below
+        // reflects the block about to be built. A no-op in the normal flow, and repeated
+        // idempotently by propose_block.
+        mempool_client.commit_block(CommitBlockArgs::default()).await.map_err(|err| {
+            error!("Mempool is not ready to start a new round: {err}");
+            BatcherError::NotReady
+        })?;
         mempool_client.resolve_batch_timestamp().await.map_err(|err| {
             error!("Failed to get timestamp from mempool: {err}");
             BatcherError::InternalError

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -723,12 +723,22 @@ impl Batcher {
         Ok(GetHeightResponse { height })
     }
 
+    /// Starts a new proposer round: aborts the previous round's proposal (the proposer flow has
+    /// no other round-transition hook), rewinds any staged txs it left in the mempool, and
+    /// returns the timestamp for the block about to be built.
     #[instrument(skip(self), err)]
-    pub async fn get_batch_timestamp(&self) -> BatcherResult<UnixTimestamp> {
+    pub async fn start_round(&mut self) -> BatcherResult<UnixTimestamp> {
+        self.abort_active_proposal().await;
+
         let mempool_client = self.mempool_client.as_ref().expect(
             "Mempool client must be present in non-validation-only mode. Unreachable code when \
              validation-only mode is enabled.",
         );
+        // The rewind is a no-op in the normal flow, and repeated idempotently by propose_block.
+        mempool_client.commit_block(CommitBlockArgs::default()).await.map_err(|err| {
+            error!("Mempool is not ready to start a new round: {err}");
+            BatcherError::NotReady
+        })?;
         mempool_client.resolve_batch_timestamp().await.map_err(|err| {
             error!("Failed to get timestamp from mempool: {err}");
             BatcherError::InternalError

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1948,7 +1948,7 @@ async fn validation_only_propose_block_returns_not_supported() {
 #[tokio::test]
 #[should_panic(expected = "Mempool client must be present in non-validation-only mode.")]
 async fn validation_only_get_batch_timestamp_panics() {
-    let batcher = create_batcher(validation_only_mock_dependencies()).await;
+    let mut batcher = create_batcher(validation_only_mock_dependencies()).await;
     batcher.get_batch_timestamp().await.unwrap();
 }
 

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1947,9 +1947,9 @@ async fn validation_only_propose_block_returns_not_supported() {
 
 #[tokio::test]
 #[should_panic(expected = "Mempool client must be present in non-validation-only mode.")]
-async fn validation_only_get_batch_timestamp_panics() {
-    let batcher = create_batcher(validation_only_mock_dependencies()).await;
-    batcher.get_batch_timestamp().await.unwrap();
+async fn validation_only_start_round_panics() {
+    let mut batcher = create_batcher(validation_only_mock_dependencies()).await;
+    batcher.start_round().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -61,9 +61,7 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
             BatcherRequest::RevertBlock(input) => {
                 BatcherResponse::RevertBlock(self.revert_block(input).await)
             }
-            BatcherRequest::GetBatchTimestamp => {
-                BatcherResponse::GetBatchTimestamp(self.get_batch_timestamp().await)
-            }
+            BatcherRequest::StartRound => BatcherResponse::StartRound(self.start_round().await),
             BatcherRequest::CallContract(input) => {
                 BatcherResponse::CallContract(self.call_contract(input).await)
             }

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -98,7 +98,8 @@ pub trait BatcherClient: Send + Sync {
     ) -> BatcherClientResult<SendTxsForProposalStatus>;
     /// Reverts the block with the given block number, only if it is the last in the storage.
     async fn revert_block(&self, input: RevertBlockInput) -> BatcherClientResult<()>;
-    async fn get_batch_timestamp(&self) -> BatcherClientResult<UnixTimestamp>;
+    /// Starts a new proposer round and returns the timestamp for the block about to be built.
+    async fn start_round(&self) -> BatcherClientResult<UnixTimestamp>;
     /// Executes a view (read-only) entry point on a contract against the latest committed batcher
     /// state and returns the retdata.
     async fn call_contract(
@@ -129,7 +130,7 @@ pub enum BatcherRequest {
     DecisionReached(DecisionReachedInput),
     AddSyncBlock(SyncBlock),
     RevertBlock(RevertBlockInput),
-    GetBatchTimestamp,
+    StartRound,
     CallContract(CallContractInput),
 }
 impl_debug_for_infra_requests_and_responses!(BatcherRequest);
@@ -157,7 +158,7 @@ pub enum BatcherResponse {
     DecisionReached(BatcherResult<Box<DecisionReachedResponse>>),
     AddSyncBlock(BatcherResult<()>),
     RevertBlock(BatcherResult<()>),
-    GetBatchTimestamp(BatcherResult<u64>),
+    StartRound(BatcherResult<UnixTimestamp>),
     CallContract(BatcherResult<CallContractOutput>),
 }
 impl_debug_for_infra_requests_and_responses!(BatcherResponse);
@@ -360,13 +361,13 @@ where
         )
     }
 
-    async fn get_batch_timestamp(&self) -> BatcherClientResult<UnixTimestamp> {
-        let request = BatcherRequest::GetBatchTimestamp;
+    async fn start_round(&self) -> BatcherClientResult<UnixTimestamp> {
+        let request = BatcherRequest::StartRound;
         handle_all_response_variants!(
             self,
             request,
             BatcherResponse,
-            GetBatchTimestamp,
+            StartRound,
             BatcherClientError,
             BatcherError,
             Direct

--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -142,7 +142,7 @@ async fn get_proposal_timestamp(
     clock: &dyn Clock,
 ) -> u64 {
     if override_timestamp {
-        match batcher.get_batch_timestamp().await {
+        match batcher.start_round().await {
             Ok(timestamp) => return timestamp,
             Err(err) => {
                 warn!("Failed to get timestamp from batcher, falling back to clock time: {err:?}");

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -2507,32 +2507,6 @@
           "extra_params": {}
         },
         {
-          "title": "get_batch_timestamp (client-side)",
-          "description": "client-side infra metrics for request type get_batch_timestamp",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
-          "title": "get_batch_timestamp (server-side)",
-          "description": "server-side infra metrics for request type get_batch_timestamp",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"get_batch_timestamp\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
           "title": "get_block_hash (client-side)",
           "description": "client-side infra metrics for request type get_block_hash",
           "type": "timeseries",
@@ -2711,6 +2685,32 @@
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_height\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_height\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
             "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_height\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "start_round (client-side)",
+          "description": "client-side infra metrics for request type start_round",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "start_round (server-side)",
+          "description": "server-side infra metrics for request type start_round",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"start_round\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
           ],
           "extra_params": {}
         },

--- a/crates/apollo_mempool/src/fifo_mempool_test.rs
+++ b/crates/apollo_mempool/src/fifo_mempool_test.rs
@@ -462,6 +462,32 @@ fn test_realign_to_earlier_block_after_rewind(mut mempool: Mempool) {
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx]);
 }
 
+// A proposer round that drains a block and aborts must get the rewound txs back on the retried
+// round, even though it pops without resolving the timestamp in between. get_txs is called
+// directly because get_txs_and_assert_expected resolves first, which would mask the bug.
+#[rstest]
+fn test_rewind_realigns_state_so_get_txs_succeeds_without_resolve(mut mempool: Mempool) {
+    let block_1_tx = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let block_2_tx = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
+
+    mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(1000, 1));
+    mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(2000, 2));
+
+    add_tx(&mut mempool, &block_1_tx);
+    add_tx(&mut mempool, &block_2_tx);
+
+    // Round 0 of block 1: resolve the timestamp and drain block 1's tx; expected_block_number
+    // advances to 2.
+    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![block_1_tx.tx.clone()]);
+
+    // Round 0 aborts before commit; round 1 starts with the round-start commit_block only.
+    commit_block(&mut mempool, [], []);
+
+    // The rewind must have realigned expected_block_number back to 1, so the pop succeeds.
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![block_1_tx.tx]);
+}
+
 #[rstest]
 fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
     let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);

--- a/crates/apollo_mempool/src/fifo_transaction_queue.rs
+++ b/crates/apollo_mempool/src/fifo_transaction_queue.rs
@@ -356,6 +356,12 @@ impl TransactionQueueTrait for FifoTransactionQueue {
 
         self.staged_txs.clear();
 
+        // Rewound txs may reference an earlier block than current_proposal_state expects.
+        // Realign so a retried round's pop_ready_chunk sees a matching head.
+        if !rewound_hashes.is_empty() {
+            let _ = self.sync_proposal_state_from_queue_front_tx();
+        }
+
         rewound_hashes
     }
 


### PR DESCRIPTION
When a proposer round drains a block's txs and then aborts (e.g., on a cende write failure), the next round's round-start `commit_block` rewinds the staged txs — but the FIFO queue's `current_proposal_state` still pointed past the drained block, so the retried round saw an empty queue and committed an empty block (observed at echonet block 6502414).

Two coordinated changes:
- `rewind_txs` realigns the proposal state to the new queue head after a rewind.
- The first batcher call of a proposer round is now an explicit round-start: `get_batch_timestamp` is renamed to `start_round` (mirroring `StartHeight`), and it aborts any stale active proposal and issues the round-start `commit_block` before resolving the timestamp for the block about to be built. `propose_block` repeats the rewind idempotently.

The regression test pops without an intervening timestamp resolution, mirroring the production flow, and was verified to fail with the fix reverted. The batcher path is only reached in Echonet mode (`override_timestamp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)