### PR TITLE
apollo_batcher,apollo_batcher_config: poll execution results faster than the mempool poll

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -430,6 +430,10 @@ impl Batcher {
                         .config
                         .dynamic_config
                         .tx_polling_interval_millis,
+                    results_polling_interval_millis: self
+                        .config
+                        .dynamic_config
+                        .results_polling_interval_millis,
                 },
                 self.config.dynamic_config.native_classes_whitelist.clone(),
                 Box::new(tx_provider),
@@ -522,6 +526,10 @@ impl Batcher {
                         .config
                         .dynamic_config
                         .validate_tx_polling_interval_millis,
+                    results_polling_interval_millis: self
+                        .config
+                        .dynamic_config
+                        .results_polling_interval_millis,
                 },
                 self.config.dynamic_config.native_classes_whitelist.clone(),
                 Box::new(tx_provider),

--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -247,6 +247,7 @@ pub struct BlockBuilderExecutionParams {
     pub proposer_idle_detection_delay: Duration,
     pub n_concurrent_txs: usize,
     pub tx_polling_interval_millis: u64,
+    pub results_polling_interval_millis: u64,
 }
 
 pub struct BlockBuilder {
@@ -320,6 +321,11 @@ impl BlockBuilderTrait for BlockBuilder {
 impl BlockBuilder {
     async fn build_block_inner(&mut self) -> BlockBuilderResult<BlockExecutionArtifacts> {
         let mut final_n_executed_txs: Option<usize> = None;
+        // Poll the mempool at most every `tx_polling_interval`, independently of the faster
+        // results-collection wake-ups (see `sleep`).
+        let tx_polling_interval =
+            Duration::from_millis(self.execution_params.tx_polling_interval_millis);
+        let mut next_mempool_poll_at = tokio::time::Instant::now();
         while !self.finished_block_txs(final_n_executed_txs) {
             if tokio::time::Instant::now() >= self.execution_params.deadline {
                 info!("Block builder deadline reached.");
@@ -370,10 +376,17 @@ impl BlockBuilder {
                 break;
             }
 
-            match self.add_txs_to_executor().await? {
-                AddTxsToExecutorResult::NoNewTxs => self.sleep().await,
-                AddTxsToExecutorResult::NewTxs => {}
+            let now = tokio::time::Instant::now();
+            if now >= next_mempool_poll_at {
+                match self.add_txs_to_executor().await? {
+                    // Keep draining while txs are flowing: re-poll next iteration without sleeping.
+                    AddTxsToExecutorResult::NewTxs => continue,
+                    AddTxsToExecutorResult::NoNewTxs => {
+                        next_mempool_poll_at = now + tx_polling_interval;
+                    }
+                }
             }
+            self.sleep(now, next_mempool_poll_at).await;
         }
 
         // The final number of transactions to consider for the block.
@@ -575,11 +588,18 @@ impl BlockBuilder {
         time_since_start >= self.execution_params.proposer_idle_detection_delay
     }
 
-    async fn sleep(&mut self) {
-        tokio::time::sleep(tokio::time::Duration::from_millis(
-            self.execution_params.tx_polling_interval_millis,
-        ))
-        .await;
+    async fn sleep(
+        &mut self,
+        now: tokio::time::Instant,
+        next_mempool_poll_at: tokio::time::Instant,
+    ) {
+        let interval = tokio::time::Duration::from_millis(if self.n_txs_in_progress() > 0 {
+            self.execution_params.results_polling_interval_millis
+        } else {
+            self.execution_params.tx_polling_interval_millis
+        });
+        let wake_at = (now + interval).min(next_mempool_poll_at);
+        tokio::time::sleep_until(wake_at).await;
     }
 }
 

--- a/crates/apollo_batcher/src/block_builder_test.rs
+++ b/crates/apollo_batcher/src/block_builder_test.rs
@@ -70,6 +70,7 @@ const BLOCK_GENERATION_LONG_DEADLINE_SECS: u64 = 5;
 const TX_CHANNEL_SIZE: usize = 50;
 const N_CONCURRENT_TXS: usize = 3;
 const TX_POLLING_INTERVAL: u64 = 100;
+const RESULTS_POLLING_INTERVAL: u64 = 100;
 const DEFAULT_IDLE_TIMEOUT_MS: Duration = Duration::from_millis(2000);
 
 struct TestExpectations {
@@ -727,6 +728,7 @@ async fn run_build_block(
             proposer_idle_detection_delay: idle_timeout_duration,
             n_concurrent_txs: N_CONCURRENT_TXS,
             tx_polling_interval_millis: TX_POLLING_INTERVAL,
+            results_polling_interval_millis: RESULTS_POLLING_INTERVAL,
         },
     );
 

--- a/crates/apollo_batcher_config/src/config.rs
+++ b/crates/apollo_batcher_config/src/config.rs
@@ -331,6 +331,11 @@ pub struct BatcherDynamicConfig {
     /// order is already fixed by the proposer, so a short interval is safe and simply reduces the
     /// delay before streamed txs are executed.
     pub validate_tx_polling_interval_millis: u64,
+    /// Time to wait (in milliseconds) between polls for completed execution results, applied while
+    /// previously added transactions are still executing. Must be in
+    /// `[1, tx_polling_interval_millis]` (0 would busy-loop; a value above the mempool poll is
+    /// moot).
+    pub results_polling_interval_millis: u64,
     /// Minimum time (in milliseconds) that must pass since block creation started before checking
     /// for idle state. If this delay has passed AND no transactions are currently being executed,
     /// the proposer will finish building the current block.
@@ -349,6 +354,7 @@ impl Default for BatcherDynamicConfig {
             n_concurrent_txs: 100,
             tx_polling_interval_millis: 10,
             validate_tx_polling_interval_millis: 10,
+            results_polling_interval_millis: 10,
             proposer_idle_detection_delay_millis: Duration::from_millis(1500),
         }
     }
@@ -380,6 +386,14 @@ impl SerializeConfig for BatcherDynamicConfig {
                  request returned no transactions. Applies when validating a proposal, where the \
                  tx order is already fixed; a short interval reduces the delay before streamed \
                  txs are executed.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "results_polling_interval_millis",
+                &self.results_polling_interval_millis,
+                "Time to wait (in milliseconds) between polls for completed execution results, \
+                 applied while previously added transactions are still executing. Must be in [1, \
+                 tx_polling_interval_millis].",
                 ParamPrivacyInput::Public,
             ),
             ser_param(
@@ -428,6 +442,17 @@ fn validate_batcher_dynamic_config(
     if idle_delay <= polling_interval {
         return Err(ValidationError::new(
             "proposer_idle_detection_delay_millis must be greater than tx_polling_interval_millis",
+        ));
+    }
+
+    // results_polling must be non-zero (0 busy-loops the build loop) and no larger than tx_polling
+    // (a results interval above the mempool poll is pointless, since results are collected at least
+    // as often as the mempool is polled).
+    let results_polling = dynamic_config.results_polling_interval_millis;
+    let tx_polling = dynamic_config.tx_polling_interval_millis;
+    if results_polling == 0 || results_polling > tx_polling {
+        return Err(ValidationError::new(
+            "results_polling_interval_millis must be in [1, tx_polling_interval_millis]",
         ));
     }
     Ok(())

--- a/crates/apollo_deployments/resources/app_configs/batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/batcher_config.json
@@ -1,6 +1,7 @@
 {
   "batcher_config.dynamic_config.n_concurrent_txs": 100,
   "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": 1500,
+  "batcher_config.dynamic_config.results_polling_interval_millis": 10,
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": false,
   "batcher_config.dynamic_config.tx_polling_interval_millis": 200,
   "batcher_config.dynamic_config.validate_tx_polling_interval_millis": 10,

--- a/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
@@ -1,6 +1,7 @@
 {
   "batcher_config.dynamic_config.n_concurrent_txs": "$$$_BATCHER_CONFIG-DYNAMIC_CONFIG-N_CONCURRENT_TXS_$$$",
   "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": "$$$_BATCHER_CONFIG-DYNAMIC_CONFIG-PROPOSER_IDLE_DETECTION_DELAY_MILLIS_$$$",
+  "batcher_config.dynamic_config.results_polling_interval_millis": 10,
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": false,
   "batcher_config.dynamic_config.tx_polling_interval_millis": 200,
   "batcher_config.dynamic_config.validate_tx_polling_interval_millis": 10,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -59,6 +59,11 @@
     "privacy": "Public",
     "value": 1500
   },
+  "batcher_config.dynamic_config.results_polling_interval_millis": {
+    "description": "Time to wait (in milliseconds) between polls for completed execution results, applied while previously added transactions are still executing. Must be in [1, tx_polling_interval_millis].",
+    "privacy": "Public",
+    "value": 10
+  },
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": {
     "description": "Whether to enable the storage reader HTTP server.",
     "privacy": "Public",


### PR DESCRIPTION
Splits execution-results polling from mempool polling in the proposer's block-builder loop.