### PR TITLE
apollo_consensus: O(1) future-vote dedup lookup instead of linear scan

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -9,7 +9,7 @@
 #[path = "manager_test.rs"]
 mod manager_test;
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -218,8 +218,9 @@ const NUM_VOTE_TYPES: usize = 2;
 /// Manages votes and proposals for future heights.
 #[derive(Debug)]
 struct ConsensusCache<ContextT: ConsensusContext> {
-    // Mapping: { Height : Vec<Vote> }
-    future_votes: BTreeMap<BlockNumber, Vec<Vote>>,
+    // Mapping: { Height : { (VoteType, Round, Voter) : Vote } }, keyed for O(1) duplicate lookup
+    // in `cache_future_vote` instead of an O(cache size) scan.
+    future_votes: BTreeMap<BlockNumber, HashMap<(VoteType, Round, ValidatorId), Vote>>,
     // Mapping: { Height : { Round : (BlockInfo, Receiver)}}
     future_proposals_cache:
         BTreeMap<BlockNumber, BTreeMap<Round, ProposalReceiverTuple<ContextT::ProposalPart>>>,
@@ -252,7 +253,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             };
             match entry.key().cmp(&height) {
                 std::cmp::Ordering::Greater => return Vec::new(),
-                std::cmp::Ordering::Equal => return entry.remove(),
+                std::cmp::Ordering::Equal => return entry.remove().into_values().collect(),
                 std::cmp::Ordering::Less => {
                     entry.remove();
                 }
@@ -306,12 +307,9 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
     fn cache_future_vote(&mut self, vote: Vote) -> Result<(), Box<EquivocationVoteReport>> {
         let cap = self.future_votes_cap();
         let votes = self.future_votes.entry(vote.height).or_default();
-        // Find a vote in the list with the same type, round, and voter. If found, do not add it to
-        // list.
-        let duplicate_vote = votes.iter().find(|v| {
-            v.vote_type == vote.vote_type && v.round == vote.round && v.voter == vote.voter
-        });
-        if let Some(duplicate_vote) = duplicate_vote {
+        // Look up a vote with the same type, round, and voter. If found, do not add it to the map.
+        let vote_key = (vote.vote_type, vote.round, vote.voter);
+        if let Some(duplicate_vote) = votes.get(&vote_key) {
             // If the two votes are identical, we just ignore this.
             if duplicate_vote == &vote {
                 Ok(())
@@ -327,7 +325,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             // not yet verified, a peer can forge votes with arbitrary voter addresses; without this
             // cap that would grow `future_votes` without bound and exhaust memory.
             if votes.len() < cap {
-                votes.push(vote);
+                votes.insert(vote_key, vote);
             } else {
                 // TODO(Matan): once the network expands beyond the current trusted set, rate-limit
                 // this log (e.g. `trace_every_n_ms!`) so that dropping votes can't itself be used


### PR DESCRIPTION
## What

Follow-up performance optimization on top of #14757 (backport of #14500, "apollo_consensus: cap cached future votes by committee size to prevent OOM"), which was just merged into `main-v0.14.3`.

`ConsensusCache::cache_future_vote` in `crates/apollo_consensus/src/manager.rs` runs on the network hot path — once per incoming consensus vote for a future height. Its duplicate/equivocation check did a **linear scan** over the per-height `Vec<Vote>`:

```rust
let duplicate_vote = votes.iter().find(|v| {
    v.vote_type == vote.vote_type && v.round == vote.round && v.voter == vote.voter
});
```

#14757 bounded that `Vec` to up to `MAX_COMMITTEE_SIZE (1000) * NUM_VOTE_TYPES (2) * (future_height_round_limit + 1)` entries per height — but every insert still pays an O(cache size) scan to check for a duplicate, so filling the cache (e.g. under vote flooding, which #14757's own cap is designed to tolerate) costs O(n²).

## Fix

Change `future_votes` from `BTreeMap<BlockNumber, Vec<Vote>>` to `BTreeMap<BlockNumber, HashMap<(VoteType, Round, ValidatorId), Vote>>`, keyed on exactly the tuple the dedup check already compared. This makes the duplicate/equivocation lookup O(1) average instead of O(n), while preserving identical semantics:
- identical vote for an existing key → `Ok(())` no-op
- same key, different vote content → `Err(EquivocationVoteReport)`
- new key at cap → dropped + warn-logged (unchanged)
- `get_current_height_votes` still returns `Vec<Vote>` for its downstream consumer (the Tendermint state machine, which is order-independent) via `.into_values().collect()`

## Verification

- `cargo build -p apollo_consensus` — clean.
- `SEED=0 cargo test -p apollo_consensus` — 92 passed, 0 failed (including the `future_votes_capped` / `future_votes_below_cap_are_all_retained` tests added by #14757).
- `cargo clippy -p apollo_consensus --all-targets --features testing` — clean.
- Reviewed by an independent Opus subagent for correctness (equivocation/dedup/cap semantics, order-independence of downstream consumers) and style; no blocking or suggestion-level findings — only a naming nit (`key` → `vote_key`), applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJxx1f7unBrK5fQqwPHQw8)_