### PR TITLE
starknet_api,blockifier: allow overriding the effective latest Starknet version at runtime

### DIFF
--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -495,6 +495,8 @@ impl VersionedConstants {
     // TODO(Arni): Consider replacing each call to this function with `latest_with_overrides`, and
     // squashing the functions together.
     /// Returns the latest versioned constants, applying the given overrides.
+    /// In Echonet mode, "latest" is the version set via
+    /// `starknet_api::versioned_constants_logic::set_effective_latest_version`.
     pub fn get_versioned_constants(
         versioned_constants_overrides: Option<VersionedConstantsOverrides>,
     ) -> Self {

--- a/crates/starknet_api/src/versioned_constants_logic.rs
+++ b/crates/starknet_api/src/versioned_constants_logic.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 #[cfg(any(test, feature = "testing"))]
 use std::path::Path;
+use std::sync::OnceLock;
 
 #[cfg(any(test, feature = "testing"))]
 use expect_test::expect_file;
@@ -19,6 +20,33 @@ use strum::IntoEnumIterator;
 
 use crate::block::StarknetVersion;
 
+/// Process-wide override of the "latest" Starknet version; set once at startup in Echonet mode
+/// so versioned-constants lookups use the replayed network's version.
+static EFFECTIVE_LATEST_VERSION: OnceLock<StarknetVersion> = OnceLock::new();
+
+/// Sets the effective latest Starknet version for this process. Meant to be called once at
+/// startup: re-setting to the same version is a no-op, but changing it to a different version
+/// panics, since the effective version must stay stable process-wide.
+pub fn set_effective_latest_version(version: StarknetVersion) {
+    if let Err(rejected_version) = EFFECTIVE_LATEST_VERSION.set(version) {
+        let existing_version = EFFECTIVE_LATEST_VERSION
+            .get()
+            .copied()
+            .expect("EFFECTIVE_LATEST_VERSION is set, since OnceLock::set returned Err");
+        assert_eq!(
+            existing_version, rejected_version,
+            "effective latest Starknet version is already set to {existing_version} and cannot be \
+             changed to {rejected_version}"
+        );
+    }
+}
+
+/// Returns the version set via [`set_effective_latest_version`], or
+/// [`StarknetVersion::LATEST`] if it was never set.
+pub fn effective_starknet_version() -> StarknetVersion {
+    EFFECTIVE_LATEST_VERSION.get().copied().unwrap_or(StarknetVersion::LATEST)
+}
+
 pub trait VersionedConstantsTrait: Debug {
     type Error: Debug;
 
@@ -31,9 +59,14 @@ pub trait VersionedConstantsTrait: Debug {
     /// Gets the contents of the JSON file for the specified Starknet version.
     fn json_str(version: &StarknetVersion) -> Result<&'static str, Self::Error>;
 
-    /// Gets the constants that shipped with the current version of the Starknet.
+    /// Gets the constants that shipped with the current version of the Starknet, honoring
+    /// [`set_effective_latest_version`] and falling back to [`StarknetVersion::LATEST`].
     /// To use custom constants, initialize the struct from a file using `from_path`.
-    fn latest_constants() -> &'static Self;
+    fn latest_constants() -> &'static Self {
+        Self::get(&effective_starknet_version()).unwrap_or_else(|_| {
+            Self::get(&StarknetVersion::LATEST).expect("Latest version should support VC.")
+        })
+    }
 
     /// Gets the constants for the specified Starknet version.
     fn get(version: &StarknetVersion) -> Result<&'static Self, Self::Error>;
@@ -184,11 +217,6 @@ macro_rules! define_versioned_constants_inner {
                     },)*
                     _ => Err(Self::Error::InvalidStarknetVersion(*version)),
                 }
-            }
-
-            fn latest_constants() -> &'static Self {
-                Self::get(&starknet_api::block::StarknetVersion::LATEST)
-                    .expect("Latest version should support VC.")
             }
 
             fn get(

--- a/crates/starknet_api/src/versioned_constants_logic.rs
+++ b/crates/starknet_api/src/versioned_constants_logic.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 #[cfg(any(test, feature = "testing"))]
 use std::path::Path;
+use std::sync::OnceLock;
 
 #[cfg(any(test, feature = "testing"))]
 use expect_test::expect_file;
@@ -19,6 +20,22 @@ use strum::IntoEnumIterator;
 
 use crate::block::StarknetVersion;
 
+/// Process-wide override of the "latest" Starknet version; set once at startup in Echonet mode
+/// so versioned-constants lookups use the replayed network's version.
+static EFFECTIVE_LATEST_VERSION: OnceLock<StarknetVersion> = OnceLock::new();
+
+/// Sets the effective latest Starknet version for this process. Write-once: calls after the
+/// first are ignored.
+pub fn set_effective_latest_version(version: StarknetVersion) {
+    EFFECTIVE_LATEST_VERSION.set(version).ok();
+}
+
+/// Returns the version set via [`set_effective_latest_version`], or
+/// [`StarknetVersion::LATEST`] if it was never set.
+pub fn effective_starknet_version() -> StarknetVersion {
+    EFFECTIVE_LATEST_VERSION.get().copied().unwrap_or(StarknetVersion::LATEST)
+}
+
 pub trait VersionedConstantsTrait: Debug {
     type Error: Debug;
 
@@ -31,9 +48,14 @@ pub trait VersionedConstantsTrait: Debug {
     /// Gets the contents of the JSON file for the specified Starknet version.
     fn json_str(version: &StarknetVersion) -> Result<&'static str, Self::Error>;
 
-    /// Gets the constants that shipped with the current version of the Starknet.
+    /// Gets the constants that shipped with the current version of the Starknet, honoring
+    /// [`set_effective_latest_version`] and falling back to [`StarknetVersion::LATEST`].
     /// To use custom constants, initialize the struct from a file using `from_path`.
-    fn latest_constants() -> &'static Self;
+    fn latest_constants() -> &'static Self {
+        Self::get(&effective_starknet_version()).unwrap_or_else(|_| {
+            Self::get(&StarknetVersion::LATEST).expect("Latest version should support VC.")
+        })
+    }
 
     /// Gets the constants for the specified Starknet version.
     fn get(version: &StarknetVersion) -> Result<&'static Self, Self::Error>;
@@ -184,11 +206,6 @@ macro_rules! define_versioned_constants_inner {
                     },)*
                     _ => Err(Self::Error::InvalidStarknetVersion(*version)),
                 }
-            }
-
-            fn latest_constants() -> &'static Self {
-                Self::get(&starknet_api::block::StarknetVersion::LATEST)
-                    .expect("Latest version should support VC.")
             }
 
             fn get(


### PR DESCRIPTION
Mechanism-only PR: a process-wide, write-once override of the "latest" Starknet version (`set_effective_latest_version` / `effective_starknet_version` in `versioned_constants_logic`). `latest_constants()` moves from the macro into a trait default that resolves the effective version, falling back to the compile-time `LATEST` when the effective version predates a given constants type.

Nothing sets the override in this PR (the gateway does, one PR upstack, in Echonet mode only). When unset, `effective_starknet_version()` returns `StarknetVersion::LATEST` and every lookup resolves exactly as before — the only added cost is one atomic `OnceLock` read per `latest_constants()` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)