### PR TITLE
deployment: simplify Docker setup doc wording per Orwell style rules

### DIFF
--- a/deployments/sequencer/local/DOCKER.md
+++ b/deployments/sequencer/local/DOCKER.md
@@ -6,7 +6,7 @@ This directory contains Docker configuration to run the CDK8S deployment setup i
 
 ### Using the Wrapper Script (Recommended)
 
-The easiest way to build and run the container is using the provided wrapper script:
+The easiest way to build and run the container is using the wrapper script:
 
 ```bash
 cd deployments/sequencer


### PR DESCRIPTION
Prose-only edit to `deployments/sequencer/local/DOCKER.md`, applying Orwell's writing rules. No facts, numbers, or names changed.

- Line 9: cut `provided` from `the provided wrapper script`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjrAzEXJmrgsDjg9YSA1c6)_