### PR TITLE
starknet_transaction_prover: avoid RequestId String clone in RequestSpanLayer

### DIFF
--- a/crates/starknet_transaction_prover/src/server/request_log.rs
+++ b/crates/starknet_transaction_prover/src/server/request_log.rs
@@ -41,6 +41,13 @@ mod request_log_test;
 /// HTTP header carrying the request id.
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
 
+/// Request extension carrying the id this layer already validated/generated,
+/// so a downstream layer (e.g. `RequestSpanLayer`) can reuse it on the
+/// plaintext path instead of re-parsing and re-validating the header it just
+/// set.
+#[derive(Clone)]
+pub(crate) struct RequestId(pub String);
+
 /// tower [`Layer`] producing [`RequestLogService`].
 #[derive(Clone, Copy, Default)]
 pub struct RequestLogLayer;
@@ -78,6 +85,7 @@ where
         let request_id = extract_or_generate_request_id(&request);
         let id_header_value = request_id_header_value(&request_id);
         request.headers_mut().insert(REQUEST_ID_HEADER, id_header_value.clone());
+        request.extensions_mut().insert(RequestId(request_id.clone()));
         let is_health_probe =
             request.method() == Method::GET && request.uri().path() == HEALTH_PATH;
         let method = request.method().clone();

--- a/crates/starknet_transaction_prover/src/server/request_span.rs
+++ b/crates/starknet_transaction_prover/src/server/request_span.rs
@@ -72,14 +72,17 @@ where
         } else {
             // Reuses the id `RequestLogLayer` already validated/generated via
             // its request extension, avoiding a second header parse and
-            // validation pass per request. Falls back to re-deriving it (the
-            // header is left untouched either way) so the layer stays correct
+            // validation pass per request. Removed rather than cloned: no
+            // downstream reader needs the extension past this point, so
+            // taking ownership skips a `String` allocation on every
+            // plaintext request. Falls back to re-deriving it (the header is
+            // left untouched either way) so the layer stays correct
             // standalone, e.g. in unit tests without `RequestLogLayer`
             // upstream.
-            request.extensions().get::<RequestId>().map_or_else(
-                || extract_or_generate_request_id(&request),
-                |request_id| request_id.0.clone(),
-            )
+            request
+                .extensions_mut()
+                .remove::<RequestId>()
+                .map_or_else(|| extract_or_generate_request_id(&request), |request_id| request_id.0)
         };
         self.inner.call(request).instrument(info_span!("http_request", request_id = %request_id))
     }

--- a/crates/starknet_transaction_prover/src/server/request_span.rs
+++ b/crates/starknet_transaction_prover/src/server/request_span.rs
@@ -24,6 +24,7 @@ use crate::server::request_log::{
     extract_or_generate_request_id,
     new_request_id,
     request_id_header_value,
+    RequestId,
     REQUEST_ID_HEADER,
 };
 
@@ -69,11 +70,16 @@ where
             request.headers_mut().insert(REQUEST_ID_HEADER, request_id_header_value(&fresh_id));
             fresh_id
         } else {
-            // Re-derives, via the shared validator, the exact id
-            // `RequestLogLayer` already assigned — the header is left
-            // untouched. This also keeps the layer correct standalone,
-            // e.g. in unit tests without `RequestLogLayer` upstream.
-            extract_or_generate_request_id(&request)
+            // Reuses the id `RequestLogLayer` already validated/generated via
+            // its request extension, avoiding a second header parse and
+            // validation pass per request. Falls back to re-deriving it (the
+            // header is left untouched either way) so the layer stays correct
+            // standalone, e.g. in unit tests without `RequestLogLayer`
+            // upstream.
+            request.extensions().get::<RequestId>().map_or_else(
+                || extract_or_generate_request_id(&request),
+                |request_id| request_id.0.clone(),
+            )
         };
         self.inner.call(request).instrument(info_span!("http_request", request_id = %request_id))
     }

--- a/crates/starknet_transaction_prover/src/server/request_span_test.rs
+++ b/crates/starknet_transaction_prover/src/server/request_span_test.rs
@@ -1,12 +1,13 @@
 use bytes::Bytes;
-use http::{Method, Request};
+use http::{Method, Request, Response, StatusCode};
 use http_body_util::Full;
 use jsonrpsee::server::HttpBody;
 use tower::{Layer, ServiceExt};
 use tower_ohttp::Decapsulated;
