### PR TITLE
apollo_l1_gas_price,apollo_l1_gas_price_config,apollo_l1_gas_price_types: add Chainlink client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,8 @@ dependencies = [
 name = "apollo_l1_gas_price"
 version = "0.19.0-rc.2"
 dependencies = [
+ "apollo_batcher_types",
+ "apollo_cairo_utils",
  "apollo_config",
  "apollo_infra",
  "apollo_infra_utils",
@@ -1874,13 +1876,17 @@ dependencies = [
  "async-trait",
  "futures",
  "lru 0.12.5",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mockall",
  "mockito",
  "papyrus_base_layer",
  "reqwest 0.12.24",
  "rstest",
  "serde_json",
+ "starknet-types-core",
  "starknet_api",
+ "strum",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -1893,7 +1899,10 @@ name = "apollo_l1_gas_price_config"
 version = "0.19.0-rc.2"
 dependencies = [
  "apollo_config",
+ "apollo_l1_gas_price_types",
+ "rstest",
  "serde",
+ "starknet-types-core",
  "starknet_api",
  "url",
  "validator",

--- a/crates/apollo_cairo_utils/src/lib.rs
+++ b/crates/apollo_cairo_utils/src/lib.rs
@@ -14,6 +14,24 @@ pub trait TryFromIterator<Item>: Sized {
     fn try_from_iter<T: Iterator<Item = Item>>(iter: &mut T) -> Result<Self, Self::Error>;
 }
 
+/// Deserializes a whole retdata into `T`, rejecting felts left over after `T` is decoded.
+///
+/// TODO(Asaf): route `CairoArray`, `CairoOption` and `apollo_staking`'s `Epoch` through this, and
+/// drop their `TryFrom<Retdata>` impls.
+pub fn deserialize_retdata<T>(retdata: Vec<Felt>) -> Result<T, RetdataDeserializationError>
+where
+    T: TryFromIterator<Felt, Error = RetdataDeserializationError>,
+{
+    let mut felt_iterator = retdata.into_iter();
+    let deserialized = T::try_from_iter(&mut felt_iterator)?;
+    if felt_iterator.next().is_some() {
+        return Err(RetdataDeserializationError::InvalidObjectLength {
+            message: "unconsumed elements in retdata".to_string(),
+        });
+    }
+    Ok(deserialized)
+}
+
 // Represents a Cairo1 `Array` containing elements that can be deserialized to `T`.
 // `T` must implement `TryFromIterator<Felt>`.
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/apollo_l1_gas_price/Cargo.toml
+++ b/crates/apollo_l1_gas_price/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 description = "Tracks and provides L1 (Ethereum) gas prices for Starknet transaction pricing."
 
 [dependencies]
+apollo_batcher_types.workspace = true
+apollo_cairo_utils.workspace = true
 apollo_config.workspace = true
 apollo_infra.workspace = true
 apollo_infra_utils.workspace = true
@@ -21,7 +23,9 @@ papyrus_base_layer.workspace = true
 reqwest.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
+starknet-types-core.workspace = true
 starknet_api.workspace = true
+strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
@@ -29,10 +33,15 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+apollo_batcher_types = { workspace = true, features = ["testing"] }
 apollo_l1_gas_price_types = { workspace = true, features = ["testing"] }
+apollo_metrics = { workspace = true, features = ["testing"] }
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 mockall.workspace = true
 mockito.workspace = true
 papyrus_base_layer = { workspace = true, features = ["testing"] }
+tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 testing = []

--- a/crates/apollo_l1_gas_price/src/chainlink_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/chainlink_oracle.rs
@@ -1,0 +1,592 @@
+use std::fmt::{Debug, Formatter, Result as FormatterResult};
+use std::marker::PhantomData;
+use std::num::NonZeroU64;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use apollo_batcher_types::batcher_types::CallContractInput;
+use apollo_batcher_types::communication::SharedBatcherClient;
+use apollo_cairo_utils::{deserialize_retdata, RetdataDeserializationError, TryFromIterator};
+use apollo_l1_gas_price_config::config::{
+    ChainlinkOracleConfig,
+    FreshnessWindow,
+    RateBounds,
+    CHAINLINK_MICRO_UNIT_DECIMALS,
+};
+use apollo_l1_gas_price_types::errors::ExchangeRateOracleClientError;
+use apollo_l1_gas_price_types::{
+    CurrencyPair,
+    EthToFri,
+    ExchangeRate,
+    ExchangeRateOracleClientTrait,
+    RateKind,
+    StrkToUsd,
+};
+use apollo_metrics::metrics::set_unix_now_seconds;
+use async_trait::async_trait;
+use futures::future::try_join;
+use futures::FutureExt;
+use starknet_api::core::ContractAddress;
+use starknet_types_core::felt::Felt;
+use tokio::time::Instant;
+use tokio_util::task::AbortOnDropHandle;
+use tracing::{debug, info, instrument, warn};
+
+use crate::metrics::{
+    register_chainlink_guard_metrics,
+    ExchangeRateOracleMetrics,
+    CHAINLINK_ORACLE_CONTRACT_CALL_ERROR_COUNT,
+    CHAINLINK_ORACLE_FUTURE_FEED_COUNT,
+    CHAINLINK_ORACLE_INVALID_FEED_ANSWER_COUNT,
+    CHAINLINK_ORACLE_RATE_OUT_OF_BOUNDS_COUNT,
+    CHAINLINK_ORACLE_STALE_FEED_COUNT,
+    ETH_TO_STRK_ORACLE_METRICS,
+    STRK_TO_USD_ORACLE_METRICS,
+};
+
+#[cfg(test)]
+#[path = "chainlink_oracle_test.rs"]
+mod chainlink_oracle_test;
+
+const LATEST_ROUND_DATA_ENTRY_POINT: &str = "latest_round_data";
+const DECIMALS_ENTRY_POINT: &str = "decimals";
+
+/// Fixed-point scale of every rate this client returns, matching `EXCHANGE_RATE_DECIMALS`.
+const RATE_DECIMALS: u32 = 18;
+const RATE_SCALE: u128 = 10u128.pow(RATE_DECIMALS);
+const MICRO_UNIT_TO_RATE_SCALE: u128 = 10u128.pow(RATE_DECIMALS - CHAINLINK_MICRO_UNIT_DECIMALS);
+
+/// The Chainlink feeds report 8 decimals today. A range is accepted rather than the exact value so
+/// that a feed upgrade does not halt pricing, bounded so the rescale to `RATE_DECIMALS` can
+/// neither underflow nor produce an absurd scale factor.
+const MIN_FEED_DECIMALS: u32 = 6;
+const MAX_FEED_DECIMALS: u32 = RATE_DECIMALS;
+
+/// Cap on the batcher error text this client relays. A reverting view call's panic data reaches
+/// the logs, the failure cache, and (when the provider runs remotely) the RPC boundary, so the cap
+/// is byte-based to bound what all three consume.
+const MAX_CONTRACT_CALL_ERROR_BYTES: usize = 256;
+const TRUNCATION_MARKER: &str = "...[truncated]";
+
+/// How many sampling intervals may separate the last valid read's block timestamp from the block
+/// timestamp being served, while that read is still served. Three read intervals, 45 minutes at the
+/// production 900 second interval. The bound applies in both directions, because a re-proposal can
+/// ask for a timestamp earlier than the read the client holds.
+const MAX_FALLBACK_SAMPLING_INTERVALS: u64 = 3;
+
+/// A rate at `RATE_DECIMALS`, or the guard trip that rejected it.
+type RateResult = Result<ExchangeRate, ExchangeRateOracleClientError>;
+/// A read in flight, resolving to a rate already dated by the block timestamp it was issued for.
+type RateQuery = AbortOnDropHandle<Result<ValidRead, ExchangeRateOracleClientError>>;
+
+/// A rate that passed every guard, and the block timestamp it was read for. That timestamp is a
+/// block timestamp rather than a local one, because the distance a later caller measures against it
+/// must come out the same on every node, including on a replay of the same block.
+#[derive(Clone, Copy, Debug)]
+struct ValidRead {
+    rate: ExchangeRate,
+    block_timestamp: u64,
+}
+
+#[derive(Default)]
+struct OracleState {
+    /// The newest read that passed every guard, served to callers while it is within
+    /// `MAX_FALLBACK_SAMPLING_INTERVALS` of their own block timestamp.
+    last_valid_read: Option<ValidRead>,
+    /// The newest query's failure, cleared by the next success. Served only when no valid read is
+    /// close enough to the caller.
+    last_error: Option<ExchangeRateOracleClientError>,
+    /// The query in flight. A single slot bounds this client to one query at a time.
+    query: Option<RateQuery>,
+    /// When the last query was spawned, on the local monotonic clock, which the refresh cadence is
+    /// measured from. Local because the cadence is this node's own scheduling, so a block
+    /// timestamp arriving from the network cannot steer it.
+    last_attempt_instant: Option<Instant>,
+}
+
+/// The Chainlink read behind a `RateKind`. Separate from `RateKind` because
+/// `ExchangeRateOracleMetrics` lives in this crate, which the types crate cannot name.
+#[async_trait]
+pub trait ChainlinkRate: RateKind {
+    /// The pair's metrics bundle, shared with the HTTP client for the same pair so each keeps one
+    /// set of Prometheus series across a migration between the two sources.
+    fn metrics() -> ExchangeRateOracleMetrics;
+
+    async fn query_rate(
+        batcher_client: &SharedBatcherClient,
+        config: &ChainlinkOracleConfig,
+        block_timestamp: u64,
+    ) -> RateResult;
+}
+
+/// Reads Chainlink's on-chain Starknet price feeds through the sequencer's own batcher.
+///
+/// Consensus calls `fetch_rate` on every proposal build and validate, so the call must not block on
+/// the batcher: the feed is read by a background query spawned at most once per
+/// `sampling_interval_seconds`, and every caller is served the last valid read while that read is
+/// within `MAX_FALLBACK_SAMPLING_INTERVALS` of the caller's own block timestamp.
+///
+/// Reads are not deterministic across nodes: `call_contract` executes against the batcher's latest
+/// committed block rather than state pinned to the queried timestamp, so two nodes can read
+/// different rounds for the same block timestamp. Chainlink's deviation threshold is far inside the
+/// `l1_gas_price_margin_percent` validators compare within, so this is not expected to reject
+/// proposals.
+#[derive(Clone)]
+pub struct ChainlinkOracleClient<Kind: ChainlinkRate> {
+    config: ChainlinkOracleConfig,
+    /// How often a healthy feed is read, however many proposals that spans.
+    sampling_interval_seconds: NonZeroU64,
+    batcher_client: SharedBatcherClient,
+    state: Arc<Mutex<OracleState>>,
+    metrics: ExchangeRateOracleMetrics,
+    _kind: PhantomData<Kind>,
+}
+
+// Manual impl: the trait requires `Debug` but `SharedBatcherClient` does not provide it.
+impl<Kind: ChainlinkRate> Debug for ChainlinkOracleClient<Kind> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FormatterResult {
+        formatter
+            .debug_struct("ChainlinkOracleClient")
+            .field("pair", &Kind::PAIR)
+            .field("config", &self.config)
+            .field("sampling_interval_seconds", &self.sampling_interval_seconds)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<Kind: ChainlinkRate> ChainlinkOracleClient<Kind> {
+    /// `sampling_interval_seconds` is the feed's own sampling cadence, taken from the same config
+    /// key the HTTP client of that feed samples on, so switching source leaves the cadence
+    /// unchanged.
+    pub fn new(
+        config: ChainlinkOracleConfig,
+        sampling_interval_seconds: NonZeroU64,
+        batcher_client: SharedBatcherClient,
+    ) -> Self {
+        let pair = Kind::PAIR;
+        info!(
+            "Creating ChainlinkOracleClient for {pair:?} with: \
+             sampling_interval_seconds={sampling_interval_seconds} config {config:?}"
+        );
+        let metrics = Kind::metrics();
+        metrics.register();
+        register_chainlink_guard_metrics();
+        let state = Arc::new(Mutex::new(OracleState::default()));
+        Self {
+            config,
+            sampling_interval_seconds,
+            batcher_client,
+            state,
+            metrics,
+            _kind: PhantomData,
+        }
+    }
+
+    /// `block_timestamp` is what every freshness guard inside the query is measured against, and
+    /// what the resulting read is dated by.
+    fn spawn_query(&self, block_timestamp: u64) -> RateQuery {
+        let batcher_client = self.batcher_client.clone();
+        let config = self.config.clone();
+        let metrics = self.metrics;
+        let pair = Kind::PAIR;
+        AbortOnDropHandle::new(tokio::spawn(async move {
+            let result = Kind::query_rate(&batcher_client, &config, block_timestamp).await;
+            match &result {
+                Ok(rate) => {
+                    metrics.success_count.increment(1);
+                    set_unix_now_seconds(metrics.last_success_timestamp);
+                    metrics.rate.set_lossy(*rate);
+                    debug!(
+                        "Resolved {pair:?} query for block timestamp {block_timestamp} to {rate}"
+                    );
+                }
+                Err(error) => {
+                    metrics.error_count.increment(1);
+                    warn!("Failed {pair:?} query for block timestamp {block_timestamp}: {error:?}");
+                }
+            }
+            result.map(|rate| ValidRead { rate, block_timestamp })
+        }))
+    }
+
+    /// Moves a finished query's outcome into `state`: a success becomes the last valid read and
+    /// clears the last error, a failure becomes the last error. Called on every `fetch_rate`, so
+    /// that a query which resolved after the last caller that could have observed it is harvested
+    /// rather than dropped together with the round trip that produced it.
+    fn harvest_finished_query(&self, state: &mut OracleState) {
+        if !state.query.as_ref().is_some_and(|query| query.is_finished()) {
+            return;
+        }
+        let joined = state
+            .query
+            .take()
+            .expect("Query must be present if it reported being finished")
+            .now_or_never()
+            .expect("Finished query must resolve immediately");
+        let result = joined.unwrap_or_else(|error| {
+            self.metrics.error_count.increment(1);
+            warn!("Query failed to join its handle: {error:?}");
+            Err(ExchangeRateOracleClientError::JoinError(error.to_string()))
+        });
+        match result {
+            Ok(valid_read) => {
+                debug!("Harvested {valid_read:?}");
+                state.last_valid_read = Some(valid_read);
+                state.last_error = None;
+            }
+            Err(error) => {
+                debug!("Harvested query failure: {error:?}");
+                state.last_error = Some(error);
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl<Kind: ChainlinkRate> ExchangeRateOracleClientTrait for ChainlinkOracleClient<Kind> {
+    #[instrument(skip(self))]
+    async fn fetch_rate(
+        &self,
+        block_timestamp: u64,
+    ) -> Result<ExchangeRate, ExchangeRateOracleClientError> {
+        // Held for the whole function: harvesting the finished query, deciding whether to spawn the
+        // next one and serving this caller are one critical section, so no caller can observe a
+        // query that was taken but whose outcome is not stored yet.
+        let mut state = self.state.lock().unwrap();
+        self.harvest_finished_query(&mut state);
+
+        let refresh_interval_seconds = if state.last_error.is_some() {
+            self.config.failure_retry_interval_seconds
+        } else {
+            self.sampling_interval_seconds.get()
+        };
+        let refresh_interval = Duration::from_secs(refresh_interval_seconds);
+        let is_refresh_due = state
+            .last_attempt_instant
+            .is_none_or(|last_attempt| last_attempt.elapsed() >= refresh_interval);
+        if state.query.is_none() && is_refresh_due {
+            state.query = Some(self.spawn_query(block_timestamp));
+            state.last_attempt_instant = Some(Instant::now());
+        }
+
+        // A caller whose own read has not resolved is served the last valid read while it is close
+        // enough. The distance is measured between block timestamps, in both directions, so a
+        // re-proposal for an earlier timestamp reaches the same decision the proposer did.
+        let max_fallback_distance_seconds =
+            MAX_FALLBACK_SAMPLING_INTERVALS.saturating_mul(self.sampling_interval_seconds.get());
+        if let Some(valid_read) = state.last_valid_read.filter(|valid_read| {
+            block_timestamp.abs_diff(valid_read.block_timestamp) <= max_fallback_distance_seconds
+        }) {
+            return Ok(valid_read.rate);
+        }
+        match state.last_error.clone() {
+            Some(error) => Err(error),
+            None => Err(ExchangeRateOracleClientError::QueryNotReadyError(block_timestamp)),
+        }
+    }
+}
+
+#[async_trait]
+impl ChainlinkRate for StrkToUsd {
+    fn metrics() -> ExchangeRateOracleMetrics {
+        STRK_TO_USD_ORACLE_METRICS
+    }
+
+    async fn query_rate(
+        batcher_client: &SharedBatcherClient,
+        config: &ChainlinkOracleConfig,
+        block_timestamp: u64,
+    ) -> RateResult {
+        read_feed(batcher_client, config.strk_usd_feed(), block_timestamp).await
+    }
+}
+
+#[async_trait]
+impl ChainlinkRate for EthToFri {
+    fn metrics() -> ExchangeRateOracleMetrics {
+        ETH_TO_STRK_ORACLE_METRICS
+    }
+
+    async fn query_rate(
+        batcher_client: &SharedBatcherClient,
+        config: &ChainlinkOracleConfig,
+        block_timestamp: u64,
+    ) -> RateResult {
+        // The two legs are separate `call_contract` calls, which exposes no block pinning, so
+        // they may straddle a block boundary. A one-block skew is orders of magnitude below
+        // the staleness bound both legs must independently pass.
+        let (eth_to_usd_rate, strk_to_usd_rate) = try_join(
+            read_feed(batcher_client, config.eth_usd_feed(), block_timestamp),
+            read_feed(batcher_client, config.strk_usd_feed(), block_timestamp),
+        )
+        .await?;
+
+        let eth_to_fri_rate = derive_eth_to_fri_rate(eth_to_usd_rate, strk_to_usd_rate)?;
+        check_rate_bounds(eth_to_fri_rate, config.eth_to_fri_bounds())?;
+        Ok(eth_to_fri_rate)
+    }
+}
+
+/// Everything one feed read needs: the feed's address, the bounds and pair its answer is judged
+/// against, and the freshness window that answer must fall in.
+#[derive(Clone, Copy, Debug)]
+struct FeedRead {
+    feed_address: ContractAddress,
+    bounds: RateBounds,
+    freshness: FreshnessWindow,
+}
+
+/// The reads a `ChainlinkOracleConfig` describes. One method per pair Chainlink quotes, so a read
+/// cannot be requested for the derived pair, which has no feed.
+trait ChainlinkFeeds {
+    fn eth_usd_feed(&self) -> FeedRead;
+    fn strk_usd_feed(&self) -> FeedRead;
+}
+
+impl ChainlinkFeeds for ChainlinkOracleConfig {
+    fn eth_usd_feed(&self) -> FeedRead {
+        FeedRead {
+            feed_address: self.eth_usd.feed_address,
+            bounds: self.eth_usd_bounds(),
+            freshness: self.freshness,
+        }
+    }
+
+    fn strk_usd_feed(&self) -> FeedRead {
+        FeedRead {
+            feed_address: self.strk_usd.feed_address,
+            bounds: self.strk_usd_bounds(),
+            freshness: self.freshness,
+        }
+    }
+}
+
+/// The feed's answer, rescaled to `RATE_DECIMALS` and checked against the feed's bounds.
+async fn read_feed(
+    batcher_client: &SharedBatcherClient,
+    feed: FeedRead,
+    block_timestamp: u64,
+) -> RateResult {
+    let pair = feed.bounds.pair;
+    let pair_name = pair.pair_name();
+    let feed_address = feed.feed_address;
+    // The feed's `decimals` is read alongside every rate rather than cached, because a feed that
+    // changes it would rescale the answer by a power of ten, and the absolute bounds are too wide
+    // to catch that. STRK/USD accepts $0.0001 to $10, so an 8-decimal answer read as 6 decimals
+    // passes as $3.00 instead of $0.03.
+    let (decimals_retdata, round_retdata) = try_join(
+        call_view(batcher_client, feed_address, DECIMALS_ENTRY_POINT, pair),
+        call_view(batcher_client, feed_address, LATEST_ROUND_DATA_ENTRY_POINT, pair),
+    )
+    .await?;
+    let feed_decimals = decode_feed_decimals(decimals_retdata, pair)?;
+
+    let round: ChainlinkRoundData = decode_retdata(round_retdata, pair)?;
+    if round.answer == 0 {
+        CHAINLINK_ORACLE_INVALID_FEED_ANSWER_COUNT.increment(1, &pair.labels());
+        return Err(ExchangeRateOracleClientError::InvalidRateError(format!(
+            "{pair_name} returned a zero answer"
+        )));
+    }
+    if block_timestamp.saturating_sub(round.updated_at) > feed.freshness.max_staleness_seconds {
+        CHAINLINK_ORACLE_STALE_FEED_COUNT.increment(1, &pair.labels());
+        return Err(ExchangeRateOracleClientError::StaleFeedError {
+            pair_name: pair_name.to_string(),
+            updated_at: round.updated_at,
+            block_timestamp,
+            max_staleness_seconds: feed.freshness.max_staleness_seconds,
+        });
+    }
+    // Catches a round dated ahead of the block being priced: the staleness check above saturates
+    // such a subtraction to zero, which alone treats it as fresh regardless of age.
+    if round.updated_at.saturating_sub(block_timestamp)
+        > feed.freshness.max_future_updated_at_seconds
+    {
+        CHAINLINK_ORACLE_FUTURE_FEED_COUNT.increment(1, &pair.labels());
+        return Err(ExchangeRateOracleClientError::FutureFeedError {
+            pair_name: pair_name.to_string(),
+            updated_at: round.updated_at,
+            block_timestamp,
+            max_future_updated_at_seconds: feed.freshness.max_future_updated_at_seconds,
+        });
+    }
+
+    let rate = rescale_to_rate_decimals(round.answer, feed_decimals)?;
+    check_rate_bounds(rate, feed.bounds)?;
+    Ok(rate)
+}
+
+async fn call_view(
+    batcher_client: &SharedBatcherClient,
+    contract_address: ContractAddress,
+    entry_point: &str,
+    pair: CurrencyPair,
+) -> Result<Vec<Felt>, ExchangeRateOracleClientError> {
+    let call_result = batcher_client
+        .call_contract(CallContractInput {
+            contract_address,
+            entry_point: entry_point.to_string(),
+            calldata: vec![],
+        })
+        .await;
+    match call_result {
+        Ok(output) => Ok(output.retdata),
+        Err(error) => {
+            CHAINLINK_ORACLE_CONTRACT_CALL_ERROR_COUNT.increment(1, &pair.labels());
+            Err(ExchangeRateOracleClientError::ContractCallError(format!(
+                "{entry_point} at {contract_address}: {}",
+                truncate_contract_call_error(error.to_string())
+            )))
+        }
+    }
+}
+
+fn truncate_contract_call_error(error_text: String) -> String {
+    if error_text.len() <= MAX_CONTRACT_CALL_ERROR_BYTES {
+        return error_text;
+    }
+    // Cut on a character boundary so the relayed text stays valid UTF-8. The nearest boundary at
+    // or below the cap is at most three bytes down.
+    let head_end = (0..=MAX_CONTRACT_CALL_ERROR_BYTES)
+        .rev()
+        .find(|byte_index| error_text.is_char_boundary(*byte_index))
+        .expect("Byte index 0 is always a character boundary");
+    format!("{}{TRUNCATION_MARKER}", &error_text[..head_end])
+}
+
+fn decode_feed_decimals(
+    decimals_retdata: Vec<Felt>,
+    pair: CurrencyPair,
+) -> Result<u32, ExchangeRateOracleClientError> {
+    let pair_name = pair.pair_name();
+    let raw_decimals: Felt = decode_retdata(decimals_retdata, pair)?;
+    let feed_decimals = u32::try_from(raw_decimals).map_err(|_| {
+        CHAINLINK_ORACLE_INVALID_FEED_ANSWER_COUNT.increment(1, &pair.labels());
+        ExchangeRateOracleClientError::ParseError(format!(
+            "{pair_name} decimals {raw_decimals} does not fit in u32"
+        ))
+    })?;
+    if !(MIN_FEED_DECIMALS..=MAX_FEED_DECIMALS).contains(&feed_decimals) {
+        CHAINLINK_ORACLE_INVALID_FEED_ANSWER_COUNT.increment(1, &pair.labels());
+        return Err(ExchangeRateOracleClientError::InvalidRateError(format!(
+            "{pair_name} reports {feed_decimals} decimals, outside the accepted range \
+             [{MIN_FEED_DECIMALS}, {MAX_FEED_DECIMALS}]"
+        )));
+    }
+    Ok(feed_decimals)
+}
+
+fn decode_retdata<T>(
+    retdata: Vec<Felt>,
+    pair: CurrencyPair,
+) -> Result<T, ExchangeRateOracleClientError>
+where
+    T: TryFromIterator<Felt, Error = RetdataDeserializationError>,
+{
+    deserialize_retdata(retdata).map_err(|error| {
+        CHAINLINK_ORACLE_CONTRACT_CALL_ERROR_COUNT.increment(1, &pair.labels());
+        ExchangeRateOracleClientError::ParseError(error.to_string())
+    })
+}
+
+fn rescale_to_rate_decimals(answer: u128, feed_decimals: u32) -> RateResult {
+    RATE_DECIMALS
+        .checked_sub(feed_decimals)
+        .and_then(|exponent| 10u128.checked_pow(exponent))
+        .and_then(|scale| answer.checked_mul(scale))
+        .ok_or_else(|| {
+            ExchangeRateOracleClientError::ArithmeticError(format!(
+                "rescaling answer {answer} from {feed_decimals} to {RATE_DECIMALS} decimals \
+                 overflowed"
+            ))
+        })
+}
+
+/// STRK per ETH, at `RATE_DECIMALS`, from two USD prices that already carry `RATE_DECIMALS`.
+fn derive_eth_to_fri_rate(
+    eth_to_usd_rate: ExchangeRate,
+    strk_to_usd_rate: ExchangeRate,
+) -> RateResult {
+    // The division cancels the two operands' scales, so the result must be scaled back up by
+    // `RATE_SCALE`. Scaling the numerator up front overflows u128, so the integer quotient and the
+    // remainder are scaled separately and recombined, which is exact: for
+    // `eth = quotient * strk + remainder`, `floor(eth * S / strk) = quotient * S +
+    // floor(remainder * S / strk)`.
+    let scaled_quotient = eth_to_usd_rate
+        .checked_div(strk_to_usd_rate)
+        .and_then(|quotient| quotient.checked_mul(RATE_SCALE));
+    let scaled_remainder = eth_to_usd_rate
+        .checked_rem(strk_to_usd_rate)
+        .and_then(|remainder| remainder.checked_mul(RATE_SCALE))
+        .and_then(|scaled_remainder| scaled_remainder.checked_div(strk_to_usd_rate));
+    scaled_quotient
+        .zip(scaled_remainder)
+        .and_then(|(quotient, remainder)| quotient.checked_add(remainder))
+        .ok_or_else(|| {
+            ExchangeRateOracleClientError::ArithmeticError(format!(
+                "deriving ETH/STRK from eth_to_usd_rate={eth_to_usd_rate} and \
+                 strk_to_usd_rate={strk_to_usd_rate} overflowed"
+            ))
+        })
+}
+
+// TODO(Asaf): bound the rate's change against the previous block's implied rate. The absolute
+// bounds below are wide enough to pass a manipulated but plausible answer, the STRK/USD pair alone
+// accepting anything from $0.0001 to $10, which only a bound relative to the last accepted rate
+// catches. It must be anchored to the block header rather than to node-local history, so that every
+// validator accepts and rejects the same values.
+/// Absolute bounds are the only defense against a feed wired to the wrong asset or a
+/// plausible-but-poisoned answer: consensus checks that validators agree with each other, never
+/// that the agreed value is sane, and every node reads the same chain state.
+fn check_rate_bounds(
+    rate: ExchangeRate,
+    bounds: RateBounds,
+) -> Result<(), ExchangeRateOracleClientError> {
+    let pair = bounds.pair;
+    let min_rate = u128::from(bounds.minimum_micro_units).saturating_mul(MICRO_UNIT_TO_RATE_SCALE);
+    let max_rate = u128::from(bounds.maximum_micro_units).saturating_mul(MICRO_UNIT_TO_RATE_SCALE);
+    if rate < min_rate || rate > max_rate {
+        CHAINLINK_ORACLE_RATE_OUT_OF_BOUNDS_COUNT.increment(1, &pair.labels());
+        return Err(ExchangeRateOracleClientError::RateOutOfBoundsError {
+            pair_name: pair.pair_name().to_string(),
+            rate,
+            min_rate,
+            max_rate,
+        });
+    }
+    Ok(())
+}
+
+/// The fields of Chainlink's `Round` that this client consumes.
+struct ChainlinkRoundData {
+    /// The price the feed reports, at the feed's own `decimals()`.
+    answer: u128,
+    /// Unix seconds at which the aggregator last wrote this round.
+    updated_at: u64,
+}
+
+impl TryFromIterator<Felt> for ChainlinkRoundData {
+    type Error = RetdataDeserializationError;
+
+    // `latest_round_data` returns `Round { round_id: felt252, answer: u128, block_num: u64,
+    // started_at: u64, updated_at: u64 }`, serialized flat as exactly five felts in that order.
+    fn try_from_iter<T: Iterator<Item = Felt>>(iter: &mut T) -> Result<Self, Self::Error> {
+        // `round_id` is phase-encoded as `(phase_id << 128) | aggregator_round_id`, so it exceeds
+        // every primitive integer type and is consumed without being decoded.
+        let _round_id = Felt::try_from_iter(iter)?;
+        // `answer` is unsigned on the Starknet feeds, so there is no sign extension to undo.
+        let raw_answer = Felt::try_from_iter(iter)?;
+        let answer = u128::try_from(raw_answer)
+            .map_err(|_| RetdataDeserializationError::U128ConversionError { felt: raw_answer })?;
+        let _block_number = Felt::try_from_iter(iter)?;
+        // `started_at` is consumed without being decoded: an aggregator that can lie about
+        // `updated_at` can lie about `started_at` too, so `started_at <= updated_at` adds no
+        // guarantee beyond the freshness window enforced on `updated_at`.
+        let _started_at = Felt::try_from_iter(iter)?;
+        let raw_updated_at = Felt::try_from_iter(iter)?;
+        let updated_at = u64::try_from(raw_updated_at).map_err(|_| {
+            RetdataDeserializationError::U64ConversionError { felt: raw_updated_at }
+        })?;
+        Ok(Self { answer, updated_at })
+    }
+}

--- a/crates/apollo_l1_gas_price/src/chainlink_oracle_test.rs
+++ b/crates/apollo_l1_gas_price/src/chainlink_oracle_test.rs
@@ -1,0 +1,1256 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use apollo_batcher_types::batcher_types::CallContractOutput;
+use apollo_batcher_types::communication::{BatcherClientError, MockBatcherClient};
+use apollo_batcher_types::errors::BatcherError;
+use apollo_metrics::metrics::{LabeledMetricCounter, MetricDetails};
+use assert_matches::assert_matches;
+use metrics::set_default_local_recorder;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use rstest::rstest;
+use strum::IntoEnumIterator;
+
+use super::*;
+
+/// The production sampling cadence, which each feed's `ExchangeRateOracleConfig` carries.
+const SAMPLING_INTERVAL_SECONDS: u64 = 900;
+const TIMESTAMP: u64 = 1_700_000_000;
+const FEED_DECIMALS: u32 = 8;
+const MAX_POLL_ATTEMPTS: usize = 1000;
+const MICRO_UNITS_PER_UNIT: u64 = 1_000_000;
+/// `decimals` and `latest_round_data`, per feed.
+const CALLS_PER_FEED_PER_QUERY: usize = 2;
+
+/// $3000 per ETH at `FEED_DECIMALS`.
+const ETH_USD_ANSWER: u128 = 300_000_000_000;
+/// $0.03 per STRK at `FEED_DECIMALS`.
+const STRK_USD_ANSWER: u128 = 3_000_000;
+/// The rate the two answers above derive to: 100,000 STRK per ETH.
+const ETH_TO_FRI_RATE: u128 = 100_000 * RATE_SCALE;
+/// $0.03 per STRK at `RATE_DECIMALS`.
+const STRK_TO_USD_RATE: u128 = 30_000_000_000_000_000;
+
+type FeedResponses = HashMap<(ContractAddress, String), Vec<Felt>>;
+
+fn test_config() -> ChainlinkOracleConfig {
+    ChainlinkOracleConfig::default()
+}
+
+fn sampling_interval() -> NonZeroU64 {
+    NonZeroU64::new(SAMPLING_INTERVAL_SECONDS).expect("Sampling interval must be non-zero")
+}
+
+/// The readings below are dated against `TIMESTAMP`, which every freshness bound is measured
+/// against.
+fn fresh_updated_at() -> u64 {
+    TIMESTAMP
+}
+
+fn stale_updated_at() -> u64 {
+    TIMESTAMP - test_config().freshness.max_staleness_seconds - 1
+}
+
+fn future_updated_at() -> u64 {
+    TIMESTAMP + test_config().freshness.max_future_updated_at_seconds + 1
+}
+
+/// One feed's mocked `decimals` and `latest_round_data` replies.
+#[derive(Clone, Copy)]
+struct FeedFixture {
+    answer: u128,
+    updated_at: u64,
+    feed_decimals: u32,
+}
+
+impl FeedFixture {
+    fn new(answer: u128, updated_at: u64) -> Self {
+        Self { answer, updated_at, feed_decimals: FEED_DECIMALS }
+    }
+
+    fn with_decimals(self, feed_decimals: u32) -> Self {
+        Self { feed_decimals, ..self }
+    }
+}
+
+fn decimals_retdata(feed_decimals: u32) -> Vec<Felt> {
+    vec![Felt::from(feed_decimals)]
+}
+
+fn round_retdata(answer: u128, updated_at: u64) -> Vec<Felt> {
+    // A realistic phase-encoded `round_id`: `(phase_id << 128) | aggregator_round_id`, which
+    // exceeds u64.
+    const PHASE_ENCODED_ROUND_ID: &str = "0x100000000000000000000000000000042";
+    const BLOCK_NUMBER: u64 = 987_654;
+    const STARTED_AT: u64 = 1_699_999_000;
+    vec![
+        Felt::from_hex_unchecked(PHASE_ENCODED_ROUND_ID),
+        Felt::from(answer),
+        Felt::from(BLOCK_NUMBER),
+        Felt::from(STARTED_AT),
+        Felt::from(updated_at),
+    ]
+}
+
+fn feed_responses(feed_address: ContractAddress, feed: FeedFixture) -> FeedResponses {
+    HashMap::from([
+        ((feed_address, DECIMALS_ENTRY_POINT.to_string()), decimals_retdata(feed.feed_decimals)),
+        (
+            (feed_address, LATEST_ROUND_DATA_ENTRY_POINT.to_string()),
+            round_retdata(feed.answer, feed.updated_at),
+        ),
+    ])
+}
+
+fn strk_usd_responses(strk_usd: FeedFixture) -> FeedResponses {
+    feed_responses(test_config().strk_usd.feed_address, strk_usd)
+}
+
+/// The STRK/USD feed with a valid `decimals` reply but no round, so exactly one of the two calls
+/// the client issues per feed fails.
+fn strk_usd_responses_without_round_data() -> FeedResponses {
+    HashMap::from([(
+        (test_config().strk_usd.feed_address, DECIMALS_ENTRY_POINT.to_string()),
+        decimals_retdata(FEED_DECIMALS),
+    )])
+}
+
+fn eth_and_strk_responses(eth_usd: FeedFixture, strk_usd: FeedFixture) -> FeedResponses {
+    let mut responses = feed_responses(test_config().eth_usd.feed_address, eth_usd);
+    responses.extend(feed_responses(test_config().strk_usd.feed_address, strk_usd));
+    responses
+}
+
+fn counting_batcher_client(responses: FeedResponses) -> (SharedBatcherClient, Arc<AtomicUsize>) {
+    let num_calls = Arc::new(AtomicUsize::new(0));
+    let num_calls_in_mock = num_calls.clone();
+    let mut batcher_client = MockBatcherClient::new();
+    batcher_client.expect_call_contract().returning(move |input| {
+        num_calls_in_mock.fetch_add(1, Ordering::SeqCst);
+        responses
+            .get(&(input.contract_address, input.entry_point.clone()))
+            .map(|retdata| CallContractOutput { retdata: retdata.clone() })
+            .ok_or(BatcherClientError::BatcherError(BatcherError::InternalError))
+    });
+    (Arc::new(batcher_client), num_calls)
+}
+
+/// Serves `responses` for the first `num_served_calls` calls and fails every call after that,
+/// which lets a test hold a successful read followed by a failing one.
+fn batcher_client_failing_after(
+    responses: FeedResponses,
+    num_served_calls: usize,
+) -> SharedBatcherClient {
+    let num_calls = AtomicUsize::new(0);
+    let mut batcher_client = MockBatcherClient::new();
+    batcher_client.expect_call_contract().returning(move |input| {
+        if num_calls.fetch_add(1, Ordering::SeqCst) >= num_served_calls {
+            return Err(BatcherClientError::BatcherError(BatcherError::InternalError));
+        }
+        responses
+            .get(&(input.contract_address, input.entry_point.clone()))
+            .map(|retdata| CallContractOutput { retdata: retdata.clone() })
+            .ok_or(BatcherClientError::BatcherError(BatcherError::InternalError))
+    });
+    Arc::new(batcher_client)
+}
+
+fn batcher_client_from_responses(responses: FeedResponses) -> SharedBatcherClient {
+    counting_batcher_client(responses).0
+}
+
+fn make_client<Kind: ChainlinkRate>(responses: FeedResponses) -> ChainlinkOracleClient<Kind> {
+    ChainlinkOracleClient::new(
+        test_config(),
+        sampling_interval(),
+        batcher_client_from_responses(responses),
+    )
+}
+
+/// A client behind the trait object, so that a test case can carry the rate kind as a factory
+/// rather than as a value.
+fn dyn_client<Kind: ChainlinkRate>(
+    responses: FeedResponses,
+) -> Arc<dyn ExchangeRateOracleClientTrait> {
+    Arc::new(make_client::<Kind>(responses))
+}
+
+/// Polls until the spawned background query resolves, mirroring how consensus retries across
+/// proposals.
+async fn resolve_rate(
+    client: &dyn ExchangeRateOracleClientTrait,
+    timestamp: u64,
+) -> Result<u128, ExchangeRateOracleClientError> {
+    for _ in 0..MAX_POLL_ATTEMPTS {
+        match client.fetch_rate(timestamp).await {
+            Err(ExchangeRateOracleClientError::QueryNotReadyError(_)) => {
+                tokio::task::yield_now().await;
+            }
+            resolved => return resolved,
+        }
+    }
+    panic!("Query did not resolve within {MAX_POLL_ATTEMPTS} attempts");
+}
+
+fn last_valid_rate<Kind: ChainlinkRate>(client: &ChainlinkOracleClient<Kind>) -> Option<u128> {
+    client.state.lock().unwrap().last_valid_read.map(|valid_read| valid_read.rate)
+}
+
+/// The failure the client holds, which a valid read close enough to the caller masks.
+fn held_error<Kind: ChainlinkRate>(
+    client: &ChainlinkOracleClient<Kind>,
+) -> Option<ExchangeRateOracleClientError> {
+    client.state.lock().unwrap().last_error.clone()
+}
+
+fn last_attempt_instant<Kind: ChainlinkRate>(
+    client: &ChainlinkOracleClient<Kind>,
+) -> Option<Instant> {
+    client.state.lock().unwrap().last_attempt_instant
+}
+
+fn is_query_in_flight<Kind: ChainlinkRate>(client: &ChainlinkOracleClient<Kind>) -> bool {
+    client.state.lock().unwrap().query.is_some()
+}
+
+/// Drives `fetch_rate` until the client holds a failure. Unlike `resolve_rate` this does not stop
+/// at the first `Ok`, which for a failing query is the last valid rate.
+async fn wait_for_held_error<Kind: ChainlinkRate>(
+    client: &ChainlinkOracleClient<Kind>,
+    timestamp: u64,
+) {
+    for _ in 0..MAX_POLL_ATTEMPTS {
+        if held_error(client).is_some() {
+            return;
+        }
+        let _ = client.fetch_rate(timestamp).await;
+        tokio::task::yield_now().await;
+    }
+    panic!("Query for timestamp {timestamp} did not fail within {MAX_POLL_ATTEMPTS} attempts");
+}
+
+/// Waits for the spawned query to finish without calling `fetch_rate`, which would harvest it.
+/// This is the state a query is left in when it resolves after the last caller that could have
+/// observed it.
+async fn wait_for_query_to_finish<Kind: ChainlinkRate>(client: &ChainlinkOracleClient<Kind>) {
+    for _ in 0..MAX_POLL_ATTEMPTS {
+        let is_finished = {
+            let state = client.state.lock().unwrap();
+            state.query.as_ref().is_some_and(|query| query.is_finished())
+        };
+        if is_finished {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("Query did not finish within {MAX_POLL_ATTEMPTS} attempts");
+}
+
+fn micro_units_to_answer(micro_units: u64, feed_decimals: u32) -> u128 {
+    u128::from(micro_units) * 10u128.pow(feed_decimals - CHAINLINK_MICRO_UNIT_DECIMALS)
+}
+
+fn micro_units_to_rate(micro_units: u64) -> u128 {
+    u128::from(micro_units) * MICRO_UNIT_TO_RATE_SCALE
+}
+
+#[tokio::test]
+async fn strk_to_usd_rescales_feed_answer_to_eighteen_decimals() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        fresh_updated_at(),
+    )));
+    // $0.03 per STRK.
+    assert_eq!(resolve_rate(&client, TIMESTAMP).await.unwrap(), STRK_TO_USD_RATE);
+}
+
+#[tokio::test]
+async fn eth_to_fri_divides_the_two_usd_legs() {
+    let updated_at = fresh_updated_at();
+    let client = make_client::<EthToFri>(eth_and_strk_responses(
+        FeedFixture::new(ETH_USD_ANSWER, updated_at),
+        FeedFixture::new(STRK_USD_ANSWER, updated_at),
+    ));
+    // $3000 per ETH over $0.03 per STRK is 100,000 STRK per ETH.
+    assert_eq!(resolve_rate(&client, TIMESTAMP).await.unwrap(), ETH_TO_FRI_RATE);
+}
+
+/// Each answer is rescaled to `RATE_DECIMALS` before the division, so the derived rate must come
+/// out the same whatever scales the two feeds report at. The widest pairs also cover the rescale
+/// of the largest answer this client accepts without overflowing.
+#[rstest]
+#[case::equal_decimals(8, 8)]
+#[case::wider_strk_feed(8, 12)]
+#[case::widest_strk_feed(6, 18)]
+#[case::widest_eth_feed(18, 6)]
+#[tokio::test]
+async fn eth_to_fri_is_independent_of_the_feeds_decimals(
+    #[case] eth_usd_decimals: u32,
+    #[case] strk_usd_decimals: u32,
+) {
+    let updated_at = fresh_updated_at();
+    // $3000 per ETH and $0.03 per STRK, expressed at each feed's own scale.
+    let client = make_client::<EthToFri>(eth_and_strk_responses(
+        FeedFixture::new(3000 * 10u128.pow(eth_usd_decimals), updated_at)
+            .with_decimals(eth_usd_decimals),
+        FeedFixture::new(3 * 10u128.pow(strk_usd_decimals) / 100, updated_at)
+            .with_decimals(strk_usd_decimals),
+    ));
+    assert_eq!(resolve_rate(&client, TIMESTAMP).await.unwrap(), ETH_TO_FRI_RATE);
+}
+
+/// The two legs do not divide evenly here, so this is the case that exercises recombining the
+/// scaled quotient with the scaled remainder, the one step of the derivation whose result cannot
+/// be read off the inputs.
+#[tokio::test]
+async fn eth_to_fri_recombines_a_non_zero_remainder() {
+    /// $0.07 per STRK at `FEED_DECIMALS`.
+    const STRK_USD_ANSWER_SEVEN_CENTS: u128 = 7_000_000;
+    /// floor(3000 / 0.07 * 10^18), that is 42857.142857... STRK per ETH.
+    const EXPECTED_RATE: u128 = 42_857_142_857_142_857_142_857;
+    let updated_at = fresh_updated_at();
+    let client = make_client::<EthToFri>(eth_and_strk_responses(
+        FeedFixture::new(ETH_USD_ANSWER, updated_at),
+        FeedFixture::new(STRK_USD_ANSWER_SEVEN_CENTS, updated_at),
+    ));
+    assert_eq!(resolve_rate(&client, TIMESTAMP).await.unwrap(), EXPECTED_RATE);
+}
+
+#[tokio::test]
+async fn strk_to_usd_rejects_stale_reading() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        stale_updated_at(),
+    )));
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::StaleFeedError { pair_name, .. })
+            if pair_name == CurrencyPair::StrkUsd.pair_name()
+    );
+}
+
+#[tokio::test]
+async fn strk_to_usd_accepts_reading_exactly_at_the_staleness_bound() {
+    let config = test_config();
+    let oldest_accepted_updated_at = TIMESTAMP - config.freshness.max_staleness_seconds;
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        oldest_accepted_updated_at,
+    )));
+    assert!(resolve_rate(&client, TIMESTAMP).await.is_ok());
+}
+
+/// The future-dated bound, checked separately from the staleness bound (see `read_feed`).
+#[rstest]
+#[case::at_the_future_bound(0, true)]
+#[case::just_past_the_future_bound(1, false)]
+#[tokio::test]
+async fn future_updated_at_is_bounded(
+    #[case] seconds_past_the_bound: u64,
+    #[case] is_accepted: bool,
+) {
+    let config = test_config();
+    let updated_at =
+        TIMESTAMP + config.freshness.max_future_updated_at_seconds + seconds_past_the_bound;
+    let client =
+        make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, updated_at)));
+
+    let result = resolve_rate(&client, TIMESTAMP).await;
+    if is_accepted {
+        assert!(result.is_ok());
+    } else {
+        assert_matches!(
+            result,
+            Err(ExchangeRateOracleClientError::FutureFeedError { pair_name, .. })
+                if pair_name == CurrencyPair::StrkUsd.pair_name()
+        );
+    }
+}
+
+/// `u64::MAX` as `updated_at` is rejected by the future bound (see `read_feed`).
+#[tokio::test]
+async fn maximal_future_updated_at_rejected() {
+    let client =
+        make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, u64::MAX)));
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::FutureFeedError { .. })
+    );
+}
+
+/// A fresh leg divided by a stale leg produces a phantom rate move, so either stale leg must
+/// reject the whole derived rate.
+#[rstest]
+#[case::stale_eth_leg(true, false, CurrencyPair::EthUsd)]
+#[case::stale_strk_leg(false, true, CurrencyPair::StrkUsd)]
+#[tokio::test]
+async fn eth_to_fri_rejects_when_either_leg_is_stale(
+    #[case] is_eth_leg_stale: bool,
+    #[case] is_strk_leg_stale: bool,
+    #[case] expected_pair: CurrencyPair,
+) {
+    let fresh_timestamp = fresh_updated_at();
+    let stale_timestamp = stale_updated_at();
+    let client = make_client::<EthToFri>(eth_and_strk_responses(
+        FeedFixture::new(
+            ETH_USD_ANSWER,
+            if is_eth_leg_stale { stale_timestamp } else { fresh_timestamp },
+        ),
+        FeedFixture::new(
+            STRK_USD_ANSWER,
+            if is_strk_leg_stale { stale_timestamp } else { fresh_timestamp },
+        ),
+    ));
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::StaleFeedError { pair_name, .. })
+            if pair_name == expected_pair.pair_name()
+    );
+}
+
+#[tokio::test]
+async fn zero_answer_rejected() {
+    let client =
+        make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(0, fresh_updated_at())));
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::InvalidRateError(message))
+            if message.contains("zero answer")
+    );
+}
+
+/// The accepted range is what bounds the rescale; a feed reporting outside it is rejected rather
+/// than mis-scaled.
+#[rstest]
+#[case::at_the_minimum(MIN_FEED_DECIMALS, true)]
+#[case::at_the_maximum(MAX_FEED_DECIMALS, true)]
+#[case::below_the_minimum(MIN_FEED_DECIMALS - 1, false)]
+#[case::above_the_maximum(MAX_FEED_DECIMALS + 1, false)]
+#[tokio::test]
+async fn feed_decimals_range_is_enforced(#[case] feed_decimals: u32, #[case] is_accepted: bool) {
+    // $0.03 per STRK, expressed at the feed's own scale.
+    let answer = 3 * 10u128.pow(feed_decimals) / 100;
+    let client = make_client::<StrkToUsd>(strk_usd_responses(
+        FeedFixture::new(answer, fresh_updated_at()).with_decimals(feed_decimals),
+    ));
+
+    let result = resolve_rate(&client, TIMESTAMP).await;
+    if is_accepted {
+        assert_eq!(result.unwrap(), STRK_TO_USD_RATE);
+    } else {
+        assert_matches!(
+            result,
+            Err(ExchangeRateOracleClientError::InvalidRateError(message))
+                if message.contains("decimals")
+        );
+    }
+}
+
+/// A decimals value too large for a `u32` must be reported as a parse failure rather than
+/// truncated into a plausible scale.
+#[tokio::test]
+async fn feed_decimals_exceeding_u32_rejected() {
+    let strk_usd_feed_address = test_config().strk_usd.feed_address;
+    let responses = HashMap::from([
+        ((strk_usd_feed_address, DECIMALS_ENTRY_POINT.to_string()), vec![Felt::MAX]),
+        (
+            (strk_usd_feed_address, LATEST_ROUND_DATA_ENTRY_POINT.to_string()),
+            round_retdata(STRK_USD_ANSWER, fresh_updated_at()),
+        ),
+    ]);
+    let client = make_client::<StrkToUsd>(responses);
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ParseError(message)) if message.contains("u32")
+    );
+}
+
+#[rstest]
+#[case::at_minimum(0, true)]
+#[case::just_below_minimum(-1, false)]
+#[tokio::test]
+async fn strk_usd_minimum_bound_is_inclusive(#[case] answer_offset: i8, #[case] is_accepted: bool) {
+    let config = test_config();
+    let boundary_answer = micro_units_to_answer(config.strk_usd.minimum_micro_units, FEED_DECIMALS);
+    let answer = boundary_answer.wrapping_add_signed(answer_offset.into());
+    let client =
+        make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(answer, fresh_updated_at())));
+
+    let result = resolve_rate(&client, TIMESTAMP).await;
+    if is_accepted {
+        assert_eq!(result.unwrap(), micro_units_to_rate(config.strk_usd.minimum_micro_units));
+    } else {
+        assert_matches!(
+            result,
+            Err(ExchangeRateOracleClientError::RateOutOfBoundsError { pair_name, .. })
+                if pair_name == CurrencyPair::StrkUsd.pair_name()
+        );
+    }
+}
+
+#[rstest]
+#[case::at_maximum(0, true)]
+#[case::just_above_maximum(1, false)]
+#[tokio::test]
+async fn strk_usd_maximum_bound_is_inclusive(#[case] answer_offset: i8, #[case] is_accepted: bool) {
+    let config = test_config();
+    let boundary_answer = micro_units_to_answer(config.strk_usd.maximum_micro_units, FEED_DECIMALS);
+    let answer = boundary_answer.wrapping_add_signed(answer_offset.into());
+    let client =
+        make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(answer, fresh_updated_at())));
+
+    let result = resolve_rate(&client, TIMESTAMP).await;
+    if is_accepted {
+        assert_eq!(result.unwrap(), micro_units_to_rate(config.strk_usd.maximum_micro_units));
+    } else {
+        assert_matches!(
+            result,
+            Err(ExchangeRateOracleClientError::RateOutOfBoundsError { pair_name, .. })
+                if pair_name == CurrencyPair::StrkUsd.pair_name()
+        );
+    }
+}
+
+#[rstest]
+#[case::at_minimum(0, true)]
+#[case::just_below_minimum(-1, false)]
+#[tokio::test]
+async fn eth_usd_minimum_bound_is_inclusive(#[case] answer_offset: i8, #[case] is_accepted: bool) {
+    let config = test_config();
+    let boundary_answer = micro_units_to_answer(config.eth_usd.minimum_micro_units, FEED_DECIMALS);
+    let eth_usd_answer = boundary_answer.wrapping_add_signed(answer_offset.into());
+    // $0.001 per STRK keeps the derived rate at 20,000 STRK per ETH, inside its own bounds, so
+    // only the ETH/USD bound can trip.
+    const STRK_USD_ANSWER_TENTH_OF_A_CENT: u128 = 100_000;
+    let updated_at = fresh_updated_at();
+    let client = make_client::<EthToFri>(eth_and_strk_responses(
+        FeedFixture::new(eth_usd_answer, updated_at),
+        FeedFixture::new(STRK_USD_ANSWER_TENTH_OF_A_CENT, updated_at),
+    ));
+
+    let result = resolve_rate(&client, TIMESTAMP).await;
+    if is_accepted {
+        assert!(result.is_ok());
+    } else {
+        assert_matches!(
+            result,
+            Err(ExchangeRateOracleClientError::RateOutOfBoundsError { pair_name, .. })
+                if pair_name == CurrencyPair::EthUsd.pair_name()
+        );
+    }
+}
+
+#[rstest]
+#[case::at_maximum(0, true)]
+#[case::just_above_maximum(1, false)]
+#[tokio::test]
+async fn eth_usd_maximum_bound_is_inclusive(#[case] answer_offset: i8, #[case] is_accepted: bool) {
+    let config = test_config();
+    let boundary_answer = micro_units_to_answer(config.eth_usd.maximum_micro_units, FEED_DECIMALS);
+    let eth_usd_answer = boundary_answer.wrapping_add_signed(answer_offset.into());
+    // $0.50 per STRK keeps the derived rate at 100,000 STRK per ETH, inside its own bounds.
+    const STRK_USD_ANSWER_FIFTY_CENTS: u128 = 50_000_000;
+    let updated_at = fresh_updated_at();
+    let client = make_client::<EthToFri>(eth_and_strk_responses(
+        FeedFixture::new(eth_usd_answer, updated_at),
+        FeedFixture::new(STRK_USD_ANSWER_FIFTY_CENTS, updated_at),
+    ));
+
+    let result = resolve_rate(&client, TIMESTAMP).await;
+    if is_accepted {
+        assert!(result.is_ok());
+    } else {
+        assert_matches!(
+            result,
+            Err(ExchangeRateOracleClientError::RateOutOfBoundsError { pair_name, .. })
+                if pair_name == CurrencyPair::EthUsd.pair_name()
+        );
+    }
+}
+
+/// Which end of the derived ETH/STRK band a case lands on.
+#[derive(Clone, Copy)]
+enum DerivedRateBound {
+    Minimum,
+    Maximum,
+}
+
+/// An ETH price well inside the ETH/USD band. The STRK price is derived from it so that the
+/// derived rate lands exactly on the requested ETH/STRK bound.
+const ETH_USD_PRICE_FOR_DERIVED_BOUNDS_MICRO_USD: u64 = 10_000 * MICRO_UNITS_PER_UNIT;
+
+fn strk_usd_answer_for_derived_rate(rate_micro_strk: u64) -> u128 {
+    // The rate is the ETH price over the STRK price, so the STRK price that produces it is the
+    // ETH price over the rate, with one extra micro-unit factor to keep both in micro units.
+    let strk_usd_price_micro_usd =
+        ETH_USD_PRICE_FOR_DERIVED_BOUNDS_MICRO_USD * MICRO_UNITS_PER_UNIT / rate_micro_strk;
+    micro_units_to_answer(strk_usd_price_micro_usd, FEED_DECIMALS)
+}
+
+/// Both legs stay inside their own bounds; only the derived rate crosses its bound. The rate moves
+/// inversely with the STRK price, which is why the offset that breaks the floor is positive and
+/// the one that breaks the ceiling is negative.
+#[rstest]
+#[case::at_minimum(DerivedRateBound::Minimum, 0, true)]
+#[case::just_below_minimum(DerivedRateBound::Minimum, 1, false)]
+#[case::at_maximum(DerivedRateBound::Maximum, 0, true)]
+#[case::just_above_maximum(DerivedRateBound::Maximum, -1, false)]
+#[tokio::test]
+async fn eth_to_fri_bounds_are_inclusive(
+    #[case] bound: DerivedRateBound,
+    #[case] strk_usd_answer_offset: i8,
+    #[case] is_accepted: bool,
+) {
+    let config = test_config();
+    let boundary_rate_micro_strk = match bound {
+        DerivedRateBound::Minimum => config.eth_to_fri.minimum_micro_units,
+        DerivedRateBound::Maximum => config.eth_to_fri.maximum_micro_units,
+    };
+    let strk_usd_answer = strk_usd_answer_for_derived_rate(boundary_rate_micro_strk)
+        .wrapping_add_signed(strk_usd_answer_offset.into());
+    let updated_at = fresh_updated_at();
+    let client = make_client::<EthToFri>(eth_and_strk_responses(
+        FeedFixture::new(
+            micro_units_to_answer(ETH_USD_PRICE_FOR_DERIVED_BOUNDS_MICRO_USD, FEED_DECIMALS),
+            updated_at,
+        ),
+        FeedFixture::new(strk_usd_answer, updated_at),
+    ));
+
+    let result = resolve_rate(&client, TIMESTAMP).await;
+    if is_accepted {
+        assert_eq!(result.unwrap(), micro_units_to_rate(boundary_rate_micro_strk));
+    } else {
+        assert_matches!(
+            result,
+            Err(ExchangeRateOracleClientError::RateOutOfBoundsError { pair_name, .. })
+                if pair_name == CurrencyPair::EthStrk.pair_name()
+        );
+    }
+}
+
+#[tokio::test]
+async fn extreme_answer_errors_instead_of_overflowing() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        u128::MAX,
+        fresh_updated_at(),
+    )));
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ArithmeticError(_))
+    );
+}
+
+#[rstest]
+#[case::too_few_felts(round_retdata(STRK_USD_ANSWER, 0).into_iter().take(4).collect())]
+#[case::too_many_felts(
+    [round_retdata(STRK_USD_ANSWER, 0), vec![Felt::ONE]].concat()
+)]
+#[case::answer_exceeding_u128(vec![Felt::ONE, Felt::MAX, Felt::ONE, Felt::ONE, Felt::ONE])]
+#[case::updated_at_exceeding_u64(
+    vec![Felt::ONE, Felt::from(STRK_USD_ANSWER), Felt::ONE, Felt::ONE, Felt::MAX]
+)]
+#[tokio::test]
+async fn malformed_retdata_rejected(#[case] malformed_round_retdata: Vec<Felt>) {
+    let strk_usd_feed_address = test_config().strk_usd.feed_address;
+    let responses = HashMap::from([
+        (
+            (strk_usd_feed_address, DECIMALS_ENTRY_POINT.to_string()),
+            decimals_retdata(FEED_DECIMALS),
+        ),
+        (
+            (strk_usd_feed_address, LATEST_ROUND_DATA_ENTRY_POINT.to_string()),
+            malformed_round_retdata,
+        ),
+    ]);
+    let client = make_client::<StrkToUsd>(responses);
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ParseError(_))
+    );
+}
+
+#[tokio::test]
+async fn first_call_spawns_a_query_and_later_calls_are_served_without_requerying() {
+    let (batcher_client, num_batcher_calls) = counting_batcher_client(strk_usd_responses(
+        FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at()),
+    ));
+    let client =
+        ChainlinkOracleClient::<StrkToUsd>::new(test_config(), sampling_interval(), batcher_client);
+
+    // The batcher round trip must never block the proposal path.
+    assert_matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    );
+
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), CALLS_PER_FEED_PER_QUERY);
+
+    const NUM_LATER_CALLS: usize = 10;
+    for _ in 0..NUM_LATER_CALLS {
+        assert_eq!(client.fetch_rate(TIMESTAMP).await.unwrap(), rate);
+    }
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), CALLS_PER_FEED_PER_QUERY);
+}
+
+/// The call that spawns the refresh must not block on it, so it is served the rate the client
+/// already holds.
+#[tokio::test(start_paused = true)]
+async fn a_call_that_spawns_a_query_is_served_the_last_valid_rate() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        fresh_updated_at(),
+    )));
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    tokio::time::advance(Duration::from_secs(SAMPLING_INTERVAL_SECONDS)).await;
+    let later_timestamp = TIMESTAMP + SAMPLING_INTERVAL_SECONDS;
+    assert_eq!(client.fetch_rate(later_timestamp).await.unwrap(), rate);
+    assert!(is_query_in_flight(&client), "the refresh was due but no query was spawned");
+}
+
+/// A held failure keeps the batcher from being queried again before the retry interval, but it must
+/// not deny the proposal path a rate the client already holds.
+#[tokio::test(start_paused = true)]
+async fn a_held_failure_does_not_mask_the_last_valid_rate() {
+    let client = ChainlinkOracleClient::<StrkToUsd>::new(
+        test_config(),
+        sampling_interval(),
+        batcher_client_failing_after(
+            strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at())),
+            CALLS_PER_FEED_PER_QUERY,
+        ),
+    );
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    tokio::time::advance(Duration::from_secs(SAMPLING_INTERVAL_SECONDS)).await;
+    let later_timestamp = TIMESTAMP + SAMPLING_INTERVAL_SECONDS;
+    wait_for_held_error(&client, later_timestamp).await;
+
+    assert_eq!(client.fetch_rate(later_timestamp).await.unwrap(), rate);
+}
+
+/// The fallback must hold for the one call that observes a failing query finish and stores the
+/// failure, not just the calls before and after it.
+#[tokio::test(start_paused = true)]
+async fn no_call_is_denied_a_rate_the_client_holds() {
+    let client = ChainlinkOracleClient::<StrkToUsd>::new(
+        test_config(),
+        sampling_interval(),
+        batcher_client_failing_after(
+            strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at())),
+            CALLS_PER_FEED_PER_QUERY,
+        ),
+    );
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    tokio::time::advance(Duration::from_secs(SAMPLING_INTERVAL_SECONDS)).await;
+    let later_timestamp = TIMESTAMP + SAMPLING_INTERVAL_SECONDS;
+    for _ in 0..MAX_POLL_ATTEMPTS {
+        if held_error(&client).is_some() {
+            break;
+        }
+        assert_eq!(
+            client.fetch_rate(later_timestamp).await.expect("Last valid rate should be served"),
+            rate
+        );
+        tokio::task::yield_now().await;
+    }
+    assert!(held_error(&client).is_some(), "the failing query was never harvested");
+}
+
+/// The retry interval governs failed reads only. A successful read is served for the whole sampling
+/// interval, however many retry intervals it spans.
+#[tokio::test(start_paused = true)]
+async fn a_successful_read_is_not_requeried_before_the_sampling_interval() {
+    let failure_retry_interval_seconds = test_config().failure_retry_interval_seconds;
+    let (batcher_client, num_batcher_calls) = counting_batcher_client(strk_usd_responses(
+        FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at()),
+    ));
+    let client =
+        ChainlinkOracleClient::<StrkToUsd>::new(test_config(), sampling_interval(), batcher_client);
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    let num_retry_intervals_before_the_refresh =
+        (SAMPLING_INTERVAL_SECONDS - 1) / failure_retry_interval_seconds;
+    assert!(num_retry_intervals_before_the_refresh > 1);
+    for num_elapsed_intervals in 1..=num_retry_intervals_before_the_refresh {
+        tokio::time::advance(Duration::from_secs(failure_retry_interval_seconds)).await;
+        let later_timestamp = TIMESTAMP + num_elapsed_intervals * failure_retry_interval_seconds;
+        assert_eq!(client.fetch_rate(later_timestamp).await.unwrap(), rate);
+    }
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), CALLS_PER_FEED_PER_QUERY);
+}
+
+/// `decimals` and `latest_round_data` are read once per sampling interval, however many proposals
+/// that interval spans.
+#[rstest]
+#[case::one_second_short(SAMPLING_INTERVAL_SECONDS - 1, false)]
+#[case::at_the_interval(SAMPLING_INTERVAL_SECONDS, true)]
+#[tokio::test(start_paused = true)]
+async fn a_healthy_feed_is_requeried_once_the_sampling_interval_elapses(
+    #[case] elapsed_seconds: u64,
+    #[case] is_requeried: bool,
+) {
+    let (batcher_client, num_batcher_calls) = counting_batcher_client(strk_usd_responses(
+        FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at()),
+    ));
+    let client =
+        ChainlinkOracleClient::<StrkToUsd>::new(test_config(), sampling_interval(), batcher_client);
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), CALLS_PER_FEED_PER_QUERY);
+
+    tokio::time::advance(Duration::from_secs(elapsed_seconds)).await;
+    assert_eq!(client.fetch_rate(TIMESTAMP + elapsed_seconds).await.unwrap(), rate);
+
+    assert_eq!(is_query_in_flight(&client), is_requeried);
+    if is_requeried {
+        wait_for_query_to_finish(&client).await;
+        assert_eq!(num_batcher_calls.load(Ordering::SeqCst), 2 * CALLS_PER_FEED_PER_QUERY);
+    } else {
+        assert_eq!(num_batcher_calls.load(Ordering::SeqCst), CALLS_PER_FEED_PER_QUERY);
+    }
+}
+
+#[tokio::test]
+async fn batcher_call_failure_is_surfaced_as_an_error() {
+    let client = make_client::<StrkToUsd>(FeedResponses::new());
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ContractCallError(_))
+    );
+}
+
+/// With no valid rate to fall back on, the caller sees the failure, and the failing feed is
+/// queried once per retry interval rather than once per call.
+#[tokio::test(start_paused = true)]
+async fn failed_query_is_held_until_the_retry_interval_elapses() {
+    let failure_retry_interval_seconds = test_config().failure_retry_interval_seconds;
+    let (batcher_client, num_batcher_calls) = counting_batcher_client(FeedResponses::new());
+    let client =
+        ChainlinkOracleClient::<StrkToUsd>::new(test_config(), sampling_interval(), batcher_client);
+
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ContractCallError(_))
+    );
+    let num_calls_after_failure = num_batcher_calls.load(Ordering::SeqCst);
+    assert_eq!(last_valid_rate(&client), None);
+
+    // Every step together stays one second short of the retry interval.
+    const NUM_LATER_CALLS: u64 = 10;
+    let step_seconds = (failure_retry_interval_seconds - 1) / NUM_LATER_CALLS;
+    assert!(step_seconds > 0);
+    for _ in 0..NUM_LATER_CALLS {
+        tokio::time::advance(Duration::from_secs(step_seconds)).await;
+        assert_matches!(
+            client.fetch_rate(TIMESTAMP).await,
+            Err(ExchangeRateOracleClientError::ContractCallError(_))
+        );
+    }
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), num_calls_after_failure);
+}
+
+/// The freshness guards are measured against the block timestamp the caller asks for, so a round
+/// written in that very block is accepted however far it leads the timestamp of the client's
+/// previous read.
+#[tokio::test]
+async fn freshness_is_measured_against_the_block_timestamp() {
+    let config = test_config();
+    let offset_into_the_interval = config.freshness.max_future_updated_at_seconds + 1;
+    assert!(offset_into_the_interval < SAMPLING_INTERVAL_SECONDS);
+    let block_timestamp = TIMESTAMP + offset_into_the_interval;
+
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        block_timestamp,
+    )));
+    assert_eq!(resolve_rate(&client, block_timestamp).await.unwrap(), STRK_TO_USD_RATE);
+}
+
+/// A failed read is retried a retry interval later, so a transient failure costs one retry interval
+/// rather than the rest of the sampling interval.
+#[tokio::test(start_paused = true)]
+async fn a_failed_read_is_retried_after_the_retry_interval() {
+    let failure_retry_interval_seconds = test_config().failure_retry_interval_seconds;
+    let (batcher_client, num_batcher_calls) = counting_batcher_client(FeedResponses::new());
+    let client =
+        ChainlinkOracleClient::<StrkToUsd>::new(test_config(), sampling_interval(), batcher_client);
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ContractCallError(_))
+    );
+    let num_calls_after_first_attempt = num_batcher_calls.load(Ordering::SeqCst);
+
+    // One second short of the retry interval, the failure still stands and nothing is queried.
+    tokio::time::advance(Duration::from_secs(failure_retry_interval_seconds - 1)).await;
+    assert_matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ContractCallError(_))
+    );
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), num_calls_after_first_attempt);
+
+    // At the retry interval the feed is queried again. The held failure is what this call is
+    // served, since the retry it spawns has nothing to answer with yet.
+    tokio::time::advance(Duration::from_secs(1)).await;
+    assert_matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ContractCallError(_))
+    );
+    assert!(is_query_in_flight(&client), "the retry interval elapsed but no query was spawned");
+    wait_for_query_to_finish(&client).await;
+    assert!(
+        num_batcher_calls.load(Ordering::SeqCst) > num_calls_after_first_attempt,
+        "the retry issued no batcher call"
+    );
+}
+
+/// A query can resolve after the last call that could have observed it. That success must still be
+/// recorded, or the round trip is wasted and the fallback ages from an older read than the client
+/// actually obtained.
+#[tokio::test]
+async fn a_success_that_resolves_after_its_last_caller_is_not_lost() {
+    let client = ChainlinkOracleClient::<StrkToUsd>::new(
+        test_config(),
+        sampling_interval(),
+        batcher_client_failing_after(
+            strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at())),
+            CALLS_PER_FEED_PER_QUERY,
+        ),
+    );
+    // The only call that could observe this query, so nothing harvests it here.
+    assert_matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    );
+    wait_for_query_to_finish(&client).await;
+    assert_eq!(last_valid_rate(&client), None);
+
+    assert_eq!(client.fetch_rate(TIMESTAMP).await.unwrap(), STRK_TO_USD_RATE);
+}
+
+/// A re-proposal asks for an earlier timestamp than the read the client resolved. It is served that
+/// read rather than being told the query is not ready.
+#[tokio::test]
+async fn a_resolved_success_is_served_to_an_earlier_timestamp() {
+    let (batcher_client, num_batcher_calls) = counting_batcher_client(strk_usd_responses(
+        FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at()),
+    ));
+    let client =
+        ChainlinkOracleClient::<StrkToUsd>::new(test_config(), sampling_interval(), batcher_client);
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+    let num_calls_after_resolution = num_batcher_calls.load(Ordering::SeqCst);
+
+    let earlier_timestamp = TIMESTAMP - SAMPLING_INTERVAL_SECONDS;
+    assert_eq!(client.fetch_rate(earlier_timestamp).await.unwrap(), rate);
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), num_calls_after_resolution);
+}
+
+/// The last valid read is served while it is within `MAX_FALLBACK_SAMPLING_INTERVALS` of the block
+/// timestamp asked for, however many intervals passed without a call.
+#[rstest]
+#[case::at_the_allowance(MAX_FALLBACK_SAMPLING_INTERVALS, true)]
+#[case::one_interval_past_the_allowance(MAX_FALLBACK_SAMPLING_INTERVALS + 1, false)]
+#[case::many_intervals_later(60, false)]
+#[tokio::test(start_paused = true)]
+async fn last_valid_rate_is_served_only_within_the_allowance(
+    #[case] num_intervals_ahead: u64,
+    #[case] is_served: bool,
+) {
+    let client = ChainlinkOracleClient::<StrkToUsd>::new(
+        test_config(),
+        sampling_interval(),
+        batcher_client_failing_after(
+            strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at())),
+            CALLS_PER_FEED_PER_QUERY,
+        ),
+    );
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    // No call is made in between, so nothing refreshes the read the client holds.
+    let elapsed_seconds = num_intervals_ahead * SAMPLING_INTERVAL_SECONDS;
+    tokio::time::advance(Duration::from_secs(elapsed_seconds)).await;
+    let later_timestamp = TIMESTAMP + elapsed_seconds;
+    wait_for_held_error(&client, later_timestamp).await;
+
+    let result = client.fetch_rate(later_timestamp).await;
+    if is_served {
+        assert_eq!(result.unwrap(), rate);
+    } else {
+        assert_matches!(result, Err(ExchangeRateOracleClientError::ContractCallError(_)));
+    }
+}
+
+/// A re-proposal asks for a timestamp the client has already read past, so it is served a read that
+/// leads it.
+#[tokio::test]
+async fn an_earlier_timestamp_is_served_a_held_rate_within_the_allowance() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        fresh_updated_at(),
+    )));
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    let earlier_timestamp = TIMESTAMP - MAX_FALLBACK_SAMPLING_INTERVALS * SAMPLING_INTERVAL_SECONDS;
+    assert_eq!(client.fetch_rate(earlier_timestamp).await.unwrap(), rate);
+}
+
+/// The allowance bounds the distance in both directions, so a timestamp further back than it is not
+/// priced from a read taken that far ahead of it.
+#[tokio::test]
+async fn an_earlier_timestamp_past_the_allowance_is_not_served_a_held_rate() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        fresh_updated_at(),
+    )));
+    resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    let earlier_timestamp =
+        TIMESTAMP - (MAX_FALLBACK_SAMPLING_INTERVALS + 1) * SAMPLING_INTERVAL_SECONDS;
+    assert_matches!(
+        client.fetch_rate(earlier_timestamp).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    );
+}
+
+/// One query per client at a time: a refresh that comes due while a query is still in flight does
+/// not start a second one.
+#[tokio::test(start_paused = true)]
+async fn no_second_query_starts_while_one_is_in_flight() {
+    let (batcher_client, num_batcher_calls) = counting_batcher_client(strk_usd_responses(
+        FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at()),
+    ));
+    let client =
+        ChainlinkOracleClient::<StrkToUsd>::new(test_config(), sampling_interval(), batcher_client);
+    // A query that never resolves, so the slot is still occupied when the refresh comes due.
+    let spawn_instant = Instant::now();
+    {
+        let mut state = client.state.lock().unwrap();
+        state.query = Some(AbortOnDropHandle::new(tokio::spawn(std::future::pending())));
+        state.last_attempt_instant = Some(spawn_instant);
+    }
+
+    tokio::time::advance(Duration::from_secs(SAMPLING_INTERVAL_SECONDS)).await;
+    assert_matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    );
+
+    assert_eq!(num_batcher_calls.load(Ordering::SeqCst), 0);
+    // A second spawn would have overwritten it.
+    assert_eq!(last_attempt_instant(&client), Some(spawn_instant));
+}
+
+/// A harvested read is dated by the timestamp its own query was issued for, not by the timestamp of
+/// the call that harvests it, so its distance from later callers keeps growing.
+#[tokio::test]
+async fn a_harvested_success_is_dated_by_its_attempt_timestamp() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        fresh_updated_at(),
+    )));
+    // The only call for this timestamp, so the query resolves unharvested.
+    assert_matches!(
+        client.fetch_rate(TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    );
+    wait_for_query_to_finish(&client).await;
+
+    let far_later_timestamp =
+        TIMESTAMP + (MAX_FALLBACK_SAMPLING_INTERVALS + 1) * SAMPLING_INTERVAL_SECONDS;
+    assert_matches!(
+        client.fetch_rate(far_later_timestamp).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    );
+}
+
+/// Both legs stay inside their own bands; only the derived rate crosses its floor. The rate moves
+/// inversely with the STRK price, so raising that price by one unit is what breaks the floor.
+fn responses_with_derived_rate_below_floor() -> FeedResponses {
+    let updated_at = fresh_updated_at();
+    let strk_usd_answer =
+        strk_usd_answer_for_derived_rate(test_config().eth_to_fri.minimum_micro_units) + 1;
+    eth_and_strk_responses(
+        FeedFixture::new(
+            micro_units_to_answer(ETH_USD_PRICE_FOR_DERIVED_BOUNDS_MICRO_USD, FEED_DECIMALS),
+            updated_at,
+        ),
+        FeedFixture::new(strk_usd_answer, updated_at),
+    )
+}
+
+/// The guard counters record why a query was rejected and, through the `currency_pair` label, which
+/// reading it was rejected on. Each guard must increment its own counter on the rejected pair's
+/// series and on no other, so that a stale ETH/USD leg is distinguishable from a stale STRK/USD
+/// leg.
+///
+/// The client is built by the case's factory rather than passed in, so that it is constructed after
+/// the local recorder is installed.
+#[rstest]
+#[case::stale_strk_feed(
+    dyn_client::<StrkToUsd>,
+    strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, stale_updated_at())),
+    &CHAINLINK_ORACLE_STALE_FEED_COUNT,
+    CurrencyPair::StrkUsd
+)]
+#[case::stale_eth_leg(
+    dyn_client::<EthToFri>,
+    eth_and_strk_responses(
+        FeedFixture::new(ETH_USD_ANSWER, stale_updated_at()),
+        FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at()),
+    ),
+    &CHAINLINK_ORACLE_STALE_FEED_COUNT,
+    CurrencyPair::EthUsd
+)]
+#[case::stale_strk_leg(
+    dyn_client::<EthToFri>,
+    eth_and_strk_responses(
+        FeedFixture::new(ETH_USD_ANSWER, fresh_updated_at()),
+        FeedFixture::new(STRK_USD_ANSWER, stale_updated_at()),
+    ),
+    &CHAINLINK_ORACLE_STALE_FEED_COUNT,
+    CurrencyPair::StrkUsd
+)]
+#[case::future_feed(
+    dyn_client::<StrkToUsd>,
+    strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, future_updated_at())),
+    &CHAINLINK_ORACLE_FUTURE_FEED_COUNT,
+    CurrencyPair::StrkUsd
+)]
+#[case::zero_answer(
+    dyn_client::<StrkToUsd>,
+    strk_usd_responses(FeedFixture::new(0, fresh_updated_at())),
+    &CHAINLINK_ORACLE_INVALID_FEED_ANSWER_COUNT,
+    CurrencyPair::StrkUsd
+)]
+// One micro-cent per STRK, far below the configured floor.
+#[case::rate_out_of_bounds(
+    dyn_client::<StrkToUsd>,
+    strk_usd_responses(FeedFixture::new(1, fresh_updated_at())),
+    &CHAINLINK_ORACLE_RATE_OUT_OF_BOUNDS_COUNT,
+    CurrencyPair::StrkUsd
+)]
+#[case::derived_rate_out_of_bounds(
+    dyn_client::<EthToFri>,
+    responses_with_derived_rate_below_floor(),
+    &CHAINLINK_ORACLE_RATE_OUT_OF_BOUNDS_COUNT,
+    CurrencyPair::EthStrk
+)]
+#[case::contract_call_failure(
+    dyn_client::<StrkToUsd>,
+    strk_usd_responses_without_round_data(),
+    &CHAINLINK_ORACLE_CONTRACT_CALL_ERROR_COUNT,
+    CurrencyPair::StrkUsd
+)]
+#[tokio::test]
+async fn guard_counters_record_the_rejection_reason_and_pair(
+    #[case] build_client: fn(FeedResponses) -> Arc<dyn ExchangeRateOracleClientTrait>,
+    #[case] responses: FeedResponses,
+    #[case] guard_counter: &'static LabeledMetricCounter,
+    #[case] rejected_pair: CurrencyPair,
+) {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = set_default_local_recorder(&recorder);
+    let client = build_client(responses);
+
+    assert!(resolve_rate(client.as_ref(), TIMESTAMP).await.is_err());
+    let rendered_metrics = recorder.handle().render();
+    for pair in CurrencyPair::iter() {
+        // A series only the guard's own increment creates reads as absent, which is the same
+        // statement as a count of zero.
+        let count = guard_counter
+            .parse_numeric_metric::<u64>(&rendered_metrics, &pair.labels())
+            .unwrap_or(0);
+        let expected_count = u64::from(pair == rejected_pair);
+        assert_eq!(
+            count,
+            expected_count,
+            "{} on pair {pair:?} recorded {count} rejections, expected {expected_count}",
+            guard_counter.get_name()
+        );
+    }
+}
+
+#[rstest]
+#[case::ascii("a plain revert reason".to_string())]
+#[case::multibyte("שלום".repeat(10))]
+fn short_contract_call_error_is_relayed_verbatim(#[case] error_text: String) {
+    assert!(error_text.len() <= MAX_CONTRACT_CALL_ERROR_BYTES);
+    assert_eq!(truncate_contract_call_error(error_text.clone()), error_text);
+}
+
+/// The cap counts bytes, so a multi-byte reason must be cut at a character boundary at or just
+/// below it, never mid-character.
+#[rstest]
+#[case::single_byte_characters("a")]
+#[case::four_byte_characters("😀")]
+fn long_contract_call_error_is_truncated_on_a_character_boundary(#[case] repeated_text: &str) {
+    const NUM_REPETITIONS: usize = 1000;
+    let error_text = repeated_text.repeat(NUM_REPETITIONS);
+    let truncated = truncate_contract_call_error(error_text.clone());
+
+    let head = truncated
+        .strip_suffix(TRUNCATION_MARKER)
+        .expect("Truncated text must carry the truncation marker");
+    assert!(error_text.starts_with(head), "the kept head must be a prefix of the original");
+    assert!(head.len() <= MAX_CONTRACT_CALL_ERROR_BYTES);
+    // Nothing is dropped beyond what the boundary requires.
+    assert!(head.len() > MAX_CONTRACT_CALL_ERROR_BYTES - repeated_text.len());
+}
+
+/// A reverting view call carries the feed contract's panic data, which the contract sizes.
+#[tokio::test]
+async fn contract_call_error_text_is_truncated() {
+    // The relayed message is the entry point and the feed address, then the capped error text.
+    const MAX_ENTRY_POINT_AND_ADDRESS_LENGTH: usize = 128;
+    const REASON_LENGTH: usize = 10_000;
+    let mut batcher_client = MockBatcherClient::new();
+    batcher_client.expect_call_contract().returning(|_| {
+        Err(BatcherClientError::BatcherError(BatcherError::ContractCallFailed {
+            reason: "a".repeat(REASON_LENGTH),
+        }))
+    });
+    let client = ChainlinkOracleClient::<StrkToUsd>::new(
+        test_config(),
+        sampling_interval(),
+        Arc::new(batcher_client),
+    );
+
+    assert_matches!(
+        resolve_rate(&client, TIMESTAMP).await,
+        Err(ExchangeRateOracleClientError::ContractCallError(message)) => {
+            assert!(message.ends_with(TRUNCATION_MARKER), "error text was not truncated: {message}");
+            assert!(
+                message.len()
+                    <= MAX_ENTRY_POINT_AND_ADDRESS_LENGTH
+                        + MAX_CONTRACT_CALL_ERROR_BYTES
+                        + TRUNCATION_MARKER.len(),
+                "error text exceeded the cap: {} bytes",
+                message.len()
+            );
+        }
+    );
+}
+
+// Each accessor names its pair and its feed independently, so what a read is attributed to and
+// which feed it reads are pinned here rather than only by the accessor's name.
+#[test]
+fn feed_accessors_carry_their_own_pair_and_feed() {
+    let config = ChainlinkOracleConfig::default();
+
+    let eth_usd = config.eth_usd_feed();
+    assert_eq!(eth_usd.bounds.pair, CurrencyPair::EthUsd);
+    assert_eq!(eth_usd.feed_address, config.eth_usd.feed_address);
+    assert_eq!(eth_usd.bounds.minimum_micro_units, config.eth_usd.minimum_micro_units);
+    assert_eq!(eth_usd.freshness.max_staleness_seconds, config.freshness.max_staleness_seconds);
+    assert_eq!(
+        eth_usd.freshness.max_future_updated_at_seconds,
+        config.freshness.max_future_updated_at_seconds
+    );
+
+    let strk_usd = config.strk_usd_feed();
+    assert_eq!(strk_usd.bounds.pair, CurrencyPair::StrkUsd);
+    assert_eq!(strk_usd.feed_address, config.strk_usd.feed_address);
+    assert_eq!(strk_usd.bounds.minimum_micro_units, config.strk_usd.minimum_micro_units);
+}

