### PR TITLE
blockifier: add the deploy_v2 syscall (Blake2 contract address derivation)

### DIFF
--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_0.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_0.json
@@ -190,6 +190,13 @@
                 "syscall_base_gas_cost": 1,
                 "memory_hole_gas_cost": 0
             },
+            "DeployV2": {
+                "step_gas_cost": 0,
+                "range_check": 0,
+                "bitwise": 0,
+                "syscall_base_gas_cost": 0,
+                "memory_hole_gas_cost": 0
+            },
             "EmitEvent": {
                 "step_gas_cost": 10,
                 "range_check": 0,
@@ -408,6 +415,11 @@
                     "range_check_builtin": 18,
                     "pedersen_builtin": 7
                 }
+            },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
             },
             "EmitEvent": {
                 "n_steps": 19,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_1.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_1.json
@@ -190,6 +190,13 @@
                 "syscall_base_gas_cost": 1,
                 "memory_hole_gas_cost": 0
             },
+            "DeployV2": {
+                "step_gas_cost": 0,
+                "range_check": 0,
+                "bitwise": 0,
+                "syscall_base_gas_cost": 0,
+                "memory_hole_gas_cost": 0
+            },
             "EmitEvent": {
                 "step_gas_cost": 10,
                 "range_check": 0,
@@ -408,6 +415,11 @@
                     "range_check_builtin": 19,
                     "pedersen_builtin": 7
                 }
+            },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
             },
             "EmitEvent": {
                 "n_steps": 61,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_1_1.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_1_1.json
@@ -190,6 +190,13 @@
                 "syscall_base_gas_cost": 1,
                 "memory_hole_gas_cost": 0
             },
+            "DeployV2": {
+                "step_gas_cost": 0,
+                "range_check": 0,
+                "bitwise": 0,
+                "syscall_base_gas_cost": 0,
+                "memory_hole_gas_cost": 0
+            },
             "EmitEvent": {
                 "step_gas_cost": 10,
                 "range_check": 0,
@@ -408,6 +415,11 @@
                     "range_check_builtin": 19,
                     "pedersen_builtin": 7
                 }
+            },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
             },
             "EmitEvent": {
                 "n_steps": 61,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_2.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_2.json
@@ -190,6 +190,13 @@
                 "syscall_base_gas_cost": 1,
                 "memory_hole_gas_cost": 0
             },
+            "DeployV2": {
+                "step_gas_cost": 0,
+                "range_check": 0,
+                "bitwise": 0,
+                "syscall_base_gas_cost": 0,
+                "memory_hole_gas_cost": 0
+            },
             "EmitEvent": {
                 "step_gas_cost": 10,
                 "range_check": 0,
@@ -408,6 +415,11 @@
                     "range_check_builtin": 18,
                     "pedersen_builtin": 7
                 }
+            },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
             },
             "EmitEvent": {
                 "n_steps": 61,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_2_1.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_2_1.json
@@ -190,6 +190,13 @@
                 "syscall_base_gas_cost": 1,
                 "memory_hole_gas_cost": 0
             },
+            "DeployV2": {
+                "step_gas_cost": 0,
+                "range_check": 0,
+                "bitwise": 0,
+                "syscall_base_gas_cost": 0,
+                "memory_hole_gas_cost": 0
+            },
             "EmitEvent": {
                 "step_gas_cost": 10,
                 "range_check": 0,
@@ -408,6 +415,11 @@
                     "range_check_builtin": 18,
                     "pedersen_builtin": 7
                 }
+            },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
             },
             "EmitEvent": {
                 "n_steps": 61,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_3.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_3.json
@@ -190,6 +190,13 @@
                 "syscall_base_gas_cost": 1,
                 "memory_hole_gas_cost": 0
             },
+            "DeployV2": {
+                "step_gas_cost": 0,
+                "range_check": 0,
+                "bitwise": 0,
+                "syscall_base_gas_cost": 0,
+                "memory_hole_gas_cost": 0
+            },
             "EmitEvent": {
                 "step_gas_cost": 10,
                 "range_check": 0,
@@ -408,6 +415,11 @@
                     "range_check_builtin": 18,
                     "pedersen_builtin": 7
                 }
