### PR TITLE
apollo_committer: restore lazy log formatting for per-block commit stats

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -770,33 +770,54 @@ fn log_block_measurements(
     #[cfg(not(feature = "os_input"))]
     let witness_log = String::new();
 
-    let stats = format!(
-        "Block {height} stats: durations in ms (total/read/compute/write): \
-         {:.0}/{:.0}/{:.0}/{:.0}, total block duration per modification in µs: {}, rates in \
-         entries/sec (read/compute/write): {}/{}/{}, modifications count \
-         (storage_tries/contracts_trie/classes_trie/emptied_storage_leaves): {}/{}/{}/{}{}, \
-         {witness_log}",
-        durations.block * 1000.0,
-        durations.read * 1000.0,
-        durations.compute * 1000.0,
-        durations.write * 1000.0,
-        total_block_duration_per_modification.map_or(String::new(), |d| format!("{d:.0}µs")),
-        read_rate.map_or(String::new(), |r| format!("{r:.0}")),
-        compute_rate.map_or(String::new(), |r| format!("{r:.0}")),
-        write_rate.map_or(String::new(), |r| format!("{r:.0}")),
-        modifications_counts.storage_tries,
-        modifications_counts.contracts_trie,
-        modifications_counts.classes_trie,
-        modifications_counts.emptied_storage_leaves,
-        emptied_leaves_percentage.map_or(String::new(), |p| format!(" ({p:.2}%)")),
-        witness_log = witness_log,
-    );
-
     // A slow committer eventually stalls consensus (proposer waits on the N-10 hash).
     let threshold_millis = commit_duration_warn_threshold.as_millis();
+    // The format arguments are duplicated across both branches (rather than pre-formatted once
+    // into a `stats` string) so tracing's per-callsite level check can skip formatting them
+    // entirely when neither branch's level is enabled; this runs on every committed block.
     if Duration::from_secs_f64(durations.block) > commit_duration_warn_threshold {
-        warn!("{stats}, block commit duration above the {threshold_millis} ms warn threshold");
+        warn!(
+            "Block {height} stats: durations in ms (total/read/compute/write): \
+             {:.0}/{:.0}/{:.0}/{:.0}, total block duration per modification in µs: {}, rates in \
+             entries/sec (read/compute/write): {}/{}/{}, modifications count \
+             (storage_tries/contracts_trie/classes_trie/emptied_storage_leaves): {}/{}/{}/{}{}, \
+             {witness_log}, block commit duration above the {threshold_millis} ms warn threshold",
+            durations.block * 1000.0,
+            durations.read * 1000.0,
+            durations.compute * 1000.0,
+            durations.write * 1000.0,
+            total_block_duration_per_modification.map_or(String::new(), |d| format!("{d:.0}µs")),
+            read_rate.map_or(String::new(), |r| format!("{r:.0}")),
+            compute_rate.map_or(String::new(), |r| format!("{r:.0}")),
+            write_rate.map_or(String::new(), |r| format!("{r:.0}")),
+            modifications_counts.storage_tries,
+            modifications_counts.contracts_trie,
+            modifications_counts.classes_trie,
+            modifications_counts.emptied_storage_leaves,
+            emptied_leaves_percentage.map_or(String::new(), |p| format!(" ({p:.2}%)")),
+            witness_log = witness_log,
+        );
     } else {
-        debug!("{stats}");
+        debug!(
+            "Block {height} stats: durations in ms (total/read/compute/write): \
+             {:.0}/{:.0}/{:.0}/{:.0}, total block duration per modification in µs: {}, rates in \
+             entries/sec (read/compute/write): {}/{}/{}, modifications count \
+             (storage_tries/contracts_trie/classes_trie/emptied_storage_leaves): {}/{}/{}/{}{}, \
+             {witness_log}",
+            durations.block * 1000.0,
+            durations.read * 1000.0,
+            durations.compute * 1000.0,
+            durations.write * 1000.0,
+            total_block_duration_per_modification.map_or(String::new(), |d| format!("{d:.0}µs")),
+            read_rate.map_or(String::new(), |r| format!("{r:.0}")),
+            compute_rate.map_or(String::new(), |r| format!("{r:.0}")),
+            write_rate.map_or(String::new(), |r| format!("{r:.0}")),
+            modifications_counts.storage_tries,
+            modifications_counts.contracts_trie,
+            modifications_counts.classes_trie,
+            modifications_counts.emptied_storage_leaves,
+            emptied_leaves_percentage.map_or(String::new(), |p| format!(" ({p:.2}%)")),
+            witness_log = witness_log,
+        );
     }
 }

