### PR TITLE
apollo_starknet_os_program: simplify README wording per Orwell style rules

### DIFF
--- a/crates/apollo_starknet_os_program/README.md
+++ b/crates/apollo_starknet_os_program/README.md
@@ -29,7 +29,7 @@ These restrictions ensure the program is safe to run on untrusted clients while 
 
 ### Smaller Footprint
 
-By removing unused functionality, the Virtual OS has a significantly smaller bytecode (~30% smaller), which reduces proving time and costs for clients.
+By removing unused functionality, the Virtual OS has a smaller bytecode (~30% smaller), which reduces proving time and costs for clients.
 
 ## Compilation
 


### PR DESCRIPTION
Prose-only edit to `crates/apollo_starknet_os_program/README.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 32: cut `significantly` — the `~30%` figure already states the magnitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_