### PR TITLE
apollo_batcher_types,apollo_batcher: get_state_commitment_infos returns Option

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1538,14 +1538,11 @@ impl Batcher {
     pub fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherResult<CompressedStateCommitmentInfos> {
-        self.storage_reader
-            .get_state_commitment_infos(block_number)
-            .map_err(|err| {
-                error!("Failed to get state commitment infos from storage: {err}");
-                BatcherError::InternalError
-            })?
-            .ok_or(BatcherError::StateCommitmentInfosNotFound(block_number))
+    ) -> BatcherResult<Option<CompressedStateCommitmentInfos>> {
+        self.storage_reader.get_state_commitment_infos(block_number).map_err(|err| {
+            error!("Failed to get state commitment infos from storage: {err}");
+            BatcherError::InternalError
+        })
     }
 
     fn get_commitment_results_and_write_to_storage(&mut self) -> BatcherResult<()> {

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -56,12 +56,13 @@ pub trait BatcherClient: Send + Sync {
     async fn propose_block(&self, input: ProposeBlockInput) -> BatcherClientResult<()>;
     /// Gets the block hash for a given block number.
     async fn get_block_hash(&self, block_number: BlockNumber) -> BatcherClientResult<BlockHash>;
-    /// Gets the compressed state commitment infos for a block.
+    /// Gets the compressed state commitment infos for a block. Returns `Ok(None)` when the block
+    /// is not committed yet.
     #[cfg(feature = "os_input")]
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<CompressedStateCommitmentInfos>;
+    ) -> BatcherClientResult<Option<CompressedStateCommitmentInfos>>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -148,7 +149,7 @@ pub enum BatcherResponse {
     ProposeBlock(BatcherResult<()>),
     GetBlockHash(BatcherResult<BlockHash>),
     #[cfg(feature = "os_input")]
-    GetStateCommitmentInfos(BatcherResult<CompressedStateCommitmentInfos>),
+    GetStateCommitmentInfos(BatcherResult<Option<CompressedStateCommitmentInfos>>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -207,7 +208,7 @@ where
     async fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
-    ) -> BatcherClientResult<CompressedStateCommitmentInfos> {
+    ) -> BatcherClientResult<Option<CompressedStateCommitmentInfos>> {
         let request = BatcherRequest::GetStateCommitmentInfos(block_number);
         handle_all_response_variants!(
             self,

--- a/crates/apollo_batcher_types/src/errors.rs
+++ b/crates/apollo_batcher_types/src/errors.rs
@@ -49,8 +49,6 @@ pub enum BatcherError {
     ProposingNotSupported,
     #[error("Proposal with ID {proposal_id} not found.")]
     ProposalNotFound { proposal_id: ProposalId },
-    #[error("State commitment infos not found for block number {0}.")]
-    StateCommitmentInfosNotFound(BlockNumber),
     #[error(
         "Storage height marker mismatch. Storage marker (first unwritten height): \
          {marker_height}, requested height: {requested_height}."

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -705,18 +705,12 @@ impl SequencerConsensusContext {
         for height in lowest_height..=height.0 {
             let block_number = BlockNumber(height);
             match self.deps.batcher.get_state_commitment_infos(block_number).await {
-                Ok(state_commitment_infos) => recent_state_commitment_infos
+                Ok(Some(state_commitment_infos)) => recent_state_commitment_infos
                     .push(StateCommitmentInfosAndNumber { state_commitment_infos, block_number }),
+                // We passed the latest block with state commitment infos.
+                Ok(None) => break,
                 Err(err) => {
-                    // This error is expected if the block is not yet committed.
-                    if !matches!(
-                        err,
-                        BatcherClientError::BatcherError(
-                            BatcherError::StateCommitmentInfosNotFound(_)
-                        )
-                    ) {
-                        warn!("Failed to get state commitment infos from batcher: {err:?}");
-                    }
+                    warn!("Failed to get state commitment infos from batcher: {err:?}");
                     break;
                 }
             }

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -926,7 +926,7 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     deps.batcher
         .expect_get_state_commitment_infos()
         .times(1)
-        .return_once(move |_| Ok(returned_infos));
+        .return_once(move |_| Ok(Some(returned_infos)));
 
     deps.setup_deps_for_build(SetupDepsArgs::default());
     deps.batcher

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -340,11 +340,7 @@ impl TestDeps {
             Err(BatcherClientError::BatcherError(BatcherError::BlockHashNotFound(block_number)))
         });
         #[cfg(feature = "os_input")]
-        self.batcher.expect_get_state_commitment_infos().returning(|block_number| {
-            Err(BatcherClientError::BatcherError(BatcherError::StateCommitmentInfosNotFound(
-                block_number,
-            )))
-        });
+        self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
     }
 
     pub(crate) fn build_context(self) -> SequencerConsensusContext {


### PR DESCRIPTION
Model an uncommitted block as Ok(None) instead of a StateCommitmentInfosNotFound error, and remove
that now-unused error variant.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>