### PR TITLE
starknet_api: make contract address derivation hash-pluggable

### DIFF
--- a/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
+++ b/crates/apollo_integration_tests/tests/test_custom_cairo0_txs.rs
@@ -13,7 +13,7 @@ use mempool_test_utils::starknet_api_test_utils::{
     AccountTransactionGenerator,
     MultiAccountTransactionGenerator,
 };
-use starknet_api::core::calculate_contract_address;
+use starknet_api::core::{calculate_contract_address, AddressDerivationHash};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::test_utils::invoke::rpc_invoke_tx;
@@ -130,6 +130,7 @@ fn generate_invoke_txs_tests_for_deploy_contract(
         test_contract.get_class_hash(),
         &calldata!(constructor_calldata_arg1, constructor_calldata_arg2),
         account_tx_generator.sender_address(),
+        AddressDerivationHash::Pedersen,
     )
     .expect("Failed to calculate contract address");
 

--- a/crates/apollo_integration_tests/tests/test_custom_cairo1_txs.rs
+++ b/crates/apollo_integration_tests/tests/test_custom_cairo1_txs.rs
@@ -16,7 +16,7 @@ use mempool_test_utils::starknet_api_test_utils::{
 };
 use mempool_test_utils::EMPTY_CONTRACT_CAIRO1_COMPILED_CLASS_HASH;
 use starknet_api::abi::abi_utils::selector_from_name;
-use starknet_api::core::{calculate_contract_address, CompiledClassHash};
+use starknet_api::core::{calculate_contract_address, AddressDerivationHash, CompiledClassHash};
 use starknet_api::rpc_transaction::RpcTransaction;
 use starknet_api::test_utils::invoke::rpc_invoke_tx;
 use starknet_api::test_utils::resource_bounds_for_testing;
@@ -178,6 +178,7 @@ fn generate_test_deploy_txs(
         // Constructor calldata of the deployed contract (test_contract).
         &calldata!(constructor_calldata_arg1, constructor_calldata_arg2),
         test_contract.get_instance_address(0), // deployer address
+        AddressDerivationHash::Pedersen,
     )
     .expect("Failed to calculate contract address");
 

--- a/crates/apollo_transaction_converter/src/transaction_converter.rs
+++ b/crates/apollo_transaction_converter/src/transaction_converter.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use mockall::automock;
 use starknet_api::consensus_transaction::{ConsensusTransaction, InternalConsensusTransaction};
 use starknet_api::contract_class::{ClassInfo, ContractClass, SierraVersion};
