### PR TITLE
apollo_consensus_orchestrator: avoid duplicate config-min gas price lookup per block

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -327,7 +327,8 @@ async fn get_proposal_content(
                     args.override_l2_gas_price_fri,
                     &args.min_l2_gas_price_per_height,
                     args.fee_actual,
-                );
+                )
+                .price;
                 let fin_payload = ProposalFinPayload {
                     commitment_parts: CommitmentParts::from(&info),
                     l2_gas_info: L2GasInfo {

--- a/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
@@ -51,7 +51,20 @@ pub fn get_min_gas_price_for_height(
         .unwrap_or(fallback_min_gas_price)
 }
 
+/// The result of [`calculate_next_l2_gas_price_for_fin`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NextL2GasPrice {
+    /// The L2 gas price for the next block.
+    pub price: GasPrice,
+    /// The configured minimum gas price for this height (from `min_l2_gas_price_per_height`, or
+    /// the versioned-constants fallback), regardless of whether an override was applied.
+    pub config_min: GasPrice,
+}
+
 /// Compute the next L2 gas price (for the fin or for updating state). Respects override when set.
+///
+/// Returns the next price alongside the configured minimum for this height, so callers that also
+/// need the configured minimum (e.g. for the "at minimum" gauge) don't have to look it up again.
 pub fn calculate_next_l2_gas_price_for_fin(
     current_l2_gas_price: GasPrice,
     height: BlockNumber,
@@ -59,21 +72,23 @@ pub fn calculate_next_l2_gas_price_for_fin(
     override_l2_gas_price_fri: Option<u128>,
     min_l2_gas_price_per_height: &[PricePerHeight],
     fee_actual: Option<GasPrice>,
-) -> GasPrice {
+) -> NextL2GasPrice {
+    let config_min = get_min_gas_price_for_height(height, min_l2_gas_price_per_height);
     if let Some(override_value) = override_l2_gas_price_fri {
         info!(
             "L2 gas price ({}) is not updated, remains on override value of {override_value} fri",
             current_l2_gas_price.0
         );
-        return GasPrice(override_value);
+        return NextL2GasPrice { price: GasPrice(override_value), config_min };
     }
     let gas_target = VersionedConstants::latest_constants().gas_target;
-    let config_min = get_min_gas_price_for_height(height, min_l2_gas_price_per_height);
     let effective_min = match fee_actual {
         Some(fa) => GasPrice(max(config_min.0, fa.0)),
         None => config_min,
     };
-    calculate_next_base_gas_price(current_l2_gas_price, l2_gas_used, gas_target, effective_min)
+    let price =
+        calculate_next_base_gas_price(current_l2_gas_price, l2_gas_used, gas_target, effective_min);
+    NextL2GasPrice { price, config_min }
 }
 
 /// Calculate the base gas price for the next block according to EIP-1559.

--- a/crates/apollo_consensus_orchestrator/src/metrics.rs
+++ b/crates/apollo_consensus_orchestrator/src/metrics.rs
@@ -15,6 +15,7 @@ define_metrics!(
         MetricCounter { CONSENSUS_L1_GAS_MISMATCH, "consensus_l1_gas_mismatch", "The number of times the L1 gas in a proposal does not match the value expected by this validator", init = 0 },
         MetricCounter { CONSENSUS_L1_DATA_GAS_MISMATCH, "consensus_l1_data_gas_mismatch", "The number of times the L1 data gas in a proposal does not match the value expected by this validator", init = 0 },
         MetricGauge { CONSENSUS_L2_GAS_PRICE, "consensus_l2_gas_price", "The L2 gas price calculated in an accepted proposal" },
+        MetricGauge { CONSENSUS_L2_GAS_PRICE_AT_MINIMUM, "consensus_l2_gas_price_at_minimum", "1 when the accepted L2 gas price is clamped at the configured minimum (min_l2_gas_price_per_height, or the versioned-constants min_gas_price fallback), else 0" },
         MetricCounter { CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR, "consensus_l1_gas_price_provider_error", "Number of times the context got an error when querying the L1 gas price provider", init=0},
         MetricCounter { CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH, "consensus_retrospective_block_hash_mismatch", "Number of times the retrospective block hashes of the state sync and the batcher mismatched", init=0},
 
@@ -97,6 +98,7 @@ pub(crate) fn register_metrics() {
     CONSENSUS_L1_GAS_MISMATCH.register();
     CONSENSUS_L1_DATA_GAS_MISMATCH.register();
     CONSENSUS_L2_GAS_PRICE.register();
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.register();
     CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR.register();
     CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH.register();
     CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER.register();

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -101,6 +101,7 @@ use crate::metrics::{
     record_validate_proposal_failure,
     register_metrics,
     CONSENSUS_L2_GAS_PRICE,
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM,
     SNIP35_FEE_ACTUAL_FRI,
     SNIP35_FEE_PROPOSAL_FRI,
     SNIP35_FEE_TARGET_ATTO_USD,
@@ -495,6 +496,11 @@ impl SequencerConsensusContext {
         self.l2_gas_price = self.calculate_next_l2_gas_price(height, l2_gas_used);
         let gas_price_u64 = u64::try_from(self.l2_gas_price.0).unwrap_or(u64::MAX);
         CONSENSUS_L2_GAS_PRICE.set_lossy(gas_price_u64);
+        let config_min = get_min_gas_price_for_height(
+            height,
+            &self.config.dynamic_config.min_l2_gas_price_per_height,
+        );
+        CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.set_lossy(u64::from(self.l2_gas_price <= config_min));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1056,6 +1062,8 @@ impl ConsensusContext for SequencerConsensusContext {
                 self.l2_gas_price = max(self.l2_gas_price, min_gas_price_for_height);
                 let gas_price_u64 = u64::try_from(self.l2_gas_price.0).unwrap_or(u64::MAX);
                 CONSENSUS_L2_GAS_PRICE.set_lossy(gas_price_u64);
+                CONSENSUS_L2_GAS_PRICE_AT_MINIMUM
+                    .set_lossy(u64::from(self.l2_gas_price <= min_gas_price_for_height));
             }
             self.current_height = Some(height);
             self.current_round = round;

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -95,6 +95,7 @@ use crate::fee_market::{
     calculate_next_l2_gas_price_for_fin,
     get_min_gas_price_for_height,
     FeeMarketInfo,
+    NextL2GasPrice,
 };
 use crate::metrics::{
     record_build_proposal_failure,
@@ -421,9 +422,13 @@ impl SequencerConsensusContext {
         self.deps.state_sync_client.add_new_block(sync_block).await
     }
 
-    /// Returns the next L2 gas price without mutating context. Used when building the fin and when
-    /// updating at decision time.
-    fn calculate_next_l2_gas_price(&self, height: BlockNumber, l2_gas_used: GasAmount) -> GasPrice {
+    /// Returns the next L2 gas price and the configured minimum used to derive it, without
+    /// mutating context. Used when building the fin and when updating at decision time.
+    fn calculate_next_l2_gas_price(
+        &self,
+        height: BlockNumber,
+        l2_gas_used: GasAmount,
+    ) -> NextL2GasPrice {
         let fee_actual = compute_fee_actual(
             &self.fee_proposals_window,
             height,
@@ -493,14 +498,12 @@ impl SequencerConsensusContext {
     }
 
     fn update_l2_gas_price(&mut self, height: BlockNumber, l2_gas_used: GasAmount) {
-        self.l2_gas_price = self.calculate_next_l2_gas_price(height, l2_gas_used);
+        let next_l2_gas_price = self.calculate_next_l2_gas_price(height, l2_gas_used);
+        self.l2_gas_price = next_l2_gas_price.price;
         let gas_price_u64 = u64::try_from(self.l2_gas_price.0).unwrap_or(u64::MAX);
         CONSENSUS_L2_GAS_PRICE.set_lossy(gas_price_u64);
-        let config_min = get_min_gas_price_for_height(
-            height,
-            &self.config.dynamic_config.min_l2_gas_price_per_height,
-        );
-        CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.set_lossy(u64::from(self.l2_gas_price <= config_min));
+        CONSENSUS_L2_GAS_PRICE_AT_MINIMUM
+            .set_lossy(u64::from(self.l2_gas_price <= next_l2_gas_price.config_min));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -888,7 +891,7 @@ impl ConsensusContext for SequencerConsensusContext {
             .update_for_reproposal(&height, &proposal_commitment, &build_param);
 
         let next_l2_gas_price =
-            self.calculate_next_l2_gas_price(init.height, finished_info.l2_gas_used);
+            self.calculate_next_l2_gas_price(init.height, finished_info.l2_gas_used).price;
         let transaction_converter = self.deps.transaction_converter.clone();
         let mut stream_sender =
             self.start_stream(HeightAndRound(height.0, build_param.round)).await;

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -64,7 +64,7 @@ use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 
 use crate::cende::{MockCendeContext, N_BLOCK_HASHES_BACK_IN_BLOB};
 use crate::dynamic_gas_price::proposal_commitment_from;
-use crate::metrics::CONSENSUS_L2_GAS_PRICE;
+use crate::metrics::{CONSENSUS_L2_GAS_PRICE, CONSENSUS_L2_GAS_PRICE_AT_MINIMUM};
 use crate::sequencer_consensus_context::{
     SequencerConsensusContext,
     SequencerConsensusContextDeps,
@@ -790,6 +790,9 @@ async fn decision_reached_sends_correct_values() {
     let metrics = recorder.handle().render();
     CONSENSUS_L2_GAS_PRICE
         .assert_eq(&metrics, VersionedConstants::latest_constants().min_gas_price.0);
+    // The price landed at the configured minimum (empty `min_l2_gas_price_per_height` → the
+    // versioned-constants fallback), so the "at minimum" gauge must report 1.
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.assert_eq(&metrics, 1);
 }
 
 // The blob's `parent_proposal_commitment` must bind the parent block's `fee_proposal_fri`, which

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -613,6 +613,32 @@
       "severity": "p5"
     },
     {
+      "name": "consensus_l2_gas_price_at_minimum",
+      "title": "L2 gas price at configured minimum",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(max(consensus_l2_gas_price_at_minimum{cluster=~\"$cluster\", namespace=~\"$namespace\"})) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "2m",
+      "severity": "p3"
+    },
+    {
       "name": "consensus_p2p_disconnections",
       "title": "Consensus p2p disconnections",
       "ruleGroup": "evaluation_rate_default",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -75,6 +75,7 @@ use crate::alert_scenarios::l1_gas_prices::{
     get_eth_to_strk_success_count_alert,
     get_l1_gas_price_provider_insufficient_history_alert,
     get_l1_gas_price_scraper_success_count_alert,
+    get_l2_gas_price_at_minimum_alert,
     get_strk_to_usd_error_count_alert,
     get_strk_to_usd_rate_frozen_alert,
     get_strk_to_usd_success_count_alert,
@@ -654,6 +655,7 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_high_empty_blocks_ratio_alert());
     alerts.push(get_l1_gas_price_provider_insufficient_history_alert());
     alerts.push(get_l1_gas_price_scraper_success_count_alert());
+    alerts.push(get_l2_gas_price_at_minimum_alert());
     alerts.push(get_l1_message_scraper_no_successes_alert());
     alerts.push(get_l1_handler_transaction_waiting_in_l1_alert());
     alerts.extend(get_primary_l1_endpoint_down_too_long_alerts());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -1,3 +1,4 @@
+use apollo_consensus_orchestrator::metrics::CONSENSUS_L2_GAS_PRICE_AT_MINIMUM;
 use apollo_l1_gas_price::metrics::{
     ETH_TO_STRK_ERROR_COUNT,
     ETH_TO_STRK_RATE,
@@ -111,6 +112,27 @@ pub(crate) fn get_l1_gas_price_provider_insufficient_history_alert() -> Alert {
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+        ObserverApplicability::NotApplicable,
+    )
+}
+
+/// Alert when the accepted L2 gas price sits at the configured minimum for a sustained window,
+/// i.e. the EIP-1559 fee market has clamped the price at its floor (demand bottomed out).
+///
+/// Fires on the `consensus_l2_gas_price_at_minimum` gauge (1 = clamped at the configured min),
+/// which the orchestrator derives per height from `min_l2_gas_price_per_height` (falling back to
+/// the versioned-constants `min_gas_price`). Emitting the "at minimum" signal from the node — where
+/// the configured min is known — avoids a hard-coded Grafana threshold that would rot on a
+/// versioned-constants change or miss any env that overrides the min (e.g. Mainnet's 15e9).
+pub(crate) fn get_l2_gas_price_at_minimum_alert() -> Alert {
+    Alert::new(
+        "consensus_l2_gas_price_at_minimum",
+        "L2 gas price at configured minimum",
+        EvaluationRate::Default,
+        format!("max({})", CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.get_name_with_filter()),
+        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
+        "2m",
+        AlertSeverity::DayOnly,
         ObserverApplicability::NotApplicable,
     )
 }


### PR DESCRIPTION
## What

Follow-up performance optimization to #14773 ("apollo_consensus_orchestrator,apollo_dashboard: alert when L2 gas price hits configured minimum").

That PR's `update_l2_gas_price()` computed the configured minimum L2 gas price **twice** per block:
1. Once inside `calculate_next_l2_gas_price()` → `calculate_next_l2_gas_price_for_fin()`, which internally calls `get_min_gas_price_for_height()` to derive the next price.
2. A second time, immediately after, via a direct `get_min_gas_price_for_height()` call, just to feed the new `consensus_l2_gas_price_at_minimum` gauge.

`update_l2_gas_price()` runs once per consensus height (i.e. once per produced/decided block), so this redundant lookup ran on every single block in steady-state operation.

## How

- `calculate_next_l2_gas_price_for_fin()` (in `fee_market/mod.rs`) now returns a new `NextL2GasPrice { price, config_min }` struct instead of a bare `GasPrice`, computing `config_min` once (moved ahead of the override-value early-return so it's always available) and handing it back to the caller.
- `calculate_next_l2_gas_price()` (private helper in `sequencer_consensus_context.rs`) propagates the same struct.
- `update_l2_gas_price()` now uses the returned `config_min` directly for the gauge comparison instead of calling `get_min_gas_price_for_height()` again.
- The two other call sites that only need the price (`repropose`, and `build_proposal.rs`'s fin-building path) destructure `.price` and ignore `config_min`.

No behavior change: the override path still returns `config_min` for the gauge exactly as before (it was already computed unconditionally for that gauge on the merged PR's code path); this only removes a redundant duplicate config lookup.

## Testing

- `cargo build -p apollo_consensus_orchestrator` — clean.
- `SEED=0 cargo test -p apollo_consensus_orchestrator --features testing` — 165 passed, 0 failed (including `decision_reached_sends_correct_values`, which asserts the gauge).
- `cargo clippy -p apollo_consensus_orchestrator --all-targets --features testing -- -D warnings` — clean.
- `scripts/rust_fmt.sh` — clean.
- Reviewed by an independent agent pass for correctness (override-path semantics, all call sites updated, no stale imports/tests) and style (switched from an ambiguous `(GasPrice, GasPrice)` tuple to a named `NextL2GasPrice` struct to avoid a positional-swap hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01561i8bHPr6H8fYniTFyJWM)_