### PR TITLE
starknet_committer,apollo_committer: avoid compressing state commitment infos twice per block

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -540,10 +540,7 @@ where
                     .await
                     .map_err(|error| self.map_internal_error_at_height(height, error))?
                     .ok_or(CommitterError::MissingPatriciaPaths { height })?;
-                Ok(ReadPathsAndCommitBlockResponse {
-                    global_root,
-                    state_commitment_infos: state_commitment_infos.compress()?,
-                })
+                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
             }
             // Flow overview:
             // 1. Fetch patricia paths for the accessed keys.
@@ -587,6 +584,9 @@ where
                     commitment_facts_count = state_commitment_infos.n_commitment_facts(),
                     deleted_nodes_count = deleted_nodes.len(),
                 );
+                // Compress once and reuse for both the DB write and the response, instead of
+                // compressing the (cloned) commitment infos twice.
+                let compressed_state_commitment_infos = state_commitment_infos.compress()?;
                 block_measurements.start_measurement(Action::Write);
                 let n_write_entries = self
                     .forest_storage
@@ -597,7 +597,7 @@ where
                         CommitmentInfosUpdate::Write(CommitmentInfosWrite {
                             block_number: height,
                             keys_digest: digest,
-                            commitment_infos: state_commitment_infos.clone(),
+                            commitment_infos: compressed_state_commitment_infos.clone(),
                         }),
                     )
                     .await
@@ -608,7 +608,7 @@ where
                 self.update_offset(next_offset);
                 Ok(ReadPathsAndCommitBlockResponse {
                     global_root,
-                    state_commitment_infos: state_commitment_infos.compress()?,
+                    state_commitment_infos: compressed_state_commitment_infos,
                 })
             }
         }

--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -534,13 +534,16 @@ where
                         expected: digest,
                     });
                 }
-                let state_commitment_infos = self
+                let compressed_state_commitment_infos = self
                     .forest_storage
                     .read_commitment_infos(height)
                     .await
                     .map_err(|error| self.map_internal_error_at_height(height, error))?
                     .ok_or(CommitterError::MissingPatriciaPaths { height })?;
-                Ok(ReadPathsAndCommitBlockResponse { global_root, state_commitment_infos })
+                Ok(ReadPathsAndCommitBlockResponse {
+                    global_root,
+                    state_commitment_infos: compressed_state_commitment_infos,
+                })
             }
             // Flow overview:
             // 1. Fetch patricia paths for the accessed keys.
@@ -584,10 +587,10 @@ where
                     commitment_facts_count = state_commitment_infos.n_commitment_facts(),
                     deleted_nodes_count = deleted_nodes.len(),
                 );
-                // Compress once and reuse for both the DB write and the response, instead of
-                // compressing the (cloned) commitment infos twice.
-                let compressed_state_commitment_infos = state_commitment_infos.compress()?;
                 block_measurements.start_measurement(Action::Write);
