### PR TITLE
apollo_consensus_orchestrator: send only the commitment-info delta the recorder is missing

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -78,14 +78,14 @@ use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error, error_span, info, instrument, trace, warn, Instrument};
 
 use crate::build_proposal::{build_proposal, BuildProposalError, ProposalBuildArguments};
-#[cfg(feature = "os_input")]
-use crate::cende::StateCommitmentInfosAndNumber;
 use crate::cende::{
     BlobParameters,
     CendeContext,
     InternalTransactionWithReceipt,
     N_BLOCK_HASHES_BACK_IN_BLOB,
 };
+#[cfg(feature = "os_input")]
+use crate::cende::{CendeAmbassadorResult, StateCommitmentInfosAndNumber};
 use crate::dynamic_gas_price::{
     compute_fee_actual,
     compute_fee_proposal,
@@ -593,6 +593,15 @@ impl SequencerConsensusContext {
             .and_then(|parent_height| self.fee_proposals_window.get(&parent_height).copied())
             .flatten();
 
+        #[cfg(feature = "os_input")]
+        let recent_state_commitment_infos =
+            self.collect_recent_state_commitment_infos(height).await.unwrap_or_else(|e| {
+                // `finalize_decision` must not fail, so continue with an empty vector.
+                error!("Failed to collect recent state commitment infos at height {height}: {e:?}");
+                Vec::new()
+            });
+        // TODO(Yoav): Add metrics for most recent state commitment infos sent.
+
         if let Err(e) = self
             .deps
             .cende_ambassador
@@ -624,9 +633,7 @@ impl SequencerConsensusContext {
                     .map(|c| proposal_commitment_from(c.partial_block_hash, parent_fee_proposal)),
                 recent_block_hashes: self.collect_recent_block_hashes(height).await,
                 #[cfg(feature = "os_input")]
-                recent_state_commitment_infos: self
-                    .collect_recent_state_commitment_infos(height)
-                    .await,
+                recent_state_commitment_infos,
                 #[cfg(feature = "os_input")]
                 initial_reads: central_objects.initial_reads,
             })
@@ -701,27 +708,48 @@ impl SequencerConsensusContext {
     async fn collect_recent_state_commitment_infos(
         &self,
         height: BlockNumber,
-    ) -> Vec<StateCommitmentInfosAndNumber> {
+    ) -> CendeAmbassadorResult<Vec<StateCommitmentInfosAndNumber>> {
+        // Send only the commitment infos the cende recorder has not stored yet, bounding the
+        // lower end by the cende recorder's commitment infos height offset.
+        let (lowest_height, cende_recorder_is_empty) =
+            match self.deps.cende_ambassador.commitment_infos_height_offset().await? {
+                Some(commitment_infos_height_offset) => (commitment_infos_height_offset.0, false),
+                // The cende recorder has stored nothing yet: fall back to block hashes window
+                // size.
+                None => (height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB), true),
+            };
         let mut recent_state_commitment_infos = Vec::with_capacity(
-            usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
-                .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
-                + 1,
+            usize::try_from(height.0.saturating_sub(lowest_height) + 1)
+                .expect("Commitment infos count should fit in usize."),
         );
-        let lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
-        for height in lowest_height..=height.0 {
-            let block_number = BlockNumber(height);
+        for block_height in lowest_height..=height.0 {
+            let block_number = BlockNumber(block_height);
             match self.deps.batcher.get_state_commitment_infos(block_number).await {
                 Ok(Some(state_commitment_infos)) => recent_state_commitment_infos
                     .push(StateCommitmentInfosAndNumber { state_commitment_infos, block_number }),
+                // In the empty-cende-recorder case, the earliest heights in the window may
+                // predate the batcher's stored commitment infos; skip that leading gap. Once at
+                // least one has been collected a None marks the end of commitment infos, so
+                // break.
+                Ok(None) if cende_recorder_is_empty && recent_state_commitment_infos.is_empty() => {
+                    debug!(
+                        "The cende recorder has no commitment infos offset and the batcher has no \
+                         state commitment infos for block {block_number} to send to it; skipping."
+                    );
+                    continue;
+                }
                 // We passed the latest block with state commitment infos.
                 Ok(None) => break,
                 Err(err) => {
-                    warn!("Failed to get state commitment infos from batcher: {err:?}");
+                    error!(
+                        "Failed to get state commitment infos from batcher for block \
+                         {block_number}: {err:?}"
+                    );
                     break;
                 }
             }
         }
-        recent_state_commitment_infos
+        Ok(recent_state_commitment_infos)
     }
 }
 

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -65,7 +65,7 @@ use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 
 #[cfg(feature = "os_input")]
-use crate::cende::StateCommitmentInfosAndNumber;
+use crate::cende::{CendeAmbassadorError, StateCommitmentInfosAndNumber};
 use crate::cende::{MockCendeContext, N_BLOCK_HASHES_BACK_IN_BLOB};
 use crate::dynamic_gas_price::proposal_commitment_from;
 use crate::metrics::{CONSENSUS_L2_GAS_PRICE, CONSENSUS_L2_GAS_PRICE_AT_MINIMUM};
@@ -922,8 +922,7 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let (mut deps, _network) = create_test_and_network_deps();
 
     // The batcher serves the compressed witness; the orchestrator forwards it verbatim.
-    let state_commitment_infos =
-        CompressedStateCommitmentInfos(b"compressed-state-commitment-infos".to_vec());
+    let state_commitment_infos = default_state_commitment_infos();
 
     let returned_infos = state_commitment_infos.clone();
     deps.batcher
@@ -954,6 +953,87 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let mut context = deps.build_context();
     let _fin = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap().await;
     context.decision_reached(HEIGHT_0, ROUND_0, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
+}
+
+#[cfg(feature = "os_input")]
+fn default_state_commitment_infos() -> CompressedStateCommitmentInfos {
+    CompressedStateCommitmentInfos(b"compressed-state-commitment-infos".to_vec())
+}
+
+/// Returns the block numbers `collect_recent_state_commitment_infos` sends for `height` when the
+/// cende recorder reports `offset` and the batcher only has stored commitment infos for heights
+/// in `committed_heights` (reporting `None` for the rest).
+#[cfg(feature = "os_input")]
+async fn collected_heights_for(
+    height: BlockNumber,
+    cende_offset: Option<BlockNumber>,
+    committed_heights: Vec<u64>,
+) -> Vec<u64> {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.batcher.expect_get_state_commitment_infos().returning(move |block_number| {
+        Ok(committed_heights.contains(&block_number.0).then(default_state_commitment_infos))
+    });
+    deps.cende_ambassador
+        .expect_commitment_infos_height_offset()
+        .times(1)
+        .return_once(move || Ok(cende_offset));
+
+    let context = deps.build_context();
+    context
+        .collect_recent_state_commitment_infos(height)
+        .await
+        .expect("offset query should succeed")
+        .iter()
+        .map(|info| info.block_number.0)
+        .collect()
+}
+
+// `height` is fixed at 100; each case sets the cende recorder's reported offset (its next
+// produced block), the heights the batcher has stored commitment infos for (a `None` from the
+// batcher marks a gap in the stored witnesses), and the block numbers we expect to send.
+#[cfg(feature = "os_input")]
+#[rstest]
+#[case::delta_above_cende_recorder(Some(BlockNumber(98)), (90..=100).collect(), vec![98, 99, 100])]
+#[case::single_new_block(Some(BlockNumber(100)), (90..=100).collect(), vec![100])]
+#[case::fallback_window_when_cende_recorder_empty(None, (90..=100).collect(), (90..=100).collect())]
+#[case::nothing_when_cende_recorder_caught_up(Some(BlockNumber(101)), (90..=100).collect(), vec![])]
+#[case::empty_cende_recorder_skips_leading_gap(None, (93..=100).collect(), (93..=100).collect())]
+#[case::empty_cende_recorder_stops_at_trailing_gap(None, (90..=95).collect(), (90..=95).collect())]
+#[case::non_empty_cende_recorder_breaks_on_first_gap(Some(BlockNumber(90)), (93..=100).collect(), vec![])]
+#[case::empty_cende_recorder_stops_at_middle_gap(None, (93..=95).chain(98..=100).collect(), (93..=95).collect())]
+#[case::non_empty_cende_recorder_stops_at_middle_gap(Some(BlockNumber(90)), (90..=92).chain(95..=100).collect(), (90..=92).collect())]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_sends_expected_delta(
+    #[case] cende_offset: Option<BlockNumber>,
+    #[case] committed_heights: Vec<u64>,
+    #[case] expected: Vec<u64>,
+) {
+    let height = BlockNumber(100);
+    let heights = collected_heights_for(height, cende_offset, committed_heights).await;
+    assert_eq!(heights, expected);
+}
+
+#[cfg(feature = "os_input")]
+#[tokio::test]
+async fn collect_recent_state_commitment_infos_errors_on_offset_query_failure() {
+    // A failed offset query must propagate, not silently fall back to genesis.
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.batcher
+        .expect_get_state_commitment_infos()
+        .returning(|_| Ok(Some(default_state_commitment_infos())));
+    deps.cende_ambassador.expect_commitment_infos_height_offset().times(1).return_once(|| {
+        Err(CendeAmbassadorError::RecorderRequestFailed {
+            path: "get_witness_height_offset".to_string(),
+            message: "request failed".to_string(),
+        })
+    });
+
+    let context = deps.build_context();
+    let result = context.collect_recent_state_commitment_infos(BlockNumber(100)).await;
+    assert!(
+        matches!(&result, Err(CendeAmbassadorError::RecorderRequestFailed { .. })),
+        "expected the offset query error to propagate, got {result:?}"
+    );
 }
 
 /// Verify that when `stop_at_height` is set and decision is reached at that height:

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -318,6 +318,10 @@ impl TestDeps {
         self.cende_ambassador
             .expect_write_prev_height_blob()
             .return_once(|_height| tokio::spawn(ready(true)));
+        // Default: cende recorder reports nothing stored → send from genesis. Delta tests
+        // override this.
+        #[cfg(feature = "os_input")]
+        self.cende_ambassador.expect_commitment_infos_height_offset().returning(|| Ok(None));
     }
 
     pub(crate) fn setup_default_gas_price_provider(&mut self) {


### PR DESCRIPTION
Bound collect_recent_state_commitment_infos' lower end by the recorder's
commitment_infos_height_offset instead of the fixed window. When the recorder reports it is empty,
fall back to a recent window (the last EMPTY_RECORDER_COMMITMENT_INFOS_FALLBACK heights) rather than
backfilling the whole chain, tolerating a leading gap of heights the batcher has not stored yet; on
a failed offset query, propagate the error instead of flooding the recorder.

Co-Authored-By: Itamar Shechter <itamar@starkware.co>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>