### PR TITLE
apollo_consensus_orchestrator,apollo_dashboard: alert when L2 gas price hits configured minimum

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/metrics.rs
+++ b/crates/apollo_consensus_orchestrator/src/metrics.rs
@@ -15,6 +15,7 @@ define_metrics!(
         MetricCounter { CONSENSUS_L1_GAS_MISMATCH, "consensus_l1_gas_mismatch", "The number of times the L1 gas in a proposal does not match the value expected by this validator", init = 0 },
         MetricCounter { CONSENSUS_L1_DATA_GAS_MISMATCH, "consensus_l1_data_gas_mismatch", "The number of times the L1 data gas in a proposal does not match the value expected by this validator", init = 0 },
         MetricGauge { CONSENSUS_L2_GAS_PRICE, "consensus_l2_gas_price", "The L2 gas price calculated in an accepted proposal" },
+        MetricGauge { CONSENSUS_L2_GAS_PRICE_AT_MINIMUM, "consensus_l2_gas_price_at_minimum", "1 when the accepted L2 gas price is clamped at the configured minimum (min_l2_gas_price_per_height, or the versioned-constants min_gas_price fallback), else 0" },
         MetricCounter { CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR, "consensus_l1_gas_price_provider_error", "Number of times the context got an error when querying the L1 gas price provider", init=0},
         MetricCounter { CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH, "consensus_retrospective_block_hash_mismatch", "Number of times the retrospective block hashes of the state sync and the batcher mismatched", init=0},
 
@@ -97,6 +98,7 @@ pub(crate) fn register_metrics() {
     CONSENSUS_L1_GAS_MISMATCH.register();
     CONSENSUS_L1_DATA_GAS_MISMATCH.register();
     CONSENSUS_L2_GAS_PRICE.register();
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.register();
     CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR.register();
     CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH.register();
     CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER.register();

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -101,6 +101,7 @@ use crate::metrics::{
     record_validate_proposal_failure,
     register_metrics,
     CONSENSUS_L2_GAS_PRICE,
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM,
     SNIP35_FEE_ACTUAL_FRI,
     SNIP35_FEE_PROPOSAL_FRI,
     SNIP35_FEE_TARGET_ATTO_USD,
@@ -495,6 +496,11 @@ impl SequencerConsensusContext {
         self.l2_gas_price = self.calculate_next_l2_gas_price(height, l2_gas_used);
         let gas_price_u64 = u64::try_from(self.l2_gas_price.0).unwrap_or(u64::MAX);
         CONSENSUS_L2_GAS_PRICE.set_lossy(gas_price_u64);
+        let config_min = get_min_gas_price_for_height(
+            height,
+            &self.config.dynamic_config.min_l2_gas_price_per_height,
+        );
+        CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.set_lossy(u64::from(self.l2_gas_price <= config_min));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1056,6 +1062,8 @@ impl ConsensusContext for SequencerConsensusContext {
                 self.l2_gas_price = max(self.l2_gas_price, min_gas_price_for_height);
                 let gas_price_u64 = u64::try_from(self.l2_gas_price.0).unwrap_or(u64::MAX);
                 CONSENSUS_L2_GAS_PRICE.set_lossy(gas_price_u64);
+                CONSENSUS_L2_GAS_PRICE_AT_MINIMUM
+                    .set_lossy(u64::from(self.l2_gas_price <= min_gas_price_for_height));
             }
             self.current_height = Some(height);
             self.current_round = round;

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -64,7 +64,7 @@ use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 
 use crate::cende::{MockCendeContext, N_BLOCK_HASHES_BACK_IN_BLOB};
 use crate::dynamic_gas_price::proposal_commitment_from;
-use crate::metrics::CONSENSUS_L2_GAS_PRICE;
+use crate::metrics::{CONSENSUS_L2_GAS_PRICE, CONSENSUS_L2_GAS_PRICE_AT_MINIMUM};
 use crate::sequencer_consensus_context::{
     SequencerConsensusContext,
     SequencerConsensusContextDeps,
@@ -790,6 +790,9 @@ async fn decision_reached_sends_correct_values() {
     let metrics = recorder.handle().render();
     CONSENSUS_L2_GAS_PRICE
         .assert_eq(&metrics, VersionedConstants::latest_constants().min_gas_price.0);
+    // The price landed at the configured minimum (empty `min_l2_gas_price_per_height` → the
+    // versioned-constants fallback), so the "at minimum" gauge must report 1.
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.assert_eq(&metrics, 1);
 }
 
 // The blob's `parent_proposal_commitment` must bind the parent block's `fee_proposal_fri`, which

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -613,6 +613,32 @@
       "severity": "p5"
     },
     {
+      "name": "consensus_l2_gas_price_at_minimum",
+      "title": "L2 gas price at configured minimum",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(max(consensus_l2_gas_price_at_minimum{cluster=~\"$cluster\", namespace=~\"$namespace\"})) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "2m",
+      "severity": "p3"
+    },
+    {
       "name": "consensus_p2p_disconnections",
       "title": "Consensus p2p disconnections",
       "ruleGroup": "evaluation_rate_default",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -75,6 +75,7 @@ use crate::alert_scenarios::l1_gas_prices::{
     get_eth_to_strk_success_count_alert,
     get_l1_gas_price_provider_insufficient_history_alert,
     get_l1_gas_price_scraper_success_count_alert,
+    get_l2_gas_price_at_minimum_alert,
     get_strk_to_usd_error_count_alert,
     get_strk_to_usd_rate_frozen_alert,
     get_strk_to_usd_success_count_alert,
@@ -654,6 +655,7 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_high_empty_blocks_ratio_alert());
     alerts.push(get_l1_gas_price_provider_insufficient_history_alert());
     alerts.push(get_l1_gas_price_scraper_success_count_alert());
+    alerts.push(get_l2_gas_price_at_minimum_alert());
     alerts.push(get_l1_message_scraper_no_successes_alert());
     alerts.push(get_l1_handler_transaction_waiting_in_l1_alert());
     alerts.extend(get_primary_l1_endpoint_down_too_long_alerts());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -1,3 +1,4 @@
+use apollo_consensus_orchestrator::metrics::CONSENSUS_L2_GAS_PRICE_AT_MINIMUM;
 use apollo_l1_gas_price::metrics::{
     ETH_TO_STRK_ERROR_COUNT,
     ETH_TO_STRK_RATE,
@@ -111,6 +112,27 @@ pub(crate) fn get_l1_gas_price_provider_insufficient_history_alert() -> Alert {
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+        ObserverApplicability::NotApplicable,
+    )
+}
+
+/// Alert when the accepted L2 gas price sits at the configured minimum for a sustained window,
+/// i.e. the EIP-1559 fee market has clamped the price at its floor (demand bottomed out).
+///
+/// Fires on the `consensus_l2_gas_price_at_minimum` gauge (1 = clamped at the configured min),
+/// which the orchestrator derives per height from `min_l2_gas_price_per_height` (falling back to
+/// the versioned-constants `min_gas_price`). Emitting the "at minimum" signal from the node — where
+/// the configured min is known — avoids a hard-coded Grafana threshold that would rot on a
+/// versioned-constants change or miss any env that overrides the min (e.g. Mainnet's 15e9).
+pub(crate) fn get_l2_gas_price_at_minimum_alert() -> Alert {
+    Alert::new(
+        "consensus_l2_gas_price_at_minimum",
+        "L2 gas price at configured minimum",
+        EvaluationRate::Default,
+        format!("max({})", CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.get_name_with_filter()),
+        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
+        "2m",
+        AlertSeverity::DayOnly,
         ObserverApplicability::NotApplicable,
     )
 }


### PR DESCRIPTION
## What

Adds a **P3 (all environments)** alert that fires when the accepted L2 gas price sits at the **configured minimum** for a sustained **2-minute** window — i.e. the EIP-1559 fee market has clamped the price at its floor (demand bottomed out).

## Why

The L2 gas price is floored at `min_l2_gas_price_per_height` (config, per height) with a versioned-constants `min_gas_price` fallback. A literal Grafana threshold would be **wrong on Mainnet** (configured min = `15e9`, not the `8e9` fallback) and would **rot** when the versioned-constants min changes (it moved `3e9`→`8e9` across 0.14.0→0.14.1). Instead, the node emits an "at minimum" signal at the point where it already knows the configured floor, so the alert stays correct across every env and version.

## How

- New gauge `consensus_l2_gas_price_at_minimum` (`apollo_consensus_orchestrator`): `1` when the committed price ≤ the configured min, emitted at both points where `consensus_l2_gas_price` is set.
- New alert `get_l2_gas_price_at_minimum_alert` (`apollo_dashboard`): `max(consensus_l2_gas_price_at_minimum) > 0`, `for: 2m`, severity **p3** (concrete for all envs, not a per-env placeholder), observer-filtered. Registered in `get_apollo_alerts()` and `dev_grafana_alerts.json` regenerated.

## Testing

- `cargo test -p apollo_dashboard default_dev_grafana_dashboard` — committed alert JSON matches the generator.
- `cargo test -p apollo_consensus_orchestrator --features testing decision_reached_sends_correct_values` — asserts the gauge is `1` when the price lands at the configured floor.
- `clippy` + `rust_fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