+            },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
             },
             "EmitEvent": {
                 "n_steps": 61,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_4.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_4.json
@@ -231,6 +231,11 @@
                     "pedersen_builtin": 7
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
+            },
             "EmitEvent": {
                 "n_steps": 61,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_5.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_5.json
@@ -253,6 +253,11 @@
                     }
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
+            },
             "EmitEvent": {
                 "n_steps": 61,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_13_6.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_13_6.json
@@ -253,6 +253,11 @@
                     }
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
+            },
             "EmitEvent": {
                 "n_steps": 61,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_14_0.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_14_0.json
@@ -260,6 +260,11 @@
                     }
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
+            },
             "EmitEvent": {
                 "n_steps": 61,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_14_1.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_14_1.json
@@ -260,6 +260,11 @@
                     }
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
+            },
             "EmitEvent": {
                 "n_steps": 61,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_14_2.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_14_2.json
@@ -264,6 +264,11 @@
                     }
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {}
+            },
             "EmitEvent": {
                 "n_steps": 61,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_14_3.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_14_3.json
@@ -264,6 +264,14 @@
                     }
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0
+                }
+            },
             "EmitEvent": {
                 "n_steps": 61,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_14_4.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_14_4.json
@@ -265,6 +265,14 @@
                     }
                 }
             },
+            "DeployV2": {
+                "n_steps": 0,
+                "n_memory_holes": 0,
+                "builtin_instance_counter": {
+                    "range_check_builtin": 0,
+                    "bitwise_builtin": 0
+                }
+            },
             "EmitEvent": {
                 "n_steps": 47,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/blockifier_versioned_constants_0_14_5.json
+++ b/crates/blockifier/resources/blockifier_versioned_constants_0_14_5.json
@@ -265,6 +265,23 @@
                     }
                 }
             },
+            "DeployV2": {
+                "constant": {
+                    "n_steps": 1173,
+                    "n_memory_holes": 0,
+                    "builtin_instance_counter": {
+                        "range_check_builtin": 21,
+                        "pedersen_builtin": 7
+                    }
+                },
+                "calldata_factor": {
+                    "n_steps": 8,
+                    "n_memory_holes": 0,
+                    "builtin_instance_counter": {
+                        "pedersen_builtin": 1
+                    }
+                }
+            },
             "EmitEvent": {
                 "n_steps": 47,
                 "n_memory_holes": 0,

--- a/crates/blockifier/resources/versioned_constants_diff_regression/0.14.2_0.14.3.txt
+++ b/crates/blockifier/resources/versioned_constants_diff_regression/0.14.2_0.14.3.txt
@@ -2,6 +2,8 @@
 ~ /os_constants/allowed_proof_versions/0: "0x50524f4f4631"
 ~ /os_constants/allowed_virtual_os_program_hashes/0: "0x53f6c9fcfd31d27279ff7d7e422b44623550a732b59fe193354a7316a96daa1"
 ~ /os_constants/execute_max_sierra_gas: 1110000000
++ /os_resources/execute_syscalls/DeployV2/builtin_instance_counter/bitwise_builtin: 0
++ /os_resources/execute_syscalls/DeployV2/builtin_instance_counter/range_check_builtin: 0
 + /os_resources/execute_syscalls/Sha512ProcessBlock/builtin_instance_counter/bitwise_builtin: 3320
 + /os_resources/execute_syscalls/Sha512ProcessBlock/builtin_instance_counter/range_check_builtin: 65
 ~ /os_resources/execute_syscalls/Sha512ProcessBlock/n_steps: 4737

--- a/crates/blockifier/resources/versioned_constants_diff_regression/0.14.4_0.14.5.txt
+++ b/crates/blockifier/resources/versioned_constants_diff_regression/0.14.4_0.14.5.txt
@@ -1,4 +1,9 @@
 ~ /os_constants/allowed_virtual_os_program_hashes/0: "0xfedbf2b6504b9217026ba2bf9b2a33e8e28ed38e5b0f84eef59075b02174b8"
++ /os_resources/execute_syscalls/DeployV2/calldata_factor: {"builtin_instance_counter":{"pedersen_builtin":1},"n_memory_holes":0,"n_steps":8}
++ /os_resources/execute_syscalls/DeployV2/constant: {"builtin_instance_counter":{"pedersen_builtin":7,"range_check_builtin":21},"n_memory_holes":0,"n_steps":1173}
+- /os_resources/execute_syscalls/DeployV2/builtin_instance_counter
+- /os_resources/execute_syscalls/DeployV2/n_memory_holes
+- /os_resources/execute_syscalls/DeployV2/n_steps
 ~ /os_resources/execute_txs_inner/Declare/n_steps: 3946
 ~ /os_resources/execute_txs_inner/DeployAccount/constant/n_steps: 5017
 ~ /os_resources/execute_txs_inner/InvokeFunction/constant/n_steps: 4787

--- a/crates/blockifier/src/blockifier_versioned_constants.rs
+++ b/crates/blockifier/src/blockifier_versioned_constants.rs
@@ -907,6 +907,7 @@ impl SyscallGasCost {
 pub struct SyscallGasCosts {
     pub call_contract: SyscallGasCost,
     pub deploy: SyscallGasCost,
+    pub deploy_v2: SyscallGasCost,
     pub get_block_hash: SyscallGasCost,
     pub get_execution_info: SyscallGasCost,
     pub library_call: SyscallGasCost,
@@ -941,6 +942,7 @@ impl SyscallGasCosts {
         let gas_cost = match *selector {
             SyscallSelector::CallContract => self.call_contract,
             SyscallSelector::Deploy => self.deploy,
+            SyscallSelector::DeployV2 => self.deploy_v2,
             SyscallSelector::EmitEvent => self.emit_event,
             SyscallSelector::GetBlockHash => self.get_block_hash,
             SyscallSelector::GetExecutionInfo => self.get_execution_info,
@@ -1111,6 +1113,7 @@ impl GasCosts {
         let syscalls = SyscallGasCosts {
             call_contract: summarize(SyscallSelector::CallContract),
             deploy: summarize(SyscallSelector::Deploy),
+            deploy_v2: summarize(SyscallSelector::DeployV2),
             get_block_hash: summarize(SyscallSelector::GetBlockHash),
             get_execution_info: summarize(SyscallSelector::GetExecutionInfo),
             library_call: summarize(SyscallSelector::LibraryCall),

--- a/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscall_executor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/deprecated_syscall_executor.rs
@@ -240,6 +240,7 @@ pub fn execute_deprecated_syscall_from_selector<T: DeprecatedSyscallExecutor>(
         // Explicitly list unsupported syscalls, so compiler can catch if a syscall is missing.
         DeprecatedSyscallSelector::GetBlockHash
         | DeprecatedSyscallSelector::GetClassHashAt
+        | DeprecatedSyscallSelector::DeployV2
         | DeprecatedSyscallSelector::GetExecutionInfo
         | DeprecatedSyscallSelector::Keccak
         | DeprecatedSyscallSelector::KeccakRound

--- a/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/mod.rs
@@ -45,6 +45,7 @@ pub enum DeprecatedSyscallSelector {
     DelegateCall,
     DelegateL1Handler,
     Deploy,
+    DeployV2,
     EmitEvent,
     GetBlockHash,
     GetBlockNumber,
@@ -89,6 +90,7 @@ impl DeprecatedSyscallSelector {
                 | Self::DelegateCall
                 | Self::DelegateL1Handler
                 | Self::Deploy
+                | Self::DeployV2
                 | Self::LibraryCall
                 | Self::LibraryCallL1Handler
                 | Self::MetaTxV0
@@ -108,6 +110,7 @@ impl TryFrom<Felt> for DeprecatedSyscallSelector {
             b"DelegateCall" => Ok(Self::DelegateCall),
             b"DelegateL1Handler" => Ok(Self::DelegateL1Handler),
             b"Deploy" => Ok(Self::Deploy),
+            b"DeployV2" => Ok(Self::DeployV2),
             b"EmitEvent" => Ok(Self::EmitEvent),
             b"GetBlockHash" => Ok(Self::GetBlockHash),
             b"GetBlockNumber" => Ok(Self::GetBlockNumber),

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -21,7 +21,13 @@ use cairo_native::starknet::{
 use num_bigint::BigUint;
 use starknet_api::block::BlockNumber;
 use starknet_api::contract_class::EntryPointType;
-use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, L1Address};
+use starknet_api::core::{
+    AddressDerivationHash,
+    ClassHash,
+    ContractAddress,
+    EntryPointSelector,
+    L1Address,
+};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::fields::{
@@ -388,6 +394,9 @@ impl StarknetSyscallHandler for &mut NativeSyscallHandler<'_> {
                 Calldata(Arc::new(calldata.to_vec())),
                 deploy_from_zero,
                 remaining_gas,
+                // The deploy_v2 syscall (Blake2 derivation) has no cairo-native handler until the
+                // upstream `StarknetSyscallHandler` trait exposes it.
+                AddressDerivationHash::Pedersen,
             )
             .map_err(|err| self.handle_error(remaining_gas, err))?;
 

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -16,7 +16,7 @@ use cairo_vm::vm::runners::cairo_runner::{ResourceTracker, RunResources};
 use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_api::block::BlockHash;
 use starknet_api::contract_class::EntryPointType;
-use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::core::{AddressDerivationHash, ClassHash, ContractAddress, EntryPointSelector};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::transaction::fields::{
     valid_resource_bounds_as_felts,
@@ -575,6 +575,28 @@ impl SyscallExecutor for SyscallHintProcessor<'_> {
             request.constructor_calldata,
             request.deploy_from_zero,
             remaining_gas,
+            AddressDerivationHash::Pedersen,
+        )?;
+        let constructor_retdata =
+            create_retdata_segment(vm, syscall_handler, &call_info.execution.retdata.0)?;
+        syscall_handler.base.inner_calls.push(call_info);
+
+        Ok(DeployResponse { contract_address: deployed_contract_address, constructor_retdata })
+    }
+
+    fn deploy_v2(
+        request: DeployRequest,
+        vm: &mut VirtualMachine,
+        syscall_handler: &mut Self,
+        remaining_gas: &mut u64,
+    ) -> Result<DeployResponse, Self::Error> {
+        let (deployed_contract_address, call_info) = syscall_handler.base.deploy(
+            request.class_hash,
+            request.contract_address_salt,
+            request.constructor_calldata,
+            request.deploy_from_zero,
+            remaining_gas,
+            AddressDerivationHash::Blake2,
         )?;
         let constructor_retdata =
             create_retdata_segment(vm, syscall_handler, &call_info.execution.retdata.0)?;

--- a/crates/blockifier/src/execution/syscalls/syscall_base.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_base.rs
@@ -385,17 +385,19 @@ impl<'state> SyscallHandlerBase<'state> {
         constructor_calldata: Calldata,
         deploy_from_zero: bool,
         remaining_gas: &mut u64,
+        address_derivation_hash: AddressDerivationHash,
     ) -> SyscallResult<(ContractAddress, CallInfo)> {
-        self.increment_syscall_linear_factor_by(
-            &SyscallSelector::Deploy,
-            constructor_calldata.0.len(),
-        );
+        let (syscall_selector, syscall_name) = match address_derivation_hash {
+            AddressDerivationHash::Pedersen => (SyscallSelector::Deploy, "deploy"),
+            AddressDerivationHash::Blake2 => (SyscallSelector::DeployV2, "deploy_v2"),
+        };
+        self.increment_syscall_linear_factor_by(&syscall_selector, constructor_calldata.0.len());
         let versioned_constants = &self.context.tx_context.block_context.versioned_constants;
         if should_reject_deploy(
             versioned_constants.disable_deploy_in_validation_mode,
             self.context.execution_mode,
         ) {
-            self.reject_syscall_in_validate_mode("deploy")?;
+            self.reject_syscall_in_validate_mode(syscall_name)?;
         }
 
         let deployer_address = self.call.storage_address;
@@ -408,7 +410,7 @@ impl<'state> SyscallHandlerBase<'state> {
             class_hash,
             &constructor_calldata,
             deployer_address_for_calculation,
-            AddressDerivationHash::Pedersen,
+            address_derivation_hash,
         )?;
 
         let ctor_context = ConstructorContext {

--- a/crates/blockifier/src/execution/syscalls/syscall_executor.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_executor.rs
@@ -133,6 +133,15 @@ pub trait SyscallExecutor {
         remaining_gas: &mut u64,
     ) -> Result<DeployResponse, Self::Error>;
 
+    /// Same as `deploy`, but derives the contract address with Blake2 (plus the Pedersen-image
+    /// escape) instead of Pedersen. The request and response layouts are identical to `deploy`.
+    fn deploy_v2(
+        request: DeployRequest,
+        vm: &mut VirtualMachine,
+        syscall_handler: &mut Self,
+        remaining_gas: &mut u64,
+    ) -> Result<DeployResponse, Self::Error>;
+
     fn emit_event(
         request: EmitEventRequest,
         vm: &mut VirtualMachine,

--- a/crates/blockifier/src/execution/syscalls/vm_syscall_utils.rs
+++ b/crates/blockifier/src/execution/syscalls/vm_syscall_utils.rs
@@ -574,6 +574,7 @@ pub(crate) fn execute_syscall_from_selector<T: SyscallExecutor>(
             execute_syscall(syscall_executor, vm, selector, T::call_contract)
         }
         SyscallSelector::Deploy => execute_syscall(syscall_executor, vm, selector, T::deploy),
+        SyscallSelector::DeployV2 => execute_syscall(syscall_executor, vm, selector, T::deploy_v2),
         SyscallSelector::EmitEvent => {
             execute_syscall(syscall_executor, vm, selector, T::emit_event)
         }

--- a/crates/starknet_os/src/hint_processor/snos_syscall_executor.rs
+++ b/crates/starknet_os/src/hint_processor/snos_syscall_executor.rs
@@ -213,6 +213,17 @@ impl<S: StateReader> SyscallExecutor for SnosHintProcessor<'_, S> {
         })
     }
 
+    // The derivation scheme only affects the address computation, which the OS performs in Cairo;
+    // the executor consumes the tracked address either way.
+    fn deploy_v2(
+        request: DeployRequest,
+        vm: &mut VirtualMachine,
+        syscall_handler: &mut Self,
+        remaining_gas: &mut u64,
+    ) -> Result<DeployResponse, Self::Error> {
+        Self::deploy(request, vm, syscall_handler, remaining_gas)
+    }
+
     fn emit_event(
         _request: EmitEventRequest,
         _vm: &mut VirtualMachine,

--- a/crates/starknet_os/src/hints/enum_definition_test.rs
+++ b/crates/starknet_os/src/hints/enum_definition_test.rs
@@ -223,7 +223,8 @@ fn test_deprecated_syscall_hint_consistency() {
                     selector,
                     // As the new and deprecated syscall selector enums are the same enum,
                     // explicitly filter out all "new" syscalls that are not supported in Cairo0.
-                    DeprecatedSyscallSelector::GetBlockHash
+                    DeprecatedSyscallSelector::DeployV2
+                        | DeprecatedSyscallSelector::GetBlockHash
                         | DeprecatedSyscallSelector::GetClassHashAt
                         | DeprecatedSyscallSelector::GetExecutionInfo
                         | DeprecatedSyscallSelector::Keccak

--- a/crates/starknet_os_flow_tests/src/os_resources_test.rs
+++ b/crates/starknet_os_flow_tests/src/os_resources_test.rs
@@ -63,9 +63,12 @@ use crate::test_manager::{
 use crate::tests::NON_TRIVIAL_RESOURCE_BOUNDS;
 
 // TODO(Dori): Delete this, or at least reduce it to a minimal set of unmeasurable syscalls.
-const UNMEASURABLE_SYSCALLS: [Selector; 12] = [
+const UNMEASURABLE_SYSCALLS: [Selector; 13] = [
     Selector::DelegateCall,
     Selector::DelegateL1Handler,
+    // TODO(Ron): measure deploy_v2 once the Cairo compiler exposes it (its versioned-constants
+    // profile is a provisional copy of Deploy's until then).
+    Selector::DeployV2,
     Selector::GetBlockNumber,
     Selector::GetBlockTimestamp,
     Selector::GetCallerAddress,


### PR DESCRIPTION
**Stack — part 7 of 9** (base: #14816). Targets **0.14.5**.

Adds the `deploy_v2` syscall to the blockifier: identical request/response layout to `deploy`, but the deployed address is derived with BLAKE2s + the Pedersen-image escape. `deploy` stays Pedersen forever.

- Selector `DeployV2` = ASCII `"DeployV2"` (felt `0x4465706c6f795632`), matching the cairo compiler PR (starkware-libs/cairo#10214).
- `SyscallHandlerBase::deploy` is parameterized by the derivation hash, so the two syscalls share one body.
- Rejected by the deprecated (Cairo-0) syscall executor.
- `DeprecatedSyscallSelector::is_calling_syscall` includes `DeployV2`: like `deploy` it runs the deployed contract's constructor as an inner call, so without it the OS logger rejects a nested constructor syscall as an unexpected parent, and the resource measurement keeps constructor cost inside `DeployV2`.
- The cairo-native handler is not wired yet — the upstream `StarknetSyscallHandler` trait does not expose the method until a cairo-native release carries it (starkware-libs/cairo_native#1649).

**Versioned constants:** `DeployV2` gets the zero-filled entry in every frozen file (0_13_0 … **0_14_4**, the sha512 precedent) and the live value in **0_14_5**. The 0_14_5 value here is a provisional copy of `Deploy`'s profile; `DeployV2` stays in `UNMEASURABLE_SYSCALLS` until a compiler that emits the libfunc is released (#14839 has the measurement). `blockifier_versioned_constants_0_14_4.json` differs from main by only the zero-filled entry, and the 0.14.3→0.14.4 diff fixture is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

