### PR TITLE
apollo_batcher: skip spawn_blocking for the non-blocking is_done check

### DIFF
--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -363,12 +363,12 @@ impl BlockBuilder {
             // Check if the block is full. This is only relevant in propose mode.
             // In validate mode, this is ignored and we simply wait for the proposer to send the
             // final number of transactions in the block.
-            let executor = self.executor.clone();
-            if !self.execution_params.is_validator
-                && spawn_blocking(move || lock_executor(&executor).is_done())
-                    .await
-                    .expect("Checking completion should succeed.")
-            {
+            // `is_done` only reads an atomic flag (see `Scheduler::done`), so unlike the other
+            // executor accesses here it is called directly instead of via `spawn_blocking`: this
+            // check now runs on every poll of the tightened `results_polling_interval_millis`
+            // loop, and routing a non-blocking read through the blocking-task pool would add a
+            // full dispatch round-trip for no benefit.
+            if !self.execution_params.is_validator && lock_executor(&self.executor).is_done() {
                 // Call `handle_executed_txs()` once more to get the last results.
                 self.handle_executed_txs().await?;
                 info!("Block is full.");


### PR DESCRIPTION
## Summary

Follow-up perf optimization found while reviewing #14842 (merged), which split the block-builder loop's polling cadence so it sleeps only `results_polling_interval_millis` (default 10ms) instead of `tx_polling_interval_millis` (e.g. 200ms in prod) while transactions are in progress. That change makes the `while` loop in `build_block_inner` iterate roughly 20x more often per block whenever there are in-flight transactions.

On every iteration, the loop checked whether the block is full via:

```rust
let executor = self.executor.clone();
if !self.execution_params.is_validator
    && spawn_blocking(move || lock_executor(&executor).is_done())
        .await
        .expect("Checking completion should succeed.")
```

`is_done()` (`TransactionExecutorTrait::is_done` → `ConcurrentTransactionExecutor::is_done` → `Scheduler::done()`) is just a single atomic load (`self.done_marker.load(Ordering::Acquire)`) — no I/O, no meaningful CPU work, and the underlying mutex (`lock_executor`'s `try_lock`) is uncontended by design since only this one task ever touches the executor. Routing this trivial, non-blocking read through `spawn_blocking` costs a full dispatch round-trip to Tokio's blocking thread pool (channel send, thread wake, context switch) for no benefit — overhead that is now paid ~20x more often per block after #14842.

This PR calls `is_done()` directly, inline, on the async task instead:

```rust
if !self.execution_params.is_validator && lock_executor(&self.executor).is_done() {
```

No other executor access changes — `handle_executed_txs()` (which does real, non-trivial work extracting execution outputs) still goes through `spawn_blocking` as before.

## Expected impact

Removes one blocking-thread-pool dispatch per block-builder loop iteration (out of the two that existed per iteration), which now fires on the tightened ~10ms cadence rather than the previous ~200ms cadence during active execution — i.e. up to ~20x more frequently per block than before #14842.

## Verification

- `cargo build -p apollo_batcher` — succeeds.
- `SEED=0 cargo test -p apollo_batcher` — all `block_builder_test` cases pass (24/24), including `case_4_block_full_before_is_done` and `case_5_block_full_after_is_done`, which exercise this exact code path. (One unrelated pre-existing failure, `batcher_test::call_contract_success`, reproduces identically on the base commit without this change — it fails trying to download the Cairo compiler, a sandbox network limitation, not a regression.)
- Reviewed by an independent Opus pass focused on correctness of the "non-blocking" claim, panic/race risk from moving the check off the blocking pool, and test coverage — no blocking or suggestion-level findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuGcRhDakkYkrwsXPswBJX)_