### PR TITLE
apollo_gateway,apollo_transaction_converter: accept replayed txs with proof facts but no proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,6 +2885,7 @@ name = "apollo_transaction_converter"
 version = "0.0.0"
 dependencies = [
  "apollo_class_manager_types",
+ "apollo_config",
  "apollo_metrics",
  "apollo_proof_manager_types",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,6 +2887,7 @@ name = "apollo_transaction_converter"
 version = "0.0.0"
 dependencies = [
  "apollo_class_manager_types",
+ "apollo_config",
  "apollo_metrics",
  "apollo_proof_manager_types",
  "assert_matches",

--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -292,11 +292,16 @@ impl ConsensusManager {
         SequencerConsensusContext::new(
             self.config.context_config.clone(),
             SequencerConsensusContextDeps {
-                transaction_converter: Arc::new(TransactionConverter::new(
-                    Arc::clone(&self.class_manager_client),
-                    Arc::clone(&self.proof_manager_client),
-                    self.config.context_config.static_config.chain_id.clone(),
-                )),
+                transaction_converter: Arc::new(
+                    TransactionConverter::new(
+                        Arc::clone(&self.class_manager_client),
+                        Arc::clone(&self.proof_manager_client),
+                        self.config.context_config.static_config.chain_id.clone(),
+                    )
+                    .with_behavior_mode(
+                        self.config.context_config.static_config.behavior_mode.clone(),
+                    ),
+                ),
                 state_sync_client: Arc::clone(&self.state_sync_client),
                 batcher: Arc::clone(&self.batcher_client),
                 cende_ambassador: Arc::new(CendeAmbassador::new(

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -548,13 +548,17 @@ pub fn create_gateway(
         class_manager_client: class_manager_client.clone(),
         runtime,
     });
-    let transaction_converter = Arc::new(TransactionConverter::new(
-        class_manager_client,
-        proof_manager_client,
-        config.static_config.chain_info.chain_id.clone(),
-    ));
+    let transaction_converter = Arc::new(
+        TransactionConverter::new(
+            class_manager_client,
+            proof_manager_client,
+            config.static_config.chain_info.chain_id.clone(),
+        )
+        .with_behavior_mode(config.static_config.behavior_mode.clone()),
+    );
     let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
         config: config.static_config.stateless_tx_validator_config.clone(),
+        behavior_mode: config.static_config.behavior_mode.clone(),
     });
 
     // Create proof archive writer: use NoOp if bucket name is empty, otherwise use real GCS.

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -542,13 +542,17 @@ pub fn create_gateway(
         class_manager_client: class_manager_client.clone(),
         runtime,
     });
-    let transaction_converter = Arc::new(TransactionConverter::new(
-        class_manager_client,
-        proof_manager_client,
-        config.static_config.chain_info.chain_id.clone(),
-    ));
+    let transaction_converter = Arc::new(
+        TransactionConverter::new(
+            class_manager_client,
+            proof_manager_client,
+            config.static_config.chain_info.chain_id.clone(),
+        )
+        .with_behavior_mode(config.static_config.behavior_mode.clone()),
+    );
     let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
         config: config.static_config.stateless_tx_validator_config.clone(),
+        behavior_mode: config.static_config.behavior_mode.clone(),
     });
 
     // Create proof archive writer: use NoOp if bucket name is empty, otherwise use real GCS.

--- a/crates/apollo_gateway/src/stateless_transaction_validator.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator.rs
@@ -1,3 +1,4 @@
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::compiler_version::VersionId;
 use apollo_gateway_config::config::StatelessTransactionValidatorConfig;
 use starknet_api::data_availability::DataAvailabilityMode;
@@ -26,6 +27,8 @@ pub trait StatelessTransactionValidatorTrait: Send + Sync {
 #[derive(Clone)]
 pub struct StatelessTransactionValidator {
     pub config: StatelessTransactionValidatorConfig,
+    // In Echonet mode, the consistency check accepts proof facts without a proof.
+    pub behavior_mode: BehaviorMode,
 }
 
 impl StatelessTransactionValidator {
@@ -253,6 +256,11 @@ impl StatelessTransactionValidator {
         let RpcInvokeTransaction::V3(tx) = tx;
         let has_proof_facts = !tx.proof_facts.is_empty();
         let has_proof = !tx.proof.is_empty();
+        // Mainnet's feeder gateway strips `proof` but keeps `proof_facts`, so replayed txs are
+        // accepted without a proof (it is not part of the tx hash and not read in execution).
+        if self.behavior_mode == BehaviorMode::Echonet && has_proof_facts && !has_proof {
+            return Ok(());
+        }
         if has_proof_facts != has_proof {
             return Err(StatelessTransactionValidatorError::ProofFactsAndProofConsistency {
                 has_proof_facts,

--- a/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 use std::vec;
 
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_gateway_config::compiler_version::{VersionId, VersionIdError};
 use apollo_gateway_config::config::StatelessTransactionValidatorConfig;
 use assert_matches::assert_matches;
@@ -45,6 +46,12 @@ use crate::test_utils::{
     TransactionType,
     NON_EMPTY_RESOURCE_BOUNDS,
 };
+
+fn stateless_validator(
+    config: StatelessTransactionValidatorConfig,
+) -> StatelessTransactionValidator {
+    StatelessTransactionValidator { config, behavior_mode: BehaviorMode::default() }
+}
 
 static DEFAULT_VALIDATOR_CONFIG: LazyLock<StatelessTransactionValidatorConfig> =
     LazyLock::new(StatelessTransactionValidatorConfig::default);
@@ -163,7 +170,7 @@ fn test_positive_flow(
     #[values(TransactionType::Declare, TransactionType::DeployAccount, TransactionType::Invoke)]
     tx_type: TransactionType,
 ) {
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator = stateless_validator(config);
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -193,7 +200,7 @@ fn valid_l2_gas_amount_on_declare(
     #[case] rpc_tx_args: RpcTransactionArgs,
 ) {
     let tx_type = TransactionType::Declare;
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator = stateless_validator(config);
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -232,8 +239,7 @@ fn test_invalid_resource_bounds(
     #[values(TransactionType::Declare, TransactionType::DeployAccount, TransactionType::Invoke)]
     tx_type: TransactionType,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG.to_owned() };
+    let tx_validator = stateless_validator(DEFAULT_VALIDATOR_CONFIG.to_owned());
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -262,8 +268,7 @@ fn test_invalid_max_l2_gas_amount(
     #[case] expected_error: StatelessTransactionValidatorError,
     #[values(TransactionType::DeployAccount, TransactionType::Invoke)] tx_type: TransactionType,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG.to_owned() };
+    let tx_validator = stateless_validator(DEFAULT_VALIDATOR_CONFIG.to_owned());
 
     let tx = rpc_tx_for_testing(tx_type, rpc_tx_args);
 
@@ -391,7 +396,7 @@ fn test_invalid_tx(
     #[case] expected_error: StatelessTransactionValidatorError,
     #[case] tx_types: Vec<TransactionType>,
 ) {
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator = stateless_validator(config);
     for tx_type in tx_types {
         let tx = rpc_tx_for_testing(tx_type, rpc_tx_args.clone());
 
@@ -473,8 +478,7 @@ fn test_declare_sierra_version_failure(
     #[case] sierra_program: Vec<Felt>,
     #[case] expected_error: StatelessTransactionValidatorError,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
+    let tx_validator = stateless_validator(DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone());
 
     let contract_class = SierraContractClass { sierra_program, ..Default::default() };
     let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
@@ -493,8 +497,7 @@ fn test_declare_sierra_version_failure(
 ))]
 #[case::max_sierra_version(create_sierra_program(&MAX_SIERRA_VERSION))]
 fn test_declare_sierra_version_sucsses(#[case] sierra_program: Vec<Felt>) {
-    let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
+    let tx_validator = stateless_validator(DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone());
 
     let contract_class = SierraContractClass { sierra_program, ..Default::default() };
     let tx = rpc_declare_tx(declare_tx_args!(), contract_class);
@@ -505,12 +508,10 @@ fn test_declare_sierra_version_sucsses(#[case] sierra_program: Vec<Felt>) {
 #[test]
 fn test_declare_contract_class_size_too_long() {
     let config_max_contract_class_object_size = 100; // Some arbitrary value, which will fail the test.
-    let tx_validator = StatelessTransactionValidator {
-        config: StatelessTransactionValidatorConfig {
-            max_contract_class_object_size: config_max_contract_class_object_size,
-            ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
-        },
-    };
+    let tx_validator = stateless_validator(StatelessTransactionValidatorConfig {
+        max_contract_class_object_size: config_max_contract_class_object_size,
+        ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+    });
     let contract_class = SierraContractClass {
         sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
         ..Default::default()
@@ -532,12 +533,10 @@ fn test_declare_contract_class_size_too_long() {
 fn test_declare_contract_bytecode_size_too_long() {
     let sierra_program = create_sierra_program(&MIN_SIERRA_VERSION);
     assert!(sierra_program.len() > 1);
-    let tx_validator = StatelessTransactionValidator {
-        config: StatelessTransactionValidatorConfig {
-            max_contract_bytecode_size: sierra_program.len() - 1,
-            ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
-        },
-    };
+    let tx_validator = stateless_validator(StatelessTransactionValidatorConfig {
+        max_contract_bytecode_size: sierra_program.len() - 1,
+        ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+    });
 
     let tx = rpc_declare_tx(
         declare_tx_args!(),
@@ -594,8 +593,7 @@ fn test_declare_entry_points_not_sorted_by_selector(
     #[case] entry_points: Vec<EntryPoint>,
     #[case] expected: StatelessTransactionValidatorResult<()>,
 ) {
-    let tx_validator =
-        StatelessTransactionValidator { config: DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone() };
+    let tx_validator = stateless_validator(DEFAULT_VALIDATOR_CONFIG_FOR_TESTING.clone());
 
     let contract_class = SierraContractClass {
         sierra_program: create_sierra_program(&MIN_SIERRA_VERSION),
@@ -660,7 +658,7 @@ fn test_client_side_proving_flag(
         allow_client_side_proving,
         ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
     };
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator = stateless_validator(config);
 
     // Check for proof data before moving values.
     let has_proof_data = proof_facts.is_some() || proof.is_some();
@@ -702,7 +700,7 @@ fn test_proof_facts_and_proof_consistency(
         allow_client_side_proving: true,
         ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
     };
-    let tx_validator = StatelessTransactionValidator { config };
+    let tx_validator = stateless_validator(config);
 
     let rpc_tx_args = RpcTransactionArgs { proof_facts, proof, ..Default::default() };
 
@@ -717,6 +715,39 @@ fn test_proof_facts_and_proof_consistency(
                 has_proof_facts,
                 has_proof,
             }) if has_proof_facts == expected_has_proof_facts && has_proof == expected_has_proof
+        );
+    }
+}
+
+// In Echonet mode replayed txs arrive with proof facts but no proof (mainnet's feeder strips
+// it); the consistency check must accept that. A proof without facts is still rejected.
+#[rstest]
+#[case::both_empty(ProofFacts::default(), Proof::default(), true)]
+#[case::both_non_empty(create_valid_proof_facts_for_testing(), Proof::proof_for_testing(), true)]
+#[case::proof_facts_only(create_valid_proof_facts_for_testing(), Proof::default(), true)]
+#[case::proof_only(ProofFacts::default(), Proof::proof_for_testing(), false)]
+fn test_proof_facts_and_proof_consistency_in_echonet_mode(
+    #[case] proof_facts: ProofFacts,
+    #[case] proof: Proof,
+    #[case] should_pass: bool,
+) {
+    let tx_validator = StatelessTransactionValidator {
+        config: StatelessTransactionValidatorConfig {
+            allow_client_side_proving: true,
+            ..*DEFAULT_VALIDATOR_CONFIG_FOR_TESTING
+        },
+        behavior_mode: BehaviorMode::Echonet,
+    };
+
+    let rpc_tx_args = RpcTransactionArgs { proof_facts, proof, ..Default::default() };
+    let tx = rpc_tx_for_testing(TransactionType::Invoke, rpc_tx_args);
+
+    if should_pass {
+        assert_matches!(tx_validator.validate(&tx), Ok(()));
+    } else {
+        assert_matches!(
+            tx_validator.validate(&tx),
+            Err(StatelessTransactionValidatorError::ProofFactsAndProofConsistency { .. })
         );
     }
 }

--- a/crates/apollo_gateway/src/test_utils.rs
+++ b/crates/apollo_gateway/src/test_utils.rs
@@ -178,9 +178,11 @@ pub fn gateway_for_benchmark(gateway_config: GatewayConfig) -> GatewayForBenchma
         class_manager_client.clone(),
         proof_manager_client.clone(),
         gateway_config.static_config.chain_info.chain_id.clone(),
-    );
+    )
+    .with_behavior_mode(gateway_config.static_config.behavior_mode.clone());
     let stateless_tx_validator = Arc::new(StatelessTransactionValidator {
         config: gateway_config.static_config.stateless_tx_validator_config.clone(),
+        behavior_mode: gateway_config.static_config.behavior_mode.clone(),
     });
     mempool_client.expect_add_tx().returning(|_| Ok(()));
     mempool_client.expect_validate_tx().returning(|_| Ok(()));

--- a/crates/apollo_transaction_converter/Cargo.toml
+++ b/crates/apollo_transaction_converter/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 apollo_class_manager_types.workspace = true
+apollo_config.workspace = true
 apollo_metrics.workspace = true
 apollo_proof_manager_types.workspace = true
 async-trait.workspace = true

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::{ClassHashes, ClassManagerClientError, SharedClassManagerClient};
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_proof_manager_types::{ProofManagerClientError, SharedProofManagerClient};
 use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
@@ -116,6 +117,7 @@ pub struct TransactionConverter {
     class_manager_client: SharedClassManagerClient,
     proof_manager_client: SharedProofManagerClient,
     chain_id: ChainId,
+    behavior_mode: BehaviorMode,
 }
 
 impl TransactionConverter {
@@ -124,7 +126,17 @@ impl TransactionConverter {
         proof_manager_client: SharedProofManagerClient,
         chain_id: ChainId,
     ) -> Self {
-        Self { class_manager_client, proof_manager_client, chain_id }
+        Self {
+            class_manager_client,
+            proof_manager_client,
+            chain_id,
+            behavior_mode: BehaviorMode::default(),
+        }
+    }
+
+    pub fn with_behavior_mode(mut self, behavior_mode: BehaviorMode) -> Self {
+        self.behavior_mode = behavior_mode;
+        self
     }
 
     async fn get_sierra(
@@ -209,11 +221,14 @@ impl TransactionConverterTrait for TransactionConverter {
             InternalRpcTransactionWithoutTxHash::Invoke(tx) => {
                 // We expect the proof to be available here because it has already been verified
                 // and stored by the proof manager in the gateway.
-                let proof = if tx.proof_facts.is_empty() {
-                    Proof::default()
-                } else {
-                    self.get_proof(&tx.proof_facts).await?
-                };
+                // Echonet exception: the gateway skipped storing the proof, so the proof
+                // manager has no entry; hand back a default proof.
+                let proof =
+                    if tx.proof_facts.is_empty() || self.behavior_mode == BehaviorMode::Echonet {
+                        Proof::default()
+                    } else {
+                        self.get_proof(&tx.proof_facts).await?
+                    };
 
                 Ok(RpcTransaction::Invoke(RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
                     resource_bounds: tx.resource_bounds,
@@ -337,7 +352,11 @@ impl TransactionConverter {
     ) -> TransactionConverterResult<(InternalRpcTransaction, Option<(ProofFacts, Proof)>)> {
         let (tx_without_hash, proof_data) = match tx {
             RpcTransaction::Invoke(RpcInvokeTransaction::V3(tx)) => {
-                let proof_data = if tx.proof_facts.is_empty() {
+                // A replayed tx arrives with proof facts and no proof; treat it as "no proof
+                // data" (skip verification and archiving). `proof_facts` stays on the tx.
+                let skip_proof_for_replay =
+                    self.behavior_mode == BehaviorMode::Echonet && tx.proof.is_empty();
+                let proof_data = if tx.proof_facts.is_empty() || skip_proof_for_replay {
                     None
                 } else {
                     Some((tx.proof_facts.clone(), tx.proof.clone()))

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::{ClassHashes, ClassManagerClientError, SharedClassManagerClient};
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_proof_manager_types::{ProofManagerClientError, SharedProofManagerClient};
 use async_trait::async_trait;
 #[cfg(any(feature = "testing", test))]
@@ -116,6 +117,9 @@ pub struct TransactionConverter {
     class_manager_client: SharedClassManagerClient,
     proof_manager_client: SharedProofManagerClient,
     chain_id: ChainId,
+    // In Echonet mode, proof verification, archiving, and lookup are skipped for replayed txs
+    // (mainnet's feeder gateway strips the proof).
+    behavior_mode: BehaviorMode,
 }
 
 impl TransactionConverter {
@@ -124,7 +128,18 @@ impl TransactionConverter {
         proof_manager_client: SharedProofManagerClient,
         chain_id: ChainId,
     ) -> Self {
-        Self { class_manager_client, proof_manager_client, chain_id }
+        Self {
+            class_manager_client,
+            proof_manager_client,
+            chain_id,
+            behavior_mode: BehaviorMode::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_behavior_mode(mut self, behavior_mode: BehaviorMode) -> Self {
+        self.behavior_mode = behavior_mode;
+        self
     }
 
     async fn get_sierra(
@@ -209,11 +224,14 @@ impl TransactionConverterTrait for TransactionConverter {
             InternalRpcTransactionWithoutTxHash::Invoke(tx) => {
                 // We expect the proof to be available here because it has already been verified
                 // and stored by the proof manager in the gateway.
-                let proof = if tx.proof_facts.is_empty() {
-                    Proof::default()
-                } else {
-                    self.get_proof(&tx.proof_facts).await?
-                };
+                // Echonet exception: the gateway skipped storing the proof, so the proof
+                // manager has no entry; hand back a default proof.
+                let proof =
+                    if tx.proof_facts.is_empty() || self.behavior_mode == BehaviorMode::Echonet {
+                        Proof::default()
+                    } else {
+                        self.get_proof(&tx.proof_facts).await?
+                    };
 
                 Ok(RpcTransaction::Invoke(RpcInvokeTransaction::V3(RpcInvokeTransactionV3 {
                     resource_bounds: tx.resource_bounds,
@@ -337,7 +355,11 @@ impl TransactionConverter {
     ) -> TransactionConverterResult<(InternalRpcTransaction, Option<(ProofFacts, Proof)>)> {
         let (tx_without_hash, proof_data) = match tx {
             RpcTransaction::Invoke(RpcInvokeTransaction::V3(tx)) => {
-                let proof_data = if tx.proof_facts.is_empty() {
+                // A replayed tx arrives with proof facts and no proof; treat it as "no proof
+                // data" (skip verification and archiving). `proof_facts` stays on the tx.
+                let skip_proof_for_replay =
+                    self.behavior_mode == BehaviorMode::Echonet && tx.proof.is_empty();
+                let proof_data = if tx.proof_facts.is_empty() || skip_proof_for_replay {
                     None
                 } else {
                     Some((tx.proof_facts.clone(), tx.proof.clone()))

--- a/crates/apollo_transaction_converter/src/transaction_converter_test.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use apollo_class_manager_types::{ClassHashes, MockClassManagerClient};
+use apollo_config::behavior_mode::BehaviorMode;
 use apollo_proof_manager_types::MockProofManagerClient;
 use assert_matches::assert_matches;
 use blockifier::context::ChainInfo;
@@ -230,4 +231,43 @@ async fn test_convert_internal_rpc_tx_to_rpc_tx_with_proof(proof_facts: ProofFac
         transaction_converter.convert_internal_rpc_tx_to_rpc_tx(internal_tx).await.unwrap();
 
     assert_eq!(rpc_tx, rpc_tx_from_internal);
+}
+
+// In Echonet mode the proof manager has no entry for a replayed tx, so converting the internal
+// tx back to RPC must not call get_proof (ProofNotFound would abort the proposal).
+#[rstest]
+#[tokio::test]
+async fn test_internal_rpc_to_rpc_in_echonet_mode_skips_proof_manager_lookup(
+    proof_facts: ProofFacts,
+) {
+    // A replayed tx: proof facts present, proof absent.
+    let rpc_tx = invoke_tx_client_side_proving(
+        CairoVersion::default(),
+        proof_facts.clone(),
+        Proof::default(),
+    );
+
+    // The mock has no expectations set, so it panics if any proof manager call is made.
+    let transaction_converter = TransactionConverter::new(
+        Arc::new(MockClassManagerClient::new()),
+        Arc::new(MockProofManagerClient::new()),
+        ChainInfo::create_for_testing().chain_id,
+    )
+    .with_behavior_mode(BehaviorMode::Echonet);
+
+    let (internal_tx, verification_handle) =
+        transaction_converter.convert_rpc_tx_to_internal_rpc_tx(rpc_tx).await.unwrap();
+    assert!(verification_handle.is_none(), "echonet must not spawn proof verification");
+
+    let rpc_tx_from_internal =
+        transaction_converter.convert_internal_rpc_tx_to_rpc_tx(internal_tx).await.unwrap();
+
+    let RpcTransaction::Invoke(starknet_api::rpc_transaction::RpcInvokeTransaction::V3(
+        round_tripped_tx,
+    )) = rpc_tx_from_internal
+    else {
+        panic!("expected a V3 invoke transaction");
+    };
+    assert_eq!(round_tripped_tx.proof_facts, proof_facts);
+    assert!(round_tripped_tx.proof.is_empty(), "proof must remain empty in an echonet round-trip");
 }


### PR DESCRIPTION
Mainnet's feeder gateway strips the `proof` field before serving transactions, so a replayed private tx arrives in Echonet with `proof_facts` but no `proof`. The proof is verification metadata only — not part of the tx hash and not read during execution — so accepting facts-without-proof on replay reproduces the original tx hash, state diff, and block hash. Two enforcement points are relaxed, both gated on `BehaviorMode::Echonet`:

- The gateway's stateless consistency check accepts facts-without-proof (proof-without-facts is still rejected — it can't result from a stripped feeder response).
- The transaction converter treats such txs as having no proof data (skips verification/archiving on ingress, and skips the proof-manager lookup when converting back to RPC for proposal streaming, where `ProofNotFound` would otherwise abort the proposal).

`TransactionConverter` gains a `with_behavior_mode` builder defaulting to Starknet, so existing callers are untouched; the gateway and consensus manager wire in the configured mode. In Starknet mode both checks behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)