### PR TITLE
apollo_gateway,apollo_gateway_config: fetch the replayed Starknet version from the recorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "pretty_assertions",
+ "reqwest 0.12.24",
  "rstest",
  "serde_json",
  "starknet-types-core",
@@ -1591,6 +1592,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
+ "url",
  "validator",
 ]
 

--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -42,6 +42,7 @@ google-cloud-storage.workspace = true
 mempool_test_utils.workspace = true
 mockall.workspace = true
 num-rational.workspace = true
+reqwest.workspace = true
 serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::SharedClassManagerClient;
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::config::GatewayConfig;
 use apollo_gateway_types::deprecated_gateway_error::{
     KnownStarknetErrorCode,
@@ -29,6 +30,7 @@ use apollo_transaction_converter::{
 };
 use async_trait::async_trait;
 use blockifier::state::contract_class_manager::ContractClassManager;
+use starknet_api::block::StarknetVersion;
 use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
@@ -39,6 +41,7 @@ use starknet_api::rpc_transaction::{
 };
 use starknet_api::transaction::fields::{Proof, ProofFacts, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
+use starknet_api::versioned_constants_logic::set_effective_latest_version;
 use starknet_types_core::felt::Felt;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -186,6 +189,25 @@ impl<
     pub async fn start(&self) {
         register_metrics();
         self.proof_archive_writer.connect().await;
+        self.set_effective_starknet_version_from_echonet().await;
+    }
+
+    /// In Echonet mode, overrides the effective latest Starknet version with the replayed
+    /// network's version so versioned-constants lookups match it. A no-op in other modes.
+    async fn set_effective_starknet_version_from_echonet(&self) {
+        if self.config.static_config.behavior_mode != BehaviorMode::Echonet {
+            return;
+        }
+        match fetch_starknet_version(&self.config.static_config.recorder_url).await {
+            Ok(starknet_version) => {
+                info!("Setting effective Starknet version from echonet: {starknet_version}");
+                set_effective_latest_version(starknet_version);
+            }
+            Err(fetch_error) => warn!(
+                "Failed to fetch the Starknet version from echonet; keeping the compile-time \
+                 latest: {fetch_error}"
+            ),
+        }
     }
 
     #[sequencer_latency_histogram(GATEWAY_ADD_TX_LATENCY, true)]
@@ -487,6 +509,30 @@ impl<
 
         Ok(Some((handle.proof_facts, handle.proof)))
     }
+}
+
+// Fetches the replayed network's Starknet version from the recorder.
+async fn fetch_starknet_version(recorder_url: &reqwest::Url) -> Result<StarknetVersion, String> {
+    const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+    let url = recorder_url
+        .join("echonet/get_starknet_version")
+        .map_err(|join_error| format!("invalid recorder URL: {join_error}"))?;
+    let response = reqwest::Client::new()
+        .get(url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|request_error| format!("request failed: {request_error}"))?;
+    if !response.status().is_success() {
+        return Err(format!("HTTP {}", response.status()));
+    }
+    let version_string = response
+        .text()
+        .await
+        .map_err(|read_error| format!("failed to read response: {read_error}"))?;
+    StarknetVersion::try_from(version_string.trim()).map_err(|parse_error| {
+        format!("failed to parse Starknet version '{}': {parse_error}", version_string.trim())
+    })
 }
 
 pub fn create_gateway(

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::SharedClassManagerClient;
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::config::GatewayConfig;
 use apollo_gateway_types::deprecated_gateway_error::{
     KnownStarknetErrorCode,
@@ -29,6 +30,7 @@ use apollo_transaction_converter::{
 };
 use async_trait::async_trait;
 use blockifier::state::contract_class_manager::ContractClassManager;
+use starknet_api::block::StarknetVersion;
 use starknet_api::executable_transaction::AccountTransaction;
 use starknet_api::rpc_transaction::{
     InternalRpcTransaction,
@@ -39,6 +41,7 @@ use starknet_api::rpc_transaction::{
 };
 use starknet_api::transaction::fields::{Proof, ProofFacts, TransactionSignature};
 use starknet_api::transaction::TransactionHash;
+use starknet_api::versioned_constants_logic::set_effective_latest_version;
 use starknet_types_core::felt::Felt;
 use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
@@ -186,6 +189,19 @@ impl<
     pub async fn start(&self) {
         register_metrics();
         self.proof_archive_writer.connect().await;
+        if self.config.static_config.behavior_mode == BehaviorMode::Echonet {
+            // Versioned-constants lookups must use the replayed network's version.
+            match fetch_starknet_version(&self.config.static_config.recorder_url).await {
+                Ok(starknet_version) => {
+                    info!("Setting effective Starknet version from echonet: {starknet_version}");
+                    set_effective_latest_version(starknet_version);
+                }
+                Err(fetch_error) => warn!(
+                    "Failed to fetch the Starknet version from echonet; keeping the compile-time \
+                     latest: {fetch_error}"
+                ),
+            }
+        }
     }
 
     #[sequencer_latency_histogram(GATEWAY_ADD_TX_LATENCY, true)]
@@ -487,6 +503,30 @@ impl<
 
         Ok(Some((handle.proof_facts, handle.proof)))
     }
+}
+
+// Fetches the replayed network's Starknet version from the recorder.
+async fn fetch_starknet_version(recorder_url: &reqwest::Url) -> Result<StarknetVersion, String> {
+    const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+    let url = recorder_url
+        .join("echonet/get_starknet_version")
+        .map_err(|join_error| format!("invalid recorder URL: {join_error}"))?;
+    let response = reqwest::Client::new()
+        .get(url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|request_error| format!("request failed: {request_error}"))?;
+    if !response.status().is_success() {
+        return Err(format!("HTTP {}", response.status()));
+    }
+    let version_string = response
+        .text()
+        .await
+        .map_err(|read_error| format!("failed to read response: {read_error}"))?;
+    StarknetVersion::try_from(version_string.trim()).map_err(|parse_error| {
+        format!("failed to parse Starknet version '{}': {parse_error}", version_string.trim())
+    })
 }
 
 pub fn create_gateway(

--- a/crates/apollo_gateway/src/gateway_test.rs
+++ b/crates/apollo_gateway/src/gateway_test.rs
@@ -142,6 +142,7 @@ fn mock_dependencies() -> MockDependencies {
             authorized_declarer_accounts: None,
             max_concurrent_declare_compilations: 5,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
+            ..Default::default()
         },
         ..Default::default()
     };

--- a/crates/apollo_gateway_config/Cargo.toml
+++ b/crates/apollo_gateway_config/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true, features = ["derive"] }
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
+url.workspace = true
 validator.workspace = true
 
 [features]

