### PR TITLE
deployment: upgrade jsii to 1.138.0 in lockfiles

### DIFF
--- a/deployments/anvil/Pipfile.lock
+++ b/deployments/anvil/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/dummy_eth2strk_oracle/Pipfile.lock
+++ b/deployments/dummy_eth2strk_oracle/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/dummy_recorder/Pipfile.lock
+++ b/deployments/dummy_recorder/Pipfile.lock
@@ -77,11 +77,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [

--- a/deployments/sequencer/Pipfile.lock
+++ b/deployments/sequencer/Pipfile.lock
@@ -167,11 +167,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57",
-                "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.134.0"
+            "version": "==1.138.0"
         },
         "jsonschema": {
             "hashes": [

--- a/deployments/sequencer_simulator/Pipfile.lock
+++ b/deployments/sequencer_simulator/Pipfile.lock
@@ -60,11 +60,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:5a44d7c3a5a326fa3d9befdb3770b380057e0a61e3804e7c4907f70d76afaaa2",
-                "sha256:c79c47899f53a7c3c4b20f80d3cd306628fe9ed1852eee970324c71eba1d974e"
+                "sha256:575a389c56e4651f33fad0e0dafdc61d001a499d3cc0630cee734fc5e0b525ae",
+                "sha256:efc66b5831c8c41e343b644f03221d71480b69c3c39dc41df15659a01ce28fbb"
             ],
-            "markers": "python_version ~= '3.8'",
-            "version": "==1.106.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==1.138.0"
         },
         "publication": {
             "hashes": [


### PR DESCRIPTION
Cherry-pick of #14690 (`0e43ee6f56`) onto `main-v0.14.3`.

## Why

`system_test_hybrid` (and the other cdk8s-based system tests) currently fail on every PR targeting `main-v0.14.3`:

```
ImportError: cannot import name 'cached_type_hints' from 'jsii._type_checking'
```

The CI resolves cdk8s-cli/jsii-pacmak unpinned at import time, and current jsii-pacmak generates bindings that require the jsii 1.138.0 Python runtime, while the lockfiles on this branch pin 1.134.0 (1.106.0 for `sequencer_simulator`). Example failing run: https://github.com/starkware-libs/sequencer/actions/runs/28937103017/job/85852561189 (PR #14165).

## Notes

- Clean cherry-pick for four of the five lockfiles.
- `deployments/sequencer_simulator/Pipfile.lock` conflicted (this branch still had jsii 1.106.0); resolved by taking the 1.138.0 entry. Its jsii runtime deps (typeguard, cattrs, attrs, publication, ...) already pin the exact versions `main` uses alongside jsii 1.138.0, and the resulting jsii entry is byte-identical to `main`'s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)