### PR TITLE
starknet_os: preallocate decompress buffers to avoid reallocations

### DIFF
--- a/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
@@ -575,7 +575,8 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
     let unique_value_bucket_lengths: Vec<usize> = header[2..2 + N_UNIQUE_BUCKETS].to_vec();
     let n_repeating_values = &header[2 + N_UNIQUE_BUCKETS];
 
-    let mut unique_values = Vec::new();
+    let n_unique_values: usize = unique_value_bucket_lengths.iter().sum();
+    let mut unique_values = Vec::with_capacity(n_unique_values + n_repeating_values);
     unique_values.extend(compressed.take(unique_value_bucket_lengths[0])); // 252 bucket.
     unique_values.extend(unpack_chunk::<125>(compressed, unique_value_bucket_lengths[1]));
     unique_values.extend(unpack_chunk::<83>(compressed, unique_value_bucket_lengths[2]));
@@ -605,7 +606,7 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
 
     let mut bucket_offset_trackers: Vec<_> = bucket_offsets;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(*data_len);
     for bucket_index in bucket_index_per_elm {
         let offset = &mut bucket_offset_trackers[bucket_index];
         let value = all_values[*offset];


### PR DESCRIPTION
## What

Follow-up perf cleanup to #14765, which removed the stale `#[allow(dead_code)]` on `stateless_compression::utils::decompress`, confirming it is live production code.

`decompress` is invoked once per block, from `PartialOsStateDiff::try_from_output_iter` (`crates/starknet_os/src/io/os_output_types.rs`), to unpack the compressed state diff — a per-block hot path in the Starknet OS.

## Why

Inside `decompress`, two `Vec`s were built with `Vec::new()` and grown via repeated `push`/`extend` in loops whose final length is already known up front from the parsed header, causing avoidable reallocations/copies on every block:

- `unique_values` (later moved into `all_values`) is filled via six `extend` calls whose combined length is `unique_value_bucket_lengths.iter().sum()`, then extended once more by exactly `n_repeating_values` entries.
- `result` is filled via one `push` per entry of `bucket_index_per_elm`, which has length `*data_len` by construction.

Every sibling unpack helper in this same file (`unpack_felts`, `unpack_felts_to`, `get_bucket_offsets`) already preallocates with `Vec::with_capacity`; `decompress` was the outlier.

## Fix

- `unique_values`: `Vec::new()` → `Vec::with_capacity(n_unique_values + n_repeating_values)`, sized for its final length after the later `all_values.extend(repeating_values)`.
- `result`: `Vec::new()` → `Vec::with_capacity(*data_len)`.

Both changes are allocation-only; contents and behavior are unchanged.

## Verification

- `cargo build -p starknet_os` — clean.
- `SEED=0 cargo test -p starknet_os stateless_compression` — 35 passed, 0 failed (directly exercises `decompress` via `test_compress_decompress`).
- `cargo clippy -p starknet_os --all-targets` — clean.
- `scripts/rust_fmt.sh` — clean, no outstanding diffs.
- Independent Opus review confirmed the capacity computations are exact (not just non-decreasing) for every code path, including zero-length edge cases, and found no other missed preallocation opportunities in the function.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYb1wxi8ScLK8s197UW1CJ)_