### PR TITLE
apollo_consensus_orchestrator,apollo_batcher,apollo_batcher_types: drop accessed_keys from blob

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1011,7 +1011,7 @@ impl Batcher {
             state_diff.clone(), // TODO(Nimrod): Remove the clone here.
             Some(state_diff_commitment),
             #[cfg(feature = "os_input")]
-            Some(accessed_keys.clone()),
+            Some(accessed_keys),
         )
         .await?;
 
@@ -1040,8 +1040,6 @@ impl Batcher {
                 compiled_class_hashes_for_migration: block_execution_artifacts
                     .compiled_class_hashes_for_migration,
                 parent_proposal_commitment,
-                #[cfg(feature = "os_input")]
-                accessed_keys,
                 #[cfg(feature = "os_input")]
                 initial_reads,
             },

--- a/crates/apollo_batcher_types/src/batcher_types.rs
+++ b/crates/apollo_batcher_types/src/batcher_types.rs
@@ -3,8 +3,6 @@ use std::ops::Deref;
 
 use blockifier::blockifier::transaction_executor::CompiledClassHashesForMigration;
 use blockifier::bouncer::{BouncerWeights, CasmHashComputationData};
-#[cfg(feature = "os_input")]
-use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::CommitmentStateDiff;
 #[cfg(feature = "os_input")]
 use blockifier::state::cached_state::StateMaps;
@@ -162,8 +160,6 @@ pub struct CentralObjects {
     pub casm_hash_computation_data_proving_gas: CasmHashComputationData,
     pub compiled_class_hashes_for_migration: CompiledClassHashesForMigration,
     pub parent_proposal_commitment: Option<ProposalCommitment>,
-    #[cfg(feature = "os_input")]
-    pub accessed_keys: AccessedKeys,
     /// Pre-block read values the OS needs to replay the block.
     #[cfg(feature = "os_input")]
     pub initial_reads: StateMaps,

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects_test.rs
@@ -46,8 +46,6 @@ use blockifier::fee::resources::{
     TransactionResources,
 };
 #[cfg(feature = "os_input")]
-use blockifier::state::accessed_keys::AccessedKeys;
-#[cfg(feature = "os_input")]
 use blockifier::state::cached_state::StateMaps;
 use blockifier::state::cached_state::{
     CommitmentStateDiff,
@@ -787,8 +785,6 @@ fn central_blob() -> AerospikeBlob {
         #[cfg(feature = "os_input")]
         recent_state_commitment_infos: recent_state_commitment_infos(),
         #[cfg(feature = "os_input")]
-        accessed_keys: AccessedKeys::default(),
-        #[cfg(feature = "os_input")]
         initial_reads: StateMaps::default(),
     };
 
@@ -822,8 +818,6 @@ fn central_blob_with_empty_or_none_fields() -> AerospikeBlob {
         recent_block_hashes: vec![],
         #[cfg(feature = "os_input")]
         recent_state_commitment_infos: vec![],
-        #[cfg(feature = "os_input")]
-        accessed_keys: AccessedKeys::default(),
         #[cfg(feature = "os_input")]
         initial_reads: StateMaps::default(),
     };
@@ -1181,15 +1175,14 @@ fn serialize_central_objects(#[case] rust_obj: impl Serialize, #[case] python_js
     let python_json: serde_json::Value = read_json_file(python_json_path);
     let rust_json = serde_json::to_value(rust_obj).unwrap();
 
-    // `recent_state_commitment_infos`, `accessed_keys` and `initial_reads` are os_input-only and
-    // absent from the central (python) blob, so strip them before comparing.
+    // `recent_state_commitment_infos` and `initial_reads` are os_input-only and absent from the
+    // central (python) blob, so strip them before comparing.
     // TODO(Itamar): Remove this stripping once the python blob includes the fields.
     #[cfg(feature = "os_input")]
     let rust_json = {
         let mut rust_json = rust_json;
         if let Some(object) = rust_json.as_object_mut() {
             object.remove("recent_state_commitment_infos");
-            object.remove("accessed_keys");
             object.remove("initial_reads");
         }
         rust_json

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -12,8 +12,6 @@ use async_trait::async_trait;
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 use blockifier::blockifier::transaction_executor::CompiledClassHashesForMigration;
 use blockifier::bouncer::{BouncerWeights, CasmHashComputationData};
-#[cfg(feature = "os_input")]
-use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::CommitmentStateDiff;
 #[cfg(feature = "os_input")]
 use blockifier::state::cached_state::StateMaps;
@@ -108,8 +106,6 @@ pub struct AerospikeBlob {
     recent_block_hashes: Vec<BlockHashAndNumber>,
     #[cfg(feature = "os_input")]
     recent_state_commitment_infos: Vec<StateCommitmentInfosAndNumber>,
-    #[cfg(feature = "os_input")]
-    accessed_keys: AccessedKeys,
     #[cfg(feature = "os_input")]
     initial_reads: StateMaps,
 }
@@ -410,8 +406,6 @@ pub struct BlobParameters {
     #[cfg(feature = "os_input")]
     pub recent_state_commitment_infos: Vec<StateCommitmentInfosAndNumber>,
     #[cfg(feature = "os_input")]
-    pub accessed_keys: AccessedKeys,
-    #[cfg(feature = "os_input")]
     pub initial_reads: StateMaps,
 }
 
@@ -470,8 +464,6 @@ impl AerospikeBlob {
             recent_block_hashes: blob_parameters.recent_block_hashes,
             #[cfg(feature = "os_input")]
             recent_state_commitment_infos: blob_parameters.recent_state_commitment_infos,
-            #[cfg(feature = "os_input")]
-            accessed_keys: blob_parameters.accessed_keys,
             #[cfg(feature = "os_input")]
             initial_reads: blob_parameters.initial_reads,
         })

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -622,8 +622,6 @@ impl SequencerConsensusContext {
                     .collect_recent_state_commitment_infos(height)
                     .await,
                 #[cfg(feature = "os_input")]
-                accessed_keys: central_objects.accessed_keys,
-                #[cfg(feature = "os_input")]
                 initial_reads: central_objects.initial_reads,
             })
             .await

--- a/crates/central_systest_blobs/src/cende_blob_regression_test.rs
+++ b/crates/central_systest_blobs/src/cende_blob_regression_test.rs
@@ -248,8 +248,6 @@ impl From<BlockData> for BlobParameters {
             #[cfg(feature = "os_input")]
             recent_state_commitment_infos: vec![],
             #[cfg(feature = "os_input")]
-            accessed_keys: Default::default(),
-            #[cfg(feature = "os_input")]
             initial_reads: Default::default(),
         }
     }


### PR DESCRIPTION
Remove the os_input-gated `accessed_keys: AccessedKeys` field from `AerospikeBlob` and its dead
plumbing: the matching `BlobParameters` field, the blob construction, and the now-unused
`CentralObjects.accessed_keys` (its only reader was the blob build). The batcher still computes
the block's accessed keys for the committer and for trimming `initial_reads`; only the blob no
longer carries them.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>