### PR TITLE
apollo_batcher,apollo_batcher_types: thread Option<AccessedKeys> through add_sync_block

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -831,8 +831,12 @@ impl Batcher {
         })
     }
 
-    #[instrument(skip(self, sync_block), err)]
-    pub async fn add_sync_block(&mut self, sync_block: SyncBlock) -> BatcherResult<()> {
+    #[instrument(skip(self, sync_block, accessed_keys), err)]
+    pub async fn add_sync_block(
+        &mut self,
+        sync_block: SyncBlock,
+        accessed_keys: Option<AccessedKeys>,
+    ) -> BatcherResult<()> {
         trace!("Received sync block: {:?}", sync_block);
         // TODO(AlonH): Use additional data from the sync block.
         let SyncBlock {
@@ -913,8 +917,6 @@ impl Batcher {
             }) => Some(header_commitments.state_diff_commitment),
         };
 
-        // Synced blocks are not executed locally, so no accessed keys are available; the block is
-        // committed via `CommitBlock`.
         self.commit_proposal_and_block(
             height,
             state_diff.clone(),
@@ -922,7 +924,7 @@ impl Batcher {
             l1_transaction_hashes.iter().copied().collect(),
             Default::default(),
             storage_commitment_block_hash,
-            None,
+            accessed_keys.as_ref(),
         )
         .await?;
 
@@ -930,7 +932,7 @@ impl Batcher {
             height,
             state_diff,
             optional_state_diff_commitment,
-            None,
+            accessed_keys,
         )
         .await?;
 
@@ -985,7 +987,7 @@ impl Batcher {
             block_execution_artifacts.execution_data.consumed_l1_handler_tx_hashes,
             block_execution_artifacts.execution_data.rejected_tx_hashes,
             StorageCommitmentBlockHash::Partial(partial_block_hash_components),
-            Some(accessed_keys.clone()),
+            Some(&accessed_keys),
         )
         .await?;
 
@@ -1069,7 +1071,7 @@ impl Batcher {
         consumed_l1_handler_tx_hashes: IndexSet<TransactionHash>,
         rejected_tx_hashes: IndexSet<TransactionHash>,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
-        accessed_keys: Option<AccessedKeys>,
+        accessed_keys: Option<&AccessedKeys>,
     ) -> BatcherResult<()> {
         info!(
             "Committing block at height {} and notifying mempool & L1 event provider of the block.",
@@ -1882,12 +1884,15 @@ impl BatcherStorageReader for StorageReader {
 
 #[cfg_attr(test, automock)]
 pub trait BatcherStorageWriter: Send + Sync {
-    fn commit_proposal(
+    // Automock requires a named lifetime for references nested in generics, while clippy flags
+    // it as needless.
+    #[allow(clippy::needless_lifetimes)]
+    fn commit_proposal<'a>(
         &mut self,
         height: BlockNumber,
         state_diff: ThinStateDiff,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
-        accessed_keys: Option<AccessedKeys>,
+        accessed_keys: Option<&'a AccessedKeys>,
     ) -> StorageResult<()>;
 
     fn revert_block(&mut self, height: BlockNumber);
@@ -1909,12 +1914,14 @@ pub trait BatcherStorageWriter: Send + Sync {
 }
 
 impl BatcherStorageWriter for StorageWriter {
-    fn commit_proposal(
+    // See the lifetime explanation on the trait method.
+    #[allow(clippy::needless_lifetimes)]
+    fn commit_proposal<'a>(
         &mut self,
         height: BlockNumber,
         state_diff: ThinStateDiff,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
-        accessed_keys: Option<AccessedKeys>,
+        accessed_keys: Option<&'a AccessedKeys>,
     ) -> StorageResult<()> {
         // TODO(AlonH): write casms.
         let mut txn = self.begin_rw_txn()?.append_state_diff(height, state_diff)?;
@@ -1930,7 +1937,7 @@ impl BatcherStorageWriter for StorageWriter {
             }
         }
         if let Some(accessed_keys) = accessed_keys {
-            txn = txn.append_accessed_keys(height, &accessed_keys)?;
+            txn = txn.append_accessed_keys(height, accessed_keys)?;
         }
         txn.commit()
     }

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -36,6 +36,7 @@ use apollo_mempool_types::communication::{
 };
 use apollo_mempool_types::mempool_types::CommitBlockArgs;
 use apollo_state_sync_types::state_sync_types::SyncBlock;
+use apollo_storage::accessed_keys::AccessedKeys;
 use apollo_storage::db::DbError;
 use apollo_storage::test_utils::get_test_storage;
 use apollo_storage::{StorageError, StorageReader, StorageWriter};
@@ -99,7 +100,7 @@ use crate::block_builder::{
     MockBlockBuilderFactoryTrait,
 };
 use crate::commitment_manager::commitment_manager_impl::CommitmentManager;
-use crate::commitment_manager::types::CommitterTaskInput;
+use crate::commitment_manager::types::{CommitterTaskInput, CommitterTaskOutput};
 use crate::metrics::{
     BATCHED_TRANSACTIONS,
     BUILDING_HEIGHT,
@@ -1188,12 +1189,17 @@ async fn proposal_startup_failure_allows_new_proposals() {
 #[case::new_sync_block(INITIAL_HEIGHT, Some(PartialBlockHashComponents {
     block_number: INITIAL_HEIGHT,
     ..Default::default()
-}))]
-#[case::old_sync_block(FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH.prev().unwrap(), None)]
+}), None)]
+#[case::old_sync_block(FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH.prev().unwrap(), None, None)]
+#[case::new_sync_block_with_accessed_keys(INITIAL_HEIGHT, Some(PartialBlockHashComponents {
+    block_number: INITIAL_HEIGHT,
+    ..Default::default()
+}), Some(AccessedKeys::default()))]
 #[tokio::test]
 async fn add_sync_block(
     #[case] block_number: BlockNumber,
     #[case] partial_block_hash_components: Option<PartialBlockHashComponents>,
+    #[case] accessed_keys: Option<AccessedKeys>,
 ) {
     let recorder = PrometheusBuilder::new().build_recorder();
     let _recorder_guard = metrics::set_default_local_recorder(&recorder);
@@ -1225,7 +1231,7 @@ async fn add_sync_block(
         block_number,
         test_state_diff(),
         storage_commitment_block_hash,
-        false,
+        accessed_keys.is_some(),
     );
 
     mock_clients
@@ -1267,7 +1273,18 @@ async fn add_sync_block(
         block_header_commitments,
         ..Default::default()
     };
-    batcher.add_sync_block(sync_block).await.unwrap();
+    batcher.add_sync_block(sync_block, accessed_keys.clone()).await.unwrap();
+
+    // Providing accessed keys should issue a `ReadPathsAndCommitBlock` committer task; otherwise a
+    // plain `Commit` task is issued.
+    wait_for_n_items(&mut batcher.commitment_manager.results_receiver, 1).await;
+    let committer_task_output = batcher.commitment_manager.results_receiver.try_recv().unwrap();
+    match committer_task_output {
+        CommitterTaskOutput::Commit(_) => assert!(accessed_keys.is_none()),
+        CommitterTaskOutput::ReadPathsAndCommitBlock(_) => assert!(accessed_keys.is_some()),
+        CommitterTaskOutput::Revert(_) => panic!("Unexpected revert committer task."),
+    }
+
     let metrics = recorder.handle().render();
     assert_eq!(
         BUILDING_HEIGHT.parse_numeric_metric::<u64>(&metrics),
@@ -1297,7 +1314,7 @@ async fn add_sync_block_mismatch_block_number() {
         block_header_commitments: Some(Default::default()),
         ..Default::default()
     };
-    let result = batcher.add_sync_block(sync_block).await;
+    let result = batcher.add_sync_block(sync_block, None).await;
     assert_eq!(
         result,
         Err(BatcherError::StorageHeightMarkerMismatch {
@@ -1327,7 +1344,7 @@ async fn add_sync_block_missing_block_header_commitments() {
         l1_transaction_hashes: Default::default(),
         block_header_commitments: None,
     };
-    let result = batcher.add_sync_block(sync_block).await;
+    let result = batcher.add_sync_block(sync_block, None).await;
     assert_eq!(result, Err(BatcherError::MissingHeaderCommitments { block_number: INITIAL_HEIGHT }))
 }
 
@@ -1357,7 +1374,7 @@ async fn add_sync_block_missing_block_header_commitments_for_new_block() {
         l1_transaction_hashes: Default::default(),
         block_header_commitments: None,
     };
-    let _ = batcher.add_sync_block(sync_block).await;
+    let _ = batcher.add_sync_block(sync_block, None).await;
 }
 
 #[rstest]
@@ -1414,7 +1431,7 @@ async fn add_sync_block_for_first_new_block() {
         block_header_commitments: Some(Default::default()),
         ..Default::default()
     };
-    batcher.add_sync_block(sync_block).await.unwrap();
+    batcher.add_sync_block(sync_block, None).await.unwrap();
 }
 
 #[rstest]
@@ -1444,7 +1461,7 @@ async fn add_sync_block_parent_hash_mismatch() {
         block_header_commitments: Some(Default::default()),
         ..Default::default()
     };
-    let _ = batcher.add_sync_block(sync_block).await;
+    let _ = batcher.add_sync_block(sync_block, None).await;
 }
 
 #[rstest]
@@ -1471,7 +1488,7 @@ async fn add_sync_block_with_partial_block_hash_but_older_than_configured_first_
         block_header_commitments: Some(Default::default()),
         ..Default::default()
     };
