### PR TITLE
starknet_patricia: actually preallocate filled-tree output map capacity

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -77,13 +77,16 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
     fn initialize_filled_tree_output_map_with_placeholders<'a>(
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
-        updated_skeleton
-            .get_nodes()
-            .filter_map(|(index, node)| match node {
-                UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
-                _ => Some((*index, OnceLock::new())),
-            })
-            .collect()
+        let nodes_iter = updated_skeleton.get_nodes();
+        // `filter_map`'s `size_hint` lower bound is always 0 (the predicate can drop every
+        // item), so collecting through it directly would not preallocate. Reserve capacity
+        // from the unfiltered iterator's exact size instead, then extend into it.
+        let mut filled_tree_output_map = HashMap::with_capacity(nodes_iter.size_hint().0);
+        filled_tree_output_map.extend(nodes_iter.filter_map(|(index, node)| match node {
+            UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
+            _ => Some((*index, OnceLock::new())),
+        }));
+        filled_tree_output_map
     }
 
     fn initialize_leaf_output_map_with_placeholders(


### PR DESCRIPTION
Follow-up to #14638, which intended to fix an O(log N) rehashing hot path in `initialize_filled_tree_output_map_with_placeholders` (called once per block per tree — storage trie and class trie) by preallocating the output `HashMap`'s capacity.

That PR's fix doesn't actually work: it switched to `updated_skeleton.get_nodes().filter_map(...).collect()`. Rust's `FilterMap` iterator adapter always reports a `size_hint()` lower bound of `0`, because the predicate can drop every item — so `HashMap`'s `FromIterator`/`extend` reserves `0` capacity up front, and the map still grows via repeated reallocation and rehashing as elements are inserted, exactly the cost the PR meant to eliminate.

This PR reserves capacity from the *unfiltered* node iterator instead — `updated_skeleton.get_nodes()` wraps a `HashMap::iter()`, which is an `ExactSizeIterator`, so its `size_hint().0` is the true node count. We call `HashMap::with_capacity` on that count, then `.extend()` the `filter_map`'d iterator into the presized map. This reserves an upper bound (it includes `UnmodifiedSubTree` nodes that get filtered out), which is a good tradeoff — a bit of extra headroom is far cheaper than the rehash cascade it avoids.

No behavior change: output map contents are identical, only the allocation strategy differs.

Verified:
- `cargo build -p starknet_patricia` — success
- `SEED=0 cargo test -p starknet_patricia` — 107 passed, 0 failed
- `cargo clippy -p starknet_patricia --all-targets` — clean
- `scripts/rust_fmt.sh` — clean
- Reviewed by an independent agent pass; no blocking issues found


---
_Generated by [Claude Code](https://claude.ai/code/session_01CU74MQe6YXDSqzzME5ik4C)_