### PR TITLE
starknet_committer: buffer streamed compress/decompress for state commitment infos

### DIFF
--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -141,8 +141,11 @@ impl<'de> Deserialize<'de> for CompressedStateCommitmentInfos {
 impl CompressedStateCommitmentInfos {
     /// Reverses [`StateCommitmentInfos::compress`]: streams the zstd-decompressed bytes straight
     /// into bincode deserialization, without materializing the decompressed payload in full.
+    ///
+    /// Bincode reads one small field at a time; without buffering, each of those reads would
+    /// otherwise turn into a separate call into the zstd decompressor.
     pub fn decompress(&self) -> Result<StateCommitmentInfos, StateCommitmentInfosCodecError> {
-        let decoder = zstd::Decoder::new(self.0.as_slice())?;
+        let decoder = std::io::BufReader::new(zstd::Decoder::new(self.0.as_slice())?);
         Ok(bincode::deserialize_from(decoder)?)
     }
 }
@@ -153,13 +156,16 @@ impl StateCommitmentInfos {
     ///
     /// Bincode encodes each hash-map as an 8-byte length followed by its entries, and each `Felt`
     /// as an 8-byte length followed by its value, so the payload is dominated by leading zeros
-    /// that zstd compresses efficiently.
+    /// that zstd compresses efficiently. Bincode also writes one small field at a time, so the
+    /// stream is buffered before reaching the encoder to avoid a separate zstd call per field.
     #[cfg(feature = "os_input")]
     pub fn compress(
         &self,
     ) -> Result<CompressedStateCommitmentInfos, StateCommitmentInfosCodecError> {
-        let mut encoder = zstd::Encoder::new(Vec::new(), zstd::DEFAULT_COMPRESSION_LEVEL)?;
-        bincode::serialize_into(&mut encoder, self)?;
+        let encoder = zstd::Encoder::new(Vec::new(), zstd::DEFAULT_COMPRESSION_LEVEL)?;
+        let mut buffered_encoder = std::io::BufWriter::new(encoder);
+        bincode::serialize_into(&mut buffered_encoder, self)?;
+        let encoder = buffered_encoder.into_inner().map_err(std::io::IntoInnerError::into_error)?;
         Ok(CompressedStateCommitmentInfos(encoder.finish()?))
     }
 

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -139,15 +139,17 @@ impl<'de> Deserialize<'de> for CompressedStateCommitmentInfos {
 
 #[cfg(feature = "os_input")]
 impl CompressedStateCommitmentInfos {
-    /// Reverses [`StateCommitmentInfos::compress`]: zstd-decompresses then bincode-deserializes.
+    /// Reverses [`StateCommitmentInfos::compress`]: streams the zstd-decompressed bytes straight
+    /// into bincode deserialization, without materializing the decompressed payload in full.
     pub fn decompress(&self) -> Result<StateCommitmentInfos, StateCommitmentInfosCodecError> {
-        let bincode_payload = zstd::decode_all(self.0.as_slice())?;
-        Ok(bincode::deserialize(&bincode_payload)?)
+        let decoder = zstd::Decoder::new(self.0.as_slice())?;
+        Ok(bincode::deserialize_from(decoder)?)
     }
 }
 
 impl StateCommitmentInfos {
-    /// Bincode-serializes and zstd-compresses the commitment infos.
+    /// Bincode-serializes and zstd-compresses the commitment infos, streaming the bincode output
+    /// directly into the zstd encoder so the uncompressed payload is never fully materialized.
     ///
     /// Bincode encodes each hash-map as an 8-byte length followed by its entries, and each `Felt`
     /// as an 8-byte length followed by its value, so the payload is dominated by leading zeros
@@ -156,11 +158,9 @@ impl StateCommitmentInfos {
     pub fn compress(
         &self,
     ) -> Result<CompressedStateCommitmentInfos, StateCommitmentInfosCodecError> {
-        let bincode_payload = bincode::serialize(self)?;
-        Ok(CompressedStateCommitmentInfos(zstd::encode_all(
-            bincode_payload.as_slice(),
-            zstd::DEFAULT_COMPRESSION_LEVEL,
-        )?))
+        let mut encoder = zstd::Encoder::new(Vec::new(), zstd::DEFAULT_COMPRESSION_LEVEL)?;
+        bincode::serialize_into(&mut encoder, self)?;
+        Ok(CompressedStateCommitmentInfos(encoder.finish()?))
     }
 
     /// Builds the commitment infos directly from the pre- and post-commit state roots and the


### PR DESCRIPTION
## Summary

Automated performance follow-up, scoped to the `CompressedStateCommitmentInfos` codec introduced in #14884 (which reached `main` around the same time as the branch-sync #14883 that triggered this review).

`StateCommitmentInfos::compress()` / `CompressedStateCommitmentInfos::decompress()` previously buffered the full uncompressed bincode payload in an intermediate `Vec<u8>` before/after feeding it to zstd. This runs once per block on the committer↔batcher critical path, and the payload is exactly the data #14884 needed to compress in the first place because it was large enough to blow past the RPC response cap.

This PR streams bincode serialization directly into a zstd encoder (and zstd-decompressed bytes directly into bincode deserialization), wrapped in `BufWriter`/`BufReader` so bincode's small per-field writes/reads are coalesced before crossing into zstd's FFI layer.

Net effect, measured with a tracking allocator on realistic payloads (~18.8 MB uncompressed):
- Peak allocation: compress 23.1 MB → 7.1 MB, decompress 96.1 MB → 62.7 MB
- Speed: ~24% faster compress, ~5% faster decompress vs. the original buffered implementation
- Compressed output is byte-identical to the original implementation (verified both directions: old-format frames decode via the new path and vice versa), so on-disk data written by the original code stays readable.

## Test plan
- [x] `cargo test -p starknet_committer --features os_input` — 129 passed
- [x] `cargo test -p apollo_committer --features os_input` — 14 passed (round-trips through `compress()`/`decompress()` via `read_paths_and_commit_block_happy_flow`, `revert_removes_witnesses_and_digest`, etc.)
- [x] `cargo test -p apollo_storage --features os_input state_commitment_infos` — 2 passed
- [x] `cargo clippy -p starknet_committer --features os_input --all-targets -- -D warnings` — clean
- [x] `scripts/rust_fmt.sh --check` — clean
- [x] Reviewed by an independent Opus pass, which verified correctness (byte-identical round-trip, no panics, matching bincode configs) and identified that the naive streaming version alone was actually a memory-for-CPU tradeoff — the `BufWriter`/`BufReader` wrapping in this PR was added specifically to address that and make it an unambiguous win.

## Note
This is scoped to the codec itself. The review also surfaced a pre-existing, higher-severity issue outside this diff's scope: `echonet/os_input_builder.py` still does `json.loads()` on what is now a bincode-encoded payload (a consequence of #14884), which will break echonet OS runs — flagging separately rather than fixing here since it's unrelated to this optimization.

---

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Azjd9mgAfziDXPxxdKmXso)_