### PR TITLE
apollo_protobuf: simplify mempool protocol doc wording per Orwell style rules

### DIFF
--- a/crates/apollo_protobuf/src/proto/p2p/proto/mempool/mempool.md
+++ b/crates/apollo_protobuf/src/proto/p2p/proto/mempool/mempool.md
@@ -15,7 +15,7 @@ Once a node receives a transaction, it should verify it against the current stat
 `validate` before continuing its propagation to other nodes.
 This is to prevent giving scale for a DDoS attack.
 
-Our choice of using Gossipsub might change in the future if we encounter performance issues with it.
+Our choice of using Gossipsub might change if we encounter performance issues with it.
 
 ## Transaction
 The object that we're passing is a [MempoolTransaction](./transaction.proto). A few notes about it:


### PR DESCRIPTION
Prose-only edit to `crates/apollo_protobuf/src/proto/p2p/proto/mempool/mempool.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 18: cut the redundant `in the future` (a change is inherently future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_