--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use apollo_config::secrets::Sensitive;
 use apollo_l1_gas_price_config::config::ExchangeRateOracleConfig;
 use apollo_l1_gas_price_types::errors::ExchangeRateOracleClientError;
-use apollo_l1_gas_price_types::ExchangeRateOracleClientTrait;
+use apollo_l1_gas_price_types::{ExchangeRate, ExchangeRateOracleClientTrait};
 use apollo_metrics::metrics::set_unix_now_seconds;
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -46,7 +46,7 @@ pub struct UrlAndHeaderMap {
     pub headers: Sensitive<HeaderMap>,
 }
 
-type PriceQuery = AbortOnDropHandle<Result<u128, ExchangeRateOracleClientError>>;
+type PriceQuery = AbortOnDropHandle<Result<ExchangeRate, ExchangeRateOracleClientError>>;
 
 /// Client for interacting with an exchange-rate oracle API.
 /// Concrete pair (ETH→STRK, STRK→USD, ...) is determined by `config.url_header_list`
@@ -59,7 +59,7 @@ pub struct ExchangeRateOracleClient {
     index: Arc<AtomicUsize>,
     url_header_list: Arc<Vec<UrlAndHeaderMap>>,
     client: reqwest::Client,
-    cached_prices: Arc<Mutex<LruCache<u64, u128>>>,
+    cached_prices: Arc<Mutex<LruCache<u64, ExchangeRate>>>,
     queries: Arc<Mutex<LruCache<u64, PriceQuery>>>,
     metrics: ExchangeRateOracleMetrics,
 }
