### PR TITLE
apollo_gateway_config: bump gateway min accepted Sierra version to 1.5.0

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/gateway_config.json
+++ b/crates/apollo_deployments/resources/app_configs/gateway_config.json
@@ -30,6 +30,6 @@
   "gateway_config.static_config.stateless_tx_validator_config.max_signature_length": 4000,
   "gateway_config.static_config.stateless_tx_validator_config.min_gas_price": 8000000000,
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.major": 1,
-  "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.minor": 1,
+  "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.minor": 5,
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.patch": 0
 }

--- a/crates/apollo_deployments/resources/app_configs/replacer_gateway_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_gateway_config.json
@@ -30,6 +30,6 @@
   "gateway_config.static_config.stateless_tx_validator_config.max_signature_length": 4000,
   "gateway_config.static_config.stateless_tx_validator_config.min_gas_price": "$$$_GATEWAY_CONFIG-STATIC_CONFIG-STATELESS_TX_VALIDATOR_CONFIG-MIN_GAS_PRICE_$$$",
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.major": 1,
-  "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.minor": 1,
+  "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.minor": 5,
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.patch": 0
 }

--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -218,7 +218,7 @@ impl Default for StatelessTransactionValidatorConfig {
             max_signature_length: 4000,
             max_contract_bytecode_size: 81920,
             max_contract_class_object_size: 4089446,
-            min_sierra_version: VersionId::new(1, 1, 0),
+            min_sierra_version: VersionId::new(1, 5, 0),
             max_sierra_version: VersionId::new(1, 9, usize::MAX),
             allow_client_side_proving: true,
             max_proof_size: 480000,

--- a/crates/apollo_gateway_config/src/config.rs
+++ b/crates/apollo_gateway_config/src/config.rs
@@ -195,7 +195,7 @@ impl Default for StatelessTransactionValidatorConfig {
             max_signature_length: 4000,
             max_contract_bytecode_size: 81920,
             max_contract_class_object_size: 4089446,
-            min_sierra_version: VersionId::new(1, 1, 0),
+            min_sierra_version: VersionId::new(1, 5, 0),
             max_sierra_version: VersionId::new(1, 9, usize::MAX),
             allow_client_side_proving: true,
             max_proof_size: 480000,

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -46,6 +46,7 @@ use apollo_consensus_orchestrator_config::config::{
     ContextStaticConfig,
 };
 use apollo_deployments::service::NodeType;
+use apollo_gateway_config::compiler_version::VersionId;
 use apollo_gateway_config::config::{
     GatewayConfig,
     GatewayStaticConfig,
@@ -846,6 +847,11 @@ pub fn create_gateway_config(
         max_calldata_length: 19,
         max_signature_length: 2,
         allow_client_side_proving: true,
+        // The declare-flow tests declare `contract_class.json`, a legacy Sierra 1.3.0 fixture that
+        // is below the production default minimum. Keep the pre-bump minimum here so these tests
+        // still exercise the declare flow; Sierra-version enforcement is covered by the stateless
+        // validator unit tests.
+        min_sierra_version: VersionId::new(1, 1, 0),
         ..Default::default()
     };
     let stateful_tx_validator_config = StatefulTransactionValidatorConfig {

--- a/crates/apollo_integration_tests/src/utils.rs
+++ b/crates/apollo_integration_tests/src/utils.rs
@@ -45,6 +45,7 @@ use apollo_consensus_orchestrator_config::config::{
     ContextStaticConfig,
 };
 use apollo_deployments::service::NodeType;
+use apollo_gateway_config::compiler_version::VersionId;
 use apollo_gateway_config::config::{
     GatewayConfig,
     GatewayStaticConfig,
@@ -831,6 +832,11 @@ pub fn create_gateway_config(
         max_calldata_length: 19,
         max_signature_length: 2,
         allow_client_side_proving: true,
+        // The declare-flow tests declare `contract_class.json`, a legacy Sierra 1.3.0 fixture that
+        // is below the production default minimum. Keep the pre-bump minimum here so these tests
+        // still exercise the declare flow; Sierra-version enforcement is covered by the stateless
+        // validator unit tests.
+        min_sierra_version: VersionId::new(1, 1, 0),
         ..Default::default()
     };
     let stateful_tx_validator_config = StatefulTransactionValidatorConfig {

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3172,7 +3172,7 @@
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.minor": {
     "description": "The minor version of the configuration.",
     "privacy": "Public",
-    "value": 1
+    "value": 5
   },
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.patch": {
     "description": "The patch version of the configuration.",

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3232,7 +3232,7 @@
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.minor": {
     "description": "The minor version of the configuration.",
     "privacy": "Public",
-    "value": 1
+    "value": 5
   },
   "gateway_config.static_config.stateless_tx_validator_config.min_sierra_version.patch": {
     "description": "The patch version of the configuration.",


### PR DESCRIPTION
## What

Raise the gateway stateless transaction validator's default `min_sierra_version` from **1.1.0 → 1.5.0**, so the gateway rejects `DECLARE` transactions whose contract class was compiled with a Sierra version below 1.5.0.

## Changes

- **`crates/apollo_gateway_config/src/config.rs`** — `StatelessTransactionValidatorConfig::default().min_sierra_version` = `VersionId::new(1, 5, 0)`.
- **`crates/apollo_node/resources/config_schema.json`** — regenerated via `cargo run --bin update_apollo_node_config_schema` (min_sierra_version.minor 1 → 5).
- **`crates/apollo_deployments/resources/app_configs/gateway_config.json`** + derived **`replacer_gateway_config.json`** — the deployment app config overrides this value at runtime, so it's bumped too (regenerated the replacer via `cargo run --bin deployment_generator`); otherwise the deployed gateway would keep min 1.1.0 and the bump would be a no-op in production.
- **`crates/apollo_integration_tests/src/utils.rs`** — the integration/e2e declare-flow tests declare `contract_class.json`, a legacy **Sierra 1.3.0** fixture that has no in-repo source to regenerate. Pin `min_sierra_version` back to `1.1.0` in the test-only `create_gateway_config` (alongside the other test-specific validator limits already there) so those flow tests keep exercising the declare path. Sierra-version enforcement itself is covered by the stateless validator unit tests.

## Testing

- `apollo_node_config`: `default_config_file_is_up_to_date` ✅
- `apollo_deployments`: `deployment_files_are_up_to_date` (+ 4 other consistency tests) ✅
- `apollo_gateway` unit tests: 160 passed, 0 failed (incl. all `stateless_transaction_validator` Sierra-version cases) ✅
- `apollo_integration_tests` compiles ✅; `declare_tx_flow` e2e re-run for confirmation (behaviorally unchanged since the test config's effective min is still 1.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)