### PR TITLE
apollo_dashboard: exclude observers from strk_to_usd_rate_frozen alert

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -2228,7 +2228,7 @@
       "name": "strk_to_usd_rate_frozen",
       "title": "Strk to Usd rate frozen",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "sum(changes(snip35_strk_usd_rate{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))",
+      "expr": "(sum(changes(snip35_strk_usd_rate{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -62,6 +62,7 @@ pub(crate) fn get_strk_to_usd_error_count_alert() -> Alert {
     )
 }
 
+/// Eth to Strk is queried when validating a proposal too, so every node's gauge moves.
 pub(crate) fn get_eth_to_strk_rate_frozen_alert() -> Alert {
     const ALERT_NAME: &str = "eth_to_strk_rate_frozen";
     oracle_rate_frozen_alert(
@@ -69,9 +70,12 @@ pub(crate) fn get_eth_to_strk_rate_frozen_alert() -> Alert {
         "Eth to Strk rate frozen",
         &ETH_TO_STRK_RATE,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+        ObserverApplicability::Applicable,
     )
 }
 
+/// Strk to Usd is queried only when building a proposal; observers never propose, so their gauge
+/// stays flat and the alert excludes them.
 pub(crate) fn get_strk_to_usd_rate_frozen_alert() -> Alert {
     const ALERT_NAME: &str = "strk_to_usd_rate_frozen";
     oracle_rate_frozen_alert(
@@ -79,6 +83,7 @@ pub(crate) fn get_strk_to_usd_rate_frozen_alert() -> Alert {
         "Strk to Usd rate frozen",
         &SNIP35_STRK_USD_RATE,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+        ObserverApplicability::NotApplicable,
     )
 }
 
@@ -191,14 +196,12 @@ fn oracle_error_count_alert(
 /// impossible for a live 18-decimal rate. Unlike the error-count alert there is deliberately no
 /// `or vector(0)`: an absent gauge must stay no-data (so an oracle that never resolves doesn't look
 /// "frozen"); only a present-but-flat gauge trips this.
-///
-/// Applies to observers too: a frozen upstream feed is env-wide and observer nodes run the same
-/// oracle client, so the alert should fire regardless of node role.
 fn oracle_rate_frozen_alert(
     name: &str,
     title: &str,
     rate_metric: &dyn MetricQueryName,
     severity: impl Into<SeverityValueOrPlaceholder>,
+    observer_applicability: ObserverApplicability,
 ) -> Alert {
     Alert::new(
         name,
@@ -208,6 +211,6 @@ fn oracle_rate_frozen_alert(
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         severity,
-        ObserverApplicability::Applicable,
+        observer_applicability,
     )
 }


### PR DESCRIPTION
## Problem

`strk_to_usd_rate_frozen` fires permanently on observer nodes (seen on `apollo-sepolia-alpha-0`, the one sepolia-alpha node whose `validator_id` is outside the committee).

Root cause: `oracle_rate_frozen_alert` hardcodes `ObserverApplicability::Applicable` for both exchange-rate oracles, but the two oracles are queried on different consensus paths:

- **eth_to_strk** is queried on the proposal *validation* path (`validate_proposal.rs` → `get_l1_prices_in_fri_and_wei`), so every node — observers included — keeps its gauge moving. `Applicable` is correct.
- **strk_to_usd** is queried only on the proposer *build* path (`build_proposal` → `compute_proposer_fee_proposal` → `resolve_fee_target`), for the SNIP-35 fee proposal. Validation bounds-checks the proposer's `fee_proposal_fri` against the local median without an oracle read. An observer never proposes, so its `snip35_strk_usd_rate` gauge is registered at 0 (`ExchangeRateOracleClient::new` registers metrics unconditionally) and never updated — present-but-flat by construction, so `sum(changes(...[1h])) < 1` is permanently true.

Not an outage: on the observer, `snip35_strk_usd_success_count` and `_error_count` are both flat 0 (zero attempts), while all validators read the rate normally via round-robin proposership.

## Fix

Parameterize `oracle_rate_frozen_alert` with `ObserverApplicability` and pass `NotApplicable` for strk_to_usd (`Applicable` for eth_to_strk, unchanged behavior). This matches the oracle success/error-count alerts, which already exclude observers. Regenerated `dev_grafana_alerts.json`; the only expression change is `strk_to_usd_rate_frozen` gaining the `and on() (is_observer == 0)` clause.

## Verification

- `SEED=0 cargo test -p apollo_dashboard` — 16 passed (includes the generated-JSON drift test)
- `cargo clippy -p apollo_dashboard --all-targets -- -D warnings` — clean
- `scripts/rust_fmt.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)