### PR TITLE
starknet_transaction_prover: remove stale allow(dead_code)

### DIFF
--- a/crates/starknet_transaction_prover/src/running/virtual_block_executor.rs
+++ b/crates/starknet_transaction_prover/src/running/virtual_block_executor.rs
@@ -400,7 +400,6 @@ pub(crate) trait VirtualBlockExecutor: Send + 'static {
     fn validate_txs_enabled(&self) -> Result<bool, VirtualBlockExecutorError>;
 }
 
-#[allow(dead_code)]
 pub(crate) struct RpcVirtualBlockExecutor {
     /// The state reader for the virtual block executor.
     pub(crate) rpc_state_reader: RpcStateReader,


### PR DESCRIPTION
Remove the stale `#[allow(dead_code)]` on the `RpcVirtualBlockExecutor` struct in `crates/starknet_transaction_prover/src/running/virtual_block_executor.rs`.

## Why the annotation is stale (the struct is live, not dead)

`RpcVirtualBlockExecutor` is constructed and fully used on a production path:

- **Constructed in production:** `RpcVirtualBlockExecutor::new` is called in `RpcRunnerFactory::create_runner` (`running/runner.rs`), which is invoked from the `VirtualSnosRunner for RpcRunnerFactory` trait impl (`run_virtual_os`). That path is reached from the server's `RpcVirtualSnosProver` (`server/rpc_impl.rs`), i.e. the crate's public service entry point — not from tests.
- **All three fields are read in production** (so removing the struct-level annotation exposes no "never read" field):
  - `rpc_state_reader` — read in the `VirtualBlockExecutor` impl (`base_block_info`, `state_reader`).
  - `config` — read in the same impl (`base_block_info`, `state_reader`).
  - `validate_txs` — read via `validate_txs_enabled` (`Ok(self.validate_txs)`), which feeds `create_execution_input`.

## Verification (venv active; `RUSTC_WRAPPER=""`, `CARGO_INCREMENTAL=0`)

With the annotation removed, the crate builds with **zero** `dead_code`/`unused`/`never read`/`never constructed` warnings in **both** configurations — the load-bearing check for a stale-annotation removal:

- `cargo build -p starknet_transaction_prover` → clean (exit 0)
- `cargo build -p starknet_transaction_prover --tests` → clean (exit 0)
- `scripts/rust_fmt.sh` → no changes
- `cargo clippy -p starknet_transaction_prover --all-targets` → clean (exit 0)
- `SEED=0 cargo test -p starknet_transaction_prover` → 136 passed, 0 failed

Since the crate builds clean in both cfgs without it, the annotation was stale (not load-bearing) and is safe to remove.

---
_Generated by [Claude Code](https://claude.ai/code/session_0121YZoMKj5VfC8ri36r16in)_