### PR TITLE
blockifier: skip cloning declared_contracts in get_os_initial_reads

### DIFF
--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -298,7 +298,8 @@ impl<S: StateReader> CachedState<S> {
     /// Returns the pre-block values the OS needs to replay the block: the values read during
     /// execution, extended with the class hash and nonce of every accessed contract and the
     /// compiled class hash of every accessed class (the OS reads these trie leaves even when
-    /// execution itself did not). `declared_contracts` is cleared, as the OS does not consume it.
+    /// execution itself did not). `declared_contracts` is left empty, as the OS does not consume
+    /// it.
     pub fn get_os_initial_reads(&mut self) -> StateResult<StateMaps> {
         // Back-fill write-only storage cells so their pre-block values are part of the initial
         // reads.
@@ -322,8 +323,8 @@ impl<S: StateReader> CachedState<S> {
             self.get_compiled_class_hash(class_hash)?;
         }
 
-        // Clone only the fields the OS consumes; `declared_contracts` is dropped rather than
-        // cloned and cleared, since a block can declare many classes.
+        // Clone field-by-field to avoid cloning `declared_contracts`, which a block with many
+        // declares makes large, only to discard it.
         let cache = self.cache.borrow();
         let initial_reads = &cache.initial_reads;
         Ok(StateMaps {

--- a/crates/blockifier/src/state/cached_state.rs
+++ b/crates/blockifier/src/state/cached_state.rs
@@ -321,9 +321,18 @@ impl<S: StateReader> CachedState<S> {
         for class_hash in declared_class_hashes {
             self.get_compiled_class_hash(class_hash)?;
         }
-        let mut os_initial_reads = self.get_initial_reads()?;
-        os_initial_reads.declared_contracts.clear();
-        Ok(os_initial_reads)
+
+        // Clone only the fields the OS consumes; `declared_contracts` is dropped rather than
+        // cloned and cleared, since a block can declare many classes.
+        let cache = self.cache.borrow();
+        let initial_reads = &cache.initial_reads;
+        Ok(StateMaps {
+            nonces: initial_reads.nonces.clone(),
+            class_hashes: initial_reads.class_hashes.clone(),
+            storage: initial_reads.storage.clone(),
+            compiled_class_hashes: initial_reads.compiled_class_hashes.clone(),
+            declared_contracts: HashMap::new(),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up performance optimization to #14624.

`get_os_initial_reads` builds its return value by calling `get_initial_reads()`, which clones the *entire* `initial_reads` `StateMaps` — including `declared_contracts: HashMap<ClassHash, bool>` — and then immediately calls `.declared_contracts.clear()` on the result, since the OS does not consume that field.

This PR replaces that clone-then-clear with a field-by-field construction of the returned `StateMaps`: `nonces`, `class_hashes`, `storage`, and `compiled_class_hashes` are cloned as before (byte-identical to the previous behavior), while `declared_contracts` is set directly to an empty `HashMap::new()` instead of being cloned and discarded.

**Impact:** for a block that declares many classes, this removes one wasted `HashMap` allocation + copy on the block-finalization hot path (`get_os_initial_reads` runs once per block when OS-initial-reads collection is enabled). No semantic change — `declared_contracts` was always cleared before being returned, so the returned value is unchanged; `StateMaps::default()` (used in the `Skip` arm) already returns an empty map in this field, so this is consistent with existing behavior.

## Test plan

- [x] `cargo build -p blockifier`
- [x] `SEED=0 cargo test -p blockifier --lib cached_state` — all 43 `state::cached_state` tests pass
- [x] `scripts/rust_fmt.sh --check` — clean
- [x] Reviewed by an Opus subagent (correctness of `HashMap::new()` vs. cloned-then-cleared map, `RefCell` borrow scoping, and style) — no blocking findings; two comment-wording nits applied
- [ ] CI green

---

_Generated by_ [_Claude Code_](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaNkWM3kEJfFCjEBRfPvB5)_