### PR TITLE
apollo_config: simplify README wording per Orwell style rules

### DIFF
--- a/crates/apollo_config/README.md
+++ b/crates/apollo_config/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-apollo-config is a flexible and powerful layered configuration system designed specifically for Apollo, a Starknet node. This system allows you to easily manage configurations for your Apollo sequencer by leveraging various sources and providing additional helpful features.
+apollo-config is a layered configuration system designed for Apollo, a Starknet node. This system allows you to manage configurations for your Apollo sequencer by using various sources and providing helpful features.
 
 ## Configuration sources
 
@@ -17,9 +17,9 @@ Supports multiple configuration sources in ascending order of overriding priorit
 
 - **Support for Nested Configuration Components:** Organize your configurations into nested components, making it easy to manage complex settings for different aspects of the application.
 
-- **Usage of Pointers:** Use pointers to merge parameters that are common to multiple components. This capability helps in streamlining configurations and avoiding duplication of settings.
+- **Usage of Pointers:** Use pointers to merge parameters that are common to multiple components. This capability helps in simplifying configurations and avoiding duplication of settings.
 
-- **Automatically-Generated Command Line Parser:** To simplify the process of handling command-line arguments, the system automatically generates a command-line parser. This means you don't have to write complex argument parsing code; it's ready to use out-of-the-box.
+- **Automatically-Generated Command Line Parser:** To simplify handling command-line arguments, the system automatically generates a command-line parser. This means you don't have to write complex argument parsing code; it's ready to use.
 
 - **Automatically-Generated Reference Configuration File:** Makes it easier for users by generating a reference configuration file. This file serves as a template that highlights all available configuration options and their default values, enabling users to customize their configurations efficiently.
 


### PR DESCRIPTION
Prose-only edits to `crates/apollo_config/README.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 5: cut marketing filler (`flexible and powerful`, `specifically`, `easily`, `additional`) and replaced jargon `leveraging` → `using`.
- Line 20: `streamlining` → `simplifying` (everyday word).
- Line 22: cut `the process of` and the cliché `out-of-the-box`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_