### PR TITLE
apollo_storage: simplify README wording per Orwell style rules

### DIFF
--- a/crates/apollo_storage/README.md
+++ b/crates/apollo_storage/README.md
@@ -2,4 +2,4 @@
 
 ## Description
 
-apollo-storage provides a writing and reading interface for various Starknet data structures to a database, designed specifically for Apollo, a Starknet sequencer.
+apollo-storage provides a writing and reading interface for Starknet data structures to a database, designed for Apollo, a Starknet sequencer.


### PR DESCRIPTION
Prose-only edit to `crates/apollo_storage/README.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 5: cut the cuttable words `various` and `specifically`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_