### PR TITLE
apollo_dashboard,starknet_committer_and_os_cli: forward os_input feature to apollo_committer

### DIFF
--- a/crates/apollo_dashboard/Cargo.toml
+++ b/crates/apollo_dashboard/Cargo.toml
@@ -8,6 +8,7 @@ description = "Dashboard and monitoring interface for the Starknet sequencer."
 
 
 [features]
+os_input = ["apollo_batcher/os_input", "apollo_committer/os_input"]
 testing = []
 
 [lints]

--- a/crates/starknet_committer_and_os_cli/Cargo.toml
+++ b/crates/starknet_committer_and_os_cli/Cargo.toml
@@ -6,6 +6,9 @@ repository.workspace = true
 license-file.workspace = true
 description = "Cli for the committer package."
 
+[features]
+os_input = ["apollo_committer/os_input"]
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Problem

`apollo_dashboard` and `starknet_committer_and_os_cli` depend on `apollo_committer` but declared no `os_input` feature to forward it — unlike `apollo_node` and `apollo_integration_tests`, which do.

In a multi-package `cargo … --all-features` build (as produced by `run_tests.py --changes_only` when the changed set includes a batcher-side crate), `--all-features` enables `apollo_committer_types/os_input` (via e.g. `apollo_batcher/os_input`) — but `--all-features` only applies to the *selected* packages. `apollo_committer`, pulled in as a plain dependency of the dashboard/CLI crate, is compiled **without** `apollo_committer/os_input`.

The result: `CommitterRequest` gains the `os_input`-gated `ReadPathsAndCommitBlock` variant while `apollo_committer`'s non-`os_input` request handler does not, so it fails to compile:

```
error[E0004]: non-exhaustive patterns: `CommitterRequest::ReadPathsAndCommitBlock(_)` not covered
```

This is invisible to the full-workspace `--all-features` clippy (which enables `apollo_committer/os_input` too) and to real node builds (`apollo_node/os_input` enables both), which is why it hasn't surfaced until a PR changed a batcher-side crate alongside a committer-dependent one.

## Fix

Forward `os_input` to `apollo_committer` from both crates, matching the existing convention in `apollo_node` / `apollo_integration_tests`. This keeps `apollo_committer_types/os_input` and `apollo_committer/os_input` consistent whenever either crate is built with `--all-features`.

## Verification

`cargo check -p apollo_batcher -p apollo_dashboard --all-features` — previously E0004, now compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
