### PR TITLE
blockifier: avoid double-cloning initial reads in get_os_initial_reads

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -303,15 +303,24 @@ impl<S: StateReader> CachedState<S> {
         // Back-fill write-only storage cells so their pre-block values are part of the initial
         // reads.
         self.update_initial_values_of_write_only_access()?;
-        let raw_initial_reads = self.get_initial_reads()?;
+        // Collect only the keys needed below, instead of cloning the entire (potentially large)
+        // initial-reads map twice per block.
+        let (contract_addresses, declared_class_hashes) = {
+            let cache = self.cache.borrow();
+            let initial_reads = &cache.initial_reads;
+            (
+                initial_reads.get_contract_addresses(),
+                initial_reads.declared_contracts.keys().copied().collect::<Vec<_>>(),
+            )
+        };
         // Force-read the contract-trie and class-trie leaves so their pre-block values are cached
         // in the initial reads.
-        for contract_address in raw_initial_reads.get_contract_addresses() {
+        for contract_address in contract_addresses {
             self.get_class_hash_at(contract_address)?;
             self.get_nonce_at(contract_address)?;
         }
-        for class_hash in raw_initial_reads.declared_contracts.keys() {
-            self.get_compiled_class_hash(*class_hash)?;
+        for class_hash in declared_class_hashes {
+            self.get_compiled_class_hash(class_hash)?;
         }
         let mut os_initial_reads = self.get_initial_reads()?;
         os_initial_reads.declared_contracts.clear();

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -305,7 +305,7 @@ impl<S: StateReader> CachedState<S> {
         self.update_initial_values_of_write_only_access()?;
         // Collect only the keys needed below, instead of cloning the entire (potentially large)
         // initial-reads map twice per block.
-        let (contract_addresses, declared_class_hashes) = {
+        let (contract_addresses, accessed_class_hashes) = {
             let cache = self.cache.borrow();
             let initial_reads = &cache.initial_reads;
             (
@@ -319,7 +319,7 @@ impl<S: StateReader> CachedState<S> {
             self.get_class_hash_at(contract_address)?;
             self.get_nonce_at(contract_address)?;
         }
-        for class_hash in declared_class_hashes {
+        for class_hash in accessed_class_hashes {
             self.get_compiled_class_hash(class_hash)?;
         }
         let mut os_initial_reads = self.get_initial_reads()?;


### PR DESCRIPTION
## Summary

Follow-up performance optimization on #14911, which introduced `OsInitialReadsCollection` to make OS-initial-reads collection opt-out for reexecution.

`CachedState::get_os_initial_reads` runs once per block during block finalization in production (`os_input` feature, used by `apollo_batcher`). It previously called `self.get_initial_reads()` — a full deep clone of the `StateMaps` struct (five `HashMap`s: `nonces`, `class_hashes`, `storage`, `compiled_class_hashes`, `declared_contracts`) — **twice**: once purely to derive two small key collections (accessed contract addresses and accessed class hashes) needed to drive the force-read loop, and again at the end for the actual return value.

The `storage` map in particular can hold thousands of entries per block, so the first clone was pure wasted work — it never even touched the storage values, only needed derived key sets.

This change computes the two derived collections (`HashSet<ContractAddress>`, `Vec<ClassHash>`) from a borrowed reference to the cache instead, dropping the borrow before the force-read loop runs (which needs `&mut self`), and removes the first full clone entirely. The second clone (needed for the final, updated result) is unchanged.

## Test plan
- [x] `cargo build -p blockifier --features os_input`
- [x] `SEED=0 cargo test -p blockifier --features os_input --lib state::cached_state` (43 passed)
- [x] `SEED=0 cargo test -p blockifier --features os_input --lib transaction_executor` (47 passed)
- [x] Reviewed by an independent agent for correctness (no double-borrow / `RefCell` panic risk, behavior parity verified against pre-change code) and style; no blocking or suggestion-level issues found


---
_Generated by [Claude Code](https://claude.ai/code/session_012Sq6TBm8eS6vgrhnop6uVT)_