### PR TITLE
blockifier: validate entry point builtins before running the Cairo VM

### DIFF
--- a/crates/blockifier/src/execution/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/entry_point_execution.rs
@@ -5,6 +5,7 @@ use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::types::layout::CairoLayoutParams;
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
+use cairo_vm::utils::is_subsequence;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::errors::memory_errors::MemoryError;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
@@ -42,6 +43,21 @@ use crate::utils::usize_from_u32;
 #[cfg(test)]
 #[path = "entry_point_execution_test.rs"]
 mod test;
+
+/// Supported Cairo 1 builtins in canonical order; an entry point's builtins must be an ordered
+/// subsequence of this list. Mirrors the OS `SelectableBuiltins` (source of truth), minus `ecdsa`
+/// (a Cairo 0 builtin). Keep in sync when a builtin is added or the OS/compiler is bumped.
+const CAIRO1_SUPPORTED_BUILTINS: [BuiltinName; 9] = [
+    BuiltinName::pedersen,
+    BuiltinName::range_check,
+    BuiltinName::bitwise,
+    BuiltinName::ec_op,
+    BuiltinName::poseidon,
+    BuiltinName::segment_arena,
+    BuiltinName::range_check96,
+    BuiltinName::add_mod,
+    BuiltinName::mul_mod,
+];
 
 // TODO(spapini): Try to refactor this file into a StarknetRunner struct.
 
@@ -166,6 +182,8 @@ pub fn initialize_execution_context_with_runner_mode<'a>(
         execution_runner_mode.disable_trace_padding(),
     )?;
 
+    // Safety net for the compiler's compile-time guarantee, checked right before use.
+    validate_entry_point_builtins(&entry_point.builtins)?;
     runner.initialize_function_runner_cairo_1(&entry_point.builtins)?;
     let mut read_only_segments = ReadOnlySegments::default();
     let program_extra_data_length = prepare_program_extra_data(
@@ -193,6 +211,16 @@ pub fn initialize_execution_context_with_runner_mode<'a>(
         entry_point,
         program_extra_data_length,
     })
+}
+
+/// Checks that `builtins` is an ordered subsequence of [`CAIRO1_SUPPORTED_BUILTINS`], rejecting
+/// unsupported builtins (e.g. `ecdsa`, `keccak`) and non-canonical ordering.
+fn validate_entry_point_builtins(builtins: &[BuiltinName]) -> Result<(), PreExecutionError> {
+    if is_subsequence(builtins, &CAIRO1_SUPPORTED_BUILTINS) {
+        Ok(())
+    } else {
+        Err(PreExecutionError::UnsupportedCairo1Builtins(builtins.to_vec()))
+    }
 }
 
 pub fn initialize_execution_context<'a>(

--- a/crates/blockifier/src/execution/entry_point_execution_test.rs
+++ b/crates/blockifier/src/execution/entry_point_execution_test.rs
@@ -2,15 +2,18 @@ use std::sync::Arc;
 
 use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
 use blockifier_test_utils::contracts::FeatureContract;
+use cairo_vm::types::builtin_name::BuiltinName;
 use rstest::rstest;
 use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::transaction::fields::Calldata;
 
+use super::{validate_entry_point_builtins, CAIRO1_SUPPORTED_BUILTINS};
 use crate::context::ChainInfo;
 use crate::execution::call_info::{CallInfo, ExtendedExecutionResources};
 use crate::execution::contract_class::TrackedResource;
 use crate::execution::entry_point::CallEntryPoint;
+use crate::execution::errors::PreExecutionError;
 use crate::test_utils::initial_test_state::test_state;
 use crate::test_utils::syscall::build_recurse_calldata;
 use crate::test_utils::{trivial_external_entry_point_new, CompilerBasedVersion, BALANCE};
