### PR TITLE
apollo_node_config: remove stale allow(dead_code)

### DIFF
--- a/crates/apollo_node_config/src/version.rs
+++ b/crates/apollo_node_config/src/version.rs
@@ -13,7 +13,6 @@ const VERSION_PATCH: u32 = 0;
 
 /// Version metadata to append to the version string.
 /// Expected values are `dev` and `stable`.
-#[allow(dead_code)]
 const VERSION_META: Metadata = Metadata::Dev;
 
 /// Textual version string.
@@ -21,7 +20,6 @@ pub const VERSION: &str = version_str();
 /// Textual version string including the metadata.
 pub const VERSION_FULL: &str = full_version_str();
 
-#[allow(dead_code)]
 const DEV_VERSION_META: &str = "dev";
 #[allow(dead_code)]
 const STABLE_VERSION_META: &str = "stable";


### PR DESCRIPTION
## What

Removes two stale `#[allow(dead_code)]` annotations in `crates/apollo_node_config/src/version.rs`, on the `VERSION_META` and `DEV_VERSION_META` constants. Both constants are **live** — only the annotations are removed. No behavior change.

## Why they're stale (reachable from a live `pub` root)

`pub const VERSION_FULL = full_version_str()` is a public constant consumed across the workspace:
- `apollo_node/src/components.rs:512`
- `apollo_node_config/src/node_config.rs:666`
- `apollo_state_sync/src/runner/mod.rs`

`full_version_str()` is a `const fn` that:
- matches on `VERSION_META` (`version.rs:43`), and
- references `DEV_VERSION_META` in the `Metadata::Dev` arm (`version.rs:44`).

So both constants are reachable from a live public root; dead-code analysis does not flag them and the annotations are stale.

## Annotations intentionally KEPT (genuinely dead in the default build — load-bearing)

These are **not** removed because the items are dead in the default build (only reachable from tests); removing their annotations reintroduces `dead_code`/`never constructed` warnings:
- `STABLE_VERSION_META` — only referenced from `metadata_str` (`version.rs:53`).
- `metadata_str` — only called from `version_test.rs` (test-only).
- `Metadata` enum / `Metadata::Stable` variant — `Stable` is only matched, never constructed in non-test code (`VERSION_META == Metadata::Dev`).

## Verification (`RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)

- `scripts/rust_fmt.sh` — clean (diff unchanged: 2 deletions)
- `cargo build -p apollo_node_config` — **zero** dead_code warnings (default cfg)
- `cargo build -p apollo_node_config --tests` — **zero** dead_code warnings (tests cfg)
- `cargo clippy -p apollo_node_config --all-targets` — clean (exit 0)
- `SEED=0 cargo test -p apollo_node_config` — 20 passed, 0 failed

## Note

This supersedes the auto-staled #14397 (closed by the stale bot without review), which removed only the `VERSION_META` annotation; this PR additionally removes the equally-stale `DEV_VERSION_META` annotation, leaving the crate with zero dead-code warnings in both cfgs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmBwfZrf99QffVxgQA1VA)_