### PR TITLE
apollo_storage,apollo_batcher,apollo_batcher_types,apollo_consensus_orchestrator: avoid full blob read for state commitment infos existence check

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1553,6 +1553,14 @@ impl Batcher {
         })
     }
 
+    #[cfg(feature = "os_input")]
+    pub fn has_state_commitment_infos(&self, block_number: BlockNumber) -> BatcherResult<bool> {
+        self.storage_reader.has_state_commitment_infos(block_number).map_err(|err| {
+            error!("Failed to check state commitment infos existence in storage: {err}");
+            BatcherError::InternalError
+        })
+    }
+
     fn get_commitment_results_and_write_to_storage(&mut self) -> BatcherResult<()> {
         self.commitment_manager
             .get_commitment_results_and_write_to_storage(
@@ -1758,6 +1766,11 @@ pub trait BatcherStorageReader: Send + Sync {
         height: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
 
+    /// Returns whether the state commitment infos for the given height are stored, without
+    /// reading the stored blob.
+    #[cfg(feature = "os_input")]
+    fn has_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<bool>;
+
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
         height: BlockNumber,
@@ -1858,6 +1871,11 @@ impl BatcherStorageReader for StorageReader {
         height: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>> {
         self.begin_ro_txn()?.get_state_commitment_infos(height)
+    }
+
+    #[cfg(feature = "os_input")]
+    fn has_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<bool> {
+        self.begin_ro_txn()?.has_state_commitment_infos(height)
     }
 
     fn get_parent_hash_and_partial_block_hash_components(

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1767,7 +1767,8 @@ pub trait BatcherStorageReader: Send + Sync {
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
 
     /// Returns whether the state commitment infos for the given height are stored, without
-    /// reading the stored blob.
+    /// reading the stored blob. `false` carries the same meaning as `get_state_commitment_infos`
+    /// returning `None`.
     #[cfg(feature = "os_input")]
     fn has_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<bool>;
 

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -31,6 +31,12 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
                     self.get_state_commitment_infos(block_number),
                 )
             }
+            #[cfg(feature = "os_input")]
+            BatcherRequest::HasStateCommitmentInfos(block_number) => {
+                BatcherResponse::HasStateCommitmentInfos(
+                    self.has_state_commitment_infos(block_number),
+                )
+            }
             BatcherRequest::GetCurrentHeight => {
                 BatcherResponse::GetCurrentHeight(self.get_height().await)
             }

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -64,7 +64,9 @@ pub trait BatcherClient: Send + Sync {
         block_number: BlockNumber,
     ) -> BatcherClientResult<Option<CompressedStateCommitmentInfos>>;
     /// Returns whether the compressed state commitment infos for a block are stored, without
-    /// transferring the (potentially large) stored blob.
+    /// transferring the (potentially large) stored blob. `false` carries the same meaning as
+    /// `get_state_commitment_infos` returning `None`: the block may not be committed yet, may
+    /// have been added via sync, or its commitment infos may have been reverted.
     #[cfg(feature = "os_input")]
     async fn has_state_commitment_infos(
         &self,

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -63,6 +63,13 @@ pub trait BatcherClient: Send + Sync {
         &self,
         block_number: BlockNumber,
     ) -> BatcherClientResult<Option<CompressedStateCommitmentInfos>>;
+    /// Returns whether the compressed state commitment infos for a block are stored, without
+    /// transferring the (potentially large) stored blob.
+    #[cfg(feature = "os_input")]
+    async fn has_state_commitment_infos(
+        &self,
+        block_number: BlockNumber,
+    ) -> BatcherClientResult<bool>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -122,6 +129,8 @@ pub enum BatcherRequest {
     GetBlockHash(BlockNumber),
     #[cfg(feature = "os_input")]
     GetStateCommitmentInfos(BlockNumber),
+    #[cfg(feature = "os_input")]
+    HasStateCommitmentInfos(BlockNumber),
     GetProposalContent(GetProposalContentInput),
     ValidateBlock(ValidateBlockInput),
     AbortProposal(ProposalId),
@@ -150,6 +159,8 @@ pub enum BatcherResponse {
     GetBlockHash(BatcherResult<BlockHash>),
     #[cfg(feature = "os_input")]
     GetStateCommitmentInfos(BatcherResult<Option<CompressedStateCommitmentInfos>>),
+    #[cfg(feature = "os_input")]
+    HasStateCommitmentInfos(BatcherResult<bool>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -215,6 +226,23 @@ where
             request,
             BatcherResponse,
             GetStateCommitmentInfos,
+            BatcherClientError,
+            BatcherError,
+            Direct
+        )
+    }
+
+    #[cfg(feature = "os_input")]
+    async fn has_state_commitment_infos(
+        &self,
+        block_number: BlockNumber,
+    ) -> BatcherClientResult<bool> {
+        let request = BatcherRequest::HasStateCommitmentInfos(block_number);
+        handle_all_response_variants!(
+            self,
+            request,
+            BatcherResponse,
+            HasStateCommitmentInfos,
             BatcherClientError,
             BatcherError,
             Direct

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -344,7 +344,7 @@ impl TestDeps {
             Err(BatcherClientError::BatcherError(BatcherError::BlockHashNotFound(block_number)))
         });
         #[cfg(feature = "os_input")]
-        self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
+        self.batcher.expect_has_state_commitment_infos().returning(|_block_number| Ok(false));
     }
 
     pub(crate) fn build_context(self) -> SequencerConsensusContext {

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -345,6 +345,8 @@ impl TestDeps {
         });
         #[cfg(feature = "os_input")]
         self.batcher.expect_has_state_commitment_infos().returning(|_block_number| Ok(false));
+        #[cfg(feature = "os_input")]
+        self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
     }
 
     pub(crate) fn build_context(self) -> SequencerConsensusContext {

--- a/crates/apollo_consensus_orchestrator/src/utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils.rs
@@ -510,7 +510,7 @@ pub(crate) async fn verify_retrospective_state_commitment_infos(
     // The batcher is queried at the retrospective height itself since apollo storage doesn't
     // guarantee the commitment infos of every height are stored (e.g. blocks added via sync);
     // the cende recorder's storage is contiguous, so its height offset is enough.
-    if batcher_client.get_state_commitment_infos(retrospective_block_number).await?.is_some() {
+    if batcher_client.has_state_commitment_infos(retrospective_block_number).await? {
         return Ok(());
     }
 

--- a/crates/apollo_consensus_orchestrator/src/utils_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils_test.rs
@@ -10,8 +10,6 @@ use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 #[cfg(feature = "os_input")]
 use rstest::rstest;
 use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
-#[cfg(feature = "os_input")]
-use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 use starknet_types_core::felt::Felt;
 
 use crate::build_proposal::ProposalBuildArguments;
@@ -358,10 +356,9 @@ async fn wait_for_retrospective_block_hash_batcher_ready_after_a_while() {
 #[cfg(feature = "os_input")]
 fn mock_batcher_commitment_infos(batcher_has_infos: bool) -> MockBatcherClient {
     let mut batcher = MockBatcherClient::new();
-    batcher.expect_get_state_commitment_infos().times(1).returning(move |block_number| {
+    batcher.expect_has_state_commitment_infos().times(1).returning(move |block_number| {
         assert_eq!(block_number, NEXT_HEIGHT_RETRO_BLOCK_NUMBER);
-        Ok(batcher_has_infos
-            .then(|| CompressedStateCommitmentInfos(b"compressed-state-commitment-infos".to_vec())))
+        Ok(batcher_has_infos)
     });
     batcher
 }

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -12,6 +12,7 @@ mod state_commitment_infos_test;
 use crate::db::serialization::{StorageSerde, StorageSerdeError};
 use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
+use crate::mmap_file::LocationInFile;
 use crate::{OffsetKind, StorageResult, StorageTransaction};
 
 // Stores the raw compressed bytes.
@@ -27,14 +28,18 @@ impl StorageSerde for CompressedStateCommitmentInfos {
 
 /// Interface for reading the OS-input commitment infos from storage.
 pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
-    /// Returns the compressed commitment infos for the given block, or `None` if not stored.
+    /// Returns the compressed commitment infos for the given block, or `None` if not stored (e.g.
+    /// the block was added via sync, or its commitment infos were reverted).
     fn get_state_commitment_infos(
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
 
     /// Returns whether the compressed commitment infos for the given block are stored, without
-    /// reading the stored blob.
+    /// reading the stored blob. `false` carries the same meaning as `get_state_commitment_infos`
+    /// returning `None`; unlike `get_state_commitment_infos`, this does not detect a stored entry
+    /// whose blob is unreadable (e.g. on-disk corruption), since that would require reading the
+    /// blob and defeat the purpose of this cheaper check.
     fn has_state_commitment_infos(&self, block_number: BlockNumber) -> StorageResult<bool>;
 }
 
@@ -62,16 +67,33 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>> {
-        let table = self.open_table(&self.tables().state_commitment_infos)?;
-        let Some(location) = table.get(self.txn(), &block_number)? else {
+        let Some(location) = self.state_commitment_infos_location(block_number)? else {
             return Ok(None);
         };
         Ok(Some(self.file_handlers().get_state_commitment_infos_unchecked(location)?))
     }
 
     fn has_state_commitment_infos(&self, block_number: BlockNumber) -> StorageResult<bool> {
+        Ok(self.state_commitment_infos_location(block_number)?.is_some())
+    }
+}
+
+trait StateCommitmentInfosLocationReader {
+    /// Looks up the stored location of the given block's compressed commitment infos, without
+    /// reading the blob itself.
+    fn state_commitment_infos_location(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<LocationInFile>>;
+}
+
+impl<T: StorageTransaction> StateCommitmentInfosLocationReader for T {
+    fn state_commitment_infos_location(
+        &self,
+        block_number: BlockNumber,
+    ) -> StorageResult<Option<LocationInFile>> {
         let table = self.open_table(&self.tables().state_commitment_infos)?;
-        Ok(table.get(self.txn(), &block_number)?.is_some())
+        Ok(table.get(self.txn(), &block_number)?)
     }
 }
 

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -32,6 +32,10 @@ pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
         &self,
         block_number: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
+
+    /// Returns whether the compressed commitment infos for the given block are stored, without
+    /// reading the stored blob.
+    fn has_state_commitment_infos(&self, block_number: BlockNumber) -> StorageResult<bool>;
 }
 
 /// Interface for writing the OS-input commitment infos to storage.
@@ -63,6 +67,11 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
             return Ok(None);
         };
         Ok(Some(self.file_handlers().get_state_commitment_infos_unchecked(location)?))
+    }
+
+    fn has_state_commitment_infos(&self, block_number: BlockNumber) -> StorageResult<bool> {
+        let table = self.open_table(&self.tables().state_commitment_infos)?;
+        Ok(table.get(self.txn(), &block_number)?.is_some())
     }
 }
 

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -40,6 +40,26 @@ fn append_and_get_state_commitment_infos() {
 }
 
 #[test]
+fn has_state_commitment_infos() {
+    let (reader, mut writer) = get_test_storage().0;
+    let height = BlockNumber(5);
+
+    assert!(!reader.begin_ro_txn().unwrap().has_state_commitment_infos(height).unwrap());
+
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_state_commitment_infos(height, &dummy_state_commitment_infos())
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    assert!(reader.begin_ro_txn().unwrap().has_state_commitment_infos(height).unwrap());
+    // A different height is still empty.
+    assert!(!reader.begin_ro_txn().unwrap().has_state_commitment_infos(BlockNumber(6)).unwrap());
+}
+
+#[test]
 fn revert_state_commitment_infos() {
     let (reader, mut writer) = get_test_storage().0;
     let height = BlockNumber(5);

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -75,6 +75,7 @@ fn revert_state_commitment_infos() {
         .unwrap();
 
     assert_eq!(reader.begin_ro_txn().unwrap().get_state_commitment_infos(height).unwrap(), None);
+    assert!(!reader.begin_ro_txn().unwrap().has_state_commitment_infos(height).unwrap());
 
     // Reverting a height with no stored infos is a no-op.
     writer


### PR DESCRIPTION
## Summary

Follow-up performance optimization to #14895 (apollo_consensus_orchestrator: verify retrospective state commitment infos before proposing).

That PR added `verify_retrospective_state_commitment_infos`, which runs once per block on the proposal-building hot path. It called `batcher_client.get_state_commitment_infos(block_number)` and only checked `Option::is_some()` on the result — but that RPC reads the *entire* compressed state-commitment-infos blob from `apollo_storage` (a table lookup plus a full blob read from the append-only mmap'd file), and in a remote (non-colocated) batcher deployment, serializes and transfers that whole blob over HTTP/JSON, just to immediately discard it.

This PR adds a lightweight `has_state_commitment_infos` existence check instead, plumbed through the stack:

- `apollo_storage`: new `has_state_commitment_infos` on `StateCommitmentInfosStorageReader`, doing only the table lookup (no blob read). Extracted a shared `state_commitment_infos_location` helper so `get_state_commitment_infos` and `has_state_commitment_infos` share the same lookup instead of duplicating it.
- `apollo_batcher`: new `has_state_commitment_infos` on `BatcherStorageReader` and on `Batcher`.
- `apollo_batcher_types`: new `BatcherClient::has_state_commitment_infos` method, request/response enum variants, and client wiring.
- `apollo_consensus_orchestrator`: `verify_retrospective_state_commitment_infos` now calls `has_state_commitment_infos` instead of `get_state_commitment_infos(...).is_some()`.

The existing `get_state_commitment_infos` client method/RPC is unchanged and still used where the actual payload is needed (`collect_recent_state_commitment_infos`, which builds the cende blob).

## Review

Reviewed by an independent pass focused on correctness and completeness of the RPC wiring. Findings addressed:
- Extracted the shared `state_commitment_infos_location` lookup so the two methods can't drift apart.
- Added revert-path test coverage for `has_state_commitment_infos` (a reverted height's blob stays in the append-only file, but the table entry — the only thing this check reads — is deleted).
- Documented that `false`/`None` carry the same meaning across the `has_`/`get_` pair, and that the existence check intentionally does not detect an unreadable stored blob (e.g. on-disk corruption), since detecting that would require reading the blob and defeat the purpose of the cheaper check.

## Test plan

- `cargo build -p apollo_storage -p apollo_batcher_types -p apollo_batcher -p apollo_consensus_orchestrator --features os_input` — clean.
- `SEED=0 cargo test -p apollo_storage -p apollo_batcher_types -p apollo_batcher -p apollo_consensus_orchestrator --features os_input` — all passing (118 + 193 + 318 + 9 doctests, etc.), 0 failures.
- `scripts/rust_fmt.sh` — no diff.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_018YEJMy3vFjgpRJ1tyWotFf)_