### PR TITLE
apollo_mempool: make fee-escalation replacement atomic to avoid dropping existing tx (#14517)

### DIFF
--- a/crates/apollo_mempool/src/fee_mempool_test.rs
+++ b/crates/apollo_mempool/src/fee_mempool_test.rs
@@ -24,7 +24,13 @@ use starknet_api::block::GasPrice;
 use starknet_api::rpc_transaction::InternalRpcTransaction;
 use starknet_api::test_utils::invoke::internal_invoke_tx;
 use starknet_api::test_utils::valid_resource_bounds_for_testing;
-use starknet_api::transaction::fields::TransactionSignature;
+use starknet_api::transaction::fields::{
+    AllResourceBounds,
+    ResourceBounds,
+    Tip,
+    TransactionSignature,
+    ValidResourceBounds,
+};
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{contract_address, declare_tx_args, felt, invoke_tx_args, nonce, tx_hash};
 
@@ -1904,6 +1910,143 @@ fn rejects_or_accepts_tx_based_on_freed_space(
     // Transactions tx1 and tx2 are evicted regardless of whether large_tx is accepted or rejected.
     // We do not revert the eviction attempt even if adding large_tx ultimately fails.
     assert!(!mempool.tx_pool.contains_account(contract_address!("0x1")));
+}
+
+// Atomic fee-escalation replacement tests (a rejected replacement must never drop the existing
+// transaction). The replacement's byte size is controlled via the signature length so it can be
+// made larger than the transaction it replaces.
+
+fn invoke_tx_with_signature_size(
+    tx_hash_value: u8,
+    address: &str,
+    tx_nonce_value: u8,
+    tip_value: u64,
+    max_l2_gas_price_value: u128,
+    signature_size: usize,
+) -> InternalRpcTransaction {
+    let resource_bounds = ValidResourceBounds::AllResources(AllResourceBounds {
+        l2_gas: ResourceBounds {
+            max_price_per_unit: GasPrice(max_l2_gas_price_value),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    internal_invoke_tx(invoke_tx_args!(
+        tx_hash: tx_hash!(tx_hash_value),
+        sender_address: contract_address!(address),
+        nonce: nonce!(tx_nonce_value),
+        tip: Tip(tip_value),
+        resource_bounds,
+        signature: TransactionSignature(vec![felt!("0x0"); signature_size].into()),
+    ))
+}
+
+fn full_mempool_with_fee_escalation(capacity_in_bytes: u64) -> Mempool {
+    Mempool::new(
+        MempoolConfig {
+            static_config: MempoolStaticConfig {
+                capacity_in_bytes,
+                enable_fee_escalation: true,
+                fee_escalation_percentage: 10,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        Arc::new(FakeClock::default()),
+    )
+}
+
+fn add_tx_input_for(
+    tx: InternalRpcTransaction,
+    address: &str,
+    account_nonce: u8,
+) -> AddTransactionArgs {
+    AddTransactionArgs {
+        tx,
+        account_state: AccountState {
+            address: contract_address!(address),
+            nonce: nonce!(account_nonce),
+        },
+    }
+}
+
+#[rstest]
+fn fee_escalation_rejected_replacement_does_not_drop_existing_tx() {
+    // Existing tx A occupies the account's next nonce (0). No other account exists, so there is
+    // nothing to evict and a larger replacement cannot be admitted.
+    let existing_tx = invoke_tx_with_signature_size(1, "0x0", 0, 90, 90, 0);
+    let mut mempool = full_mempool_with_fee_escalation(existing_tx.total_bytes());
+    add_tx(&mut mempool, &add_tx_input_for(existing_tx.clone(), "0x0", 0));
+
+    // Higher-fee but larger replacement at the same nonce: rejected, and A must remain.
+    let larger_replacement =
+        add_tx_input_for(invoke_tx_with_signature_size(2, "0x0", 0, 100, 100, 32), "0x0", 0);
+    add_tx_expect_error(&mut mempool, &larger_replacement, MempoolError::MempoolFull);
+
+    assert!(
+        mempool.tx_pool.get_by_tx_hash(existing_tx.tx_hash()).is_ok(),
+        "rejected replacement must not drop the existing transaction"
+    );
+    assert!(mempool.tx_pool.get_by_tx_hash(larger_replacement.tx.tx_hash()).is_err());
+}
+
+#[rstest]
+fn fee_escalation_rejected_replacement_of_gapped_tx_keeps_existing_tx() {
+    // Existing tx A sits at a future nonce (5) while the account nonce is 0, so A is gapped. A
+    // gapped account is never granted eviction, so a larger replacement is rejected.
+    let existing_tx = invoke_tx_with_signature_size(1, "0x0", 5, 90, 90, 0);
+    let mut mempool = full_mempool_with_fee_escalation(existing_tx.total_bytes());
+    add_tx(&mut mempool, &add_tx_input_for(existing_tx.clone(), "0x0", 0));
+
+    let larger_replacement =
+        add_tx_input_for(invoke_tx_with_signature_size(2, "0x0", 5, 100, 100, 32), "0x0", 0);
+    add_tx_expect_error(&mut mempool, &larger_replacement, MempoolError::MempoolFull);
+
+    assert!(
+        mempool.tx_pool.get_by_tx_hash(existing_tx.tx_hash()).is_ok(),
+        "rejected replacement of a gapped tx must not drop it"
+    );
+}
+
+#[rstest]
+fn fee_escalation_same_size_replacement_succeeds_on_full_pool() {
+    // The common case: a same-size, higher-fee bump at the next nonce. Crediting A's freed bytes
+    // nets to zero, so it must replace A on a full pool without any eviction.
+    let existing_tx = invoke_tx_with_signature_size(1, "0x0", 0, 90, 90, 4);
+    let mut mempool = full_mempool_with_fee_escalation(existing_tx.total_bytes());
+    add_tx(&mut mempool, &add_tx_input_for(existing_tx.clone(), "0x0", 0));
+
+    let replacement =
+        add_tx_input_for(invoke_tx_with_signature_size(2, "0x0", 0, 100, 100, 4), "0x0", 0);
+    add_tx(&mut mempool, &replacement);
+
+    assert!(mempool.tx_pool.get_by_tx_hash(replacement.tx.tx_hash()).is_ok(), "B must replace A");
+    assert!(mempool.tx_pool.get_by_tx_hash(existing_tx.tx_hash()).is_err(), "A must be removed");
+}
+
+#[rstest]
+fn fee_escalation_larger_replacement_evicts_to_make_room() {
+    // A larger replacement at the account's next nonce gets the same eviction support as a fresh
+    // next-nonce tx: a third-party gap account is evicted to fit the delta, and A is replaced
+    // (never dropped). Locks in that eviction never targets A.
+    let existing_tx = invoke_tx_with_signature_size(1, "0x0", 0, 90, 90, 0);
+    let evictable_tx = invoke_tx_with_signature_size(2, "0x1", 5, 0, 100, 0);
+    let capacity = existing_tx.total_bytes() + evictable_tx.total_bytes();
+    let mut mempool = full_mempool_with_fee_escalation(capacity);
+    add_tx(&mut mempool, &add_tx_input_for(existing_tx.clone(), "0x0", 0));
+    add_tx(&mut mempool, &add_tx_input_for(evictable_tx.clone(), "0x1", 0));
+
+    // Delta (4 signature felts) is far smaller than the evictable tx, so eviction frees enough.
+    let larger_replacement =
+        add_tx_input_for(invoke_tx_with_signature_size(3, "0x0", 0, 100, 100, 4), "0x0", 0);
+    add_tx(&mut mempool, &larger_replacement);
+
+    assert!(mempool.tx_pool.get_by_tx_hash(larger_replacement.tx.tx_hash()).is_ok());
+    assert!(mempool.tx_pool.get_by_tx_hash(existing_tx.tx_hash()).is_err(), "A must be replaced");
+    assert!(
+        mempool.tx_pool.get_by_tx_hash(evictable_tx.tx_hash()).is_err(),
+        "third-party gap account must be evicted, never A"
+    );
 }
 
 // Stuck-tx counter tests.

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -402,7 +402,7 @@ impl Mempool {
     pub fn validate_tx(&mut self, args: ValidationArgs) -> MempoolResult<()> {
         let tx_reference = (&args).into();
         self.validate_incoming_tx(tx_reference, args.account_nonce)?;
-        self.handle_fee_escalation(tx_reference, true)?;
+        self.validate_fee_escalation(tx_reference)?;
 
         Ok(())
     }
@@ -415,10 +415,29 @@ impl Mempool {
         account_nonce: Nonce,
     ) -> MempoolResult<()> {
         self.validate_incoming_tx(tx_reference, account_nonce)?;
-        self.handle_fee_escalation(tx_reference, false)?;
+        let replaced_tx_reference = self.validate_fee_escalation(tx_reference)?;
 
-        if self.exceeds_capacity(tx) {
-            self.handle_capacity_overflow(tx, account_nonce)?;
+        // The replaced transaction is still pooled, so its bytes still count toward
+        // `size_in_bytes()`. Credit what its removal will free: a same-size bump nets to zero (no
+        // overflow handling), and a larger replacement only needs room for the delta, consistent
+        // with how a fresh next-nonce transaction is treated. The removal happens only after
+        // capacity is confirmed below, so a rejected incoming transaction never strands the
+        // account.
+        let freed_bytes = replaced_tx_reference.map_or(0, |reference| {
+            self.tx_pool
+                .get_by_tx_hash(reference.tx_hash)
+                .expect("Replacement target from pool must exist.")
+                .total_bytes()
+        });
+
+        if self.exceeds_capacity(tx, freed_bytes) {
+            self.handle_capacity_overflow(tx, account_nonce, freed_bytes)?;
+        }
+
+        // Capacity is confirmed: this is the final, infallible mutation before the incoming
+        // transaction is inserted by the caller.
+        if let Some(existing_tx_reference) = replaced_tx_reference {
+            self.remove_replaced_tx(existing_tx_reference);
         }
 
         Ok(())
@@ -591,7 +610,7 @@ impl Mempool {
             // Fee mode: only add transactions with matching account nonce.
             // Remove queued transactions the account might have. This includes old nonce
             // transactions that have become obsolete; those with an equal nonce should
-            // already have been removed in `handle_fee_escalation`.
+            // already have been removed via fee escalation (`remove_replaced_tx`).
             self.tx_queue.remove_by_address(address);
             self.insert_to_tx_queue(tx_reference);
         }
@@ -734,18 +753,14 @@ impl Mempool {
         Ok(())
     }
 
-    /// This method checks if an incoming transaction with the same (address, nonce) already exists
-    /// in the pool and determines whether the incoming transaction should replace it based on fee
-    /// escalation rules.
-    /// If `validation_only` is `true`, only validates whether replacement would be allowed without
-    /// actually removing the existing transaction. If `false`, removes the existing transaction
-    /// when replacement is valid.
-    /// Note: This method will **not** add the new incoming transaction.
-    fn handle_fee_escalation(
-        &mut self,
+    /// Validates whether the incoming transaction may replace an existing one at the same
+    /// `(address, nonce)` via fee escalation, without mutating any state. Returns the existing
+    /// transaction to be replaced when a valid replacement exists, `None` when there is nothing to
+    /// replace, or an error when a replacement is present but not permitted.
+    fn validate_fee_escalation(
+        &self,
         incoming_tx_reference: TransactionReference,
-        validation_only: bool,
-    ) -> MempoolResult<()> {
+    ) -> MempoolResult<Option<TransactionReference>> {
         let TransactionReference { address, nonce, .. } = incoming_tx_reference;
 
         self.validate_no_delayed_declare_front_run(incoming_tx_reference)?;
@@ -755,13 +770,13 @@ impl Mempool {
                 return Err(MempoolError::DuplicateNonce { address, nonce });
             };
 
-            return Ok(());
+            return Ok(None);
         }
 
         let Some(existing_tx_reference) = self.tx_pool.get_by_address_and_nonce(address, nonce)
         else {
             // Replacement irrelevant: no existing transaction with the same nonce for address.
-            return Ok(());
+            return Ok(None);
         };
 
         if !self.should_replace_tx(&existing_tx_reference, &incoming_tx_reference) {
@@ -773,19 +788,20 @@ impl Mempool {
             return Err(MempoolError::DuplicateNonce { address, nonce });
         }
 
-        if validation_only {
-            return Ok(());
-        }
+        Ok(Some(existing_tx_reference))
+    }
 
-        debug!("{existing_tx_reference} will be replaced by {incoming_tx_reference}.");
+    /// Removes the existing transaction that is being replaced via fee escalation. Must be called
+    /// only after the incoming replacement is guaranteed to be admitted, so the account is never
+    /// left without a transaction at this nonce.
+    fn remove_replaced_tx(&mut self, existing_tx_reference: TransactionReference) {
+        debug!("{existing_tx_reference} is being replaced via fee escalation.");
 
         self.tx_queue.remove_txs(&[existing_tx_reference]);
         self.tx_pool
             .remove(existing_tx_reference.tx_hash)
             .expect("Transaction hash from pool must exist.");
-        self.decrement_stuck_txs_if_gap_account(address, 1);
-
-        Ok(())
+        self.decrement_stuck_txs_if_gap_account(existing_tx_reference.address, 1);
     }
 
     fn should_replace_tx(
@@ -918,9 +934,14 @@ impl Mempool {
         }
     }
 
-    // Returns true if the mempool will exceeds its capacity by adding the given transaction.
-    fn exceeds_capacity(&self, tx: &InternalRpcTransaction) -> bool {
-        self.size_in_bytes() + tx.total_bytes() > self.config.static_config.capacity_in_bytes
+    // Returns true if adding the given transaction would exceed the mempool capacity, after
+    // crediting `freed_bytes` that an accompanying removal (e.g. a fee-escalation replacement)
+    // will free. `freed_bytes` is 0 when there is no such removal.
+    fn exceeds_capacity(&self, tx: &InternalRpcTransaction, freed_bytes: u64) -> bool {
+        // The to-be-removed transaction is still counted in `size_in_bytes()` here, so subtract
+        // what its removal frees. `saturating_sub` guards the (impossible) underflow defensively.
+        (self.size_in_bytes() + tx.total_bytes()).saturating_sub(freed_bytes)
+            > self.config.static_config.capacity_in_bytes
     }
 
     fn update_accounts_with_gap(&mut self, address_to_nonce: AddressToNonce) {
@@ -1003,6 +1024,7 @@ impl Mempool {
         &mut self,
         tx: &InternalRpcTransaction,
         account_nonce: Nonce,
+        freed_bytes: u64,
     ) -> Result<(), MempoolError> {
         let address = tx.contract_address();
 
@@ -1011,7 +1033,10 @@ impl Mempool {
         let closing_gap = tx.nonce() == account_nonce;
         let creating_gap = (account_has_gap || !account_has_txs) && !closing_gap;
 
-        if !creating_gap && self.try_make_space(tx.total_bytes()) {
+        // Only the net growth must be evicted: an accompanying replacement removal frees
+        // `freed_bytes` (0 when there is no replacement).
+        let required_space = tx.total_bytes().saturating_sub(freed_bytes);
+        if !creating_gap && self.try_make_space(required_space) {
             return Ok(());
         }
 


### PR DESCRIPTION
Backport of #14517 to `main-v0.14.3`.

Clean `git cherry-pick -x` of `d1dc85d2a5`. No `starknet_version` change (`V0_14_3` preserved).
