### PR TITLE
apollo_node_config: drop apollo_storage dep, use apollo_storage_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ dependencies = [
  "apollo_sierra_compilation_config",
  "apollo_staking_config",
  "apollo_state_sync_config",
- "apollo_storage",
+ "apollo_storage_config",
  "blockifier",
  "clap",
  "const_format",

--- a/crates/apollo_node_config/Cargo.toml
+++ b/crates/apollo_node_config/Cargo.toml
@@ -35,7 +35,6 @@ apollo_reverts.workspace = true
 apollo_sierra_compilation_config.workspace = true
 apollo_staking_config.workspace = true
 apollo_state_sync_config.workspace = true
-apollo_storage.workspace = true
 blockifier.workspace = true
 clap.workspace = true
 const_format.workspace = true
@@ -48,5 +47,6 @@ validator.workspace = true
 [dev-dependencies]
 apollo_config = { workspace = true, features = ["testing"] }
 apollo_infra_utils = { workspace = true, features = ["testing"] }
+apollo_storage_config.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true

--- a/crates/apollo_node_config/src/config_test.rs
+++ b/crates/apollo_node_config/src/config_test.rs
@@ -5,7 +5,7 @@ use apollo_infra::component_client::RemoteClientConfig;
 use apollo_infra::component_server::{LocalServerConfig, RemoteServerConfig};
 use apollo_infra_utils::dumping::serialize_to_file_test;
 use apollo_state_sync_config::config::{StateSyncConfig, StateSyncStaticConfig};
-use apollo_storage::{StorageConfig, StorageScope};
+use apollo_storage_config::{StorageConfig, StorageScope};
 use rstest::rstest;
 use validator::Validate;
 


### PR DESCRIPTION
apollo_node_config only used apollo_storage for StorageConfig/StorageScope
inside a #[cfg(test)] module, but listed it as a regular dependency,
unconditionally pulling in libmdbx. Both types are pure re-exports from
apollo_storage_config as of the previous commit; depend on that instead,
moved to dev-dependencies since it's test-only.

Found by the team-review of the apollo_storage_config extraction.