@@ -99,7 +99,7 @@ impl ExchangeRateOracleClient {
     fn spawn_query(
         &self,
         quantized_timestamp: u64,
-    ) -> AbortOnDropHandle<Result<u128, ExchangeRateOracleClientError>> {
+    ) -> AbortOnDropHandle<Result<ExchangeRate, ExchangeRateOracleClientError>> {
         assert!(
             self.config.lag_interval_seconds > 0,
             "lag_interval_seconds should be greater than 0"
@@ -166,7 +166,7 @@ impl ExchangeRateOracleClient {
 fn resolve_query(
     body: String,
     metrics: &ExchangeRateOracleMetrics,
-) -> Result<u128, ExchangeRateOracleClientError> {
+) -> Result<ExchangeRate, ExchangeRateOracleClientError> {
     let Ok(json): Result<serde_json::Value, _> = serde_json::from_str(&body) else {
         return Err(ExchangeRateOracleClientError::ParseError(format!(
             "Failed to parse JSON: {body}"
@@ -218,7 +218,10 @@ impl ExchangeRateOracleClientTrait for ExchangeRateOracleClient {
     /// - `price`: a hexadecimal string representing the price.
     /// - `decimals`: a `u64` value, must be equal to `EXCHANGE_RATE_DECIMALS`.
     #[instrument(skip(self))]
-    async fn fetch_rate(&self, timestamp: u64) -> Result<u128, ExchangeRateOracleClientError> {
+    async fn fetch_rate(
+        &self,
+        timestamp: u64,
+    ) -> Result<ExchangeRate, ExchangeRateOracleClientError> {
         const NUMBER_OF_TIMESTAMPS_BACK: u64 = 1;
         let quantized_timestamp = (timestamp - self.config.lag_interval_seconds)
             .checked_div(self.config.lag_interval_seconds)

--- a/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
@@ -7,6 +7,7 @@ use apollo_infra_utils::info_every_n_ms;
 use apollo_l1_gas_price_config::config::L1GasPriceProviderConfig;
 use apollo_l1_gas_price_types::errors::L1GasPriceProviderError;
 use apollo_l1_gas_price_types::{
+    ExchangeRate,
     ExchangeRateOracleClientTrait,
     GasPriceData,
     L1GasPriceProviderResult,
@@ -202,14 +203,14 @@ impl L1GasPriceProvider {
         Ok(price_info_out)
     }
 
-    pub async fn eth_to_fri_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<u128> {
+    pub async fn eth_to_fri_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<ExchangeRate> {
         self.eth_to_strk_oracle_client
             .fetch_rate(timestamp)
             .await
             .map_err(L1GasPriceProviderError::ExchangeRateOracleClientError)
     }
 
-    pub async fn strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<u128> {
+    pub async fn strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<ExchangeRate> {
         self.strk_to_usd_oracle_client
             .fetch_rate(timestamp)
             .await

--- a/crates/apollo_l1_gas_price/src/lib.rs
+++ b/crates/apollo_l1_gas_price/src/lib.rs
@@ -5,9 +5,11 @@
 //! Each block proposal needs two independent inputs:
 //! - **L1 gas prices (WEI)** — mean `base_fee_per_gas` and `blob_fee` over the last N Ethereum
 //!   blocks, maintained by [`l1_gas_price_provider`].
-//! - **ETH→STRK rate** — current market rate from one of several oracle endpoints, queried by
-//!   [`exchange_rate_oracle`]. Multiple URLs are tried in round-robin; if the in-flight query for
-//!   the current time bucket hasn't resolved yet, the previous bucket's cached rate is used.
+//! - **ETH→STRK rate**, current market rate from an oracle: either the HTTP endpoints queried by
+//!   [`exchange_rate_oracle`], which are tried in round-robin, or Chainlink's on-chain Starknet
+//!   price feeds read through the batcher by [`chainlink_oracle`]. Neither blocks the proposal
+//!   path: the HTTP client caches per quantized timestamp, the Chainlink client refreshes on a
+//!   timer, and both serve the rate they already hold while a query is in flight.
 //!
 //! When combining these in `apollo_consensus_orchestrator`, the fallback chain is:
 //!
@@ -28,6 +30,7 @@
 //! unusable precisely when it is already degraded. The configured minimums and the default
 //! ETH→STRK rate are safe floors the operator has verified are always economically viable.
 
+pub mod chainlink_oracle;
 pub mod communication;
 pub mod exchange_rate_oracle;
 pub mod l1_gas_price_provider;

--- a/crates/apollo_l1_gas_price/src/metrics.rs
+++ b/crates/apollo_l1_gas_price/src/metrics.rs
@@ -1,3 +1,5 @@
+use std::sync::Once;
+
 use apollo_infra::metrics::{
     InfraMetrics,
     LocalClientMetrics,
@@ -5,11 +7,20 @@ use apollo_infra::metrics::{
     RemoteClientMetrics,
     RemoteServerMetrics,
 };
-use apollo_l1_gas_price_types::L1_GAS_PRICE_REQUEST_LABELS;
+use apollo_l1_gas_price_types::{
+    CurrencyPair,
+    L1_GAS_PRICE_REQUEST_LABELS,
+    LABEL_NAME_CURRENCY_PAIR,
+};
 use apollo_metrics::metrics::{MetricCounter, MetricDetails, MetricGauge};
-use apollo_metrics::{define_infra_metrics, define_metrics};
+use apollo_metrics::{define_infra_metrics, define_metrics, generate_permutation_labels};
 
 define_infra_metrics!(l1_gas_price);
+
+generate_permutation_labels! {
+    CURRENCY_PAIR_LABELS,
+    (LABEL_NAME_CURRENCY_PAIR, CurrencyPair),
+}
 
 define_metrics!(
     L1GasPrice => {
@@ -21,6 +32,11 @@ define_metrics!(
         MetricCounter { ETH_TO_STRK_SUCCESS_COUNT, "eth_to_strk_success_count", "Number of times the query to the Eth to Strk oracle succeeded", init=0 },
         MetricCounter { SNIP35_STRK_USD_ERROR_COUNT, "snip35_strk_usd_error_count", "Number of times the query to the STRK to USD oracle failed due to an error or timeout", init=0 },
         MetricCounter { SNIP35_STRK_USD_SUCCESS_COUNT, "snip35_strk_usd_success_count", "Number of times the query to the STRK to USD oracle succeeded", init=0 },
+        LabeledMetricCounter { CHAINLINK_ORACLE_STALE_FEED_COUNT, "chainlink_oracle_stale_feed_count", "Number of times a Chainlink price feed reading was rejected because its update timestamp was older than the accepted staleness bound", init=0, labels = CURRENCY_PAIR_LABELS },
+        LabeledMetricCounter { CHAINLINK_ORACLE_FUTURE_FEED_COUNT, "chainlink_oracle_future_feed_count", "Number of times a Chainlink price feed reading was rejected because its update timestamp led the queried timestamp by more than the accepted tolerance", init=0, labels = CURRENCY_PAIR_LABELS },
+        LabeledMetricCounter { CHAINLINK_ORACLE_RATE_OUT_OF_BOUNDS_COUNT, "chainlink_oracle_rate_out_of_bounds_count", "Number of times a Chainlink rate was rejected because it fell outside the configured absolute sanity bounds", init=0, labels = CURRENCY_PAIR_LABELS },
+        LabeledMetricCounter { CHAINLINK_ORACLE_INVALID_FEED_ANSWER_COUNT, "chainlink_oracle_invalid_feed_answer_count", "Number of times a Chainlink feed returned a zero answer or a decimals value outside the accepted range", init=0, labels = CURRENCY_PAIR_LABELS },
+        LabeledMetricCounter { CHAINLINK_ORACLE_CONTRACT_CALL_ERROR_COUNT, "chainlink_oracle_contract_call_error_count", "Number of times a Chainlink feed call to the batcher failed or returned undecodable retdata", init=0, labels = CURRENCY_PAIR_LABELS },
         MetricGauge { L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS, "l1_gas_price_scraper_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful L1 gas price scrape" },
         MetricGauge { ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS, "eth_to_strk_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful ETH→STRK oracle query" },
         MetricGauge { SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS, "snip35_strk_usd_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful STRK→USD oracle query" },
@@ -41,14 +57,22 @@ pub struct ExchangeRateOracleMetrics {
     pub success_count: &'static MetricCounter,
     pub error_count: &'static MetricCounter,
     pub last_success_timestamp: &'static MetricGauge,
+    /// Guards this set's registration. Private so that every set is one of the constants below,
+    /// each of which owns a distinct guard.
+    registration_guard: &'static Once,
 }
 
 impl ExchangeRateOracleMetrics {
+    /// Runs once per process per metric set: `register` resets each metric to its initial value
+    /// rather than merely describing it, so two clients serving the same pair would otherwise wipe
+    /// each other's counts depending on construction order.
     pub fn register(&self) {
-        self.rate.register();
-        self.success_count.register();
-        self.error_count.register();
-        self.last_success_timestamp.register();
+        self.registration_guard.call_once(|| {
+            self.rate.register();
+            self.success_count.register();
+            self.error_count.register();
+            self.last_success_timestamp.register();
+        });
     }
 }
 
@@ -62,15 +86,19 @@ impl std::fmt::Debug for ExchangeRateOracleMetrics {
             .field("success_count", &self.success_count.get_name())
             .field("error_count", &self.error_count.get_name())
             .field("last_success_timestamp", &self.last_success_timestamp.get_name())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
+
+static ETH_TO_STRK_REGISTRATION: Once = Once::new();
+static STRK_TO_USD_REGISTRATION: Once = Once::new();
 
 pub const ETH_TO_STRK_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOracleMetrics {
     rate: &ETH_TO_STRK_RATE,
     success_count: &ETH_TO_STRK_SUCCESS_COUNT,
     error_count: &ETH_TO_STRK_ERROR_COUNT,
     last_success_timestamp: &ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    registration_guard: &ETH_TO_STRK_REGISTRATION,
 };
 
 pub const STRK_TO_USD_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOracleMetrics {
@@ -78,12 +106,30 @@ pub const STRK_TO_USD_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOr
     success_count: &SNIP35_STRK_USD_SUCCESS_COUNT,
     error_count: &SNIP35_STRK_USD_ERROR_COUNT,
     last_success_timestamp: &SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    registration_guard: &STRK_TO_USD_REGISTRATION,
 };
 
 pub(crate) fn register_provider_metrics() {
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY.register();
     L1_GAS_PRICE_LATEST_MEAN_VALUE.register();
     L1_DATA_GAS_PRICE_LATEST_MEAN_VALUE.register();
+}
+
+/// Guard-trip counters shared by all `ChainlinkOracleClient` instances. They record *why* a query
+/// was rejected, and the `currency_pair` label records which reading it was rejected on. The
+/// per-pair
+/// `ExchangeRateOracleMetrics::error_count` records which client the rejection failed.
+///
+/// Registered once per process, for the same reason as `ExchangeRateOracleMetrics::register`.
+pub(crate) fn register_chainlink_guard_metrics() {
+    static REGISTER_GUARD_METRICS: Once = Once::new();
+    REGISTER_GUARD_METRICS.call_once(|| {
+        CHAINLINK_ORACLE_STALE_FEED_COUNT.register();
+        CHAINLINK_ORACLE_FUTURE_FEED_COUNT.register();
+        CHAINLINK_ORACLE_RATE_OUT_OF_BOUNDS_COUNT.register();
+        CHAINLINK_ORACLE_INVALID_FEED_ANSWER_COUNT.register();
+        CHAINLINK_ORACLE_CONTRACT_CALL_ERROR_COUNT.register();
+    });
 }
 
 pub(crate) fn register_scraper_metrics() {

--- a/crates/apollo_l1_gas_price_config/Cargo.toml
+++ b/crates/apollo_l1_gas_price_config/Cargo.toml
@@ -11,7 +11,12 @@ workspace = true
 
 [dependencies]
 apollo_config.workspace = true
+apollo_l1_gas_price_types.workspace = true
 serde = { workspace = true, features = ["derive"] }
+starknet-types-core.workspace = true
 starknet_api.workspace = true
 url.workspace = true
 validator.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/apollo_l1_gas_price_config/src/config.rs
+++ b/crates/apollo_l1_gas_price_config/src/config.rs
@@ -14,12 +14,14 @@ use apollo_config::dumping::{
     SerializeConfig,
 };
 use apollo_config::secrets::Sensitive;
-use apollo_config::validators::validate_ascii;
+use apollo_config::validators::{create_validation_error, validate_ascii};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
+use apollo_l1_gas_price_types::CurrencyPair;
 use serde::{Deserialize, Serialize};
-use starknet_api::core::ChainId;
+use starknet_api::core::{ChainId, ContractAddress};
+use starknet_types_core::felt::Felt;
 use url::Url;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 
 #[cfg(test)]
 #[path = "config_test.rs"]
@@ -91,6 +93,298 @@ impl Default for ExchangeRateOracleConfig {
             max_cache_size: 100,
             query_timeout_sec: 10,
         }
+    }
+}
+
+/// Decimals of the micro-unit sanity bounds in `ChainlinkOracleConfig`.
+pub const CHAINLINK_MICRO_UNIT_DECIMALS: u32 = 6;
+
+/// Inclusive absolute bounds on a rate, in micro units (1e-6) of the pair's quote currency, so that
+/// they fit in a `u64`, together with the pair they bound. Carrying the pair means a caller cannot
+/// check a rate against another pair's band or report the trip under the wrong pair.
+#[derive(Clone, Copy, Debug)]
+pub struct RateBounds {
+    pub minimum_micro_units: u64,
+    pub maximum_micro_units: u64,
+    pub pair: CurrencyPair,
+}
+
+/// A pair Chainlink quotes on Starknet.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Validate)]
+pub struct ChainlinkFeedConfig {
+    pub feed_address: ContractAddress,
+    pub minimum_micro_units: u64,
+    pub maximum_micro_units: u64,
+}
+
+impl ChainlinkFeedConfig {
+    fn bounds(&self, pair: CurrencyPair) -> RateBounds {
+        RateBounds {
+            minimum_micro_units: self.minimum_micro_units,
+            maximum_micro_units: self.maximum_micro_units,
+            pair,
+        }
+    }
+}
+
+impl SerializeConfig for ChainlinkFeedConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
+            ser_param(
+                "feed_address",
+                &self.feed_address,
+                "Address of the Chainlink proxy feed quoting this pair on Starknet.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "minimum_micro_units",
+                &self.minimum_micro_units,
+                "Lowest accepted price for this pair, in micro units (1e-6) of the quote \
+                 currency, so a value of 20000000 on ETH/USD means $20.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "maximum_micro_units",
+                &self.maximum_micro_units,
+                "Highest accepted price for this pair, in micro units (1e-6) of the quote \
+                 currency, so a value of 50000000000 on ETH/USD means $50,000.",
+                ParamPrivacyInput::Public,
+            ),
+        ])
+    }
+}
+
+/// A pair derived from two quoted pairs, so bounded but not read.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Validate)]
+pub struct DerivedRateConfig {
+    pub minimum_micro_units: u64,
+    pub maximum_micro_units: u64,
+}
+
+impl DerivedRateConfig {
+    fn bounds(&self, pair: CurrencyPair) -> RateBounds {
+        RateBounds {
+            minimum_micro_units: self.minimum_micro_units,
+            maximum_micro_units: self.maximum_micro_units,
+            pair,
+        }
+    }
+}
+
+impl SerializeConfig for DerivedRateConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
+            ser_param(
+                "minimum_micro_units",
+                &self.minimum_micro_units,
+                "Lowest accepted rate for this pair, in micro units (1e-6) of the quote currency, \
+                 so a value of 10000000000 on ETH/STRK means 10,000 STRK per ETH.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "maximum_micro_units",
+                &self.maximum_micro_units,
+                "Highest accepted rate for this pair, in micro units (1e-6) of the quote \
+                 currency, so a value of 1000000000000 on ETH/STRK means 1,000,000 STRK per ETH.",
+                ParamPrivacyInput::Public,
+            ),
+        ])
+    }
+}
+
+/// The window a feed round's `updated_at` must fall in, relative to the block being priced.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Validate)]
+#[validate(schema(function = "validate_freshness_window"))]
+pub struct FreshnessWindow {
+    #[validate(range(min = 1))]
+    pub max_staleness_seconds: u64,
+    pub max_future_updated_at_seconds: u64,
+}
+
+/// The two bounds are both seconds and adjacent, so an exchanged pair is only caught here: the
+/// backward bound covers the feed's heartbeat and the forward one only clock skew, so the forward
+/// bound sits well below the backward one.
+fn validate_freshness_window(freshness: &FreshnessWindow) -> Result<(), ValidationError> {
+    if freshness.max_future_updated_at_seconds >= freshness.max_staleness_seconds {
+        return Err(create_validation_error(
+            format!(
+                "max_future_updated_at_seconds ({}) is not below max_staleness_seconds ({})",
+                freshness.max_future_updated_at_seconds, freshness.max_staleness_seconds
+            ),
+            "inverted freshness window",
+            "Keep max_future_updated_at_seconds, which covers clock skew, below \
+             max_staleness_seconds, which covers the feed's heartbeat.",
+        ));
+    }
+    Ok(())
+}
+
+impl SerializeConfig for FreshnessWindow {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
+            ser_param(
+                "max_staleness_seconds",
+                &self.max_staleness_seconds,
+                "Maximum age (seconds) of a feed's `updated_at` relative to the block timestamp \
+                 being priced. An older reading is rejected, and for the derived ETH/STRK rate a \
+                 single stale leg rejects the whole rate.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "max_future_updated_at_seconds",
+                &self.max_future_updated_at_seconds,
+                "Maximum amount (seconds) by which a feed's `updated_at` may lead the block \
+                 timestamp being priced. Covers the clock skew between the sequencer that wrote \
+                 the round and this node.",
+                ParamPrivacyInput::Public,
+            ),
+        ])
+    }
+}
+
+/// Configuration for reading Chainlink's on-chain Starknet price feeds through the batcher.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Validate)]
+#[validate(schema(function = "validate_chainlink_oracle_config"))]
+pub struct ChainlinkOracleConfig {
+    /// Micro-USD per ETH.
+    #[validate(nested)]
+    pub eth_usd: ChainlinkFeedConfig,
+    /// Micro-USD per STRK.
+    #[validate(nested)]
+    pub strk_usd: ChainlinkFeedConfig,
+    /// Micro-STRK per ETH.
+    #[validate(nested)]
+    pub eth_to_fri: DerivedRateConfig,
+    #[validate(nested)]
+    pub freshness: FreshnessWindow,
+    #[validate(range(min = 1))]
+    pub failure_retry_interval_seconds: u64,
+}
+
+impl ChainlinkOracleConfig {
+    pub fn eth_usd_bounds(&self) -> RateBounds {
+        self.eth_usd.bounds(CurrencyPair::EthUsd)
+    }
+
+    pub fn strk_usd_bounds(&self) -> RateBounds {
+        self.strk_usd.bounds(CurrencyPair::StrkUsd)
+    }
+
+    pub fn eth_to_fri_bounds(&self) -> RateBounds {
+        self.eth_to_fri.bounds(CurrencyPair::EthStrk)
+    }
+}
+
+impl Default for ChainlinkOracleConfig {
+    fn default() -> Self {
+        // Chainlink proxy addresses on Starknet mainnet. The proxies are used rather than the
+        // aggregators behind them, because aggregators are rotated without notice.
+        const ETH_USD_PROXY_ADDRESS: &str =
+            "0x06b2ef9b416ad0f996b2a8ac0dd771b1788196f51c96f5b000df2e47ac756d26";
+        const STRK_USD_PROXY_ADDRESS: &str =
+            "0x076a0254cdadb59b86da3b5960bf8d73779cac88edc5ae587cab3cedf03226ec";
+        // The feeds guarantee an update at least once per 24h heartbeat; the extra hour absorbs
+        // the delay between the heartbeat deadline and the update landing on-chain.
+        const HEARTBEAT_PLUS_MARGIN_SECONDS: u64 = (24 + 1) * 3600;
+        const MICRO_UNITS_PER_UNIT: u64 = 10u64.pow(CHAINLINK_MICRO_UNIT_DECIMALS);
+        // A round's `updated_at` is the timestamp of the Starknet block that wrote it, and the
+        // client checks it against the block timestamp being priced. Both come from a sequencer's
+        // clock, so this only has to cover the skew between them.
+        const MAX_FUTURE_UPDATED_AT_SECONDS: u64 = 300;
+
+        Self {
+            // $20 .. $50,000 per ETH: ~10x above the all-time high and far below any plausible
+            // market, but tight enough to reject a feed wired to a different asset.
+            eth_usd: ChainlinkFeedConfig {
+                feed_address: parse_feed_address(ETH_USD_PROXY_ADDRESS),
+                minimum_micro_units: 20 * MICRO_UNITS_PER_UNIT,
+                maximum_micro_units: 50_000 * MICRO_UNITS_PER_UNIT,
+            },
+            // $0.0001 .. $10 per STRK. Wide on purpose: its job is wrong-feed detection, and the
+            // fee-level damage on this leg is bounded separately by the cap on the L2 gas price.
+            strk_usd: ChainlinkFeedConfig {
+                feed_address: parse_feed_address(STRK_USD_PROXY_ADDRESS),
+                minimum_micro_units: MICRO_UNITS_PER_UNIT / 10_000,
+                maximum_micro_units: 10 * MICRO_UNITS_PER_UNIT,
+            },
+            // 10,000 .. 1,000,000 STRK per ETH. The pair trades near 1.3e5, so the bounds sit
+            // roughly 10x either side of spot. The floor is the load-bearing side: this rate
+            // reaches L1 gas pricing through `wei_to_fri` with no ratchet and no clamp,
+            // so a poisoned feed that passes both USD legs can undercharge L1 gas by at
+            // most the spot-to-floor ratio.
+            eth_to_fri: DerivedRateConfig {
+                minimum_micro_units: 10_000 * MICRO_UNITS_PER_UNIT,
+                maximum_micro_units: 1_000_000 * MICRO_UNITS_PER_UNIT,
+            },
+            freshness: FreshnessWindow {
+                max_staleness_seconds: HEARTBEAT_PLUS_MARGIN_SECONDS,
+                max_future_updated_at_seconds: MAX_FUTURE_UPDATED_AT_SECONDS,
+            },
+            // Successful reads are sampled once per sampling interval, which is 15 minutes in
+            // production, so a failure that waited for the next sample would freeze the price for
+            // that long.
+            failure_retry_interval_seconds: 60,
+        }
+    }
+}
+
+/// Cross-field checks the per-field `range` attributes cannot express: a zero minimum silently
+/// disables a guard, and an inverted pair rejects every reading forever.
+/// The config key a pair's bounds live under, so a validation error names the key to edit.
+fn bounds_config_key(pair: CurrencyPair) -> &'static str {
+    match pair {
+        CurrencyPair::EthUsd => "eth_usd",
+        CurrencyPair::StrkUsd => "strk_usd",
+        CurrencyPair::EthStrk => "eth_to_fri",
+    }
+}
+
+fn validate_chainlink_oracle_config(config: &ChainlinkOracleConfig) -> Result<(), ValidationError> {
+    for bounds in [config.eth_usd_bounds(), config.strk_usd_bounds(), config.eth_to_fri_bounds()] {
+        let pair_name = bounds_config_key(bounds.pair);
+        if bounds.minimum_micro_units == 0 {
+            return Err(create_validation_error(
+                format!("{pair_name}.minimum_micro_units is zero"),
+                "zero sanity bound",
+                "A zero minimum disables the lower sanity bound; set it to the lowest plausible \
+                 value.",
+            ));
+        }
+        if bounds.minimum_micro_units >= bounds.maximum_micro_units {
+            return Err(create_validation_error(
+                format!(
+                    "{pair_name}.minimum_micro_units ({}) is not below \
+                     {pair_name}.maximum_micro_units ({})",
+                    bounds.minimum_micro_units, bounds.maximum_micro_units
+                ),
+                "inverted sanity bounds",
+                "Ensure each minimum sanity bound is strictly below its maximum.",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_feed_address(hex_address: &str) -> ContractAddress {
+    ContractAddress::try_from(Felt::from_hex(hex_address).expect("Invalid feed address felt"))
+        .expect("Invalid feed contract address")
+}
+
+impl SerializeConfig for ChainlinkOracleConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        let mut config = BTreeMap::from_iter([ser_param(
+            "failure_retry_interval_seconds",
+            &self.failure_retry_interval_seconds,
+            "How long (seconds) after a failed read the feed is read again. Successful reads are \
+             governed by the sampling interval instead, which is the per-feed \
+             `lag_interval_seconds`.",
+            ParamPrivacyInput::Public,
+        )]);
+        config.extend(prepend_sub_config_name(self.eth_usd.dump(), "eth_usd"));
+        config.extend(prepend_sub_config_name(self.strk_usd.dump(), "strk_usd"));
+        config.extend(prepend_sub_config_name(self.eth_to_fri.dump(), "eth_to_fri"));
+        config.extend(prepend_sub_config_name(self.freshness.dump(), "freshness"));
+        config
     }
 }
 

--- a/crates/apollo_l1_gas_price_config/src/config_test.rs
+++ b/crates/apollo_l1_gas_price_config/src/config_test.rs
@@ -1,6 +1,9 @@
+use std::mem::swap;
+
+use rstest::rstest;
 use validator::Validate;
 
-use super::L1GasPriceProviderConfig;
+use super::{ChainlinkOracleConfig, FreshnessWindow, L1GasPriceProviderConfig};
 
 // A zero mean window would make the provider divide by zero when computing the mean gas price,
 // so it must be rejected at config load instead of panicking later during block production.
@@ -13,4 +16,104 @@ fn rejects_zero_number_of_blocks_for_mean() {
 #[test]
 fn accepts_default_number_of_blocks_for_mean() {
     assert!(L1GasPriceProviderConfig::default().validate().is_ok());
+}
+
+#[test]
+fn accepts_default_chainlink_oracle_config() {
+    assert!(ChainlinkOracleConfig::default().validate().is_ok());
+}
+
+/// One pair's sanity bounds, as `(minimum_micro_units, maximum_micro_units)`.
+type SelectBounds = fn(&mut ChainlinkOracleConfig) -> (&mut u64, &mut u64);
+
+/// Makes a pair's sanity bounds unusable.
+type BreakBounds = fn(&mut u64, &mut u64);
+
+fn eth_usd_bounds(config: &mut ChainlinkOracleConfig) -> (&mut u64, &mut u64) {
+    (&mut config.eth_usd.minimum_micro_units, &mut config.eth_usd.maximum_micro_units)
+}
+
+fn strk_usd_bounds(config: &mut ChainlinkOracleConfig) -> (&mut u64, &mut u64) {
+    (&mut config.strk_usd.minimum_micro_units, &mut config.strk_usd.maximum_micro_units)
+}
+
+fn eth_to_fri_bounds(config: &mut ChainlinkOracleConfig) -> (&mut u64, &mut u64) {
+    (&mut config.eth_to_fri.minimum_micro_units, &mut config.eth_to_fri.maximum_micro_units)
+}
+
+fn zero_minimum(minimum_micro_units: &mut u64, _maximum_micro_units: &mut u64) {
+    *minimum_micro_units = 0;
+}
+
+fn invert_bounds(minimum_micro_units: &mut u64, maximum_micro_units: &mut u64) {
+    swap(minimum_micro_units, maximum_micro_units);
+}
+
+fn equalize_bounds(minimum_micro_units: &mut u64, maximum_micro_units: &mut u64) {
+    *maximum_micro_units = *minimum_micro_units;
+}
+
+// Every combination must fail at config load, not at runtime. The validator checks the three pairs
+// in one loop, so each pair is covered on each failure mode.
+#[rstest]
+fn rejects_unusable_chainlink_sanity_bounds(
+    #[values(eth_usd_bounds, strk_usd_bounds, eth_to_fri_bounds)] select_bounds: SelectBounds,
+    #[values(zero_minimum, invert_bounds, equalize_bounds)] break_bounds: BreakBounds,
+) {
+    let mut config = ChainlinkOracleConfig::default();
+    let (minimum_micro_units, maximum_micro_units) = select_bounds(&mut config);
+    break_bounds(minimum_micro_units, maximum_micro_units);
+    assert!(config.validate().is_err());
+}
+
+// A zero `max_staleness_seconds` halts pricing, by rejecting every reading not written in the
+// block's own second. A zero `failure_retry_interval_seconds` re-queries the feed on every
+// proposal for as long as it keeps failing.
+#[rstest]
+#[case::zero_max_staleness(ChainlinkOracleConfig {
+    freshness: FreshnessWindow {
+        max_staleness_seconds: 0,
+        ..ChainlinkOracleConfig::default().freshness
+    },
+    ..Default::default()
+})]
+#[case::zero_failure_retry_interval(ChainlinkOracleConfig {
+    failure_retry_interval_seconds: 0,
+    ..Default::default()
+})]
+fn rejects_out_of_range_chainlink_fields(#[case] config: ChainlinkOracleConfig) {
+    assert!(config.validate().is_err());
+}
+
+// The default window's two bounds, pinned by direction rather than by name, so exchanging them in
+// the `Default` literal fails here instead of only where a test happens to depend on their sizes.
+#[test]
+fn default_freshness_window_reaches_further_back_than_forward() {
+    let freshness = ChainlinkOracleConfig::default().freshness;
+
+    assert_eq!(freshness.max_staleness_seconds, (24 + 1) * 3600);
+    assert_eq!(freshness.max_future_updated_at_seconds, 300);
+}
+
+#[rstest]
+#[case::inverted(FreshnessWindow {
+    max_staleness_seconds: 300,
+    max_future_updated_at_seconds: 90_000,
+})]
+#[case::equal(FreshnessWindow { max_staleness_seconds: 300, max_future_updated_at_seconds: 300 })]
+fn rejects_a_forward_bound_at_or_above_the_backward_bound(#[case] freshness: FreshnessWindow) {
+    let config = ChainlinkOracleConfig { freshness, ..Default::default() };
+
+    assert!(config.validate().is_err());
+}
+
+// The validator's single loop must cover all three pairs, not just the two read from a feed.
+#[rstest]
+#[case::eth_usd(|config: &mut ChainlinkOracleConfig| config.eth_usd.minimum_micro_units = 0)]
+#[case::strk_usd(|config: &mut ChainlinkOracleConfig| config.strk_usd.minimum_micro_units = 0)]
+#[case::eth_to_fri(|config: &mut ChainlinkOracleConfig| config.eth_to_fri.minimum_micro_units = 0)]
+fn rejects_a_zero_minimum_on_every_pair(#[case] zero_the_minimum: fn(&mut ChainlinkOracleConfig)) {
+    let mut config = ChainlinkOracleConfig::default();
+    zero_the_minimum(&mut config);
+    assert!(config.validate().is_err());
 }

--- a/crates/apollo_l1_gas_price_types/src/errors.rs
+++ b/crates/apollo_l1_gas_price_types/src/errors.rs
@@ -49,6 +49,32 @@ pub enum ExchangeRateOracleClientError {
     AllUrlsFailedError(u64, usize),
     #[error("Invalid rate from oracle: {0}")]
     InvalidRateError(String),
+    #[error(
+        "Stale {pair_name} price feed: last updated at {updated_at}, priced for block timestamp \
+         {block_timestamp}, maximum accepted staleness is {max_staleness_seconds} seconds"
+    )]
+    StaleFeedError {
+        pair_name: String,
+        updated_at: u64,
+        block_timestamp: u64,
+        max_staleness_seconds: u64,
+    },
+    #[error(
+        "The {pair_name} price feed is dated {updated_at}, more than \
+         {max_future_updated_at_seconds} seconds ahead of the block timestamp {block_timestamp}"
+    )]
+    FutureFeedError {
+        pair_name: String,
+        updated_at: u64,
+        block_timestamp: u64,
+        max_future_updated_at_seconds: u64,
+    },
+    #[error("Rate {rate} for {pair_name} is outside the accepted range [{min_rate}, {max_rate}]")]
+    RateOutOfBoundsError { pair_name: String, rate: u128, min_rate: u128, max_rate: u128 },
+    #[error("Contract call to price feed failed: {0}")]
+    ContractCallError(String),
+    #[error("Arithmetic overflow while computing rate: {0}")]
+    ArithmeticError(String),
 }
 
 impl From<reqwest::Error> for ExchangeRateOracleClientError {

--- a/crates/apollo_l1_gas_price_types/src/lib.rs
+++ b/crates/apollo_l1_gas_price_types/src/lib.rs
@@ -21,7 +21,39 @@ use starknet_api::block::{BlockTimestamp, GasPrice};
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use tracing::instrument;
 
-pub const DEFAULT_ETH_TO_FRI_RATE: u128 = 10_u128.pow(21);
+pub const DEFAULT_ETH_TO_FRI_RATE: ExchangeRate = 10_u128.pow(21);
+
+/// A currency conversion rate, as an 18-decimal fixed-point integer. The pair it converts is not
+/// part of the type: callers name it at the field or method that carries the rate.
+pub type ExchangeRate = u128;
+
+/// Which currency pair an oracle reading, rate or guard trip belongs to. Without it a stale ETH/USD
+/// leg and a stale STRK/USD leg are indistinguishable, since the ETH/STRK rate reads both.
+pub const LABEL_NAME_CURRENCY_PAIR: &str = "currency_pair";
+
+/// The pair a reading or rate quotes, used in guard errors and as the guard counters' label value.
+#[derive(Clone, Copy, Debug, EnumIter, IntoStaticStr, PartialEq, Eq, VariantNames)]
+#[strum(serialize_all = "snake_case")]
+pub enum CurrencyPair {
+    EthUsd,
+    StrkUsd,
+    /// Derived from the two USD pairs: no Chainlink feed on Starknet quotes ETH in STRK.
+    EthStrk,
+}
+
+impl CurrencyPair {
+    pub fn pair_name(self) -> &'static str {
+        match self {
+            CurrencyPair::EthUsd => "ETH/USD",
+            CurrencyPair::StrkUsd => "STRK/USD",
+            CurrencyPair::EthStrk => "ETH/STRK",
+        }
+    }
+
+    pub fn labels(self) -> [(&'static str, &'static str); 1] {
+        [(LABEL_NAME_CURRENCY_PAIR, self.into())]
+    }
+}
 
 pub type SharedL1GasPriceClient = Arc<dyn L1GasPriceProviderClient>;
 pub type L1GasPriceProviderResult<T> = Result<T, L1GasPriceProviderError>;
