### PR TITLE
echonet: validate block_number as int in os_runner_worker to close path traversal

### DIFF
--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -164,6 +164,36 @@ class PathsConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class OsRunnerConfig:
+    """
+    Configuration for running the Starknet OS over each received blob, via the
+    block-hash CLI binary's `os run-os-stateless` subcommand (which must be
+    built with the `os_input` and `transaction_serde` features).
+    """
+
+    enabled: bool = True
+    layout: str = "all_cairo"
+    cli_timeout_secs: int = 600
+    chain_id: str = "SN_MAIN"
+    strk_fee_token_address: str = (
+        "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+    )
+    # Bounded backlog of OS-run tasks; tasks beyond it are dropped (logged) so the
+    # Flask handler never blocks blob storage.
+    queue_size: int = 30
+    # Worker threads draining the queue, one OS CLI subprocess each. At ~5 runs/min
+    # per worker vs ~26 mainnet blocks/min, ≥6 are needed; 8 also uses the pod's
+    # cpu-limit headroom under burst while staying within the memory limit.
+    parallelism: int = 8
+    # Width of the blob's `recent_state_commitment_infos` vector
+    # (N_BLOCK_HASHES_BACK_IN_BLOB): a block's commit info is only reachable from
+    # blobs at most this many heights newer.
+    recent_state_commitment_window: int = 10
+    # Most-recent failed-OS-run input dumps to keep on the PVC for debugging.
+    max_failed_dumps: int = 10
+
+
+@dataclass(frozen=True, slots=True)
 class TxFilterConfig:
     """Transaction forwarding filter parameters."""
 
@@ -203,6 +233,7 @@ class EchonetConfig:
     block_store: BlockStoreTuning
     severity: SeverityConfig
     paths: PathsConfig
+    os_runner: OsRunnerConfig
     tx_filter: TxFilterConfig
     l1: L1Config
     gcp_logs: GcpLogsConfig
@@ -262,6 +293,7 @@ class EchonetConfig:
             ),
             severity=SeverityConfig(),
             paths=PathsConfig(),
+            os_runner=OsRunnerConfig(),
             tx_filter=TxFilterConfig(
                 blocked_senders=helpers.parse_csv_to_lower_set(blocked_senders_csv),
             ),

--- a/echonet/k8s/echonet/deployment.yaml
+++ b/echonet/k8s/echonet/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - >
               export PYTHONPATH=/app:${PYTHONPATH:-} &&
               python -m pip install --no-cache-dir --disable-pip-version-check
-              flask gunicorn requests aiohttp 'kubernetes<36' eth_abi zstandard &&
+              flask gunicorn requests aiohttp 'kubernetes<36' eth_abi 'cairo-lang==0.14.0.1' zstandard &&
               echo "[echonet] starting gunicorn on :80 (1 worker, 4 threads)" &&
               gunicorn -w 1 --threads 4 -b 0.0.0.0:80 echonet.echo_center:app --timeout 60 --access-logfile -
           workingDir: /app

