### PR TITLE
starknet_patricia: actually pre-allocate filled-tree output map capacity

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -77,13 +77,15 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
     fn initialize_filled_tree_output_map_with_placeholders<'a>(
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
-        updated_skeleton
-            .get_nodes()
-            .filter_map(|(index, node)| match node {
-                UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
-                _ => Some((*index, OnceLock::new())),
-            })
-            .collect()
+        // `filter_map` erases the exact lower bound of `size_hint`, so capacity must be reserved
+        // from the underlying node iterator before filtering to actually avoid rehashing.
+        let nodes = updated_skeleton.get_nodes();
+        let mut filled_tree_output_map = HashMap::with_capacity(nodes.size_hint().0);
+        filled_tree_output_map.extend(nodes.filter_map(|(index, node)| match node {
+            UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
+            _ => Some((*index, OnceLock::new())),
+        }));
+        filled_tree_output_map
     }
 
     fn initialize_leaf_output_map_with_placeholders(

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -78,10 +78,13 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
         // `filter_map` erases the exact lower bound of `size_hint`, so capacity must be reserved
-        // from the underlying node iterator before filtering to actually avoid rehashing.
-        let nodes = updated_skeleton.get_nodes();
-        let mut filled_tree_output_map = HashMap::with_capacity(nodes.size_hint().0);
-        filled_tree_output_map.extend(nodes.filter_map(|(index, node)| match node {
+        // from the underlying node iterator (whose `size_hint` is exact, since it comes from a
+        // `HashMap::iter()`) before filtering, to actually avoid rehashing. This over-reserves for
+        // the `UnmodifiedSubTree` nodes filtered out below, trading bounded extra capacity for
+        // skipping a separate counting pass.
+        let node_iterator = updated_skeleton.get_nodes();
+        let mut filled_tree_output_map = HashMap::with_capacity(node_iterator.size_hint().0);
+        filled_tree_output_map.extend(node_iterator.filter_map(|(index, node)| match node {
             UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
             _ => Some((*index, OnceLock::new())),
         }));

--- a/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/updated_skeleton_tree/tree.rs
@@ -30,7 +30,9 @@ pub trait UpdatedSkeletonTree<'a>: Sized + Send + Sync {
     /// Does the skeleton represents an empty-tree (i.e. all leaves are empty).
     fn is_empty(&self) -> bool;
 
-    /// Returns an iterator over all (node index, node) pairs in the tree.
+    /// Returns an iterator over all (node index, node) pairs in the tree. Callers rely on an
+    /// exact `size_hint` (lower bound equal to the true count) to pre-allocate; implementations
+    /// must not wrap this in an adapter (e.g. `filter`) that only yields a lower bound of `0`.
     fn get_nodes(&self) -> impl Iterator<Item = (&NodeIndex, &UpdatedSkeletonNode)>;
 
     /// Returns the node with the given index.


### PR DESCRIPTION
## Summary

Follow-up fix on top of #14638, which merged with the stated goal of pre-allocating `initialize_filled_tree_output_map_with_placeholders`'s output `HashMap` to avoid O(log N) rehashing during tree fill — a hot path called once per block per Merkle tree (storage + class tries).

That PR's implementation doesn't actually achieve the goal: it collects through a `.filter_map(...).collect()` chain, but `Iterator::filter_map`'s `size_hint()` always reports a lower bound of `0` (verified empirically — a `HashMap::iter()` filtered through `filter_map` degrades from an exact `size_hint` to `(0, Some(n))`). `HashMap`'s `Extend` impl (which backs `.collect()`) reserves capacity based on exactly that lower bound, so the merged code reserves **zero** extra capacity up front and still rehashes while filling — the same cost the PR claimed to remove.

## Fix

- Capture `size_hint()` from the raw `get_nodes()` iterator (exact, since it comes from a `HashMap::iter()`) *before* applying `.filter_map`, and explicitly `HashMap::with_capacity(...)` + `.extend(...)` instead of relying on `.collect()`'s internal reservation.
- Document on the `get_nodes` trait method that callers rely on this exact `size_hint`, so a future implementation wrapping it in a filtering adapter doesn't silently regress the optimization again.
- Note the deliberate (and bounded) over-allocation for `UnmodifiedSubTree` nodes that get filtered out, as a documented tradeoff against a separate counting pass.

## Verification

- `cargo build -p starknet_patricia` — clean.
- `SEED=0 cargo test -p starknet_patricia` — 107 passed, 0 failed.
- Reviewed by an independent Opus pass; no blocking issues, two suggestion-level items addressed (documentation of the size_hint contract and the over-allocation tradeoff).

🤖 Generated with a scheduled Claude Code review of merged PR #14638.


---
_Generated by [Claude Code](https://claude.ai/code/session_015cTjgteomFa2zu4xh6L2yJ)_