### PR TITLE
starknet_committer,starknet_patricia,starknet_patricia_storage: hoist per-node db key prefix in index-layout serialization

### DIFF
--- a/crates/starknet_committer/src/db/facts_db/db.rs
+++ b/crates/starknet_committer/src/db/facts_db/db.rs
@@ -14,6 +14,7 @@ use starknet_patricia_storage::map_storage::MapStorage;
 use starknet_patricia_storage::storage_trait::{
     DbHashMap,
     DbKey,
+    DbKeyPrefix,
     DbOperationMap,
     PatriciaStorageResult,
     Storage,
@@ -68,6 +69,9 @@ impl<'a, L: Leaf> NodeLayout<'a, L> for FactsNodeLayout {
         _node_index: NodeIndex,
         key_context: &<L as HasStaticPrefix>::KeyContext,
         filled_node: FilledNode<LeafBase, HashOutput>,
+        // In facts layout the prefix depends on the node's type (inner node vs. leaf), so it
+        // can't be hoisted out of the per-node loop; always recompute it from `key_context`.
+        _prefix_hint: Option<&DbKeyPrefix>,
     ) -> (DbKey, Self::NodeDbObject) {
         let hash_filled_node = Self::convert_node_data_and_leaf(filled_node);
 

--- a/crates/starknet_committer/src/db/facts_db/types.rs
+++ b/crates/starknet_committer/src/db/facts_db/types.rs
@@ -54,7 +54,7 @@ impl<'a> SubTreeTrait<'a> for FactsSubTree<'a> {
             PatriciaPrefix::InnerNode.into()
         };
         let suffix = self.root_hash.0.to_bytes_be();
-        create_db_key(prefix, FACT_LAYOUT_DB_KEY_SEPARATOR, &suffix)
+        create_db_key(&prefix, FACT_LAYOUT_DB_KEY_SEPARATOR, &suffix)
     }
 }
 /// Used for reading the roots in facts layout case.

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -29,6 +29,7 @@ use starknet_patricia_storage::storage_trait::PatriciaStorageError;
 use starknet_patricia_storage::storage_trait::{
     DbHashMap,
     DbKey,
+    DbKeyPrefix,
     DbOperationMap,
     DbValue,
     PatriciaStorageResult,
@@ -65,6 +66,7 @@ use crate::db::index_db::leaves::{
 };
 use crate::db::index_db::types::{
     get_node_index_db_key,
+    get_node_index_db_key_with_prefix,
     EmptyNodeData,
     IndexFilledNode,
     IndexFilledNodeWithHasher,
@@ -192,13 +194,17 @@ where
         node_index: NodeIndex,
         key_context: &<L as HasStaticPrefix>::KeyContext,
         filled_node: FilledNode<LeafBase, HashOutput>,
+        prefix_hint: Option<&DbKeyPrefix>,
     ) -> (DbKey, Self::NodeDbObject) {
         let filled_node = Self::convert_node_data_and_leaf(filled_node);
 
         let db_filled_node = IndexFilledNodeWithHasher::<L, H>::new(filled_node);
 
         let suffix = &node_index.0.to_be_bytes();
-        let key = db_filled_node.get_db_key(key_context, suffix);
+        let key = match prefix_hint {
+            Some(prefix) => IndexFilledNodeWithHasher::<L, H>::db_key_from_prefix(prefix, suffix),
+            None => db_filled_node.get_db_key(key_context, suffix),
+        };
 
         (key, db_filled_node)
     }
@@ -345,9 +351,12 @@ impl<S: Storage> ForestWriterWithMetadata for IndexDb<S> {
                 get_node_index_db_key::<IndexLayoutContractState>(&EmptyKeyContext, *node_index)
             }))
             .chain(storage_tries.iter().flat_map(|(contract_address, node_indices)| {
+                // All of a contract's node keys share the same address-derived prefix; compute
+                // it once per contract instead of once per node.
+                let prefix = IndexLayoutStarknetStorageValue::get_static_prefix(contract_address);
                 node_indices.iter().map(move |node_index| {
-                    get_node_index_db_key::<IndexLayoutStarknetStorageValue>(
-                        contract_address,
+                    get_node_index_db_key_with_prefix::<IndexLayoutStarknetStorageValue>(
+                        &prefix,
                         *node_index,
                     )
                 })

--- a/crates/starknet_committer/src/db/index_db/types.rs
+++ b/crates/starknet_committer/src/db/index_db/types.rs
@@ -214,6 +214,17 @@ pub(crate) fn get_node_index_db_key<L: Leaf>(
     node_index: NodeIndex,
 ) -> DbKey {
     let prefix = L::get_static_prefix(key_context);
+    get_node_index_db_key_with_prefix::<L>(&prefix, node_index)
+}
+
+/// Like `get_node_index_db_key`, but takes an already-computed prefix (see
+/// `HasDynamicPrefix::static_prefix_hint`) instead of deriving it from a key context. Useful when
+/// building keys for many node indices that share the same prefix, to avoid recomputing it for
+/// each one.
+pub(crate) fn get_node_index_db_key_with_prefix<L: Leaf>(
+    prefix: &DbKeyPrefix,
+    node_index: NodeIndex,
+) -> DbKey {
     let suffix = node_index.0.to_be_bytes();
     create_db_key(prefix, L::DB_KEY_SEPARATOR, &suffix)
 }

--- a/crates/starknet_patricia/src/db_layout.rs
+++ b/crates/starknet_patricia/src/db_layout.rs
@@ -1,6 +1,6 @@
 use starknet_api::hash::HashOutput;
 use starknet_patricia_storage::db_object::{DBObject, HasStaticPrefix};
-use starknet_patricia_storage::storage_trait::DbKey;
+use starknet_patricia_storage::storage_trait::{DbKey, DbKeyPrefix};
 
 use crate::patricia_merkle_tree::filled_tree::node::FilledNode;
 use crate::patricia_merkle_tree::node_data::inner_node::{BinaryData, EdgeData, NodeData};
@@ -42,10 +42,15 @@ pub trait NodeLayout<'a, L: Leaf> {
     ///
     /// During the construction of a `FilledTree` we compute the hashes and carry `FilledNode<L,
     /// HashOutput>`, hence, the `FilledNode` type is not necessarily what we want to store.
+    ///
+    /// `prefix_hint`, when `Some`, is the db key prefix for `key_context`, precomputed once by
+    /// the caller for the whole tree (see `HasDynamicPrefix::static_prefix_hint`) — implementers
+    /// should prefer it over recomputing the prefix from `key_context` for every node.
     fn get_db_object<LeafBase: Leaf + Into<L>>(
         node_index: NodeIndex,
         key_context: &<L as HasStaticPrefix>::KeyContext,
         filled_node: FilledNode<LeafBase, HashOutput>,
+        prefix_hint: Option<&DbKeyPrefix>,
     ) -> (DbKey, Self::NodeDbObject);
 
     /// A utility function to convert a `FilledNode<LeafBase, HashOutput>` to a `FilledNode<L,

--- a/crates/starknet_patricia/src/patricia_merkle_tree/external_test_utils.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/external_test_utils.rs
@@ -127,7 +127,7 @@ pub fn create_32_bytes_entry(simple_val: u128) -> [u8; 32] {
 
 fn create_inner_node_patricia_key(val: Felt) -> DbKey {
     create_db_key(
-        DbKeyPrefix::new(DEFAULT_PATRICIA_NODE_PREFIX.into()),
+        &DbKeyPrefix::new(DEFAULT_PATRICIA_NODE_PREFIX.into()),
         DEFAULT_DB_KEY_SEPARATOR,
         &val.to_bytes_be(),
     )
@@ -135,7 +135,7 @@ fn create_inner_node_patricia_key(val: Felt) -> DbKey {
 
 pub fn create_leaf_patricia_key<L: LeafWithEmptyKeyContext>(val: u128) -> DbKey {
     create_db_key(
-        L::get_static_prefix(&EmptyKeyContext),
+        &L::get_static_prefix(&EmptyKeyContext),
         DEFAULT_DB_KEY_SEPARATOR,
         &U256::from(val).to_be_bytes(),
     )
@@ -214,7 +214,7 @@ pub fn create_root_edge_entry(old_root: u128, subtree_height: SubTreeHeight) -> 
     let length = SubTreeHeight::ACTUAL_HEIGHT.0 - subtree_height.0;
     let new_root = old_root + u128::from(length);
     let key = create_db_key(
-        DbKeyPrefix::new(DEFAULT_PATRICIA_NODE_PREFIX.into()),
+        &DbKeyPrefix::new(DEFAULT_PATRICIA_NODE_PREFIX.into()),
         DEFAULT_DB_KEY_SEPARATOR,
         &Felt::from(new_root).to_bytes_be(),
     );

--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use async_recursion::async_recursion;
 use starknet_api::hash::HashOutput;
-use starknet_patricia_storage::db_object::{DBObject, HasStaticPrefix};
+use starknet_patricia_storage::db_object::{DBObject, HasDynamicPrefix, HasStaticPrefix};
 use starknet_patricia_storage::errors::SerializationResult;
 use starknet_patricia_storage::storage_trait::DbHashMap;
 
@@ -361,13 +361,18 @@ impl<L: Leaf + 'static> FilledTree<L> for FilledTreeImpl<L> {
         &self,
         key_context: &<Layout::DbLeaf as HasStaticPrefix>::KeyContext,
     ) -> SerializationResult<DbHashMap> {
+        // All nodes in this call share `key_context` (e.g. one contract's storage trie shares
+        // its contract address), so the db key prefix, when it doesn't depend on node data, is
+        // computed once here instead of once per node.
+        let prefix_hint = Layout::NodeDbObject::static_prefix_hint(key_context);
+
         // This function iterates over each node in the tree, using the node's `db_key` as the
         // hashmap key and the result of the node's `serialize` method as the value.
         self.get_all_nodes()
             .iter()
             .map(|(index, node)| {
                 let (db_key, node_db_object) =
-                    Layout::get_db_object(*index, key_context, node.clone());
+                    Layout::get_db_object(*index, key_context, node.clone(), prefix_hint.as_ref());
                 let db_value = node_db_object.serialize()?;
                 Ok((db_key, db_value))
             })

--- a/crates/starknet_patricia_storage/src/db_object.rs
+++ b/crates/starknet_patricia_storage/src/db_object.rs
@@ -10,6 +10,16 @@ pub trait HasDynamicPrefix {
 
     /// Returns the storage key prefix of the DB object.
     fn get_prefix(&self, key_context: &Self::KeyContext) -> DbKeyPrefix;
+
+    /// Returns the storage key prefix without an instance, when it depends only on
+    /// `key_context` and not on the object's data (e.g. node type). Callers that compute the
+    /// prefix for many objects sharing the same `key_context` (such as all the nodes of a single
+    /// contract's storage trie) can call this once and reuse the result, instead of paying the
+    /// prefix's allocation cost per object. Returns `None` when the prefix is data-dependent, in
+    /// which case callers must fall back to per-object `get_prefix`.
+    fn static_prefix_hint(_key_context: &Self::KeyContext) -> Option<DbKeyPrefix> {
+        None
+    }
 }
 
 pub trait HasStaticPrefix {
@@ -27,6 +37,10 @@ impl<T: HasStaticPrefix> HasDynamicPrefix for T {
 
     fn get_prefix(&self, key_context: &Self::KeyContext) -> DbKeyPrefix {
         T::get_static_prefix(key_context)
+    }
+
+    fn static_prefix_hint(key_context: &Self::KeyContext) -> Option<DbKeyPrefix> {
+        Some(T::get_static_prefix(key_context))
     }
 }
 
@@ -52,6 +66,12 @@ pub trait DBObject: Sized + HasDynamicPrefix {
 
     /// Returns a [DbKey] from a prefix and a suffix.
     fn get_db_key(&self, key_context: &Self::KeyContext, suffix: &[u8]) -> DbKey {
-        create_db_key(self.get_prefix(key_context), Self::DB_KEY_SEPARATOR, suffix)
+        create_db_key(&self.get_prefix(key_context), Self::DB_KEY_SEPARATOR, suffix)
+    }
+
+    /// Returns a [DbKey] from a precomputed prefix (see [HasDynamicPrefix::static_prefix_hint])
+    /// and a suffix, without needing an instance.
+    fn db_key_from_prefix(prefix: &DbKeyPrefix, suffix: &[u8]) -> DbKey {
+        create_db_key(prefix, Self::DB_KEY_SEPARATOR, suffix)
     }
 }

--- a/crates/starknet_patricia_storage/src/db_object.rs
+++ b/crates/starknet_patricia_storage/src/db_object.rs
@@ -1,6 +1,10 @@
 use crate::errors::{DeserializationError, SerializationResult};
 use crate::storage_trait::{create_db_key, DbKey, DbKeyPrefix, DbValue};
 
+#[cfg(test)]
+#[path = "db_object_test.rs"]
+mod db_object_test;
+
 pub struct EmptyKeyContext;
 
 pub trait HasDynamicPrefix {

--- a/crates/starknet_patricia_storage/src/db_object_test.rs
+++ b/crates/starknet_patricia_storage/src/db_object_test.rs
@@ -1,0 +1,72 @@
+use std::borrow::Cow;
+
+use super::{DBObject, EmptyDeserializationContext, HasDynamicPrefix, HasStaticPrefix};
+use crate::errors::{DeserializationError, SerializationResult};
+use crate::storage_trait::{DbKeyPrefix, DbValue};
+
+/// A key context whose bytes participate in the prefix, mirroring index layout's use of the
+/// contract address as the storage-trie prefix. Guards that the hoisted prefix is derived from
+/// `key_context` and nothing else.
+struct PrefixKeyContext(Vec<u8>);
+
+/// A minimal `DBObject` that carries data unrelated to its prefix, so we can assert the prefix is
+/// independent of the object's contents.
+struct StaticPrefixObject {
+    unrelated_data: u8,
+}
+
+impl HasStaticPrefix for StaticPrefixObject {
+    type KeyContext = PrefixKeyContext;
+
+    fn get_static_prefix(key_context: &Self::KeyContext) -> DbKeyPrefix {
+        DbKeyPrefix::new(Cow::Owned(key_context.0.clone()))
+    }
+}
+
+impl DBObject for StaticPrefixObject {
+    const DB_KEY_SEPARATOR: &[u8] = b":";
+
+    type DeserializeContext = EmptyDeserializationContext;
+
+    fn serialize(&self) -> SerializationResult<DbValue> {
+        Ok(DbValue(vec![self.unrelated_data]))
+    }
+
+    fn deserialize(
+        value: &DbValue,
+        _deserialize_context: &Self::DeserializeContext,
+    ) -> Result<Self, DeserializationError> {
+        Ok(Self { unrelated_data: value.0[0] })
+    }
+}
+
+#[test]
+fn static_prefix_hint_matches_get_prefix_for_static_prefix_types() {
+    let key_context = PrefixKeyContext(vec![7, 8, 9]);
+    let object = StaticPrefixObject { unrelated_data: 42 };
+
+    let hint = StaticPrefixObject::static_prefix_hint(&key_context);
+    assert_eq!(
+        hint.as_ref().map(DbKeyPrefix::to_bytes),
+        Some(object.get_prefix(&key_context).to_bytes()),
+        "the hoisted hint must equal the per-instance prefix",
+    );
+}
+
+#[test]
+fn hoisted_and_per_instance_db_keys_are_identical() {
+    let key_context = PrefixKeyContext(vec![7, 8, 9]);
+    let suffix = [1, 2, 3, 4];
+
+    // Two objects with different data but the same key context must produce the same key via the
+    // hoisted path, and it must match the per-instance path.
+    let first_object = StaticPrefixObject { unrelated_data: 1 };
+    let second_object = StaticPrefixObject { unrelated_data: 2 };
+
+    let prefix = StaticPrefixObject::static_prefix_hint(&key_context)
+        .expect("a static-prefix type must yield a hint");
+    let hoisted_key = StaticPrefixObject::db_key_from_prefix(&prefix, &suffix);
+
+    assert_eq!(hoisted_key, first_object.get_db_key(&key_context, &suffix));
+    assert_eq!(hoisted_key, second_object.get_db_key(&key_context, &suffix));
+}

--- a/crates/starknet_patricia_storage/src/storage_trait.rs
+++ b/crates/starknet_patricia_storage/src/storage_trait.rs
@@ -373,6 +373,6 @@ impl Serialize for DbKey {
 }
 
 /// Returns a `DbKey` from a prefix , separator, and suffix.
-pub fn create_db_key(prefix: DbKeyPrefix, separator: &[u8], suffix: &[u8]) -> DbKey {
+pub fn create_db_key(prefix: &DbKeyPrefix, separator: &[u8], suffix: &[u8]) -> DbKey {
     DbKey([prefix.to_bytes(), separator, suffix].concat())
 }

--- a/crates/starknet_transaction_prover/src/running/committer_utils.rs
+++ b/crates/starknet_transaction_prover/src/running/committer_utils.rs
@@ -186,7 +186,7 @@ fn insert_inner_nodes<S: std::hash::BuildHasher>(
         let filled_node = FactDbFilledNode::<StarknetStorageValue>::from((HashOutput(*hash), node));
         let value = filled_node.serialize()?;
         let node_prefix: DbKeyPrefix = PatriciaPrefix::InnerNode.into();
-        let key = create_db_key(node_prefix, FACT_LAYOUT_DB_KEY_SEPARATOR, &hash.to_bytes_be());
+        let key = create_db_key(&node_prefix, FACT_LAYOUT_DB_KEY_SEPARATOR, &hash.to_bytes_be());
         db_map.insert(key, value);
     }
 
@@ -281,7 +281,7 @@ fn add_dummy_node_for_orphan_child(
     if !has_preimage.contains(child_hash) {
         let node_prefix: DbKeyPrefix = PatriciaPrefix::InnerNode.into();
         let key =
-            create_db_key(node_prefix, FACT_LAYOUT_DB_KEY_SEPARATOR, &child_hash.to_bytes_be());
+            create_db_key(&node_prefix, FACT_LAYOUT_DB_KEY_SEPARATOR, &child_hash.to_bytes_be());
         db_map.entry(key).or_insert_with(|| dummy_value.clone());
     }
 }


### PR DESCRIPTION
## Summary

Follow-up performance review of #14850 (which removed a redundant `.to_vec()` copy in `create_db_key`), scoped to the same hot path: Patricia trie DB key construction, which runs once per node per block during block commitment.

In the index-layout storage backend, `IndexLayoutStarknetStorageValue::get_static_prefix` (`crates/starknet_committer/src/db/index_db/leaves.rs`) rebuilds a fresh 32-byte `Vec<u8>` from a contract's address for **every node** in that contract's storage trie (inner nodes and leaves alike) — even though every node serialized in one `FilledTree::serialize` call, or deleted in one `serialize_deleted_nodes` iteration, shares the same contract address. For a contract with thousands of modified storage slots in a block, this recomputes and heap-allocates an identical prefix thousands of times instead of once.

Facts layout doesn't have this problem — its prefix depends on node type (inner vs. leaf), not just on the key context — so it's left untouched.

## Change

- `starknet_patricia_storage::db_object`: added `HasDynamicPrefix::static_prefix_hint(key_context) -> Option<DbKeyPrefix>`, a hook that returns the prefix without an instance when it depends only on `key_context` (`Some`, via the blanket `HasStaticPrefix` impl — covers index layout) or `None` when it's node-data-dependent (facts layout's manual `HasDynamicPrefix` impl doesn't get the blanket override, so it stays `None`, and its `get_db_object` ignores the hint — unchanged behavior).
- `starknet_patricia::db_layout` + `filled_tree::tree`: `NodeLayout::get_db_object` gained a `prefix_hint: Option<&DbKeyPrefix>` parameter; `FilledTreeImpl::serialize` computes the hint once before its per-node loop and reuses it for every node.
- `starknet_committer::db::index_db::db`: `IndexNodeLayout::get_db_object` uses the hint when present; `serialize_deleted_nodes` (a separate per-contract loop) now computes the prefix once per contract instead of once per node index.
- `create_db_key` now borrows its prefix (`&DbKeyPrefix`) instead of taking it by value, since callers with a precomputed prefix no longer need to move it per node; all call sites updated.
- Added unit tests (`starknet_patricia_storage::db_object_test`) directly pinning the invariant the optimization relies on: the hoisted hint equals the per-instance prefix, and two objects sharing a key context but differing in data produce identical db keys via both paths.

## Test plan

- [x] `cargo build -p starknet_patricia_storage -p starknet_patricia -p starknet_committer -p starknet_transaction_prover`
- [x] `SEED=0 cargo test -p starknet_patricia_storage -p starknet_patricia -p starknet_committer -p starknet_transaction_prover` — all green, with two known-unrelated exceptions confirmed pre-existing on a clean `origin/main` checkout:
  - `starknet_transaction_prover`'s `test_compiled_class_v1_to_casm_round_trip` fails in this sandbox because it needs to download the Cairo 1 compiler over a network the sandbox doesn't have; reproduces identically on `origin/main`.
  - `starknet_patricia_storage`'s `test_storage_concurrent_access::case_2_mdbx_storage` uses a hardcoded `/tmp/test_mdbx_storage` path with no cleanup between runs; it only fails when the suite is re-run repeatedly against leftover on-disk state from a prior run in the same environment. Passes cleanly otherwise.
- [x] `unset CI && scripts/rust_fmt.sh` — no diff
- [x] Reviewed by an independent Opus pass, which added the `db_object_test.rs` unit tests above and confirmed no blocking issues; a second independent Opus pass reached the same verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQNuoKFwFs933ZC5oRvcAC)_