### PR TITLE
apollo_mempool: use saturating_sub for n_stuck_txs accounting (#14560)

### DIFF
--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -933,7 +933,7 @@ impl Mempool {
 
     fn decrement_stuck_txs_if_gap_account(&mut self, address: ContractAddress, n: usize) {
         if self.accounts_with_gap.contains(&address) {
-            self.n_stuck_txs -= n;
+            self.n_stuck_txs = self.n_stuck_txs.saturating_sub(n);
         }
     }
 
@@ -941,7 +941,8 @@ impl Mempool {
     // n_stuck_txs. No-op if the address was not tracked.
     fn remove_from_accounts_with_gap(&mut self, address: ContractAddress) {
         if self.accounts_with_gap.swap_remove(&address) {
-            self.n_stuck_txs -= self.tx_pool.n_txs_for_address(address);
+            self.n_stuck_txs =
+                self.n_stuck_txs.saturating_sub(self.tx_pool.n_txs_for_address(address));
         }
     }
 


### PR DESCRIPTION
Backport of #14560 to `main-v0.14.3`.

Clean `git cherry-pick -x` of `7368031982`. No `starknet_version` change (`V0_14_3` preserved).

Stacked on `matanl/bp-14517-mempool-atomic-replace` — merge that first.
