### PR TITLE
starknet_transaction_prover: avoid redundant request-id re-parse in RequestSpanLayer

### DIFF
--- a/crates/starknet_transaction_prover/src/server/request_log.rs
+++ b/crates/starknet_transaction_prover/src/server/request_log.rs
@@ -41,6 +41,13 @@ mod request_log_test;
 /// HTTP header carrying the request id.
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
 
+/// Request extension carrying the id this layer already validated/generated,
+/// so a downstream layer (e.g. `RequestSpanLayer`) can reuse it on the
+/// plaintext path instead of re-parsing and re-validating the header it just
+/// set.
+#[derive(Clone)]
+pub(crate) struct RequestId(pub String);
+
 /// tower [`Layer`] producing [`RequestLogService`].
 #[derive(Clone, Copy, Default)]
 pub struct RequestLogLayer;
@@ -78,6 +85,7 @@ where
         let request_id = extract_or_generate_request_id(&request);
         let id_header_value = request_id_header_value(&request_id);
         request.headers_mut().insert(REQUEST_ID_HEADER, id_header_value.clone());
+        request.extensions_mut().insert(RequestId(request_id.clone()));
         let is_health_probe =
             request.method() == Method::GET && request.uri().path() == HEALTH_PATH;
         let method = request.method().clone();

--- a/crates/starknet_transaction_prover/src/server/request_span.rs
+++ b/crates/starknet_transaction_prover/src/server/request_span.rs
@@ -24,6 +24,7 @@ use crate::server::request_log::{
     extract_or_generate_request_id,
     new_request_id,
     request_id_header_value,
+    RequestId,
     REQUEST_ID_HEADER,
 };
 
@@ -69,11 +70,16 @@ where
             request.headers_mut().insert(REQUEST_ID_HEADER, request_id_header_value(&fresh_id));
             fresh_id
         } else {
-            // Re-derives, via the shared validator, the exact id
-            // `RequestLogLayer` already assigned — the header is left
-            // untouched. This also keeps the layer correct standalone,
-            // e.g. in unit tests without `RequestLogLayer` upstream.
-            extract_or_generate_request_id(&request)
+            // Reuses the id `RequestLogLayer` already validated/generated via
+            // its request extension, avoiding a second header parse and
+            // validation pass per request. Falls back to re-deriving it (the
+            // header is left untouched either way) so the layer stays correct
+            // standalone, e.g. in unit tests without `RequestLogLayer`
+            // upstream.
+            request.extensions().get::<RequestId>().map_or_else(
+                || extract_or_generate_request_id(&request),
+                |request_id| request_id.0.clone(),
+            )
         };
         self.inner.call(request).instrument(info_span!("http_request", request_id = %request_id))
     }

--- a/crates/starknet_transaction_prover/src/server/request_span_test.rs
+++ b/crates/starknet_transaction_prover/src/server/request_span_test.rs
@@ -1,12 +1,13 @@
 use bytes::Bytes;
-use http::{Method, Request};
+use http::{Method, Request, Response, StatusCode};
 use http_body_util::Full;
 use jsonrpsee::server::HttpBody;
 use tower::{Layer, ServiceExt};
 use tower_ohttp::Decapsulated;
+use tracing_test::traced_test;
 
 use crate::server::middleware_test_utils::{echo_request_id_service, read_body_and_headers};
-use crate::server::request_log::{RequestLogLayer, REQUEST_ID_HEADER};
+use crate::server::request_log::{RequestId, RequestLogLayer, REQUEST_ID_HEADER};
 use crate::server::request_span::RequestSpanLayer;
 
 #[tokio::test]
