### PR TITLE
apollo_consensus: O(1) future-vote dedup lookup instead of linear scan

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -9,7 +9,7 @@
 #[path = "manager_test.rs"]
 mod manager_test;
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -216,11 +216,18 @@ pub struct EquivocationVoteReport {
 /// [`VoteType::Precommit`]). Used to bound the future-vote cache.
 const NUM_VOTE_TYPES: usize = 2;
 
+/// Key identifying a vote for deduplication/equivocation purposes: a validator may cast at most
+/// one vote per (type, round).
+type VoteKey = (VoteType, Round, ValidatorId);
+
 /// Manages votes and proposals for future heights.
 #[derive(Debug)]
 struct ConsensusCache<ContextT: ConsensusContext> {
-    // Mapping: { Height : Vec<Vote> }
-    future_votes: BTreeMap<BlockNumber, Vec<Vote>>,
+    // Mapping: { Height : { (VoteType, Round, Voter) : Vote } }. Keyed by `VoteKey` (rather than
+    // storing a `Vec`) so that duplicate/equivocation lookups in `cache_future_vote` are O(1)
+    // instead of a linear scan, which matters since that scan runs on every future-height vote
+    // received, including a flood of forged votes up to `future_votes_cap()`.
+    future_votes: BTreeMap<BlockNumber, HashMap<VoteKey, Vote>>,
     // Mapping: { Height : { Round : (BlockInfo, Receiver)}}
     future_proposals_cache:
         BTreeMap<BlockNumber, BTreeMap<Round, ProposalReceiverTuple<ContextT::ProposalPart>>>,
@@ -253,7 +260,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             };
             match entry.key().cmp(&height) {
                 std::cmp::Ordering::Greater => return Vec::new(),
-                std::cmp::Ordering::Equal => return entry.remove(),
+                std::cmp::Ordering::Equal => return entry.remove().into_values().collect(),
                 std::cmp::Ordering::Less => {
                     entry.remove();
                 }
@@ -307,12 +314,8 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
     fn cache_future_vote(&mut self, vote: Vote) -> Result<(), Box<EquivocationVoteReport>> {
         let cap = self.future_votes_cap();
         let votes = self.future_votes.entry(vote.height).or_default();
-        // Find a vote in the list with the same type, round, and voter. If found, do not add it to
-        // list.
-        let duplicate_vote = votes.iter().find(|v| {
-            v.vote_type == vote.vote_type && v.round == vote.round && v.voter == vote.voter
-        });
-        if let Some(duplicate_vote) = duplicate_vote {
+        let key = (vote.vote_type, vote.round, vote.voter);
+        if let Some(duplicate_vote) = votes.get(&key) {
             // If the two votes are identical, we just ignore this.
             if duplicate_vote == &vote {
                 Ok(())
@@ -328,7 +331,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             // not yet verified, a peer can forge votes with arbitrary voter addresses; without this
             // cap that would grow `future_votes` without bound and exhaust memory.
             if votes.len() < cap {
-                votes.push(vote);
+                votes.insert(key, vote);
             } else {
                 // TODO(Matan): once the network expands beyond the current trusted set, rate-limit
                 // this log (e.g. `trace_every_n_ms!`) so that dropping votes can't itself be used


### PR DESCRIPTION
## What

Follow-up performance optimization to #14500 (backported to `main-v0.14.3` as #14757, merged today), which added a static cap to `ConsensusCache::cache_future_vote` (`crates/apollo_consensus/src/manager.rs`) to bound the per-height future-vote cache and prevent an OOM from a flood of forged votes.

That fix left the pre-existing dedup/equivocation check as a linear scan (`votes.iter().find(...)`) over the per-height `Vec<Vote>`, run on **every incoming future-height vote**. Worst case, this scan is O(N) where N can reach the new cap (`MAX_COMMITTEE_SIZE (1000) * NUM_VOTE_TYPES (2) * (future_height_round_limit + 1)`) — i.e. under precisely the adversarial flood scenario the cap was added to defend against, filling the cache costs O(cap²) instead of O(cap).

## Fix

Key the per-height future-vote cache by `(VoteType, Round, ValidatorId)` (`HashMap` instead of `Vec`), the same tuple the old scan compared on. This turns the dedup/equivocation lookup in `cache_future_vote` into an O(1) average hash lookup. `get_current_height_votes` now collects `.into_values()` from the map — vote order was never semantically meaningful (each cached vote is replayed independently via `shc.handle_vote`, and network delivery order isn't guaranteed either).

Behavior is otherwise unchanged: identical resent votes are still silently ignored, conflicting votes at the same key still report equivocation, and the cap is still enforced on the same distinct-key count as before (the `Vec` was already deduped by this key prior to every `push`, so `Vec::len()` and `HashMap::len()` count the same thing).

## Verification

- `cargo build -p apollo_consensus` — clean.
- `SEED=0 cargo test -p apollo_consensus` — 95 passed, incl. `cache_future_vote_deduplication`, `future_votes_capped`, `future_votes_below_cap_are_all_retained`.
- `cargo clippy -p apollo_consensus --all-targets` — clean.
- Reviewed by an independent Opus pass for correctness (equivocation/cap/ordering semantics preserved) and style; no blocking issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Joc2JZJYfRrUNDR3dj8PDu)_