### PR TITLE
apollo_mempool: track the block number being built in the FIFO queue

### DIFF
--- a/crates/apollo_mempool/src/communication.rs
+++ b/crates/apollo_mempool/src/communication.rs
@@ -172,7 +172,7 @@ impl MempoolCommunicationWrapper {
     }
 
     fn resolve_batch_timestamp(&mut self) -> MempoolResult<UnixTimestamp> {
-        Ok(self.mempool.resolve_batch_timestamp())
+        Ok(self.mempool.resolve_block_metadata().timestamp)
     }
 
     // Fetches tx block metadata from recorder and updates mempool.

--- a/crates/apollo_mempool/src/fifo_mempool_test.rs
+++ b/crates/apollo_mempool/src/fifo_mempool_test.rs
@@ -6,6 +6,7 @@ use apollo_mempool_config::config::{MempoolConfig, MempoolDynamicConfig, Mempool
 use apollo_mempool_types::mempool_types::{AccountState, AddTransactionArgs};
 use apollo_time::test_utils::FakeClock;
 use rstest::{fixture, rstest};
+use starknet_api::block::BlockNumber;
 use starknet_api::test_utils::invoke::internal_invoke_tx;
 use starknet_api::test_utils::valid_resource_bounds_for_testing;
 use starknet_api::transaction::fields::TransactionSignature;
@@ -230,7 +231,7 @@ fn test_declare_txs_preserve_fifo_order(mut mempool: Mempool) {
 }
 
 #[rstest]
-fn test_resolve_batch_timestamp_persists_after_queue_emptied(mut mempool: Mempool) {
+fn test_resolved_timestamp_persists_after_queue_emptied(mut mempool: Mempool) {
     let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
     let input2 = add_tx_input!(tx_hash: 2, address: "0x1", tx_nonce: 1, account_nonce: 0);
 
@@ -241,13 +242,13 @@ fn test_resolve_batch_timestamp_persists_after_queue_emptied(mut mempool: Mempoo
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 
     // Consume all txs, emptying the queue.
     get_txs_and_assert_expected(&mut mempool, 2, &[input1.tx, input2.tx]);
 
     // Timestamp should persist after queue is emptied.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 }
 
 #[rstest]
@@ -267,7 +268,7 @@ fn test_get_txs_does_not_return_txs_with_different_timestamp(mut mempool: Mempoo
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
 
     // Request one transaction from the first timestamp batch.
     get_txs_and_assert_expected(&mut mempool, 1, &[input1.tx]);
@@ -279,7 +280,7 @@ fn test_get_txs_does_not_return_txs_with_different_timestamp(mut mempool: Mempoo
     assert_eq!(mempool.get_txs(10).unwrap(), vec![]);
 
     // Resolve to advance to timestamp 1001.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx]);
 }
 
@@ -293,7 +294,7 @@ fn test_get_txs_same_block_spans_multiple_chunks(mut mempool: Mempool) {
         add_tx(&mut mempool, &input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     // First chunk: block builder fetches 100 txs.
     let chunk1 = mempool.get_txs(100).unwrap();
     assert_eq!(chunk1.len(), 100);
@@ -322,19 +323,44 @@ fn test_get_txs_pauses_once_on_block_number_gap(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx, input2.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input3.tx]);
 
     // Block 4 is missing.
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
 
     // Block 5 is present.
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input4.tx, input5.tx]);
+}
+
+#[rstest]
+fn test_resolve_block_metadata_returns_built_block_number_for_empty_block(mut mempool: Mempool) {
+    let input1 = add_tx_input!(tx_hash: 1, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    let input2 = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
+
+    // Block 10 has a tx, block 11 is empty, block 12 has a tx.
+    mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(1000, 10));
+    mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(1200, 12));
+
+    add_tx(&mut mempool, &input1);
+    add_tx(&mut mempool, &input2);
+
+    // Build block 10.
+    assert_eq!(mempool.resolve_block_metadata().block_number, Some(BlockNumber(10)));
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
+
+    // Build block 11 (empty). The built block number must be 11, not 12.
+    assert_eq!(mempool.resolve_block_metadata().block_number, Some(BlockNumber(11)));
+    assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
+
+    // Build block 12 (non-empty).
+    assert_eq!(mempool.resolve_block_metadata().block_number, Some(BlockNumber(12)));
+    assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 }
 
 // Consecutive mainnet blocks can share a wall-clock timestamp; a single get_txs call must not
@@ -352,11 +378,11 @@ fn test_get_txs_stops_at_block_boundary_on_shared_timestamp(mut mempool: Mempool
     add_tx(&mut mempool, &block_10_tx);
 
     // First proposal builds block 9 — it must contain only block 9's tx.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![block_9_tx.tx]);
 
     // Second proposal builds block 10 with its tx.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![block_10_tx.tx]);
 }
 
@@ -375,17 +401,17 @@ fn test_get_txs_returns_empty_result_with_gaps(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 
     for _ in 0..19 {
-        assert_eq!(mempool.resolve_batch_timestamp(), 300);
+        assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
         assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 300);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 300);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input3.tx]);
 }
 
