### PR TITLE
deployment: simplify deployment docs README wording per Orwell style rules

### DIFF
--- a/deployments/sequencer/docs/README.md
+++ b/deployments/sequencer/docs/README.md
@@ -1,6 +1,6 @@
 # Configuration Documentation
 
-This directory contains comprehensive documentation for all Kubernetes manifest configurations available in the Sequencer deployment system.
+This directory contains documentation for all Kubernetes manifest configurations available in the Sequencer deployment system.
 
 ## Configuration System
 


### PR DESCRIPTION
Prose-only edit to `deployments/sequencer/docs/README.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 3: cut filler `comprehensive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_