### PR TITLE
apollo_consensus_orchestrator: demote batcher dep to dev

### DIFF
--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -7,7 +7,6 @@ license-file.workspace = true
 description = "Implements the consensus context and orchestrates the node's components accordingly"
 
 [dependencies]
-apollo_batcher.workspace = true
 apollo_batcher_types.workspace = true
 apollo_class_manager_types.workspace = true
 apollo_config.workspace = true


### PR DESCRIPTION
The orchestrator's only apollo_batcher usage is a cfg(test) module
(src/cende/central_objects_test.rs), and a dev-dependencies twin already
existed — the normal edge dragged apollo_batcher (and its
apollo_state_reader/apollo_starknet_client chain) into
apollo_consensus_manager's graph for nothing.