+                // The same compressed payload is persisted to the forest DB and returned to the
+                // caller, so it's computed once here rather than once per consumer.
+                let compressed_state_commitment_infos = state_commitment_infos.compress()?;
                 let n_write_entries = self
                     .forest_storage
                     .write_with_metadata_and_commitment_infos(

--- a/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
+++ b/crates/apollo_committer/src/request_paths_and_commit_block_tests.rs
@@ -35,6 +35,7 @@ use starknet_committer::patricia_merkle_tree::types::{
     class_hash_into_node_index,
     CommitmentInfo,
     CompiledClassHash as CommitterCompiledClassHash,
+    CompressedStateCommitmentInfos,
     StateCommitmentInfos,
 };
 use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
@@ -295,7 +296,7 @@ fn verify_witness_patricia_paths(
 async fn assert_witnesses_and_digest_present(
     committer: &mut ApolloTestCommitter,
     height: BlockNumber,
-    expected_commitment_infos: &StateCommitmentInfos,
+    expected_commitment_infos: &CompressedStateCommitmentInfos,
 ) {
     assert_eq!(
         committer.load_witnesses_digest(height).await.unwrap(),
@@ -372,8 +373,12 @@ async fn read_paths_and_commit_block_happy_flow() {
     let replay_response = committer.read_paths_and_commit_block(request).await.unwrap();
     assert_eq!(response.global_root, replay_response.global_root);
     assert_eq!(commitment_infos, decompress_response_commitment_infos(&replay_response));
-    assert_witnesses_and_digest_present(&mut committer, BlockNumber(height), &commitment_infos)
-        .await;
+    assert_witnesses_and_digest_present(
+        &mut committer,
+        BlockNumber(height),
+        &response.state_commitment_infos,
+    )
+    .await;
 }
 
 /// Flow overview:
@@ -402,7 +407,7 @@ async fn revert_removes_witnesses_and_digest() {
     assert_witnesses_and_digest_present(
         &mut committer,
         BlockNumber(height_1),
-        &decompress_response_commitment_infos(&block_1_response),
+        &block_1_response.state_commitment_infos,
     )
     .await;
 

--- a/crates/starknet_committer/src/db/forest_trait_witnesses.rs
+++ b/crates/starknet_committer/src/db/forest_trait_witnesses.rs
@@ -19,13 +19,13 @@ use crate::forest::deleted_nodes::DeletedNodes;
 use crate::forest::filled_forest::FilledForest;
 use crate::forest::forest_errors::ForestResult;
 use crate::patricia_merkle_tree::tree::SortedLeafIndices;
-use crate::patricia_merkle_tree::types::{StarknetForestProofs, StateCommitmentInfos};
+use crate::patricia_merkle_tree::types::{CompressedStateCommitmentInfos, StarknetForestProofs};
 
 /// The information required to write the OS-input commitment infos to the database.
 pub struct CommitmentInfosWrite {
     pub block_number: BlockNumber,
     pub keys_digest: [u8; 32],
-    pub commitment_infos: StateCommitmentInfos,
+    pub commitment_infos: CompressedStateCommitmentInfos,
 }
 
 /// Commitment-infos DB operation, which can be either delete or write.
@@ -36,7 +36,7 @@ pub enum CommitmentInfosUpdate {
     Delete(BlockNumber),
 }
 
-/// Reads the committed OS-input commitment infos ([`StateCommitmentInfos`]) for a block height.
+/// Reads the committed OS-input commitment infos (compressed, as stored) for a block height.
 #[async_trait]
 pub trait ForestReaderWithWitnesses:
     ForestReader<InitialReadContext: EmptyInitialReadContext> + Send
@@ -44,7 +44,7 @@ pub trait ForestReaderWithWitnesses:
     async fn read_commitment_infos(
         &mut self,
         height: BlockNumber,
-    ) -> ForestResult<Option<StateCommitmentInfos>>;
+    ) -> ForestResult<Option<CompressedStateCommitmentInfos>>;
 
     /// Fetches Patricia witness paths for OS input, optionally staging serialized trie node KVs on
     /// an in-memory overlay so reads match post-commit state before the forest is persisted.

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -371,8 +371,7 @@ impl<S: Storage + ImmutableReadOnlyStorage + Sync + Send + 'static> ForestReader
     ) -> ForestResult<Option<CompressedStateCommitmentInfos>> {
         let db_key = DbKey(block_number_based_key(&PATRICIA_PATHS_PREFIX, DbBlockNumber(height)));
 
-        // Stored pre-compressed; return as-is instead of decompressing just to have the caller
-        // recompress it for the response.
+        // Values are stored already compressed; return them as-is.
         Ok(self
             .get_from_storage(db_key)
             .await?

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -24,8 +24,6 @@ use starknet_patricia_storage::storage_trait::AsyncStorage;
 use starknet_patricia_storage::storage_trait::DbOperation;
 #[cfg(feature = "os_input")]
 use starknet_patricia_storage::storage_trait::ImmutableReadOnlyStorage;
-#[cfg(feature = "os_input")]
-use starknet_patricia_storage::storage_trait::PatriciaStorageError;
 use starknet_patricia_storage::storage_trait::{
     DbHashMap,
     DbKey,
@@ -74,8 +72,6 @@ use crate::db::index_db::types::{
 use crate::db::serde_db_utils::DbBlockNumber;
 use crate::forest::deleted_nodes::DeletedNodes;
 use crate::forest::filled_forest::FilledForest;
-#[cfg(feature = "os_input")]
-use crate::forest::forest_errors::ForestError;
 use crate::forest::forest_errors::ForestResult;
 use crate::forest::original_skeleton_forest::{ForestSortedIndices, OriginalSkeletonForest};
 use crate::hash_function::hash::TreeHashFunctionImpl;
@@ -84,11 +80,7 @@ use crate::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 use crate::patricia_merkle_tree::tree::{fetch_all_patricia_paths, SortedLeafIndices};
 use crate::patricia_merkle_tree::types::CompiledClassHash;
 #[cfg(feature = "os_input")]
-use crate::patricia_merkle_tree::types::{
-    CompressedStateCommitmentInfos,
-    StarknetForestProofs,
-    StateCommitmentInfos,
-};
+use crate::patricia_merkle_tree::types::{CompressedStateCommitmentInfos, StarknetForestProofs};
 
 /// Set to 2^251 + 1 to avoid collisions with contract addresses prefixes.
 pub(crate) static FIRST_AVAILABLE_PREFIX_FELT: LazyLock<Felt> =
@@ -376,19 +368,15 @@ impl<S: Storage + ImmutableReadOnlyStorage + Sync + Send + 'static> ForestReader
     async fn read_commitment_infos(
         &mut self,
         height: BlockNumber,
-    ) -> ForestResult<Option<StateCommitmentInfos>> {
+    ) -> ForestResult<Option<CompressedStateCommitmentInfos>> {
         let db_key = DbKey(block_number_based_key(&PATRICIA_PATHS_PREFIX, DbBlockNumber(height)));
 
-        Ok(match self.get_from_storage(db_key).await? {
-            None => None,
-            Some(DbValue(bytes)) => {
-                Some(CompressedStateCommitmentInfos(bytes).decompress().map_err(|e| {
-                    ForestError::PatriciaStorage(PatriciaStorageError::Deserialization(
-                        DeserializationError::ValueError(Box::new(e)),
-                    ))
-                })?)
-            }
-        })
+        // Stored pre-compressed; return as-is instead of decompressing just to have the caller
+        // recompress it for the response.
+        Ok(self
+            .get_from_storage(db_key)
+            .await?
+            .map(|DbValue(bytes)| CompressedStateCommitmentInfos(bytes)))
     }
 
     async fn fetch_patricia_witnesses(
@@ -463,7 +451,7 @@ impl<S: Storage + Send> ForestWriterWithMetadataAndWitnesses for IndexDb<S> {
                 keys_digest,
                 commitment_infos,
             }) => {
-                let encoded = DbValue(commitment_infos.compress()?.0);
+                let encoded = DbValue(commitment_infos.0);
                 operations.insert(
                     Self::metadata_key(ForestMetadataType::AccessedKeysDigest(DbBlockNumber(
                         block_number,

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -11,8 +11,6 @@ use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
 };
 use starknet_patricia::patricia_merkle_tree::node_data::leaf::SkeletonLeaf;
 use starknet_patricia::patricia_merkle_tree::types::{NodeIndex, SubTreeHeight};
-#[cfg(feature = "os_input")]
-use starknet_patricia_storage::errors::SerializationError;
 use starknet_types_core::felt::{Felt, FromStrError};
 
 use crate::block_committer::input::{try_node_index_into_contract_address, StarknetStorageValue};
@@ -104,18 +102,6 @@ pub enum StateCommitmentInfosCodecError {
     Bincode(#[from] bincode::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
-}
-
-#[cfg(feature = "os_input")]
-impl From<StateCommitmentInfosCodecError> for SerializationError {
-    fn from(error: StateCommitmentInfosCodecError) -> Self {
-        match error {
-            StateCommitmentInfosCodecError::Bincode(error) => {
-                SerializationError::IOSerialize(std::io::Error::other(error))
-            }
-            StateCommitmentInfosCodecError::Io(error) => SerializationError::IOSerialize(error),
-        }
-    }
 }
 
 /// The compressed form of [`StateCommitmentInfos`]. Serializes as a base64 string.


### PR DESCRIPTION
## Summary

Follow-up performance fix to #14884 ("compress state commitment infos"), which introduced `CompressedStateCommitmentInfos` so the committer's OS-input witness data travels compressed across the batcher/orchestrator/storage boundaries instead of as a large JSON-serialized structure.

That PR left two redundant-work paths in `Committer::read_paths_and_commit_block` (`crates/apollo_committer/src/committer.rs`):

- **CommitTip branch (new block commits)**: `state_commitment_infos` was compressed *twice* per committed block — once via a full clone fed into `write_with_metadata_and_commitment_infos` (which internally compressed it again to persist to the forest DB), and once more directly for the RPC response. This PR compresses once and reuses the (much cheaper to clone) compressed bytes for both the DB write and the response.
- **Historical/replay branch**: `read_commitment_infos` decompressed the already-compressed bytes read from storage into a full `StateCommitmentInfos`, only for the caller to immediately recompress them for the response — a pure decompress+recompress round trip on data that was never touched in between. `ForestReaderWithWitnesses::read_commitment_infos` now returns `CompressedStateCommitmentInfos` directly (a raw byte passthrough from storage), skipping decompression on this path entirely.

Also: `CommitmentInfosWrite.commitment_infos` changed from `StateCommitmentInfos` to `CompressedStateCommitmentInfos`, so `IndexDb::write_with_metadata_and_commitment_infos` stores the bytes as-is instead of compressing them itself. Removed the now-unreachable `From<StateCommitmentInfosCodecError> for SerializationError` impl whose only caller was the deleted internal `compress()` call.

An Opus review pass confirmed the change is behavior-preserving (same bytes to DB, same bytes in the response) and flagged one metric-semantics nuance, which is addressed by keeping `compress()` inside the `Action::Write` measurement window so write-latency metrics stay comparable to before.

## Test plan

- [x] `cargo check -p starknet_committer -p apollo_committer -p apollo_committer_types` with and without `--features os_input,testing`
- [x] `cargo test -p starknet_committer -p apollo_committer --features os_input,testing` — 129 + 14 tests pass
- [x] `cargo clippy -p starknet_committer -p apollo_committer -p apollo_committer_types --features os_input,testing --all-targets -- -D warnings` — clean
- [x] `scripts/rust_fmt.sh --check` — no diff

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QdQH5898m3XVzEUPq94aRZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdQH5898m3XVzEUPq94aRZ)_