### PR TITLE
starknet_os: preallocate decompress result vectors to avoid reallocation

### DIFF
--- a/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
@@ -575,7 +575,7 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
     let unique_value_bucket_lengths: Vec<usize> = header[2..2 + N_UNIQUE_BUCKETS].to_vec();
     let n_repeating_values = &header[2 + N_UNIQUE_BUCKETS];
 
-    let mut unique_values = Vec::new();
+    let mut unique_values = Vec::with_capacity(unique_value_bucket_lengths.iter().sum());
     unique_values.extend(compressed.take(unique_value_bucket_lengths[0])); // 252 bucket.
     unique_values.extend(unpack_chunk::<125>(compressed, unique_value_bucket_lengths[1]));
     unique_values.extend(unpack_chunk::<83>(compressed, unique_value_bucket_lengths[2]));
@@ -605,7 +605,7 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
 
     let mut bucket_offset_trackers: Vec<_> = bucket_offsets;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(*data_len);
     for bucket_index in bucket_index_per_elm {
         let offset = &mut bucket_offset_trackers[bucket_index];
         let value = all_values[*offset];


### PR DESCRIPTION
## Context

Follow-up to #14765, which removed a stale `#[allow(dead_code)]` from `stateless_compression::utils::decompress` and confirmed it has a live, non-test caller: `PartialOsStateDiff::try_from_output_iter` (`crates/starknet_os/src/io/os_output_types.rs`), reached from production code parsing the OS state diff — i.e. `decompress` runs once per block over the full state diff, which can hold thousands of `Felt` entries on mainnet.

## Problem

Two `Vec`s inside `decompress` grow from `Vec::new()` (capacity 0) via repeated `push`/`extend`, even though their final length is already known at the point of allocation, from the already-decoded header:

- `unique_values`: final length = `unique_value_bucket_lengths.iter().sum()` (the six subsequent `.extend()` calls append at most that many elements total).
- `result`: final length = `*data_len` (the loop that follows pushes exactly one element per entry in `bucket_index_per_elm`, which has at most `data_len` elements).

Growing from 0 means ~`log2(N)` reallocations and O(N) redundant `Felt` copies per block, on a per-block hot path.

## Fix

Preallocate both `Vec`s with their known final capacity via `Vec::with_capacity`, mirroring the pattern already used elsewhere in this file (e.g. `unpack_felts`, `unpack_felts_to`, `get_bucket_offsets`, and the identical `unique_value_bucket_lengths.iter().sum()` expression already used in `compress` at line 420).

This is behavior-neutral — `Vec::with_capacity` cannot panic or change output; at worst (malformed/truncated input) it's a slightly-oversized upper-bound allocation, never undersized in a way that would require more than the normal growth-on-overflow the original code already relied on.

## Verification

With `sequencer_venv` active and `RUSTC_WRAPPER=""` (sccache unavailable in this environment):
- `cargo build -p starknet_os` — clean.
- `SEED=0 cargo test -p starknet_os stateless_compression` — 35 passed, 0 failed.
- `cargo clippy -p starknet_os --all-targets` — clean.
- `scripts/rust_fmt.sh` — no diff beyond this change.

An independent Opus review verified the capacity calculations are exact for well-formed input (and merely a safe upper bound otherwise), confirmed no new panic/overflow surface is introduced, and confirmed the optimization is real (not a no-op) given mainnet block sizes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHx5w4Xp5DBX5oBBTTFEvt)_