### PR TITLE
apollo_consensus_orchestrator_config: add fetch_accessed_keys_from_centralized config

### DIFF
--- a/crates/apollo_consensus_orchestrator_config/src/config.rs
+++ b/crates/apollo_consensus_orchestrator_config/src/config.rs
@@ -177,6 +177,9 @@ pub struct ContextStaticConfig {
     #[serde(deserialize_with = "deserialize_milliseconds_to_duration")]
     pub retrospective_block_hash_retry_interval_millis: Duration,
     pub behavior_mode: BehaviorMode,
+    /// When adding a synced block, fetch its accessed keys from the recorder so the node can build
+    /// the state commitment infos locally.
+    pub fetch_accessed_keys_from_centralized: bool,
 }
 
 impl SerializeConfig for ContextStaticConfig {
@@ -241,6 +244,13 @@ impl SerializeConfig for ContextStaticConfig {
             "Behavior mode: 'starknet' for production, 'echonet' for test/replay mode.",
             ParamPrivacyInput::Public,
         )]);
+        dump.extend([ser_param(
+            "fetch_accessed_keys_from_centralized",
+            &self.fetch_accessed_keys_from_centralized,
+            "Fetch accessed keys from the centralized recorder for synced blocks, enabling local \
+             state commitment infos construction.",
+            ParamPrivacyInput::Public,
+        )]);
         dump
     }
 }
@@ -257,6 +267,7 @@ impl Default for ContextStaticConfig {
             build_proposal_time_ratio_for_retrospective_block_hash: 0.7,
             retrospective_block_hash_retry_interval_millis: Duration::from_millis(500),
             behavior_mode: BehaviorMode::default(),
+            fetch_accessed_keys_from_centralized: false,
         }
     }
 }

--- a/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
@@ -36,6 +36,7 @@
   "consensus_manager_config.context_config.static_config.block_timestamp_window_seconds": 1,
   "consensus_manager_config.context_config.static_config.build_proposal_time_ratio_for_retrospective_block_hash": 0.7,
   "consensus_manager_config.context_config.static_config.builder_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "consensus_manager_config.context_config.static_config.fetch_accessed_keys_from_centralized": false,
   "consensus_manager_config.context_config.dynamic_config.build_proposal_margin_millis": 1000,
   "consensus_manager_config.context_config.dynamic_config.min_l2_gas_price_per_height": "",
   "consensus_manager_config.context_config.static_config.l1_da_mode": true,

--- a/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
@@ -54,6 +54,7 @@
   "consensus_manager_config.context_config.static_config.block_timestamp_window_seconds": 1,
   "consensus_manager_config.context_config.static_config.build_proposal_time_ratio_for_retrospective_block_hash": 0.7,
   "consensus_manager_config.context_config.static_config.builder_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+  "consensus_manager_config.context_config.static_config.fetch_accessed_keys_from_centralized": false,
   "consensus_manager_config.context_config.static_config.l1_da_mode": true,
   "consensus_manager_config.context_config.static_config.proposal_buffer_size": 512,
   "consensus_manager_config.context_config.static_config.retrospective_block_hash_retry_interval_millis": 500,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2814,6 +2814,11 @@
     "pointer_target": "chain_id",
     "privacy": "Public"
   },
+  "consensus_manager_config.context_config.static_config.fetch_accessed_keys_from_centralized": {
+    "description": "Fetch accessed keys from the centralized recorder for synced blocks, enabling local state commitment infos construction.",
+    "privacy": "Public",
+    "value": false
+  },
   "consensus_manager_config.context_config.static_config.l1_da_mode": {
     "description": "The data availability mode, true: Blob, false: Calldata.",
     "privacy": "Public",


### PR DESCRIPTION
Config flag for fetching a synced block's accessed keys from the centralized
recorder so the node can build the witness locally. No effect yet; wired up in
a later commit.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>