### PR TITLE
apollo_l1_gas_price_types,apollo_consensus_orchestrator: document STRK/USD rate direction

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/dynamic_gas_price/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/dynamic_gas_price/mod.rs
@@ -95,8 +95,8 @@ pub fn compute_fee_actual(
 ///
 /// `target_atto_usd_per_l2_gas` is in atto-USD (atto = 10⁻¹⁸; so a value of
 /// `3_000_000_000` means 3·10⁻⁹ USD = 3 nanodollars per L2 gas unit).
-/// `strk_usd_rate` is the STRK/USD price with 18 decimals (from the oracle); a rate of `0`
-/// returns `None` (treat as oracle failure: callers freeze at `fee_actual`).
+/// `strk_usd_rate` is the STRK/USD price as USD per STRK with 18 decimals (from the oracle);
+/// a rate of `0` returns `None` (treat as oracle failure: callers freeze at `fee_actual`).
 /// Returns the target in FRI; the multiplicative margin clamp in `compute_fee_proposal`
 /// keeps the published proposal bounded relative to `fee_actual`.
 pub fn compute_fee_target(

--- a/crates/apollo_l1_gas_price_types/src/lib.rs
+++ b/crates/apollo_l1_gas_price_types/src/lib.rs
@@ -101,10 +101,12 @@ pub trait L1GasPriceProviderClient: Send + Sync {
         timestamp: BlockTimestamp,
     ) -> L1GasPriceProviderClientResult<PriceInfo>;
 
-    /// ETH/FRI rate as 18-decimal fixed-point integer (e.g. 5000 STRK per ETH → `5000 * 10^18`).
+    /// ETH/FRI rate as 18-decimal fixed-point integer, quoted as FRI per ETH
+    /// (e.g. 5000 STRK per ETH → `5000 * 10^18`).
     async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
 
-    /// STRK/USD rate as 18-decimal fixed-point integer (e.g. 24.5 STRK per USD → `24.5 * 10^18`).
+    /// STRK/USD rate as 18-decimal fixed-point integer, quoted as USD per STRK
+    /// (e.g. STRK at $0.50 → `0.5 * 10^18`).
     async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
 }
 


### PR DESCRIPTION
## What

The doc example on `get_strk_to_usd_rate` was inverted. It read:

> STRK/USD rate as 18-decimal fixed-point integer (e.g. 24.5 STRK per USD → `24.5 * 10^18`)

But `compute_fee_target` **divides** by this rate:

```rust
// floor_fri = target_atto_usd_per_l2_gas * 10^18 / strk_usd_rate
```

Dimensional analysis forces the rate to be **USD per STRK** × 10^18, and the test fixture says so literally: `// Target: $3e-9/gas = 3_000_000_000 atto-USD. STRK at $0.50 = 500_000_000_000_000_000.`

## Why it matters

Following the comment instead of the code inverts the rate. Nothing in the pipeline catches it: `compute_fee_target` accepts any non-zero `u128`, and the only downstream guard is the 0.2%/block `fee_proposal_margin_ppt` clamp, which *softens* a wrong fee target over time rather than rejecting it.

This came out of the [L1 price oracle replacement](https://starkwareindustries.slack.com/archives/D0ACHD9K27N/p1786280310659939) work, where a new oracle client has to produce this rate from a feed quoted in the opposite direction. Correcting the comment first so the implementation is not written against it.

## Also in this PR

Two neighbouring docs a reader would plausibly land on instead, stated explicitly rather than left implicit:

- `get_rate` → now says "quoted as **FRI per ETH**" (verified correct against `GasPrice::wei_to_fri`; it was right, just implicit).
- the `strk_usd_rate` parameter doc on `compute_fee_target` itself, which is where the division actually happens and was the more likely landing spot when debugging a mispriced block.

Docs only. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)