### PR TITLE
blockifier_test_utils: delete dead code (unsure, review carefully)

### DIFF
--- a/crates/blockifier_test_utils/src/cairo_compile.rs
+++ b/crates/blockifier_test_utils/src/cairo_compile.rs
@@ -5,7 +5,6 @@ use std::process::{Command, Output, Stdio};
 
 use apollo_infra_utils::cairo0_compiler::Cairo0Script;
 use apollo_infra_utils::cairo0_compiler_test_utils::verify_cairo0_compiler_deps;
-use apollo_infra_utils::cairo_compiler_version::CAIRO1_COMPILER_VERSION;
 use apollo_infra_utils::path::{project_path, resolve_project_relative_path};
 use tempfile::NamedTempFile;
 use tracing::info;
@@ -13,10 +12,6 @@ use tracing::info;
 pub enum CompilationArtifacts {
     Cairo0 { casm: Vec<u8> },
     Cairo1 { casm: Vec<u8>, sierra: Vec<u8> },
-}
-
-pub fn cairo1_compiler_tag() -> String {
-    format!("v{CAIRO1_COMPILER_VERSION}")
 }
 
 /// Path to local compiler package directory, of the specified version.

--- a/crates/blockifier_test_utils/src/contracts.rs
+++ b/crates/blockifier_test_utils/src/contracts.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
@@ -580,15 +579,6 @@ impl FeatureContract {
         Self::all_feature_contracts().filter(|contract| {
             matches!(contract.cairo_version(), CairoVersion::Cairo1(RunnableCairo1::Casm))
         })
-    }
-
-    pub fn all_cairo1_casm_compiler_versions() -> HashSet<CairoVersionString> {
-        Self::all_feature_contracts()
-            .filter(|contract| {
-                contract.cairo_version() == CairoVersion::Cairo1(RunnableCairo1::Casm)
-            })
-            .map(|contract| contract.fixed_version())
-            .collect()
     }
 }
 


### PR DESCRIPTION
> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

## What

Removes two unused `pub fn` helpers from `blockifier_test_utils` and their now-orphaned imports:

- `FeatureContract::all_cairo1_casm_compiler_versions` (`contracts.rs`) and the `use std::collections::HashSet;` it was the sole user of.
- `cairo1_compiler_tag` (`cairo_compile.rs`) and the `use apollo_infra_utils::cairo_compiler_version::CAIRO1_COMPILER_VERSION;` import it was the sole user of. (That symbol is still used elsewhere in `contracts.rs:310`, so the import there is retained.)

## Why these look dead

A workspace-wide grep for each identifier finds **only the definition site** — no callers in any crate, in `tests/`/`benches/`, or in the sibling repos `starkware-industries/sequencer-devops` and `starkware-industries/starkware`. Both are inherent `pub fn`s (not behind a trait, macro, `serde`, FFI, or reflection), so a textual grep fully captures their references.

## What a human must verify

`blockifier_test_utils` is a **test-utility crate whose `pub fn`s form its public API**. These two have no in-workspace or sibling-repo callers, but I cannot rule out an **external consumer** (e.g. another repository's test harness) that depends on `cairo1_compiler_tag` or `all_cairo1_casm_compiler_versions`. Please confirm no out-of-tree consumer relies on them before merging.

## Verification (local)

Env workarounds applied (`RUSTC_WRAPPER=`, `CARGO_INCREMENTAL=0`):

- `cargo build -p blockifier_test_utils` — clean, zero warnings.
- `cargo build -p blockifier_test_utils --tests` — clean, zero warnings.
- `cargo clippy -p blockifier_test_utils --all-targets` — clean.
- `SEED=0 cargo test -p blockifier_test_utils` — all tests pass.

> [!CAUTION]
> REVIEW WITH CARE! THIS PR REQUIRES CAREFUL HUMAN REVIEW.
> If you find this to be a false positive **comment in detail why this code should be kept** and **close the PR**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnZ828mqinFGRq7LVU9Km1)_