### PR TITLE
apollo_consensus_orchestrator: truncate proof tasks to executed tx count on Fin (H-1)

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -331,7 +331,7 @@ impl TestDeps {
             .return_const(Ok(DEFAULT_STRK_TO_USD_RATE));
     }
 
-    fn setup_default_state_sync_get_block(&mut self) {
+    pub(crate) fn setup_default_state_sync_get_block(&mut self) {
         self.state_sync_client.expect_get_block().returning(|_| Ok(SyncBlock::default()));
     }
 

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -142,7 +142,10 @@ pub(crate) async fn validate_proposal(
     mut args: ProposalValidateArguments,
 ) -> ValidateProposalResult<ProposalCommitment> {
     let mut content = Vec::new();
-    let mut verify_and_store_proof_tasks: Vec<VerifyAndStoreProofTask> = Vec::new();
+    // One entry per received transaction, in the same order as `content`, so the tasks can be
+    // truncated in lockstep with `content` once `executed_transaction_count` is known. `None`
+    // marks a transaction that spawned no proof task.
+    let mut verify_and_store_proof_tasks: Vec<Option<VerifyAndStoreProofTask>> = Vec::new();
     let now = args.deps.clock.now();
 
     let Some(deadline) = now.checked_add_signed(chrono::TimeDelta::from_std(args.timeout).unwrap())
@@ -492,7 +495,7 @@ async fn handle_proposal_part(
     batcher: &dyn BatcherClient,
     proposal_part: Option<ProposalPart>,
     content: &mut Vec<Vec<InternalConsensusTransaction>>,
-    verify_and_store_proof_tasks: &mut Vec<VerifyAndStoreProofTask>,
+    verify_and_store_proof_tasks: &mut Vec<Option<VerifyAndStoreProofTask>>,
     transaction_converter: Arc<dyn TransactionConverterTrait>,
     deadline_params: &ProposalDeadlineParams,
     fee_proposal: Option<GasPrice>,
@@ -529,6 +532,14 @@ async fn handle_proposal_part(
 
             *content = truncate_to_executed_txs(content, executed_txs_count);
 
+            // Drop proof tasks for transactions that were streamed but not executed (those beyond
+            // `executed_txs_count`), mirroring the truncation of `content`. The task list is kept
+            // in transaction order with one slot per transaction, so truncating to the executed
+            // count keeps exactly the tasks for executed transactions. Awaiting proofs for
+            // excluded transactions would let an unexecuted (possibly invalid-proof) transaction
+            // fail an otherwise-valid proposal.
+            verify_and_store_proof_tasks.truncate(executed_txs_count);
+
             // Verification and store proof tasks are spawned during consensus transaction
             // conversion, running concurrently with batcher execution. Since the fin
             // is always the last proposal part, we await all tasks here to ensure every
@@ -536,7 +547,7 @@ async fn handle_proposal_part(
             // The tasks themselves are not cancelled, they continue running in the background,
             // but we stop waiting for them.
             let start = Instant::now();
-            for task in verify_and_store_proof_tasks.drain(..) {
+            for task in verify_and_store_proof_tasks.drain(..).flatten() {
                 tokio::select! {
                     _ = deadline_params.cancel_token.cancelled() => {
                         let duration = start.elapsed();
@@ -623,7 +634,9 @@ async fn handle_proposal_part(
                 Vec<InternalConsensusTransaction>,
                 Vec<Option<VerifyAndStoreProofTask>>,
             ) = conversion_results.into_iter().unzip();
-            verify_and_store_proof_tasks.extend(tasks.into_iter().flatten());
+            // Keep one slot per transaction (including `None`s) so the task list stays aligned
+            // with `content` for later truncation to `executed_transaction_count`.
+            verify_and_store_proof_tasks.extend(tasks);
 
             debug!(
                 "Converted transactions to internal representation. hashes={:?}",

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
@@ -39,12 +39,15 @@ use crate::sequencer_consensus_context::BuiltProposals;
 fn fee_proposal_margin_ppt() -> u128 {
     VersionedConstants::latest_constants().fee_proposal_margin_ppt
 }
+use apollo_transaction_converter::TransactionConverterError;
+
 use crate::test_utils::{
     create_test_and_network_deps,
     proposal_init,
     SetupDepsArgs,
     TestDeps,
     CHANNEL_SIZE,
+    INTERNAL_TX_BATCH,
     TIMEOUT,
     TX_BATCH,
 };
@@ -245,6 +248,86 @@ async fn fin_with_inflated_executed_tx_count_is_rejected() {
 
     let res = validate_proposal(proposal_args.into()).await;
     assert_matches!(res, Err(ValidateProposalError::ProposalPartFailed(_, _)));
+}
+
+// Regression test for the proof-task/`content` truncation mismatch: a proposer may stream more
+// transactions than it executes, and the excluded tail is dropped from `content` on `Fin`. The
+// proof-verification tasks must be truncated in lockstep, otherwise a failing proof on an
+// unexecuted (excluded) transaction would wrongly fail an otherwise-valid proposal.
+#[tokio::test]
+async fn fin_does_not_await_proofs_for_unexecuted_txs() {
+    let (mut proposal_args, mut content_sender) = create_proposal_validate_arguments();
+
+    // Replace the default deps with a bespoke set: identical defaults except the transaction
+    // converter, which attaches a *failing* proof task to the last (soon-to-be-excluded)
+    // transaction. mockall matches expectations FIFO, so the default converter cannot be
+    // overridden in place — the whole deps set is rebuilt here.
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.setup_default_cende_ambassador();
+    deps.setup_default_gas_price_provider();
+    deps.setup_default_state_sync_get_block();
+    deps.setup_default_batcher_get_block_hash();
+
+    let n_executed = TX_BATCH.len() - 1;
+    for (index, (tx, internal_tx)) in TX_BATCH.iter().zip(INTERNAL_TX_BATCH.iter()).enumerate() {
+        let tx_matcher = tx.clone();
+        let internal_tx = internal_tx.clone();
+        deps.transaction_converter
+            .expect_convert_consensus_tx_to_internal_consensus_tx()
+            .withf(move |candidate| candidate == &tx_matcher)
+            .times(1)
+            .returning(move |_| {
+                // Only the excluded tail transaction carries a proof task, and it fails.
+                let task = (index >= n_executed).then(|| {
+                    tokio::spawn(async {
+                        Err(TransactionConverterError::ProofNotFound { facts_hash: Felt::ZERO })
+                    })
+                });
+                Ok((internal_tx.clone(), task))
+            });
+    }
+
+    deps.batcher
+        .expect_start_height()
+        .withf(|input| input.height == BlockNumber(0))
+        .return_const(Ok(()));
+    deps.batcher.expect_validate_block().times(1).returning(|_| Ok(()));
+    deps.batcher
+        .expect_send_txs_for_proposal()
+        .times(1)
+        .returning(|_| Ok(SendTxsForProposalStatus::Processing));
+    deps.batcher.expect_finish_proposal().times(1).returning(move |input| {
+        assert_eq!(input.final_n_executed_txs, n_executed);
+        Ok(FinishProposalStatus::Finished(FinishedProposalInfo {
+            artifact: FinishedProposalInfoWithoutParent {
+                proposal_commitment: ProposalCommitment::default(),
+                final_n_executed_txs: n_executed,
+                block_header_commitments: BlockHeaderCommitments::default(),
+                l2_gas_used: GasAmount::default(),
+            },
+            parent_proposal_commitment: None,
+        }))
+    });
+    proposal_args.deps = deps;
+
+    // Stream all transactions, then declare that only the first `n_executed` were executed.
+    content_sender
+        .send(ProposalPart::Transactions(TransactionBatch { transactions: TX_BATCH.clone() }))
+        .await
+        .unwrap();
+    content_sender
+        .send(ProposalPart::Fin(ProposalFin {
+            proposal_commitment: test_validate_expected_commitment(),
+            executed_transaction_count: n_executed.try_into().unwrap(),
+            fin_payload: None,
+        }))
+        .await
+        .unwrap();
+
+    // The failing proof belongs to an excluded transaction, so it is truncated away and the
+    // proposal validates successfully instead of being rejected.
+    let res = validate_proposal(proposal_args.into()).await;
+    assert_matches!(res, Ok(_));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes **H-1** from the Sequencer Security Report (2026-06-30): a validator can reject an otherwise-valid proposal because it verifies proofs for transactions that were streamed but excluded from the committed block.

## Root cause

On `ProposalPart::Transactions`, the validator collects proof-verification tasks into a **flat** `Vec`, losing per-transaction alignment. On `ProposalPart::Fin` it truncates `content` to `executed_transaction_count` (head-keeping, dropping the excluded tail) but does **not** truncate the proof-task vector — it awaits *every* task, including those for tail transactions that are not part of the block. Any excluded-tx proof failure returns `HandledProposalPart::Failed`, rejecting a valid block → round skip / liveness regression.

An attacker can submit a tx with an invalid proof; if the proposer streams it but cuts the block short before executing it, the proposer produces a valid block yet all validators reject it.

## Fix

- Keep the proof tasks as `Vec<Option<VerifyAndStoreProofTask>>` — one slot per streamed tx, preserving index alignment (no more flattening).
- On `Fin`, `truncate(executed_transaction_count)` the task vector in lockstep with `content`, then await only the surviving tasks.

## Test

Adds `fin_does_not_await_proofs_for_unexecuted_txs`: attaches a failing proof task to an excluded tail tx, sends `Fin` with `executed_transaction_count` excluding it, and asserts the proposal finishes (not `Failed`). **Verified to fail without the truncation fix.**

## Verification

Built and tested with `cargo +1.95` (`--features testing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