@@ -82,8 +114,8 @@ pub enum L1GasPriceResponse {
     Initialize(L1GasPriceProviderResult<()>),
     GetGasPrice(L1GasPriceProviderResult<PriceInfo>),
     AddGasPrice(L1GasPriceProviderResult<()>),
-    GetEthToFriRate(L1GasPriceProviderResult<u128>),
-    GetStrkToUsdRate(L1GasPriceProviderResult<u128>),
+    GetEthToFriRate(L1GasPriceProviderResult<ExchangeRate>),
+    GetStrkToUsdRate(L1GasPriceProviderResult<ExchangeRate>),
 }
 impl_debug_for_infra_requests_and_responses!(L1GasPriceResponse);
 
@@ -101,22 +133,48 @@ pub trait L1GasPriceProviderClient: Send + Sync {
         timestamp: BlockTimestamp,
     ) -> L1GasPriceProviderClientResult<PriceInfo>;
 
-    /// ETH/FRI rate as 18-decimal fixed-point integer, quoted as FRI per ETH
-    /// (e.g. 5000 STRK per ETH → `5000 * 10^18`).
-    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
+    /// ETH/FRI rate, quoted as FRI per ETH (e.g. 5000 STRK per ETH → `5000 * 10^18`).
+    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<ExchangeRate>;
 
