### PR TITLE
apollo_consensus_orchestrator: use HashSet instead of IndexSet for duplicate-tx tracking

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -2,6 +2,7 @@
 #[path = "validate_proposal_test.rs"]
 mod validate_proposal_test;
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -26,7 +27,6 @@ use apollo_transaction_converter::{TransactionConverterTrait, VerifyAndStoreProo
 use apollo_versioned_constants::VersionedConstants;
 use futures::channel::mpsc;
 use futures::StreamExt;
-use indexmap::IndexSet;
 use starknet_api::block::{BlockNumber, GasPrice, StarknetVersion};
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::data_availability::L1DataAvailabilityMode;
@@ -144,7 +144,7 @@ pub(crate) async fn validate_proposal(
 ) -> ValidateProposalResult<ProposalCommitment> {
     let mut content = Vec::new();
     let mut verify_and_store_proof_tasks: Vec<VerifyAndStoreProofTask> = Vec::new();
-    let mut seen_tx_hashes: IndexSet<TransactionHash> = IndexSet::new();
+    let mut seen_tx_hashes: HashSet<TransactionHash> = HashSet::new();
     let now = args.deps.clock.now();
 
     let Some(deadline) = now.checked_add_signed(chrono::TimeDelta::from_std(args.timeout).unwrap())
@@ -495,7 +495,7 @@ async fn handle_proposal_part(
     batcher: &dyn BatcherClient,
     proposal_part: Option<ProposalPart>,
     content: &mut Vec<Vec<InternalConsensusTransaction>>,
-    seen_tx_hashes: &mut IndexSet<TransactionHash>,
+    seen_tx_hashes: &mut HashSet<TransactionHash>,
     verify_and_store_proof_tasks: &mut Vec<VerifyAndStoreProofTask>,
     transaction_converter: Arc<dyn TransactionConverterTrait>,
     deadline_params: &ProposalDeadlineParams,


### PR DESCRIPTION
## Summary

Follow-up performance review of #14840, scoped to the duplicate-transaction-hash tracking it added to the proposal validation hot path in `crates/apollo_consensus_orchestrator/src/validate_proposal.rs`.

#14840 introduced `seen_tx_hashes: IndexSet<TransactionHash>` in `validate_proposal`, populated once per transaction in every proposal part received during consensus proposal validation (`handle_proposal_part`) — a genuine per-transaction, per-block hot path.

`seen_tx_hashes` is only ever inserted into and queried for membership (`!seen_tx_hashes.insert(tx_hash)`); it is never iterated or indexed anywhere in the file (verified via `grep -n "seen_tx_hashes" -r crates/apollo_consensus_orchestrator/src/`). `IndexSet` (from `indexmap`) exists specifically to provide insertion-order iteration, at the cost of an auxiliary dense-vector layer on top of the hash table — overhead this call site never benefits from. Swapping to `std::collections::HashSet` removes that bookkeeping from every transaction insertion, with a smaller memory footprint, while leaving behavior identical (`insert` returns `bool` = "was newly inserted" on both types; `TransactionHash: Hash + Eq` satisfies both).

The removed `use indexmap::IndexSet;` was the only use of `IndexSet` in this file; `indexmap` remains a dependency of the crate for unrelated usage elsewhere (`cende/central_objects.rs`).

## Test plan
- `cargo build -p apollo_consensus_orchestrator` — clean
- `SEED=0 cargo test -p apollo_consensus_orchestrator` — 177 passed, 0 failed, including `duplicate_transaction_hash_in_proposal_is_rejected_before_batcher`, which exercises this exact code path
- Reviewed by an independent Opus pass: confirmed the set is never iterated elsewhere, the substitution is behavior-preserving, and the import removal breaks nothing — no blocking or suggestion findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ8grrsVcz9dQaaTWDafeT)_