### PR TITLE
deployments,ci: publish an os_input feature-variant sequencer image

### DIFF
--- a/.github/workflows/sequencer_docker-publish.yml
+++ b/.github/workflows/sequencer_docker-publish.yml
@@ -12,6 +12,15 @@ on:
           - release
           - debug
           - profiling
+      image_tag:
+        description: >
+          Publish under this exact tag (the os_input variant gets it with a -os-input suffix),
+          e.g. the short SHA of the main commit whose code this build matches. Must not already
+          exist, to avoid replacing a published image. Leave empty to publish only the
+          branch-scoped dispatch tags.
+        required: false
+        default: ""
+        type: string
   push:
     tags:
       - "v*.*.*"
@@ -62,6 +71,9 @@ jobs:
             type=sha,prefix=,format=short,enable=${{ startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
             # Manual workflow dispatch
             type=raw,value={{branch}}{{tag}}-{{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
+            # Explicit tag for a dispatch, so a build whose code matches a main commit can
+            # be published as <main-short-sha> for downstream consumers to pin.
+            type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
 
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
@@ -74,3 +86,31 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: BUILD_MODE=${{ inputs.build_mode || 'release' }}
+
+      # os_input feature-variant image, published alongside every tag under a `-os-input`
+      # suffix; consumed by the starkware repo's apollo cende system test until os_input
+      # becomes the default build.
+      - name: Extract Docker metadata (os_input variant)
+        id: meta-os-input
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}/sequencer
+          tags: |
+            type=raw,enable=${{ startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }},value={{tag}},suffix=-os-input
+            type=sha,prefix=,format=short,suffix=-os-input,enable=${{ startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
+            type=raw,value={{branch}}{{tag}}-{{sha}}-os-input,enable=${{ github.event_name == 'workflow_dispatch' }}
+            # Explicit tag for a dispatch, so a build whose code matches a main commit can be
+            # published as <main-short-sha>-os-input for downstream consumers to pin.
+            type=raw,value=${{ inputs.image_tag }},suffix=-os-input,enable=${{ inputs.image_tag != '' }}
+
+      - name: Build and push Docker image (os_input variant)
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        with:
+          context: .
+          file: deployments/images/sequencer/Dockerfile
+          push: true
+          tags: ${{ steps.meta-os-input.outputs.tags }}
+          labels: ${{ steps.meta-os-input.outputs.labels }}
+          build-args: |
+            BUILD_MODE=${{ inputs.build_mode || 'release' }}
+            CARGO_FEATURES=cairo_native,os_input

--- a/deployments/images/sequencer/Dockerfile
+++ b/deployments/images/sequencer/Dockerfile
@@ -19,6 +19,10 @@ WORKDIR /app
 ARG BUILD_MODE=release
 ENV BUILD_MODE=${BUILD_MODE}
 
+# Comma-separated cargo features for the apollo_node build; extended (e.g. with os_input) to
+# publish feature-variant images without affecting the default build.
+ARG CARGO_FEATURES=cairo_native
+
 # Validate BUILD_MODE value.
 RUN if [ "$BUILD_MODE" != "release" ] && [ "$BUILD_MODE" != "debug" ] && [ "$BUILD_MODE" != "profiling" ]; then \
         echo "Error: BUILD_MODE must be 'release', 'debug', or 'profiling' (got '$BUILD_MODE')" >&2; \
@@ -35,7 +39,7 @@ RUN BUILD_FLAGS=""; \
     elif [ "$BUILD_MODE" = "profiling" ]; then \
         BUILD_FLAGS="--profile profiling"; \
     fi; \
-    cargo build $BUILD_FLAGS --bin apollo_node --features cairo_native
+    cargo build $BUILD_FLAGS --bin apollo_node --features "$CARGO_FEATURES"
 
 # Install compiler binaries used for Sierra compilation at runtime.
 # Binaries land under $CARGO_TOOLS_ROOT/<binary>-<version>/bin/<binary>; the


### PR DESCRIPTION
## What

Adds a `CARGO_FEATURES` build-arg to the sequencer Dockerfile (default `cairo_native`, so the default image is unchanged) and a second publish step that builds the same Dockerfile with `cairo_native,os_input`, tagged with a `-os-input` suffix alongside every existing tag.

## Why

The starkware repo's apollo cende system test needs a node that produces **OS witnesses** (`recent_state_commitment_infos`) in its cende blobs, so the witness pipeline can be validated end-to-end *before* `os_input` becomes the sequencer's default build. Today no published image has the feature enabled, so that test cannot run against merged code.

With this, the systest pins `<sequencer_commit_main()>-os-input` and validates witnesses continuously; when `os_input` becomes the default, the consumer drops the suffix and this step can be deleted.

## Notes

- Default builds are byte-identical in behavior: `--features "$CARGO_FEATURES"` with the arg defaulting to `cairo_native`.
- The dispatch-only `os_input_image_tag` input lets a manual run publish the variant under an explicit tag (e.g. the short SHA of the main commit whose code the build matches), which is how the first image was produced for the consumer PR before this lands.
- Cost: roughly doubles this workflow's build time on tag pushes (a second full cargo build; chef caching does not carry across the feature change).

## Verification

- `cargo check -p apollo_node --features cairo_native,os_input` clean on current main.
- An image built exactly this way (main's code + `CARGO_FEATURES=cairo_native,os_input`) ran a full apollo cende system test on k3d: node produced 3000+ blocks, the python recorder stored witnesses for every one, and the newest payloads decoded (base64 → zstd → bincode) with Patricia roots chaining across consecutive blocks.