### PR TITLE
apollo_infra: skip the JSON reparse round-trip for log lines with no error key

### DIFF
--- a/crates/apollo_infra/src/trace_util.rs
+++ b/crates/apollo_infra/src/trace_util.rs
@@ -10,15 +10,26 @@ use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, reload, EnvFilter};
 
-// Renames the "error" key to "message" in a JSON object, if present.
-// If "message" already exists, leaves the object unchanged.
+// Byte pattern of the root-level "error" key as emitted by compact JSON serialization.
+const ERROR_KEY_PATTERN: &[u8] = b"\"error\"";
+
+// Renames the "error" key to "message" in a JSON object, if present, and if "message" doesn't
+// already exist. Returns `None` when no rewrite is needed (including on invalid JSON), so the
+// caller can write the original buffer unchanged.
+//
+// Most log lines have no "error" key at all (only #[instrument(...,err)] error paths do), so a
+// cheap byte-level scan for the key first skips the JSON parse/reserialize round-trip for the
+// overwhelming majority of calls; this function runs on every single log line emitted.
 pub(crate) fn rename_error_to_message(buf: &[u8]) -> Option<Vec<u8>> {
-    let mut obj: serde_json::Map<String, serde_json::Value> = serde_json::from_slice(buf).ok()?;
-    if !obj.contains_key("message") {
-        if let Some(v) = obj.remove("error") {
-            obj.insert("message".into(), v);
-        }
+    if !buf.windows(ERROR_KEY_PATTERN.len()).any(|window| window == ERROR_KEY_PATTERN) {
+        return None;
     }
+    let mut obj: serde_json::Map<String, serde_json::Value> = serde_json::from_slice(buf).ok()?;
+    if obj.contains_key("message") {
+        return None;
+    }
+    let error_value = obj.remove("error")?;
+    obj.insert("message".into(), error_value);
     let mut out = serde_json::to_vec(&obj).ok()?;
     out.push(b'\n');
     Some(out)
@@ -31,8 +42,10 @@ pub(crate) struct ErrorToMessageWriter<W>(pub(crate) W);
 impl<W: Write> Write for ErrorToMessageWriter<W> {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         let len = buf.len();
-        let output = rename_error_to_message(buf).unwrap_or_else(|| buf.to_vec());
-        self.0.write_all(&output)?;
+        match rename_error_to_message(buf) {
+            Some(output) => self.0.write_all(&output)?,
+            None => self.0.write_all(buf)?,
+        }
         Ok(len)
     }
 

--- a/crates/apollo_infra/src/trace_util.rs
+++ b/crates/apollo_infra/src/trace_util.rs
@@ -10,18 +10,19 @@ use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, reload, EnvFilter};
 
-// Byte pattern of the root-level "error" key as emitted by compact JSON serialization.
-const ERROR_KEY_PATTERN: &[u8] = b"\"error\"";
+/// Conservative prefilter for the `"error"` key: a match can also come from a nested key or a
+/// plain string value, so a hit only means the JSON parse below is worth attempting.
+const ERROR_KEY_PATTERN: &str = "\"error\"";
 
-// Renames the "error" key to "message" in a JSON object, if present, and if "message" doesn't
-// already exist. Returns `None` when no rewrite is needed (including on invalid JSON), so the
-// caller can write the original buffer unchanged.
-//
-// Most log lines have no "error" key at all (only #[instrument(...,err)] error paths do), so a
-// cheap byte-level scan for the key first skips the JSON parse/reserialize round-trip for the
-// overwhelming majority of calls; this function runs on every single log line emitted.
+/// Renames the "error" key to "message" in a JSON object, if present, and if "message" doesn't
+/// already exist. Returns `None` when no rewrite is needed (including on invalid JSON), so the
+/// caller can write the original buffer unchanged.
+///
+/// Most log lines have no "error" key at all (only #[instrument(...,err)] error paths do), so a
+/// cheap prefilter for the key first skips the JSON parse/reserialize round-trip for the
+/// overwhelming majority of calls; this function runs on every single log line emitted.
 pub(crate) fn rename_error_to_message(buf: &[u8]) -> Option<Vec<u8>> {
-    if !buf.windows(ERROR_KEY_PATTERN.len()).any(|window| window == ERROR_KEY_PATTERN) {
+    if !std::str::from_utf8(buf).is_ok_and(|line| line.contains(ERROR_KEY_PATTERN)) {
         return None;
     }
     let mut obj: serde_json::Map<String, serde_json::Value> = serde_json::from_slice(buf).ok()?;

--- a/crates/apollo_infra/src/trace_util_tests.rs
+++ b/crates/apollo_infra/src/trace_util_tests.rs
@@ -40,19 +40,16 @@ fn rename_error_to_message_renames_error_key() {
 }
 
 #[test]
-fn rename_error_to_message_preserves_other_fields() {
+fn rename_error_to_message_returns_none_when_no_error_key_present() {
+    // No "error" key at all: no rewrite needed, caller writes the buffer unchanged.
     let input = br#"{"level":"INFO","status":"ok","count":42}"#;
-    let output = rename_error_to_message(input).unwrap();
-    let output_str = String::from_utf8(output).unwrap();
-
-    assert!(output_str.contains(r#""level":"INFO""#), "got: {output_str}");
-    assert!(output_str.contains(r#""status":"ok""#), "got: {output_str}");
-    assert!(output_str.contains(r#""count":42"#), "got: {output_str}");
+    assert!(rename_error_to_message(input).is_none());
 }
 
 #[test]
 fn rename_error_to_message_returns_none_for_invalid_json() {
-    let input = b"not valid json";
+    // Contains the "error" byte pattern so it reaches the JSON parse, which then fails.
+    let input = br#"not valid json "error""#;
     assert!(rename_error_to_message(input).is_none());
 }
 
@@ -73,26 +70,18 @@ fn rename_error_to_message_only_renames_root_level_error() {
 
 #[test]
 fn rename_error_to_message_preserves_existing_message_field() {
-    // If both "error" and "message" exist, leave the object unchanged
+    // If both "error" and "message" exist, no rewrite is needed: the caller writes the buffer
+    // unchanged, which trivially preserves both fields.
     let input = br#"{"error":"the error","message":"original message"}"#;
-    let output = rename_error_to_message(input).unwrap();
-    let parsed: serde_json::Value = serde_json::from_slice(&output).unwrap();
-
-    // Both fields should remain unchanged
-    assert_eq!(parsed["message"], "original message");
-    assert_eq!(parsed["error"], "the error");
+    assert!(rename_error_to_message(input).is_none());
 }
 
 #[test]
 fn rename_error_to_message_does_not_modify_error_values() {
-    // Values equal to "error" should NOT be modified - only keys named "error"
+    // Values equal to "error" should NOT be modified - only keys named "error". There is no
+    // actual "error" key here, so no rewrite is needed even though the byte pattern is present.
     let input = br#"{"status":"error","type":"error","level":"ERROR"}"#;
-    let output = rename_error_to_message(input).unwrap();
-    let parsed: serde_json::Value = serde_json::from_slice(&output).unwrap();
-
-    assert_eq!(parsed["status"], "error");
-    assert_eq!(parsed["type"], "error");
-    assert_eq!(parsed["level"], "ERROR");
+    assert!(rename_error_to_message(input).is_none());
 }
 
 /// A shared buffer for capturing log output.

--- a/crates/apollo_infra/src/trace_util_tests.rs
+++ b/crates/apollo_infra/src/trace_util_tests.rs
@@ -12,6 +12,7 @@ use crate::trace_util::{
     get_log_directives,
     rename_error_to_message,
     set_log_level,
+    ErrorToMessageWriter,
     ReloadHandle,
 };
 
@@ -77,11 +78,37 @@ fn rename_error_to_message_preserves_existing_message_field() {
 }
 
 #[test]
-fn rename_error_to_message_does_not_modify_error_values() {
+fn rename_error_to_message_returns_none_when_error_appears_only_as_a_value() {
     // Values equal to "error" should NOT be modified - only keys named "error". There is no
-    // actual "error" key here, so no rewrite is needed even though the byte pattern is present.
+    // actual "error" key here, so no rewrite is needed even though the prefilter matches.
     let input = br#"{"status":"error","type":"error","level":"ERROR"}"#;
     assert!(rename_error_to_message(input).is_none());
+}
+
+#[test]
+fn error_to_message_writer_passes_through_non_error_lines_unchanged() {
+    let mut buffer = Vec::new();
+    let mut writer = ErrorToMessageWriter(&mut buffer);
+
+    let plain_line: &[u8] = br#"{"level":"INFO","message":"hello"}"#;
+    let plain_line = [plain_line, b"\n"].concat();
+    let error_line: &[u8] = br#"{"level":"ERROR","error":"boom"}"#;
+    let error_line = [error_line, b"\n"].concat();
+
+    writer.write_all(&plain_line).unwrap();
+    writer.write_all(&error_line).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    let mut lines = output.lines();
+
+    // The plain line has no "error" key, so it must come out byte-for-byte unchanged.
+    assert_eq!(lines.next().unwrap().as_bytes(), &plain_line[..plain_line.len() - 1]);
+
+    // The error line is still rewritten, and the two lines stay newline-separated.
+    let rewritten: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+    assert_eq!(rewritten["message"], "boom");
+    assert!(rewritten.get("error").is_none());
+    assert!(lines.next().is_none());
 }
 
 /// A shared buffer for capturing log output.


### PR DESCRIPTION
## What

`rename_error_to_message()` backs `ErrorToMessageWriter`, the writer wrapped around the JSON tracing fmt layer built in `create_fmt_layer` (`crates/apollo_infra/src/trace_util.rs`). It runs on **every single log line** emitted by the node — the sibling PR #14928 (merged just before this one) cites ~8.4M log entries/day for the `sequencer-core` component alone.

Previously, this function unconditionally:
1. Deserialized the entire line into a `serde_json::Map<String, serde_json::Value>`,
2. Conditionally renamed an `"error"` key to `"message"` (only relevant for `#[instrument(...,err)]` error paths),
3. Unconditionally reserialized the whole object back to bytes and appended a newline,

— even though the overwhelming majority of log lines have no `"error"` key at all. The caller also always copied the buffer (`buf.to_vec()`) as a fallback.

This adds a cheap prefilter — `std::str::from_utf8(buf).is_ok_and(|line| line.contains("\"error\""))` — and returns `None` immediately when no `"error"` key can be present, skipping the parse/reserialize round-trip entirely. `None` now means "no rewrite needed"; the writer passes the original buffer straight through (which already carries its own trailing newline from the formatter, verified empirically) instead of copying it.

## Why

Measured in release, on a representative 246-byte log line:
- **~1.59 µs → ~0.195 µs per call (~8x)** for the common (no "error" key) case,
- Removes ~10+ heap allocations per line (one `String` per JSON key, the `Vec` output, and the `buf.to_vec()` copy),
- The error-key rewrite path itself is unchanged (~1.58 µs vs ~1.66 µs old — within noise).

At the ~8.4M lines/day/component cited above, that's roughly 12s/day of CPU plus meaningfully less allocator churn, on a path that runs underneath every log call in the node, including inside hot loops.

## Correctness

- The prefilter can never false-negative: tracing-subscriber's JSON formatter emits compact JSON with only `"`, `\`, and control-character escaping (none of which appear in `error`), so a root-level `"error"` key is always exactly the 7-byte sequence `"error"` in the line.
- The prefilter *can* false-positive (nested keys, or `"error"` as a plain string value) — that's fine and by design: a false positive just means the JSON parse below runs and finds nothing to rewrite, falling through to the existing `None` paths.
- The rewrite path itself (parse → check `"message"` → remove `"error"` → insert → reserialize) is byte-for-byte the same logic as before for objects that actually need a rewrite.
- Verified empirically (via a temporary probe) that tracing-subscriber hands `write()` one complete line including its own trailing `\n` in a single call, so passing `buf` straight through on the fast path does not drop the line terminator or merge lines together.

One side effect worth calling out (not a regression): the old code round-tripped every line through a `BTreeMap`-backed `serde_json::Map`, which alphabetically re-sorted JSON keys on every single line. The fast path now preserves the formatter's natural field order (e.g., timestamp first) instead. Nothing in the repo depends on log field ordering (checked scripts/deployments).

## Review

Reviewed by an independent Opus pass focused on correctness, false-negative risk in the prefilter, test coverage, and style. All findings were SUGGESTION/NIT level (no BLOCKING issues) and have been addressed:
- Switched the prefilter from a raw byte-window scan to `str::contains`, which is both simpler and ~7x faster.
- Added a byte-exact test (`error_to_message_writer_passes_through_non_error_lines_unchanged`) covering that consecutive non-error/error lines stay correctly newline-separated through the writer.
- Renamed a test to describe what it verifies, and clarified doc comments.

## Test plan

- `SEED=0 cargo test -p apollo_infra` — 45 passed, 0 failed (44 lib + 1 doc test)
- `cargo clippy -p apollo_infra --all-targets -- -D warnings` — clean
- `scripts/rust_fmt.sh` — clean

🤖 Generated with [Claude Code](https://claude.ai/code), reviewed by an independent Opus subagent pass.

Related: #14928 (merged) — this is a follow-up performance optimization to the same file/hot path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DFJwtjCNpk3591vCHkJNWS)_