--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::converters::{
     deserialize_comma_separated_str,
     serialize_optional_comma_separated,
@@ -18,6 +19,7 @@ use blockifier::context::ChainInfo;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_types_core::felt::Felt;
+use url::Url;
 use validator::Validate;
 
 use crate::compiler_version::VersionId;
@@ -55,6 +57,8 @@ pub struct GatewayStaticConfig {
     #[validate(range(min = 1))]
     pub max_concurrent_declare_compilations: usize,
     pub proof_archive_writer_config: ProofArchiveWriterConfig,
+    pub behavior_mode: BehaviorMode,
+    pub recorder_url: Url,
 }
 
 impl Default for GatewayStaticConfig {
@@ -71,6 +75,10 @@ impl Default for GatewayStaticConfig {
             authorized_declarer_accounts: None,
             max_concurrent_declare_compilations: DEFAULT_MAX_CONCURRENT_DECLARE_COMPILATIONS,
             proof_archive_writer_config: ProofArchiveWriterConfig::default(),
+            behavior_mode: BehaviorMode::default(),
+            recorder_url: "https://recorder_url"
+                .parse()
+                .expect("recorder_url must be a valid Recorder URL"),
         }
     }
 }
@@ -116,6 +124,21 @@ impl SerializeConfig for GatewayStaticConfig {
             self.proof_archive_writer_config.dump(),
             "proof_archive_writer_config",
         ));
+        dump.extend([
+            ser_param(
+                "behavior_mode",
+                &self.behavior_mode,
+                "Behavior mode: 'starknet' for production, 'echonet' for test/replay mode.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "recorder_url",
+                &self.recorder_url,
+                "The URL of the recorder service; used in Echonet mode to fetch the replayed \
+                 network's Starknet version at startup.",
+                ParamPrivacyInput::Public,
+            ),
+        ]);
         dump
     }
 }

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -851,6 +851,7 @@ pub fn create_gateway_config(
             authorized_declarer_accounts: None,
             max_concurrent_declare_compilations: 5,
             proof_archive_writer_config,
+            ..Default::default()
         },
         ..Default::default()
     }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3014,6 +3014,11 @@
     "privacy": "TemporaryValue",
     "value": true
   },
