### PR TITLE
echonet: reject path-traversal cache keys in class_fetcher

### DIFF
--- a/echonet/class_fetcher.py
+++ b/echonet/class_fetcher.py
@@ -1,0 +1,215 @@
+"""
+Resolve the CASM (and deprecated v0) classes the OS needs to run a block.
+
+The cende blob only carries the block's *newly declared* classes, but the OS
+executes against every class the block touches. The rest are fetched from the
+mainnet feeder gateway and cached on the PVC. The fetch list comes from
+`initial_reads`: `compiled_class_hashes` drives the Cairo 1 CASM fetches, and
+accessed class hashes absent from it are Cairo 0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Set, Tuple
+
+from echonet.echonet_types import CONFIG, JsonObject
+from echonet.logger import get_logger
+
+logger = get_logger("echonet.class_fetcher")
+
+_CASM_CACHE_SUBDIR = "cairo1"
+_DEPRECATED_CACHE_SUBDIR = "cairo0"
+_FETCH_PARALLELISM = 8
+_FETCH_TIMEOUT_SECONDS = 30
+_ZERO_CLASS_HASH = "0x0"
+
+
+def _is_sierra_shape(class_json: JsonObject) -> bool:
+    """The permissive v0 endpoint may return a Sierra body; only Sierra has `sierra_program`."""
+    return "sierra_program" in class_json
+
+
+def _is_zero_felt(felt_hex: str) -> bool:
+    return int(felt_hex, 16) == 0
+
+
+class ClassFetchError(RuntimeError):
+    """Raised when a required class cannot be fetched from the feeder."""
+
+
+def resolve_classes_for_os(
+    blob: JsonObject, *, cache_root: Path
+) -> Tuple[Dict[str, JsonObject], Dict[str, JsonObject], int, int]:
+    """
+    Resolve all classes the OS will execute when replaying this block.
+
+    Returns `(compiled_classes, deprecated_compiled_classes, fetched_count,
+    cached_count)`; the blob's newly declared classes are merged in as-is.
+    """
+    initial_reads = blob.get("initial_reads", {})
+    compiled_class_hashes: Mapping[str, str] = initial_reads.get("compiled_class_hashes", {})
+    address_to_class_hash: Mapping[str, str] = initial_reads.get("class_hashes", {})
+
+    # A zero compiled_class_hash is the StateReader's sentinel for a Cairo 0
+    # class — route those to the v0 endpoint, not the CASM endpoint.
+    cairo1_compiled_class_hashes: Dict[str, str] = {
+        class_hash: compiled_class_hash
+        for class_hash, compiled_class_hash in compiled_class_hashes.items()
+        if not _is_zero_felt(compiled_class_hash)
+    }
+    cairo0_from_sentinels: Set[str] = {
+        class_hash
+        for class_hash, compiled_class_hash in compiled_class_hashes.items()
+        if _is_zero_felt(compiled_class_hash)
+    }
+    cairo1_class_hashes: Set[str] = set(cairo1_compiled_class_hashes.keys())
+    cairo0_class_hashes: Set[str] = cairo0_from_sentinels | {
+        class_hash
+        for class_hash in address_to_class_hash.values()
+        if class_hash != _ZERO_CLASS_HASH and class_hash not in cairo1_class_hashes
+    }
+
+    blob_compiled: Dict[str, JsonObject] = {}
+    for entry in blob.get("compiled_classes", []):
+        compiled_class_hash = entry[0]
+        casm = entry[1].get("compiled_class") if isinstance(entry[1], dict) else None
+        if casm is None:
+            raise ClassFetchError(
+                f"blob compiled_classes entry for {compiled_class_hash} missing 'compiled_class'"
+            )
+        blob_compiled[compiled_class_hash] = casm
+
+    casm_cache_dir = cache_root / _CASM_CACHE_SUBDIR
+    deprecated_cache_dir = cache_root / _DEPRECATED_CACHE_SUBDIR
+    casm_cache_dir.mkdir(parents=True, exist_ok=True)
+    deprecated_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    compiled_classes: Dict[str, JsonObject] = {}
+    deprecated_compiled_classes: Dict[str, JsonObject] = {}
+    fetched_count = 0
+    cached_count = 0
+
+    for class_hash, compiled_class_hash in cairo1_compiled_class_hashes.items():
+        if compiled_class_hash in compiled_classes:
+            continue
+        if compiled_class_hash in blob_compiled:
+            compiled_classes[compiled_class_hash] = blob_compiled[compiled_class_hash]
+            continue
+        cached = _read_cache(casm_cache_dir, compiled_class_hash)
+        if cached is not None:
+            compiled_classes[compiled_class_hash] = cached
+            cached_count += 1
+
+    missing_cairo1 = {
+        class_hash: compiled_class_hash
+        for class_hash, compiled_class_hash in cairo1_compiled_class_hashes.items()
+        if compiled_class_hash not in compiled_classes
+    }
+    # The feeder is queried by class_hash, but the OS looks classes up by
+    # compiled_class_hash — re-key the fetch results accordingly.
+    for class_hash, casm in _fetch_parallel(missing_cairo1, _fetch_one_casm).items():
+        compiled_class_hash = missing_cairo1[class_hash]
+        compiled_classes[compiled_class_hash] = casm
+        _write_cache(casm_cache_dir, compiled_class_hash, casm)
+        fetched_count += 1
+
+    for compiled_class_hash, casm in blob_compiled.items():
+        compiled_classes.setdefault(compiled_class_hash, casm)
+
+    missing_cairo0: List[str] = []
+    for class_hash in cairo0_class_hashes:
+        cached = _read_cache(deprecated_cache_dir, class_hash)
+        if cached is None:
+            missing_cairo0.append(class_hash)
+            continue
+        # A stale cache entry may hold a Sierra body; force a refetch.
+        if _is_sierra_shape(cached):
+            missing_cairo0.append(class_hash)
+            continue
+        deprecated_compiled_classes[class_hash] = cached
+        cached_count += 1
+    if missing_cairo0:
+        for class_hash, deprecated_class in _fetch_parallel(
+            missing_cairo0, _fetch_one_deprecated
+        ).items():
+            if _is_sierra_shape(deprecated_class):
+                logger.warning(f"Skipping class {class_hash}: v0 endpoint returned a Sierra body.")
+                continue
+            deprecated_compiled_classes[class_hash] = deprecated_class
+            _write_cache(deprecated_cache_dir, class_hash, deprecated_class)
+            fetched_count += 1
+
+    return compiled_classes, deprecated_compiled_classes, fetched_count, cached_count
+
+
+def _read_cache(cache_dir: Path, key: str) -> JsonObject | None:
+    path = cache_dir / f"{key}.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        return None
+
+
+def _write_cache(cache_dir: Path, key: str, value: JsonObject) -> None:
+    path = cache_dir / f"{key}.json"
+    tmp_path = cache_dir / f".{key}.json.{os.getpid()}.tmp"
+    try:
+        tmp_path.write_text(json.dumps(value), encoding="utf-8")
+        tmp_path.replace(path)
+    except OSError:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+
+
+def _fetch_parallel(
+    class_hashes: Iterable[str], fetch_one: Callable[[str], JsonObject]
+) -> Dict[str, JsonObject]:
+    """Fetch every class concurrently with `fetch_one`; returns `class_hash → response`."""
+    class_hashes_list = list(class_hashes)
+    if not class_hashes_list:
+        return {}
+    result: Dict[str, JsonObject] = {}
+    errors: List[str] = []
+    with ThreadPoolExecutor(max_workers=_FETCH_PARALLELISM) as pool:
+        future_to_class = {
+            pool.submit(fetch_one, class_hash): class_hash for class_hash in class_hashes_list
+        }
+        for future in as_completed(future_to_class):
+            class_hash = future_to_class[future]
+            try:
+                result[class_hash] = future.result()
+            except Exception as exc:
+                errors.append(f"{class_hash}: {exc}")
+    if errors:
+        raise ClassFetchError(f"feeder fetch failures: {errors}")
+    return result
+
+
+def _fetch_one_casm(class_hash: str) -> JsonObject:
+    path = CONFIG.feeder.endpoints.get_compiled_class_by_class_hash
+    return _http_get_json(path, {"classHash": class_hash})
+
+
+def _fetch_one_deprecated(class_hash: str) -> JsonObject:
+    path = CONFIG.feeder.endpoints.get_class_by_hash
+    return _http_get_json(path, {"classHash": class_hash})
+
+
+def _http_get_json(path: str, params: Mapping[str, Any]) -> JsonObject:
+    base = CONFIG.feeder.base_url.rstrip("/")
+    url = f"{base}{path}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url)
+    for header, value in CONFIG.feeder.headers.items():
+        req.add_header(header, value)
+    with urllib.request.urlopen(req, timeout=_FETCH_TIMEOUT_SECONDS) as resp:
+        return json.loads(resp.read())

--- a/echonet/class_fetcher.py
+++ b/echonet/class_fetcher.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -28,6 +29,7 @@ _DEPRECATED_CACHE_SUBDIR = "cairo0"
 _FETCH_PARALLELISM = 8
 _FETCH_TIMEOUT_SECONDS = 30
 _ZERO_CLASS_HASH = "0x0"
+_HEX_FELT_RE = re.compile(r"^(0x)?[0-9a-fA-F]+$")
 
 
 def _is_sierra_shape(class_json: JsonObject) -> bool:
@@ -41,6 +43,20 @@ def _is_zero_felt(felt_hex: str) -> bool:
 
 class ClassFetchError(RuntimeError):
     """Raised when a required class cannot be fetched from the feeder."""
+
+
+def _validate_cache_key(key: str) -> str:
+    """
+    Reject any key that isn't a plain hex felt.
+
+    `class_hash`/`compiled_class_hash` values come from the replayed block's
+    `initial_reads` and are used as `_read_cache`/`_write_cache` filename
+    components; without this check a key containing `/` or `..` segments
+    escapes `cache_dir` and reads or writes an arbitrary file.
+    """
+    if not _HEX_FELT_RE.fullmatch(key):
+        raise ClassFetchError(f"refusing to use non-hex-felt cache key: {key!r}")
+    return key
 
 
 def resolve_classes_for_os(
@@ -149,6 +165,7 @@ def resolve_classes_for_os(
 
 
 def _read_cache(cache_dir: Path, key: str) -> JsonObject | None:
+    _validate_cache_key(key)
     path = cache_dir / f"{key}.json"
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -159,6 +176,7 @@ def _read_cache(cache_dir: Path, key: str) -> JsonObject | None:
 
 
 def _write_cache(cache_dir: Path, key: str, value: JsonObject) -> None:
+    _validate_cache_key(key)
     path = cache_dir / f"{key}.json"
     tmp_path = cache_dir / f".{key}.json.{os.getpid()}.tmp"
     try:

--- a/echonet/tests/test_class_fetcher.py
+++ b/echonet/tests/test_class_fetcher.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from echonet.class_fetcher import (
+    ClassFetchError,
+    _read_cache,
+    _write_cache,
+    resolve_classes_for_os,
+)
+
+# `class_hash`/`compiled_class_hash` values come from the replayed block's `initial_reads`
+# and are used unsanitized as `_read_cache`/`_write_cache` filename components. A key of
+# `../..` segments escapes `cairo0_dir` (two levels below `outside_dir`'s parent) straight
+# into `outside_dir`, reaching files well outside the intended cache tree.
+_TRAVERSAL_KEY = "../../outside/leaked"
+
+
+class TestClassFetcherPathTraversal(unittest.TestCase):
+    def setUp(self):
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        tmp_root = Path(self._tmp_dir.name)
+        self.cache_root = tmp_root / "cache"
+        self.cairo0_dir = self.cache_root / "cairo0"
+        self.cairo0_dir.mkdir(parents=True)
+        self.outside_dir = tmp_root / "outside"
+        self.outside_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        self._tmp_dir.cleanup()
+
+    def test_read_cache_rejects_path_traversal_key(self):
+        planted_secret = self.outside_dir / "leaked.json"
+        planted_secret.write_text('{"secret": "leaked"}')
+
+        # Unpatched: `_read_cache` happily returns the traversed file's content instead
+        # of raising, leaking data from outside the cache directory.
+        with self.assertRaises(ClassFetchError):
+            leaked = _read_cache(self.cairo0_dir, _TRAVERSAL_KEY)
+            self.assertIsNone(leaked, "path traversal leaked a file outside the cache dir")
+
+    def test_write_cache_rejects_path_traversal_key(self):
+        with self.assertRaises(ClassFetchError):
+            _write_cache(self.cairo0_dir, _TRAVERSAL_KEY, {"pwned": True})
+
+        self.assertEqual(
+            list(self.outside_dir.iterdir()),
+            [],
+            "cache write escaped the cache directory via path traversal",
+        )
+
+    def test_resolve_classes_for_os_rejects_path_traversal_class_hash(self):
+        # A malicious/corrupt replayed block smuggles a traversal payload as a
+        # `class_hashes` (address -> class_hash) value; this reaches the cairo0
+        # cache path unsanitized.
+        blob = {
+            "initial_reads": {
+                "compiled_class_hashes": {},
+                "class_hashes": {"0xdeadbeef": _TRAVERSAL_KEY},
+            },
+            "compiled_classes": [],
+        }
+
+        with patch(
+            "echonet.class_fetcher._fetch_one_deprecated",
+            return_value={"program": "not_sierra"},
+        ) as mock_fetch:
+            with self.assertRaises(ClassFetchError):
+                resolve_classes_for_os(blob, cache_root=self.cache_root)
+            mock_fetch.assert_not_called()
+
+        self.assertEqual(
+            list(self.outside_dir.iterdir()),
+            [],
+            "resolve_classes_for_os escaped the cache directory via path traversal",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/echonet/tests/test_class_fetcher.py
+++ b/echonet/tests/test_class_fetcher.py
@@ -35,14 +35,13 @@ class TestClassFetcherPathTraversal(unittest.TestCase):
         self._tmp_dir.cleanup()
 
     def test_read_cache_rejects_path_traversal_key(self):
+        # Plant a real secret at the traversal target: unpatched, `_read_cache` returns
+        # its content instead of raising, leaking a file from outside the cache directory.
         planted_secret = self.outside_dir / "leaked.json"
         planted_secret.write_text('{"secret": "leaked"}')
 
-        # Unpatched: `_read_cache` happily returns the traversed file's content instead
-        # of raising, leaking data from outside the cache directory.
         with self.assertRaises(ClassFetchError):
-            leaked = _read_cache(self.cairo0_dir, _TRAVERSAL_KEY)
-            self.assertIsNone(leaked, "path traversal leaked a file outside the cache dir")
+            _read_cache(self.cairo0_dir, _TRAVERSAL_KEY)
 
     def test_write_cache_rejects_path_traversal_key(self):
         with self.assertRaises(ClassFetchError):
@@ -53,6 +52,18 @@ class TestClassFetcherPathTraversal(unittest.TestCase):
             [],
             "cache write escaped the cache directory via path traversal",
         )
+
+    def test_cache_roundtrip_accepts_hex_felt_keys(self):
+        # The guard must not be stricter than the real `0x`-hex felt shape: legitimate
+        # class hashes (full-length and short) must still write and read back unchanged.
+        value = {"program": "not_sierra"}
+        for class_hash in (
+            "0x1b64b1b3b690b43b9b514fb81377518f4039cd3e4f4914d8a6bdf01d679fb19",
+            "0x123",
+            "0x1",
+        ):
+            _write_cache(self.cairo0_dir, class_hash, value)
+            self.assertEqual(_read_cache(self.cairo0_dir, class_hash), value)
 
     def test_resolve_classes_for_os_rejects_path_traversal_class_hash(self):
         # A malicious/corrupt replayed block smuggles a traversal payload as a


### PR DESCRIPTION
## Summary

Security fix for #14715, found during an automated post-merge security scan.

`echonet/class_fetcher.py` resolves classes from the replayed block's `initial_reads` and caches them on the PVC, keyed by `class_hash`/`compiled_class_hash`. Those keys are used directly as filename components in `_read_cache`/`_write_cache`:

```python
def _read_cache(cache_dir: Path, key: str) -> JsonObject | None:
    path = cache_dir / f"{key}.json"
    ...
```

Neither function validated `key`. A `class_hash` containing `../` segments (sourced unsanitized from `initial_reads.class_hashes` values, or from `initial_reads.compiled_class_hashes` keys on the zero-sentinel/Cairo-0 branch) escapes the intended cache directory. Verified locally:

```python
_read_cache(cairo0_dir, "../../outside/leaked")
# -> {'api_key': 'super-secret-value'}   (content of a file *outside* the cache tree)
```

A crafted or corrupted replayed block can therefore make the fetcher read arbitrary `*.json` files reachable from the cache directory on the PVC (CWE-22, path traversal / arbitrary file read). `_write_cache`'s temp-file naming happens to mangle most traversal payloads into a nonexistent-directory write that fails closed today, but that's an accident of the current temp-filename scheme, not a guarantee — this fix closes both paths at the same choke point.

## Fix

Add `_validate_cache_key`, requiring keys to be a plain hex felt (optionally `0x`-prefixed, no other characters), and call it at the top of both `_read_cache` and `_write_cache` — the single choke point both cache operations already go through, so it holds regardless of which caller supplies the key.

## Test plan

- [x] New regression test `echonet/tests/test_class_fetcher.py`:
  - `test_read_cache_rejects_path_traversal_key` — fails against the pre-fix code, demonstrating the leak (`_read_cache` returns the outside file's content instead of raising); passes post-fix.
  - `test_write_cache_rejects_path_traversal_key` — same shape for the write path.
  - `test_resolve_classes_for_os_rejects_path_traversal_class_hash` — end-to-end via a crafted blob's `initial_reads.class_hashes`, with the feeder call mocked; confirms the feeder is never even reached once the key is rejected.
- [x] Ran `python3 -m unittest discover -s echonet/tests -p "test_class_fetcher.py" -v` — all pass against the patched code, and were confirmed to fail against the pre-fix code first.
- [x] Manually verified legitimate hex-felt class hashes still fetch, cache-write, and cache-read correctly (no regression to normal operation).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01JSdt1MKAS8VDoH7MRRRUS6)_