### PR TITLE
apollo_protobuf: guard Felt252 conversion against malformed length (#14525)

### DIFF
--- a/crates/apollo_protobuf/src/converters/common.rs
+++ b/crates/apollo_protobuf/src/converters/common.rs
@@ -6,10 +6,21 @@ use super::ProtobufConversionError;
 use crate::protobuf;
 use crate::sync::{BlockHashOrNumber, Direction, Query};
 
+#[cfg(test)]
+#[path = "common_test.rs"]
+mod common_test;
+
 impl TryFrom<protobuf::Felt252> for starknet_types_core::felt::Felt {
     type Error = ProtobufConversionError;
     fn try_from(value: protobuf::Felt252) -> Result<Self, Self::Error> {
         let mut felt = [0; 32];
+        if value.elements.len() != 32 {
+            return Err(ProtobufConversionError::BytesDataLengthMismatch {
+                type_description: "Felt252",
+                num_expected: 32,
+                value: value.elements,
+            });
+        }
         felt.copy_from_slice(&value.elements);
         // TODO(Shahak): use from_bytes_checked once it's available.
         Ok(Self::from_bytes_be(&felt))

--- a/crates/apollo_protobuf/src/converters/common_test.rs
+++ b/crates/apollo_protobuf/src/converters/common_test.rs
@@ -1,0 +1,32 @@
+use rstest::rstest;
+use starknet_types_core::felt::Felt;
+
+use crate::converters::ProtobufConversionError;
+use crate::protobuf;
+
+#[test]
+fn felt252_round_trip() {
+    let felt = Felt::from(0x1234_5678_u64);
+    let protobuf_felt = protobuf::Felt252::from(felt);
+    let result = Felt::try_from(protobuf_felt).unwrap();
+    assert_eq!(felt, result);
+}
+
+#[rstest]
+#[case::too_few_bytes(vec![0; 31])]
+#[case::too_many_bytes(vec![0; 33])]
+#[case::empty(vec![])]
+fn felt252_too_few_bytes_returns_error(#[case] elements: Vec<u8>) {
+    let result = Felt::try_from(protobuf::Felt252 { elements });
+    assert!(
+        matches!(
+            result,
+            Err(ProtobufConversionError::BytesDataLengthMismatch {
+                type_description: "Felt252",
+                num_expected: 32,
+                ..
+            })
+        ),
+        "expected BytesDataLengthMismatch for Felt252, got {result:?}",
+    );
+}


### PR DESCRIPTION
Backport of #14525 to `main-v0.14.3`.

Clean `git cherry-pick -x` of `c06936a9a0`. No `starknet_version` change (`V0_14_3` preserved).
