### PR TITLE
apollo_batcher,apollo_batcher_config: shorter tx polling interval for proposal validation (#14633)

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -521,7 +521,7 @@ impl Batcher {
                     tx_polling_interval_millis: self
                         .config
                         .dynamic_config
-                        .tx_polling_interval_millis,
+                        .validate_tx_polling_interval_millis,
                 },
                 self.config.dynamic_config.native_classes_whitelist.clone(),
                 Box::new(tx_provider),

--- a/crates/apollo_batcher_config/src/config.rs
+++ b/crates/apollo_batcher_config/src/config.rs
@@ -321,8 +321,16 @@ pub struct BatcherDynamicConfig {
     /// Number of transactions in each request from the tx_provider.
     pub n_concurrent_txs: usize,
     /// Time to wait (in milliseconds) between transaction requests when the previous request
-    /// returned no transactions.
+    /// returned no transactions. Applies when proposing, where the provider polls the mempool.
+    /// Kept intentionally high: a coarse interval makes txs accumulate between polls so ordering
+    /// is decided by tip/priority fee, rather than letting a tx win inclusion purely by arriving
+    /// a few ms earlier (i.e. by sitting geographically close to our node). It also reduces
+    /// mempool polling load.
     pub tx_polling_interval_millis: u64,
+    /// Same as `tx_polling_interval_millis`, but applied when validating a proposal. Here the tx
+    /// order is already fixed by the proposer, so a short interval is safe and simply reduces the
+    /// delay before streamed txs are executed.
+    pub validate_tx_polling_interval_millis: u64,
     /// Minimum time (in milliseconds) that must pass since block creation started before checking
     /// for idle state. If this delay has passed AND no transactions are currently being executed,
     /// the proposer will finish building the current block.
@@ -340,6 +348,7 @@ impl Default for BatcherDynamicConfig {
             storage_reader_server_dynamic_config: StorageReaderServerDynamicConfig::default(),
             n_concurrent_txs: 100,
             tx_polling_interval_millis: 10,
+            validate_tx_polling_interval_millis: 10,
             proposer_idle_detection_delay_millis: Duration::from_millis(1500),
         }
     }
@@ -359,7 +368,18 @@ impl SerializeConfig for BatcherDynamicConfig {
                 "tx_polling_interval_millis",
                 &self.tx_polling_interval_millis,
                 "Time to wait (in milliseconds) between transaction requests when the previous \
-                 request returned no transactions.",
+                 request returned no transactions. Applies when proposing (polls the mempool). \
+                 Kept intentionally high so txs accumulate between polls and ordering is decided \
+                 by tip/priority fee rather than by arrival latency (geographic proximity).",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "validate_tx_polling_interval_millis",
+                &self.validate_tx_polling_interval_millis,
+                "Time to wait (in milliseconds) between transaction requests when the previous \
+                 request returned no transactions. Applies when validating a proposal, where the \
+                 tx order is already fixed; a short interval reduces the delay before streamed \
+                 txs are executed.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(

--- a/crates/apollo_deployments/resources/app_configs/batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/batcher_config.json
@@ -3,6 +3,7 @@
   "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": 1500,
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": false,
   "batcher_config.dynamic_config.tx_polling_interval_millis": 200,
+  "batcher_config.dynamic_config.validate_tx_polling_interval_millis": 10,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.l1_gas": 4400000,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.message_segment_length": 3700,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.n_events": 5000,

--- a/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
@@ -3,6 +3,7 @@
   "batcher_config.dynamic_config.proposer_idle_detection_delay_millis": "$$$_BATCHER_CONFIG-DYNAMIC_CONFIG-PROPOSER_IDLE_DETECTION_DELAY_MILLIS_$$$",
   "batcher_config.dynamic_config.storage_reader_server_dynamic_config.enable": false,
   "batcher_config.dynamic_config.tx_polling_interval_millis": 200,
+  "batcher_config.dynamic_config.validate_tx_polling_interval_millis": 10,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.l1_gas": 4400000,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.message_segment_length": 3700,
   "batcher_config.static_config.block_builder_config.bouncer_config.block_max_capacity.n_events": "$$$_BATCHER_CONFIG-STATIC_CONFIG-BLOCK_BUILDER_CONFIG-BOUNCER_CONFIG-BLOCK_MAX_CAPACITY-N_EVENTS_$$$",

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -65,7 +65,12 @@
     "value": false
   },
   "batcher_config.dynamic_config.tx_polling_interval_millis": {
-    "description": "Time to wait (in milliseconds) between transaction requests when the previous request returned no transactions.",
+    "description": "Time to wait (in milliseconds) between transaction requests when the previous request returned no transactions. Applies when proposing (polls the mempool). Kept intentionally high so txs accumulate between polls and ordering is decided by tip/priority fee rather than by arrival latency (geographic proximity).",
+    "privacy": "Public",
+    "value": 10
+  },
+  "batcher_config.dynamic_config.validate_tx_polling_interval_millis": {
+    "description": "Time to wait (in milliseconds) between transaction requests when the previous request returned no transactions. Applies when validating a proposal, where the tx order is already fixed; a short interval reduces the delay before streamed txs are executed.",
     "privacy": "Public",
     "value": 10
   },


### PR DESCRIPTION
Backport of #14633 to `main-v0.14.3` (cherry-pick of 7edccbe8db, clean).

Splits the block-builder polling knob: adds `validate_tx_polling_interval_millis` (default 10ms) for the proposal **validate** path, leaving `tx_polling_interval_millis` (prod 200ms) for the **propose** path. Validators read from a free in-process channel, so the 200ms sleep was pure latency (~200ms per idle poll) with no benefit; they now fall through to the 10ms default with no deployment change (prod only overrides the propose value).

Self-contained: includes the `config_schema.json` regen and both deployment presets (`batcher_config.json`, `replacer_batcher_config.json`).