-    /// STRK/USD rate as 18-decimal fixed-point integer, quoted as USD per STRK
-    /// (e.g. STRK at $0.50 → `0.5 * 10^18`).
-    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
+    /// STRK/USD rate, quoted as USD per STRK (e.g. STRK at $0.50 → `0.5 * 10^18`).
+    async fn get_strk_to_usd_rate(
+        &self,
+        timestamp: u64,
+    ) -> L1GasPriceProviderClientResult<ExchangeRate>;
 }
 
 #[cfg_attr(any(feature = "testing", test), automock)]
 #[async_trait]
 pub trait ExchangeRateOracleClientTrait: Send + Sync + Debug {
-    /// Fetches a rate as a u128 for the given timestamp. The semantics of the rate (e.g.
-    /// ETH/FRI, STRK/USD) are determined by the URLs the implementation is configured with;
-    /// callers label the per-instance meaning at the field that holds the trait object.
-    async fn fetch_rate(&self, timestamp: u64) -> Result<u128, ExchangeRateOracleClientError>;
+    /// Fetches the rate for the given timestamp. Which pair the rate converts (e.g. ETH/FRI,
+    /// STRK/USD) is fixed per implementation instance by its configuration; callers label the
+    /// per-instance meaning at the field that holds the trait object.
+    async fn fetch_rate(
+        &self,
+        timestamp: u64,
+    ) -> Result<ExchangeRate, ExchangeRateOracleClientError>;
+}
+
+/// The rate an oracle client instance produces, carried as a type parameter so a client cannot be
+/// built for a pair no implementation reads.
+pub trait RateKind: Send + Sync + Debug + 'static {
+    const PAIR: CurrencyPair;
+}
+
+/// FRI per ETH, derived from the ETH/USD and STRK/USD pairs.
+#[derive(Clone, Copy, Debug)]
+pub struct EthToFri;
+
+impl RateKind for EthToFri {
+    const PAIR: CurrencyPair = CurrencyPair::EthStrk;
+}
+
+/// USD per STRK.
+#[derive(Clone, Copy, Debug)]
+pub struct StrkToUsd;
+
+impl RateKind for StrkToUsd {
+    const PAIR: CurrencyPair = CurrencyPair::StrkUsd;
 }
 
 #[async_trait]
