### PR TITLE
apollo_batcher,apollo_consensus_orchestrator: avoid full blob transfer for retrospective commitment infos check

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1535,6 +1535,13 @@ impl Batcher {
         })
     }
 
+    pub fn has_state_commitment_infos(&self, block_number: BlockNumber) -> BatcherResult<bool> {
+        self.storage_reader.has_state_commitment_infos(block_number).map_err(|err| {
+            error!("Failed to check state commitment infos existence in storage: {err}");
+            BatcherError::InternalError
+        })
+    }
+
     fn get_commitment_results_and_write_to_storage(&mut self) -> BatcherResult<()> {
         self.commitment_manager
             .get_commitment_results_and_write_to_storage(
@@ -1738,6 +1745,10 @@ pub trait BatcherStorageReader: Send + Sync {
         height: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>>;
 
+    /// Returns whether the compressed commitment infos for the given height are stored, without
+    /// reading the stored blob.
+    fn has_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<bool>;
+
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
         height: BlockNumber,
@@ -1836,6 +1847,10 @@ impl BatcherStorageReader for StorageReader {
         height: BlockNumber,
     ) -> StorageResult<Option<CompressedStateCommitmentInfos>> {
         self.begin_ro_txn()?.get_state_commitment_infos(height)
+    }
+
+    fn has_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<bool> {
+        self.begin_ro_txn()?.has_state_commitment_infos(height)
     }
 
     fn get_parent_hash_and_partial_block_hash_components(

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -30,6 +30,11 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
                     self.get_state_commitment_infos(block_number),
                 )
             }
+            BatcherRequest::HasStateCommitmentInfos(block_number) => {
+                BatcherResponse::HasStateCommitmentInfos(
+                    self.has_state_commitment_infos(block_number),
+                )
+            }
             BatcherRequest::GetCurrentHeight => {
                 BatcherResponse::GetCurrentHeight(self.get_height().await)
             }

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -61,6 +61,12 @@ pub trait BatcherClient: Send + Sync {
         &self,
         block_number: BlockNumber,
     ) -> BatcherClientResult<Option<CompressedStateCommitmentInfos>>;
+    /// Returns whether the compressed state commitment infos for a block are stored, without
+    /// transferring the stored blob.
+    async fn has_state_commitment_infos(
+        &self,
+        block_number: BlockNumber,
+    ) -> BatcherClientResult<bool>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -119,6 +125,7 @@ pub enum BatcherRequest {
     ProposeBlock(ProposeBlockInput),
     GetBlockHash(BlockNumber),
     GetStateCommitmentInfos(BlockNumber),
+    HasStateCommitmentInfos(BlockNumber),
     GetProposalContent(GetProposalContentInput),
     ValidateBlock(ValidateBlockInput),
     AbortProposal(ProposalId),
@@ -146,6 +153,7 @@ pub enum BatcherResponse {
     ProposeBlock(BatcherResult<()>),
     GetBlockHash(BatcherResult<BlockHash>),
     GetStateCommitmentInfos(BatcherResult<Option<CompressedStateCommitmentInfos>>),
+    HasStateCommitmentInfos(BatcherResult<bool>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -210,6 +218,22 @@ where
             request,
             BatcherResponse,
             GetStateCommitmentInfos,
+            BatcherClientError,
+            BatcherError,
+            Direct
+        )
+    }
+
+    async fn has_state_commitment_infos(
+        &self,
+        block_number: BlockNumber,
+    ) -> BatcherClientResult<bool> {
+        let request = BatcherRequest::HasStateCommitmentInfos(block_number);
+        handle_all_response_variants!(
+            self,
+            request,
+            BatcherResponse,
+            HasStateCommitmentInfos,
             BatcherClientError,
             BatcherError,
             Direct

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -236,7 +236,7 @@ impl TestDeps {
                 });
             block_number = block_number.unchecked_next();
         }
-        self.setup_default_batcher_get_block_hash();
+        self.setup_default_batcher_storage_queries();
     }
 
     pub(crate) fn setup_deps_for_validate(&mut self, args: SetupDepsArgs) {
@@ -297,7 +297,7 @@ impl TestDeps {
                 });
             block_number = block_number.unchecked_next();
         }
-        self.setup_default_batcher_get_block_hash();
+        self.setup_default_batcher_storage_queries();
     }
 
     pub(crate) fn setup_default_transaction_converter(&mut self) {
@@ -338,10 +338,12 @@ impl TestDeps {
         self.state_sync_client.expect_get_block().returning(|_| Ok(SyncBlock::default()));
     }
 
-    pub(crate) fn setup_default_batcher_get_block_hash(&mut self) {
+    pub(crate) fn setup_default_batcher_storage_queries(&mut self) {
         self.batcher.expect_get_block_hash().returning(|block_number| {
             Err(BatcherClientError::BatcherError(BatcherError::BlockHashNotFound(block_number)))
         });
+        // has_state_commitment_infos backs verify_retrospective_state_commitment_infos;
+        // get_state_commitment_infos backs collect_recent_state_commitment_infos.
         self.batcher.expect_has_state_commitment_infos().returning(|_block_number| Ok(false));
         self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
     }

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -343,6 +343,7 @@ impl TestDeps {
             Err(BatcherClientError::BatcherError(BatcherError::BlockHashNotFound(block_number)))
         });
         self.batcher.expect_has_state_commitment_infos().returning(|_block_number| Ok(false));
+        self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
     }
 
     pub(crate) fn build_context(self) -> SequencerConsensusContext {

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -342,7 +342,7 @@ impl TestDeps {
         self.batcher.expect_get_block_hash().returning(|block_number| {
             Err(BatcherClientError::BatcherError(BatcherError::BlockHashNotFound(block_number)))
         });
-        self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
+        self.batcher.expect_has_state_commitment_infos().returning(|_block_number| Ok(false));
     }
 
     pub(crate) fn build_context(self) -> SequencerConsensusContext {

--- a/crates/apollo_consensus_orchestrator/src/utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils.rs
@@ -506,7 +506,7 @@ pub(crate) async fn verify_retrospective_state_commitment_infos(
     // The batcher is queried at the retrospective height itself since apollo storage doesn't
     // guarantee the commitment infos of every height are stored (e.g. blocks added via sync);
     // the cende recorder's storage is contiguous, so its height offset is enough.
-    if batcher_client.get_state_commitment_infos(retrospective_block_number).await?.is_some() {
+    if batcher_client.has_state_commitment_infos(retrospective_block_number).await? {
         return Ok(());
     }
 

--- a/crates/apollo_consensus_orchestrator/src/utils_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils_test.rs
@@ -7,7 +7,6 @@ use assert_matches::assert_matches;
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
 use rstest::rstest;
 use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
-use starknet_committer::patricia_merkle_tree::types::CompressedStateCommitmentInfos;
 use starknet_types_core::felt::Felt;
 
 use crate::build_proposal::ProposalBuildArguments;
@@ -346,10 +345,9 @@ async fn wait_for_retrospective_block_hash_batcher_ready_after_a_while() {
 
 fn mock_batcher_commitment_infos(batcher_has_infos: bool) -> MockBatcherClient {
     let mut batcher = MockBatcherClient::new();
-    batcher.expect_get_state_commitment_infos().times(1).returning(move |block_number| {
+    batcher.expect_has_state_commitment_infos().times(1).returning(move |block_number| {
         assert_eq!(block_number, NEXT_HEIGHT_RETRO_BLOCK_NUMBER);
-        Ok(batcher_has_infos
-            .then(|| CompressedStateCommitmentInfos(b"compressed-state-commitment-infos".to_vec())))
+        Ok(batcher_has_infos)
     });
     batcher
 }

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -2620,6 +2620,32 @@
           "extra_params": {}
         },
         {
+          "title": "has_state_commitment_infos (client-side)",
+          "description": "client-side infra metrics for request type has_state_commitment_infos",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
+          "title": "has_state_commitment_infos (server-side)",
+          "description": "server-side infra metrics for request type has_state_commitment_infos",
+          "type": "timeseries",
+          "exprs": [
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
+            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"has_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "propose_block (client-side)",
           "description": "client-side infra metrics for request type propose_block",
           "type": "timeseries",


### PR DESCRIPTION
## Summary

Follow-up performance optimization on top of #14914, which added `has_state_commitment_infos` (an existence-only check that avoids reading the stored blob) at the storage layer but didn't wire it through to its intended caller.

`verify_retrospective_state_commitment_infos` in `apollo_consensus_orchestrator` runs once per produced block — a per-block hot path in consensus block production — and only needed to know whether the batcher has stored the retrospective height's commitment infos. It was calling `batcher_client.get_state_commitment_infos(...).await?.is_some()`, which fetches and transfers the full compressed commitment-infos blob across the batcher's RPC boundary (a local mpsc channel or, for a remote batcher, HTTP + JSON via hyper) just to discard it and check `is_some()`.

This PR wires the new existence-only check end-to-end:
- `apollo_batcher_types`: adds `has_state_commitment_infos` to the `BatcherClient` trait plus a `HasStateCommitmentInfos` request/response RPC variant pair, mirroring the existing `get_state_commitment_infos` plumbing.
- `apollo_batcher`: adds `Batcher::has_state_commitment_infos` and the corresponding `BatcherStorageReader` trait method (backed by the storage layer's existing `has_state_commitment_infos`), and dispatches the new RPC request.
- `apollo_consensus_orchestrator`: `verify_retrospective_state_commitment_infos` now calls `has_state_commitment_infos` directly instead of fetching and discarding the full blob.
- Regenerates `dev_grafana.json` for the new request variant's infra-metrics panels, and updates/renames affected test fixtures.

## Expected impact

Removes a full compressed-witness blob transfer (serialize + deserialize, and for remote batchers a network round trip) from a call that runs on every produced block and only ever needed a boolean.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test -p apollo_storage -p apollo_batcher -p apollo_batcher_types -p apollo_consensus_orchestrator -p apollo_dashboard` — all pass (193/193 in apollo_consensus_orchestrator)
- [x] `cargo clippy` on touched crates — no warnings
- [x] Independent Opus review pass; the one blocking finding (stale generated dashboard JSON) was fixed and reverified

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LawqajQe8bHks9fXSKWufW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LawqajQe8bHks9fXSKWufW)_