### PR TITLE
deployment: simplify sequencer deployment README wording per Orwell style rules

### DIFF
--- a/deployments/sequencer/README.md
+++ b/deployments/sequencer/README.md
@@ -1,6 +1,6 @@
 # Sequencer CDK8S Deployment Configuration Guide
 
-CDK8s is an open-source framework for defining Kubernetes applications using programming languages and object-oriented APIs. CDK8s apps synthesize into standard Kubernetes manifests that can be applied to any Kubernetes cluster.
+CDK8s is an open-source framework for defining Kubernetes applications using programming languages and object-oriented APIs. CDK8s apps synthesize into standard Kubernetes manifests you can apply to any Kubernetes cluster.
 
 **Official documentation:** [https://cdk8s.io/docs/latest](https://cdk8s.io/docs/latest)
 


### PR DESCRIPTION
Prose-only edit to `deployments/sequencer/README.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 3: passive → active `manifests that can be applied to any Kubernetes cluster` → `manifests you can apply to any Kubernetes cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_