### PR TITLE
ci: publish a portable ARM64 transaction prover image

### DIFF
--- a/.github/workflows/starknet_transaction_prover_docker_publish.yml
+++ b/.github/workflows/starknet_transaction_prover_docker_publish.yml
@@ -29,7 +29,9 @@ jobs:
             target_cpu: znver5
           - platform: linux/arm64
             runner: namespace-profile-small-ubuntu-24-04-arm64
-            target_cpu: neoverse-v2
+            # The release tag must run on the generic AArch64 baseline, including
+            # Linux containers on Apple Silicon hosts.
+            target_cpu: ""
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- publish the `linux/arm64` transaction-prover release artifact without a CPU-specific `TARGET_CPU`
- retain the existing `znver5` tuning for the AMD64 artifact

The current ARM64 release is compiled for `neoverse-v2`, which enables instructions unavailable on Apple Silicon. The published multi-architecture tag selects this true ARM64 image on M3 Docker hosts, where it exits with `SIGILL` before becoming healthy. Leaving `TARGET_CPU` empty makes the Dockerfile use Rust's generic AArch64 baseline while preserving the existing ARM64 image and manifest layout.

## Validation
- `git diff --check`
- YAML syntax parse
- confirmed the Dockerfile only sets `-C target-cpu=...` when `TARGET_CPU` is non-empty

A native ARM64 startup smoke test can be added separately once an appropriate runner/test RPC fixture is available.