### PR TITLE
apollo_gateway: stop auto-discovering bench helper as a bench target

### DIFF
--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -5,6 +5,11 @@ name = "apollo_gateway"
 repository.workspace = true
 version.workspace = true
 description = "Gateway component for receiving and validating transactions submitted to the Starknet sequencer."
+# The sole bench target is the explicit [[bench]] below (benches/main.rs, gated on the `testing`
+# feature). Disabling bench auto-discovery keeps benches/utils.rs — a helper module included by
+# benches/main.rs — from also being picked up as a standalone, feature-less bench target, which
+# breaks `cargo bench`/`cargo clippy --benches` when `testing` is not enabled.
+autobenches = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
benches/utils.rs is a helper module included by benches/main.rs (the explicit
[[bench]], gated on the `testing` feature). Cargo's bench auto-discovery also
picked utils.rs up as a standalone, feature-less bench target, so
`cargo bench`/`cargo clippy --benches` failed to compile it without
`--features testing` (it references apollo_gateway::test_utils). Set
autobenches = false so only the explicit [[bench]] is a bench target.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>