### PR TITLE
starknet_committer_and_os_cli: add rust-to-python serde python-test variants for commitment infos and state maps

### DIFF
--- a/crates/starknet_committer_and_os_cli/src/committer_cli/tests/python_tests.rs
+++ b/crates/starknet_committer_and_os_cli/src/committer_cli/tests/python_tests.rs
@@ -21,7 +21,12 @@ use starknet_committer::hash_function::hash::{
 };
 use starknet_committer::patricia_merkle_tree::leaf::leaf_impl::ContractState;
 use starknet_committer::patricia_merkle_tree::tree::OriginalSkeletonTrieConfig;
-use starknet_committer::patricia_merkle_tree::types::CompiledClassHash;
+use starknet_committer::patricia_merkle_tree::types::{
+    CommitmentInfo,
+    CompiledClassHash,
+    CompressedStateCommitmentInfos,
+    StateCommitmentInfos,
+};
 use starknet_patricia::patricia_merkle_tree::filled_tree::node::FilledNode;
 use starknet_patricia::patricia_merkle_tree::node_data::inner_node::{
     BinaryData,
@@ -68,6 +73,8 @@ pub enum CommitterPythonTestRunner {
     TreeHeightComparison,
     SerializeForRustCommitterFlowTest,
     ComputeHashSingleTree,
+    StateCommitmentInfosSerialize,
+    CompressedStateCommitmentInfosDecompress,
     MaybePanic,
     LogError,
 }
@@ -106,6 +113,10 @@ impl TryFrom<String> for CommitterPythonTestRunner {
             "compare_tree_height" => Ok(Self::TreeHeightComparison),
             "serialize_to_rust_committer_flow_test" => Ok(Self::SerializeForRustCommitterFlowTest),
             "tree_test" => Ok(Self::ComputeHashSingleTree),
+            "state_commitment_infos_serialize_test" => Ok(Self::StateCommitmentInfosSerialize),
+            "compressed_state_commitment_infos_decompress_test" => {
+                Ok(Self::CompressedStateCommitmentInfosDecompress)
+            }
             "maybe_panic" => Ok(Self::MaybePanic),
             "log_error" => Ok(Self::LogError),
             _ => Err(PythonTestError::UnknownTestName(value)),
@@ -180,6 +191,10 @@ impl PythonTestRunner for CommitterPythonTestRunner {
                 .await;
                 // 3. Serialize and return output.
                 Ok(output)
+            }
+            Self::StateCommitmentInfosSerialize => state_commitment_infos_serialize_test(),
+            Self::CompressedStateCommitmentInfosDecompress => {
+                compressed_state_commitment_infos_decompress_test(Self::non_optional_input(input)?)
             }
             Self::MaybePanic => {
                 let is_panic: bool = serde_json::from_str(Self::non_optional_input(input)?)?;
@@ -678,6 +693,61 @@ async fn test_storage_node(data: HashMap<String, String>) -> CommitterPythonTest
 
     // Serialize the storage to a JSON string and handle serialization errors.
     Ok(serde_json::to_string(&rust_fact_storage)?)
+}
+
+/// Deterministic values, mirrored by `EXPECTED_STATE_COMMITMENT_INFOS` in the python
+/// serialization test.
+fn python_test_state_commitment_infos() -> StateCommitmentInfos {
+    let commitment_info =
+        |previous_root: u128, updated_root: u128, commitment_facts| CommitmentInfo {
+            previous_root: HashOutput(Felt::from(previous_root)),
+            updated_root: HashOutput(Felt::from(updated_root)),
+            tree_height: SubTreeHeight::ACTUAL_HEIGHT,
+            commitment_facts,
+        };
+    // A zero and a >16-byte felt exercise the variable-length felt encoding of the compressed
+    // (bincode) form.
+    let contracts_trie_facts = HashMap::from([(
+        HashOutput(Felt::from(0x30_u128)),
+        vec![
+            Felt::from(0x40_u128),
+            Felt::ZERO,
+            Felt::from_hex_unchecked("0x123456789abcdef0123456789abcdef0123456789abcdef"),
+        ],
+    )]);
+    let storage_trie_facts =
+        HashMap::from([(HashOutput(Felt::from(0x70_u128)), vec![Felt::from(0x80_u128)])]);
+    StateCommitmentInfos {
+        contracts_trie_commitment_info: commitment_info(1, 2, contracts_trie_facts),
+        classes_trie_commitment_info: commitment_info(3, 4, HashMap::new()),
+        storage_tries_commitment_infos: HashMap::from([
+            (ContractAddress::from(0x1234_u128), commitment_info(5, 6, storage_trie_facts)),
+            (ContractAddress::from(0x5678_u128), commitment_info(7, 8, HashMap::new())),
+        ]),
+    }
+}
+
+/// Serializes a deterministic [`StateCommitmentInfos`] in both its wire forms: plain JSON and
+/// compressed (base64 of zstd of bincode).
+fn state_commitment_infos_serialize_test() -> CommitterPythonTestResult {
+    let state_commitment_infos = python_test_state_commitment_infos();
+    let compressed = serde_json::to_value(state_commitment_infos.compress().map_err(|error| {
+        PythonTestError::SpecificError(CommitterSpecificTestError::Serialization(error.into()))
+    })?)?;
+    Ok(serde_json::to_string(&json!({
+        "state_commitment_infos": state_commitment_infos,
+        "compressed": compressed,
+    }))?)
+}
+
+/// Deserializes a compressed [`StateCommitmentInfos`] from its base64 wire form, decompresses it
+/// and returns the plain JSON form.
+fn compressed_state_commitment_infos_decompress_test(input: &str) -> CommitterPythonTestResult {
+    let compressed: CompressedStateCommitmentInfos = serde_json::from_str(input)?;
+    let state_commitment_infos = compressed.decompress().map_err(|error| {
+        PythonTestError::SpecificError(CommitterSpecificTestError::Serialization(error.into()))
+    })?;
+    Ok(serde_json::to_string(&state_commitment_infos)?)
 }
 
 /// Generates a dummy random filled forest and serializes it to a JSON string.

--- a/crates/starknet_committer_and_os_cli/src/os_cli/tests/python_tests.rs
+++ b/crates/starknet_committer_and_os_cli/src/os_cli/tests/python_tests.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+
+use blockifier::state::cached_state::StateMaps;
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::state::StorageKey;
 use starknet_os::test_utils::errors::OsSpecificTestError;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::Blake2Felt252;
@@ -11,6 +16,7 @@ pub enum OsPythonTestRunner {
     AggregatorInputDeserialization,
     OsInputDeserialization,
     EncodeFelts,
+    StateMapsSerialize,
 }
 
 // Implements conversion from a string to the test runner.
@@ -22,6 +28,7 @@ impl TryFrom<String> for OsPythonTestRunner {
             "aggregator_input_deserialization" => Ok(Self::AggregatorInputDeserialization),
             "os_input_deserialization" => Ok(Self::OsInputDeserialization),
             "encode_felts" => Ok(Self::EncodeFelts),
+            "state_maps_serialize_test" => Ok(Self::StateMapsSerialize),
             _ => Err(PythonTestError::UnknownTestName(value)),
         }
     }
@@ -41,8 +48,39 @@ impl PythonTestRunner for OsPythonTestRunner {
                 let felts: Vec<Felt> = serde_json::from_str(Self::non_optional_input(input)?)?;
                 Ok(format!("{:?}", Blake2Felt252::encode_felts_to_u32s(&felts)))
             }
+            Self::StateMapsSerialize => state_maps_serialize_test(),
         }
     }