@@ -41,6 +42,41 @@ async fn decapsulated_gets_fresh_id_discarding_inbound() {
     let (id, _headers) = read_body_and_headers(response).await;
     assert_ne!(id, "envelope-abc", "must discard the client-supplied inner id");
     assert!(uuid::Uuid::parse_str(&id).is_ok(), "must mint a fresh UUID, got {id:?}");
+}
+
+/// Proves the fast path actually reads the `RequestId` extension instead of
+/// re-parsing the header: the two are set to different values here, which
+/// `RequestLogLayer` never lets happen in production, and the span (checked
+/// via a log line emitted inside it) must carry the extension's value, not
+/// the header's.
+#[tokio::test]
+#[traced_test]
+async fn plaintext_prefers_request_id_extension_over_header() {
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(REQUEST_ID_HEADER, "header-value")
+        .body(HttpBody::new(Full::new(Bytes::new())))
+        .expect("static body is infallible");
+    request.extensions_mut().insert(RequestId("extension-value".to_string()));
+
+    let logging_service = tower::service_fn(|_request: Request<HttpBody>| async move {
+        tracing::info!("handler invoked");
+        Ok::<_, std::convert::Infallible>(
+            Response::builder()
+                .status(StatusCode::OK)
+                .body(HttpBody::new(Full::new(Bytes::new())))
+                .expect("static body is infallible"),
+        )
+    });
+
+    RequestSpanLayer.layer(logging_service).oneshot(request).await.unwrap();
+
+    assert!(logs_contain("extension-value"), "span must carry the RequestId extension's value");
+    assert!(
+        !logs_contain("header-value"),
+        "the mismatched header value must not leak into the span"
+    );
 }
 
 /// The cross-layer plaintext contract: with `RequestLogLayer` (outer) stacked


### PR DESCRIPTION
## What

Follow-up perf cleanup to #14222, which added `RequestSpanLayer` (`crates/starknet_transaction_prover/src/server/request_span.rs`) below the OHTTP layer to bind a tracing span with a request-id over every HTTP request handled by the transaction-prover server.

For plaintext (non-OHTTP) requests, `RequestSpanLayer` called `extract_or_generate_request_id(&request)`, which re-parses and re-validates the `x-request-id` header (UTF-8 conversion, length check, byte-by-byte ASCII-safety scan, `String` allocation) on **every single request** — even though the upstream `RequestLogLayer` (`request_log.rs`), earlier in the same middleware chain (`prover_http_middleware!` in `server.rs`), already computed and validated that exact id moments earlier.

## Fix

`RequestLogLayer::call` now stashes the already-validated id in a new `RequestId(String)` request extension right after computing it. `RequestSpanLayer::call` reads that extension first, and only falls back to `extract_or_generate_request_id` when the extension is absent — e.g. when `RequestSpanLayer` is exercised standalone in unit tests without `RequestLogLayer` upstream. The OHTTP-decapsulated branch (fresh envelope-unlinkable id) is untouched — it never reads this extension.

This is safe because request extensions survive `MapRequestBodyLayer` (`http::Request::map` preserves them) and the OHTTP layer's non-OHTTP passthrough route (`inner.oneshot(request)` with the request unchanged), so the extension set by the outer `RequestLogLayer` reaches the inner `RequestSpanLayer` unmodified in the production chain.

## Tests

- Added `plaintext_prefers_request_id_extension_over_header`, which sets the `RequestId` extension and the `x-request-id` header to two different values (a state `RequestLogLayer` never produces in practice) and asserts, via a traced log line emitted inside the span, that the extension's value — not the header's — is what the span carries. This locks in the fast path so a future refactor can't silently regress back to header re-parsing.
- All pre-existing `starknet_transaction_prover` / `tower_ohttp` tests pass (122 passed, 0 regressions; the only failure, `test_compiled_class_v1_to_casm_round_trip`, is a pre-existing, network-dependent Cairo-compiler-download failure unrelated to this change and reproduces identically on the unmodified base branch).
- `cargo clippy -p starknet_transaction_prover -p tower_ohttp --all-targets` is clean.
- `scripts/rust_fmt.sh` applied, no outstanding diffs.

An independent Opus review confirmed correctness (no cross-request leak — the extension lives in per-request `http::Extensions`, not shared service state; OHTTP unlinkability is fully preserved) and flagged two style/coverage suggestions, both addressed in this PR (`map_or_else` instead of `map().unwrap_or_else()`, and the extension-vs-header divergence test above).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3mvGUJMwN5w18HG58LXjy)_