### PR TITLE
apollo_node_config: enforce config_manager runs locally (no remote client) (#14519)

### DIFF
--- a/crates/apollo_node_config/src/config_test.rs
+++ b/crates/apollo_node_config/src/config_test.rs
@@ -209,6 +209,51 @@ fn validation_only_with_mempool_p2p_enabled_fails() {
     assert!(format!("{err:?}").contains("mempool_p2p"), "Unexpected error: {err:?}");
 }
 
+// The config manager is a local infrastructure component; running it remotely would make its
+// consumers (e.g. the mempool) reach it over a network RPC that can fail mid-request. Both
+// remote-capable execution modes must be rejected at validation time so the client is always local.
+#[test]
+fn config_manager_remote_is_rejected() {
+    // `config_manager_config` is None so the per-component "set iff running locally" check passes
+    // (remote is not running locally) and we reach the config_manager-specific validation.
+    let config = SequencerNodeConfig {
+        components: ComponentConfig {
+            config_manager: ReactiveComponentExecutionConfig::remote(VALID_URL.into(), VALID_PORT),
+            ..Default::default()
+        },
+        config_manager_config: None,
+        state_sync_config: Some(state_sync_config_with_full_archive()),
+        ..Default::default()
+    };
+    let err = config.validate_node_config().unwrap_err();
+    assert!(
+        format!("{err:?}").contains("config_manager must run locally"),
+        "Unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn config_manager_local_with_remote_enabled_is_rejected() {
+    // This mode runs locally, so the default (Some) config_manager_config satisfies the
+    // per-component check and we reach the config_manager-specific validation.
+    let config = SequencerNodeConfig {
+        components: ComponentConfig {
+            config_manager: ReactiveComponentExecutionConfig::local_with_remote_enabled(
+                VALID_URL.into(),
+                VALID_PORT,
+            ),
+            ..Default::default()
+        },
+        state_sync_config: Some(state_sync_config_with_full_archive()),
+        ..Default::default()
+    };
+    let err = config.validate_node_config().unwrap_err();
+    assert!(
+        format!("{err:?}").contains("config_manager must run locally"),
+        "Unexpected error: {err:?}"
+    );
+}
+
 #[test]
 fn validation_only_with_tx_ingestion_disabled_succeeds() {
     let config = SequencerNodeConfig {

--- a/crates/apollo_node_config/src/node_config.rs
+++ b/crates/apollo_node_config/src/node_config.rs
@@ -47,7 +47,7 @@ use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
 
 use crate::component_config::{ComponentConfig, ValidateTxIngestionComponentsDisabled};
-use crate::component_execution_config::ExpectedComponentConfig;
+use crate::component_execution_config::{ExpectedComponentConfig, ReactiveComponentExecutionMode};
 use crate::monitoring::MonitoringConfig;
 use crate::version::VERSION_FULL;
 
@@ -554,6 +554,28 @@ impl SequencerNodeConfig {
             sierra_compiler_config
         );
         validate_component_config_is_set_iff_running_locally!(state_sync, state_sync_config);
+
+        // The config manager is a local infrastructure component: every node runs its own instance
+        // and its consumers (e.g. the mempool) reach it over an in-process channel. Allowing it to
+        // run remotely would turn the per-request `get_*_dynamic_config` calls into network RPCs,
+        // where a transient failure would crash the consuming component. Enforce here that it is
+        // never exposed over (or reached over) the network so that client is always local.
+        match self.components.config_manager.execution_mode {
+            ReactiveComponentExecutionMode::Remote
+            | ReactiveComponentExecutionMode::LocalExecutionWithRemoteEnabled => {
+                return Err(ConfigError::ComponentConfigMismatch {
+                    component_config_mismatch: format!(
+                        "config_manager must run locally without a remote server (execution mode \
+                         must be Disabled or LocalExecutionWithRemoteDisabled), but is {:?}. It \
+                         is a local infrastructure component and must be co-located with its \
+                         consumers.",
+                        self.components.config_manager.execution_mode
+                    ),
+                });
+            }
+            ReactiveComponentExecutionMode::LocalExecutionWithRemoteDisabled
+            | ReactiveComponentExecutionMode::Disabled => {}
+        }
 
         // Validate proposer_idle_detection_delay < batcher_deadline.
         // The batcher_deadline = proposal_timeout - build_proposal_margin.


### PR DESCRIPTION
Backport of #14519 to `main-v0.14.3`.

Clean `git cherry-pick -x` of `6f60e5f0c6`. No `starknet_version` change (`V0_14_3` preserved).
