### PR TITLE
starknet_patricia_storage: delete dead code (unsure, review carefully)

### DIFF
--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -376,12 +376,3 @@ impl Serialize for DbKey {
 pub fn create_db_key(prefix: DbKeyPrefix, separator: &[u8], suffix: &[u8]) -> DbKey {
     DbKey([prefix.to_bytes(), separator, suffix].concat().to_vec())
 }
-
-/// Extracts the suffix from a `DbKey`. If the key doesn't match the prefix, None is returned.
-pub fn try_extract_suffix_from_db_key<'a>(
-    key: &'a DbKey,
-    prefix: &DbKeyPrefix,
-) -> Option<&'a [u8]> {
-    // Ignore the ':' char that appears after the prefix.
-    key.0.strip_prefix(prefix.to_bytes()).map(|s| &s[1..])
-}


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

This PR removes the unused public function `try_extract_suffix_from_db_key` from `starknet_patricia_storage::storage_trait`.

**Why it appears dead**
- `try_extract_suffix_from_db_key` has **zero references anywhere in the sequencer workspace** (a whole-word grep across `crates/`, including tests and benches, matches only its definition).
- **Zero references in either sibling repo** (`starkware-industries/sequencer-devops`, `starkware-industries/starkware`), and no similarly-named variant (`extract_suffix`, `suffix_from_db`) is referenced anywhere.
- It is the inverse of `create_db_key` (which **is** used): a helper for parsing a suffix back out of a `DbKey`. No code path ever parses keys back — the DB keys are only ever constructed via `create_db_key` — so the extractor has never been wired up.
- It predates the available git history of this file (added long ago and never used since).

**What a human must verify**
- The function is `pub`. Confirm no consumer outside the three repos checked above depends on it, and that it is not scaffolding for a planned key-parsing / reverse-lookup path.

**Scope notes**
- No imports are orphaned: `DbKey`, `DbKeyPrefix`, and `DbKeyPrefix::to_bytes` remain used by `create_db_key` and other items in the module.

**Verification** (env: `RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)
- `cargo build -p starknet_patricia_storage` and `cargo build -p starknet_patricia_storage --tests`: zero `dead_code`/`unused_*` warnings.
- `cargo clippy -p starknet_patricia_storage --all-targets`: clean.
- `SEED=0 cargo test -p starknet_patricia_storage`: passes.

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9cNc2b5LZ4kegPJY7zNRn)_