### PR TITLE
blockifier,apollo_gateway,apollo_p2p_sync: keep test-utils out of production build graphs

### DIFF
--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -39,7 +39,6 @@ blockifier.workspace = true
 blockifier_test_utils = { workspace = true, optional = true }
 clap.workspace = true
 google-cloud-storage.workspace = true
-mempool_test_utils.workspace = true
 mockall.workspace = true
 num-rational.workspace = true
 reqwest.workspace = true
@@ -70,6 +69,7 @@ blockifier_test_utils.workspace = true
 cairo-lang-sierra-to-casm.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 expect-test.workspace = true
+mempool_test_utils.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 mockall.workspace = true

--- a/crates/apollo_p2p_sync/Cargo.toml
+++ b/crates/apollo_p2p_sync/Cargo.toml
@@ -15,7 +15,6 @@ apollo_protobuf.workspace = true
 apollo_state_sync_metrics.workspace = true
 apollo_state_sync_types.workspace = true
 apollo_storage.workspace = true
-apollo_test_utils.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
@@ -38,6 +37,7 @@ apollo_class_manager_types = { workspace = true, features = ["testing"] }
 apollo_network = { workspace = true, features = ["testing"] }
 apollo_protobuf = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
+apollo_test_utils.workspace = true
 assert_matches.workspace = true
 lazy_static.workspace = true
 mockall.workspace = true

--- a/crates/apollo_p2p_sync/src/client/transaction.rs
+++ b/crates/apollo_p2p_sync/src/client/transaction.rs
@@ -12,8 +12,25 @@ use apollo_storage::{StorageError, StorageReader, StorageWriter};
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt};
 use starknet_api::block::{BlockBody, BlockNumber};
-use starknet_api::test_utils::invoke::{invoke_tx, InvokeTxArgs};
-use starknet_api::transaction::{FullTransaction, Transaction, TransactionOutput};
+use starknet_api::core::{ContractAddress, Nonce};
+use starknet_api::data_availability::DataAvailabilityMode;
+use starknet_api::transaction::fields::{
+    AccountDeploymentData,
+    AllResourceBounds,
+    Calldata,
+    PaymasterData,
+    ProofFacts,
+    Tip,
+    TransactionSignature,
+    ValidResourceBounds,
+};
+use starknet_api::transaction::{
+    FullTransaction,
+    InvokeTransaction,
+    InvokeTransactionV3,
+    Transaction,
+    TransactionOutput,
+};
 
 use super::block_data_stream_builder::{
     BadPeerError,
@@ -113,12 +130,27 @@ impl BlockDataStreamBuilder<FullTransaction> for TransactionStreamFactory {
             })
             .take(num_transactions)
             .collect::<Vec<_>>(),
-            transactions: std::iter::repeat_with(|| {
-                Transaction::Invoke(invoke_tx(InvokeTxArgs::default()))
-            })
-            .take(num_transactions)
-            .collect::<Vec<_>>(),
+            transactions: vec![empty_invoke_transaction(); num_transactions],
         };
         (block_body, block_number)
     }
+}
+
+/// An all-zero invoke transaction, used to pad a block body to the transaction count reported by
+/// the sync block. The sync block carries only transaction hashes, so the bodies themselves are
+/// placeholders and are never executed or fee-checked.
+fn empty_invoke_transaction() -> Transaction {
+    Transaction::Invoke(InvokeTransaction::V3(InvokeTransactionV3 {
+        resource_bounds: ValidResourceBounds::AllResources(AllResourceBounds::default()),
+        tip: Tip::default(),
+        signature: TransactionSignature::default(),
+        nonce: Nonce::default(),
+        sender_address: ContractAddress::default(),
+        calldata: Calldata::default(),
+        nonce_data_availability_mode: DataAvailabilityMode::L1,
+        fee_data_availability_mode: DataAvailabilityMode::L1,
+        paymaster_data: PaymasterData::default(),
+        account_deployment_data: AccountDeploymentData::default(),
+        proof_facts: ProofFacts::default(),
+    }))
 }

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [features]
 benchmarking = []
 cairo_native = [
-  "blockifier_test_utils/cairo_native",
+  "blockifier_test_utils?/cairo_native",
   "dep:apollo_compilation_utils",
   "dep:apollo_compile_to_native",
   "dep:cairo-native",


### PR DESCRIPTION
Three vectors pulled workspace test-utils crates and testing features into
the production apollo_node and blockifier_reexecution images via Cargo
feature unification:
- blockifier's cairo_native feature spec was missing a ? on
  blockifier_test_utils/cairo_native, force-enabling the optional test-only
  dep in every cairo_native build.
- apollo_gateway carried mempool_test_utils as a normal dependency for one
  cfg(test) import, dragging papyrus_base_layer/testing (Anvil node
  bindings) into the node.
- apollo_p2p_sync carried apollo_test_utils as a normal dependency for
  cfg(test)-only imports.

apollo_p2p_sync's placeholder sync transactions (client/transaction.rs)
turn out to genuinely use testing-gated starknet_api constructors and only
compiled through the unification leak. They are now built by a local
empty_invoke_transaction helper: the sync block carries only transaction
hashes, so these bodies exist to pad the block body to the reported
transaction count and are never executed or fee-checked. The one value that
changes is the placeholder's resource bounds, which drop from the testing
helper's max_price_per_unit of 1 to zero.

Note: dropping papyrus_base_layer/testing from the node graph also flips
the compiled L1 Starknet contract ABI from the testing mock
(StarknetForSequencerTesting.json) to the real Starknet-0.10.3.4.json in
ethereum_base_layer_contract.rs. The production-used ABI surface (message
events, stateBlockNumber/stateBlockHash) is identical in both files.

After: apollo_node's cairo_native graph has no workspace test-utils crates
and no workspace testing features; apollo_gateway drops from 709 to 642
unique normal deps; testing + cairo_native builds still resolve
blockifier_test_utils/cairo_native.