--- a/echonet/os_runner_worker.py
+++ b/echonet/os_runner_worker.py
@@ -1,0 +1,156 @@
+"""
+Standalone CLI tool that runs the Starknet OS for one block.
+
+echo_center spawns this as a subprocess per OS run so all retained heap
+(captured CLI output, intermediate JSON dicts, cairo-lang imports) dies with
+the process. The `--input-path` JSON carries `blob`, `state_commitment_infos`,
+`block_document`, `block_number`, and `block_hash_commitments_payload`. Log
+lines go to stderr (captured and re-logged by echo_center); non-zero exit
+means failure, with the failing OS input dumped under /data/echonet/os_runs/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from echonet.class_fetcher import resolve_classes_for_os
+from echonet.echonet_types import CONFIG
+from echonet.os_input_builder import build_os_cli_input
+
+_CLASS_CACHE_SUBDIR = "class_cache"
+
+
+def _prune_old_failed_dumps(dump_root: Path, *, keep: int) -> None:
+    """Keep at most `keep` most-recent `block_<N>_failed` directories; delete the rest."""
+    try:
+        entries = [
+            child
+            for child in dump_root.iterdir()
+            if child.is_dir() and child.name.startswith("block_") and child.name.endswith("_failed")
+        ]
+    except OSError:
+        return
+    if len(entries) <= keep:
+        return
+    entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    for stale in entries[keep:]:
+        shutil.rmtree(stale, ignore_errors=True)
+
+
+def _log(msg: str) -> None:
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-path", required=True, type=Path)
+    args = parser.parse_args()
+    with args.input_path.open("r", encoding="utf-8") as fp:
+        payload = json.load(fp)
+    blob = payload["blob"]
+    state_commitment_infos = payload["state_commitment_infos"]
+    block_document = payload["block_document"]
+    block_number = payload["block_number"]
+    block_hash_commitments_payload = payload["block_hash_commitments_payload"]
+
+    cli_path = CONFIG.paths.block_hash_cli_path
+    if not cli_path.exists():
+        _log(f"Missing committer-and-os-cli binary at: {cli_path}")
+        return 2
+    timeout = CONFIG.os_runner.cli_timeout_secs
+    repo_root = Path(__file__).resolve().parent.parent
+
+    with tempfile.TemporaryDirectory(prefix="echonet_os_", dir=repo_root) as tmp:
+        tmp_path = Path(tmp)
+        input_path = tmp_path / "input.json"
+        output_path = tmp_path / "output.json"
+        cairo_pie_zip_path = tmp_path / "pie.zip"
+        raw_os_output_path = tmp_path / "raw_os_output.json"
+        os_cli_input = build_os_cli_input(
+            blob,
+            state_commitment_infos=state_commitment_infos,
+            block_number=block_number,
+            prev_block_hash=block_document["parent_block_hash"],
+            new_block_hash=block_document["block_hash"],
+            block_hash_commitments_payload=block_hash_commitments_payload,
+            chain_id=CONFIG.os_runner.chain_id,
+            strk_fee_token_address=CONFIG.os_runner.strk_fee_token_address,
+            layout=CONFIG.os_runner.layout,
+            cairo_pie_zip_path=str(cairo_pie_zip_path),
+            raw_os_output_path=str(raw_os_output_path),
+        )
+        cache_root = CONFIG.paths.log_dir / _CLASS_CACHE_SUBDIR
+        (
+            compiled_classes,
+            deprecated_compiled_classes,
+            fetched_count,
+            cached_count,
+        ) = resolve_classes_for_os(blob, cache_root=cache_root)
+        os_input = os_cli_input["os_hints"]["os_input"]
+        os_input["compiled_classes"] = compiled_classes
+        os_input["deprecated_compiled_classes"] = deprecated_compiled_classes
+        _log(
+            f"block {block_number} classes: "
+            f"compiled={len(compiled_classes)} deprecated={len(deprecated_compiled_classes)} "
+            f"fetched={fetched_count} cached={cached_count}"
+        )
+        input_path.write_text(json.dumps(os_cli_input), encoding="utf-8")
+        try:
+            subprocess.run(
+                [
+                    str(cli_path),
+                    "os",
+                    "run-os-stateless",
+                    "--input-path",
+                    str(input_path),
+                    "--output-path",
+                    str(output_path),
+                ],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=timeout,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            # A timeout raises TimeoutExpired (not a CalledProcessError), so catch both:
+            # otherwise a timed-out run skips this dump and the tempdir is torn down with
+            # the failing input still inside.
+            dump_root = CONFIG.paths.log_dir / "os_runs"
+            dump_dir = dump_root / f"block_{block_number}_failed"
+            try:
+                dump_dir.mkdir(parents=True, exist_ok=True)
+                (dump_dir / "input.json").write_bytes(input_path.read_bytes())
+                _prune_old_failed_dumps(dump_root, keep=CONFIG.os_runner.max_failed_dumps)
+            except Exception as dump_err:
+                _log(f"Failed to dump input.json: {dump_err}")
+            outcome = (
+                f"timed out after {timeout}s"
+                if isinstance(exc, subprocess.TimeoutExpired)
+                else f"failed (exit {exc.returncode})"
+            )
+            _log(
+                f"OS CLI run {outcome} for block {block_number}; "
+                f"input dumped at {dump_dir}/input.json\n"
+                f"stderr (last 2KB): {(exc.stderr or '')[-2048:]}"
+            )
+            return 1
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        _log(
+            f"block {block_number} OS output: "
+            f"da_segment_len={len(result.get('da_segment') or [])} "
+            f"unused_hints_count={len(result.get('unused_hints') or [])}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/echonet/os_runner_worker.py
+++ b/echonet/os_runner_worker.py
@@ -57,7 +57,10 @@ def main() -> int:
     blob = payload["blob"]
     state_commitment_infos = payload["state_commitment_infos"]
     block_document = payload["block_document"]
-    block_number = payload["block_number"]
+    # Cast to int (as every other echonet ingestion point does for this field): block_number
+    # is later interpolated into a filesystem path for failed-run dumps, so an unvalidated
+    # string here would let a malformed payload traverse outside the dump directory.
+    block_number = int(payload["block_number"])
     block_hash_commitments_payload = payload["block_hash_commitments_payload"]
 
     cli_path = CONFIG.paths.block_hash_cli_path

--- a/echonet/tests/test_os_runner_worker.py
+++ b/echonet/tests/test_os_runner_worker.py
@@ -1,0 +1,128 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from echonet import os_runner_worker
+
+
+def _write_payload(input_path: Path, block_number) -> None:
+    input_path.write_text(
+        json.dumps(
+            {
+                "blob": {},
+                "state_commitment_infos": {},
+                "block_document": {"parent_block_hash": "0x0", "block_hash": "0x1"},
+                "block_number": block_number,
+                "block_hash_commitments_payload": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _fake_config(log_dir: Path, cli_path: Path) -> MagicMock:
+    config = MagicMock()
+    config.paths.block_hash_cli_path = cli_path
+    config.paths.log_dir = log_dir
+    config.os_runner.cli_timeout_secs = 5
+    config.os_runner.chain_id = "SN_MAIN"
+    config.os_runner.strk_fee_token_address = "0x0"
+    config.os_runner.layout = "all_cairo"
+    config.os_runner.max_failed_dumps = 10
+    return config
+
+
+class TestOsRunnerWorkerBlockNumberValidation(unittest.TestCase):
+    """
+    `block_number` from the `--input-path` payload is interpolated into a
+    failed-run dump directory name (`dump_root / f"block_{block_number}_failed"`).
+    Without validation, a malformed value such as "../../../tmp/pwned" escapes
+    the intended `os_runs` directory (pathlib splits on "/" when joining), letting
+    an attacker-influenced payload create directories and write files anywhere
+    reachable by a relative walk from `os_runs`.
+    """
+
+    def test_path_traversal_block_number_is_rejected_before_any_side_effect(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_dir = tmp_path / "data" / "echonet"
+            log_dir.mkdir(parents=True)
+            cli_path = tmp_path / "fake_cli"
+            cli_path.touch()
+            input_path = tmp_path / "input.json"
+            _write_payload(input_path, "../../../../tmp/echonet_poc_pwned")
+
+            fake_config = _fake_config(log_dir, cli_path)
+            # With no validation, `dump_root / f"block_{block_number}_failed"` resolves
+            # (verified against the pre-fix code) to log_dir/tmp/echonet_poc_pwned_failed —
+            # a sibling of log_dir/echonet, i.e. outside the intended os_runs sandbox.
+            traversal_target = log_dir.parent / "tmp" / "echonet_poc_pwned_failed"
+
+            def fake_subprocess_run(cmd, **kwargs):
+                # If reached, the CLI subprocess "fails", driving main() into the
+                # failed-run dump branch that builds the path from block_number.
+                raise os_runner_worker.subprocess.CalledProcessError(
+                    1, cmd, output="", stderr="boom"
+                )
+
+            with patch.object(os_runner_worker, "CONFIG", fake_config), patch.object(
+                sys, "argv", ["os_runner_worker.py", "--input-path", str(input_path)]
+            ), patch.object(
+                os_runner_worker, "build_os_cli_input", return_value={"os_hints": {"os_input": {}}}
+            ) as mock_build_input, patch.object(
+                os_runner_worker, "resolve_classes_for_os", return_value=({}, {}, 0, 0)
+            ), patch.object(
+                os_runner_worker.subprocess, "run", side_effect=fake_subprocess_run
+            ):
+                with self.assertRaises(ValueError):
+                    os_runner_worker.main()
+
+            # The traversal payload must never reach input assembly, the CLI subprocess,
+            # or the failed-run dump: validation must happen up front, not rely on
+            # downstream code paths to keep the write inside `os_runs`.
+            mock_build_input.assert_not_called()
+            self.assertFalse(traversal_target.exists(), "block_number escaped the dump sandbox")
+            self.assertFalse((log_dir / "os_runs").exists())
+
+    def test_valid_block_number_still_succeeds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            log_dir = tmp_path / "data" / "echonet"
+            log_dir.mkdir(parents=True)
+            cli_path = tmp_path / "fake_cli"
+            cli_path.touch()
+            input_path = tmp_path / "input.json"
+            _write_payload(input_path, "12345")
+
+            fake_config = _fake_config(log_dir, cli_path)
+
+            def fake_subprocess_run(cmd, **kwargs):
+                output_path = Path(cmd[cmd.index("--output-path") + 1])
+                output_path.write_text(json.dumps({"da_segment": [], "unused_hints": []}))
+                return MagicMock(returncode=0)
+
+            with patch.object(os_runner_worker, "CONFIG", fake_config), patch.object(
+                sys, "argv", ["os_runner_worker.py", "--input-path", str(input_path)]
+            ), patch.object(
+                os_runner_worker, "build_os_cli_input", return_value={"os_hints": {"os_input": {}}}
+            ) as mock_build_input, patch.object(
+                os_runner_worker, "resolve_classes_for_os", return_value=({}, {}, 0, 0)
+            ), patch.object(
+                os_runner_worker.subprocess, "run", side_effect=fake_subprocess_run
+            ):
+                exit_code = os_runner_worker.main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(mock_build_input.call_args.kwargs["block_number"], 12345)
+            self.assertIsInstance(mock_build_input.call_args.kwargs["block_number"], int)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Automated security scan of #14717 found that `echonet/os_runner_worker.py` takes `block_number` straight from the `--input-path` JSON payload and interpolates it, unvalidated, into the failed-run dump directory name:

```python
block_number = payload["block_number"]
...
dump_dir = dump_root / f"block_{block_number}_failed"
dump_dir.mkdir(parents=True, exist_ok=True)
(dump_dir / "input.json").write_bytes(input_path.read_bytes())
```

`pathlib` splits on `/` when joining path components, so a malformed `block_number` (e.g. containing `../`) lets the resulting directory/file write escape the intended `os_runs` sandbox. Every other `block_number` ingestion point in `echonet/` (e.g. `echo_center.py`'s blob/write-blob handling) already casts this field with `int(...)`; `os_runner_worker.py` was the one place that didn't, despite `build_os_cli_input`'s own signature declaring `block_number: int`.

- Not currently reachable in production: the caller that would wire `echo_center` to spawn this subprocess hasn't landed yet (per #14717's own commit message: "echo_center *will* spawn this per OS run"). This closes the gap defensively before that wiring PR lands, rather than relying on the future caller to remember to sanitize.

## Fix

`echonet/os_runner_worker.py`: cast `block_number` to `int` right at extraction, matching the established convention elsewhere in `echonet/`.

## Test

`echonet/tests/test_os_runner_worker.py` (new):
- `test_path_traversal_block_number_is_rejected_before_any_side_effect`: feeds a `block_number` of `"../../../../tmp/echonet_poc_pwned"` through the failed-run dump path. Verified this test **fails** against the pre-fix code — the traversal write actually lands at `<log_dir>/tmp/echonet_poc_pwned_failed/input.json`, outside the intended `<log_dir>/echonet/os_runs/` sandbox. With the fix, `int()` raises `ValueError` before any of `build_os_cli_input`, the CLI subprocess, or the dump write are reached.
- `test_valid_block_number_still_succeeds`: regression check that a normal numeric `block_number` (including as a JSON string) still flows through correctly as an `int`.

```
python3 -m unittest echonet.tests.test_os_runner_worker -v
```
both pass with the fix; the traversal test fails on the pre-fix code.

Refs #14717.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kqhp1aQVT33tneWqKYxdni)_