### PR TITLE
starknet_patricia: pre-size filled-tree output map with exact node count

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -81,7 +81,8 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
         // `filter_map`'s size hint has a lower bound of 0 (the predicate can reject
         // everything), so collecting directly from it allocates with no capacity hint and
         // rehashes as the map grows. Read the exact node count from the underlying iterator
-        // first and pre-allocate with it instead.
+        // first and pre-allocate with it instead: it is a safe upper bound for the filtered
+        // map (some nodes are unmodified subtrees and get dropped), so no rehash is needed.
         let mut filled_tree_output_map = HashMap::with_capacity(nodes.size_hint().0);
         filled_tree_output_map.extend(nodes.filter_map(|(index, node)| match node {
             UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -77,13 +77,17 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
     fn initialize_filled_tree_output_map_with_placeholders<'a>(
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
-        updated_skeleton
-            .get_nodes()
-            .filter_map(|(index, node)| match node {
-                UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
-                _ => Some((*index, OnceLock::new())),
-            })
-            .collect()
+        let nodes = updated_skeleton.get_nodes();
+        // `filter_map`'s size hint has a lower bound of 0 (the predicate can reject
+        // everything), so collecting directly from it allocates with no capacity hint and
+        // rehashes as the map grows. Read the exact node count from the underlying iterator
+        // first and pre-allocate with it instead.
+        let mut filled_tree_output_map = HashMap::with_capacity(nodes.size_hint().0);
+        filled_tree_output_map.extend(nodes.filter_map(|(index, node)| match node {
+            UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
+            _ => Some((*index, OnceLock::new())),
+        }));
+        filled_tree_output_map
     }
 
     fn initialize_leaf_output_map_with_placeholders(


### PR DESCRIPTION
## Why

Follow-up to #14638 (merged), "starknet_patricia: pre-allocate filled-tree output map to avoid rehashing". That PR's stated intent was to eliminate `HashMap` rehashing in `initialize_filled_tree_output_map_with_placeholders` — a hot path called once per block per modified tree (storage + class) — by switching from a `HashMap::new()` + loop to:

```rust
updated_skeleton
    .get_nodes()
    .filter_map(|(index, node)| match node {
        UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
        _ => Some((*index, OnceLock::new())),
    })
    .collect()
```

However, this doesn't actually achieve that goal: `Iterator::filter_map`'s `size_hint()` always has a lower bound of `0` (the predicate can reject every element), and `HashMap: FromIterator` reserves capacity based on `iter.size_hint().0`. So `.collect()` from a `filter_map` iterator still allocates with a capacity hint of `0` and rehashes as the map grows via `extend` — the same rehashing cost the PR intended to remove.

## What

- `get_nodes()` returns `self.skeleton_tree.iter()` over a `HashMap<NodeIndex, UpdatedSkeletonNode>`, whose iterator has an *exact* `size_hint` (lower == upper == remaining length). Read that exact node count from the iterator **before** wrapping it in `filter_map`, and pre-allocate the output map with `HashMap::with_capacity` using it, then `extend` from the `filter_map`d iterator.
- This capacity is a safe upper bound for the filtered map (it also counts `UnmodifiedSubTree` nodes, which are excluded from the result), so the map is allocated once with zero rehashes.

## Validation

- `cargo build -p starknet_patricia` — clean.
- `SEED=0 cargo test -p starknet_patricia` — 107 passed, 0 failed.
- `cargo clippy -p starknet_patricia --all-targets` — clean.
- `scripts/rust_fmt.sh` — clean.
- Reviewed by an independent Opus pass; no blocking findings (one comment-clarity nit applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012fsm31HjJg8geCTySySDCg)_