### PR TITLE
starknet_patricia,starknet_patricia_storage: cut redundant hashmap work in per-block hot paths

### DIFF
--- a/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
+++ b/crates/starknet_patricia/src/patricia_merkle_tree/filled_tree/tree.rs
@@ -77,13 +77,16 @@ impl<L: Leaf + 'static> FilledTreeImpl<L> {
     fn initialize_filled_tree_output_map_with_placeholders<'a>(
         updated_skeleton: &impl UpdatedSkeletonTree<'a>,
     ) -> HashMap<NodeIndex, OnceLock<HashFilledNode<L>>> {
-        updated_skeleton
-            .get_nodes()
-            .filter_map(|(index, node)| match node {
-                UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
-                _ => Some((*index, OnceLock::new())),
-            })
-            .collect()
+        let nodes = updated_skeleton.get_nodes();
+        // `filter_map`'s size hint has a lower bound of 0, so `collect` alone would not
+        // preallocate; reserve using the (exact) unfiltered node count instead to avoid rehashing
+        // as the map grows.
+        let mut filled_tree_output_map = HashMap::with_capacity(nodes.size_hint().0);
+        filled_tree_output_map.extend(nodes.filter_map(|(index, node)| match node {
+            UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
+            _ => Some((*index, OnceLock::new())),
+        }));
+        filled_tree_output_map
     }
 
     fn initialize_leaf_output_map_with_placeholders(

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -347,8 +347,8 @@ impl Storage for RocksDbStorage {
 
     async fn mset(&mut self, key_to_value: DbHashMap) -> PatriciaStorageResult<()> {
         let mut batch = WriteBatch::default();
-        for key in key_to_value.keys() {
-            batch.put(&key.0, &key_to_value[key].0);
+        for (key, value) in key_to_value.iter() {
+            batch.put(&key.0, &value.0);
         }
         Ok(self.db.write_opt(&batch, &self.options.write_options)?)
     }


### PR DESCRIPTION
## Summary

Follow-up performance review of #14850 (`starknet_patricia_storage: remove redundant copy in create_db_key`), scoped to two more hot-path hashmap inefficiencies found while auditing the surrounding storage/commit code.

**1. `RocksDbStorage::mset` — redundant hashmap re-lookup per key**

```rust
// before
for key in key_to_value.keys() {
    batch.put(&key.0, &key_to_value[key].0);
}
// after
for (key, value) in key_to_value.iter() {
    batch.put(&key.0, &value.0);
}
```

`mset` iterated `.keys()` and then re-looked-up each value via `key_to_value[key]` (the `Index` impl), hashing and probing the map a second time for every one of the O(N_nodes) entries written per block. `.iter()` yields `(key, value)` directly — same pattern `multi_set_and_delete` right below it already uses.

**2. `FilledTreeImpl::initialize_filled_tree_output_map_with_placeholders` — lost capacity hint after the `OnceLock` refactor**

This function used to build its output map with an explicit `with_capacity` hint (added in #14641 to avoid O(log N) rehash-on-grow). It has since been rewritten to `updated_skeleton.get_nodes().filter_map(...).collect()` as part of switching placeholders from `Mutex<Option<T>>` to `OnceLock<T>`. `filter_map`'s `size_hint()` lower bound is always 0 (filtering may drop every element), so `collect`/`extend` can no longer preallocate, silently reintroducing the rehashing cost the earlier fix removed.

```rust
// after
let nodes = updated_skeleton.get_nodes();
let mut filled_tree_output_map = HashMap::with_capacity(nodes.size_hint().0);
filled_tree_output_map.extend(nodes.filter_map(|(index, node)| match node {
    UpdatedSkeletonNode::UnmodifiedSubTree(_) => None,
    _ => Some((*index, OnceLock::new())),
}));
filled_tree_output_map
```

`get_nodes()` is backed by a plain `HashMap::iter()`, so its `size_hint().0` is exact — reserving on the unfiltered count is a safe (tight) upper bound for the filtered map, with identical resulting contents.

## Test plan
- [x] `cargo build -p starknet_patricia -p starknet_patricia_storage`
- [x] `SEED=0 cargo test -p starknet_patricia` — 107 passed
- [x] `SEED=0 cargo test -p starknet_patricia_storage` — 8 passed, including `storage_test::test_storage_concurrent_access::case_1_rocksdb_storage` which exercises the `mset` path
- [x] Reviewed by an independent Opus pass: confirmed `filter_map`'s size_hint semantics, confirmed `get_nodes()`'s size_hint is exact, confirmed no double-consume/behavior change, no blocking or suggestion findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016vvwrw58x2vcyartVyMGea)_