### PR TITLE
apollo_consensus_orchestrator: stamp proposals and cende blobs with the effective Starknet version

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -33,6 +33,7 @@ use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ContractAddress;
 use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::transaction::TransactionHash;
+use starknet_api::versioned_constants_logic::effective_starknet_version;
 use starknet_api::StarknetApiError;
 use strum::{EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use tokio_util::sync::CancellationToken;
@@ -205,7 +206,7 @@ async fn initiate_build(args: &mut ProposalBuildArguments) -> BuildProposalResul
         l1_data_gas_price_wei: l1_prices_wei.l1_data_gas_price,
         l1_gas_price_fri: l1_prices_fri.l1_gas_price,
         l1_data_gas_price_fri: l1_prices_fri.l1_data_gas_price,
-        starknet_version: starknet_api::block::StarknetVersion::LATEST,
+        starknet_version: effective_starknet_version(),
         // TODO(Asmaa): Put the real value once we have it.
         // Sentinel until then; see `expected_version_constant_commitment` for why this is the
         // single source of truth shared with the validator.

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -768,6 +768,7 @@ fn central_blob() -> AerospikeBlob {
 
     let blob_parameters = BlobParameters {
         block_info: block_info(),
+        starknet_version: StarknetVersion::LATEST,
         state_diff: thin_state_diff(),
         compressed_state_diff: Some(commitment_state_diff()),
         transactions_with_execution_infos,
@@ -806,6 +807,7 @@ fn central_blob_with_empty_or_none_fields() -> AerospikeBlob {
     let mock_class_manager = MockClassManagerClient::new();
     let blob_parameters = BlobParameters {
         block_info: block_info(),
+        starknet_version: StarknetVersion::LATEST,
         state_diff: thin_state_diff(),
         compressed_state_diff: None,
         transactions_with_execution_infos: vec![],

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -391,6 +391,8 @@ pub struct InternalTransactionWithReceipt {
 #[derive(Debug, Default)]
 pub struct BlobParameters {
     pub block_info: BlockInfo,
+    // The version stamped on the proposal (the replayed network's version in Echonet mode).
+    pub starknet_version: StarknetVersion,
     pub state_diff: ThinStateDiff,
     pub compressed_state_diff: Option<CommitmentStateDiff>,
     pub bouncer_weights: BouncerWeights,
@@ -422,7 +424,7 @@ impl AerospikeBlob {
         let block_timestamp = blob_parameters.block_info.block_timestamp.0;
 
         let block_info =
-            CentralBlockInfo::from((blob_parameters.block_info, StarknetVersion::LATEST));
+            CentralBlockInfo::from((blob_parameters.block_info, blob_parameters.starknet_version));
         let state_diff = CentralStateDiff::from((blob_parameters.state_diff, block_info.clone()));
         let compressed_state_diff =
             blob_parameters.compressed_state_diff.map(|compressed_state_diff| {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -592,6 +592,7 @@ impl SequencerConsensusContext {
             .cende_ambassador
             .prepare_blob_for_next_height(BlobParameters {
                 block_info: cende_block_info,
+                starknet_version: init.starknet_version,
                 state_diff,
                 compressed_state_diff: central_objects.compressed_state_diff,
                 transactions_with_execution_infos,

--- a/crates/central_systest_blobs/src/cende_blob_regression_test.rs
+++ b/crates/central_systest_blobs/src/cende_blob_regression_test.rs
@@ -231,6 +231,7 @@ impl From<BlockData> for BlobParameters {
         };
 
         Self {
+            starknet_version: block_info.starknet_version,
             block_info,
             state_diff,
             compressed_state_diff: Some(commitment_state_diff),


### PR DESCRIPTION
Stamps `ProposalInit.starknet_version` with `effective_starknet_version()` instead of the hardcoded `StarknetVersion::LATEST`, and threads the proposal's version into the cende blob (`BlobParameters.starknet_version`, used for `CentralBlockInfo`) instead of hardcoding `LATEST` there too. In Echonet mode the blob thus carries the replayed network's version.

Production behavior is provably unchanged: with the override unset the proposer stamps `LATEST`, and the validator side (unchanged) rejects any proposal whose `starknet_version` differs from the expected `LATEST` (`validate_proposal.rs`), so production blobs stay byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)