-use starknet_api::core::{ChainId, ClassHash};
+use starknet_api::core::{AddressDerivationHash, ChainId, ClassHash};
 use starknet_api::executable_transaction::{
     AccountTransaction,
     Transaction as ExecutableTransaction,
@@ -395,7 +395,8 @@ impl TransactionConverter {
                 )
             }
             RpcTransaction::DeployAccount(RpcDeployAccountTransaction::V3(tx)) => {
-                let contract_address = tx.calculate_contract_address()?;
+                let contract_address =
+                    tx.calculate_contract_address(AddressDerivationHash::Pedersen)?;
                 (
                     InternalRpcTransactionWithoutTxHash::DeployAccount(
                         InternalRpcDeployAccountTransaction {

--- a/crates/blockifier/src/execution/contract_address_test.rs
+++ b/crates/blockifier/src/execution/contract_address_test.rs
@@ -2,7 +2,12 @@ use blockifier_test_utils::cairo_versions::CairoVersion;
 use blockifier_test_utils::contracts::FeatureContract;
 use rstest::rstest;
 use starknet_api::abi::abi_utils::selector_from_name;
-use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress};
+use starknet_api::core::{
+    calculate_contract_address,
+    AddressDerivationHash,
+    ClassHash,
+    ContractAddress,
+};
 use starknet_api::transaction::fields::{Calldata, ContractAddressSalt};
 use starknet_api::{calldata, felt};
 
@@ -38,9 +43,14 @@ fn test_calculate_contract_address() {
             initial_gas: versioned_constants.infinite_gas_for_vm_mode(),
             ..Default::default()
         };
-        let contract_address =
-            calculate_contract_address(salt, class_hash, constructor_calldata, deployer_address)
-                .unwrap();
+        let contract_address = calculate_contract_address(
+            salt,
+            class_hash,
+            constructor_calldata,
+            deployer_address,
+            AddressDerivationHash::Pedersen,
+        )
+        .unwrap();
 
         assert_eq!(
             entry_point_call.execute_directly(state).unwrap().execution,

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscalls_test.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::contract_class::compiled_class_hash::HashVersion;
-use starknet_api::core::calculate_contract_address;
+use starknet_api::core::{calculate_contract_address, AddressDerivationHash};
 use starknet_api::state::StorageKey;
 use starknet_api::test_utils::{
     CHAIN_ID_FOR_TESTS,
@@ -489,6 +489,7 @@ fn test_deploy(
         class_hash,
         &Calldata(constructor_calldata.into()),
         test_contract.get_instance_address(0),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
     assert_eq!(

--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -20,6 +20,7 @@ use starknet_api::block::{BlockInfo, BlockNumber, BlockTimestamp};
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ClassHash,
     ContractAddress,
     EntryPointSelector,
@@ -617,6 +618,7 @@ impl DeprecatedSyscallExecutor for DeprecatedSyscallHintProcessor<'_> {
             request.class_hash,
             &request.constructor_calldata,
             deployer_address_for_calculation,
+            AddressDerivationHash::Pedersen,
         )?;
 
         // Increment the Deploy syscall's linear cost counter by the number of elements in the

--- a/crates/blockifier/src/execution/stack_trace_test.rs
+++ b/crates/blockifier/src/execution/stack_trace_test.rs
@@ -15,6 +15,7 @@ use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::abi::constants::CONSTRUCTOR_ENTRY_POINT_NAME;
 use starknet_api::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ClassHash,
     ContractAddress,
     EntryPointSelector,
@@ -774,6 +775,7 @@ fn test_contract_ctor_frame_stack_trace(
         faulty_class_hash,
         &calldata![validate_constructor],
         account_address,
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
     // Invoke the deploy_contract function on the dummy account to deploy the faulty contract.

--- a/crates/blockifier/src/execution/syscalls/syscall_base.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_base.rs
@@ -8,6 +8,7 @@ use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::contract_class::EntryPointType;
 use starknet_api::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ClassHash,
     ContractAddress,
     EntryPointSelector,
@@ -407,6 +408,7 @@ impl<'state> SyscallHandlerBase<'state> {
             class_hash,
             &constructor_calldata,
             deployer_address_for_calculation,
+            AddressDerivationHash::Pedersen,
         )?;
 
         let ctor_context = ConstructorContext {

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/deploy.rs
@@ -8,7 +8,7 @@ use expect_test::expect;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use starknet_api::contract_class::SierraVersion;
-use starknet_api::core::calculate_contract_address;
+use starknet_api::core::{calculate_contract_address, AddressDerivationHash};
 use starknet_api::transaction::fields::{Calldata, ContractAddressSalt, Fee};
 use starknet_api::{calldata, felt};
 use test_case::test_case;
@@ -63,6 +63,7 @@ fn no_constructor(runnable_version: RunnableCairo1) {
         class_hash,
         &calldata![],
         deployer_contract.get_instance_address(0),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
 
@@ -120,6 +121,7 @@ fn with_constructor(runnable_version: RunnableCairo1) {
         class_hash,
         &Calldata(constructor_calldata.clone().into()),
         deployer_contract.get_instance_address(0),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
 

--- a/crates/blockifier/src/transaction/account_transactions_test.rs
+++ b/crates/blockifier/src/transaction/account_transactions_test.rs
@@ -26,6 +26,7 @@ use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCom
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ClassHash,
     CompiledClassHash,
     ContractAddress,
@@ -1631,6 +1632,7 @@ fn test_deploy_account_constructor_storage_write(
         class_hash,
         &constructor_calldata,
         ContractAddress::default(),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
     let read_storage_arg = state.get_storage_at(deployed_contract_address, storage_key).unwrap();

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -1,5 +1,5 @@
 use starknet_api::contract_class::ClassInfo;
-use starknet_api::core::{ContractAddress, Nonce};
+use starknet_api::core::{AddressDerivationHash, ContractAddress, Nonce};
 use starknet_api::executable_transaction::{
     AccountTransaction as ApiExecutableTransaction,
     DeclareTransaction,
@@ -102,7 +102,8 @@ impl Transaction {
             StarknetApiTransaction::DeployAccount(deploy_account) => {
                 let contract_address = match deployed_contract_address {
                     Some(address) => address,
-                    None => deploy_account.calculate_contract_address()?,
+                    None => deploy_account
+                        .calculate_contract_address(AddressDerivationHash::Pedersen)?,
                 };
                 ApiExecutableTransaction::DeployAccount(DeployAccountTransaction {
                     tx: deploy_account,

--- a/crates/starknet_api/src/core.rs
+++ b/crates/starknet_api/src/core.rs
@@ -322,16 +322,45 @@ impl TryFrom<StarkHash> for ContractAddress {
     }
 }
 
-// TODO(Noa): Add a hash_function as a parameter
+/// The hash function used to derive a contract address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AddressDerivationHash {
+    Pedersen,
+    Blake2,
+}
+
 pub fn calculate_contract_address(
     salt: ContractAddressSalt,
     class_hash: ClassHash,
     constructor_calldata: &Calldata,
     deployer_address: ContractAddress,
+    address_derivation_hash: AddressDerivationHash,
 ) -> Result<ContractAddress, StarknetApiError> {
-    let constructor_calldata_hash = Pedersen::hash_array(&constructor_calldata.0);
+    match address_derivation_hash {
+        AddressDerivationHash::Pedersen => calculate_contract_address_inner::<Pedersen>(
+            salt,
+            class_hash,
+            constructor_calldata,
+            deployer_address,
+        ),
+        AddressDerivationHash::Blake2 => calculate_contract_address_inner::<Blake2Felt252>(
+            salt,
+            class_hash,
+            constructor_calldata,
+            deployer_address,
+        ),
+    }
+}
+
+fn calculate_contract_address_inner<H: CoreStarkHash>(
+    salt: ContractAddressSalt,
+    class_hash: ClassHash,
+    constructor_calldata: &Calldata,
+    deployer_address: ContractAddress,
+) -> Result<ContractAddress, StarknetApiError> {
+    let constructor_calldata_hash = H::hash_array(&constructor_calldata.0);
     let contract_address_prefix = format!("0x{}", hex::encode(CONTRACT_ADDRESS_PREFIX));
-    let address = Pedersen::hash_array(&[
+    let address = H::hash_array(&[
         Felt::from_hex(contract_address_prefix.as_str()).map_err(|_| {
             StarknetApiError::OutOfRange { string: contract_address_prefix.clone() }
         })?,

--- a/crates/starknet_api/src/core_test.rs
+++ b/crates/starknet_api/src/core_test.rs
@@ -9,6 +9,7 @@ use crate::core::{
     ascii_as_felt,
     calculate_contract_address,
     felt_to_u128,
+    AddressDerivationHash,
     ChainId,
     ContractAddress,
     EthAddress,
@@ -61,9 +62,14 @@ fn test_calculate_contract_address() {
     let constructor_calldata =
         Calldata(vec![Felt::from(60_u16), Felt::from(70_u16), Felt::MAX].into());
 
-    let actual_address =
-        calculate_contract_address(salt, class_hash, &constructor_calldata, deployer_address)
-            .unwrap();
+    let actual_address = calculate_contract_address(
+        salt,
+        class_hash,
+        &constructor_calldata,
+        deployer_address,
+        AddressDerivationHash::Pedersen,
+    )
+    .unwrap();
 
     let constructor_calldata_hash = Pedersen::hash_array(&constructor_calldata.0);
     let address = Pedersen::hash_array(&[

--- a/crates/starknet_api/src/executable_transaction.rs
+++ b/crates/starknet_api/src/executable_transaction.rs
@@ -12,7 +12,14 @@ use thiserror::Error;
 
 use crate::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
 use crate::contract_class::{ClassInfo, ContractClass};
-use crate::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use crate::core::{
+    AddressDerivationHash,
+    ChainId,
+    ClassHash,
+    CompiledClassHash,
+    ContractAddress,
+    Nonce,
+};
 use crate::data_availability::DataAvailabilityMode;
 use crate::transaction::fields::{
     AccountDeploymentData,
@@ -324,7 +331,8 @@ impl DeployAccountTransaction {
         deploy_account_tx: crate::transaction::DeployAccountTransaction,
         chain_id: &ChainId,
     ) -> Result<Self, StarknetApiError> {
-        let contract_address = deploy_account_tx.calculate_contract_address()?;
+        let contract_address =
+            deploy_account_tx.calculate_contract_address(AddressDerivationHash::Pedersen)?;
         let tx_hash =
             deploy_account_tx.calculate_transaction_hash(chain_id, &deploy_account_tx.version())?;
         Ok(Self { tx: deploy_account_tx, tx_hash, contract_address })

--- a/crates/starknet_api/src/rpc_transaction.rs
+++ b/crates/starknet_api/src/rpc_transaction.rs
@@ -11,7 +11,14 @@ use starknet_core::types::EntryPointsByType as StarknetCoreEntryPointsByType;
 use strum::{EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 
 use crate::contract_class::EntryPointType;
-use crate::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use crate::core::{
+    AddressDerivationHash,
+    ChainId,
+    ClassHash,
+    CompiledClassHash,
+    ContractAddress,
+    Nonce,
+};
 use crate::data_availability::DataAvailabilityMode;
 use crate::state::{EntryPoint, SierraContractClass};
 use crate::transaction::fields::{
@@ -178,7 +185,7 @@ impl RpcTransaction {
         match self {
             RpcTransaction::Declare(RpcDeclareTransaction::V3(tx)) => Ok(tx.sender_address),
             RpcTransaction::DeployAccount(RpcDeployAccountTransaction::V3(tx)) => {
-                tx.calculate_contract_address()
+                tx.calculate_contract_address(AddressDerivationHash::Pedersen)
             }
             RpcTransaction::Invoke(RpcInvokeTransaction::V3(tx)) => Ok(tx.sender_address),
         }
@@ -542,7 +549,13 @@ impl TransactionHasher for RpcDeployAccountTransactionV3 {
         chain_id: &ChainId,
         transaction_version: &TransactionVersion,
     ) -> Result<TransactionHash, StarknetApiError> {
-        get_deploy_account_transaction_v3_hash(self, chain_id, transaction_version)
+        let contract_address = self.calculate_contract_address(AddressDerivationHash::Pedersen)?;
+        get_deploy_account_transaction_v3_hash(
+            self,
+            chain_id,
+            transaction_version,
+            contract_address,
+        )
     }
 }
 

--- a/crates/starknet_api/src/test_utils/deploy_account.rs
+++ b/crates/starknet_api/src/test_utils/deploy_account.rs
@@ -1,7 +1,7 @@
 use starknet_crypto::Felt;
 
 use super::{NonceManager, TestingTxArgs};
-use crate::core::{ClassHash, Nonce};
+use crate::core::{AddressDerivationHash, ClassHash, Nonce};
 use crate::data_availability::DataAvailabilityMode;
 use crate::executable_transaction::{
     AccountTransaction,
@@ -125,7 +125,7 @@ pub fn executable_deploy_account_tx(deploy_tx_args: DeployAccountTxArgs) -> Acco
     let tx_hash = deploy_tx_args.tx_hash;
     let tx_nonce = deploy_tx_args.nonce;
     let tx = deploy_account_tx(deploy_tx_args, tx_nonce);
-    let contract_address = tx.calculate_contract_address().unwrap();
+    let contract_address = tx.calculate_contract_address(AddressDerivationHash::Pedersen).unwrap();
     let deploy_account_tx = ExecutableDeployAccountTransaction { tx, tx_hash, contract_address };
 
     AccountTransaction::DeployAccount(deploy_account_tx)
@@ -176,7 +176,7 @@ pub fn internal_deploy_account_tx(deploy_tx_args: DeployAccountTxArgs) -> Intern
         unreachable!();
     };
 
-    let contract_address = tx.calculate_contract_address().unwrap();
+    let contract_address = tx.calculate_contract_address(AddressDerivationHash::Pedersen).unwrap();
     let tx_without_hash =
         InternalRpcTransactionWithoutTxHash::DeployAccount(InternalRpcDeployAccountTransaction {
             tx: RpcDeployAccountTransaction::V3(tx),

--- a/crates/starknet_api/src/transaction.rs
+++ b/crates/starknet_api/src/transaction.rs
@@ -10,6 +10,7 @@ use starknet_types_core::felt::Felt;
 use crate::block::{BlockHash, BlockNumber};
 use crate::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ChainId,
     ClassHash,
     CompiledClassHash,
@@ -158,7 +159,8 @@ impl TryFrom<(Transaction, &ChainId)> for executable_transaction::Transaction {
         let tx_hash = tx.calculate_transaction_hash(chain_id)?;
         match tx {
             Transaction::DeployAccount(tx) => {
-                let contract_address = tx.calculate_contract_address()?;
+                let contract_address =
+                    tx.calculate_contract_address(AddressDerivationHash::Pedersen)?;
                 Ok(executable_transaction::Transaction::Account(
                     executable_transaction::AccountTransaction::DeployAccount(
                         executable_transaction::DeployAccountTransaction {
@@ -426,7 +428,10 @@ impl TransactionHasher for DeclareTransaction {
 }
 
 pub trait CalculateContractAddress {
-    fn calculate_contract_address(&self) -> StarknetApiResult<ContractAddress>;
+    fn calculate_contract_address(
+        &self,
+        address_derivation_hash: AddressDerivationHash,
+    ) -> StarknetApiResult<ContractAddress>;
 }
 
 /// A trait intended for deploy account transactions. Structs implementing this trait derive the
@@ -460,7 +465,10 @@ impl<T: DeployTransactionTrait> CalculateContractAddress for T {
     /// Calculates the contract address for the contract deployed by a deploy account transaction.
     /// For more details see:
     /// <https://docs.starknet.io/learn/cheatsheets/transactions-reference#deploy-account-v3>
-    fn calculate_contract_address(&self) -> StarknetApiResult<ContractAddress> {
+    fn calculate_contract_address(
+        &self,
+        address_derivation_hash: AddressDerivationHash,
+    ) -> StarknetApiResult<ContractAddress> {
         // When the contract is deployed via a deploy-account transaction, the deployer address is
         // zero.
         const DEPLOYER_ADDRESS: ContractAddress = ContractAddress(PatriciaKey::ZERO);
@@ -469,6 +477,7 @@ impl<T: DeployTransactionTrait> CalculateContractAddress for T {
             self.class_hash(),
             self.constructor_calldata(),
             DEPLOYER_ADDRESS,
+            address_derivation_hash,
         )
     }
 }
@@ -492,7 +501,13 @@ impl TransactionHasher for DeployAccountTransactionV1 {
         chain_id: &ChainId,
         transaction_version: &TransactionVersion,
     ) -> Result<TransactionHash, StarknetApiError> {
-        get_deploy_account_transaction_v1_hash(self, chain_id, transaction_version)
+        let contract_address = self.calculate_contract_address(AddressDerivationHash::Pedersen)?;
+        get_deploy_account_transaction_v1_hash(
+            self,
+            chain_id,
+            transaction_version,
+            contract_address,
+        )
     }
 }
 
@@ -517,7 +532,13 @@ impl TransactionHasher for DeployAccountTransactionV3 {
         chain_id: &ChainId,
         transaction_version: &TransactionVersion,
     ) -> Result<TransactionHash, StarknetApiError> {
-        get_deploy_account_transaction_v3_hash(self, chain_id, transaction_version)
+        let contract_address = self.calculate_contract_address(AddressDerivationHash::Pedersen)?;
+        get_deploy_account_transaction_v3_hash(
+            self,
+            chain_id,
+            transaction_version,
+            contract_address,
+        )
     }
 }
 
@@ -532,10 +553,17 @@ pub enum DeployAccountTransaction {
 }
 
 impl CalculateContractAddress for DeployAccountTransaction {
-    fn calculate_contract_address(&self) -> StarknetApiResult<ContractAddress> {
+    fn calculate_contract_address(
+        &self,
+        address_derivation_hash: AddressDerivationHash,
+    ) -> StarknetApiResult<ContractAddress> {
         match self {
-            DeployAccountTransaction::V1(tx) => tx.calculate_contract_address(),
-            DeployAccountTransaction::V3(tx) => tx.calculate_contract_address(),
+            DeployAccountTransaction::V1(tx) => {
+                tx.calculate_contract_address(address_derivation_hash)
+            }
+            DeployAccountTransaction::V3(tx) => {
+                tx.calculate_contract_address(address_derivation_hash)
+            }
         }
     }
 }
@@ -611,7 +639,8 @@ impl TransactionHasher for DeployTransaction {
         chain_id: &ChainId,
         transaction_version: &TransactionVersion,
     ) -> Result<TransactionHash, StarknetApiError> {
-        get_deploy_transaction_hash(self, chain_id, transaction_version)
+        let contract_address = self.calculate_contract_address(AddressDerivationHash::Pedersen)?;
+        get_deploy_transaction_hash(self, chain_id, transaction_version, contract_address)
     }
 }
 

--- a/crates/starknet_api/src/transaction_hash.rs
+++ b/crates/starknet_api/src/transaction_hash.rs
@@ -3,7 +3,15 @@ use std::sync::LazyLock;
 use starknet_types_core::felt::Felt;
 
 use crate::block::BlockNumber;
-use crate::core::{ascii_as_felt, ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use crate::core::{
+    ascii_as_felt,
+    AddressDerivationHash,
+    ChainId,
+    ClassHash,
+    CompiledClassHash,
+    ContractAddress,
+    Nonce,
+};
 use crate::crypto::utils::HashChain;
 use crate::data_availability::DataAvailabilityMode;
 use crate::transaction::fields::{
@@ -86,15 +94,20 @@ pub fn get_transaction_hash(
                 get_declare_transaction_v3_hash(declare_v3, chain_id, transaction_version)
             }
         },
-        Transaction::Deploy(deploy) => {
-            get_deploy_transaction_hash(deploy, chain_id, transaction_version)
-        }
+        Transaction::Deploy(deploy) => get_deploy_transaction_hash(
+            deploy,
+            chain_id,
+            transaction_version,
+            deploy.calculate_contract_address(AddressDerivationHash::Pedersen)?,
+        ),
         Transaction::DeployAccount(deploy_account) => match deploy_account {
             DeployAccountTransaction::V1(deploy_account_v1) => {
                 get_deploy_account_transaction_v1_hash(
                     deploy_account_v1,
                     chain_id,
                     transaction_version,
+                    deploy_account_v1
+                        .calculate_contract_address(AddressDerivationHash::Pedersen)?,
                 )
             }
             DeployAccountTransaction::V3(deploy_account_v3) => {
@@ -102,6 +115,8 @@ pub fn get_transaction_hash(
                     deploy_account_v3,
                     chain_id,
                     transaction_version,
+                    deploy_account_v3
+                        .calculate_contract_address(AddressDerivationHash::Pedersen)?,
                 )
             }
         },
@@ -140,7 +155,12 @@ fn get_deprecated_transaction_hashes(
         match transaction {
             Transaction::Declare(_) => vec![],
             Transaction::Deploy(deploy) => {
-                vec![get_deprecated_deploy_transaction_hash(deploy, chain_id, transaction_version)?]
+                vec![get_deprecated_deploy_transaction_hash(
+                    deploy,
+                    chain_id,
+                    transaction_version,
+                    deploy.calculate_contract_address(AddressDerivationHash::Pedersen)?,
+                )?]
             }
             Transaction::DeployAccount(_) => vec![],
             Transaction::Invoke(invoke) => match invoke {
@@ -248,16 +268,30 @@ pub(crate) fn get_deploy_transaction_hash(
     transaction: &DeployTransaction,
     chain_id: &ChainId,
     transaction_version: &TransactionVersion,
+    contract_address: ContractAddress,
 ) -> Result<TransactionHash, StarknetApiError> {
-    get_common_deploy_transaction_hash(transaction, chain_id, false, transaction_version)
+    get_common_deploy_transaction_hash(
+        transaction,
+        chain_id,
+        false,
+        transaction_version,
+        contract_address,
+    )
 }
 
 fn get_deprecated_deploy_transaction_hash(
     transaction: &DeployTransaction,
     chain_id: &ChainId,
     transaction_version: &TransactionVersion,
+    contract_address: ContractAddress,
 ) -> Result<TransactionHash, StarknetApiError> {
-    get_common_deploy_transaction_hash(transaction, chain_id, true, transaction_version)
+    get_common_deploy_transaction_hash(
+        transaction,
+        chain_id,
+        true,
+        transaction_version,
+        contract_address,
+    )
 }
 
 fn get_common_deploy_transaction_hash(
@@ -265,9 +299,8 @@ fn get_common_deploy_transaction_hash(
     chain_id: &ChainId,
     is_deprecated: bool,
     transaction_version: &TransactionVersion,
+    contract_address: ContractAddress,
 ) -> Result<TransactionHash, StarknetApiError> {
-    let contract_address = transaction.calculate_contract_address()?;
-
     Ok(TransactionHash(
         HashChain::new()
         .chain(&DEPLOY)
@@ -667,14 +700,13 @@ pub(crate) fn get_deploy_account_transaction_v1_hash(
     transaction: &DeployAccountTransactionV1,
     chain_id: &ChainId,
     transaction_version: &TransactionVersion,
+    contract_address: ContractAddress,
 ) -> Result<TransactionHash, StarknetApiError> {
     let calldata_hash = HashChain::new()
         .chain(&transaction.class_hash.0)
         .chain(&transaction.contract_address_salt.0)
         .chain_iter(transaction.constructor_calldata.0.iter())
         .get_pedersen_hash();
-
-    let contract_address = transaction.calculate_contract_address()?;
 
     Ok(TransactionHash(
         HashChain::new()
@@ -706,14 +738,12 @@ pub(crate) trait DeployAccountTransactionV3Trait {
     fn contract_address_salt(&self) -> &ContractAddressSalt;
 }
 
-pub(crate) fn get_deploy_account_transaction_v3_hash<
-    T: DeployAccountTransactionV3Trait + CalculateContractAddress,
->(
+pub(crate) fn get_deploy_account_transaction_v3_hash<T: DeployAccountTransactionV3Trait>(
     transaction: &T,
     chain_id: &ChainId,
     transaction_version: &TransactionVersion,
+    contract_address: ContractAddress,
 ) -> Result<TransactionHash, StarknetApiError> {
-    let contract_address = transaction.calculate_contract_address()?;
     let tip_resource_bounds_hash =
         get_tip_resource_bounds_hash(&transaction.resource_bounds(), transaction.tip())?;
     let paymaster_data_hash =

--- a/crates/starknet_os_flow_tests/src/fuzz_tests.rs
+++ b/crates/starknet_os_flow_tests/src/fuzz_tests.rs
@@ -19,6 +19,7 @@ use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ClassHash,
     ContractAddress,
     EntryPointSelector,
@@ -824,6 +825,7 @@ impl FuzzTestContext {
             class_hash,
             &calldata![***FUZZ_ADDRESS_ORCHESTRATOR],
             ContractAddress::default(),
+            AddressDerivationHash::Pedersen,
         )
         .unwrap()
     }

--- a/crates/starknet_os_flow_tests/src/initial_state.rs
+++ b/crates/starknet_os_flow_tests/src/initial_state.rs
@@ -12,6 +12,7 @@ use starknet_api::block::BlockNumber;
 use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
 use starknet_api::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ClassHash,
     CompiledClassHash,
     ContractAddress,
@@ -375,6 +376,7 @@ pub(crate) fn get_deploy_contract_tx_and_address_with_salt_and_deployer(
         class_hash,
         &ctor_calldata,
         if deploy_from_zero { ContractAddress::default() } else { *FUNDED_ACCOUNT_ADDRESS },
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
     (deploy_contract_tx, contract_address)
@@ -407,6 +409,7 @@ pub(crate) fn calculate_strk_fee_token_address() -> ContractAddress {
         strk_fee_token_class_hash(),
         &strk_fee_token_constructor_calldata(),
         *FUNDED_ACCOUNT_ADDRESS,
+        AddressDerivationHash::Pedersen,
     )
     .unwrap()
 }

--- a/crates/starknet_os_flow_tests/src/tests.rs
+++ b/crates/starknet_os_flow_tests/src/tests.rs
@@ -21,6 +21,7 @@ use starknet_api::contract_class::compiled_class_hash::HashVersion;
 use starknet_api::contract_class::{ClassInfo, ContractClass, SierraVersion};
 use starknet_api::core::{
     calculate_contract_address,
+    AddressDerivationHash,
     ClassHash,
     ContractAddress,
     EthAddress,
@@ -243,6 +244,7 @@ async fn declare_deploy_scenario(
         class_hash,
         &Calldata(constructor_calldata[1..].to_vec().into()),
         *FUNDED_ACCOUNT_ADDRESS,
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
     test_builder.add_funded_account_invoke(invoke_tx_args! { calldata: deploy_contract_calldata });
@@ -1160,6 +1162,7 @@ async fn test_new_class_execution_info(#[values(true, false)] use_kzg_da: bool) 
         test_class_hash,
         &Calldata(Arc::new(ctor_calldata)),
         main_contract_address,
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
 
@@ -1354,6 +1357,7 @@ async fn test_new_account_flow(#[values(true, false)] use_kzg_da: bool) {
         faulty_account_class_hash,
         &ctor_calldata,
         ContractAddress::default(),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
     // Fund the address.
@@ -1883,6 +1887,7 @@ async fn test_deploy_account_v3_empty_deployment_data_span_emit() {
         class_hash,
         &constructor_calldata,
         ContractAddress::default(),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
     test_builder.add_fund_address_tx_with_default_amount(account_address);
@@ -1946,6 +1951,7 @@ async fn test_deprecated_tx_info() {
         class_hash,
         &calldata![],
         ContractAddress::default(),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
 
@@ -2207,9 +2213,14 @@ async fn test_inner_deploy_failure() {
     // Precompute the expected deploy address of the new empty contract instance.
     let salt = ContractAddressSalt(Felt::from(127));
     let empty_class_hash = get_class_hash_of_feature_contract(empty_contract);
-    let expected_deploy_address =
-        calculate_contract_address(salt, empty_class_hash, &calldata![], test_contract_address)
-            .unwrap();
+    let expected_deploy_address = calculate_contract_address(
+        salt,
+        empty_class_hash,
+        &calldata![],
+        test_contract_address,
+        AddressDerivationHash::Pedersen,
+    )
+    .unwrap();
 
     let calldata = create_calldata(
         test_contract_address,
@@ -2287,6 +2298,7 @@ async fn test_block_info(#[values(true, false)] is_cairo0: bool) {
         class_hash,
         &calldata![is_validate],
         ContractAddress::default(),
+        AddressDerivationHash::Pedersen,
     )
     .unwrap();
 


### PR DESCRIPTION
**Stack — part 1 of 9** (`ron/contract-address/*`, one commit per branch). Targets **0.14.5**.

Introduces `AddressDerivationHash { Pedersen, Blake2 }` and parameterizes `calculate_contract_address` over it through a generic inner helper.

The scheme is selected **per transaction version at the derivation sites** — there is no network-wide cutover, no protocol-version gate and no runtime flag. Every caller in this PR still passes `Pedersen`, so this is a behavior-preserving refactor that prepares `DeployAccount` v4 (#14813) and the `deploy_v2` syscall (#14817).

The deploy / deploy-account transaction-hash functions now take the already-derived `ContractAddress` as a parameter instead of recomputing it. That leaves the broad `TransactionHasher` trait unchanged and keeps the scheme choice at the derivation sites, where the per-version dispatch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
