### PR TITLE
starknet_os: remove stale allow(dead_code)

### DIFF
--- a/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
@@ -541,7 +541,6 @@ where
 }
 
 /// Decompresses the given compressed data.
-#[allow(dead_code)]
 pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
     fn unpack_chunk<const LENGTH: usize>(
         compressed: &mut impl Iterator<Item = Felt>,


### PR DESCRIPTION
## Description

Removes the stale `#[allow(dead_code)]` on `stateless_compression::utils::decompress`. The function is **not dead** — the annotation is no longer load-bearing and only hides that fact from readers.

### Why the annotation is stale (live caller in the default build)

`decompress` has a live, non-test caller:
- Imported (ungated) at `crates/starknet_os/src/io/os_output_types.rs:10`.
- Called at `os_output_types.rs:407`, inside `impl TryFromOutputIter for PartialOsStateDiff::try_from_output_iter`.
- That impl is reached from production code at `crates/starknet_os/src/io/os_output.rs:394`: `OsStateDiff::Partial(PartialOsStateDiff::try_from_output_iter(...))`.

None of these are behind `#[cfg(...)]`. `stateless_compression` is `pub(crate)`, so `decompress` is crate-internal (not part of the public API) and *would* be reported `dead_code` if it were actually unused — it is not. The workspace already builds in CI with `RUSTFLAGS: "-D warnings"`, and the ungated `use ... decompress;` alone would fail that build if the function were dead.

### Verification

Run locally with the cairo0 venv active (`RUSTC_WRAPPER=""`, `CARGO_INCREMENTAL=0`):
- `cargo build -p starknet_os` — **zero** dead-code/unused warnings.
- `cargo build -p starknet_os --tests` — **zero** dead-code/unused warnings.
- `scripts/rust_fmt.sh` — clean, no changes.
- `cargo clippy -p starknet_os --all-targets` — clean, exit 0.
- `SEED=0 cargo test -p starknet_os stateless_compression` — 35 passed, 0 failed (directly exercises `decompress`).

This change is behavior-neutral: it removes an annotation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_016XoX1Vh9HertuF6zhMLo7k)_