### PR TITLE
apollo_transaction_converter,blockifier: drop test-only blockifier dep and dead build-deps section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,7 +2888,6 @@ dependencies = [
  "apollo_proof_manager_types",
  "assert_matches",
  "async-trait",
- "blockifier",
  "blockifier_test_utils",
  "mempool_test_utils",
  "mockall",

--- a/crates/apollo_transaction_converter/Cargo.toml
+++ b/crates/apollo_transaction_converter/Cargo.toml
@@ -30,7 +30,6 @@ tracing.workspace = true
 apollo_class_manager_types = { workspace = true, features = ["testing"] }
 apollo_proof_manager_types = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
-blockifier = { workspace = true, features = ["testing"] }
 blockifier_test_utils.workspace = true
 mempool_test_utils.workspace = true
 mockall.workspace = true

--- a/crates/apollo_transaction_converter/src/transaction_converter_test.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter_test.rs
@@ -4,7 +4,6 @@ use apollo_class_manager_types::{ClassHashes, MockClassManagerClient};
 use apollo_config::behavior_mode::BehaviorMode;
 use apollo_proof_manager_types::MockProofManagerClient;
 use assert_matches::assert_matches;
-use blockifier::context::ChainInfo;
 use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
 use mempool_test_utils::starknet_api_test_utils::{
     declare_tx,
@@ -17,7 +16,7 @@ use starknet_api::compiled_class_hash;
 use starknet_api::consensus_transaction::ConsensusTransaction;
 use starknet_api::executable_transaction::ValidateCompiledClassHashError;
 use starknet_api::rpc_transaction::{RpcDeclareTransaction, RpcTransaction};
-use starknet_api::test_utils::{path_in_resources, read_json_file};
+use starknet_api::test_utils::{path_in_resources, read_json_file, CHAIN_ID_FOR_TESTS};
 use starknet_api::transaction::fields::{Proof, ProofFacts};
 
 use crate::transaction_converter::{
@@ -54,7 +53,7 @@ fn create_transaction_converter(
     TransactionConverter::new(
         Arc::new(MockClassManagerClient::new()),
         Arc::new(mock_proof_manager_client),
-        ChainInfo::create_for_testing().chain_id,
+        CHAIN_ID_FOR_TESTS.clone(),
     )
 }
 
@@ -102,7 +101,7 @@ async fn test_compiled_class_hash_mismatch() {
     let transaction_converter = TransactionConverter::new(
         Arc::new(mock_class_manager_client),
         Arc::new(mock_proof_manager_client),
-        ChainInfo::create_for_testing().chain_id,
+        CHAIN_ID_FOR_TESTS.clone(),
     );
 
     let err =
@@ -251,7 +250,7 @@ async fn test_internal_rpc_to_rpc_in_echonet_mode_skips_proof_manager_lookup(
     let transaction_converter = TransactionConverter::new(
         Arc::new(MockClassManagerClient::new()),
         Arc::new(MockProofManagerClient::new()),
-        ChainInfo::create_for_testing().chain_id,
+        CHAIN_ID_FOR_TESTS.clone(),
     )
     .with_behavior_mode(BehaviorMode::Echonet);
 

--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -108,8 +108,6 @@ starknet_api = { workspace = true, features = ["testing"] }
 test-case.workspace = true
 tikv-jemallocator.workspace = true
 
-[build-dependencies]
-apollo_infra_utils.workspace = true
 
 [[bench]]
 harness = false


### PR DESCRIPTION
apollo_transaction_converter's tests used blockifier only for
ChainInfo::create_for_testing().chain_id, which is CHAIN_ID_FOR_TESTS from
starknet_api::test_utils — already a dev-dependency here. Swapping the two
call sites removes the whole blockifier stack from this crate's test builds.

blockifier's [build-dependencies] section is dead config: the crate has no
build script (build.rs was removed), so cargo never compiles it.