### PR TITLE
blockifier,apollo_consensus_orchestrator: compute accessed keys from call infos

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
@@ -1,23 +1,35 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use apollo_class_manager_types::MockClassManagerClient;
+use blockifier::blockifier_versioned_constants::VersionedConstants;
+use blockifier::execution::call_info::{CallInfo, StorageAccessTracker};
+use blockifier::execution::entry_point::CallEntryPoint;
+use blockifier::state::cached_state::CommitmentStateDiff;
+use blockifier::state::stateful_compression::ALIAS_COUNTER_STORAGE_KEY;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use reqwest::StatusCode;
 use rstest::rstest;
 use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
 use starknet_api::block::{BlockInfo, BlockNumber};
+use starknet_api::core::{ContractAddress, BLOCK_HASH_TABLE_ADDRESS};
+use starknet_api::state::StorageKey;
 use starknet_api::test_utils::read_json_file;
+use starknet_api::transaction::fields::{snos_block_number_from_proof_facts, ProofFacts};
+use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
+use starknet_types_core::felt::Felt;
 use url::Url;
 
+use super::central_objects::CentralTransactionWritten;
 use super::{
     CendeAmbassador,
     RECORDER_GET_ACCESSED_KEYS_INPUT_PATH,
     RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH,
     RECORDER_WRITE_BLOB_PATH,
 };
