### PR TITLE
apollo_mempool: drop emptied gap accounts on tx expiry to fix accounts_with_gap leak

### DIFF
--- a/crates/apollo_mempool/src/fee_mempool_test.rs
+++ b/crates/apollo_mempool/src/fee_mempool_test.rs
@@ -2038,6 +2038,66 @@ fn stuck_txs_counter_expiry_decrements_count() {
 }
 
 #[test]
+fn stuck_txs_counter_expiry_removes_emptied_gap_account() {
+    let fake_clock = Arc::new(FakeClock::default());
+    let mut mempool = Mempool::new(
+        MempoolConfig {
+            dynamic_config: MempoolDynamicConfig { transaction_ttl: Duration::from_secs(60) },
+            ..Default::default()
+        },
+        fake_clock.clone(),
+    );
+
+    // Gap account with a single stuck tx (nonce 2, gap at 0 and 1).
+    let tx_nonce_2 = add_tx_input!(tx_hash: 1, address: "0x0", tx_nonce: 2, account_nonce: 0);
+    add_tx(&mut mempool, &tx_nonce_2);
+    assert_gap_metrics(&mempool, 1, 1);
+
+    // Expire the account's only stuck tx, then trigger the expiry sweep via a tx for another
+    // address.
+    fake_clock.advance(Duration::from_secs(61));
+    let trigger = add_tx_input!(tx_hash: 2, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    add_tx(&mut mempool, &trigger);
+
+    // The stuck tx is non-queued, so it never re-enters update_accounts_with_gap; the emptied gap
+    // account must still leave accounts_with_gap so both counters return to zero.
+    assert_gap_metrics(&mempool, 0, 0);
+}
+
+#[test]
+fn stuck_txs_counter_expiry_removes_gap_account_with_multiple_stuck_txs() {
+    let fake_clock = Arc::new(FakeClock::default());
+    let mut mempool = Mempool::new(
+        MempoolConfig {
+            dynamic_config: MempoolDynamicConfig { transaction_ttl: Duration::from_secs(60) },
+            ..Default::default()
+        },
+        fake_clock.clone(),
+    );
+
+    // Gap account with two stuck txs (nonces 2 and 3, gap at 0 and 1), submitted at the same time
+    // so they expire together in a single sweep.
+    let tx_nonce_2 = add_tx_input!(tx_hash: 1, address: "0x0", tx_nonce: 2, account_nonce: 0);
+    let tx_nonce_3 = add_tx_input!(tx_hash: 2, address: "0x0", tx_nonce: 3, account_nonce: 0);
+    for tx in [&tx_nonce_2, &tx_nonce_3] {
+        add_tx(&mut mempool, tx);
+    }
+    assert_gap_metrics(&mempool, 1, 2);
+
+    // Expire both stuck txs, then trigger the sweep via a tx for another address.
+    fake_clock.advance(Duration::from_secs(61));
+    let trigger = add_tx_input!(tx_hash: 3, address: "0x1", tx_nonce: 0, account_nonce: 0);
+    add_tx(&mut mempool, &trigger);
+
+    // All of the account's stuck txs expired in one sweep, so both counters must reach zero. This
+    // guards the two-phase structure of remove_expired_txs: the account must stay in
+    // accounts_with_gap until every stuck tx is decremented (decrement_stuck_txs_if_gap_account
+    // only acts while the account is tracked), and only then be removed. Merging decrement and
+    // removal into one loop would no-op the second tx's decrement and leave stuck_txs == 1.
+    assert_gap_metrics(&mempool, 0, 0);
+}
+
+#[test]
 fn stuck_txs_counter_eviction_decrements_count() {
     let tx_gap = add_tx_input!(tx_hash: 1, address: "0x0", tx_nonce: 2, account_nonce: 0);
     let capacity = tx_gap.tx.total_bytes();

--- a/crates/apollo_mempool/src/mempool.rs
+++ b/crates/apollo_mempool/src/mempool.rs
@@ -840,6 +840,17 @@ impl Mempool {
             self.decrement_stuck_txs_if_gap_account(tx_ref.address, 1);
         }
 
+        // Drop gap accounts that expiry left with no pool txs. Their stuck txs are non-queued, so
+        // the queued-tx map returned below never re-evaluates them; without this they
+        // linger in `accounts_with_gap` (accounts_with_gap > 0 while stuck_txs == 0). Runs
+        // after the decrement loop above: removing an account from the set early would make
+        // its per-tx stuck decrements no-op.
+        for tx_ref in &removed_txs {
+            if !self.tx_pool.contains_account(tx_ref.address) {
+                self.remove_from_accounts_with_gap(tx_ref.address);
+            }
+        }
+
         let queued_txs = self.tx_queue.remove_txs(&removed_txs);
 
         self.log_and_count_expired_txs(&removed_txs);


### PR DESCRIPTION
## Problem

On mainnet Grafana (v0.14.3), `mempool_accounts_with_gap` never drops below 1, while `mempool_stuck_txs` sometimes hits 0 — an impossible pair, since a nonce-gap account must hold at least one stuck tx. One counter is leaking.

**Root cause** (`Mempool::remove_expired_txs`): when a gap account's *stuck* txs expire (TTL), the per-tx loop correctly decrements `n_stuck_txs`, but the `AddressToNonce` map it returns — the only input to `update_accounts_with_gap` — is built from `queued_txs` only. Stuck txs are **never in `tx_queue`** (fee mode enqueues only txs whose nonce == account nonce; a gap tx has a higher nonce), so a gap account whose stuck txs all expire is never re-evaluated and lingers in `accounts_with_gap`. There's no GC (only a `TODO(clean_accounts)`), so it self-heals only if a new tx for that account later arrives or it's committed/evicted → a persistent floor of ~1 ghost account (`accounts_with_gap` > 0 while `stuck_txs` == 0).

### Evidence (GCP logs, `apollo-mainnet-0`, `sequencer-mempool`, 11:02–11:07 UTC)
- Bot accounts repeatedly enter the gap state (`Account 0x04678eb4…61b5 has a nonce gap; 1 transaction(s) are now stuck.`, also `0x048ddc…441f`, `0x05aed2…2cba`).
- The same stuck tx hashes (`0x3e17…ff87c`, `0x4c30…1e84`) are `Removed expired transactions` three times, exactly 5 min apart (10:51/10:56/11:01) — stuck txs expiring, P2P-rebroadcast, re-expiring.

## Fix

After the existing decrement loop, drop any account expiry left with no pool txs (mirrors the emptiness cleanup already in `try_make_space`):

```rust
for tx_ref in &removed_txs {
    if !self.tx_pool.contains_account(tx_ref.address) {
        self.remove_from_accounts_with_gap(tx_ref.address);
    }
}
```

Must be a **separate** loop after the decrements, otherwise removing an account from the set early would make its remaining per-tx `decrement_stuck_txs_if_gap_account` calls no-op and undercount. `remove_from_accounts_with_gap` subtracts `n_txs_for_address` = 0 at cleanup time (no double-decrement) and is idempotent on duplicate addresses.

Note: deliberately **not** fixed by mapping all `removed_txs` into the returned nonce map — `resolve_nonce(addr, hint)` falls back to `hint` only when state has no committed/staged nonce; for a stuck tx `hint = tx.nonce > account_nonce`, which would mis-evaluate accounts that still hold txs. The correct signal is nonce-independent: the account has no pool txs left.

## Tests

Added `stuck_txs_counter_expiry_removes_emptied_gap_account` (the existing `_expiry_decrements_count` only expires 1 of 2 txs, so the account legitimately stays and the leak was uncovered). A single stuck tx fully expires → asserts both counters return to 0. **Fails pre-fix** with `accounts_with_gap mismatch left=1 right=0` (the exact prod symptom); passes post-fix.

Verified: full `apollo_mempool` suite 113/0, `rust_fmt.sh` clean, `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)