### PR TITLE
apollo_batcher: avoid a redundant AccessedKeys clone in decision_reached

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1897,8 +1897,10 @@ pub trait BatcherStorageWriter: Send + Sync {
         storage_commitment_block_hash: StorageCommitmentBlockHash,
     ) -> StorageResult<()>;
 
+    // clippy suggests eliding `'a`, but elision fails to compile under `#[automock]` (E0106 /
+    // E0637): the reference is nested inside `Option`, which the macro's codegen can't handle
+    // without a named lifetime.
     #[cfg(feature = "os_input")]
-    // The explicit lifetime is required by `#[automock]`'s codegen; it cannot use an elided one.
     #[allow(clippy::needless_lifetimes)]
     fn commit_proposal<'a>(
         &mut self,
@@ -1939,13 +1941,12 @@ pub trait BatcherStorageWriter: Send + Sync {
 }
 
 impl BatcherStorageWriter for StorageWriter {
-    #[allow(clippy::needless_lifetimes)]
-    fn commit_proposal<#[cfg(feature = "os_input")] 'a>(
+    fn commit_proposal(
         &mut self,
         height: BlockNumber,
         state_diff: ThinStateDiff,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
-        #[cfg(feature = "os_input")] accessed_keys: Option<&'a AccessedKeys>,
+        #[cfg(feature = "os_input")] accessed_keys: Option<&AccessedKeys>,
     ) -> StorageResult<()> {
         // TODO(AlonH): write casms.
         let mut txn = self.begin_rw_txn()?.append_state_diff(height, state_diff)?;

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -985,7 +985,7 @@ impl Batcher {
             block_execution_artifacts.execution_data.rejected_tx_hashes,
             StorageCommitmentBlockHash::Partial(partial_block_hash_components),
             #[cfg(feature = "os_input")]
-            Some(accessed_keys.clone()),
+            Some(&accessed_keys),
         )
         .await?;
 
@@ -1075,7 +1075,7 @@ impl Batcher {
         consumed_l1_handler_tx_hashes: IndexSet<TransactionHash>,
         rejected_tx_hashes: IndexSet<TransactionHash>,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
-        #[cfg(feature = "os_input")] accessed_keys: Option<AccessedKeys>,
+        #[cfg(feature = "os_input")] accessed_keys: Option<&AccessedKeys>,
     ) -> BatcherResult<()> {
         info!(
             "Committing block at height {} and notifying mempool & L1 event provider of the block.",
@@ -1898,12 +1898,14 @@ pub trait BatcherStorageWriter: Send + Sync {
     ) -> StorageResult<()>;
 
     #[cfg(feature = "os_input")]
-    fn commit_proposal(
+    // The explicit lifetime is required by `#[automock]`'s codegen; it cannot use an elided one.
+    #[allow(clippy::needless_lifetimes)]
+    fn commit_proposal<'a>(
         &mut self,
         height: BlockNumber,
         state_diff: ThinStateDiff,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
-        accessed_keys: Option<AccessedKeys>,
+        accessed_keys: Option<&'a AccessedKeys>,
     ) -> StorageResult<()>;
 
     fn revert_block(&mut self, height: BlockNumber);
@@ -1937,12 +1939,13 @@ pub trait BatcherStorageWriter: Send + Sync {
 }
 
 impl BatcherStorageWriter for StorageWriter {
-    fn commit_proposal(
+    #[allow(clippy::needless_lifetimes)]
+    fn commit_proposal<#[cfg(feature = "os_input")] 'a>(
         &mut self,
         height: BlockNumber,
         state_diff: ThinStateDiff,
         storage_commitment_block_hash: StorageCommitmentBlockHash,
-        #[cfg(feature = "os_input")] accessed_keys: Option<AccessedKeys>,
+        #[cfg(feature = "os_input")] accessed_keys: Option<&'a AccessedKeys>,
     ) -> StorageResult<()> {
         // TODO(AlonH): write casms.
         let mut txn = self.begin_rw_txn()?.append_state_diff(height, state_diff)?;
@@ -1959,7 +1962,7 @@ impl BatcherStorageWriter for StorageWriter {
         }
         #[cfg(feature = "os_input")]
         if let Some(accessed_keys) = accessed_keys {
-            txn = txn.append_accessed_keys(height, &accessed_keys)?;
+            txn = txn.append_accessed_keys(height, accessed_keys)?;
         }
         txn.commit()
     }


### PR DESCRIPTION
## Summary

Follow-up perf review of #14871 ("apollo_batcher: write accessed keys in the same storage transaction as the state diff").

That PR's `Batcher::decision_reached` builds the block's `AccessedKeys` once (a `BTreeSet`-based set of every storage/contract/class-trie leaf touched during block execution, sized proportionally to block activity) and then `.clone()`s it twice per committed block:
- once to pass into `commit_proposal_and_block` → `StorageWriter::commit_proposal`
- once to pass into `write_commitment_results_and_add_new_task` (which queues a commitment task that must own its copy across an async boundary)

Tracing the first path down to `append_accessed_keys` (`apollo_storage/src/accessed_keys.rs`) shows it only ever reads `&AccessedKeys` to serialize it — it never needs ownership. So the first clone was pure waste, executed once per committed block.

## Change

- `BatcherStorageWriter::commit_proposal` (trait + `StorageWriter` impl) and the internal `commit_proposal_and_block` helper now take `Option<&AccessedKeys>` instead of `Option<AccessedKeys>` for the `os_input`-gated accessed-keys parameter.
- The `decision_reached` call site passes `Some(&accessed_keys)` instead of `Some(accessed_keys.clone())`. The remaining clone (for the queued commitment task) and the final move into `DecisionReachedResponse` are unchanged — both still need to own their own copy.
- Because `BatcherStorageWriter` is `#[cfg_attr(test, automock)]`, the reference parameter needs a named lifetime rather than an elided one (elision fails under the macro's codegen with E0106/E0637, since the reference is nested inside `Option`). Added `#[allow(clippy::needless_lifetimes)]` with an explanatory comment on the trait method only — the `StorageWriter` impl isn't automocked and compiles fine with a plain elided lifetime.

## Verification

- `cargo clippy -p apollo_batcher --all-targets -- -D warnings` clean, both with `--features os_input` and with default features.
- `SEED=0 cargo test -p apollo_batcher` passes fully in both configurations (118 tests with `os_input`, 117 without).
- `scripts/rust_fmt.sh` clean.
- Independently reviewed by a separate agent pass, which confirmed the ownership/borrow-checker reasoning and the automock lifetime requirement, and suggested simplifying the impl side (applied here).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GhzkhQy6EF4Zffz9qyRdU3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhzkhQy6EF4Zffz9qyRdU3)_