### PR TITLE
starknet_patricia_storage: remove redundant copy in create_db_key

### DIFF
--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -374,5 +374,5 @@ impl Serialize for DbKey {
 
 /// Returns a `DbKey` from a prefix , separator, and suffix.
 pub fn create_db_key(prefix: DbKeyPrefix, separator: &[u8], suffix: &[u8]) -> DbKey {
-    DbKey([prefix.to_bytes(), separator, suffix].concat().to_vec())
+    DbKey([prefix.to_bytes(), separator, suffix].concat())
 }


### PR DESCRIPTION
## Summary

Follow-up performance review of #14838 (dead-code removal in `starknet_patricia_storage::storage_trait`), scoped to hot-path optimizations in that same file.

`create_db_key` built its buffer via `[prefix, separator, suffix].concat()` — which already allocates and returns an owned `Vec<u8>` — and then called `.to_vec()` on the result, cloning the whole buffer into a second, immediately-discarded allocation:

```rust
// before
DbKey([prefix.to_bytes(), separator, suffix].concat().to_vec())
// after
DbKey([prefix.to_bytes(), separator, suffix].concat())
```

`create_db_key` is called via `DBObject::get_db_key` for every Patricia-tree node key construction (facts DB, index DB, and the transaction prover's committer utils) — a per-node, per-block hot path. Removing the redundant `.to_vec()` eliminates one heap allocation and one memcpy per key, with byte-for-byte identical output.

## Test plan
- [x] `cargo build -p starknet_patricia_storage`
- [x] `SEED=0 cargo test -p starknet_patricia_storage` — 8 passed
- [x] `cargo build -p starknet_committer -p starknet_patricia` (downstream callers of `create_db_key`) — clean
- [x] Reviewed by an independent Opus pass: verified all call sites treat the returned `DbKey` opaquely (no reliance on the old double-copy's capacity/aliasing), and confirmed `.concat()` on `&[u8]` slices resolves unambiguously to `Vec<u8>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCgybCqdWGWSWbknjWQ4jN)_