--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -760,45 +760,21 @@ fn log_block_measurements(
     commit_duration_warn_threshold: Duration,
     #[cfg(feature = "os_input")] fetched_witnesses_count: usize,
 ) {
-    #[cfg(feature = "os_input")]
-    let witness_log = format!(
-        "witness fetch ms (pre-commit/post-commit): {:.0}/{:.0}, witness entries: {}",
-        durations.fetch_witnesses_first_pass * 1000.0,
-        durations.fetch_witnesses_second_pass * 1000.0,
-        fetched_witnesses_count,
-    );
-    #[cfg(not(feature = "os_input"))]
-    let witness_log = String::new();
-
-    // A slow committer eventually stalls consensus (proposer waits on the N-10 hash).
-    let threshold_millis = commit_duration_warn_threshold.as_millis();
-    // The format arguments are duplicated across both branches (rather than pre-formatted once
-    // into a `stats` string) so tracing's per-callsite level check can skip formatting them
-    // entirely when neither branch's level is enabled; this runs on every committed block.
-    if Duration::from_secs_f64(durations.block) > commit_duration_warn_threshold {
-        warn!(
-            "Block {height} stats: durations in ms (total/read/compute/write): \
-             {:.0}/{:.0}/{:.0}/{:.0}, total block duration per modification in µs: {}, rates in \
-             entries/sec (read/compute/write): {}/{}/{}, modifications count \
-             (storage_tries/contracts_trie/classes_trie/emptied_storage_leaves): {}/{}/{}/{}{}, \
-             {witness_log}, block commit duration above the {threshold_millis} ms warn threshold",
-            durations.block * 1000.0,
-            durations.read * 1000.0,
-            durations.compute * 1000.0,
-            durations.write * 1000.0,
-            total_block_duration_per_modification.map_or(String::new(), |d| format!("{d:.0}µs")),
-            read_rate.map_or(String::new(), |r| format!("{r:.0}")),
-            compute_rate.map_or(String::new(), |r| format!("{r:.0}")),
-            write_rate.map_or(String::new(), |r| format!("{r:.0}")),
-            modifications_counts.storage_tries,
-            modifications_counts.contracts_trie,
-            modifications_counts.classes_trie,
-            modifications_counts.emptied_storage_leaves,
-            emptied_leaves_percentage.map_or(String::new(), |p| format!(" ({p:.2}%)")),
-            witness_log = witness_log,
+    // Building the message is deferred to a closure, invoked from inside the warn!/debug! macro
+    // args, so tracing's per-callsite level check can skip formatting entirely (this runs on
+    // every committed block, and only one of the two branches below is ever enabled at a time).
+    let format_block_stats = || {
+        #[cfg(feature = "os_input")]
+        let witness_log = format!(
+            "witness fetch ms (pre-commit/post-commit): {:.0}/{:.0}, witness entries: {}",
+            durations.fetch_witnesses_first_pass * 1000.0,
+            durations.fetch_witnesses_second_pass * 1000.0,
+            fetched_witnesses_count,
         );
-    } else {
-        debug!(
+        #[cfg(not(feature = "os_input"))]
+        let witness_log = String::new();
+
+        format!(
             "Block {height} stats: durations in ms (total/read/compute/write): \
              {:.0}/{:.0}/{:.0}/{:.0}, total block duration per modification in µs: {}, rates in \
              entries/sec (read/compute/write): {}/{}/{}, modifications count \
@@ -817,7 +793,17 @@ fn log_block_measurements(
             modifications_counts.classes_trie,
             modifications_counts.emptied_storage_leaves,
             emptied_leaves_percentage.map_or(String::new(), |p| format!(" ({p:.2}%)")),
-            witness_log = witness_log,
+        )
+    };
+
+    // A slow committer eventually stalls consensus (proposer waits on the N-10 hash).
+    if Duration::from_secs_f64(durations.block) > commit_duration_warn_threshold {
+        warn!(
+            "{}, block commit duration above the {} ms warn threshold",
+            format_block_stats(),
+            commit_duration_warn_threshold.as_millis(),
         );
+    } else {
+        debug!("{}", format_block_stats());
     }
 }

--- a/crates/apollo_committer/src/committer_test.rs
+++ b/crates/apollo_committer/src/committer_test.rs
@@ -337,5 +337,6 @@ async fn no_warn_when_block_commit_within_duration_threshold() {
     let mut committer = new_test_committer().await;
     committer.config.commit_duration_warn_threshold_millis = Duration::from_secs(3600);
     committer.commit_block(commit_block_request(1, Some(1), 0)).await.unwrap();
+    assert!(logs_contain("Block 0 stats"));
     assert!(!logs_contain("block commit duration above the"));
 }


### PR DESCRIPTION
## Summary

Follow-up performance fix for #14888, which added a `commit_duration_warn_threshold_millis`-based WARN log to `log_block_measurements` (`crates/apollo_committer/src/committer.rs`). That change pre-built the block-stats message via a bare `let stats = format!(...)` *before* passing it into `warn!(...)`/`debug!(...)`.

`log_block_measurements` runs once per committed block, on the committer's block-finalization path (a slow committer stalls consensus, per the existing comment). `tracing`'s `debug!`/`warn!` macros are designed to be zero-cost when a level is disabled: the callsite's "interest" is checked *before* any of the macro's format arguments are evaluated, so formatting work is skipped entirely when that level isn't active. Building the message with a standalone `format!()` outside of the macro call defeats that — it unconditionally does the string formatting (5+ nested `format!` calls for optional fields) on every single block, even when the subscriber is at INFO level and neither branch will actually emit a line.

## Fix

- Moved the message formatting into a `format_block_stats` closure invoked from inside the `warn!`/`debug!` macro args, restoring the callsite-interest laziness (only one of the two branches runs per call, and its formatting only happens if that level is enabled).
- This also happens to make the pre-existing `witness_log` formatting (under the `os_input` feature) lazy for the same reason.
- Net removal of duplicate code vs. formatting the message twice (once per branch).
- Strengthened `no_warn_when_block_commit_within_duration_threshold` to also assert the debug branch actually emits a log line (previously it only asserted the *absence* of the warn suffix).

## Test plan

- [x] `cargo build -p apollo_committer`
- [x] `SEED=0 cargo test -p apollo_committer` — 12/12 passed, including both duration-threshold tests
- [x] `cargo clippy -p apollo_committer --all-targets` — clean
- [x] `scripts/rust_fmt.sh` — no diff
- [x] Reviewed by an independent Opus pass, which verified the duplicated-then-deduped log message is byte-identical to the original and found no blocking issues

---
_Generated by [Claude Code](https://claude.ai/code/session_015xrdV4ZumpSc3gni9gj7XH)_