@@ -167,7 +225,7 @@ where
         )
     }
     #[instrument(skip(self))]
-    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128> {
+    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<ExchangeRate> {
         let request = L1GasPriceRequest::GetEthToFriRate(timestamp);
         handle_all_response_variants!(
             self,
@@ -180,7 +238,10 @@ where
         )
     }
     #[instrument(skip(self))]
-    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128> {
+    async fn get_strk_to_usd_rate(
+        &self,
+        timestamp: u64,
+    ) -> L1GasPriceProviderClientResult<ExchangeRate> {
         let request = L1GasPriceRequest::GetStrkToUsdRate(timestamp);
         handle_all_response_variants!(
             self,


### PR DESCRIPTION
Stacked on #14938. Second PR of the [L1 price oracle replacement](https://starkwareindustries.slack.com/archives/D0ACHD9K27N/p1786280310659939).

## What

`ChainlinkOracleClient`, an `ExchangeRateOracleClientTrait` implementation that reads Chainlink's on-chain Starknet feeds through **our own batcher**, replacing the Pragma HTTP API (now a gated commercial beta returning `401 No API key`).

**Lands dark.** `ChainlinkOracleConfig` is not attached to `L1GasPriceProviderConfig`, and nothing constructs the client outside its own module, so `config_schema.json` is untouched and there is no behavior change. The config enum that selects it per feed comes in a later PR, which makes going live a config rollout rather than a deploy.

## The two rates

Reads `latest_round_data()` on the feed **proxies** (never the aggregators, which rotate behind them via `phase_id`):

- **STRK/USD** → the answer rescaled 8→18 decimals, as USD per STRK.
- **ETH/STRK** → `eth_usd / strk_usd` at 18 decimals. Every Chainlink feed on Starknet mainnet is USD-quoted; no direct pair exists.

`answer` is `u128` **unsigned** on these contracts, so there is no signed-felt decoding. `round_id` is phase-encoded `(phase_id << 128) | round`, so it is consumed as a `Felt` and never narrowed.

## Non-blocking

`fetch_rate` keeps the spawn-and-cache shape of the HTTP client: quantize, check cache, spawn a background query, return `QueryNotReadyError`. No batcher round trip lands on the proposal build/validate path. Failures are cached for the rest of the bucket to bound retries (a hostile feed would otherwise cost 4 blocking VM executions *per block*), and still fall back to the previous bucket's rate so a transient error does not become a hard error for a whole interval.

## Guards

All reject rather than substitute, so the existing degradation ladder handles them.

| Guard | Why |
|---|---|
| Staleness on `updated_at`, **bounded in both directions** | Without a future bound, a feed reporting `updated_at = u64::MAX` reads as permanently fresh forever. Both legs of the derived rate are checked: one fresh and one stale leg manufactures phantom rate moves worse than freezing both. |
| Absolute sanity bounds per pair and on the derived rate | Consensus only checks that validators *agree with each other*, and every node reads the same chain state, so a poisoned feed produces unanimous agreement on a wrong value. These bounds are the only thing that notices. |
| Zero answers, decimals range, all arithmetic | Feed retdata is fully adversarial: a single owner key can `upgrade` the proxy class. |

Bounds were calibrated against the incoming L2 fee cap and verified not to clip it: the STRK/USD band contains the entire `[min, 10x min]` fee range with 58.7x headroom below and 170.5x above. The ETH/STRK floor was raised from 100 to 10,000 STRK/ETH during review, cutting the worst-case L1 undercharge from 1304x to 13x. That leg matters more because it reaches L1 gas pricing via `wei_to_fri` with **no ratchet** and no clamp, unlike the SNIP-35 leg's 0.2%/block limit.

## Deferred, not dropped

The plan's **rate-of-change bound** is not here. Anchoring it to node-local history would make acceptance differ between validators, so it needs the previous block's implied rate and arrives with the block-header fallback work.

## Known dependency before going live

`Batcher::call_contract` reaches `call_view_entry_point` with `initial_gas = HIGH_GAS_AMOUNT` and **`limit_steps = false`**, and the batcher's `LocalComponentServer` processes one request at a time with no priority preemption. A hostile feed contract could therefore stall block production. That needs a batcher-side bound and is tracked separately; this PR only adds a `TODO` at the call site. Worth knowing that this would be `call_contract`'s **first production consumer** anywhere in the tree.

## Testing

86 tests. Every guard at its exact boundary and one step past, malformed retdata, overflow, the spawn-and-cache and negative-caching behaviour with call counters, the guard counters via a thread-local Prometheus recorder, and truncation on a multi-byte character boundary.

Reviewed through two adversarial rounds (correctness, security, tests, readability). Round 2 caught that round 1's negative-caching fix had introduced an availability regression, and that a `decimals()` cache could pin a 100x mis-scale for the process lifetime; both are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)