### PR TITLE
apollo_cairo_utils,apollo_staking: drop blockifier dep, take Vec<Felt> instead of Retdata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,6 @@ dependencies = [
 name = "apollo_cairo_utils"
 version = "0.0.0"
 dependencies = [
- "blockifier",
  "starknet-types-core",
  "thiserror 1.0.69",
 ]

--- a/crates/apollo_cairo_utils/Cargo.toml
+++ b/crates/apollo_cairo_utils/Cargo.toml
@@ -7,7 +7,6 @@ license-file.workspace = true
 description = "Cairo related utilities."
 
 [dependencies]
-blockifier.workspace = true
 starknet-types-core.workspace = true
 thiserror.workspace = true
 

--- a/crates/apollo_cairo_utils/src/lib.rs
+++ b/crates/apollo_cairo_utils/src/lib.rs
@@ -1,4 +1,3 @@
-use blockifier::execution::call_info::Retdata;
 use starknet_types_core::felt::Felt;
 use thiserror::Error;
 
@@ -75,16 +74,16 @@ where
     }
 }
 
-impl<T> TryFrom<Retdata> for CairoArray<T>
+impl<T> TryFrom<Vec<Felt>> for CairoArray<T>
 where
     T: TryFromIterator<Felt, Error = RetdataDeserializationError>,
 {
     type Error = RetdataDeserializationError;
 
-    fn try_from(retdata: Retdata) -> Result<Self, Self::Error> {
-        let mut iter = retdata.0.into_iter();
+    fn try_from(felts: Vec<Felt>) -> Result<Self, Self::Error> {
+        let mut iter = felts.into_iter();
 
-        // The first Felt in the Retdata must be the number of structs in the array.
+        // The first Felt in the retdata must be the number of structs in the array.
         let raw_num_items = Felt::try_from_iter(&mut iter)?;
 
         let num_items = usize::try_from(raw_num_items).map_err(|_| {
@@ -120,15 +119,15 @@ where
     }
 }
 
-impl<T> TryFrom<Retdata> for CairoOption<T>
+impl<T> TryFrom<Vec<Felt>> for CairoOption<T>
 where
     T: TryFromIterator<Felt, Error = RetdataDeserializationError>,
 {
     type Error = RetdataDeserializationError;
 
     /// Deserializes a Cairo `Option<T>` from retdata.
-    fn try_from(retdata: Retdata) -> Result<Self, Self::Error> {
-        let mut iter = retdata.0.into_iter();
+    fn try_from(felts: Vec<Felt>) -> Result<Self, Self::Error> {
+        let mut iter = felts.into_iter();
         let result = Option::<T>::try_from_iter(&mut iter)?;
         if iter.next().is_some() {
             return Err(RetdataDeserializationError::InvalidObjectLength {

--- a/crates/apollo_staking/src/cairo_staking_contract.rs
+++ b/crates/apollo_staking/src/cairo_staking_contract.rs
@@ -87,7 +87,7 @@ impl StakingContract for CairoStakingContract {
     async fn get_previous_epoch(&self) -> StakingContractResult<Option<Epoch>> {
         info!("Calling staking contract {GET_PREVIOUS_EPOCH_DATA_ENTRY_POINT}.");
         let retdata = self.call_view(GET_PREVIOUS_EPOCH_DATA_ENTRY_POINT, vec![]).await?;
-        let epoch = CairoOption::<Epoch>::try_from(retdata)?.0;
+        let epoch = CairoOption::<Epoch>::try_from(retdata.0)?.0;
         info!("Retrieved previous epoch from contract: {epoch:?}.");
         Ok(epoch)
     }

--- a/crates/apollo_staking/src/contract_types.rs
+++ b/crates/apollo_staking/src/contract_types.rs
@@ -78,7 +78,7 @@ impl TryFromIterator<Felt> for Epoch {
 
 impl ContractStaker {
     pub fn from_retdata_many(retdata: Retdata) -> Result<Vec<Self>, RetdataDeserializationError> {
-        Ok(CairoArray::try_from(retdata)?.0)
+        Ok(CairoArray::try_from(retdata.0)?.0)
     }
 }
 

--- a/crates/apollo_staking/src/contract_types_test.rs
+++ b/crates/apollo_staking/src/contract_types_test.rs
@@ -138,20 +138,16 @@ fn epoch_try_from_conversion_errors(#[case] raw_felts: Vec<Felt>) {
 
 #[rstest]
 fn optional_epoch_try_from_some() {
-    let result = CairoOption::<Epoch>::try_from(Retdata(vec![
-        Felt::ZERO,
-        Felt::ONE,
-        Felt::TWO,
-        Felt::THREE,
-    ]))
-    .unwrap()
-    .0;
+    let result =
+        CairoOption::<Epoch>::try_from(vec![Felt::ZERO, Felt::ONE, Felt::TWO, Felt::THREE])
+            .unwrap()
+            .0;
     assert_eq!(result, Some(Epoch { epoch_id: 1, start_block: BlockNumber(2), epoch_length: 3 }));
 }
 
 #[rstest]
 fn optional_epoch_try_from_none() {
-    let result = CairoOption::<Epoch>::try_from(Retdata(vec![Felt::ONE])).unwrap().0;
+    let result = CairoOption::<Epoch>::try_from(vec![Felt::ONE]).unwrap().0;
     assert_eq!(result, None);
 }
 
@@ -161,12 +157,12 @@ fn optional_epoch_try_from_none() {
 #[case::some_long_length(vec![Felt::ZERO, Felt::ONE, Felt::ONE, Felt::ONE, Felt::ONE])]
 #[case::none_wrong_length(vec![Felt::ONE, Felt::TWO])]
 fn optional_epoch_try_from_invalid_length(#[case] raw_felts: Vec<Felt>) {
-    let err = CairoOption::<Epoch>::try_from(Retdata(raw_felts)).unwrap_err();
+    let err = CairoOption::<Epoch>::try_from(raw_felts).unwrap_err();
     assert_matches!(err, RetdataDeserializationError::InvalidObjectLength { .. });
 }
 
 #[rstest]
 fn optional_epoch_try_from_invalid_variant() {
-    let err = CairoOption::<Epoch>::try_from(Retdata(vec![Felt::TWO])).unwrap_err();
+    let err = CairoOption::<Epoch>::try_from(vec![Felt::TWO]).unwrap_err();
     assert_matches!(err, RetdataDeserializationError::UnexpectedEnumVariant { variant: 2 });
 }


### PR DESCRIPTION
apollo_cairo_utils imported blockifier solely for Retdata, a newtype over
Vec<Felt>, dragging the full execution stack into its dependency tree
(352 -> 17 unique normal deps). Take Vec<Felt> directly and let callers
unwrap the newtype. apollo_staking, the only current consumer, already
depends on blockifier for its own Retdata handling, so this does not
shrink any shipped binary today; it makes apollo_cairo_utils cheap for
future consumers and shrinks its rebuild cone.