### PR TITLE
apollo_config_manager_config: default config sampling interval to 20s

### DIFF
--- a/crates/apollo_config_manager_config/src/config.rs
+++ b/crates/apollo_config_manager_config/src/config.rs
@@ -32,7 +32,7 @@ impl SerializeConfig for ConfigManagerConfig {
 
 impl Default for ConfigManagerConfig {
     fn default() -> Self {
-        Self { enable_config_updates: false, config_update_interval_secs: 60.0 }
+        Self { enable_config_updates: false, config_update_interval_secs: 20.0 }
     }
 }
 

--- a/crates/apollo_deployments/resources/app_configs/config_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/config_manager_config.json
@@ -1,4 +1,4 @@
 {
-    "config_manager_config.config_update_interval_secs": 60.0,
+    "config_manager_config.config_update_interval_secs": 20.0,
     "config_manager_config.enable_config_updates": true
 }

--- a/crates/apollo_deployments/resources/app_configs/replacer_config_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_config_manager_config.json
@@ -1,4 +1,4 @@
 {
-  "config_manager_config.config_update_interval_secs": 60.0,
+  "config_manager_config.config_update_interval_secs": 20.0,
   "config_manager_config.enable_config_updates": true
 }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2457,7 +2457,7 @@
   "config_manager_config.config_update_interval_secs": {
     "description": "Update interval in seconds for config updates",
     "privacy": "Public",
-    "value": 60.0
+    "value": 20.0
   },
   "config_manager_config.enable_config_updates": {
     "description": "Enables the resampling of the config every `config_update_interval_secs` seconds",


### PR DESCRIPTION
## What

Change the dynamic config manager's default sampling interval from **60s (1 minute)** to **20s** so the config re-sampling loop (`config_manager_runner`) reacts ~3× faster.

The value lives in a source-of-truth Rust `Default` plus three generated/hand-maintained JSON artifacts; all four are updated to stay consistent:

- `apollo_config_manager_config/src/config.rs` — `ConfigManagerConfig::default().config_update_interval_secs` `60.0` → `20.0`.
- `apollo_deployments/.../app_configs/config_manager_config.json` — hand-maintained base preset (this is what actually runs in prod; it also sets `enable_config_updates: true`).
- `apollo_node/resources/config_schema.json` — regenerated via `cargo run --bin update_apollo_node_config_schema`.
- `apollo_deployments/.../app_configs/replacer_config_manager_config.json` — regenerated via `cargo run --bin deployment_generator`.

`enable_config_updates` is intentionally left unchanged (separate concern).

## Verification

- `cargo build -p apollo_config_manager_config` — clean.
- `SEED=0 cargo test -p apollo_node_config` — 16 passed, incl. `default_config_file_is_up_to_date`.
- `SEED=0 cargo test -p apollo_deployments` — 5 passed, incl. `deployment_files_are_up_to_date` and `duplicate_config_entries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)