### PR TITLE
apollo_batcher: write accessed keys in the same storage transaction as the state diff

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -97,8 +97,6 @@ use blockifier::bouncer::BouncerConfig;
 use blockifier::concurrency::worker_pool::WorkerPool;
 use blockifier::context::BlockContext;
 use blockifier::execution::entry_point::call_view_entry_point;
-#[cfg(feature = "os_input")]
-use blockifier::state::cached_state::CommitmentStateDiff;
 use blockifier::state::contract_class_manager::ContractClassManager;
 use blockifier::state::state_api::StateReader;
 use blockifier::transaction::objects::TransactionExecutionInfo;
@@ -900,6 +898,8 @@ impl Batcher {
             }) => Some(header_commitments.state_diff_commitment),
         };
 
+        // Synced blocks are not executed locally, so no accessed keys are available; the block is
+        // committed via `CommitBlock`.
         self.commit_proposal_and_block(
             height,
             state_diff.clone(),
@@ -907,11 +907,11 @@ impl Batcher {
             l1_transaction_hashes.iter().copied().collect(),
             Default::default(),
             storage_commitment_block_hash,
+            #[cfg(feature = "os_input")]
+            None,
         )
         .await?;
 
-        // Synced blocks are not executed locally, so no accessed keys are available; the block is
-        // committed via `CommitBlock`.
         self.write_commitment_results_and_add_new_task(
             height,
             state_diff,
@@ -963,6 +963,10 @@ impl Batcher {
         let state_diff_commitment =
             partial_block_hash_components.header_commitments.state_diff_commitment;
         let parent_proposal_commitment = self.get_parent_proposal_commitment(height)?;
+
+        #[cfg(feature = "os_input")]
+        let accessed_keys = self.build_block_accessed_keys(&block_execution_artifacts);
+
         self.commit_proposal_and_block(
             height,
             state_diff.clone(),
@@ -970,6 +974,8 @@ impl Batcher {
             block_execution_artifacts.execution_data.consumed_l1_handler_tx_hashes,
             block_execution_artifacts.execution_data.rejected_tx_hashes,
             StorageCommitmentBlockHash::Partial(partial_block_hash_components),
+            #[cfg(feature = "os_input")]
+            Some(accessed_keys.clone()),
         )
         .await?;
 
@@ -980,14 +986,6 @@ impl Batcher {
                 .into_iter()
                 .map(|(tx_hash, (info, _))| (tx_hash, info))
                 .unzip();
-
-        #[cfg(feature = "os_input")]
-        let accessed_keys = self.write_block_accessed_keys(
-            height,
-            &block_execution_artifacts.commitment_state_diff,
-            &block_execution_artifacts.execution_data.proof_facts_block_numbers,
-            &tx_execution_infos,
-        )?;
 
         // The OS only needs the read values for the keys it accesses; drop the extra reads (e.g.
         // reverted-tx reads).
@@ -1040,28 +1038,25 @@ impl Batcher {
         })
     }
 
-    /// Builds the accessed keys for the block, persists them to storage, and returns them.
+    /// Builds the accessed keys for the block.
     #[cfg(feature = "os_input")]
-    fn write_block_accessed_keys(
-        &mut self,
-        height: BlockNumber,
-        commitment_state_diff: &CommitmentStateDiff,
-        proof_facts_block_numbers: &IndexMap<TransactionHash, BlockNumber>,
-        tx_execution_infos: &[TransactionExecutionInfo],
-    ) -> BatcherResult<AccessedKeys> {
-        let accessed_keys = AccessedKeys::new(
-            tx_execution_infos.iter(),
-            proof_facts_block_numbers.values(),
-            commitment_state_diff,
+    fn build_block_accessed_keys(
+        &self,
+        block_execution_artifacts: &BlockExecutionArtifacts,
+    ) -> AccessedKeys {
+        AccessedKeys::new(
+            block_execution_artifacts
+                .execution_data
+                .execution_infos_and_signatures
+                .values()
+                .map(|(execution_info, _signature)| execution_info),
+            block_execution_artifacts.execution_data.proof_facts_block_numbers.values(),
+            &block_execution_artifacts.commitment_state_diff,
             &self.versioned_constants(),
-        );
-        self.storage_writer.write_accessed_keys(height, &accessed_keys).map_err(|err| {
-            error!("Failed to write accessed keys to storage: {}", err);
-            BatcherError::InternalError
-        })?;
-        Ok(accessed_keys)
+        )
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn commit_proposal_and_block(
         &mut self,
         height: BlockNumber,
@@ -1070,6 +1065,7 @@ impl Batcher {
         consumed_l1_handler_tx_hashes: IndexSet<TransactionHash>,
         rejected_tx_hashes: IndexSet<TransactionHash>,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
+        #[cfg(feature = "os_input")] accessed_keys: Option<AccessedKeys>,
     ) -> BatcherResult<()> {
         info!(
             "Committing block at height {} and notifying mempool & L1 event provider of the block.",
@@ -1099,7 +1095,13 @@ impl Batcher {
 
         // Commit the proposal to the storage.
         self.storage_writer
-            .commit_proposal(height, state_diff, storage_commitment_block_hash)
+            .commit_proposal(
+                height,
+                state_diff,
+                storage_commitment_block_hash,
+                #[cfg(feature = "os_input")]
+                accessed_keys,
+            )
             .map_err(|err| {
                 error!("Failed to commit proposal to storage: {}", err);
                 BatcherError::InternalError
@@ -1877,11 +1879,21 @@ impl BatcherStorageReader for StorageReader {
 
 #[cfg_attr(test, automock)]
 pub trait BatcherStorageWriter: Send + Sync {
+    #[cfg(not(feature = "os_input"))]
     fn commit_proposal(
         &mut self,
         height: BlockNumber,
         state_diff: ThinStateDiff,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
+    ) -> StorageResult<()>;
+
+    #[cfg(feature = "os_input")]
+    fn commit_proposal(
+        &mut self,
+        height: BlockNumber,
+        state_diff: ThinStateDiff,
+        storage_commitment_block_hash: StorageCommitmentBlockHash,
+        accessed_keys: Option<AccessedKeys>,
     ) -> StorageResult<()>;
 
     fn revert_block(&mut self, height: BlockNumber);
@@ -1912,13 +1924,6 @@ pub trait BatcherStorageWriter: Send + Sync {
     ) -> StorageResult<()>;
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()>;
-
-    #[cfg(feature = "os_input")]
-    fn write_accessed_keys(
-        &mut self,
-        height: BlockNumber,
-        accessed_keys: &AccessedKeys,
-    ) -> StorageResult<()>;
 }
 
 impl BatcherStorageWriter for StorageWriter {
@@ -1927,6 +1932,7 @@ impl BatcherStorageWriter for StorageWriter {
         height: BlockNumber,
         state_diff: ThinStateDiff,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
+        #[cfg(feature = "os_input")] accessed_keys: Option<AccessedKeys>,
     ) -> StorageResult<()> {
         // TODO(AlonH): write casms.
         let mut txn = self.begin_rw_txn()?.append_state_diff(height, state_diff)?;
@@ -1940,6 +1946,10 @@ impl BatcherStorageWriter for StorageWriter {
                 txn =
                     txn.set_partial_block_hash_components(&height, &partial_block_hash_components)?
             }
+        }
+        #[cfg(feature = "os_input")]
+        if let Some(accessed_keys) = accessed_keys {
+            txn = txn.append_accessed_keys(height, &accessed_keys)?;
         }
         txn.commit()
     }
@@ -1985,15 +1995,6 @@ impl BatcherStorageWriter for StorageWriter {
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()> {
         self.begin_rw_txn()?.set_block_hash(&height, block_hash)?.commit()
-    }
-
-    #[cfg(feature = "os_input")]
-    fn write_accessed_keys(
-        &mut self,
-        height: BlockNumber,
-        accessed_keys: &AccessedKeys,
-    ) -> StorageResult<()> {
-        self.begin_rw_txn()?.append_accessed_keys(height, accessed_keys)?.commit()
     }
 }
 

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -196,6 +196,47 @@ fn get_overlapping_state_diffs(n_state_diffs: u64) -> Vec<ThinStateDiff> {
     state_diffs
 }
 
+/// Expects a single `commit_proposal` call with the given arguments. Under `os_input`,
+/// `expect_accessed_keys` states whether accessed keys should be written with the state diff
+/// (ignored otherwise).
+#[cfg_attr(not(feature = "os_input"), allow(unused_variables))]
+fn expect_commit_proposal_once(
+    storage_writer: &mut MockBatcherStorageWriter,
+    expected_height: BlockNumber,
+    expected_state_diff: ThinStateDiff,
+    expected_storage_commitment_block_hash: StorageCommitmentBlockHash,
+    expect_accessed_keys: bool,
+) {
+    #[cfg(not(feature = "os_input"))]
+    storage_writer
+        .expect_commit_proposal()
+        .times(1)
+        .with(
+            eq(expected_height),
+            eq(expected_state_diff),
+            eq(expected_storage_commitment_block_hash),
+        )
+        .returning(|_, _, _| Ok(()));
+    #[cfg(feature = "os_input")]
+    storage_writer
+        .expect_commit_proposal()
+        .times(1)
+        .withf(move |height, state_diff, storage_commitment_block_hash, accessed_keys| {
+            *height == expected_height
+                && *state_diff == expected_state_diff
+                && *storage_commitment_block_hash == expected_storage_commitment_block_hash
+                && accessed_keys.is_some() == expect_accessed_keys
+        })
+        .returning(|_, _, _, _| Ok(()));
+}
+
+fn expect_commit_proposal_success(storage_writer: &mut MockBatcherStorageWriter) {
+    #[cfg(not(feature = "os_input"))]
+    storage_writer.expect_commit_proposal().returning(|_, _, _| Ok(()));
+    #[cfg(feature = "os_input")]
+    storage_writer.expect_commit_proposal().returning(|_, _, _, _| Ok(()));
+}
+
 fn write_state_diff(batcher: &mut Batcher, height: BlockNumber, state_diff: &ThinStateDiff) {
     batcher
         .storage_writer
@@ -203,6 +244,8 @@ fn write_state_diff(batcher: &mut Batcher, height: BlockNumber, state_diff: &Thi
             height,
             state_diff.clone(),
             StorageCommitmentBlockHash::Partial(PartialBlockHashComponents::default()),
+            #[cfg(feature = "os_input")]
+            None,
         )
         .expect("set_state_diff failed");
 }
@@ -1194,11 +1237,13 @@ async fn add_sync_block(
     storage_reader.expect_global_root_height().returning(move || Ok(block_number));
 
     let mut storage_writer = MockBatcherStorageWriter::new();
-    storage_writer
-        .expect_commit_proposal()
-        .times(1)
-        .with(eq(block_number), eq(test_state_diff()), eq(storage_commitment_block_hash))
-        .returning(|_, _, _| Ok(()));
+    expect_commit_proposal_once(
+        &mut storage_writer,
+        block_number,
+        test_state_diff(),
+        storage_commitment_block_hash,
+        false,
+    );
 
     mock_clients
         .mempool_client
@@ -1351,19 +1396,16 @@ async fn add_sync_block_for_first_new_block() {
         .times(1)
         .with(eq(FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH.prev().unwrap()), eq(DUMMY_BLOCK_HASH))
         .returning(|_, _| Ok(()));
-    mock_dependencies
-        .storage_writer
-        .expect_commit_proposal()
-        .times(1)
-        .with(
-            eq(FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH),
-            eq(ThinStateDiff::default()),
-            eq(StorageCommitmentBlockHash::Partial(PartialBlockHashComponents {
-                block_number: FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH,
-                ..Default::default()
-            })),
-        )
-        .returning(|_, _, _| Ok(()));
+    expect_commit_proposal_once(
+        &mut mock_dependencies.storage_writer,
+        FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH,
+        ThinStateDiff::default(),
+        StorageCommitmentBlockHash::Partial(PartialBlockHashComponents {
+            block_number: FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH,
+            ..Default::default()
+        }),
+        false,
+    );
 
     mock_dependencies
         .clients
@@ -1553,19 +1595,13 @@ async fn decision_reached() {
         .returning(|_, _, _| Ok(()));
 
     let expected_partial_block_hash = expected_artifacts.partial_block_hash_components();
-    mock_dependencies
-        .storage_writer
-        .expect_commit_proposal()
-        .times(1)
-        .with(
-            eq(INITIAL_HEIGHT),
-            eq(expected_artifacts.thin_state_diff()),
-            eq(StorageCommitmentBlockHash::Partial(expected_partial_block_hash)),
-        )
-        .returning(|_, _, _| Ok(()));
-
-    #[cfg(feature = "os_input")]
-    mock_dependencies.storage_writer.expect_write_accessed_keys().times(1).returning(|_, _| Ok(()));
+    expect_commit_proposal_once(
+        &mut mock_dependencies.storage_writer,
+        INITIAL_HEIGHT,
+        expected_artifacts.thin_state_diff(),
+        StorageCommitmentBlockHash::Partial(expected_partial_block_hash),
+        true,
+    );
 
     mock_dependencies
         .storage_reader
@@ -1635,9 +1671,7 @@ async fn test_execution_info_order_is_kept() {
     mock_dependencies.clients.l1_provider_client.expect_start_block().returning(|_, _| Ok(()));
     mock_dependencies.clients.mempool_client.expect_commit_block().returning(|_| Ok(()));
     mock_dependencies.clients.l1_provider_client.expect_commit_block().returning(|_, _, _| Ok(()));
-    mock_dependencies.storage_writer.expect_commit_proposal().returning(|_, _, _| Ok(()));
-    #[cfg(feature = "os_input")]
-    mock_dependencies.storage_writer.expect_write_accessed_keys().times(1).returning(|_, _| Ok(()));
+    expect_commit_proposal_success(&mut mock_dependencies.storage_writer);
 
     let block_builder_result = BlockExecutionArtifacts::create_for_testing().await;
     // Check that the execution_infos were initiated properly for this test.
@@ -1734,10 +1768,7 @@ async fn decision_reached_return_success_when_l1_commit_block_fails(
         .times(1)
         .returning(move |_, _, _| Err(l1_error.clone()));
 
-    mock_dependencies.storage_writer.expect_commit_proposal().returning(|_, _, _| Ok(()));
-
-    #[cfg(feature = "os_input")]
-    mock_dependencies.storage_writer.expect_write_accessed_keys().times(1).returning(|_, _| Ok(()));
+    expect_commit_proposal_success(&mut mock_dependencies.storage_writer);
 
     mock_dependencies.clients.mempool_client.expect_commit_block().returning(|_| Ok(()));
 
@@ -1985,9 +2016,7 @@ async fn validation_only_decision_reached_skips_mempool_notification() {
 
     mock_deps.clients.l1_provider_client.expect_start_block().returning(|_, _| Ok(()));
     mock_deps.clients.l1_provider_client.expect_commit_block().times(1).returning(|_, _, _| Ok(()));
-    mock_deps.storage_writer.expect_commit_proposal().returning(|_, _, _| Ok(()));
-    #[cfg(feature = "os_input")]
-    mock_deps.storage_writer.expect_write_accessed_keys().times(1).returning(|_, _| Ok(()));
+    expect_commit_proposal_success(&mut mock_deps.storage_writer);
 
     let mut block_builder_factory = MockBlockBuilderFactoryTrait::new();
     mock_create_builder_for_validate_block(


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>