### PR TITLE
apollo_mempool_p2p: log tx identifiers instead of the full received batch

### DIFF
--- a/crates/apollo_mempool_p2p/src/runner/mod.rs
+++ b/crates/apollo_mempool_p2p/src/runner/mod.rs
@@ -104,8 +104,23 @@ impl ComponentStarter for MempoolP2pRunner {
                 Some((message_result, broadcasted_message_metadata)) = self.broadcasted_topic_server.next() => {
                     match message_result {
                         Ok(message) => {
-                            // TODO(alonl): consider calculating the tx_hash and printing it instead of the entire tx.
-                            debug!("Received transaction batch from network, forwarding to gateway. Batch: {:?}", message.0);
+                            // Identifiers only. Debug-formatting the whole batch made this the
+                            // largest log site in this component. The tx_hash would identify a
+                            // transaction better, but computing it needs a ChainId that the
+                            // runner does not hold, so (sender, nonce) stands in for it.
+                            debug!(
+                                "Received a batch of {} transactions from network, forwarding to \
+                                 gateway. (sender_address, nonce): {:?}",
+                                message.0.len(),
+                                message
+                                    .0
+                                    .iter()
+                                    .map(|rpc_tx| (
+                                        rpc_tx.calculate_sender_address().ok(),
+                                        rpc_tx.nonce()
+                                    ))
+                                    .collect::<Vec<_>>()
+                            );
                             for rpc_tx in message.0 {
                                 let permit = match gateway_semaphore.clone().try_acquire_owned() {
                                     Ok(permit) => permit,


### PR DESCRIPTION
## What

The p2p runner Debug-formatted the entire received transaction batch on every gossip message:

```rust
// TODO(alonl): consider calculating the tx_hash and printing it instead of the entire tx.
debug!("Received transaction batch from network, forwarding to gateway. Batch: {:?}", message.0);
```

Now it logs the batch size plus the `(sender_address, nonce)` pair per transaction.

## Why

Part of a round of log-cost reduction. Measured over 24h of Mainnet logs via Log Analytics, this single line is **30% of all `sequencer-mempool` log bytes** — ~$50/month across Mainnet + Testnet.

## On the TODO

The TODO asks for `tx_hash`, and that would be the better identifier. I did **not** do that: `RpcTransaction` carries no hash, and `calculate_transaction_hash` needs a `ChainId`, which the runner does not hold. Plumbing a `ChainId` into `MempoolP2pRunner` is a real change to the component's construction, well beyond a logging fix, so I left the TODO in place conceptually and used `(sender_address, nonce)` — the pair that identifies a transaction at this point in the flow — as the stand-in. Happy to do the `ChainId` plumbing in a follow-up if reviewers prefer the hash.

Note `calculate_sender_address()` is a field read for Invoke and Declare; only DeployAccount computes anything (a single contract-address hash), and those are rare. `tracing` macros do not evaluate their arguments when the callsite is disabled, so this costs nothing when `apollo_mempool_p2p` is below `debug`.

## Test plan

- `cargo build -p apollo_mempool_p2p`
- `SEED=0 cargo test -p apollo_mempool_p2p` — 11 passed, 0 failed
- `scripts/rust_fmt.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)