### PR TITLE
starknet_os: preallocate decompress result and unique_values buffers

### DIFF
--- a/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
@@ -575,7 +575,9 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
     let unique_value_bucket_lengths: Vec<usize> = header[2..2 + N_UNIQUE_BUCKETS].to_vec();
     let n_repeating_values = &header[2 + N_UNIQUE_BUCKETS];
 
-    let mut unique_values = Vec::new();
+    // `data_len` is the exact final length of `result` below, and of `all_values` (into which
+    // `unique_values` is moved after being extended with the repeating values).
+    let mut unique_values = Vec::with_capacity(*data_len);
     unique_values.extend(compressed.take(unique_value_bucket_lengths[0])); // 252 bucket.
     unique_values.extend(unpack_chunk::<125>(compressed, unique_value_bucket_lengths[1]));
     unique_values.extend(unpack_chunk::<83>(compressed, unique_value_bucket_lengths[2]));
@@ -605,7 +607,7 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
 
     let mut bucket_offset_trackers: Vec<_> = bucket_offsets;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(*data_len);
     for bucket_index in bucket_index_per_elm {
         let offset = &mut bucket_offset_trackers[bucket_index];
         let value = all_values[*offset];


### PR DESCRIPTION
## Description

Follow-up performance pass triggered by the merge of #14765, which removed a stale `#[allow(dead_code)]` on `stateless_compression::utils::decompress` — confirming it is live production code, not dead code. `decompress` runs once per block on the full state-diff output (`PartialOsStateDiff::try_from_output_iter`, `crates/starknet_os/src/io/os_output_types.rs:407`), iterating over every decompressed value, so its allocation pattern is a real hot path.

Two `Vec`s in `decompress` (`unique_values` and `result`) were started with `Vec::new()` and grown purely via `.extend()`/`.push()` in loops, incurring reallocate-and-copy cycles as capacity doubled during growth. Both vectors' final sizes are known upfront from the decompressed header: `data_len` is the exact final length of `result`, and of the `all_values` buffer that `unique_values` is moved into after being extended with the repeating values. This change preallocates both with `Vec::with_capacity(*data_len)`, eliminating the reallocations.

### Verification

- `RUSTC_WRAPPER="" CARGO_INCREMENTAL=0 cargo build -p starknet_os` — clean build.
- `RUSTC_WRAPPER="" CARGO_INCREMENTAL=0 SEED=0 cargo test -p starknet_os stateless_compression` — 35 passed, 0 failed (directly exercises `decompress` via `test_compress_decompress` and `test_cairo_compress`).
- `cargo clippy -p starknet_os --all-targets` — clean, no warnings.
- `scripts/rust_fmt.sh` — clean.
- Reviewed by an independent Opus pass, which confirmed `data_len` is provably the exact final length in both cases (traced through `compress()`/`CompressionSet::new`), confirmed no new OOM surface from adversarial input (since `data_len` is already used to preallocate elsewhere in the same function, and is bounded by `HEADER_ELM_BOUND` regardless), and found no other equally-safe preallocation wins in the same function.

This change is behavior-neutral: it only affects allocation strategy, not the decompressed output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrxMa21xTA4K9hNKFqGPFL)_