### PR TITLE
apollo_storage,apollo_batcher_types,apollo_batcher: add commitment infos height offset query

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1553,6 +1553,14 @@ impl Batcher {
         })
     }
 
+    #[cfg(feature = "os_input")]
+    pub fn get_state_commitment_infos_height_offset(&self) -> BatcherResult<Option<BlockNumber>> {
+        self.storage_reader.state_commitment_infos_height_offset().map_err(|err| {
+            error!("Failed to get state commitment infos height offset from storage: {err}");
+            BatcherError::InternalError
+        })
+    }
+
     fn get_commitment_results_and_write_to_storage(&mut self) -> BatcherResult<()> {
         self.commitment_manager
             .get_commitment_results_and_write_to_storage(
@@ -1758,6 +1766,10 @@ pub trait BatcherStorageReader: Send + Sync {
         height: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
 
+    /// Returns one past the latest height, or `None` when no commitment infos are stored.
+    #[cfg(feature = "os_input")]
+    fn state_commitment_infos_height_offset(&self) -> StorageResult<Option<BlockNumber>>;
+
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
         height: BlockNumber,
@@ -1858,6 +1870,11 @@ impl BatcherStorageReader for StorageReader {
         height: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>> {
         self.begin_ro_txn()?.get_state_commitment_infos(height)
+    }
+
+    #[cfg(feature = "os_input")]
+    fn state_commitment_infos_height_offset(&self) -> StorageResult<Option<BlockNumber>> {
+        self.begin_ro_txn()?.get_state_commitment_infos_height_offset()
     }
 
     fn get_parent_hash_and_partial_block_hash_components(

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -31,6 +31,12 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
                     self.get_state_commitment_infos(block_number),
                 )
             }
+            #[cfg(feature = "os_input")]
+            BatcherRequest::GetStateCommitmentInfosHeightOffset => {
+                BatcherResponse::GetStateCommitmentInfosHeightOffset(
+                    self.get_state_commitment_infos_height_offset(),
+                )
+            }
             BatcherRequest::GetCurrentHeight => {
                 BatcherResponse::GetCurrentHeight(self.get_height().await)
             }

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -63,6 +63,12 @@ pub trait BatcherClient: Send + Sync {
         &self,
         block_number: BlockNumber,
     ) -> BatcherClientResult<Option<CompressedStateCommitmentInfos>>;
+    /// Gets the batcher's commitment infos height offset: one past the latest stored block.
+    /// Returns `Ok(None)` when no commitment infos are stored.
+    #[cfg(feature = "os_input")]
+    async fn get_state_commitment_infos_height_offset(
+        &self,
+    ) -> BatcherClientResult<Option<BlockNumber>>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -122,6 +128,8 @@ pub enum BatcherRequest {
     GetBlockHash(BlockNumber),
     #[cfg(feature = "os_input")]
     GetStateCommitmentInfos(BlockNumber),
+    #[cfg(feature = "os_input")]
+    GetStateCommitmentInfosHeightOffset,
     GetProposalContent(GetProposalContentInput),
     ValidateBlock(ValidateBlockInput),
     AbortProposal(ProposalId),
@@ -150,6 +158,8 @@ pub enum BatcherResponse {
     GetBlockHash(BatcherResult<BlockHash>),
     #[cfg(feature = "os_input")]
     GetStateCommitmentInfos(BatcherResult<Option<CompressedStateCommitmentInfos>>),
+    #[cfg(feature = "os_input")]
+    GetStateCommitmentInfosHeightOffset(BatcherResult<Option<BlockNumber>>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -215,6 +225,22 @@ where
             request,
             BatcherResponse,
             GetStateCommitmentInfos,
+            BatcherClientError,
+            BatcherError,
+            Direct
+        )
+    }
+
+    #[cfg(feature = "os_input")]
+    async fn get_state_commitment_infos_height_offset(
+        &self,
+    ) -> BatcherClientResult<Option<BlockNumber>> {
+        let request = BatcherRequest::GetStateCommitmentInfosHeightOffset;
+        handle_all_response_variants!(
+            self,
+            request,
+            BatcherResponse,
+            GetStateCommitmentInfosHeightOffset,
             BatcherClientError,
             BatcherError,
             Direct

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -10,7 +10,7 @@ pub use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitme
 mod state_commitment_infos_test;
 
 use crate::db::serialization::{StorageSerde, StorageSerdeError};
-use crate::db::table_types::Table;
+use crate::db::table_types::{DbCursorTrait, Table};
 use crate::db::{TransactionKind, RW};
 use crate::{OffsetKind, StorageResult, StorageTransaction};
 
@@ -32,6 +32,10 @@ pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
+
+    /// Returns the commitment infos height offset: one past the latest stored block.
+    /// Returns `None` when no commitment infos are stored.
+    fn get_state_commitment_infos_height_offset(&self) -> StorageResult<Option<BlockNumber>>;
 }
 
 /// Interface for writing the OS-input commitment infos to storage.
@@ -63,6 +67,18 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
             return Ok(None);
         };
         Ok(Some(self.file_handlers().get_state_commitment_infos_unchecked(location)?))
+    }
+
+    fn get_state_commitment_infos_height_offset(&self) -> StorageResult<Option<BlockNumber>> {
+        let table = self.open_table(&self.tables().state_commitment_infos)?;
+        let mut cursor = table.cursor(self.txn())?;
+        // Returns the block number one past the latest stored block.
+        let latest_entry = match cursor.lower_bound(&BlockNumber(u32::MAX.into()))? {
+            Some(entry) => Some(entry),
+            None => cursor.prev()?,
+        };
+        Ok(latest_entry
+            .map(|(latest_block_number, _location)| latest_block_number.unchecked_next()))
     }
 }
 

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -65,3 +65,43 @@ fn revert_state_commitment_infos() {
         .commit()
         .unwrap();
 }
+
+#[test]
+fn get_state_commitment_infos_height_offset() {
+    let (reader, mut writer) = get_test_storage().0;
+
+    // No commitment infos stored yet.
+    assert_eq!(
+        reader.begin_ro_txn().unwrap().get_state_commitment_infos_height_offset().unwrap(),
+        None
+    );
+
+    for height in [BlockNumber(5), BlockNumber(6)] {
+        writer
+            .begin_rw_txn()
+            .unwrap()
+            .append_state_commitment_infos(height, &dummy_state_commitment_infos())
+            .unwrap()
+            .commit()
+            .unwrap();
+    }
+
+    // The offset is one past the latest stored height.
+    assert_eq!(
+        reader.begin_ro_txn().unwrap().get_state_commitment_infos_height_offset().unwrap(),
+        Some(BlockNumber(7))
+    );
+
+    // Reverting the latest stored height moves the offset back.
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .revert_state_commitment_infos(BlockNumber(6))
+        .unwrap()
+        .commit()
+        .unwrap();
+    assert_eq!(
+        reader.begin_ro_txn().unwrap().get_state_commitment_infos_height_offset().unwrap(),
+        Some(BlockNumber(6))
+    );
+}


### PR DESCRIPTION
Expose the batcher's state commitment infos height offset (one past the
latest stored height, None when nothing is stored), backed by a storage
cursor over the state_commitment_infos table.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>