### PR TITLE
blockifier: pre-reserve capacity when rebuilding trimmed state maps

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -407,7 +407,12 @@ impl StateMaps {
             map: &HashMap<K, V>,
             keys: &BTreeSet<K>,
         ) -> HashMap<K, V> {
-            keys.iter().filter_map(|key| map.get(key).map(|value| (*key, *value))).collect()
+            // `collect()` only reserves for the filter_map's lower size-hint bound (0), causing
+            // repeated reallocation and rehashing as the map grows; reserve the tight upper bound
+            // on the result size instead.
+            let mut result = HashMap::with_capacity(keys.len().min(map.len()));
+            result.extend(keys.iter().filter_map(|key| map.get(key).map(|value| (*key, *value))));
+            result
         }
         self.storage = intersect(&self.storage, &accessed_keys.storage_keys);
         self.nonces = intersect(&self.nonces, &accessed_keys.accessed_contracts);


### PR DESCRIPTION
## Summary

Follow-up performance optimization to #14625.

`StateMaps::trim_to_accessed_keys` rebuilds each `HashMap` via `.collect()` on a `filter_map` iterator over the accessed-keys `BTreeSet`. `filter_map`'s size hint has a lower bound of 0 (since the filter can drop any number of elements), so `collect()`'s internal `reserve()` call is a no-op — the resulting `HashMap` grows through repeated reallocation and rehashing as elements are inserted instead of being sized once up front.

This PR pre-reserves capacity for `min(keys.len(), map.len())` before extending, which is a tight upper bound on the final size: accessed keys are (almost always) a subset of the map being intersected, since `get_os_initial_reads` already force-reads the nonce/class-hash/compiled-class-hash of every contract that ends up in `accessed_keys`.

**Why this matters:** `trim_to_accessed_keys` runs once per block in `apollo_batcher`'s hot path. Avoiding the incremental grow-and-rehash cycle removes a constant-factor overhead from a function whose cost already scales with block size.

## Test plan

- [x] `cargo build -p blockifier`
- [x] `cargo clippy -p blockifier --lib` (clean)
- [x] `SEED=0 cargo test -p blockifier --lib state::cached_state` (43 passed)
- [x] `scripts/rust_fmt.sh` (no diff beyond the change)
- [x] Reviewed by an Opus subagent for correctness and style; two nits addressed (tighter capacity bound, comment length)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzWvNVLye1Jcrh1u2Pu5hd)_