+  "gateway_config.static_config.behavior_mode": {
+    "description": "Behavior mode: 'starknet' for production, 'echonet' for test/replay mode.",
+    "pointer_target": "behavior_mode",
+    "privacy": "Public"
+  },
   "gateway_config.static_config.block_declare": {
     "description": "If true, the gateway will block declare transactions.",
     "privacy": "Public",
@@ -3098,6 +3103,11 @@
     "description": "The name of the bucket to write proofs to. An empty string indicates a test environment that does not connect to GCS.",
     "privacy": "Public",
     "value": "proof-archive"
+  },
+  "gateway_config.static_config.recorder_url": {
+    "description": "The URL of the recorder service; used in Echonet mode to fetch the replayed network's Starknet version at startup.",
+    "pointer_target": "recorder_url",
+    "privacy": "Public"
   },
   "gateway_config.static_config.stateful_tx_validator_config.max_allowed_nonce_gap": {
     "description": "The maximum allowed gap between the account nonce and the transaction nonce.",

--- a/crates/apollo_node_config/src/config_test.rs
+++ b/crates/apollo_node_config/src/config_test.rs
@@ -1,4 +1,6 @@
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_config::dumping::{combine_config_map_and_pointers, SerializeConfig};
+use apollo_gateway_config::config::GatewayConfig;
 use apollo_infra::component_client::RemoteClientConfig;
 use apollo_infra::component_server::{LocalServerConfig, RemoteServerConfig};
 use apollo_infra_utils::dumping::serialize_to_file_test;
@@ -99,6 +101,36 @@ fn default_config_file_is_up_to_date() {
 fn validate_config_success() {
     let config = SequencerNodeConfig::default();
     assert!(config.validate().is_ok());
+}
+
+fn echonet_gateway_config() -> GatewayConfig {
+    let mut gateway_config = GatewayConfig::default();
+    gateway_config.static_config.behavior_mode = BehaviorMode::Echonet;
+    gateway_config
+}
+
+#[test]
+fn echonet_with_remote_batcher_fails() {
+    let config = SequencerNodeConfig {
+        components: ComponentConfig {
+            batcher: ReactiveComponentExecutionConfig::remote(VALID_URL.to_string(), VALID_PORT),
+            ..Default::default()
+        },
+        gateway_config: Some(echonet_gateway_config()),
+        batcher_config: None,
+        ..Default::default()
+    };
+    let err = config.validate_node_config().unwrap_err();
+    assert!(format!("{err:?}").contains("consolidated"), "Unexpected error: {err:?}");
+}
+
+#[test]
+fn echonet_consolidated_succeeds() {
+    let config = SequencerNodeConfig {
+        gateway_config: Some(echonet_gateway_config()),
+        ..Default::default()
+    };
+    assert!(config.validate_node_config().is_ok(), "{:?}", config.validate_node_config());
 }
 
 #[rstest]

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -151,6 +151,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
             set_pointing_param_paths(&[
                 "consensus_manager_config.cende_config.recorder_url",
                 "batcher_config.static_config.pre_confirmed_cende_config.recorder_url",
+                "gateway_config.static_config.recorder_url",
                 "mempool_config.static_config.recorder_url",
             ]),
         ),
@@ -211,6 +212,7 @@ pub static CONFIG_POINTERS: LazyLock<ConfigPointers> = LazyLock::new(|| {
         ),
         set_pointing_param_paths(&[
             "consensus_manager_config.context_config.static_config.behavior_mode",
+            "gateway_config.static_config.behavior_mode",
             "mempool_config.static_config.behavior_mode",
         ]),
     ));

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -493,6 +493,8 @@ impl SequencerNodeConfig {
     }
 
     fn cross_member_validations(&self) -> Result<(), ConfigError> {
+        self.validate_echonet_requires_consolidated()?;
+
         macro_rules! validate_component_config_is_set_iff_running_locally {
             ($component_field:ident, $config_field:ident) => {{
                 // The component config should be set iff its running locally.
@@ -609,6 +611,31 @@ impl SequencerNodeConfig {
 
         self.validate_validation_only_config()?;
 
+        Ok(())
+    }
+
+    /// In Echonet mode the gateway sets the process-global effective Starknet version at startup
+    /// (`set_effective_latest_version`), so versioned-constants lookups use the replayed network's
+    /// version. That override lives only in the gateway process's memory, so the batcher, which
+    /// executes with those versioned constants, must run in the same process. Require a
+    /// consolidated deployment.
+    fn validate_echonet_requires_consolidated(&self) -> Result<(), ConfigError> {
+        // A `Some` gateway_config means the gateway runs locally in this process, i.e. this is the
+        // process that sets the version.
+        let Some(gateway_config) = &self.gateway_config else {
+            return Ok(());
+        };
+        if gateway_config.static_config.behavior_mode == BehaviorMode::Echonet
+            && !self.components.batcher.is_running_locally()
+        {
+            return Err(ConfigError::ComponentConfigMismatch {
+                component_config_mismatch: "Echonet behavior mode requires a consolidated \
+                                            deployment: the batcher must run in the same process \
+                                            as the gateway, which sets the effective Starknet \
+                                            version process-locally."
+                    .to_string(),
+            });
+        }
         Ok(())
     }
 


### PR DESCRIPTION
In Echonet mode, versioned-constants lookups must use the replayed network's Starknet version, not the compile-time latest — otherwise execution diverges from mainnet. The gateway now fetches the version from the recorder's `echonet/get_starknet_version` endpoint at startup (with a 5s timeout) and installs it via `set_effective_latest_version`; on failure it logs a warning and keeps the compile-time latest.

Config: `GatewayStaticConfig` gains `behavior_mode` and `recorder_url`, both pointer targets of the existing global params, so deployed config files remain valid unchanged. Config schema regenerated.

In Starknet mode the fetch never runs and the new config fields are unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)