### PR TITLE
apollo_consensus_orchestrator,apollo_dashboard: add metric for last state commitment infos sent

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -52,6 +52,8 @@ use url::Url;
 
 use crate::dynamic_gas_price::FeeProposalInfo;
 use crate::fee_market::FeeMarketInfo;
+#[cfg(feature = "os_input")]
+use crate::metrics::CENDE_LAST_STATE_COMMITMENT_INFOS_BLOCK_NUMBER;
 use crate::metrics::{
     record_write_failure,
     CendeWriteFailureReason,
@@ -388,6 +390,12 @@ async fn send_write_blob(request_builder: RequestBuilder, blob: &AerospikeBlob) 
                 );
                 print_write_blob_response(response).await;
                 CENDE_WRITE_BLOB_SUCCESS.increment(1);
+                #[cfg(feature = "os_input")]
+                if let Some(last_state_commitment_infos) = blob.recent_state_commitment_infos.last()
+                {
+                    CENDE_LAST_STATE_COMMITMENT_INFOS_BLOCK_NUMBER
+                        .set_lossy(last_state_commitment_infos.block_number.0);
+                }
                 true
             } else {
                 warn!(

--- a/crates/apollo_consensus_orchestrator/src/metrics.rs
+++ b/crates/apollo_consensus_orchestrator/src/metrics.rs
@@ -27,6 +27,7 @@ define_metrics!(
         // TODO(dvir): add a counter for successful blob writes and failed blob writes.
         MetricHistogram { CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY, "cende_write_prev_height_blob_latency", "Be careful with this metric, if the blob was already written by another request, the latency is much lower since writing to Aerospike is not needed." },
         MetricCounter { CENDE_WRITE_BLOB_SUCCESS , "cende_write_blob_success", "The number of successful blob writes to Aerospike", init = 0 },
+        MetricGauge { CENDE_LAST_STATE_COMMITMENT_INFOS_BLOCK_NUMBER, "cende_last_state_commitment_infos_block_number", "The block number of the most recent state commitment infos sent" },
         LabeledMetricCounter { CENDE_WRITE_BLOB_FAILURE , "cende_write_blob_failure", "The number of failed blob writes to Aerospike", init = 0, labels = CENDE_WRITE_BLOB_FAILURE_REASON },
 
         // Proposal build failure metrics
@@ -105,6 +106,7 @@ pub(crate) fn register_metrics() {
     CENDE_PREPARE_BLOB_FOR_NEXT_HEIGHT_LATENCY.register();
     CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY.register();
     CENDE_WRITE_BLOB_SUCCESS.register();
+    CENDE_LAST_STATE_COMMITMENT_INFOS_BLOCK_NUMBER.register();
     CENDE_WRITE_BLOB_FAILURE.register();
     CONSENSUS_BUILD_PROPOSAL_FAILURE.register();
     CONSENSUS_VALIDATE_PROPOSAL_FAILURE.register();

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -600,7 +600,6 @@ impl SequencerConsensusContext {
                 error!("Failed to collect recent state commitment infos at height {height}: {e:?}");
                 Vec::new()
             });
-        // TODO(Yoav): Add metrics for most recent state commitment infos sent.
 
         if let Err(e) = self
             .deps

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -371,6 +371,15 @@
           }
         },
         {
+          "title": "Last State Commitment Infos Block Number",
+          "description": "The block number of the most recent state commitment infos sent",
+          "type": "stat",
+          "exprs": [
+            "cende_last_state_commitment_infos_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "Write Preconfirmed Block Success",
           "description": "The number of successful writes to Cende for preconfirmed blocks (10m window). Each preconfirmed block may involve multiple writes.",
           "type": "timeseries",

--- a/crates/apollo_dashboard/src/panels/consensus.rs
+++ b/crates/apollo_dashboard/src/panels/consensus.rs
@@ -47,6 +47,7 @@ use apollo_consensus_manager::metrics::{
 };
 use apollo_consensus_orchestrator::metrics::{
     CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER,
+    CENDE_LAST_STATE_COMMITMENT_INFOS_BLOCK_NUMBER,
     CENDE_WRITE_BLOB_FAILURE,
     CENDE_WRITE_BLOB_SUCCESS,
     CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY,
@@ -332,6 +333,15 @@ fn get_panel_cende_last_prepared_blob_block_number() -> Panel {
         PanelType::Stat,
     )
     .with_log_query("Blob for block number")
+}
+
+fn get_panel_cende_last_state_commitment_infos_block_number() -> Panel {
+    Panel::new(
+        "Last State Commitment Infos Block Number",
+        "The block number of the most recent state commitment infos sent",
+        CENDE_LAST_STATE_COMMITMENT_INFOS_BLOCK_NUMBER.get_name_with_filter().to_string(),
+        PanelType::Stat,
+    )
 }
 
 fn get_panel_cende_write_prev_height_blob_latency() -> Panel {
@@ -716,6 +726,7 @@ pub(crate) fn get_cende_row() -> Row {
             get_panel_cende_write_blob_failure(),
             get_panel_cende_write_prev_height_blob_latency(),
             get_panel_cende_last_prepared_blob_block_number(),
+            get_panel_cende_last_state_commitment_infos_block_number(),
             get_panel_cende_write_preconfirmed_block(),
             get_panel_cende_write_preconfirmed_block_failure(),
         ],


### PR DESCRIPTION
apollo_dashboard: make native compilation alert severity env-configurable (#14893)

* workspace: emit line-tables-only debuginfo in dev profile (#14877)

Adds `[profile.dev] debug = "line-tables-only"` to keep panic/backtrace
file:line and tracing call-site info while dropping the full DWARF
variable/type info that dominates codegen time, linker memory, and
target/ disk. A `dev-debug` profile (`cargo build --profile dev-debug`)
restores full debug info on demand.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* apollo_dashboard: make native compilation alert severity env-configurable

Replaces the hardcoded p4 severity with a per-environment placeholder, so
testnet and integration can run this alert at p5 while mainnet keeps p4.
Persists the manual override applied in starkware-envs-integration#2648.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

* revert unwanted file

---------

Co-authored-by: Avi Cohen <avi.cohen@starkware.co>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

apollo_consensus_orchestrator,apollo_dashboard: add metric for last state commitment infos sent