### PR TITLE
apollo_dashboard: remove noisy http_server_high_transaction_failure_ratio alert

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -1159,32 +1159,6 @@
       "severity": "p5"
     },
     {
-      "name": "http_server_high_transaction_failure_ratio",
-      "title": "http server high transaction failure ratio",
-      "ruleGroup": "evaluation_rate_default",
-      "expr": "((increase(http_server_added_transactions_failure{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]) - increase(http_server_added_transactions_deprecated_error{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) / clamp_min(increase(http_server_added_transactions_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]), 1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
-      "conditions": [
-        {
-          "evaluator": {
-            "params": [
-              0.5
-            ],
-            "type": "gt"
-          },
-          "operator": {
-            "type": "and"
-          },
-          "reducer": {
-            "params": [],
-            "type": "avg"
-          },
-          "type": "query"
-        }
-      ],
-      "for": "30s",
-      "severity": "p5"
-    },
-    {
       "name": "http_server_internal_error_once",
       "title": "http server internal error once",
       "ruleGroup": "evaluation_rate_default",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -106,7 +106,6 @@ use crate::alert_scenarios::transaction_delays::{
 };
 use crate::alert_scenarios::transaction_failures::{
     get_http_server_high_deprecated_transaction_failure_ratio,
-    get_http_server_high_transaction_failure_ratio,
     get_http_server_internal_error_once,
     get_http_server_internal_error_ratio,
     get_mempool_transaction_drop_ratio,
@@ -617,7 +616,6 @@ pub fn get_apollo_alerts() -> Alerts {
         get_general_pod_state_crashloopbackoff(),
         get_general_pod_high_cpu_utilization(),
         get_http_server_high_deprecated_transaction_failure_ratio(),
-        get_http_server_high_transaction_failure_ratio(),
         get_http_server_internal_error_once(),
         get_http_server_no_successful_transactions(),
         get_l1_events_provider_errors_alert(),

--- a/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/transaction_failures.rs
@@ -1,6 +1,5 @@
 use apollo_http_server::metrics::{
     ADDED_TRANSACTIONS_DEPRECATED_ERROR,
-    ADDED_TRANSACTIONS_FAILURE,
     ADDED_TRANSACTIONS_INTERNAL_ERROR,
     ADDED_TRANSACTIONS_TOTAL,
 };
@@ -32,24 +31,6 @@ pub(crate) fn get_http_server_high_deprecated_transaction_failure_ratio() -> Ale
             ADDED_TRANSACTIONS_TOTAL.get_name_with_filter()
         ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.1, AlertLogicalOp::And)],
-        PENDING_DURATION_DEFAULT,
-        AlertSeverity::Informational,
-        ObserverApplicability::NotApplicable,
-    )
-}
-
-pub(crate) fn get_http_server_high_transaction_failure_ratio() -> Alert {
-    Alert::new(
-        "http_server_high_transaction_failure_ratio",
-        "http server high transaction failure ratio",
-        EvaluationRate::Default,
-        format!(
-            "(increase({}[1h]) - increase({}[1h])) / clamp_min(increase({}[1h]), 1)",
-            ADDED_TRANSACTIONS_FAILURE.get_name_with_filter(),
-            ADDED_TRANSACTIONS_DEPRECATED_ERROR.get_name_with_filter(),
-            ADDED_TRANSACTIONS_TOTAL.get_name_with_filter()
-        ),
-        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.5, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         AlertSeverity::Informational,
         ObserverApplicability::NotApplicable,


### PR DESCRIPTION
## What

Removes the `http_server_high_transaction_failure_ratio` alert.

## Why

The alert's numerator counts **every** gateway rejection as a "failure":

```
(added_transactions_failure - deprecated_error) / total  > 0.5   (1h window, for 30s)
```

On a public endpoint the majority of rejections are benign, client-caused outcomes — fee-too-low, `ValidateFailure`, duplicate transaction, and duplicate/old nonce — none of which indicate sequencer health. As a result the ratio sits above the 0.5 threshold on healthy nodes and the alert fires continuously (it's only p5/Informational, but it's noise). There was a standing `TODO` to unify it with the regular failure rate.

Genuine sequencer faults are already covered by `http_server_internal_error_ratio` (>1%) and `http_server_internal_error_once`, so this alert is redundant.

## Notes

- The alert used a hardcoded `Informational` severity (not a placeholder), so no per-environment override entries reference it — removal does not affect deploy-time placeholder/override validation.
- `dev_grafana_alerts.json` was regenerated via `cargo run --bin sequencer_dashboard_generator` (not hand-edited).

## Test

- `cargo build -p apollo_dashboard`
- `SEED=0 cargo test -p apollo_dashboard` (incl. `dashboard_definitions_test::default_dev_grafana_dashboard`, which enforces the checked-in JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)