### PR TITLE
apollo_consensus: use HashMap for future-vote cache dedup lookups

### DIFF
--- a/crates/apollo_consensus/src/manager.rs
+++ b/crates/apollo_consensus/src/manager.rs
@@ -9,7 +9,7 @@
 #[path = "manager_test.rs"]
 mod manager_test;
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -216,11 +216,15 @@ pub struct EquivocationVoteReport {
 /// [`VoteType::Precommit`]). Used to bound the future-vote cache.
 const NUM_VOTE_TYPES: usize = 2;
 
+/// Key identifying a single validator's vote within a height: a validator casts at most one
+/// non-equivocating vote per (type, round).
+type VoteKey = (VoteType, Round, ValidatorId);
+
 /// Manages votes and proposals for future heights.
 #[derive(Debug)]
 struct ConsensusCache<ContextT: ConsensusContext> {
-    // Mapping: { Height : Vec<Vote> }
-    future_votes: BTreeMap<BlockNumber, Vec<Vote>>,
+    // Mapping: { Height : { VoteKey : Vote } }
+    future_votes: BTreeMap<BlockNumber, HashMap<VoteKey, Vote>>,
     // Mapping: { Height : { Round : (BlockInfo, Receiver)}}
     future_proposals_cache:
         BTreeMap<BlockNumber, BTreeMap<Round, ProposalReceiverTuple<ContextT::ProposalPart>>>,
@@ -253,7 +257,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             };
             match entry.key().cmp(&height) {
                 std::cmp::Ordering::Greater => return Vec::new(),
-                std::cmp::Ordering::Equal => return entry.remove(),
+                std::cmp::Ordering::Equal => return entry.remove().into_values().collect(),
                 std::cmp::Ordering::Less => {
                     entry.remove();
                 }
@@ -307,12 +311,9 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
     fn cache_future_vote(&mut self, vote: Vote) -> Result<(), Box<EquivocationVoteReport>> {
         let cap = self.future_votes_cap();
         let votes = self.future_votes.entry(vote.height).or_default();
-        // Find a vote in the list with the same type, round, and voter. If found, do not add it to
-        // list.
-        let duplicate_vote = votes.iter().find(|v| {
-            v.vote_type == vote.vote_type && v.round == vote.round && v.voter == vote.voter
-        });
-        if let Some(duplicate_vote) = duplicate_vote {
+        let key = (vote.vote_type, vote.round, vote.voter);
+        // Look up a vote with the same type, round, and voter. If found, do not add it again.
+        if let Some(duplicate_vote) = votes.get(&key) {
             // If the two votes are identical, we just ignore this.
             if duplicate_vote == &vote {
                 Ok(())
@@ -328,7 +329,7 @@ impl<ContextT: ConsensusContext> ConsensusCache<ContextT> {
             // not yet verified, a peer can forge votes with arbitrary voter addresses; without this
             // cap that would grow `future_votes` without bound and exhaust memory.
             if votes.len() < cap {
-                votes.push(vote);
+                votes.insert(key, vote);
             } else {
                 // TODO(Matan): once the network expands beyond the current trusted set, rate-limit
                 // this log (e.g. `trace_every_n_ms!`) so that dropping votes can't itself be used


### PR DESCRIPTION
## What

`ConsensusCache::cache_future_vote` (`crates/apollo_consensus/src/manager.rs`) is called on every incoming consensus vote for a future height/round. For each vote it did a linear scan (`votes.iter().find(...)`) over the whole per-height `Vec<Vote>` to check for a duplicate/equivocating vote from the same `(vote_type, round, voter)`, before pushing the new vote or dropping it once the cap was reached.

This PR replaces `future_votes: BTreeMap<BlockNumber, Vec<Vote>>` with `future_votes: BTreeMap<BlockNumber, HashMap<VoteKey, Vote>>`, where `VoteKey = (VoteType, Round, ValidatorId)`, turning the per-vote dedup check + insert into an O(1) average-case `HashMap` lookup instead of an O(N) scan.

## Why this is a hot path worth optimizing

Follows up on #14500 / #14757 ("statically cap cached future votes to prevent OOM"), which bounded the per-height cache to `MAX_COMMITTEE_SIZE (1000) * NUM_VOTE_TYPES (2) * (future_height_round_limit + 1)` — up to **~12,000** entries in the production config (`future_height_round_limit = 5`). Since vote signatures aren't verified at this stage, a peer can send votes with adversarial/arbitrary voter addresses, so the cache can genuinely fill toward that cap under load. That means the pre-existing linear scan could run in O(N) per vote with N in the thousands, i.e. up to O(N²) total CPU work while a hostile or lagging peer floods future-height votes — on a hot path that runs continuously while the node is live.

`get_current_height_votes` now collects the `HashMap`'s values instead of returning the `Vec` directly, so iteration order is no longer push order. This is safe: the sole caller feeds each vote individually into `shc.handle_vote(msg)`, and consensus vote handling is accumulative/quorum-counting and order-independent for a fixed vote set (each validator has at most one non-equivocating vote per `(type, round)`).

## Tests

- `SEED=0 cargo test -p apollo_consensus`: 95 passed (includes the existing `future_votes_capped`, `future_votes_below_cap_are_all_retained`, `cache_future_vote_deduplication` tests, which still pass unmodified against the new `HashMap`-backed cache).
- `cargo clippy -p apollo_consensus --all-targets --features testing`: clean.
- Reviewed by an independent Opus pass for correctness (HashMap key bounds, equivocation-path behavior preservation, ordering safety, style) — no blocking issues found.

Ref: #14757 (backport of #14500, merged into `main-v0.14.3` on 2026-07-12), original: #14500.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMdqE4qqnZcac7ERPAne3P)_