### PR TITLE
apollo_storage: demote the mmap flush log to trace

### DIFF
--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -159,7 +159,7 @@ use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContract
 use starknet_api::state::{SierraContractClass, StorageKey, ThinStateDiff};
 use starknet_api::transaction::{Transaction, TransactionHash, TransactionOutput};
 use starknet_types_core::felt::Felt;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 use validator::Validate;
 use version::{StorageVersionError, Version};
 
@@ -1215,7 +1215,7 @@ impl FileHandlers<RW> {
     // TODO(dan): Consider 1. flushing only the relevant files, 2. flushing concurrently.
     #[latency_histogram("storage_file_handler_flush_latency_seconds", false)]
     fn flush(&self) {
-        debug!("Flushing the mmap files.");
+        trace!("Flushing the mmap files.");
         self.thin_state_diff.flush();
         self.contract_class.flush();
         self.casm.flush();


### PR DESCRIPTION
## What

`StorageTxn::flush()` logs a constant string `"Flushing the mmap files."` on every call. This demotes it from `debug!` to `trace!`.

## Why

Part of a round of log-cost reduction. Measured against 24h of Mainnet logs via Log Analytics:

- **1.83M entries/day** across the six Mainnet nodes
- **3.83%** of all `sequencer-core` log bytes
- **~$79/month** across Mainnet + Testnet at the $0.50/GiB ingestion rate

The line carries no information beyond "a flush happened", and the `#[latency_histogram("storage_file_handler_flush_latency_seconds")]` attribute on the same function already records both the occurrence and the duration.

Note that production runs with `RUST_LOG=debug,cairo_vm=warn`, so `debug!` is **not** filtered out there — `trace!` is. That is why this is a demotion to `trace!` rather than `debug!`.

Worth knowing for context: ~54% of every log entry's billed size is fixed GCP envelope (pod labels, resource, insertId, timestamps), so removing a high-frequency line is worth roughly 2x what its message length suggests.

## Test plan

- `cargo build -p apollo_storage`
- `SEED=0 cargo test -p apollo_storage` — 327 passed, 0 failed
- `scripts/rust_fmt.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)