-    let _ = batcher.add_sync_block(sync_block).await;
+    let _ = batcher.add_sync_block(sync_block, None).await;
 }
 
 #[tokio::test]

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -59,8 +59,8 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
             BatcherRequest::FinishProposal(input) => {
                 BatcherResponse::FinishProposal(self.finish_proposal(input).await)
             }
-            BatcherRequest::AddSyncBlock(sync_block) => {
-                BatcherResponse::AddSyncBlock(self.add_sync_block(sync_block).await)
+            BatcherRequest::AddSyncBlock(sync_block, accessed_keys) => {
+                BatcherResponse::AddSyncBlock(self.add_sync_block(sync_block, accessed_keys).await)
             }
             BatcherRequest::RevertBlock(input) => {
                 BatcherResponse::RevertBlock(self.revert_block(input).await)

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -11,6 +11,7 @@ use apollo_infra::{
 use apollo_metrics::generate_permutation_labels;
 use apollo_state_sync_types::state_sync_types::SyncBlock;
 use async_trait::async_trait;
+use blockifier::state::accessed_keys::AccessedKeys;
 #[cfg(any(feature = "testing", test))]
 use mockall::automock;
 use serde::{Deserialize, Serialize};
@@ -81,8 +82,13 @@ pub trait BatcherClient: Send + Sync {
     /// with this height.
     async fn start_height(&self, input: StartHeightInput) -> BatcherClientResult<()>;
     /// Adds a block from the state sync. Updates the batcher's state and commits the
-    /// transactions to the mempool.
-    async fn add_sync_block(&self, sync_block: SyncBlock) -> BatcherClientResult<()>;
+    /// transactions to the mempool.  If `accessed_keys` are present, the batcher builds the state
+    /// commitment infos.
+    async fn add_sync_block(
+        &self,
+        sync_block: SyncBlock,
+        accessed_keys: Option<AccessedKeys>,
+    ) -> BatcherClientResult<()>;
     /// Notifies the batcher that a decision has been reached.
     /// This closes the process of the given height, and the accepted proposal is committed.
     async fn decision_reached(
@@ -133,7 +139,7 @@ pub enum BatcherRequest {
     StartHeight(StartHeightInput),
     GetCurrentHeight,
     DecisionReached(DecisionReachedInput),
-    AddSyncBlock(SyncBlock),
+    AddSyncBlock(SyncBlock, Option<AccessedKeys>),
     RevertBlock(RevertBlockInput),
     StartRound,
     CallContract(CallContractInput),
@@ -342,8 +348,12 @@ where
         )
     }
 
-    async fn add_sync_block(&self, sync_block: SyncBlock) -> BatcherClientResult<()> {
-        let request = BatcherRequest::AddSyncBlock(sync_block);
+    async fn add_sync_block(
+        &self,
+        sync_block: SyncBlock,
+        accessed_keys: Option<AccessedKeys>,
+    ) -> BatcherClientResult<()> {
+        let request = BatcherRequest::AddSyncBlock(sync_block, accessed_keys);
         handle_all_response_variants!(
             self,
             request,

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1138,7 +1138,7 @@ impl ConsensusContext for SequencerConsensusContext {
             "Adding sync block to Batcher for height {}",
             sync_block.block_header_without_hash.block_number,
         );
-        if let Err(e) = self.deps.batcher.add_sync_block(sync_block).await {
+        if let Err(e) = self.deps.batcher.add_sync_block(sync_block, None).await {
             error!("Failed to add sync block to Batcher: {e:?}");
             return false;
         }

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -1839,7 +1839,7 @@ async fn test_first_height_keeps_sync_provided_l2_gas_price() {
         Ok(sync_block)
     });
     deps.setup_default_expectations();
-    deps.batcher.expect_add_sync_block().times(1).return_once(|_| Ok(()));
+    deps.batcher.expect_add_sync_block().times(1).return_once(|_, _| Ok(()));
     deps.batcher.expect_start_height().times(2).returning(|_| Ok(()));
 
     let mut context = deps.build_context();


### PR DESCRIPTION
Add an accessed_keys parameter to the BatcherClient::add_sync_block trait
method, the AddSyncBlock request variant, and the batcher implementation.
In os_input builds a Some value is persisted so the commitment task builds
the block's witness; None preserves the plain CommitBlock path. All callers
pass None here (behavior unchanged); the consensus fetch is wired next.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>