-use crate::cende::{BlobParameters, CendeConfig, CendeContext};
+use crate::cende::{BlobParameters, BlockAccessedKeysData, CendeConfig, CendeContext};
 use crate::metrics::{
     register_metrics,
     CendeWriteFailureReason,
@@ -313,8 +325,89 @@ async fn get_accessed_keys_input(
         let block_data = result.unwrap().expect("expected block data");
         assert_eq!(block_data.transactions.len(), 1);
         assert_eq!(block_data.execution_infos.len(), 1);
+        assert!(
+            block_data.transactions[0]
+                .proof_facts()
+                .is_some_and(|proof_facts| proof_facts.is_empty())
+        );
     } else {
         assert!(result.unwrap().is_none());
     }
     mock.assert();
+}
+
+#[test]
+fn compute_accessed_keys() {
+    // A transaction carrying proof facts of a client-side proof; the block number the proof is
+    // verified against must map to a block hash table entry.
+    let proof_facts = ProofFacts::snos_proof_facts_for_testing();
+    let proof_facts_block_number = snos_block_number_from_proof_facts(&proof_facts)
+        .expect("the test proof facts must carry a block number");
+    let mut tx_json: serde_json::Value = read_json_file("central_invoke_tx.json");
+    tx_json["tx"]["proof_facts"] = serde_json::to_value(&proof_facts).unwrap();
+    let transaction: CentralTransactionWritten = serde_json::from_value(tx_json).unwrap();
+
+    // An execution info whose call info read a storage key.
+    let read_address = ContractAddress::from(0x300_u16);
+    let read_key = StorageKey::from(0x400_u16);
+    let execution_info = CentralTransactionExecutionInfo::from(TransactionExecutionInfo {
+        execute_call_info: Some(CallInfo {
+            call: CallEntryPoint { storage_address: read_address, ..Default::default() },
+            storage_access_tracker: StorageAccessTracker {
+                accessed_storage_keys: [read_key].into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
+    // A state diff writing to a storage key of another contract.
+    let written_address = ContractAddress::from(0x500_u16);
+    let written_key = StorageKey::from(0x600_u16);
+    let mut state_diff = CommitmentStateDiff::default();
+    state_diff.storage_updates.entry(written_address).or_default().insert(written_key, Felt::ONE);
+
+    let block_accessed_keys_data = BlockAccessedKeysData {
+        transactions: vec![transaction],
+        execution_infos: vec![execution_info],
+    };
+    let accessed_keys = block_accessed_keys_data.compute_accessed_keys(&state_diff);
+
+    // The latest versioned constants enable stateful compression, so the alias contract entries
+    // predicted from the state diff are also included: the alias counter, the written address and
+    // the written key.
+    let alias_contract_address = VersionedConstants::latest_constants()
+        .os_constants
+        .os_contract_addresses
+        .alias_contract_address();
+    // 6 storage keys and 4 accessed contracts, all asserted below.
+    assert_eq!(accessed_keys.len(), 10);
+    assert!(accessed_keys.storage_keys.contains(&(read_address, read_key)));
+    assert!(accessed_keys.storage_keys.contains(&(written_address, written_key)));
+    assert!(
+        accessed_keys
+            .storage_keys
+            .contains(&(BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(proof_facts_block_number.0)))
+    );
+    assert!(
+        accessed_keys.storage_keys.contains(&(alias_contract_address, ALIAS_COUNTER_STORAGE_KEY))
+    );
+    assert!(
+        accessed_keys
+            .storage_keys
+            .contains(&(alias_contract_address, StorageKey(written_address.0)))
+    );
+    assert!(accessed_keys.storage_keys.contains(&(alias_contract_address, written_key)));
+    // Assert all the contracts are present.
+    assert_eq!(
+        accessed_keys.accessed_contracts,
+        BTreeSet::from([
+            read_address,
+            written_address,
+            BLOCK_HASH_TABLE_ADDRESS,
+            alias_contract_address
+        ])
+    );
+    assert!(accessed_keys.accessed_class_hashes.is_empty());
 }

--- a/crates/apollo_consensus_orchestrator/src/cende/central_objects.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/central_objects.rs
@@ -439,6 +439,22 @@ pub(crate) struct CentralTransactionWritten {
     time_created: u64,
 }
 
+impl CentralTransactionWritten {
+    /// The transaction's proof facts, if any (only invoke transactions carry them). When the
+    /// transaction includes a client-side proof, its proof facts name the block whose state the
+    /// proof is verified against, and the Starknet OS reads that block's hash from the block hash
+    /// table. The accessed-keys computation reads the proof facts to include the corresponding
+    /// block hash table entry.
+    pub(crate) fn proof_facts(&self) -> Option<&ProofFacts> {
+        match &self.tx {
+            CentralTransaction::Invoke(CentralInvokeTransaction::V3(invoke)) => {
+                Some(&invoke.proof_facts)
+            }
+            _ => None,
+        }
+    }
+}
+
 // This function gets SierraContractClass only for declare_tx, otherwise use None.
 impl TryFrom<(InternalConsensusTransaction, Option<&SierraContractClass>, u64)>
     for CentralTransactionWritten

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -11,7 +11,9 @@ use apollo_proc_macros::sequencer_latency_histogram;
 use async_trait::async_trait;
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 use blockifier::blockifier::transaction_executor::CompiledClassHashesForMigration;
+use blockifier::blockifier_versioned_constants::VersionedConstants;
 use blockifier::bouncer::{BouncerWeights, CasmHashComputationData};
+use blockifier::state::accessed_keys::AccessedKeys;
 use blockifier::state::cached_state::{CommitmentStateDiff, StateMaps};
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use central_objects::{
@@ -42,6 +44,8 @@ use starknet_api::block::{BlockHashAndNumber, BlockInfo, BlockNumber, StarknetVe
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::ClassHash;
 use starknet_api::state::ThinStateDiff;
+use starknet_api::transaction::fields::snos_block_number_from_proof_facts;
+use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 use tokio::sync::Mutex;
 use tokio::task::{self, JoinHandle};
@@ -138,16 +142,35 @@ pub trait CendeContext: Send + Sync {
 }
 
 /// The raw per-block data the recorder returns from `get_accessed_keys_input`. The caller computes
-/// the block's [`AccessedKeys`](blockifier::state::accessed_keys::AccessedKeys) from this, with
-/// data it already holds for a synced block.
-// TODO(Yoav): Remove the expect once the accessed-keys computation lands and reads these fields.
-#[cfg_attr(not(test), expect(dead_code))]
+/// the block's `AccessedKeys` from this, with data it already holds for a synced block.
 #[derive(Debug, Deserialize)]
 pub struct BlockAccessedKeysData {
     /// One entry per transaction, in the same central format as the blob's `transactions` field.
     pub(crate) transactions: Vec<CentralTransactionWritten>,
     /// One execution info per transaction.
     pub(crate) execution_infos: Vec<CentralTransactionExecutionInfo>,
+}
+
+impl BlockAccessedKeysData {
+    /// Computes the block's `AccessedKeys` from the recorder-supplied transactions and execution
+    /// infos, the synced block's `state_diff`, and the latest versioned constants. Mirrors
+    /// `AccessedKeys::new`, but sources the call infos from the central execution infos and the
+    /// proof-facts block numbers from the transactions.
+    pub fn compute_accessed_keys(&self, state_diff: &CommitmentStateDiff) -> AccessedKeys {
+        let proof_facts_block_numbers: Vec<BlockNumber> = self
+            .transactions
+            .iter()
+            .filter_map(|transaction| {
+                transaction.proof_facts().and_then(snos_block_number_from_proof_facts)
+            })
+            .collect();
+        AccessedKeys::from_call_infos(
+            self.execution_infos.iter().flat_map(|execution_info| execution_info.call_info_iter()),
+            &proof_facts_block_numbers,
+            state_diff,
+            VersionedConstants::latest_constants(),
+        )
+    }
 }
 
 #[derive(Clone)]

--- a/crates/blockifier/src/state/accessed_keys.rs
+++ b/crates/blockifier/src/state/accessed_keys.rs
@@ -10,6 +10,7 @@ use starknet_api::state::StorageKey;
 use super::cached_state::{CommitmentStateDiff, StateChangesKeys, StorageEntry};
 use super::stateful_compression::predicted_alias_storage_entries;
 use crate::blockifier_versioned_constants::VersionedConstants;
+use crate::execution::call_info::CallInfo;
 use crate::transaction::objects::TransactionExecutionInfo;
 
 #[cfg(test)]
@@ -75,21 +76,42 @@ impl AccessedKeys {
         state_diff: &CommitmentStateDiff,
         versioned_constants: &VersionedConstants,
     ) -> Self {
+        Self::from_call_infos(
+            execution_infos
+                .into_iter()
+                .flat_map(|execution_info| execution_info.non_optional_call_infos())
+                .flat_map(|call_info| call_info.iter()),
+            proof_facts_block_numbers,
+            state_diff,
+            versioned_constants,
+        )
+    }
+
+    /// Like `Self::new`, but takes the transactions' call infos directly, already flattened over
+    /// the call trees (each `&CallInfo` and all its descendants). Lets callers that only have the
+    /// call infos — e.g. reconstructed from the recorder's central execution infos — reuse the
+    /// exact same computation without owning blockifier `TransactionExecutionInfo`s.
+    pub fn from_call_infos<'a>(
+        call_infos: impl IntoIterator<Item = &'a CallInfo>,
+        proof_facts_block_numbers: impl IntoIterator<Item = &'a BlockNumber>,
+        state_diff: &CommitmentStateDiff,
+        versioned_constants: &VersionedConstants,
+    ) -> Self {
         let mut storage_keys: BTreeSet<StorageEntry> = BTreeSet::new();
         let mut accessed_contracts: BTreeSet<ContractAddress> = BTreeSet::new();
         let mut accessed_class_hashes: BTreeSet<ClassHash> = BTreeSet::new();
 
         // Scan the call infos.
-        for execution_info in execution_infos {
-            for call_info in execution_info.non_optional_call_infos().flat_map(|ci| ci.iter()) {
-                storage_keys.extend(call_info.get_visited_storage_entries());
-                storage_keys.extend(call_info.storage_access_tracker.accessed_blocks.iter().map(
-                    |block_number| (BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(block_number.0)),
-                ));
-                accessed_contracts.extend(call_info.get_visited_contract_addresses());
-                if let Some(class_hash) = call_info.call.class_hash {
-                    accessed_class_hashes.insert(class_hash);
-                }
+        for call_info in call_infos {
+            storage_keys.extend(call_info.get_visited_storage_entries());
+            storage_keys.extend(
+                call_info.storage_access_tracker.accessed_blocks.iter().map(|block_number| {
+                    (BLOCK_HASH_TABLE_ADDRESS, StorageKey::from(block_number.0))
+                }),
+            );
+            accessed_contracts.extend(call_info.get_visited_contract_addresses());
+            if let Some(class_hash) = call_info.call.class_hash {
+                accessed_class_hashes.insert(class_hash);
             }
         }
 

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -782,6 +782,19 @@ impl From<CommitmentStateDiff> for ThinStateDiff {
     }
 }
 
+impl From<ThinStateDiff> for CommitmentStateDiff {
+    fn from(thin_state_diff: ThinStateDiff) -> Self {
+        // Drops `deprecated_declared_classes: Vec<ClassHash>`, which has no counterpart in
+        // `CommitmentStateDiff`.
+        Self {
+            address_to_class_hash: thin_state_diff.deployed_contracts,
+            address_to_nonce: thin_state_diff.nonces,
+            storage_updates: thin_state_diff.storage_diffs,
+            class_hash_to_compiled_class_hash: thin_state_diff.class_hash_to_compiled_class_hash,
+        }
+    }
+}
+
 /// Used to track the state diff size, which is determined by the number of new keys.
 /// Also, can be used to accuratly measure the contribution of a single (say, transactional)
 /// state to a cumulative state diff - provides set-like functionallities for this porpuse.


### PR DESCRIPTION
Add AccessedKeys::from_call_infos (a reusable variant of AccessedKeys::new that
takes already-flattened call infos) and From<ThinStateDiff> for CommitmentStateDiff
in blockifier, plus BlockAccessedKeysData::compute_accessed_keys in the consensus
orchestrator, which builds a synced block's accessed keys from the recorder-supplied
transactions and execution infos. No callers yet.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>