+}
+
+/// Serializes a deterministic blockifier [`StateMaps`] (the wire form of the block's
+/// initial reads), mirrored by `test_state_maps_serde` in the python rust_vm_os_test.
+fn state_maps_serialize_test() -> OsPythonTestResult {
+    let first_contract = ContractAddress::from(0x1234_u128);
+    let second_contract = ContractAddress::from(0x5678_u128);
+    let first_class_hash = ClassHash(Felt::from(0xAA_u128));
+    let second_class_hash = ClassHash(Felt::from(0xBB_u128));
+    let state_maps = StateMaps {
+        nonces: HashMap::from([
+            (first_contract, Nonce(Felt::from(0x1_u128))),
+            (second_contract, Nonce(Felt::from(0x0_u128))),
+        ]),
+        class_hashes: HashMap::from([
+            (first_contract, first_class_hash),
+            (second_contract, second_class_hash),
+        ]),
+        storage: HashMap::from([
+            ((first_contract, StorageKey::from(0x1_u128)), Felt::from(0x64_u128)),
+            ((first_contract, StorageKey::from(0x2_u128)), Felt::from(0xC8_u128)),
+            ((second_contract, StorageKey::from(0x3_u128)), Felt::from(0x12C_u128)),
+        ]),
+        compiled_class_hashes: HashMap::from([(
+            first_class_hash,
+            CompiledClassHash(Felt::from(0xA00_u128)),
+        )]),
+        declared_contracts: HashMap::from([(first_class_hash, true), (second_class_hash, false)]),
+    };
+    Ok(serde_json::to_string(&state_maps)?)
 }
 
 /// Deserialize the OS input string into an `OsInput` struct.


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>