### PR TITLE
apollo_gateway: validate builtins of declared compiled classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,8 @@ dependencies = [
  "blockifier",
  "blockifier_test_utils",
  "cairo-lang-sierra-to-casm",
+ "cairo-lang-starknet-classes",
+ "cairo-vm",
  "clap",
  "criterion",
  "google-cloud-storage",

--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -37,6 +37,8 @@ apollo_transaction_converter.workspace = true
 async-trait.workspace = true
 blockifier.workspace = true
 blockifier_test_utils = { workspace = true, optional = true }
+cairo-lang-starknet-classes.workspace = true
+cairo-vm.workspace = true
 clap.workspace = true
 google-cloud-storage.workspace = true
 mempool_test_utils.workspace = true

--- a/crates/apollo_gateway/src/errors.rs
+++ b/crates/apollo_gateway/src/errors.rs
@@ -91,6 +91,11 @@ pub enum StatelessTransactionValidatorError {
         "Client-side proof is too large: size {proof_size} (maximum allowed: {max_proof_size})."
     )]
     ProofTooLarge { proof_size: usize, max_proof_size: usize },
+    #[error(
+        "The compiled contract class uses unsupported builtins or an invalid builtin order: \
+         {builtins:?}. Builtins must be an ordered subsequence of {supported_builtins:?}."
+    )]
+    UnsupportedBuiltins { builtins: Vec<String>, supported_builtins: Vec<String> },
 }
 
 impl From<StatelessTransactionValidatorError> for GatewaySpecError {
@@ -115,7 +120,8 @@ impl From<StatelessTransactionValidatorError> for GatewaySpecError {
             | StatelessTransactionValidatorError::MaxGasAmountTooHigh { .. }
             | StatelessTransactionValidatorError::ClientSideProvingNotAllowed
             | StatelessTransactionValidatorError::ProofFactsAndProofConsistency { .. }
-            | StatelessTransactionValidatorError::ProofTooLarge { .. } => {
+            | StatelessTransactionValidatorError::ProofTooLarge { .. }
+            | StatelessTransactionValidatorError::UnsupportedBuiltins { .. } => {
                 GatewaySpecError::ValidationFailure { data: e.to_string() }
             }
         }
@@ -201,6 +207,11 @@ impl From<StatelessTransactionValidatorError> for StarknetError {
             }
             StatelessTransactionValidatorError::ProofTooLarge { .. } => {
                 StarknetErrorCode::UnknownErrorCode("StarknetErrorCode.PROOF_TOO_LARGE".to_string())
+            }
+            StatelessTransactionValidatorError::UnsupportedBuiltins { .. } => {
+                StarknetErrorCode::UnknownErrorCode(
+                    "StarknetErrorCode.INVALID_CONTRACT_CLASS".to_string(),
+                )
             }
         };
         StarknetError { code, message }

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -70,6 +70,7 @@ use crate::stateful_transaction_validator::{
     StatefulTransactionValidatorTrait,
 };
 use crate::stateless_transaction_validator::{
+    validate_casm_builtins,
     StatelessTransactionValidator,
     StatelessTransactionValidatorTrait,
 };
@@ -253,6 +254,15 @@ impl<
         let (internal_tx, executable_tx, proof_data) =
             self.convert_rpc_tx_to_internal_and_executable_txs(tx, &tx_signature).await?;
         drop(compilation_permit);
+
+        // Validate the compiled class builtins (only available post-compilation).
+        if let AccountTransaction::Declare(declare_tx) = &executable_tx {
+            validate_casm_builtins(declare_tx.casm_contract_class()).map_err(|e| {
+                let error = StarknetError::from(e);
+                metric_counters.record_add_tx_failure(&error);
+                error
+            })?;
+        }
 
         let mut stateful_transaction_validator = self
             .stateful_tx_validator_factory

--- a/crates/apollo_gateway/src/stateless_transaction_validator.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator.rs
@@ -1,5 +1,7 @@
 use apollo_gateway_config::compiler_version::VersionId;
 use apollo_gateway_config::config::StatelessTransactionValidatorConfig;
+use cairo_lang_starknet_classes::casm_contract_class::{CasmContractClass, CasmContractEntryPoint};
+use cairo_vm::utils::is_subsequence;
 use starknet_api::data_availability::DataAvailabilityMode;
 use starknet_api::rpc_transaction::{
     RpcDeclareTransaction,
@@ -17,6 +19,20 @@ use crate::errors::{StatelessTransactionValidatorError, StatelessTransactionVali
 #[cfg(test)]
 #[path = "stateless_transaction_validator_test.rs"]
 mod stateless_transaction_validator_test;
+
+/// The builtins supported for Cairo 1 (Sierra) contracts, in their canonical order.
+const CAIRO1_SUPPORTED_BUILTINS: [&str; 10] = [
+    "pedersen",
+    "range_check",
+    "ecdsa",
+    "bitwise",
+    "ec_op",
+    "poseidon",
+    "segment_arena",
+    "range_check96",
+    "add_mod",
+    "mul_mod",
+];
 
 #[cfg_attr(test, mockall::automock)]
 pub trait StatelessTransactionValidatorTrait: Send + Sync {
@@ -359,4 +375,39 @@ impl StatelessTransactionValidatorTrait for StatelessTransactionValidator {
     fn validate(&self, tx: &RpcTransaction) -> StatelessTransactionValidatorResult<()> {
         Self::validate(self, tx)
     }
+}
+
+/// Validates the builtins of a compiled (CASM) contract class. Each entry point's builtins must be
+/// an ordered subsequence of [`CAIRO1_SUPPORTED_BUILTINS`]. This runs on the output of the
+/// Sierra-to-CASM compilation, so it must be called by the gateway after the class is compiled.
+pub(crate) fn validate_casm_builtins(
+    casm_contract_class: &CasmContractClass,
+) -> StatelessTransactionValidatorResult<()> {
+    let entry_points_by_type = &casm_contract_class.entry_points_by_type;
+    for entry_point in entry_points_by_type
+        .constructor
+        .iter()
+        .chain(entry_points_by_type.external.iter())
+        .chain(entry_points_by_type.l1_handler.iter())
+    {
+        validate_entry_point_builtins(entry_point)?;
+    }
+
+    Ok(())
+}
+
+fn validate_entry_point_builtins(
+    entry_point: &CasmContractEntryPoint,
+) -> StatelessTransactionValidatorResult<()> {
+    // The builtins must be supported and appear in the canonical order, i.e. form an ordered
+    // subsequence of `CAIRO1_SUPPORTED_BUILTINS`.
+    let builtins: Vec<&str> = entry_point.builtins.iter().map(String::as_str).collect();
+    if is_subsequence(&builtins, &CAIRO1_SUPPORTED_BUILTINS) {
+        return Ok(());
+    }
+
+    Err(StatelessTransactionValidatorError::UnsupportedBuiltins {
+        builtins: entry_point.builtins.clone(),
+        supported_builtins: CAIRO1_SUPPORTED_BUILTINS.iter().map(|b| b.to_string()).collect(),
+    })
 }

--- a/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
+++ b/crates/apollo_gateway/src/stateless_transaction_validator_test.rs
@@ -5,6 +5,11 @@ use apollo_gateway_config::compiler_version::{VersionId, VersionIdError};
 use apollo_gateway_config::config::StatelessTransactionValidatorConfig;
 use assert_matches::assert_matches;
 use blockifier::test_utils::create_valid_proof_facts_for_testing;
+use cairo_lang_starknet_classes::casm_contract_class::{
+    CasmContractClass,
+    CasmContractEntryPoint,
+    CasmContractEntryPoints,
+};
 use rstest::rstest;
 use starknet_api::block::GasPrice;
 use starknet_api::core::{EntryPointSelector, L2_ADDRESS_UPPER_BOUND};
@@ -35,6 +40,7 @@ use starknet_types_core::felt::Felt;
 
 use crate::errors::StatelessTransactionValidatorResult;
 use crate::stateless_transaction_validator::{
+    validate_casm_builtins,
     StatelessTransactionValidator,
     StatelessTransactionValidatorError,
 };
@@ -719,4 +725,82 @@ fn test_proof_facts_and_proof_consistency(
             }) if has_proof_facts == expected_has_proof_facts && has_proof == expected_has_proof
         );
     }
+}
+
+fn casm_entry_points(builtins_per_entry_point: Vec<Vec<&str>>) -> Vec<CasmContractEntryPoint> {
+    builtins_per_entry_point
+        .into_iter()
+        .map(|builtins| CasmContractEntryPoint {
+            builtins: builtins.into_iter().map(String::from).collect(),
+            ..Default::default()
+        })
+        .collect()
+}
+
+fn casm_contract_class_with_builtins(
+    constructor: Vec<Vec<&str>>,
+    external: Vec<Vec<&str>>,
+    l1_handler: Vec<Vec<&str>>,
+) -> CasmContractClass {
+    CasmContractClass {
+        prime: Default::default(),
+        compiler_version: String::new(),
+        bytecode: vec![],
+        bytecode_segment_lengths: None,
+        hints: vec![],
+        pythonic_hints: None,
+        entry_points_by_type: CasmContractEntryPoints {
+            constructor: casm_entry_points(constructor),
+            external: casm_entry_points(external),
+            l1_handler: casm_entry_points(l1_handler),
+        },
+    }
+}
+
+// Tests that a compiled class whose every entry point uses supported builtins in the canonical
+// order passes validation.
+#[rstest]
+#[case::no_builtins(vec![])]
+#[case::single_builtin(vec!["range_check"])]
+#[case::strict_subsequence(vec!["pedersen", "range_check", "poseidon"])]
+#[case::all_supported_builtins(vec![
+    "pedersen",
+    "range_check",
+    "ecdsa",
+    "bitwise",
+    "ec_op",
+    "poseidon",
+    "segment_arena",
+    "range_check96",
+    "add_mod",
+    "mul_mod",
+])]
+fn test_validate_casm_builtins_valid(#[case] builtins: Vec<&str>) {
+    // Place the builtins in an l1_handler entry point to also cover non-first entry-point kinds.
+    let casm_contract_class =
+        casm_contract_class_with_builtins(vec![vec!["range_check"]], vec![], vec![builtins]);
+
+    assert_matches!(validate_casm_builtins(&casm_contract_class), Ok(()));
+}
+
+// Tests that a compiled class with an unsupported or wrongly-ordered builtin list is rejected, and
+// that the offending builtins are reported.
+#[rstest]
+#[case::wrong_order(vec!["range_check", "pedersen"])]
+#[case::unknown_builtin(vec!["range_check", "keccak"])]
+#[case::duplicate_builtin(vec!["range_check", "range_check"])]
+fn test_validate_casm_builtins_invalid(#[case] builtins: Vec<&str>) {
+    let expected_builtins: Vec<String> = builtins.iter().map(|b| b.to_string()).collect();
+    // Put the offending entry point last (l1_handler) to ensure all entry-point kinds are scanned.
+    let casm_contract_class = casm_contract_class_with_builtins(
+        vec![vec!["pedersen"]],
+        vec![vec!["range_check"]],
+        vec![builtins],
+    );
+
+    assert_matches!(
+        validate_casm_builtins(&casm_contract_class),
+        Err(StatelessTransactionValidatorError::UnsupportedBuiltins { builtins, .. })
+            if builtins == expected_builtins
+    );
 }


### PR DESCRIPTION
Validate that each entry point of a declared class's compiled CASM uses only supported builtins, in the canonical order (an ordered subsequence of the supported list). Runs in the gateway after Sierra-to-CASM compilation.

**Draft / CI-only.** Base branch is `yonatan/apollo-0.14.3-rc.12-base`, pinned at tag `APOLLO-0.14.3-RC.12` (`9f78ee7`), so CI runs on a clean single-commit diff. Not intended for merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)