### PR TITLE
apollo_dashboard: fall back to vector(1) so no-data doesn't fire add_tx idle alerts

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -980,7 +980,7 @@
       "name": "gateway_add_tx_idle_p2p_rpc",
       "title": "Gateway add_tx idle (p2p+rpc)",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1240,7 +1240,7 @@
       "name": "http_server_no_successful_transactions",
       "title": "http server no successful transactions",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -1552,7 +1552,7 @@
       "name": "mempool_add_tx_idle_p2p_rpc",
       "title": "Mempool add_tx idle (p2p+rpc)",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/tps.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/tps.rs
@@ -30,8 +30,13 @@ fn build_idle_alert(
     metric_name_with_filter: &str,
     alert_severity: AlertSeverity,
 ) -> Alert {
+    // Fall back to `vector(1)`, not `vector(0)`, when the metric has no samples: a transient
+    // scrape/ingestion gap makes `increase` return empty, and `or vector(0)` would turn that into a
+    // hard `0` that trips `< 0.1` and false-pages even while tx ingestion is healthy. A real idle
+    // keeps the counter present, so `increase` yields a present `0` and still fires; a dead pod is
+    // caught by the `pod_state_*` alerts. The fallback must stay `>=` the idle threshold (`< 0.1`).
     let expr_template_string =
-        format!("sum(increase({}[{{}}s])) or vector(0)", metric_name_with_filter);
+        format!("sum(increase({}[{{}}s])) or vector(1)", metric_name_with_filter);
     Alert::new(
         alert_name,
         alert_title,


### PR DESCRIPTION
## Problem

At ~16:50 IDT on 2026-07-22 the p2 alert `apollo-sepolia-alpha-3-gateway_add_tx_idle_(p2p+rpc)` fired on Testnet, but the tx-rate panel showed no dip.

The three idle alerts built by `build_idle_alert` — `gateway_add_tx_idle_p2p_rpc` (p2), `mempool_add_tx_idle_p2p_rpc` (p1), `http_server_no_successful_transactions` (p5) — use:

```
sum(increase(<metric>[Ws])) or vector(0)   <   0.1   for 30s
```

A transient metric **scrape/ingestion gap** makes `increase(...)` return *empty*, and `or vector(0)` turns that into a hard **0**, which trips `< 0.1` and pages — even while tx ingestion is perfectly healthy.

## Evidence (apollo-sepolia-alpha-3, 2026-07-22 ~13:48–13:51 UTC)

- `count_over_time(gateway_transactions_received[1m])`: 36 → 18 → **absent 13:49–13:51** → 16 → 34 (a ~3-min scrape gap; counter caught up +404 at 13:51:30).
- `up{...gateway-pod-monitoring}` stayed `1`; the pod never restarted; RPC "Recorded transaction" logs were continuous (35 txs at 13:50).
- Backfilled data + `increase` interpolation now read ~230 tx/2min straight through the gap → the Grafana panel looks fine, which is why the false page is invisible after the fact.

So the pipeline was healthy; only the metric plane blipped, and `or vector(0)` converted "can't compute" into "exactly zero".

## Fix

Flip the shared helper's fallback `or vector(0)` → `or vector(1)` (`crates/apollo_dashboard/src/alert_scenarios/tps.rs`). An unscrapeable series reads as `1` (≥ the `0.1` threshold) → no page; a **real** idle keeps the counter present so `increase` returns a present `0` → still fires. Zero added latency.

This is the same fix already shipped for `consensus_block_number_stuck` (#14705, backport #14752) in `block_production_halt.rs`; it was never propagated to the `tps.rs` idle alerts.

## Verification

- Regenerated `dev_grafana_alerts.json` via `sequencer_dashboard_generator` — diff is exactly the three idle-alert expressions flipped `vector(0)` → `vector(1)`, nothing else.
- `SEED=0 cargo test -p apollo_dashboard` — 16 passed, 0 failed (incl. the `default_dev_grafana_dashboard` fixture round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)