### PR TITLE
starknet_committer: allocate decompress buffer from zstd frame header size

### DIFF
--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -143,8 +143,8 @@ impl CompressedStateCommitmentInfos {
     ///
     /// The one-shot compressor writes the decompressed size into the frame header, so the output
     /// buffer is allocated to that exact size up front instead of growing incrementally while
-    /// streaming the frame. Falls back to streaming decode if the size is absent, which should
-    /// not happen for frames produced by [`StateCommitmentInfos::compress`].
+    /// streaming the frame. Entries written before the compressor became one-shot carry no size in
+    /// their header, so those fall back to streaming decode.
     pub fn decompress(&self) -> Result<StateCommitmentInfos, StateCommitmentInfosCodecError> {
         let decompressed_size = zstd::zstd_safe::get_frame_content_size(&self.0)
             .ok()

--- a/crates/starknet_committer/src/patricia_merkle_tree/types.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types.rs
@@ -140,8 +140,20 @@ impl<'de> Deserialize<'de> for CompressedStateCommitmentInfos {
 #[cfg(feature = "os_input")]
 impl CompressedStateCommitmentInfos {
     /// Reverses [`StateCommitmentInfos::compress`]: zstd-decompresses then bincode-deserializes.
+    ///
+    /// The one-shot compressor writes the decompressed size into the frame header, so the output
+    /// buffer is allocated to that exact size up front instead of growing incrementally while
+    /// streaming the frame. Falls back to streaming decode if the size is absent, which should
+    /// not happen for frames produced by [`StateCommitmentInfos::compress`].
     pub fn decompress(&self) -> Result<StateCommitmentInfos, StateCommitmentInfosCodecError> {
-        let bincode_payload = zstd::decode_all(self.0.as_slice())?;
+        let decompressed_size = zstd::zstd_safe::get_frame_content_size(&self.0)
+            .ok()
+            .flatten()
+            .and_then(|size| usize::try_from(size).ok());
+        let bincode_payload = match decompressed_size {
+            Some(size) => zstd::bulk::decompress(&self.0, size)?,
+            None => zstd::decode_all(self.0.as_slice())?,
+        };
         Ok(bincode::deserialize(&bincode_payload)?)
     }
 }

--- a/crates/starknet_committer/src/patricia_merkle_tree/types_test.rs
+++ b/crates/starknet_committer/src/patricia_merkle_tree/types_test.rs
@@ -53,6 +53,24 @@ fn test_compressed_state_commitment_infos_frame_header_declares_decompressed_siz
     assert_eq!(compressed.decompress().unwrap(), commitment_infos);
 }
 
+/// Entries written before `compress` became one-shot carry no decompressed size in their frame
+/// header; they must still decompress.
+#[cfg(feature = "os_input")]
+#[test]
+fn test_decompress_frame_without_declared_decompressed_size() {
+    let commitment_infos = StateCommitmentInfos::default();
+    let streamed_frame = CompressedStateCommitmentInfos(
+        zstd::encode_all(
+            bincode::serialize(&commitment_infos).unwrap().as_slice(),
+            zstd::DEFAULT_COMPRESSION_LEVEL,
+        )
+        .unwrap(),
+    );
+
+    assert_eq!(zstd::zstd_safe::get_frame_content_size(&streamed_frame.0).unwrap(), None);
+    assert_eq!(streamed_frame.decompress().unwrap(), commitment_infos);
+}
+
 #[test]
 fn test_compressed_state_commitment_infos_json_form_is_base64_string() {
     let compressed = CompressedStateCommitmentInfos(vec![40, 181, 47, 253, 0, 88]);


### PR DESCRIPTION
## Summary

Follow-up perf optimization to #14906, which switched `StateCommitmentInfos::compress()` from streaming `zstd::encode_all` to one-shot `zstd::bulk::compress`. That PR's own doc comment noted the point of the change was that a one-shot frame's header carries the decompressed size, "letting consumers allocate the output buffer without reading the frame" — but the corresponding `CompressedStateCommitmentInfos::decompress()` was left on the old streaming path (`zstd::decode_all`), which grows its output `Vec` incrementally instead of using that known size.

This PR completes the symmetric optimization:
- Read the decompressed size from the frame header via `zstd::zstd_safe::get_frame_content_size`.
- When present, decompress directly into a single pre-sized allocation with `zstd::bulk::decompress(&self.0, size)`.
- Fall back to the original streaming `zstd::decode_all` when the size is absent (e.g. entries written to the DB before #14906, when compression was still streamed and frames didn't declare a content size) — this keeps old DB entries readable.

`compress`/`decompress` run once per block on the commit read/write path (`crates/starknet_committer/src/db/index_db/db.rs`, `crates/apollo_committer/src/committer.rs`), so this avoids reallocation-and-copy overhead from incremental buffer growth during decompression on every block.

## Review notes

An independent review verified:
- `zstd::bulk::decompress` never truncates on a too-small capacity — it returns an `Err`, correctly propagated as `StateCommitmentInfosCodecError::Io`.
- Legacy (pre-#14906) streamed frames report `Ok(None)` from `get_frame_content_size` and correctly take the fallback path (added test coverage for this).
- The only non-test caller of `decompress()` reads bytes this same process wrote to its own DB, so the payload isn't adversarial/network-controlled input; no allocation cap was added for that reason.

## Test plan
- [x] `cargo build -p starknet_committer --features os_input`
- [x] `SEED=0 cargo test -p starknet_committer --features os_input` (131 passed, including a new test for the pre-#14906 streamed-frame fallback and the existing frame-header-size test)
- [x] `cargo clippy -p starknet_committer --features os_input --all-targets` (clean)
- [x] `scripts/rust_fmt.sh` (clean)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01B3F8WUqu3Wbw8ZiV9tZH8t

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3F8WUqu3Wbw8ZiV9tZH8t)_