### PR TITLE
apollo_config_manager: retry a dynamic config dispatch the component rejected

### DIFF
--- a/crates/apollo_config_manager/src/config_manager_runner.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner.rs
@@ -143,18 +143,23 @@ impl ConfigManagerRunner {
         } else {
             // Log the diff between the latest and the new node dynamic config.
             self.log_config_diff(&self.latest_node_dynamic_config, &node_dynamic_config);
-            // Update the latest node dynamic config.
-            self.latest_node_dynamic_config = node_dynamic_config.clone();
             match self
                 .config_manager_client
                 .set_node_dynamic_config(node_dynamic_config.clone())
                 .await
             {
                 Ok(()) => {
+                    // Recorded only once the component has accepted it, so that a failed dispatch
+                    // is retried on the next update instead of being seen as no change.
+                    self.latest_node_dynamic_config = node_dynamic_config.clone();
                     info!("Successfully updated dynamic config");
                     Ok(node_dynamic_config)
                 }
-                Err(e) => Err(format!("Failed to update dynamic config: {:?}", e).into()),
+                Err(e) => {
+                    CONFIG_MANAGER_UPDATE_ERRORS.increment(1);
+                    error!("ConfigManagerRunner: failed to update dynamic config: {e}");
+                    Err(format!("Failed to update dynamic config: {:?}", e).into())
+                }
             }
         }
     }

--- a/crates/apollo_config_manager/src/config_manager_runner_tests.rs
+++ b/crates/apollo_config_manager/src/config_manager_runner_tests.rs
@@ -5,9 +5,11 @@ use std::time::Duration;
 use apollo_config::CONFIG_FILE_ARG;
 use apollo_config_manager_config::config::ConfigManagerConfig;
 use apollo_config_manager_types::communication::{
+    ConfigManagerClientError,
     MockConfigManagerClient,
     SharedConfigManagerClient,
 };
+use apollo_config_manager_types::errors::ConfigManagerError;
 use apollo_consensus_config::config::ConsensusDynamicConfig;
 use apollo_node_config::component_execution_config::ReactiveComponentExecutionConfig;
 use apollo_node_config::config_utils::{load_and_validate_config, DeploymentBaseAppConfig};
@@ -264,6 +266,51 @@ async fn update_config_rejects_idle_delay_above_batcher_deadline() {
         .expect_err("Refresh should reject an idle delay that exceeds the batcher deadline")
         .to_string();
     assert!(error.contains("proposer_idle_detection_delay_millis"), "Unexpected error: {error}");
+}
+
+/// A dispatch the component rejects must not be recorded as applied: the next update has to try
+/// again, rather than compare against a config the node never received and see no change.
+#[tokio::test]
+async fn failed_dispatch_is_retried_on_the_next_update() {
+    let (_temp_file, cli_args, _) = create_temp_config_file_and_args();
+
+    let mut mock_client = MockConfigManagerClient::new();
+    // Both updates must reach the client. Were the failure recorded as applied, the second would
+    // take the "no change" path and never dispatch.
+    mock_client.expect_set_node_dynamic_config().times(2).returning(|_| {
+        Err(ConfigManagerClientError::ConfigManagerError(ConfigManagerError::InvalidConfig(
+            "rejected by the component".to_string(),
+        )))
+    });
+
+    let mut runner = ConfigManagerRunner::new(
+        ConfigManagerConfig::default(),
+        Arc::new(mock_client),
+        NodeDynamicConfig::default(),
+        cli_args,
+    );
+
+    runner.update_config().await.expect_err("Dispatch fails");
+    runner.update_config().await.expect_err("Dispatch fails again");
+}
+
+/// The counterpart: once the component accepts the config, an unchanged file is not re-dispatched.
+#[tokio::test]
+async fn accepted_dispatch_is_not_repeated_while_the_config_is_unchanged() {
+    let (_temp_file, cli_args, _) = create_temp_config_file_and_args();
+
+    let mut mock_client = MockConfigManagerClient::new();
+    mock_client.expect_set_node_dynamic_config().times(1).return_const(Ok(()));
+
+    let mut runner = ConfigManagerRunner::new(
+        ConfigManagerConfig::default(),
+        Arc::new(mock_client),
+        NodeDynamicConfig::default(),
+        cli_args,
+    );
+
+    runner.update_config().await.expect("First update should dispatch");
+    runner.update_config().await.expect("Second update should be a no-op");
 }
 
 #[tokio::test]

--- a/crates/apollo_config_manager/src/metrics.rs
+++ b/crates/apollo_config_manager/src/metrics.rs
@@ -15,7 +15,7 @@ define_metrics!(
         MetricCounter {
             CONFIG_MANAGER_UPDATE_ERRORS,
             "config_manager_update_errors",
-            "Number of config manager update errors (load/validate)",
+            "Number of config manager update errors (load/validate/dispatch)",
             init = 0
         },
     },


### PR DESCRIPTION
Fixes #14925. Independent of #14924 — branched from `main`, touches only the dispatch branch of `update_config`.

## Problem

`update_config` advanced `latest_node_dynamic_config` **before** awaiting `set_node_dynamic_config`:

```rust
self.latest_node_dynamic_config = node_dynamic_config.clone();   // <-- advanced first
match self.config_manager_client.set_node_dynamic_config(node_dynamic_config.clone()).await {
    Ok(()) => { ... }
    Err(e) => Err(format!("Failed to update dynamic config: {:?}", e).into()),   // no revert, no metric
}
```

When the dispatch failed, two things went wrong together:

1. **Never retried.** `latest_` already held the new value, so every later tick took the `latest == new` early return and did nothing. The node kept running the **old** config indefinitely, while the runner behaved as though the new one had been applied.
2. **Never alerted.** Unlike the load and validate paths, this one did not increment `CONFIG_MANAGER_UPDATE_ERRORS`, so `config_manager_update_error_increase` could not fire. The dropped update was completely silent.

This is the one path where a config change can be lost with no signal. `set_node_dynamic_config` can legitimately fail — the receiving component validates the dynamic config, and it is a channel-based call that can error under load.

## Change

Record the config only once the component has accepted it, and count the failure:

- `latest_node_dynamic_config` is assigned inside the `Ok` arm. Leaving it untouched on failure means the next 20s tick sees a difference and retries by itself.
- The `Err` arm increments `CONFIG_MANAGER_UPDATE_ERRORS` and logs, so a *persistent* failure surfaces through the existing alert instead of going quiet. A single transient rejection self-heals on the next tick.

## Tests

- `failed_dispatch_is_retried_on_the_next_update` — a client that always rejects must be called **twice** across two `update_config` calls. Verified this fails on the old ordering (mockall reports the second dispatch never happens).
- `accepted_dispatch_is_not_repeated_while_the_config_is_unchanged` — the counterpart, pinning that a successful dispatch is still recorded, so an unchanged file is not re-dispatched every tick.

`cargo test -p apollo_config_manager` — 17 passed. `scripts/rust_fmt.sh --check` and clippy clean.

## Scope

Found while reviewing #14924 but present on `main` well before it; kept separate so an unrelated pre-existing bug does not ride along on that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)