### PR TITLE
apollo_consensus: use IndexMap for O(1) future-vote dedup lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ dependencies = [
  "async-trait",
  "enum-as-inner",
  "futures",
+ "indexmap 2.14.0",
  "lazy_static",
  "lru 0.12.5",
  "mockall",

--- a/crates/apollo_consensus/Cargo.toml
+++ b/crates/apollo_consensus/Cargo.toml
@@ -23,6 +23,7 @@ apollo_storage = { workspace = true }
 apollo_time = { workspace = true, features = ["tokio"] }
 async-trait.workspace = true
 futures.workspace = true
+indexmap.workspace = true
 lazy_static.workspace = true
 lru.workspace = true
 mockall = { workspace = true, optional = true }

--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -30,7 +30,9 @@ use futures::channel::mpsc::{self};
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
+use indexmap::IndexMap;
 use starknet_api::block::BlockNumber;
+use starknet_api::core::ContractAddress;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, instrument, trace, warn};
 
@@ -219,8 +221,11 @@ const NUM_VOTE_TYPES: usize = 2;
 /// Manages votes and proposals for future heights.
 #[derive(Debug)]
 struct ConsensusCache<ContextT: ConsensusContext> {
-    // Mapping: { Height : Vec<Vote> }
-    future_votes: BTreeMap<BlockNumber, Vec<Vote>>,
+    // Mapping: { Height : { (VoteType, Round, Voter) : Vote } }. Keyed by the same triple used
+    // for duplicate/equivocation detection so lookups are O(1) instead of an O(cache size) scan;
+    // `IndexMap` preserves insertion order so `get_current_height_votes` still replays votes in
+    // the order they were cached.
+    future_votes: BTreeMap<BlockNumber, IndexMap<(VoteType, Round, ContractAddress), Vote>>,
     // Mapping: { Height : { Round : (BlockInfo, Receiver)}}
     future_proposals_cache:
         BTreeMap<BlockNumber, BTreeMap<Round, ProposalReceiverTuple<ContextT::ProposalPart>>>,
@@ -253,7 +258,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             };
             match entry.key().cmp(&height) {
                 std::cmp::Ordering::Greater => return Vec::new(),
-                std::cmp::Ordering::Equal => return entry.remove(),
+                std::cmp::Ordering::Equal => return entry.remove().into_values().collect(),
                 std::cmp::Ordering::Less => {
                     entry.remove();
                 }
@@ -307,12 +312,9 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
     fn cache_future_vote(&mut self, vote: Vote) -> Result<(), Box<EquivocationVoteReport>> {
         let cap = self.future_votes_cap();
         let votes = self.future_votes.entry(vote.height).or_default();
-        // Find a vote in the list with the same type, round, and voter. If found, do not add it to
-        // list.
-        let duplicate_vote = votes.iter().find(|v| {
-            v.vote_type == vote.vote_type && v.round == vote.round && v.voter == vote.voter
-        });
-        if let Some(duplicate_vote) = duplicate_vote {
+        // Look up a vote with the same type, round, and voter. If found, do not add it again.
+        let key = (vote.vote_type, vote.round, vote.voter);
+        if let Some(duplicate_vote) = votes.get(&key) {
             // If the two votes are identical, we just ignore this.
             if duplicate_vote == &vote {
                 Ok(())
@@ -328,7 +330,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             // not yet verified, a peer can forge votes with arbitrary voter addresses; without this
             // cap that would grow `future_votes` without bound and exhaust memory.
             if votes.len() < cap {
-                votes.push(vote);
+                votes.insert(key, vote);
             } else {
                 // TODO(Matan): once the network expands beyond the current trusted set, rate-limit
                 // this log (e.g. `trace_every_n_ms!`) so that dropping votes can't itself be used


### PR DESCRIPTION
## What

Follow-up performance optimization on top of #14500 (backported to `main-v0.14.3` as #14757), which added a cap to `ConsensusCache::future_votes` to prevent an OOM DoS from adversarial future-height vote flooding.

`ConsensusCache::cache_future_vote` — invoked once per future-height vote received over the p2p network, every consensus round — stored votes per height in a `Vec<Vote>` and did a **linear scan** (`votes.iter().find(...)`) over the whole vector to find an existing `(vote_type, round, voter)` entry for dedup/equivocation detection. #14500 bounded that vector to up to `MAX_COMMITTEE_SIZE (1000) * NUM_VOTE_TYPES (2) * cached_rounds` (~4000 by default), which caps worst-case memory but leaves every vote insertion scanning up to ~4000 entries under adversarial flooding — since vote signatures aren't verified before caching, a peer can forge arbitrary voter addresses to fill the cache, making this effectively O(cap²) total work per height under sustained flooding.

## Change

Replace `future_votes: BTreeMap<BlockNumber, Vec<Vote>>` with `future_votes: BTreeMap<BlockNumber, IndexMap<(VoteType, Round, ContractAddress), Vote>>` (`indexmap` is already a workspace dependency used elsewhere in this repo). This turns the dedup/equivocation lookup into an O(1) hash lookup instead of an O(n) scan. `IndexMap` preserves insertion order, so `get_current_height_votes` (which drains the cache for sequential processing) still replays votes in the exact order they were cached, matching the previous `Vec` behavior.

No functional/observable behavior change: the cap check (`votes.len() < cap`), the metric (`.len()`), and the equivocation-report path are all unchanged.

## Tests

- `SEED=0 cargo test -p apollo_consensus`: 95 passed (including the `#14500` tests `future_votes_capped` and `future_votes_below_cap_are_all_retained`, and the pre-existing `cache_future_vote_deduplication`).
- `cargo build -p apollo_consensus` and `cargo clippy -p apollo_consensus --all-targets --features testing`: clean.
- Reviewed by an independent Opus pass for correctness (key equivalence to the old scan predicate, ordering/determinism, and that the optimization is legitimate) — no blocking issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWkL1VEwZ9DjrBTJxBj2Rm)_