@@ -395,16 +421,16 @@ fn test_get_txs_after_queue_emptied_still_resolves_new_tx(mut mempool: Mempool) 
     mempool.update_tx_block_metadata(tx_hash!(1), tx_metadata(100, 1));
     add_tx(&mut mempool, &input1);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input1.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 100);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 100);
     assert_eq!(mempool.get_txs(10).unwrap(), Vec::new());
 
     let input2 = add_tx_input!(tx_hash: 2, address: "0x2", tx_nonce: 0, account_nonce: 0);
     mempool.update_tx_block_metadata(tx_hash!(2), tx_metadata(200, 2));
     add_tx(&mut mempool, &input2);
-    assert_eq!(mempool.resolve_batch_timestamp(), 200);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 200);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![input2.tx]);
 }
 
@@ -423,15 +449,15 @@ fn test_rewind_partial_block_then_continue_to_next_block(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 3, &[input1.tx, input2.tx, input3.tx.clone()]);
 
     // Only tx 1 and 2 are committed; tx3 rewinds.
     commit_block(&mut mempool, [("0x1", 2)], []);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx]);
-    assert_eq!(mempool.resolve_batch_timestamp(), 2000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 2000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input5.tx]);
 }
 
@@ -447,18 +473,18 @@ fn test_realign_to_earlier_block_after_rewind(mut mempool: Mempool) {
     add_tx(&mut mempool, &input2);
 
     // Drain block 1. Expected_block_number = 2.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, std::slice::from_ref(&input1.tx));
 
     // Rewind tx of block 1. Expected_block_number is still 2.
     commit_block(&mut mempool, [], []);
 
     // Realign to block 1.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input1.tx]);
 
     // Now expected_block_number has advanced to 2 again; block-2 tx is next.
-    assert_eq!(mempool.resolve_batch_timestamp(), 2000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 2000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx]);
 }
 
@@ -478,7 +504,7 @@ fn test_rewind_realigns_state_so_get_txs_succeeds_without_resolve(mut mempool: M
 
     // Round 0 of block 1: resolve the timestamp and drain block 1's tx; expected_block_number
     // advances to 2.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![block_1_tx.tx.clone()]);
 
     // Round 0 aborts before commit; round 1 starts with the round-start commit_block only.
@@ -505,7 +531,7 @@ fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     // Fetch tx1 and tx2; leave tx3 in queue.
     get_txs_and_assert_expected(&mut mempool, 2, &[input1.tx, input2.tx.clone()]);
 
@@ -516,16 +542,18 @@ fn test_rewind_preserves_timestamp_order(mut mempool: Mempool) {
     add_tx(&mut mempool, &input4);
 
     // Rewound tx2 is at the front → timestamp must still be 1000, not 1001.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input2.tx, input3.tx]);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 1, &[input4.tx]);
 }
 
 #[rstest]
-fn test_resolve_batch_timestamp_returns_zero_when_never_had_transactions(mut mempool: Mempool) {
-    assert_eq!(mempool.resolve_batch_timestamp(), 0);
+fn test_resolve_block_metadata_returns_zero_timestamp_when_never_had_transactions(
+    mut mempool: Mempool,
+) {
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 0);
 }
 
 #[rstest]
@@ -543,7 +571,7 @@ fn test_rewind_many_transactions_from_same_address(mut mempool: Mempool) {
         add_tx(&mut mempool, input);
     }
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(
         &mut mempool,
         10,
@@ -553,12 +581,12 @@ fn test_rewind_many_transactions_from_same_address(mut mempool: Mempool) {
     // Commit only nonces 0 and 1; nonces 2, 3, 4 are rewound.
     commit_block(&mut mempool, [("0x1", 2)], []);
 
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[input3.tx, input4.tx, input5.tx]);
 
     commit_block(&mut mempool, [("0x1", 5)], []);
     // Queue should now be empty
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[]);
 }
 
