### PR TITLE
starknet_api: do not panic on malformed resource_bounds in tx json deserializer (#14412)

### DIFF
--- a/crates/starknet_api/src/serde_utils.rs
+++ b/crates/starknet_api/src/serde_utils.rs
@@ -160,23 +160,18 @@ where
 /// In old transactions, the resource bounds names are lowercase.
 /// Need to convert to uppercase for deserialization to work.
 fn upper_case_resource_bounds_names(raw_transaction: &mut Value) {
-    let resource_bounds = raw_transaction
-        .get_mut("resource_bounds")
-        .expect("tx should contain resource_bounds field")
-        .as_object_mut()
-        .expect("resource_bounds should be an object");
+    let Some(resource_bounds) =
+        raw_transaction.get_mut("resource_bounds").and_then(Value::as_object_mut)
+    else {
+        return;
+    };
 
-    if let Some(l1_gas_value) = resource_bounds.remove("l1_gas") {
-        resource_bounds.insert("L1_GAS".to_string(), l1_gas_value);
-
-        let l2_gas_value = resource_bounds
-            .remove("l2_gas")
-            .expect("If tx contains l1_gas, it should contain l2_gas");
-        resource_bounds.insert("L2_GAS".to_string(), l2_gas_value);
-    }
-
-    if let Some(l1_data_gas_value) = resource_bounds.remove("l1_data_gas") {
-        resource_bounds.insert("L1_DATA_GAS".to_string(), l1_data_gas_value);
+    for (lower_case_name, upper_case_name) in
+        [("l1_gas", "L1_GAS"), ("l2_gas", "L2_GAS"), ("l1_data_gas", "L1_DATA_GAS")]
+    {
+        if let Some(resource_bounds_value) = resource_bounds.remove(lower_case_name) {
+            resource_bounds.insert(upper_case_name.to_string(), resource_bounds_value);
+        }
     }
 }
 

--- a/crates/starknet_api/src/serde_utils_test.rs
+++ b/crates/starknet_api/src/serde_utils_test.rs
@@ -10,6 +10,7 @@ use crate::deprecated_contract_class::{
 use crate::serde_utils::{
     bytes_from_hex_str,
     deserialize_optional_contract_class_abi_entry_vector,
+    deserialize_transaction_json_to_starknet_api_tx,
     hex_str_from_bytes,
     BytesAsHex,
     InnerDeserializationError,
@@ -185,4 +186,26 @@ fn deserialize_optional_contract_class_abi_entry_vector_none() {
     "#;
     let res: DummyContractClass = serde_json::from_str(json).unwrap();
     assert_eq!(res, DummyContractClass { abi: None });
+}
+
+/// V3 transaction JSON may arrive from untrusted sources; a missing or malformed
+/// `resource_bounds` field must surface as a deserialization error, not a panic.
+#[test]
+fn deserialize_transaction_json_does_not_panic_on_malformed_resource_bounds() {
+    // Missing resource_bounds field.
+    let raw_transaction = serde_json::json!({"type": "INVOKE", "version": "0x3"});
+    assert!(deserialize_transaction_json_to_starknet_api_tx(raw_transaction).is_err());
+
+    // resource_bounds is not an object.
+    let raw_transaction =
+        serde_json::json!({"type": "INVOKE", "version": "0x3", "resource_bounds": 5});
+    assert!(deserialize_transaction_json_to_starknet_api_tx(raw_transaction).is_err());
+
+    // l1_gas without l2_gas.
+    let raw_transaction = serde_json::json!({
+        "type": "DECLARE",
+        "version": "0x3",
+        "resource_bounds": {"l1_gas": {"max_amount": "0x0", "max_price_per_unit": "0x0"}}
+    });
+    assert!(deserialize_transaction_json_to_starknet_api_tx(raw_transaction).is_err());
 }


### PR DESCRIPTION
Backport of #14412 to the `main-v0.14.3` release branch.

**What:** `upper_case_resource_bounds_names` panicked via `.expect()` on malformed V3-transaction JSON (missing/non-object `resource_bounds`, or `l1_gas` without `l2_gas`). This is reachable from user-controlled input through `apollo_http_server`'s add-transaction path, so a crafted body could panic the serving task. This backport returns a `Result` instead.

**How:** clean `git cherry-pick -x` of `3428d34e39` onto `main-v0.14.3`. Its ancestor #14408 (which moved the deserializer into `starknet_api`) is already on the release branch, so no additional prerequisite.

**Protocol:** no `starknet_version` change — this touches only `starknet_api/src/serde_utils.rs`; `V0_14_3` is preserved.
