### PR TITLE
apollo_deployments: lower propose-path mempool poll interval to 10ms

### DIFF
--- a/crates/apollo_deployments/resources/app_configs/batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/batcher_config.json
@@ -3,7 +3,7 @@
   "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": 1500,
   "batcher_config.dynamic_config.results_polling_interval_millis": 10,
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": false,
-  "batcher_config.dynamic_config.tx_polling_interval_millis": 200,
+  "batcher_config.dynamic_config.tx_polling_interval_millis": 10,
   "batcher_config.dynamic_config.validate_tx_polling_interval_millis": 10,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.l1_gas": 4400000,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.message_segment_length": 3700,

--- a/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
@@ -3,7 +3,7 @@
   "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": "$$$_BATCHER_CONFIG-DYNAMIC_CONFIG-PROPOSER_IDLE_DETECTION_DELAY_MILLIS_$$$",
   "batcher_config.dynamic_config.results_polling_interval_millis": 10,
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": false,
-  "batcher_config.dynamic_config.tx_polling_interval_millis": 200,
+  "batcher_config.dynamic_config.tx_polling_interval_millis": 10,
   "batcher_config.dynamic_config.validate_tx_polling_interval_millis": 10,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.l1_gas": 4400000,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.message_segment_length": 3700,


### PR DESCRIPTION
## What

Config-only companion to #14842. Lowers the propose-path mempool poll `tx_polling_interval_millis`
200 → 10 in the batcher app configs (`batcher_config.json` + generated `replacer_batcher_config.json`).

With #14842 removing the ~200ms execution-result-collection wait, the remaining mid-block latency is
the mempool pull wait, which is `U(0, tx_polling_interval_millis)`. Dropping the interval to 10ms cuts
the average mid-block pull wait from ~100ms to ~5ms.

## Cost / trade-off

Idle `get_txs` rate rises from 5/s to 100/s on a local (in-process mpsc) channel — negligible. The
interval was originally raised to 200 (#13393) so that txs accumulate between polls and ordering is
decided by tip/priority fee rather than by arrival latency (geographic proximity). This reverses that
trade-off in favor of latency, so it is kept as a **separate commit** stacked on #14842 and can be
reverted independently if the ordering trade-off turns out to matter.

## Verification

`cargo test -p apollo_deployments` — `deployment_files_are_up_to_date` passes (both `batcher_config.json`
and the generated `replacer_batcher_config.json` are consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)