### PR TITLE
apollo_starknet_client: drop the feeder call-started log, add latency to the outcome

### DIFF
--- a/crates/apollo_starknet_client/src/reader/mod.rs
+++ b/crates/apollo_starknet_client/src/reader/mod.rs
@@ -7,6 +7,7 @@ pub mod objects;
 mod starknet_feeder_gateway_client_test;
 
 use std::collections::HashMap;
+use std::time::Instant;
 
 use apollo_config::secrets::Sensitive;
 use async_trait::async_trait;
@@ -211,15 +212,18 @@ impl StarknetFeederGatewayClient {
     }
 
     async fn request_with_retry_url(&self, url: Url) -> ReaderClientResult<String> {
-        debug!("Call to feeder started. url={url:?}");
+        let call_start = Instant::now();
         let result = self
             .client
             .request_with_retry(self.client.internal_client.get(url.clone()))
             .await
             .map_err(Into::<ReaderClientError>::into);
+        let elapsed = call_start.elapsed();
         match &result {
-            Ok(_) => debug!("Call to feeder succeeded. url={url:?}"),
-            Err(err) => debug!("Call to feeder failed. url={url:?}. Error = {err}"),
+            Ok(_) => debug!("Call to feeder succeeded. url={url:?}. elapsed={elapsed:?}"),
+            Err(err) => {
+                debug!("Call to feeder failed. url={url:?}. elapsed={elapsed:?}. Error = {err}")
+            }
         }
         result
     }


### PR DESCRIPTION
## What

`request_with_retry_url` logged twice per feeder HTTP call:

```rust
debug!("Call to feeder started. url={url:?}");
let result = ...;
match &result {
    Ok(_)    => debug!("Call to feeder succeeded. url={url:?}"),
    Err(err) => debug!("Call to feeder failed. url={url:?}. Error = {err}"),
}
```

This drops the "started" line and adds the measured call duration to the outcome line (both the success and the failure branch — failures are where latency matters most, e.g. distinguishing a timeout from an immediate refusal).

## Why

Part of a round of log-cost reduction. Measured over 24h of Mainnet logs via Log Analytics, these two lines are the **single largest log site on `sequencer-core`**:

| site | entries/24h (6 nodes) | % of `sequencer-core` bytes |
|---|---|---|
| `reader/mod.rs:214` "Call to feeder started" | 2,205,531 | 5.78% |
| `reader/mod.rs:221` "Call to feeder succeeded" | 2,205,483 | 5.78% |

Together **11.56%** of the container, ~$240/month across Mainnet + Testnet. That is ~4.25 feeder calls/sec/node, each costing two log entries.

The "started" line carried no information the outcome line doesn't, other than "a call is in flight" — which the new `elapsed` field conveys, and more usefully.

## Follow-up worth considering (not in this PR)

The surviving line still formats the URL with `{url:?}`, which expands a ~60-character URL into ~400 characters:

```
url=Url { scheme: "https", cannot_be_a_base: false, username: "", password: None,
          host: Some(Domain("feeder.alpha-mainnet.starknet.io")), port: None,
          path: "/feeder_gateway/get_block", query: Some("blockNumber=latest&..."), fragment: None }
```

Switching to `url.as_str()` would save roughly another $60/month for a one-token change. I left it out because it changes the log's shape and wasn't part of the agreed scope — happy to fold it in if reviewers want it.

## Test plan

- `cargo build -p apollo_starknet_client`
- `SEED=0 cargo test -p apollo_starknet_client` — 76 passed, 0 failed
- `scripts/rust_fmt.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)