### PR TITLE
apollo_consensus_orchestrator: build proposals from replayed block metadata in echonet mode

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -28,7 +28,7 @@ use apollo_protobuf::consensus::{
 };
 use apollo_time::time::{Clock, DateTime};
 use apollo_transaction_converter::TransactionConverterError;
-use starknet_api::block::GasPrice;
+use starknet_api::block::{GasPrice, ReplayBlockMetadata};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
@@ -49,6 +49,8 @@ use crate::utils::{
     truncate_to_executed_txs,
     wait_for_retrospective_block_hash,
     GasPriceParams,
+    L1PricesInFri,
+    L1PricesInWei,
     PreviousProposalInitInfo,
     RetrospectiveBlockHashError,
     StreamSender,
@@ -73,8 +75,9 @@ pub(crate) struct ProposalBuildArguments {
     pub proposal_round: Round,
     pub retrospective_block_hash_deadline: DateTime,
     pub retrospective_block_hash_retry_interval_millis: Duration,
-    // If true, for echonet mode, use the timestamp from the original block.
-    pub override_timestamp: bool,
+    // If true (Echonet mode), build the proposal from the replayed block's metadata (timestamp
+    // and gas prices) instead of the clock and the gas price provider.
+    pub override_block_metadata: bool,
     pub override_l2_gas_price_fri: Option<u128>,
     pub min_l2_gas_price_per_height: Vec<PricePerHeight>,
     pub compare_retrospective_block_hash: bool,
@@ -136,36 +139,59 @@ pub(crate) async fn build_proposal(
     Ok(proposal_commitment)
 }
 
-async fn get_proposal_timestamp(
-    override_timestamp: bool,
+async fn get_proposal_metadata(
+    override_block_metadata: bool,
     batcher: &dyn BatcherClient,
     clock: &dyn Clock,
-) -> u64 {
-    if override_timestamp {
+) -> ReplayBlockMetadata {
+    if override_block_metadata {
         match batcher.get_block_metadata().await {
-            Ok(block_metadata) => return block_metadata.timestamp,
+            Ok(block_metadata) => return block_metadata,
             Err(err) => {
-                warn!("Failed to get timestamp from batcher, falling back to clock time: {err:?}");
+                warn!(
+                    "Failed to get block metadata from batcher, falling back to the clock \
+                     timestamp and zero gas prices: {err:?}"
+                );
             }
         }
     }
-    clock.unix_now()
+    ReplayBlockMetadata { timestamp: clock.unix_now(), ..Default::default() }
 }
 
 async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResult<ProposalInit> {
-    let timestamp = get_proposal_timestamp(
-        args.override_timestamp,
+    let proposal_metadata = get_proposal_metadata(
+        args.override_block_metadata,
         args.deps.batcher.as_ref(),
         args.deps.clock.as_ref(),
     )
     .await;
-    let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
-        args.deps.l1_gas_price_provider.clone(),
-        timestamp,
-        args.previous_proposal_init.as_ref(),
-        &args.gas_price_params,
-    )
-    .await;
+    let timestamp = proposal_metadata.timestamp;
+    let (l1_prices_fri, l1_prices_wei, l2_gas_price_fri) = if args.override_block_metadata {
+        info!(
+            "Building proposal for height {} from replayed block metadata: {proposal_metadata:?}",
+            args.build_param.height,
+        );
+        (
+            L1PricesInFri {
+                l1_gas_price: proposal_metadata.l1_gas_price_fri,
+                l1_data_gas_price: proposal_metadata.l1_data_gas_price_fri,
+            },
+            L1PricesInWei {
+                l1_gas_price: proposal_metadata.l1_gas_price_wei,
+                l1_data_gas_price: proposal_metadata.l1_data_gas_price_wei,
+            },
+            proposal_metadata.l2_gas_price_fri,
+        )
+    } else {
+        let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
+            args.deps.l1_gas_price_provider.clone(),
+            timestamp,
+            args.previous_proposal_init.as_ref(),
+            &args.gas_price_params,
+        )
+        .await;
+        (l1_prices_fri, l1_prices_wei, args.l2_gas_price)
+    };
     let init = ProposalInit {
         height: args.build_param.height,
         round: args.build_param.round,
@@ -174,7 +200,7 @@ async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResul
         builder: args.builder_address,
         timestamp,
         l1_da_mode: args.l1_da_mode,
-        l2_gas_price_fri: args.l2_gas_price,
+        l2_gas_price_fri,
         l1_gas_price_wei: l1_prices_wei.l1_gas_price,
         l1_data_gas_price_wei: l1_prices_wei.l1_data_gas_price,
         l1_gas_price_fri: l1_prices_fri.l1_gas_price,

--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -28,7 +28,7 @@ use apollo_protobuf::consensus::{
 };
 use apollo_time::time::{Clock, DateTime};
 use apollo_transaction_converter::TransactionConverterError;
-use starknet_api::block::GasPrice;
+use starknet_api::block::{GasPrice, ReplayBlockMetadata};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
@@ -49,6 +49,8 @@ use crate::utils::{
     truncate_to_executed_txs,
     wait_for_retrospective_block_hash,
     GasPriceParams,
+    L1PricesInFri,
+    L1PricesInWei,
     PreviousProposalInitInfo,
     RetrospectiveBlockHashError,
     StreamSender,
@@ -73,8 +75,9 @@ pub(crate) struct ProposalBuildArguments {
     pub proposal_round: Round,
     pub retrospective_block_hash_deadline: DateTime,
     pub retrospective_block_hash_retry_interval_millis: Duration,
-    // If true, for echonet mode, use the timestamp from the original block.
-    pub override_timestamp: bool,
+    // If true (Echonet mode), build the proposal from the replayed block's metadata (timestamp
+    // and gas prices) instead of the clock and the gas price provider.
+    pub override_block_metadata: bool,
     pub override_l2_gas_price_fri: Option<u128>,
     pub min_l2_gas_price_per_height: Vec<PricePerHeight>,
     pub compare_retrospective_block_hash: bool,
@@ -136,36 +139,59 @@ pub(crate) async fn build_proposal(
     Ok(proposal_commitment)
 }
 
-async fn get_proposal_timestamp(
-    override_timestamp: bool,
+async fn get_proposal_metadata(
+    override_block_metadata: bool,
     batcher: &dyn BatcherClient,
     clock: &dyn Clock,
-) -> u64 {
-    if override_timestamp {
+) -> ReplayBlockMetadata {
+    if override_block_metadata {
         match batcher.start_round().await {
-            Ok(block_metadata) => return block_metadata.timestamp,
+            Ok(block_metadata) => return block_metadata,
             Err(err) => {
-                warn!("Failed to get timestamp from batcher, falling back to clock time: {err:?}");
+                warn!(
+                    "Failed to get block metadata from batcher, falling back to the clock \
+                     timestamp and zero gas prices: {err:?}"
+                );
             }
         }
     }
-    clock.unix_now()
+    ReplayBlockMetadata { timestamp: clock.unix_now(), ..Default::default() }
 }
 
 async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResult<ProposalInit> {
-    let timestamp = get_proposal_timestamp(
-        args.override_timestamp,
+    let proposal_metadata = get_proposal_metadata(
+        args.override_block_metadata,
         args.deps.batcher.as_ref(),
         args.deps.clock.as_ref(),
     )
     .await;
-    let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
-        args.deps.l1_gas_price_provider.clone(),
-        timestamp,
-        args.previous_proposal_init.as_ref(),
-        &args.gas_price_params,
-    )
-    .await;
+    let timestamp = proposal_metadata.timestamp;
+    let (l1_prices_fri, l1_prices_wei, l2_gas_price_fri) = if args.override_block_metadata {
+        info!(
+            "Building proposal for height {} from replayed block metadata: {proposal_metadata:?}",
+            args.build_param.height,
+        );
+        (
+            L1PricesInFri {
+                l1_gas_price: proposal_metadata.l1_gas_price_fri,
+                l1_data_gas_price: proposal_metadata.l1_data_gas_price_fri,
+            },
+            L1PricesInWei {
+                l1_gas_price: proposal_metadata.l1_gas_price_wei,
+                l1_data_gas_price: proposal_metadata.l1_data_gas_price_wei,
+            },
+            proposal_metadata.l2_gas_price_fri,
+        )
+    } else {
+        let (l1_prices_fri, l1_prices_wei) = get_l1_prices_in_fri_and_wei(
+            args.deps.l1_gas_price_provider.clone(),
+            timestamp,
+            args.previous_proposal_init.as_ref(),
+            &args.gas_price_params,
+        )
+        .await;
+        (l1_prices_fri, l1_prices_wei, args.l2_gas_price)
+    };
     let init = ProposalInit {
         height: args.build_param.height,
         round: args.build_param.round,
@@ -174,7 +200,7 @@ async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResul
         builder: args.builder_address,
         timestamp,
         l1_da_mode: args.l1_da_mode,
-        l2_gas_price_fri: args.l2_gas_price,
+        l2_gas_price_fri,
         l1_gas_price_wei: l1_prices_wei.l1_gas_price,
         l1_data_gas_price_wei: l1_prices_wei.l1_data_gas_price,
         l1_gas_price_fri: l1_prices_fri.l1_gas_price,

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -775,7 +775,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 self.config.static_config.build_proposal_time_ratio_for_retrospective_block_hash,
             );
 
-        let override_timestamp = match self.config.static_config.behavior_mode {
+        let override_block_metadata = match self.config.static_config.behavior_mode {
             BehaviorMode::Echonet => true,
             BehaviorMode::Starknet => false,
         };
@@ -813,7 +813,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 .config
                 .static_config
                 .retrospective_block_hash_retry_interval_millis,
-            override_timestamp,
+            override_block_metadata,
             override_l2_gas_price_fri: self.config.dynamic_config.override_l2_gas_price_fri,
             min_l2_gas_price_per_height: self
                 .config

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -493,7 +493,7 @@ pub(crate) struct TestProposalBuildArguments {
     pub proposal_round: Round,
     pub retrospective_block_hash_deadline: DateTime,
     pub retrospective_block_hash_retry_interval_millis: Duration,
-    pub override_timestamp: bool,
+    pub override_block_metadata: bool,
     pub override_l2_gas_price_fri: Option<u128>,
     pub min_l2_gas_price_per_height: Vec<PricePerHeight>,
     pub compare_retrospective_block_hash: bool,
@@ -519,7 +519,7 @@ impl From<TestProposalBuildArguments> for ProposalBuildArguments {
             retrospective_block_hash_deadline: args.retrospective_block_hash_deadline,
             retrospective_block_hash_retry_interval_millis: args
                 .retrospective_block_hash_retry_interval_millis,
-            override_timestamp: args.override_timestamp,
+            override_block_metadata: args.override_block_metadata,
             override_l2_gas_price_fri: args.override_l2_gas_price_fri,
             min_l2_gas_price_per_height: args.min_l2_gas_price_per_height,
             compare_retrospective_block_hash: args.compare_retrospective_block_hash,
@@ -552,7 +552,7 @@ pub(crate) fn create_proposal_build_arguments()
     let cancel_token = CancellationToken::new();
     let previous_proposal_init = None;
     let proposal_round = 0;
-    let override_timestamp = false;
+    let override_block_metadata = false;
 
     (
         TestProposalBuildArguments {
@@ -572,7 +572,7 @@ pub(crate) fn create_proposal_build_arguments()
             proposal_round,
             retrospective_block_hash_deadline,
             retrospective_block_hash_retry_interval_millis,
-            override_timestamp,
+            override_block_metadata,
             override_l2_gas_price_fri: None,
             min_l2_gas_price_per_height: vec![],
             compare_retrospective_block_hash: true,


### PR DESCRIPTION
Consumes the replay metadata introduced downstack: in Echonet mode (`override_timestamp` → renamed `override_block_metadata`), `build_proposal` now takes the proposal's L1/L2 gas prices from the replayed block's metadata instead of the gas price provider and fee market, alongside the already-overridden timestamp. This removes echonet's dependency on the oracle/provider path for price parity with mainnet.

In Starknet mode the branch is untouched: clock timestamp, `get_l1_prices_in_fri_and_wei`, and the fee-market `l2_gas_price`, exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)