### PR TITLE
apollo_protobuf: avoid redundant entry-point/program clones in class conversions

### DIFF
--- a/crates/apollo_protobuf/src/converters/class.rs
+++ b/crates/apollo_protobuf/src/converters/class.rs
@@ -159,29 +159,26 @@ impl From<deprecated_contract_class::ContractClass> for protobuf::Cairo0Class {
             None => "".to_string(),
         };
 
+        // `value` is owned and not used again, so entry points can be moved out of the map
+        // instead of cloned.
+        let mut entry_points_by_type = value.entry_points_by_type;
         protobuf::Cairo0Class {
-            constructors: value
-                .entry_points_by_type
-                .get(&EntryPointType::Constructor)
-                .unwrap_or(&vec![])
-                .iter()
-                .cloned()
+            constructors: entry_points_by_type
+                .remove(&EntryPointType::Constructor)
+                .unwrap_or_default()
+                .into_iter()
                 .map(protobuf::EntryPoint::from)
                 .collect(),
-            externals: value
-                .entry_points_by_type
-                .get(&EntryPointType::External)
-                .unwrap_or(&vec![])
-                .iter()
-                .cloned()
+            externals: entry_points_by_type
+                .remove(&EntryPointType::External)
+                .unwrap_or_default()
+                .into_iter()
                 .map(protobuf::EntryPoint::from)
                 .collect(),
-            l1_handlers: value
-                .entry_points_by_type
-                .get(&EntryPointType::L1Handler)
-                .unwrap_or(&vec![])
-                .iter()
-                .cloned()
+            l1_handlers: entry_points_by_type
+                .remove(&EntryPointType::L1Handler)
+                .unwrap_or_default()
+                .into_iter()
                 .map(protobuf::EntryPoint::from)
                 .collect(),
             abi: encoded_abi,
@@ -201,8 +198,7 @@ impl TryFrom<protobuf::Cairo1Class> for state::SierraContractClass {
         let contract_class_version = value.contract_class_version;
 
         let mut entry_points_by_type = HashMap::new();
-        let entry_points =
-            value.entry_points.clone().ok_or(missing("Cairo1Class::entry_points"))?;
+        let entry_points = value.entry_points.ok_or(missing("Cairo1Class::entry_points"))?;
         if !entry_points.constructors.is_empty() {
             entry_points_by_type.insert(
                 EntryPointType::Constructor,
@@ -249,36 +245,26 @@ impl From<state::SierraContractClass> for protobuf::Cairo1Class {
     fn from(value: state::SierraContractClass) -> Self {
         let abi = value.abi;
 
-        let program =
-            value.sierra_program.clone().into_iter().map(protobuf::Felt252::from).collect();
+        let program = value.sierra_program.into_iter().map(protobuf::Felt252::from).collect();
 
+        // `value` is owned and not used again, so entry points can be moved out of
+        // `entry_points_by_type` directly instead of round-tripping through a cloned
+        // `HashMap` per entry-point kind (`to_hash_map` clones all three vectors on every call).
+        let entry_points_by_type = value.entry_points_by_type;
         let entry_points = Some(protobuf::Cairo1EntryPoints {
-            constructors: value
-                .entry_points_by_type
-                .to_hash_map()
-                .get(&EntryPointType::Constructor)
-                .unwrap_or(&vec![])
-                .iter()
-                .cloned()
+            constructors: entry_points_by_type
+                .constructor
+                .into_iter()
                 .map(protobuf::SierraEntryPoint::from)
                 .collect(),
-
-            externals: value
-                .entry_points_by_type
-                .to_hash_map()
-                .get(&EntryPointType::External)
-                .unwrap_or(&vec![])
-                .iter()
-                .cloned()
+            externals: entry_points_by_type
+                .external
+                .into_iter()
                 .map(protobuf::SierraEntryPoint::from)
                 .collect(),
-            l1_handlers: value
-                .entry_points_by_type
-                .to_hash_map()
-                .get(&EntryPointType::L1Handler)
-                .unwrap_or(&vec![])
-                .iter()
-                .cloned()
+            l1_handlers: entry_points_by_type
+                .l1handler
+                .into_iter()
                 .map(protobuf::SierraEntryPoint::from)
                 .collect(),
         });


### PR DESCRIPTION
## What

Perf follow-up prompted by reviewing #14746 (backport of #14525, "apollo_protobuf: guard Felt252 conversion against malformed length") for hot-path issues in `apollo_protobuf`'s converters, which run for every element of every block/class synced over P2P.

While auditing `crates/apollo_protobuf/src/converters/class.rs` I found redundant cloning in the Cairo0/Cairo1 contract-class ⇄ protobuf conversions:

- `From<state::SierraContractClass> for protobuf::Cairo1Class` called `EntryPointByType::to_hash_map()` **three separate times** (once per entry-point kind). `to_hash_map()` (`starknet_api::rpc_transaction`) clones **all three** underlying `Vec<EntryPoint>` on every call, so this was 9 full vector clones plus 3 more `.iter().cloned()` clones just to build one protobuf message — and it also cloned the full `sierra_program` felt vector (can be large for big contracts).
- `TryFrom<protobuf::Cairo1Class> for state::SierraContractClass` cloned `value.entry_points` even though `value` is consumed by-value and never read again afterward.
- `From<deprecated_contract_class::ContractClass> for protobuf::Cairo0Class` did the same `.get(&type).unwrap_or(&vec[]).iter().cloned()` pattern per entry-point kind, again on an owned, never-reused `value`.

Since `value` is owned in all three conversions and not used again after these extractions, the fields can simply be moved out instead of cloned. This removes all the clones/HashMap round-trips without changing behavior — the field mapping (`constructor`/`external`/`l1handler` ↔ `EntryPointType::{Constructor,External,L1Handler}`) and empty-case fallback (`unwrap_or_default()` vs. the old `unwrap_or(&vec[])`) are preserved exactly.

This runs on every contract class synced or served over the P2P class-sync protocol, so it's a real (if modest per-call) win, not cosmetic.

## Verification

- `cargo build -p apollo_protobuf` — clean.
- `cargo clippy -p apollo_protobuf --all-targets` — clean.
- `SEED=0 cargo test -p apollo_protobuf` — 70 passed, including `converters::class::class_test::convert_cairo_0_class_to_protobuf_and_back`. The only failure (`protoc_regression_test::protoc_output_matches_result_of_running_protoc`) is a pre-existing, environment-only failure (sandbox blocks the GitHub download of `protoc`) reproduced identically on unmodified `main`.
- Reviewed by an independent agent for correctness (field-mapping equivalence, partial-move safety, edge-case behavior on absent entry-point kinds) — no issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSqbyVHh1njhV18VSHAbUV)_