+use tracing_test::traced_test;
 
 use crate::server::middleware_test_utils::{echo_request_id_service, read_body_and_headers};
-use crate::server::request_log::{RequestLogLayer, REQUEST_ID_HEADER};
+use crate::server::request_log::{RequestId, RequestLogLayer, REQUEST_ID_HEADER};
 use crate::server::request_span::RequestSpanLayer;
 
 #[tokio::test]
@@ -41,6 +42,41 @@ async fn decapsulated_gets_fresh_id_discarding_inbound() {
     let (id, _headers) = read_body_and_headers(response).await;
     assert_ne!(id, "envelope-abc", "must discard the client-supplied inner id");
     assert!(uuid::Uuid::parse_str(&id).is_ok(), "must mint a fresh UUID, got {id:?}");
+}
+
+/// Proves the fast path actually reads the `RequestId` extension instead of
+/// re-parsing the header: the two are set to different values here, which
+/// `RequestLogLayer` never lets happen in production, and the span (checked
+/// via a log line emitted inside it) must carry the extension's value, not
+/// the header's.
+#[tokio::test]
+#[traced_test]
+async fn plaintext_prefers_request_id_extension_over_header() {
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(REQUEST_ID_HEADER, "header-value")
+        .body(HttpBody::new(Full::new(Bytes::new())))
+        .expect("static body is infallible");
+    request.extensions_mut().insert(RequestId("extension-value".to_string()));
+
+    let logging_service = tower::service_fn(|_request: Request<HttpBody>| async move {
+        tracing::info!("handler invoked");
+        Ok::<_, std::convert::Infallible>(
+            Response::builder()
+                .status(StatusCode::OK)
+                .body(HttpBody::new(Full::new(Bytes::new())))
+                .expect("static body is infallible"),
+        )
+    });
+
+    RequestSpanLayer.layer(logging_service).oneshot(request).await.unwrap();
+
+    assert!(logs_contain("extension-value"), "span must carry the RequestId extension's value");
+    assert!(
+        !logs_contain("header-value"),
+        "the mismatched header value must not leak into the span"
+    );
 }
 
 /// The cross-layer plaintext contract: with `RequestLogLayer` (outer) stacked


### PR DESCRIPTION
## What

Follow-up perf cleanup to #14743, which had `RequestSpanLayer::call` (`crates/starknet_transaction_prover/src/server/request_span.rs`) reuse the id `RequestLogLayer` already validated by reading it back out of a `RequestId(String)` request extension, via:

```rust
request.extensions().get::<RequestId>().map_or_else(
    || extract_or_generate_request_id(&request),
    |request_id| request_id.0.clone(),
)
```

That still allocates a fresh `String` (clone) on every plaintext request, even though nothing downstream ever reads the `RequestId` extension again.

## Fix

Swap the borrow-and-clone for a remove-and-move:

```rust
request.extensions_mut().remove::<RequestId>().map_or_else(
    || extract_or_generate_request_id(&request),
    |request_id| request_id.0,
)
```

`git grep` confirms `RequestId` is only ever inserted in `request_log.rs` and read in this one spot in `request_span.rs` — the request handed to `self.inner.call(request)` afterward (`MapResponseBodyLayer → CompressionLayer → jsonrpsee`) has no knowledge of this `pub(crate)` type. Taking ownership instead of cloning removes one heap allocation per plaintext HTTP request handled by the transaction-prover server, with no behavior change: the OHTTP/`Decapsulated` branch is untouched, and the header-based fallback (for standalone use without `RequestLogLayer` upstream) is preserved since the header itself is never removed.

## Tests

- All `starknet_transaction_prover` tests pass (122 passed, 1 pre-existing unrelated failure — `test_compiled_class_v1_to_casm_round_trip`, a network-dependent Cairo-compiler-download failure reproducing identically on the unmodified base branch, same as noted in #14743).
- `cargo clippy -p starknet_transaction_prover -p tower_ohttp --all-targets` is clean.
- `scripts/rust_fmt.sh` applied, no outstanding diffs.
- An independent Opus review confirmed correctness (no other reader of the `RequestId` extension, no retry/replay path in the middleware stack that would need the extension to persist, OHTTP branch unaffected, existing tests still valid since `.remove()` is behaviorally identical to `.get()` for a single call).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWQJNTHmEmHPqj2bMiHMfr)_