### PR TITLE
apollo_consensus: store decided round in Decision to drop fragile precommits[0] index (#14605)

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -162,9 +162,7 @@ where
             .await?
         {
             RunHeightRes::Decision(decision) => {
-                // We expect there to be under 100 validators, so this is a reasonable number of
-                // precommits to print.
-                let round = decision.precommits[0].round;
+                let round = decision.round;
                 // Proposer should never fail here, we already checked it in the state machine.
                 let proposer = get_proposer_for_height(
                     &run_consensus_args.committee_provider,
@@ -176,6 +174,7 @@ where
                 if proposer == run_consensus_args.consensus_config.dynamic_config.validator_id {
                     CONSENSUS_DECISIONS_REACHED_AS_PROPOSER.increment(1);
                 }
+                // Under 100 validators expected, so printing all precommits is reasonable.
                 info!(
                     "DECISION_REACHED: Decision reached for round {} with proposer {}. {:?}",
                     round, proposer, decision
@@ -508,11 +507,7 @@ impl<ContextT: ConsensusContext> MultiHeightManager<ContextT> {
         let res = match consensus_result {
             Ok(ok) => match ok {
                 RunHeightRes::Decision(decision) => {
-                    let decided_round = decision
-                        .precommits
-                        .first()
-                        .expect("Decision must contain at least one precommit")
-                        .round;
+                    let decided_round = decision.round;
                     let wait_for_last_commitment =
                         self.consensus_config.dynamic_config.stop_at_height == Some(height);
                     // Commit decision to context.

--- a/crates/apollo_consensus/src/state_machine.rs
+++ b/crates/apollo_consensus/src/state_machine.rs
@@ -712,7 +712,7 @@ impl StateMachine {
             .map(|(_vote_key, (v, _w))| v.clone())
             .collect();
 
-        let decision = Decision { precommits: supporting_precommits, block: *proposal_id };
+        let decision = Decision { precommits: supporting_precommits, block: *proposal_id, round };
         VecDeque::from([SMRequest::DecisionReached(decision)])
     }
 

--- a/crates/apollo_consensus/src/state_machine_test.rs
+++ b/crates/apollo_consensus/src/state_machine_test.rs
@@ -70,6 +70,7 @@ fn assert_decision_reached(wrapper: &mut TestWrapper, expected_block: Option<Pro
     match wrapper.next_request().unwrap() {
         SMRequest::DecisionReached(dec) => {
             assert_eq!(dec.block, expected_block.unwrap());
+            assert_eq!(dec.round, ROUND, "Decision should carry the round it was reached at");
             assert!(!dec.precommits.is_empty(), "Decision should have precommits");
         }
         req => panic!("Expected DecisionReached, got {:?}", req),
@@ -672,6 +673,40 @@ fn observer_node_reaches_decision() {
     advance_to_precommit_quorum_then_maybe_timeout(&mut wrapper, PROPOSAL_ID, 3, false);
     // Once a quorum of precommits is observed, the node should generate a decision event.
     assert_decision_reached(&mut wrapper, PROPOSAL_ID);
+}
+
+#[test]
+fn decision_carries_the_round_it_was_reached_at() {
+    let decided_round = ROUND + 1;
+    let mut wrapper = TestWrapper::new(
+        *VALIDATOR_ID,
+        UNIT_VALIDATOR_WEIGHTS.clone(),
+        |_: Round| *PROPOSER_ID,
+        |_: Round| Ok(*PROPOSER_ID),
+        QuorumType::Byzantine,
+        IS_OBSERVER,
+    );
+
+    advance_validator_after_start(&mut wrapper);
+
+    // A precommit quorum at the next round skips the current round; once the proposal is validated
+    // there, the observer reaches a decision at that round.
+    for _ in 0..3 {
+        wrapper.send_precommit(PROPOSAL_ID, decided_round);
+    }
+    wrapper.send_finished_validation(PROPOSAL_ID, decided_round);
+
+    let mut decision = None;
+    while let Some(request) = wrapper.next_request() {
+        if let SMRequest::DecisionReached(dec) = request {
+            decision = Some(dec);
+            break;
+        }
+    }
+    let decision = decision.expect("Expected a DecisionReached request");
+    assert_eq!(decision.round, decided_round);
+    assert!(!decision.precommits.is_empty());
+    assert!(decision.precommits.iter().all(|vote| vote.round == decided_round));
 }
 
 #[test_case(QuorumType::Byzantine; "byzantine")]

--- a/crates/apollo_consensus/src/types.rs
+++ b/crates/apollo_consensus/src/types.rs
@@ -118,6 +118,8 @@ pub trait ConsensusContext {
 pub struct Decision {
     pub precommits: Vec<Vote>,
     pub block: ProposalCommitment,
+    /// The round at which this decision was reached.
+    pub round: Round,
 }
 
 pub struct BroadcastVoteChannel {


### PR DESCRIPTION
Backport of #14605 to `main-v0.14.3`.

Clean `git cherry-pick -x` of `a87f118a83`. No `starknet_version` change (`V0_14_3` preserved).

Stacked on `matanl/bp-14500-future-vote-cap` — merge that first.
