### PR TITLE
deployment: simplify local-testing README wording per Orwell style rules

### DIFF
--- a/deployments/local-testing/README.md
+++ b/deployments/local-testing/README.md
@@ -10,7 +10,7 @@ This environment can be deployed in two ways:
 
 ### Option 1: Vagrant VM (Recommended)
 
-The Vagrant setup provides a fully isolated development environment with all prerequisites pre-installed. This is the recommended approach for consistent, reproducible environments.
+The Vagrant setup provides an isolated development environment with all prerequisites pre-installed. This is the recommended approach for consistent, reproducible environments.
 
 #### Vagrant Prerequisites
 


### PR DESCRIPTION
Prose-only edit to `deployments/local-testing/README.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 13: cut `fully` from `a fully isolated development environment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_