### PR TITLE
apollo_consensus: treat buffered FinishedValidation as a handled proposal (H-5)

### DIFF
--- a/crates/apollo_consensus/src/state_machine.rs
+++ b/crates/apollo_consensus/src/state_machine.rs
@@ -180,7 +180,20 @@ impl StateMachine {
     }
 
     pub(crate) fn has_proposal_for_round(&self, round: Round) -> bool {
-        self.proposals.contains_key(&round)
+        if self.proposals.contains_key(&round) {
+            return true;
+        }
+        // While `awaiting_finished_building` is true, a `FinishedValidation`/`FinishedBuilding`
+        // for `round` may be buffered in `events_queue` but not yet applied to `proposals`. A
+        // duplicate/replayed proposal for that round must still be treated as already handled,
+        // otherwise a second validation is started and its `FinishedValidation` panics on the
+        // `proposals.insert` assertion once the queue is flushed. Mirror the `events_queue` scan
+        // that `received_vote` performs for buffered votes.
+        self.events_queue.iter().any(|event| match event {
+            StateMachineEvent::FinishedValidation(_, event_round, _)
+            | StateMachineEvent::FinishedBuilding(_, event_round) => *event_round == round,
+            _ => false,
+        })
     }
 
     pub(crate) fn last_self_prevote(&self) -> Option<Vote> {

--- a/crates/apollo_consensus/src/state_machine_test.rs
+++ b/crates/apollo_consensus/src/state_machine_test.rs
@@ -429,6 +429,37 @@ fn buffer_events_during_get_proposal(vote: Option<ProposalCommitment>) {
     assert_no_more_requests(&mut wrapper);
 }
 
+// Regression test: while building a proposal, a `FinishedValidation` for another round is buffered
+// in `events_queue` and not yet applied to `proposals`. `has_proposal_for_round` must still report
+// that round as handled, otherwise SHC would start a duplicate validation whose second
+// `FinishedValidation` panics on the `proposals` insert once the queue is flushed.
+#[test]
+fn has_proposal_for_round_sees_buffered_finished_validation() {
+    let mut wrapper = TestWrapper::new(
+        *PROPOSER_ID,
+        UNIT_VALIDATOR_WEIGHTS.clone(),
+        |_: Round| *PROPOSER_ID,
+        |_: Round| Ok(*PROPOSER_ID),
+        QuorumType::Byzantine,
+        NOT_OBSERVER,
+    );
+
+    // Enter the building state: `awaiting_finished_building` is now true, so subsequent events
+    // (other than FinishedBuilding for the current round) are buffered in `events_queue`.
+    advance_proposer_after_start(&mut wrapper);
+
+    let other_round = ROUND + 1;
+    assert!(!wrapper.state_machine.has_proposal_for_round(other_round));
+
+    // A validation for a different round completes and is buffered rather than applied.
+    wrapper.send_finished_validation(PROPOSAL_ID, other_round);
+    assert_no_more_requests(&mut wrapper);
+
+    // Even though the proposal is not yet in `proposals`, the buffered event marks the round as
+    // handled, so a replayed proposal for it would be rejected instead of double-validated.
+    assert!(wrapper.state_machine.has_proposal_for_round(other_round));
+}
+
 #[test]
 fn only_send_precommit_with_prevote_quorum_and_proposal() {
     let mut wrapper = TestWrapper::new(


### PR DESCRIPTION
## Summary

Fixes **H-5** from the Sequencer Security Report (2026-06-30): a single duplicate proposal message received while the node is building its own proposal causes a deterministic panic.

## Root cause

The SHC removes a round from `pending_validation_rounds` **before** the state machine processes the `FinishedValidation` event. While the SM is building (`awaiting_finished_building`), that event is buffered in `events_queue` and the proposal is not yet in `proposals`. `has_proposal_for_round` only checked `proposals`, never `events_queue` — so a replayed/duplicate `ProposalInit` for that round passes both guards and starts a **second** validation, queuing a second `FinishedValidation`. When `FinishedBuilding` flushes the queue, the first insert succeeds and the second hits `assert!(old.is_none(), "SHC should handle conflicts & replays")` → panic / crash.

The `received_vote` path already scans `events_queue` for buffered votes; the proposal path lacked the equivalent guard.

## Fix

`has_proposal_for_round` now also returns `true` when a `FinishedValidation`/`FinishedBuilding` for that round is buffered in `events_queue`, mirroring the `received_vote` pattern. The duplicate `ProposalInit` is then correctly treated as already-handled.

## Test

Adds `has_proposal_for_round_sees_buffered_finished_validation`: while `awaiting_finished_building`, sends a `FinishedValidation` for a round (buffered), and asserts `has_proposal_for_round` returns `true`. **Verified to fail without the fix.** All 95 `apollo_consensus` lib tests pass.

## Verification

Built and tested with `cargo +1.95` (`--features testing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
