### PR TITLE
blockifier: avoid cloning cumulative executed-class-hash set per tx

### DIFF
--- a/crates/blockifier/src/bouncer.rs
+++ b/crates/blockifier/src/bouncer.rs
@@ -638,14 +638,14 @@ impl Bouncer {
         // rather than the cumulative state attributes.
         let marginal_state_changes_keys =
             tx_state_changes_keys.difference(&self.state_changes_keys);
-        let executed_class_hashes = &self
+        let accumulated_executed_class_hashes = &self
             .accumulated_weights
             .casm_hash_computation_data_sierra_gas
             .class_hash_to_casm_hash_computation_gas;
         let marginal_executed_class_hashes: HashSet<ClassHash> = tx_execution_summary
             .executed_class_hashes
             .iter()
-            .filter(|class_hash| !executed_class_hashes.contains_key(class_hash))
+            .filter(|class_hash| !accumulated_executed_class_hashes.contains_key(class_hash))
             .cloned()
             .collect();
         let n_marginal_visited_storage_entries = tx_execution_summary

--- a/crates/blockifier/src/bouncer.rs
+++ b/crates/blockifier/src/bouncer.rs
@@ -638,9 +638,14 @@ impl Bouncer {
         // rather than the cumulative state attributes.
         let marginal_state_changes_keys =
             tx_state_changes_keys.difference(&self.state_changes_keys);
-        let marginal_executed_class_hashes = tx_execution_summary
+        let executed_class_hashes = &self
+            .accumulated_weights
+            .casm_hash_computation_data_sierra_gas
+            .class_hash_to_casm_hash_computation_gas;
+        let marginal_executed_class_hashes: HashSet<ClassHash> = tx_execution_summary
             .executed_class_hashes
-            .difference(&self.get_executed_class_hashes())
+            .iter()
+            .filter(|class_hash| !executed_class_hashes.contains_key(class_hash))
             .cloned()
             .collect();
         let n_marginal_visited_storage_entries = tx_execution_summary


### PR DESCRIPTION
## Context

Follow-up perf review of #14776, which was just merged to `main-v0.14.3`. That PR added a `block_full_recorded` flag to `Bouncer` to fix a metric over-counting bug in `Bouncer::try_update`. While reviewing that hot path, I found an existing inefficiency in the same function.

## Problem

`Bouncer::try_update` runs once per transaction during block building (called from `crates/blockifier/src/concurrency/worker_logic.rs` and `crates/blockifier/src/blockifier/transaction_executor.rs`). It computed the marginal executed class hashes via:

```rust
let marginal_executed_class_hashes = tx_execution_summary
    .executed_class_hashes
    .difference(&self.get_executed_class_hashes())
    .cloned()
    .collect();
```

`get_executed_class_hashes()` clones the **entire block-cumulative** set of executed class hashes into a fresh `HashSet` — on every single transaction. This is an O(cumulative classes) allocation per tx, i.e. effectively quadratic over a block with many transactions, and directly contradicts the comment immediately above the call site: "The countings here should be linear in the transactional state changes and execution info rather than the cumulative state attributes."

## Fix

Instead of cloning the whole accumulated map's keys into a new set, reference the accumulated map directly and filter the (small, per-transaction) `tx_execution_summary.executed_class_hashes` against it with `contains_key`. This reduces the cost from O(cumulative classes) to O(classes touched by this transaction), with identical output — `HashSet::difference` and this filter both yield exactly the elements of the tx's set that are absent from the accumulated map, and both read from the same underlying data.

The public `get_executed_class_hashes()` method is left unchanged; it's still used, but only once per block (not once per tx) by `starknet_transaction_prover`'s virtual block executor.

## Testing

- `cargo build -p blockifier` — clean.
- `cargo clippy -p blockifier --lib -- -D warnings` — clean.
- `rust_fmt.sh` — clean (no diff beyond this change).
- `cargo test -p blockifier --lib bouncer` — all bouncer tests pass, including `test_block_full_metric_recorded_once_per_block` (the regression test added by #14776). 9 pre-existing failures in unrelated `bouncer` tests are due to this sandboxed environment being unable to download the Cairo compiler binary (`cairo_compile.rs`); verified identical failures occur on the base commit without this change.
- Independently reviewed by an Opus subagent for correctness/semantic equivalence and style; one variable renamed for clarity as a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcVvR7RURZkkj7SyZGEgUU)_