@@ -590,7 +618,7 @@ fn test_expired_popped_txs_are_not_rewound() {
     fake_clock.advance(Duration::from_secs(65));
 
     // Both txs are popped then pruned as expired, so no tx should be returned.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     assert_eq!(mempool.get_txs(10).unwrap(), vec![]);
 
     // Commit should not rewind expired popped txs back into queue.
@@ -614,14 +642,14 @@ fn test_rejected_tx_removes_same_address_from_fifo_queue(mut mempool: Mempool) {
     }
 
     // Stage only the first tx (timestamp 1000).
-    assert_eq!(mempool.resolve_batch_timestamp(), 1000);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1000);
     get_txs_and_assert_expected(&mut mempool, 10, &[rejected_tx.tx]);
 
     // Reject tx. In FIFO, this removes same-address queued txs.
     commit_block(&mut mempool, [], [tx_hash!(1)]);
 
     // Next timestamp batch should include only the other address tx.
-    assert_eq!(mempool.resolve_batch_timestamp(), 1001);
+    assert_eq!(mempool.resolve_block_metadata().timestamp, 1001);
     get_txs_and_assert_expected(&mut mempool, 10, &[other_address_tx.tx]);
 }
 

--- a/crates/apollo_mempool/src/fifo_transaction_queue.rs
+++ b/crates/apollo_mempool/src/fifo_transaction_queue.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use apollo_mempool_types::mempool_types::{TransactionQueueSnapshot, TxBlockMetadata};
@@ -8,7 +9,7 @@ use starknet_api::transaction::TransactionHash;
 use tracing::debug;
 
 use crate::mempool::TransactionReference;
-use crate::transaction_queue_trait::{RewindData, TransactionQueueTrait};
+use crate::transaction_queue_trait::{BlockMetadata, RewindData, TransactionQueueTrait};
 
 /// A FIFO (First-In-First-Out) transaction queue that orders transactions by arrival time.
 /// Used in Echonet mode to preserve the original transaction order from the source chain.
@@ -47,7 +48,7 @@ impl CurrentProposalState {
             .next()
             .expect("Block number overflow while advancing expected block after pop.");
         // Consecutive blocks can share a timestamp, so gate further pops until the next
-        // resolve_timestamp call re-syncs the state to the queue head.
+        // resolve_metadata call re-syncs the state to the queue head.
         self.emit_empty_block = true;
     }
 }
@@ -75,9 +76,7 @@ pub struct FifoTransactionQueue {
     // Temporary map from transaction hash to metadata before the transaction is inserted to
     // queue.
     pending_metadata: HashMap<TransactionHash, TxBlockMetadata>,
-    // Tracks current proposal metadata in FIFO mode:
-    // - timestamp returned by resolve_timestamp()
-    // - expected block number for get_txs()
+    // Proposal state set by resolve_metadata(); gates which txs pop_ready_chunk() may return.
     current_proposal_state: Option<CurrentProposalState>,
 }
 
@@ -159,8 +158,9 @@ impl FifoTransactionQueue {
             .collect()
     }
 
-    /// Returns that head transaction's timestamp.
-    fn sync_proposal_state_from_queue_front_tx(&mut self) -> UnixTimestamp {
+    /// Syncs `current_proposal_state` from the queue's head transaction and returns the
+    /// metadata (timestamp and block number) of the block about to be built.
+    fn sync_proposal_state_from_queue_front_tx(&mut self) -> BlockMetadata {
         let &front_tx = self
             .queue
             .front()
@@ -172,25 +172,31 @@ impl FifoTransactionQueue {
                 expected_block_number: front_tx.block_number,
                 emit_empty_block: false,
             });
-            return front_tx.timestamp;
+            return BlockMetadata {
+                timestamp: front_tx.timestamp,
+                block_number: Some(front_tx.block_number),
+            };
         };
 
-        let (expected_block_number, emit_empty_block) =
-            if front_tx.block_number < prev_state.expected_block_number {
+        // The built and expected block numbers differ only in the empty-block case, where the
+        // state must already point past the gap so subsequent calls don't re-detect it.
+        let (built_block_number, expected_block_number, emit_empty_block) =
+            match front_tx.block_number.cmp(&prev_state.expected_block_number) {
                 // Rewind placed earlier-block txs at the head; realign to that block.
-                (front_tx.block_number, false)
-            } else if front_tx.block_number > prev_state.expected_block_number {
-                // Head skips blocks, emit an empty block and advance by one.
-                (
+                Ordering::Less => (front_tx.block_number, front_tx.block_number, false),
+                // Head matches the expected block; process normally.
+                Ordering::Equal => {
+                    (prev_state.expected_block_number, prev_state.expected_block_number, false)
+                }
+                // Head skips blocks: build an empty block and advance the state by one.
+                Ordering::Greater => (
+                    prev_state.expected_block_number,
                     prev_state
                         .expected_block_number
                         .next()
                         .expect("Block number overflow while advancing expected block."),
                     true,
-                )
-            } else {
-                // Head matches the expected block; process normally.
-                (prev_state.expected_block_number, false)
+                ),
             };
 
         self.current_proposal_state = Some(CurrentProposalState {
@@ -198,7 +204,7 @@ impl FifoTransactionQueue {
             expected_block_number,
             emit_empty_block,
         });
-        front_tx.timestamp
+        BlockMetadata { timestamp: front_tx.timestamp, block_number: Some(built_block_number) }
     }
 }
 
