### PR TITLE
apollo_gateway: validate entry point return types of declared sierra classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,6 +1541,7 @@ name = "apollo_gateway"
 version = "0.19.0-rc.2"
 dependencies = [
  "apollo_class_manager_types",
+ "apollo_compilation_utils",
  "apollo_config",
  "apollo_gateway_config",
  "apollo_gateway_types",
@@ -1558,8 +1559,10 @@ dependencies = [
  "async-trait",
  "blockifier",
  "blockifier_test_utils",
+ "cairo-lang-sierra",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-starknet-classes",
+ "cairo-lang-utils",
  "cairo-vm",
  "clap",
  "criterion",

--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -23,6 +23,7 @@ testing = [
 
 [dependencies]
 apollo_class_manager_types.workspace = true
+apollo_compilation_utils.workspace = true
 apollo_config.workspace = true
 apollo_gateway_config.workspace = true
 apollo_gateway_types.workspace = true
@@ -37,7 +38,9 @@ apollo_transaction_converter.workspace = true
 async-trait.workspace = true
 blockifier.workspace = true
 blockifier_test_utils = { workspace = true, optional = true }
+cairo-lang-sierra.workspace = true
 cairo-lang-starknet-classes.workspace = true
+cairo-lang-utils.workspace = true
 cairo-vm.workspace = true
 clap.workspace = true
 google-cloud-storage.workspace = true

--- a/crates/apollo_gateway/src/errors.rs
+++ b/crates/apollo_gateway/src/errors.rs
@@ -18,6 +18,9 @@ use starknet_api::StarknetApiError;
 use thiserror::Error;
 use tracing::{debug, error, warn};
 
+// This is the gateway's copy of the compiler's validation error, not the cairo crate's enum.
+use crate::sierra_entry_point_validation::StarknetSierraCompilationError;
+
 pub type GatewayResult<T> = Result<T, StarknetError>;
 
 #[derive(Debug, Error)]
@@ -96,6 +99,8 @@ pub enum StatelessTransactionValidatorError {
          {builtins:?}. Builtins must be an ordered subsequence of {supported_builtins:?}."
     )]
     UnsupportedBuiltins { builtins: Vec<String>, supported_builtins: Vec<String> },
+    #[error(transparent)]
+    SierraValidationError(#[from] StarknetSierraCompilationError),
 }
 
 impl From<StatelessTransactionValidatorError> for GatewaySpecError {
@@ -121,7 +126,8 @@ impl From<StatelessTransactionValidatorError> for GatewaySpecError {
             | StatelessTransactionValidatorError::ClientSideProvingNotAllowed
             | StatelessTransactionValidatorError::ProofFactsAndProofConsistency { .. }
             | StatelessTransactionValidatorError::ProofTooLarge { .. }
-            | StatelessTransactionValidatorError::UnsupportedBuiltins { .. } => {
+            | StatelessTransactionValidatorError::UnsupportedBuiltins { .. }
+            | StatelessTransactionValidatorError::SierraValidationError(..) => {
                 GatewaySpecError::ValidationFailure { data: e.to_string() }
             }
         }
@@ -208,7 +214,8 @@ impl From<StatelessTransactionValidatorError> for StarknetError {
             StatelessTransactionValidatorError::ProofTooLarge { .. } => {
                 StarknetErrorCode::UnknownErrorCode("StarknetErrorCode.PROOF_TOO_LARGE".to_string())
             }
-            StatelessTransactionValidatorError::UnsupportedBuiltins { .. } => {
+            StatelessTransactionValidatorError::UnsupportedBuiltins { .. }
+            | StatelessTransactionValidatorError::SierraValidationError(..) => {
                 StarknetErrorCode::UnknownErrorCode(
                     "StarknetErrorCode.INVALID_CONTRACT_CLASS".to_string(),
                 )

--- a/crates/apollo_gateway/src/gateway.rs
+++ b/crates/apollo_gateway/src/gateway.rs
@@ -49,6 +49,7 @@ use crate::errors::{
     mempool_client_result_to_deprecated_gw_result,
     transaction_converter_err_to_deprecated_gw_err,
     GatewayResult,
+    StatelessTransactionValidatorError,
 };
 use crate::metrics::{
     register_metrics,
@@ -63,6 +64,7 @@ use crate::proof_archive_writer::{
     ProofArchiveError,
     ProofArchiveWriterTrait,
 };
+use crate::sierra_entry_point_validation::validate_entry_point_return_types;
 use crate::state_reader::StateReaderFactory;
 use crate::stateful_transaction_validator::{
     StatefulTransactionValidatorFactory,
@@ -251,6 +253,15 @@ impl<
             None
         };
 
+        // The Sierra class is kept for post-compilation validation, as the executable tx holds
+        // only the compiled class.
+        let sierra_contract_class = match &tx {
+            RpcTransaction::Declare(RpcDeclareTransaction::V3(declare_tx)) => {
+                Some(declare_tx.contract_class.clone())
+            }
+            RpcTransaction::DeployAccount(_) | RpcTransaction::Invoke(_) => None,
+        };
+
         let (internal_tx, executable_tx, proof_data) =
             self.convert_rpc_tx_to_internal_and_executable_txs(tx, &tx_signature).await?;
         drop(compilation_permit);
@@ -262,6 +273,16 @@ impl<
                 metric_counters.record_add_tx_failure(&error);
                 error
             })?;
+
+            // Validate the entry point return types of the Sierra class. Done post-compilation so
+            // that the program is known to deserialize successfully.
+            if let Some(sierra_contract_class) = &sierra_contract_class {
+                validate_entry_point_return_types(sierra_contract_class).map_err(|e| {
+                    let error = StarknetError::from(StatelessTransactionValidatorError::from(e));
+                    metric_counters.record_add_tx_failure(&error);
+                    error
+                })?;
+            }
         }
 
         let mut stateful_transaction_validator = self

--- a/crates/apollo_gateway/src/lib.rs
+++ b/crates/apollo_gateway/src/lib.rs
@@ -4,6 +4,7 @@ pub mod gateway;
 pub mod gateway_fixed_block_state_reader;
 pub mod metrics;
 pub mod proof_archive_writer;
+mod sierra_entry_point_validation;
 mod state_reader;
 #[cfg(any(feature = "testing", test))]
 mod state_reader_test_utils;

--- a/crates/apollo_gateway/src/sierra_entry_point_validation.rs
+++ b/crates/apollo_gateway/src/sierra_entry_point_validation.rs
@@ -1,0 +1,223 @@
+//! Validation of the entry point return types of a declared Sierra class, as performed by the
+//! Sierra-to-CASM compiler.
+//!
+//! The code is copied from `cairo_lang_starknet_classes::casm_contract_class` (the version pinned
+//! in the workspace) and intentionally mirrors it as closely as possible to ease diffing against
+//! the original. The deliberate divergences are:
+//! - Only the entry point return type validation is kept; the rest of the signature checks (which
+//!   compilation re-runs anyway), compilation, hashing and CASM entry point construction are
+//!   dropped.
+//! - The panic type of an entry point's error variant must be the empty struct (a fix not yet
+//!   present in the pinned compiler version).
+//!
+//! As in the original, `TypeResolver` panics on a malformed program (out-of-range type ids), so
+//! this validation must only run on classes that already compiled successfully.
+
+use apollo_compilation_utils::class_utils::into_contract_class_for_compilation;
+use cairo_lang_sierra::extensions::array::ArrayType;
+use cairo_lang_sierra::extensions::enm::EnumType;
+use cairo_lang_sierra::extensions::felt252::Felt252Type;
+use cairo_lang_sierra::extensions::snapshot::SnapshotType;
+use cairo_lang_sierra::extensions::structure::StructType;
+use cairo_lang_sierra::extensions::NamedType;
+use cairo_lang_sierra::ids::{ConcreteTypeId, GenericTypeId};
+use cairo_lang_sierra::program::{ConcreteTypeLongId, GenericArg, TypeDeclaration};
+use cairo_lang_starknet_classes::contract_class::ContractEntryPoint;
+use cairo_lang_utils::require;
+use starknet_api::state::SierraContractClass;
+use thiserror::Error;
+
+// Trimmed copy of `cairo_lang_starknet_classes::casm_contract_class`'s error enum of the same
+// name, keeping only the variants produced by the entry point return type validation, plus a
+// variant for a Sierra program that fails to deserialize (the compiler fails earlier in that
+// case, before reaching this validation).
+#[derive(Error, Debug, Eq, PartialEq)]
+pub enum StarknetSierraCompilationError {
+    #[error("Failed deserializing the Sierra program: {0}")]
+    SierraProgramDeserializationFailed(String),
+    #[error("Invalid entry point.")]
+    EntryPointError,
+    #[error("Invalid entry point signature.")]
+    InvalidEntryPointSignature,
+}
+
+/// Validates the return type of every entry point of the given class, as the Sierra-to-CASM
+/// compiler (`CasmContractClass::from_contract_class`) does before compiling it.
+pub fn validate_entry_point_return_types(
+    contract_class: &SierraContractClass,
+) -> Result<(), StarknetSierraCompilationError> {
+    let contract_class = into_contract_class_for_compilation(contract_class);
+    let extracted_program = contract_class.extract_sierra_program(false).map_err(|error| {
+        StarknetSierraCompilationError::SierraProgramDeserializationFailed(error.to_string())
+    })?;
+    let program = extracted_program.program;
+
+    let validate_entry_point = |contract_entry_point: &ContractEntryPoint| {
+        let Some(function) = program.funcs.get(contract_entry_point.function_idx) else {
+            return Err(StarknetSierraCompilationError::EntryPointError);
+        };
+
+        // The expected return types are [builtins.., gas_builtin, system, PanicResult].
+        let (panic_result, _output_builtins) = function
+            .signature
+            .ret_types
+            .split_last()
+            .ok_or(StarknetSierraCompilationError::InvalidEntryPointSignature)?;
+
+        let type_resolver = TypeResolver { type_decl: &program.type_declarations };
+        require(type_resolver.is_valid_entry_point_return_type(panic_result))
+            .ok_or(StarknetSierraCompilationError::InvalidEntryPointSignature)?;
+
+        Ok(())
+    };
+
+    for entry_point in contract_class
+        .entry_points_by_type
+        .constructor
+        .iter()
+        .chain(contract_class.entry_points_by_type.external.iter())
+        .chain(contract_class.entry_points_by_type.l1_handler.iter())
+    {
+        validate_entry_point(entry_point)?;
+    }
+
+    Ok(())
+}
+
+/// Context for resolving types.
+pub struct TypeResolver<'a> {
+    type_decl: &'a [TypeDeclaration],
+}
+
+impl TypeResolver<'_> {
+    fn get_long_id(&self, type_id: &ConcreteTypeId) -> &ConcreteTypeLongId {
+        &self.type_decl[type_id.id as usize].long_id
+    }
+
+    fn get_generic_id(&self, type_id: &ConcreteTypeId) -> &GenericTypeId {
+        &self.get_long_id(type_id).generic_id
+    }
+
+    fn is_felt252_array_snapshot(&self, ty: &ConcreteTypeId) -> bool {
+        let long_id = self.get_long_id(ty);
+        if long_id.generic_id != SnapshotType::id() {
+            return false;
+        }
+
+        let [GenericArg::Type(inner_ty)] = long_id.generic_args.as_slice() else {
+            return false;
+        };
+
+        self.is_felt252_array(inner_ty)
+    }
+
+    fn is_felt252_array(&self, ty: &ConcreteTypeId) -> bool {
+        let long_id = self.get_long_id(ty);
+        if long_id.generic_id != ArrayType::id() {
+            return false;
+        }
+
+        let [GenericArg::Type(element_ty)] = long_id.generic_args.as_slice() else {
+            return false;
+        };
+
+        *self.get_generic_id(element_ty) == Felt252Type::id()
+    }
+
+    fn is_felt252_span(&self, ty: &ConcreteTypeId) -> bool {
+        let long_id = self.get_long_id(ty);
+        if long_id.generic_id != StructType::ID {
+            return false;
+        }
+
+        let [GenericArg::UserType(_), GenericArg::Type(element_ty)] =
+            long_id.generic_args.as_slice()
+        else {
+            return false;
+        };
+
+        self.is_felt252_array_snapshot(element_ty)
+    }
+
+    fn is_valid_entry_point_return_type(&self, ty: &ConcreteTypeId) -> bool {
+        // The return type must be an enum with two variants: (result, error).
+        let Some((result_tuple_ty, err_ty)) = self.extract_result_ty(ty) else {
+            return false;
+        };
+
+        // The result variant must be a tuple with one element: Span<felt252>;
+        let Some(result_ty) = self.extract_struct1(result_tuple_ty) else {
+            return false;
+        };
+        if !self.is_felt252_span(result_ty) {
+            return false;
+        }
+
+        // If the error type is Array<felt252>, it's a good error type, using the old panic
+        // mechanism.
+        if self.is_felt252_array(err_ty) {
+            return true;
+        }
+
+        // Otherwise, the error type must be a struct with two fields: (panic, data)
+        let Some((panic_ty, err_data_ty)) = self.extract_struct2(err_ty) else {
+            return false;
+        };
+
+        // The panic field must be the empty struct, as the entry point ABI expects the error
+        // variant to be laid out as an `Array<felt252>` only.
+        if !self.is_empty_struct(panic_ty) {
+            return false;
+        }
+
+        // The data field must be an Array<felt252>.
+        self.is_felt252_array(err_data_ty)
+    }
+
+    /// Returns true if the type is the empty struct: a struct without any members.
+    fn is_empty_struct(&self, ty: &ConcreteTypeId) -> bool {
+        let long_id = self.get_long_id(ty);
+        if long_id.generic_id != StructType::id() {
+            return false;
+        }
+        let [GenericArg::UserType(_), members @ ..] = long_id.generic_args.as_slice() else {
+            return false;
+        };
+        members.is_empty()
+    }
+
+    /// Extracts types `TOk`, `TErr` from the type `Result<TOk, TErr>`.
+    fn extract_result_ty(&self, ty: &ConcreteTypeId) -> Option<(&ConcreteTypeId, &ConcreteTypeId)> {
+        let long_id = self.get_long_id(ty);
+        require(long_id.generic_id == EnumType::id())?;
+        let [GenericArg::UserType(_), GenericArg::Type(result_tuple_ty), GenericArg::Type(err_ty)] =
+            long_id.generic_args.as_slice()
+        else {
+            return None;
+        };
+        Some((result_tuple_ty, err_ty))
+    }
+
+    /// Extracts type `T` from the tuple type `(T,)`.
+    fn extract_struct1(&self, ty: &ConcreteTypeId) -> Option<&ConcreteTypeId> {
+        let long_id = self.get_long_id(ty);
+        require(long_id.generic_id == StructType::id())?;
+        let [GenericArg::UserType(_), GenericArg::Type(ty0)] = long_id.generic_args.as_slice()
+        else {
+            return None;
+        };
+        Some(ty0)
+    }
+
+    /// Extracts types `T0`, `T1` from the tuple type `(T0, T1)`.
+    fn extract_struct2(&self, ty: &ConcreteTypeId) -> Option<(&ConcreteTypeId, &ConcreteTypeId)> {
+        let long_id = self.get_long_id(ty);
+        require(long_id.generic_id == StructType::id())?;
+        let [GenericArg::UserType(_), GenericArg::Type(ty0), GenericArg::Type(ty1)] =
+            long_id.generic_args.as_slice()
+        else {
+            return None;
+        };
+        Some((ty0, ty1))
+    }
+}


### PR DESCRIPTION
Validate, in the gateway, the entry point return types of a declared Sierra class the same way the Sierra-to-CASM compiler does, plus a stricter rule the pinned compiler does not yet have: the panic type of an entry point's error variant must be the empty struct (the entry point ABI expects the error variant to be laid out as an `Array<felt252>` only).

The validation logic is a near-verbatim copy of `cairo_lang_starknet_classes::casm_contract_class::TypeResolver` (trimmed to the return-type check) to ease diffing against the original. It runs in `add_tx_inner` post-compilation, next to the existing CASM builtins validation, and rejects violations with `INVALID_CONTRACT_CLASS`.

Verified against a demo broken class (non-empty panic struct): the pinned compiler accepts it, the new gateway check rejects it with `InvalidEntryPointSignature`; a valid control class passes.

Tagged as APOLLO-0.14.3-RC.12.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)