### PR TITLE
apollo_consensus: statically cap cached future votes to prevent OOM (#14500)

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -24,7 +24,7 @@ use apollo_network::network_manager::BroadcastTopicClientTrait;
 use apollo_network_types::network_types::BroadcastedMessageMetadata;
 use apollo_protobuf::consensus::{BuildParam, ProposalInit, Vote, VoteType};
 use apollo_protobuf::converters::ProtobufConversionError;
-use apollo_staking::committee_provider::{CommitteeProvider, CommitteeTrait};
+use apollo_staking::committee_provider::{CommitteeProvider, CommitteeTrait, MAX_COMMITTEE_SIZE};
 use apollo_time::time::{Clock, ClockExt, DefaultClock};
 use futures::channel::mpsc::{self};
 use futures::future::BoxFuture;
@@ -211,6 +211,10 @@ pub struct EquivocationVoteReport {
     pub new_vote: Vote,
 }
 
+/// Number of vote types a validator can cast per round ([`VoteType::Prevote`] and
+/// [`VoteType::Precommit`]). Used to bound the future-vote cache.
+const NUM_VOTE_TYPES: usize = 2;
+
 /// Manages votes and proposals for future heights.
 #[derive(Debug)]
 struct ConsensusCache<ContextT: ConsensusContext> {
@@ -286,8 +290,21 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
         self.get_current_height_proposals(height);
     }
 
+    /// Maximum number of future votes cached per height: an upper bound on the number of distinct,
+    /// non-equivocating votes an honest committee can produce across the cached future rounds
+    /// (`MAX_COMMITTEE_SIZE * NUM_VOTE_TYPES * rounds`). Uses the static `MAX_COMMITTEE_SIZE`
+    /// rather than the live committee size so the cap is always available (e.g. on syncing
+    /// nodes that never run a height locally).
+    fn future_votes_cap(&self) -> usize {
+        let cached_rounds = usize::try_from(self.future_msg_limit.future_height_round_limit)
+            .expect("future_height_round_limit should fit in usize")
+            + 1;
+        MAX_COMMITTEE_SIZE.saturating_mul(NUM_VOTE_TYPES).saturating_mul(cached_rounds)
+    }
+
     /// Caches a vote for a future height.
     fn cache_future_vote(&mut self, vote: Vote) -> Result<(), Box<EquivocationVoteReport>> {
+        let cap = self.future_votes_cap();
         let votes = self.future_votes.entry(vote.height).or_default();
         // Find a vote in the list with the same type, round, and voter. If found, do not add it to
         // list.
@@ -306,8 +323,23 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
                 }))
             }
         } else {
-            // If no duplicate vote was found, we add the vote to the list.
-            votes.push(vote);
+            // Bound the cache to what an honest committee could produce. Since vote signatures are
+            // not yet verified, a peer can forge votes with arbitrary voter addresses; without this
+            // cap that would grow `future_votes` without bound and exhaust memory.
+            if votes.len() < cap {
+                votes.push(vote);
+            } else {
+                // TODO(Matan): once the network expands beyond the current trusted set, rate-limit
+                // this log (e.g. `trace_every_n_ms!`) so that dropping votes can't itself be used
+                // as a log-flood DoS.
+                warn!(
+                    height = vote.height.0,
+                    round = vote.round,
+                    voter = ?vote.voter,
+                    cap,
+                    "Dropping future vote: per-height cache cap reached."
+                );
+            }
             Ok(())
         }
     }

--- a/crates/apollo_consensus/src/manager_test.rs
+++ b/crates/apollo_consensus/src/manager_test.rs
@@ -26,6 +26,7 @@ use apollo_staking::committee_provider::{
     MockCommitteeProvider,
     MockCommitteeTrait,
     Staker,
+    MAX_COMMITTEE_SIZE,
 };
 use apollo_storage::StorageConfig;
 use apollo_test_utils::{get_rng, GetTestInstance};
@@ -41,7 +42,7 @@ use starknet_types_core::felt::Felt;
 use tokio::sync::Mutex;
 use tracing_test::traced_test;
 
-use super::{run_consensus, MultiHeightManager, RunHeightRes};
+use super::{run_consensus, ConsensusCache, MultiHeightManager, RunHeightRes, NUM_VOTE_TYPES};
 use crate::manager::CONSENSUS_RUNNING_PAST_STOP_HEIGHT;
 use crate::storage::MockHeightVotedStorageTrait;
 use crate::test_utils::{
@@ -1289,6 +1290,45 @@ async fn cache_future_vote_deduplication(consensus_config: ConsensusConfig) {
         reported_messages_receiver.try_next().is_err(),
         "Expected no additional report_peer calls (duplicate should be silently ignored)"
     );
+}
+
+/// Builds `n` distinct validator ids, for use as distinct vote voters.
+fn distinct_voters(n: usize) -> Vec<ValidatorId> {
+    (0..n)
+        .map(|i| {
+            let offset = u64::try_from(i).expect("voter index should fit in u64");
+            (DEFAULT_VALIDATOR_ID + 1 + offset).into()
+        })
+        .collect()
+}
+
+/// The number of future votes cached for a height is statically bounded by the
+/// `MAX_COMMITTEE_SIZE`-derived cap, even when flooded with votes from arbitrary (forged) voters.
+#[test]
+fn future_votes_capped() {
+    let mut cache = ConsensusCache::<MockTestContext>::new(FutureMsgLimitsConfig::default());
+    let cached_rounds = usize::try_from(FutureMsgLimitsConfig::default().future_height_round_limit)
+        .expect("future_height_round_limit should fit in usize")
+        + 1;
+    let expected_cap = MAX_COMMITTEE_SIZE * NUM_VOTE_TYPES * cached_rounds;
+
+    // Flood more distinct-voter future votes than the cap allows.
+    for voter in distinct_voters(expected_cap + 5) {
+        cache.cache_future_vote(prevote(Some(Felt::ONE), HEIGHT_1, ROUND_0, voter)).unwrap();
+    }
+
+    assert_eq!(cache.future_votes[&HEIGHT_1].len(), expected_cap);
+}
+
+/// Honest volume (well under the cap) is fully retained.
+#[test]
+fn future_votes_below_cap_are_all_retained() {
+    let mut cache = ConsensusCache::<MockTestContext>::new(FutureMsgLimitsConfig::default());
+    let num_votes = 50;
+    for voter in distinct_voters(num_votes) {
+        cache.cache_future_vote(prevote(Some(Felt::ONE), HEIGHT_1, ROUND_0, voter)).unwrap();
+    }
+    assert_eq!(cache.future_votes[&HEIGHT_1].len(), num_votes);
 }
 
 #[rstest]

--- a/crates/apollo_staking/src/committee_provider.rs
+++ b/crates/apollo_staking/src/committee_provider.rs
@@ -12,6 +12,11 @@ use thiserror::Error;
 
 use crate::staking_contract::StakingContractError;
 
+/// A generous upper bound on the committee size, used by consumers that need a static bound on
+/// committee-derived quantities (e.g. sizing caches) without fetching the live committee. The
+/// configured committee size is operationally ~100; this leaves ample headroom.
+pub const MAX_COMMITTEE_SIZE: usize = 1000;
+
 pub type StakerSet = Vec<Staker>;
 
 #[cfg_attr(test, derive(Clone))]


### PR DESCRIPTION
Backport of #14500 to `main-v0.14.3`.

Clean `git cherry-pick -x` of `86b206775f`. No `starknet_version` change (`V0_14_3` preserved).
