### PR TITLE
apollo_starknet_os_program: fix stale virtual-OS doc/comment inconsistencies

### DIFF
--- a/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execution_constraints.cairo
+++ b/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execution_constraints.cairo
@@ -48,7 +48,7 @@ func check_proof_facts{range_check_ptr, contract_state_changes: DictAccess*}(
     let proof_header = cast(proof_facts, ProofHeader*);
     assert proof_header.proof_variant = VIRTUAL_SNOS;
     assert is_program_hash_allowed(proof_header.program_hash) = TRUE;
-    // Proof version may be V0 (legacy) or V1 (current).
+    // Only proof version V1 is accepted.
     with_attr error_message("Unsupported proof version") {
         assert proof_header.proof_version = PROOF_VERSION_V1;
     }

--- a/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/virtual_os_output.cairo
+++ b/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/virtual_os_output.cairo
@@ -33,7 +33,6 @@ const PROOF_VERSION_V1 = 'PROOF1';
 //      - Deploy
 //      - GetBlockHash
 //      - ReplaceClass
-//      - Keccak
 //      - MetaTxV0
 //
 // 4. Cairo 1 only:


### PR DESCRIPTION
## Summary
Fixes two documentation inconsistencies in the Starknet OS core that were surfaced by the v0.14.3 soundness audit. **Comment-only** — no change to the compiled OS program or its hash, so no fixture/program-hash regen is needed.

## Issues fixed
1. **`virtual_os_output.cairo`** — the `VIRTUAL_SNOS0` version-contract doc listed **Keccak** as a *blocked* syscall, but the virtual OS actually enables it: `execute_syscalls__virtual.cairo` dispatches `KECCAK_SELECTOR` → `execute_keccak()` using the AIR-verified `KeccakBuiltin`. The doc was stale. Removed Keccak from the blocked list.
   - Output format is unchanged and the v0.14.3 program hash (`ALLOWED_VIRTUAL_OS_PROGRAM_HASHES_0`) already reflects the keccak-enabled behavior, so `VIRTUAL_OS_OUTPUT_VERSION` intentionally stays `'VIRTUAL_SNOS0'`.
2. **`execution_constraints.cairo`** — the `check_proof_facts` comment claimed "Proof version may be V0 (legacy) or V1 (current)" while the assert accepts **only** `PROOF_VERSION_V1`. Corrected the comment to match the (stricter, correct) code.

## Soundness note
Neither issue was a soundness bug — the code is correct in both cases (Keccak is verified by its builtin; only V1 proofs are accepted). These fixes align the docs/comments with the actual, intended behavior ahead of the audit.

## Verification
All changed lines are comments (`//`); `git diff` touches no code. The compiled program and program hash are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)