@@ -96,4 +99,35 @@ fn test_charged_resources_computation(
     let call_info = entry_point_call.execute_directly(&mut state).unwrap();
 
     assert_charged_resource_as_expected_rec(&call_info);
+}
+
+#[rstest]
+// The full supported list, in canonical order.
+#[case(CAIRO1_SUPPORTED_BUILTINS.to_vec())]
+// A proper (non-contiguous) ordered subsequence.
+#[case(vec![BuiltinName::pedersen, BuiltinName::range_check, BuiltinName::poseidon])]
+#[case(vec![BuiltinName::range_check, BuiltinName::add_mod, BuiltinName::mul_mod])]
+// No builtins is a (trivially valid) subsequence.
+#[case(vec![])]
+fn validate_entry_point_builtins_accepts_supported_ordered(#[case] builtins: Vec<BuiltinName>) {
+    validate_entry_point_builtins(&builtins).unwrap();
+}
+
+#[rstest]
+// Supported builtins in a non-canonical order.
+#[case(vec![BuiltinName::range_check, BuiltinName::pedersen])]
+// A duplicated builtin cannot be a subsequence of the (duplicate-free) supported list.
+#[case(vec![BuiltinName::range_check, BuiltinName::range_check])]
+// Cairo 0 builtins that are never emitted for Cairo 1 contracts.
+#[case(vec![BuiltinName::ecdsa])]
+#[case(vec![BuiltinName::output, BuiltinName::pedersen])]
+// A builtin outside the selectable set.
+#[case(vec![BuiltinName::range_check, BuiltinName::keccak])]
+fn validate_entry_point_builtins_rejects_invalid(#[case] builtins: Vec<BuiltinName>) {
+    match validate_entry_point_builtins(&builtins) {
+        Err(PreExecutionError::UnsupportedCairo1Builtins(returned_builtins)) => {
+            assert_eq!(returned_builtins, builtins)
+        }
+        other => panic!("Expected UnsupportedCairo1Builtins({builtins:?}), got {other:?}."),
+    }
 }

--- a/crates/blockifier/src/execution/errors.rs
+++ b/crates/blockifier/src/execution/errors.rs
@@ -52,6 +52,8 @@ pub enum PreExecutionError {
     UninitializedStorageAddress(ContractAddress),
     #[error("Called builtins: {0:?} are unsupported in a Cairo0 contract")]
     UnsupportedCairo0Builtin(HashSet<BuiltinName>),
+    #[error("Entry point uses unsupported builtins or an invalid builtin order: {0:?}.")]
+    UnsupportedCairo1Builtins(Vec<BuiltinName>),
     #[error(
         "Insufficient entry point initial gas, must be greater than the entry point initial \
          budget."


### PR DESCRIPTION
## What

Adds a runtime safety net in `initialize_execution_context_with_runner_mode` (blockifier) that validates a Cairo 1 entry point's builtins **right before they are handed to the Cairo runner** (the `runner.initialize_function_runner_cairo_1(&entry_point.builtins)` call). The builtins must form an **ordered subsequence** of the supported set `CAIRO1_SUPPORTED_BUILTINS`, which mirrors the OS `SelectableBuiltins` struct (`builtins.cairo`) minus `ecdsa` (a Cairo 0 builtin never emitted for Cairo 1). On failure it returns `PreExecutionError::InvalidBuiltins`.

## Why

Alternative to #14801. That PR performs the same conceptual check at `add_class`/declare time in the class manager. This instead places the check as a **defensive guard at the point of use** in execution — a safety net immediately before the builtins are consumed by the VM. The Sierra compiler already enforces this ordering/support constraint at compile time, so a failure here signals a malformed compiled class rather than a normal path.

## Details

- `CAIRO1_SUPPORTED_BUILTINS`: `[pedersen, range_check, bitwise, ec_op, poseidon, segment_arena, range_check96, add_mod, mul_mod]` — canonical order, `ecdsa` excluded. The OS remains the source of truth; a `NOTE` asks to keep it in sync with `SelectableBuiltins`.
- The subsequence test uses `cairo_vm::utils::is_subsequence` (same helper already used by the OS's `extract_builtins_from_implicit_args`). It rejects unsupported builtins (`ecdsa`, `keccak`, `output`, …), non-canonical order, and duplicates; an empty builtin list is trivially valid.
- Scoped to the VM execution path (line the task points at). Unknown builtin *names* already panic earlier in the CASM→`EntryPointV1` conversion, so by this point builtins are valid `BuiltinName`s — the value-add here is the supported-subset + canonical-order check.

## Testing

`rstest`-parameterized unit tests over `validate_entry_point_builtins` covering the full canonical list, proper subsequences, empty, non-canonical order, duplicates, and Cairo 0 / non-selectable builtins. `cargo test -p blockifier` (entry_point_execution) is green; `cargo clippy -p blockifier` and `rust_fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)