@@ -228,7 +234,7 @@ impl TransactionQueueTrait for FifoTransactionQueue {
 
         let Some(current_state) = self.current_proposal_state.as_mut() else {
             panic!(
-                "FIFO pop_ready_chunk: missing proposal state; resolve_timestamp must run before \
+                "FIFO pop_ready_chunk: missing proposal state; resolve_metadata must run before \
                  get_txs for this queue"
             );
         };
@@ -373,23 +379,26 @@ impl TransactionQueueTrait for FifoTransactionQueue {
         0
     }
 
-    fn resolve_timestamp(&mut self) -> UnixTimestamp {
+    fn resolve_metadata(&mut self) -> BlockMetadata {
         if self.queue.front().is_some() {
             return self.sync_proposal_state_from_queue_front_tx();
         }
-        // Queue is empty: reuse previous timestamp if it exists, otherwise return 0.
+        // Queue is empty: reuse the previous timestamp and block number if they exist.
         match self.current_proposal_state {
             Some(state) => {
                 debug!(
-                    "FIFO resolve_timestamp: queue empty, reusing last_timestamp={:?}, \
+                    "FIFO resolve_metadata: queue empty, reusing last_timestamp={:?}, \
                      expected_block={:?}",
                     state.timestamp, state.expected_block_number
                 );
-                state.timestamp
+                BlockMetadata {
+                    timestamp: state.timestamp,
+                    block_number: Some(state.expected_block_number),
+                }
             }
             None => {
-                debug!("FIFO resolve_timestamp: queue empty, no previous proposal state");
-                0
+                debug!("FIFO resolve_metadata: queue empty, no previous proposal state");
+                BlockMetadata { timestamp: 0, block_number: None }
             }
         }
     }

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -17,7 +17,7 @@ use apollo_mempool_types::mempool_types::{
 use apollo_time::time::{Clock, DateTime};
 use indexmap::IndexSet;
 use rand::{rng, RngExt};
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::GasPrice;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
@@ -47,7 +47,7 @@ use crate::metrics::{
     MEMPOOL_TRANSACTIONS_RECEIVED,
 };
 use crate::transaction_pool::TransactionPool;
-use crate::transaction_queue_trait::{RewindData, TransactionQueueTrait};
+use crate::transaction_queue_trait::{BlockMetadata, RewindData, TransactionQueueTrait};
 use crate::utils::try_increment_nonce;
 
 #[cfg(test)]
@@ -288,14 +288,14 @@ impl Mempool {
         matches!(self.config.static_config.behavior_mode, BehaviorMode::Echonet)
     }
 
-    pub fn resolve_batch_timestamp(&mut self) -> UnixTimestamp {
+    pub(crate) fn resolve_block_metadata(&mut self) -> BlockMetadata {
         if !self.is_fifo() {
             let timestamp = self.clock.unix_now();
-            debug!("Mempool resolve_batch_timestamp (Fee): timestamp={}", timestamp);
-            return timestamp;
+            debug!("Mempool resolve_block_metadata (Fee): timestamp={}", timestamp);
+            return BlockMetadata { timestamp, block_number: None };
         }
 
-        self.tx_queue.resolve_timestamp()
+        self.tx_queue.resolve_metadata()
     }
 
     pub(crate) fn update_tx_block_metadata(

--- a/crates/apollo_mempool/src/test_utils.rs
+++ b/crates/apollo_mempool/src/test_utils.rs
@@ -310,9 +310,9 @@ pub fn get_txs_and_assert_expected(
     n_txs: usize,
     expected_txs: &[InternalRpcTransaction],
 ) {
-    // In FIFO mode, we need to resolve batch timestamp first to set the timestamp threshold.
+    // In FIFO mode, resolve_block_metadata must run before get_txs to set the proposal state
     if mempool.is_fifo() {
-        let _ = mempool.resolve_batch_timestamp();
+        let _ = mempool.resolve_block_metadata().timestamp;
     }
     let txs = mempool.get_txs(n_txs).unwrap();
     assert_eq!(txs, expected_txs);

--- a/crates/apollo_mempool/src/transaction_queue_trait.rs
+++ b/crates/apollo_mempool/src/transaction_queue_trait.rs
@@ -2,11 +2,18 @@ use std::collections::HashMap;
 
 use apollo_mempool_types::mempool_types::{TransactionQueueSnapshot, TxBlockMetadata};
 use indexmap::IndexSet;
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::{BlockNumber, GasPrice, UnixTimestamp};
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::transaction::TransactionHash;
 
 use crate::mempool::TransactionReference;
+
+// Metadata of the block the next get_txs call will draw from.
+// `block_number` is `None` for queues that don't track block numbers (fee-priority mode).
+pub(crate) struct BlockMetadata {
+    pub timestamp: UnixTimestamp,
+    pub block_number: Option<BlockNumber>,
+}
 
 // Data needed for rewinding transactions back into the queue after a block commit.
 // Different queue types require different data.
@@ -67,10 +74,10 @@ pub trait TransactionQueueTrait: Send + Sync {
     // Default implementation is a no-op (for queues that don't support metadata updates).
     fn update_tx_block_metadata(&mut self, _tx_hash: TransactionHash, _metadata: TxBlockMetadata) {}
 
-    // Returns the sequencing timestamp and may update queue-internal state.
-    // Default implementation returns 0 for queues that don't use timestamp gating.
-    fn resolve_timestamp(&mut self) -> UnixTimestamp {
-        0
+    // Returns the metadata of the block about to be built and may update queue-internal state.
+    // Default implementation is for queues that don't use timestamp gating.
+    fn resolve_metadata(&mut self) -> BlockMetadata {
+        BlockMetadata { timestamp: 0, block_number: None }
     }
 
     // Default implementation returns empty vec.

--- a/crates/apollo_mempool/src/transaction_queue_trait.rs
+++ b/crates/apollo_mempool/src/transaction_queue_trait.rs
@@ -2,11 +2,20 @@ use std::collections::HashMap;
 
 use apollo_mempool_types::mempool_types::{TransactionQueueSnapshot, TxBlockMetadata};
 use indexmap::IndexSet;
-use starknet_api::block::{GasPrice, UnixTimestamp};
+use starknet_api::block::{BlockNumber, GasPrice, UnixTimestamp};
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::transaction::TransactionHash;
 
 use crate::mempool::TransactionReference;
+
+// Metadata of the block the next get_txs call will draw from.
+// `block_number` is `None` for queues that don't track block numbers (fee-priority mode).
+pub(crate) struct BlockMetadata {
+    pub timestamp: UnixTimestamp,
+    // Read by the replay-block-metadata flow added later in the stack; unused on its own here.
+    #[allow(dead_code)]
+    pub block_number: Option<BlockNumber>,
+}
 
 // Data needed for rewinding transactions back into the queue after a block commit.
 // Different queue types require different data.
@@ -67,10 +76,10 @@ pub trait TransactionQueueTrait: Send + Sync {
     // Default implementation is a no-op (for queues that don't support metadata updates).
     fn update_tx_block_metadata(&mut self, _tx_hash: TransactionHash, _metadata: TxBlockMetadata) {}
 
-    // Returns the sequencing timestamp and may update queue-internal state.
-    // Default implementation returns 0 for queues that don't use timestamp gating.
-    fn resolve_timestamp(&mut self) -> UnixTimestamp {
-        0
+    // Returns the metadata of the block about to be built and may update queue-internal state.
+    // Default implementation is for queues that don't use timestamp gating.
+    fn resolve_metadata(&mut self) -> BlockMetadata {
+        BlockMetadata { timestamp: 0, block_number: None }
     }
 
     // Default implementation returns empty vec.


### PR DESCRIPTION
Extends the FIFO queue's proposal state to report which block is being built alongside the timestamp: `resolve_timestamp` becomes `resolve_metadata`, returning a `BlockMetadata { timestamp, block_number }` (block number is `None` in fee-priority mode, which doesn't track blocks).

The subtle case is a gap in the replayed chain: when the queue head skips ahead, the state advances past the gap so subsequent calls don't re-detect it, but the block being built *right now* is the empty one — `sync_proposal_state_from_queue_front_tx` is restructured as a single `match` on the head/expected ordering that yields both numbers explicitly, and a new test pins the empty-block numbering.

Internal to apollo_mempool; the client-facing API still returns only the timestamp at this point in the stack. Fee-mode behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)