### PR TITLE
apollo_dashboard: fall back to vector(1) on no-data for consensus_block_number_stuck (#14705)

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -382,7 +382,7 @@
       "name": "consensus_block_number_stuck",
       "title": "Consensus Block Number Stuck",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -408,7 +408,7 @@
       "name": "consensus_block_number_stuck_long_time",
       "title": "Consensus Block Number Stuck Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
@@ -30,8 +30,13 @@ fn get_consensus_block_number_stuck(
     alert_severity: impl Into<SeverityValueOrPlaceholder>,
 ) -> Alert {
     let name = title.to_lowercase().replace(' ', "_");
+    // Fall back to `vector(1)`, not `vector(0)`, when the metric has no samples: an absent/late
+    // series (e.g. transient query-time gaps for a remote-region node) must not read as a halt.
+    // A real halt keeps the gauge present, so `increase` yields a present `0` and still fires;
+    // a dead pod is caught by the `pod_state_not_ready` / `pod_state_crashloopbackoff` alerts.
+    // The fallback must stay `>=` the stuck threshold (`< 1`).
     let expr_template_string = format!(
-        "sum(increase({}[{{}}s])) or vector(0)",
+        "sum(increase({}[{{}}s])) or vector(1)",
         CONSENSUS_BLOCK_NUMBER.get_name_with_filter()
     );
     Alert::new(


### PR DESCRIPTION
Backport of #14705 to `main-v0.14.3`.

Clean `git cherry-pick -x` of `d6d91ab8b5`. No `starknet_version` change (`V0_14_3` preserved).

Generated `dev_grafana_alerts.json` regenerated and verified identical (no-op).
