### PR TITLE
apollo_consensus_orchestrator: add CendeContext::get_accessed_keys_input

### DIFF
--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -40,7 +40,7 @@ reqwest-middleware = { workspace = true, features = ["json"] }
 reqwest-retry.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
-shared_execution_objects.workspace = true
+shared_execution_objects = { workspace = true, features = ["deserialize"] }
 starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_committer.workspace = true

--- a/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
@@ -2,13 +2,21 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use apollo_class_manager_types::MockClassManagerClient;
+use blockifier::transaction::objects::TransactionExecutionInfo;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use reqwest::StatusCode;
 use rstest::rstest;
+use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
 use starknet_api::block::{BlockInfo, BlockNumber};
+use starknet_api::test_utils::read_json_file;
 use url::Url;
 
-use super::{CendeAmbassador, RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH, RECORDER_WRITE_BLOB_PATH};
+use super::{
+    CendeAmbassador,
+    RECORDER_GET_ACCESSED_KEYS_INPUT_PATH,
+    RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH,
+    RECORDER_WRITE_BLOB_PATH,
+};
 use crate::cende::{BlobParameters, CendeConfig, CendeContext};
 use crate::metrics::{
     register_metrics,
@@ -247,4 +255,66 @@ async fn prepare_blob_for_next_height() {
     );
 
     CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER.assert_eq(&recorder.handle().render(), HEIGHT_TO_WRITE.0);
+}
+
+#[rstest]
+// Recorder returns the block's transactions and execution infos → `Ok(Some(..))`.
+#[case::parses_some(200, true, false)]
+// Recorder responds with `null` (it has no data stored) → `Ok(None)`.
+#[case::none_when_recorder_has_none(200, false, false)]
+// Non-transient failure status → `Err`.
+#[case::errors_on_failure_status(400, true, true)]
+#[tokio::test]
+async fn get_accessed_keys_input(
+    #[case] mock_status_code: usize,
+    #[case] recorder_has_block: bool,
+    #[case] expect_error: bool,
+) {
+    const BLOCK_NUMBER: BlockNumber = BlockNumber(7);
+
+    let mut server = mockito::Server::new_async().await;
+    let url = server.url();
+
+    // The block's data in central-object form (matching the recorder's `AccessedKeysInput`): one
+    // transaction (the canonical central invoke-tx fixture, whose proof facts are empty) and one
+    // execution info. The transaction is a full `CentralTransactionWritten` — the same type the
+    // blob's `transactions` field uses.
+    let execution_info = CentralTransactionExecutionInfo::from(TransactionExecutionInfo::default());
+    let tx_json: serde_json::Value = read_json_file("central_invoke_tx.json");
+    let block_data_body = serde_json::json!({
+        "transactions": [tx_json],
+        "execution_infos": [serde_json::to_value(&execution_info).unwrap()],
+    })
+    .to_string();
+    // `null` matches the recorder's response when it does not have the block.
+    let response_body = if recorder_has_block { block_data_body } else { "null".to_string() };
+
+    let mock = server
+        .mock("GET", RECORDER_GET_ACCESSED_KEYS_INPUT_PATH)
+        .match_query(mockito::Matcher::UrlEncoded(
+            "block_number".into(),
+            BLOCK_NUMBER.0.to_string(),
+        ))
+        .with_status(mock_status_code)
+        .with_header("content-type", "application/json")
+        .with_body(response_body)
+        .create();
+
+    let cende_ambassador = CendeAmbassador::new(
+        CendeConfig { recorder_url: url.parse::<Url>().unwrap(), ..Default::default() },
+        Arc::new(MockClassManagerClient::new()),
+    );
+
+    let result = cende_ambassador.get_accessed_keys_input(BLOCK_NUMBER).await;
+
+    if expect_error {
+        assert!(result.is_err());
+    } else if recorder_has_block {
+        let block_data = result.unwrap().expect("expected block data");
+        assert_eq!(block_data.transactions.len(), 1);
+        assert_eq!(block_data.execution_infos.len(), 1);
+    } else {
+        assert!(result.unwrap().is_none());
+    }
+    mock.assert();
 }

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects.rs
@@ -184,8 +184,7 @@ impl From<(CommitmentStateDiff, CentralBlockInfo)> for CentralStateDiff {
     }
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 struct CentralResourceBounds {
     #[serde(rename = "L1_GAS")]
     l1_gas: ResourceBounds,
@@ -205,8 +204,7 @@ impl From<AllResourceBounds> for CentralResourceBounds {
     }
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 struct CentralInvokeTransactionV3 {
     resource_bounds: CentralResourceBounds,
     tip: Tip,
@@ -244,16 +242,14 @@ impl From<(InternalRpcInvokeTransactionV3, TransactionHash)> for CentralInvokeTr
     }
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 #[serde(tag = "version")]
 enum CentralInvokeTransaction {
     #[serde(rename = "0x3")]
     V3(CentralInvokeTransactionV3),
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 struct CentralDeployAccountTransactionV3 {
     resource_bounds: CentralResourceBounds,
     tip: Tip,
@@ -295,8 +291,7 @@ impl From<(InternalRpcDeployAccountTransaction, TransactionHash)>
     }
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 #[serde(tag = "version")]
 enum CentralDeployAccountTransaction {
     #[serde(rename = "0x3")]
@@ -307,8 +302,7 @@ fn into_string_tuple(val: SierraVersion) -> (String, String, String) {
     (format!("0x{:x}", val.major), format!("0x{:x}", val.minor), format!("0x{:x}", val.patch))
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 struct CentralDeclareTransactionV3 {
     resource_bounds: CentralResourceBounds,
     tip: Tip,
@@ -361,16 +355,14 @@ impl TryFrom<(InternalRpcDeclareTransactionV3, &SierraContractClass, Transaction
     }
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 #[serde(tag = "version")]
 enum CentralDeclareTransaction {
     #[serde(rename = "0x3")]
     V3(CentralDeclareTransactionV3),
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 struct CentralL1HandlerTransaction {
     contract_address: ContractAddress,
     entry_point_selector: EntryPointSelector,
@@ -393,8 +385,7 @@ impl From<L1HandlerTransaction> for CentralL1HandlerTransaction {
     }
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 #[serde(tag = "type")]
 enum CentralTransaction {
     #[serde(rename = "INVOKE_FUNCTION")]
@@ -442,11 +433,9 @@ impl TryFrom<(InternalConsensusTransaction, Option<&SierraContractClass>)> for C
     }
 }
 
-#[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize))]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(serde::Deserialize, Debug, PartialEq, Serialize)]
 pub(crate) struct CentralTransactionWritten {
     tx: CentralTransaction,
-    // The timestamp is required for monitoring data, we use the block timestamp for this.
     time_created: u64,
 }
 

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -35,6 +35,7 @@ use reqwest::Response;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{Jitter, RetryTransientMiddleware};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
 use starknet_api::block::{BlockHashAndNumber, BlockInfo, BlockNumber, StarknetVersion};
@@ -127,6 +128,26 @@ pub trait CendeContext: Send + Sync {
     /// recorder has not stored yet.
     /// `Ok(None)` when the recorder has stored nothing; `Err` on query failure.
     async fn commitment_infos_height_offset(&self) -> CendeAmbassadorResult<Option<BlockNumber>>;
+
+    /// Fetches the raw per-block data, from which the caller computes the block's accessed keys.
+    /// Returns `None` when the recorder does not have the block.
+    async fn get_accessed_keys_input(
+        &self,
+        block_number: BlockNumber,
+    ) -> CendeAmbassadorResult<Option<BlockAccessedKeysData>>;
+}
+
+/// The raw per-block data the recorder returns from `get_accessed_keys_input`. The caller computes
+/// the block's [`AccessedKeys`](blockifier::state::accessed_keys::AccessedKeys) from this, with
+/// data it already holds for a synced block.
+// TODO(Yoav): Remove the expect once the accessed-keys computation lands and reads these fields.
+#[cfg_attr(not(test), expect(dead_code))]
+#[derive(Debug, Deserialize)]
+pub struct BlockAccessedKeysData {
+    /// One entry per transaction, in the same central format as the blob's `transactions` field.
+    pub(crate) transactions: Vec<CentralTransactionWritten>,
+    /// One execution info per transaction.
+    pub(crate) execution_infos: Vec<CentralTransactionExecutionInfo>,
 }
 
 #[derive(Clone)]
@@ -138,6 +159,7 @@ pub struct CendeAmbassador {
     write_blob_url: Url,
     get_latest_received_block_url: Url,
     commitment_infos_height_offset_url: Url,
+    get_accessed_keys_input_url: Url,
     client: ClientWithMiddleware,
     class_manager: SharedClassManagerClient,
 }
@@ -154,6 +176,9 @@ pub const RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH: &str =
 /// infos the recorder has not stored yet). Returns null when the recorder has stored nothing.
 pub const RECORDER_GET_COMMITMENT_INFOS_HEIGHT_OFFSET_PATH: &str =
     concatcp!(RECORDER_PREFIX, "/get_witness_height_offset");
+/// The path to fetch accessed keys from the Recorder.
+pub const RECORDER_GET_ACCESSED_KEYS_INPUT_PATH: &str =
+    concatcp!(RECORDER_PREFIX, "/get_accessed_keys_input");
 
 #[derive(Debug, Deserialize)]
 struct BlockNumberResponse {
@@ -181,6 +206,10 @@ impl CendeAmbassador {
                 .recorder_url
                 .join(RECORDER_GET_COMMITMENT_INFOS_HEIGHT_OFFSET_PATH)
                 .expect("Failed to construct get commitment infos height offset URL"),
+            get_accessed_keys_input_url: cende_config
+                .recorder_url
+                .join(RECORDER_GET_ACCESSED_KEYS_INPUT_PATH)
+                .expect("Failed to construct get accessed keys URL"),
             // Bound each attempt by the max retry interval. Without a per-attempt timeout
             // `RetryTransientMiddleware` only retries attempts that *return* a transient error, so
             // a request that hangs against a slow recorder would block until the build deadline
@@ -259,16 +288,24 @@ async fn fetch_block_number(
     url: &Url,
     path: &str,
 ) -> CendeAmbassadorResult<Option<BlockNumber>> {
+    let parsed: BlockNumberResponse = send_recorder_get(client.get(url.as_str()), path).await?;
+    Ok(parsed.block_number.map(BlockNumber))
+}
+
+/// Sends `request` to a recorder GET endpoint and deserializes the JSON body into `T`, mapping
+/// transport, non-success status, and parse failures to `RecorderRequestFailed`. `path` is used
+/// only for diagnostics.
+async fn send_recorder_get<T: DeserializeOwned>(
+    request: RequestBuilder,
+    path: &str,
+) -> CendeAmbassadorResult<T> {
     let recorder_error = |message: String| CendeAmbassadorError::RecorderRequestFailed {
         path: path.to_string(),
         message,
     };
 
-    let response = client
-        .get(url.as_str())
-        .send()
-        .await
-        .map_err(|e| recorder_error(format!("request failed: {e}")))?;
+    let response =
+        request.send().await.map_err(|e| recorder_error(format!("request failed: {e}")))?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -276,11 +313,7 @@ async fn fetch_block_number(
         return Err(recorder_error(format!("returned error status {status}: {body}")));
     }
 
-    let parsed = response
-        .json::<BlockNumberResponse>()
-        .await
-        .map_err(|e| recorder_error(format!("failed to parse response: {e}")))?;
-    Ok(parsed.block_number.map(BlockNumber))
+    response.json::<T>().await.map_err(|e| recorder_error(format!("failed to parse response: {e}")))
 }
 
 #[async_trait]
@@ -358,6 +391,20 @@ impl CendeContext for CendeAmbassador {
             &self.client,
             &self.commitment_infos_height_offset_url,
             RECORDER_GET_COMMITMENT_INFOS_HEIGHT_OFFSET_PATH,
+        )
+        .await
+    }
+
+    async fn get_accessed_keys_input(
+        &self,
+        block_number: BlockNumber,
+    ) -> CendeAmbassadorResult<Option<BlockAccessedKeysData>> {
+        // The recorder responds with `null` when it has no data stored for the block.
+        send_recorder_get(
+            self.client
+                .get(self.get_accessed_keys_input_url.as_str())
+                .query(&[("block_number", block_number.0)]),
+            RECORDER_GET_ACCESSED_KEYS_INPUT_PATH,
         )
         .await
     }


### PR DESCRIPTION
New os_input-gated trait method plus CendeAmbassador implementation that
fetches a committed block's accessed keys from the recorder, returning None
when the recorder has none stored. Reuses the shared send_recorder_get helper
(extracted from fetch_block_number) for the request/status/parse error
handling, and adds the get_accessed_keys endpoint path/URL. No callers yet.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>