### PR TITLE
apollo_dashboard,apollo_consensus_orchestrator: alert on the L2 gas price bounds

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/metrics.rs
+++ b/crates/apollo_consensus_orchestrator/src/metrics.rs
@@ -17,7 +17,6 @@ define_metrics!(
         MetricGauge { CONSENSUS_L2_GAS_PRICE, "consensus_l2_gas_price", "The L2 gas price calculated in an accepted proposal" },
         MetricGauge { CONSENSUS_L2_GAS_PRICE_AT_MINIMUM, "consensus_l2_gas_price_at_minimum", "1 when the accepted L2 gas price is clamped at the configured minimum (min_l2_gas_price_per_height, or the versioned-constants min_gas_price fallback), else 0" },
         // Counter, not gauge: a gauge resets to 0 on restart, hiding clamps that already occurred.
-        // [Temporary comment] Panel and alerts arrive in #14947.
         LabeledMetricCounter { CONSENSUS_L2_GAS_PRICE_CLAMPED, "consensus_l2_gas_price_clamped", "Number of times a clamp bound the computed next L2 gas price. `minimum`: the previous price was below the effective minimum, i.e. still ramping up towards the floor. A price at or above the floor is not counted, even when the floor raised it; see consensus_l2_gas_price_at_minimum. `maximum`: bound by the ceiling, including when only the SNIP-35 floor was clipped, in which case the published price can be below the ceiling", init = 0, labels = L2_GAS_PRICE_CLAMP_BOUND },
         MetricCounter { CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR, "consensus_l1_gas_price_provider_error", "Number of times the context got an error when querying the L1 gas price provider", init=0},
         MetricCounter { CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH, "consensus_retrospective_block_hash_mismatch", "Number of times the retrospective block hashes of the state sync and the batcher mismatched", init=0},
@@ -43,8 +42,8 @@ define_metrics!(
         MetricGauge { SNIP35_FEE_PROPOSAL_FRI, "snip35_fee_proposal_fri", "The fee_proposal this node published in the latest block, in Fri" },
         MetricGauge { SNIP35_FEE_TARGET_FRI, "snip35_fee_target_fri", "The fee_target computed from the STRK/USD oracle, in Fri" },
         MetricGauge { SNIP35_FEE_TARGET_ATTO_USD, "snip35_fee_target_atto_usd", "Configured target USD cost per L2 gas unit, in atto-USD" },
-        // [Temporary comment] Registered here so the alert in #14947 has a series to read. The
-        // increment site arrives with the fee-proposal band clamp, which is deferred to `main`.
+        // [Temporary comment] The increment site arrives with the fee-proposal band clamp, which
+        // is deferred to `main`, so this counter stays at zero on this lineage.
         MetricCounter { SNIP35_FEE_TARGET_ABOVE_MAXIMUM, "snip35_fee_target_above_maximum", "Number of blocks whose oracle-derived fee_target exceeded the L2 gas price maximum. Excludes targets from the override_l2_gas_price_fri operator pin", init = 0 },
     }
 );
@@ -54,7 +53,7 @@ pub const LABEL_L2_GAS_PRICE_CLAMP_BOUND: &str = "l2_gas_price_clamp_bound";
 // Which bound a clamp applied: the effective minimum in force, or the `l2_gas_price_cap` ceiling.
 #[derive(IntoStaticStr, EnumIter, VariantNames)]
 #[strum(serialize_all = "snake_case")]
-pub(crate) enum L2GasPriceClampBound {
+pub enum L2GasPriceClampBound {
     Minimum,
     Maximum,
 }

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -319,6 +319,17 @@
             "consensus_l2_gas_price{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / 1e9"
           ],
           "extra_params": {}
+        },
+        {
+          "title": "L2 Gas Price Clamped By Bound",
+          "description": "The number of blocks whose computed L2 gas price was pulled to a bound (10m window). The minimum series ticks throughout an ordinary ramp towards the SNIP-35 floor; the maximum series is the one that signals trouble",
+          "type": "timeseries",
+          "exprs": [
+            "sum by (l2_gas_price_clamp_bound) (increase(consensus_l2_gas_price_clamped{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m]))"
+          ],
+          "extra_params": {
+            "log_query": "\"maximum gas price\" OR \"below minimum gas price\""
+          }
         }
       ],
       "collapsed": true
@@ -423,6 +434,17 @@
             "snip35_fee_target_fri{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / 1e9"
           ],
           "extra_params": {}
+        },
+        {
+          "title": "Fee Target Above Maximum",
+          "description": "The number of blocks whose oracle-derived fee_target exceeded the L2 gas price maximum (10m window)",
+          "type": "timeseries",
+          "exprs": [
+            "increase(snip35_fee_target_above_maximum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m])"
+          ],
+          "extra_params": {
+            "log_query": "\"exceeds the L2 gas price maximum\""
+          }
         },
         {
           "title": "Fee Target (USD per 1B L2 gas)",

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -613,6 +613,32 @@
       "severity": "p5"
     },
     {
+      "name": "consensus_l2_gas_price_above_maximum",
+      "title": "L2 gas price computation above the configured maximum",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(consensus_l2_gas_price_clamped{cluster=~\"$cluster\", namespace=~\"$namespace\", l2_gas_price_clamp_bound=\"maximum\"}[5m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "10m",
+      "severity": "p2"
+    },
+    {
       "name": "consensus_l2_gas_price_at_minimum",
       "title": "L2 gas price at configured minimum",
       "ruleGroup": "evaluation_rate_default",
@@ -2067,6 +2093,32 @@
       ],
       "for": "30s",
       "severity": "p3"
+    },
+    {
+      "name": "snip35_fee_target_above_maximum",
+      "title": "SNIP-35 fee target above the L2 gas price maximum",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "sum(increase(snip35_fee_target_above_maximum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[5m])) or vector(0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              0.0
+            ],
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "10m",
+      "severity": "p4"
     },
     {
       "name": "staking_epoch_id_mismatch",

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -76,7 +76,6 @@ use crate::alert_scenarios::l1_gas_prices::{
     get_eth_to_strk_rate_out_of_bounds_alert,
     get_l1_gas_price_provider_insufficient_history_alert,
     get_l1_gas_price_scraper_success_count_alert,
-    get_l2_gas_price_at_minimum_alert,
     get_strk_to_usd_error_count_alert,
     get_strk_to_usd_oracle_stale_alert,
     get_strk_to_usd_rate_frozen_alert,
@@ -85,6 +84,11 @@ use crate::alert_scenarios::l1_gas_prices::{
 use crate::alert_scenarios::l1_handlers::{
     get_l1_handler_transaction_waiting_in_l1_alert,
     get_l1_message_scraper_no_successes_alert,
+};
+use crate::alert_scenarios::l2_gas_price::{
+    get_l2_gas_price_above_maximum_alert,
+    get_l2_gas_price_at_minimum_alert,
+    get_snip35_fee_target_above_maximum_alert,
 };
 use crate::alert_scenarios::mempool_size::{
     get_mempool_evictions_count_alert,
@@ -671,6 +675,8 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_l1_gas_price_provider_insufficient_history_alert());
     alerts.push(get_l1_gas_price_scraper_success_count_alert());
     alerts.push(get_l2_gas_price_at_minimum_alert());
+    alerts.push(get_l2_gas_price_above_maximum_alert());
+    alerts.push(get_snip35_fee_target_above_maximum_alert());
     alerts.push(get_l1_message_scraper_no_successes_alert());
     alerts.push(get_l1_handler_transaction_waiting_in_l1_alert());
     alerts.extend(get_primary_l1_endpoint_down_too_long_alerts());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -1,4 +1,3 @@
-use apollo_consensus_orchestrator::metrics::CONSENSUS_L2_GAS_PRICE_AT_MINIMUM;
 use apollo_l1_gas_price::metrics::{
     EXCHANGE_RATE_ORACLE_ERROR_COUNT,
     EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
@@ -148,27 +147,6 @@ pub(crate) fn get_l1_gas_price_provider_insufficient_history_alert() -> Alert {
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
-        ObserverApplicability::NotApplicable,
-    )
-}
-
-/// Alert when the accepted L2 gas price sits at the configured minimum for a sustained window,
-/// i.e. the EIP-1559 fee market has clamped the price at its floor (demand bottomed out).
-///
-/// Fires on the `consensus_l2_gas_price_at_minimum` gauge (1 = clamped at the configured min),
-/// which the orchestrator derives per height from `min_l2_gas_price_per_height` (falling back to
-/// the versioned-constants `min_gas_price`). Emitting the "at minimum" signal from the node — where
-/// the configured min is known — avoids a hard-coded Grafana threshold that would rot on a
-/// versioned-constants change or miss any env that overrides the min (e.g. Mainnet's 15e9).
-pub(crate) fn get_l2_gas_price_at_minimum_alert() -> Alert {
-    Alert::new(
-        "consensus_l2_gas_price_at_minimum",
-        "L2 gas price at configured minimum",
-        EvaluationRate::Default,
-        format!("max({})", CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.get_name_with_filter()),
-        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
-        "2m",
-        AlertSeverity::DayOnly,
         ObserverApplicability::NotApplicable,
     )
 }

--- a/crates/apollo_dashboard/src/alert_scenarios/l2_gas_price.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l2_gas_price.rs
@@ -1,0 +1,94 @@
+use apollo_consensus_orchestrator::metrics::{
+    L2GasPriceClampBound,
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM,
+    CONSENSUS_L2_GAS_PRICE_CLAMPED,
+    LABEL_L2_GAS_PRICE_CLAMP_BOUND,
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM,
+};
+use apollo_metrics::metrics::MetricQueryName;
+
+use crate::alerts::{
+    Alert,
+    AlertComparisonOp,
+    AlertCondition,
+    AlertLogicalOp,
+    AlertSeverity,
+    EvaluationRate,
+    ObserverApplicability,
+};
+use crate::query_builder::{sum_increase, sum_increase_with_label};
+
+#[cfg(test)]
+#[path = "l2_gas_price_test.rs"]
+mod l2_gas_price_test;
+
+/// Sampling window for the counters below, kept shorter than the pending duration of the alerts
+/// that use it so that a single clamped block stops counting before it can page.
+const COUNTER_SAMPLING_WINDOW: &str = "5m";
+
+/// Alert while the accepted L2 gas price rests at the configured minimum, i.e. the EIP-1559 fee
+/// market bottomed out.
+///
+/// Reads the `consensus_l2_gas_price_at_minimum` indicator, not the `minimum` clamp counter (which
+/// instead counts blocks still ramping up towards the floor). The node emits it because the
+/// configured minimum is known there, so the alert follows overrides and versioned-constants
+/// changes.
+pub(crate) fn get_l2_gas_price_at_minimum_alert() -> Alert {
+    Alert::new(
+        "consensus_l2_gas_price_at_minimum",
+        "L2 gas price at configured minimum",
+        EvaluationRate::Default,
+        format!("max({})", CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.get_name_with_filter()),
+        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
+        "2m",
+        AlertSeverity::DayOnly,
+        ObserverApplicability::NotApplicable,
+    )
+}
+
+/// Alert while the computed L2 gas price keeps running into the ceiling
+/// (`MAX_GAS_PRICE_MULTIPLIER` times the configured minimum): either the price itself is capped
+/// there, or the SNIP-35 floor alone has risen above it while the published price ramps up to
+/// match.
+///
+/// Reads the node's own comparison against the ceiling, so the alert inherits whatever bound the
+/// node enforces. Applies to observers: every node derives the same price per block.
+pub(crate) fn get_l2_gas_price_above_maximum_alert() -> Alert {
+    let above_maximum_query = sum_increase_with_label(
+        &CONSENSUS_L2_GAS_PRICE_CLAMPED,
+        LABEL_L2_GAS_PRICE_CLAMP_BOUND,
+        L2GasPriceClampBound::Maximum.into(),
+        COUNTER_SAMPLING_WINDOW,
+    );
+    Alert::new(
+        "consensus_l2_gas_price_above_maximum",
+        "L2 gas price computation above the configured maximum",
+        EvaluationRate::Default,
+        format!("{above_maximum_query} or vector(0)"),
+        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
+        "10m",
+        AlertSeverity::Regular,
+        ObserverApplicability::Applicable,
+    )
+}
+
+/// Alert while the oracle-derived `fee_target` keeps exceeding the ceiling, which pins this node's
+/// `fee_proposal` to the maximum.
+///
+/// Separate from `get_l2_gas_price_above_maximum_alert` because it names the cause: a STRK/USD feed
+/// reporting STRK far too cheap, rather than congestion, so the remedy is the feed not the traffic.
+pub(crate) fn get_snip35_fee_target_above_maximum_alert() -> Alert {
+    Alert::new(
+        "snip35_fee_target_above_maximum",
+        "SNIP-35 fee target above the L2 gas price maximum",
+        EvaluationRate::Default,
+        format!(
+            "{} or vector(0)",
+            sum_increase(&SNIP35_FEE_TARGET_ABOVE_MAXIMUM, COUNTER_SAMPLING_WINDOW)
+        ),
+        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
+        "10m",
+        AlertSeverity::WorkingHours,
+        ObserverApplicability::Applicable,
+    )
+}

--- a/crates/apollo_dashboard/src/alert_scenarios/l2_gas_price_test.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l2_gas_price_test.rs
@@ -1,0 +1,106 @@
+use std::collections::HashSet;
+
+use apollo_consensus_orchestrator::metrics::{
+    L2GasPriceClampBound,
+    LABEL_L2_GAS_PRICE_CLAMP_BOUND,
+};
+use serde_json::Value;
+
+use super::{
+    get_l2_gas_price_above_maximum_alert,
+    get_l2_gas_price_at_minimum_alert,
+    get_snip35_fee_target_above_maximum_alert,
+};
+use crate::alert_definitions::get_apollo_alerts;
+use crate::alerts::Alert;
+
+/// The reading every metric these alerts watch produces on a freshly restarted pod: the Prometheus
+/// exporter renders a registered-but-unset counter or gauge as 0.
+const POST_RESTART_READING: f64 = 0.0;
+
+fn alert_as_json(alert: &Alert) -> Value {
+    serde_json::to_value(alert).expect("Alert should serialize.")
+}
+
+fn condition_is_satisfied_by(alert_json: &Value, reading: f64) -> bool {
+    let evaluator = &alert_json["conditions"][0]["evaluator"];
+    let comparison_value = evaluator["params"][0]
+        .as_f64()
+        .expect("Condition should compare against a concrete value.");
+    match evaluator["type"].as_str().expect("Condition should name a comparison operator.") {
+        "gt" => reading > comparison_value,
+        "lt" => reading < comparison_value,
+        operator => panic!("Unexpected comparison operator: {operator}."),
+    }
+}
+
+#[test]
+fn severity_and_pending_duration_match_the_paging_intent() {
+    // p2 pages immediately: the ceiling makes the network unusable. The other three are bounded
+    // elsewhere, so they can wait for a person to look.
+    let expected_paging = [
+        (get_l2_gas_price_at_minimum_alert(), "p3", "2m"),
+        (get_l2_gas_price_above_maximum_alert(), "p2", "10m"),
+        (get_snip35_fee_target_above_maximum_alert(), "p4", "10m"),
+    ];
+
+    for (alert, severity, pending_duration) in expected_paging {
+        let alert_json = alert_as_json(&alert);
+        let name = &alert_json["name"];
+        assert_eq!(alert_json["severity"], severity, "Wrong severity for {name}.");
+        assert_eq!(alert_json["for"], pending_duration, "Wrong pending duration for {name}.");
+    }
+}
+
+#[test]
+fn alerts_with_a_zero_baseline_stay_silent_on_a_post_restart_reading() {
+    // These three read a counter increase or a 1/0 indicator, for which 0 is the true "nothing
+    // observed" reading, so a pod restart must not satisfy their condition.
+    for alert in [
+        get_l2_gas_price_at_minimum_alert(),
+        get_l2_gas_price_above_maximum_alert(),
+        get_snip35_fee_target_above_maximum_alert(),
+    ] {
+        let alert_json = alert_as_json(&alert);
+        assert!(
+            !condition_is_satisfied_by(&alert_json, POST_RESTART_READING),
+            "{} fires on a restarted pod that has decided no block yet.",
+            alert_json["name"]
+        );
+    }
+}
+
+#[test]
+fn ceiling_alert_selects_the_maximum_clamp_bound() {
+    // The counter is incremented from the node's own comparison against the ceiling, so the alert
+    // carries no threshold of its own that could drift away from the enforced bound.
+    let alert_json = alert_as_json(&get_l2_gas_price_above_maximum_alert());
+    let expression = alert_json["expr"].as_str().expect("Expression should be a string.");
+    let maximum_bound: &str = L2GasPriceClampBound::Maximum.into();
+    assert!(
+        expression.contains(&format!("{LABEL_L2_GAS_PRICE_CLAMP_BOUND}=\"{maximum_bound}\"")),
+        "Expression must select the maximum bound, got: {expression}."
+    );
+    assert_eq!(alert_json["conditions"][0]["evaluator"]["params"][0], 0.0);
+}
+
+#[test]
+fn all_l2_gas_price_alerts_are_registered() {
+    let registered_alerts = serde_json::to_value(get_apollo_alerts())
+        .expect("Alerts should serialize.")["alerts"]
+        .as_array()
+        .expect("Alerts should serialize to an array.")
+        .iter()
+        .map(|alert| alert["name"].as_str().expect("Alert should have a name.").to_string())
+        .collect::<HashSet<_>>();
+
+    for alert in [
+        get_l2_gas_price_at_minimum_alert(),
+        get_l2_gas_price_above_maximum_alert(),
+        get_snip35_fee_target_above_maximum_alert(),
+    ] {
+        let alert_json = alert_as_json(&alert);
+        let name = alert_json["name"].as_str().expect("Alert should have a name.");
+        assert!(registered_alerts.contains(name), "{name} is defined but never registered.");
+    }
+}

--- a/crates/apollo_dashboard/src/alert_scenarios/mod.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/mod.rs
@@ -5,6 +5,7 @@ pub mod infra_alerts;
 pub mod l1_endpoints;
 pub mod l1_gas_prices;
 pub mod l1_handlers;
+pub mod l2_gas_price;
 pub mod mempool_size;
 pub mod preconfirmed;
 pub mod remote_server_connections;

--- a/crates/apollo_dashboard/src/panels/consensus.rs
+++ b/crates/apollo_dashboard/src/panels/consensus.rs
@@ -52,12 +52,15 @@ use apollo_consensus_orchestrator::metrics::{
     CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY,
     CONSENSUS_BUILD_PROPOSAL_FAILURE,
     CONSENSUS_L2_GAS_PRICE,
+    CONSENSUS_L2_GAS_PRICE_CLAMPED,
     CONSENSUS_VALIDATE_PROPOSAL_FAILURE,
     LABEL_BUILD_PROPOSAL_FAILURE_REASON,
     LABEL_CENDE_FAILURE_REASON,
+    LABEL_L2_GAS_PRICE_CLAMP_BOUND,
     LABEL_VALIDATE_PROPOSAL_FAILURE_REASON,
     SNIP35_FEE_ACTUAL_FRI,
     SNIP35_FEE_PROPOSAL_FRI,
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM,
     SNIP35_FEE_TARGET_ATTO_USD,
     SNIP35_FEE_TARGET_FRI,
 };
@@ -326,6 +329,25 @@ fn get_panel_consensus_l2_gas_price() -> Panel {
         format!("{} / 1e9", CONSENSUS_L2_GAS_PRICE.get_name_with_filter()),
         PanelType::TimeSeries,
     )
+}
+
+fn get_panel_consensus_l2_gas_price_clamped() -> Panel {
+    Panel::new(
+        "L2 Gas Price Clamped By Bound",
+        format!(
+            "The number of blocks whose computed L2 gas price was pulled to a bound \
+             ({DEFAULT_DURATION} window). The minimum series ticks throughout an ordinary ramp \
+             towards the SNIP-35 floor; the maximum series is the one that signals trouble"
+        ),
+        sum_by_label(
+            &CONSENSUS_L2_GAS_PRICE_CLAMPED,
+            LABEL_L2_GAS_PRICE_CLAMP_BOUND,
+            DisplayMethod::Increase(DEFAULT_DURATION),
+            false,
+        ),
+        PanelType::TimeSeries,
+    )
+    .with_log_query("\"maximum gas price\" OR \"below minimum gas price\"")
 }
 
 fn get_panel_cende_last_prepared_blob_block_number() -> Panel {
@@ -695,6 +717,7 @@ pub(crate) fn get_consensus_row() -> Row {
             get_panel_consensus_proof_manager_store_latency(),
             get_panel_consensus_timeouts_by_type(),
             get_panel_consensus_l2_gas_price(),
+            get_panel_consensus_l2_gas_price_clamped(),
         ],
     )
 }
@@ -751,6 +774,19 @@ fn get_panel_snip35_fee_target() -> Panel {
         format!("{} / 1e9", SNIP35_FEE_TARGET_FRI.get_name_with_filter()),
         PanelType::TimeSeries,
     )
+}
+
+fn get_panel_snip35_fee_target_above_maximum() -> Panel {
+    Panel::new(
+        "Fee Target Above Maximum",
+        format!(
+            "The number of blocks whose oracle-derived fee_target exceeded the L2 gas price \
+             maximum ({DEFAULT_DURATION} window)"
+        ),
+        increase(&SNIP35_FEE_TARGET_ABOVE_MAXIMUM, DEFAULT_DURATION),
+        PanelType::TimeSeries,
+    )
+    .with_log_query("\"exceeds the L2 gas price maximum\"")
 }
 
 fn get_panel_snip35_fee_target_atto_usd() -> Panel {
@@ -858,6 +894,7 @@ pub(crate) fn get_snip35_row() -> Row {
             get_panel_snip35_fee_actual(),
             get_panel_snip35_fee_proposal(),
             get_panel_snip35_fee_target(),
+            get_panel_snip35_fee_target_above_maximum(),
             get_panel_snip35_fee_target_atto_usd(),
             get_panel_snip35_strk_usd_rate(),
             get_panel_snip35_strk_usd_success_count(),


### PR DESCRIPTION
Adds three L2 gas price alerts and two supporting panels, on top of the published-price cap in #14978.

`snip35_fee_target_above_maximum` is defined and registered in #14978 but has no increment site on this lineage: the fee-proposal band clamp that increments it (#14946) is deferred to `main`, so that one alert is inert here and goes live with the port. The other two are driven by #14978's counters and are live.

- P2 when the computed price keeps running into the ceiling. It reads the clamp counter, so it carries no threshold of its own and inherits whatever bound the node enforces.
- P4 when the oracle-derived `fee_target` exceeds the ceiling, separate from the P2 because it names the feed rather than congestion as the cause.
- The pre-existing P3 at-the-minimum alert relocates into the new `l2_gas_price` module byte-identical, executing the standing TODO in `alert_definitions.rs`. The generated alert JSON diffs as additions only.

A fourth alert, P4 while the accepted price runs far above the configured minimum but still inside the band, was in an earlier revision and is removed at the reviewer's request pending a decision with Ohad Barta. It will land separately if it is wanted.

Every expression is written so a freshly restarted pod stays quiet. All three alerts fire on a plain `> 0`, so nothing here needs a per-deployment threshold and the alert overrides are untouched.

---

## Detailed Summary for AI Bots

Adds the L2 gas price alerts Ohad Barta asked for, on top of the two-way cap.

- P2 (`AlertSeverity::Regular`) `consensus_l2_gas_price_above_maximum`, while the
  computed price keeps running into the ceiling (`MAX_GAS_PRICE_MULTIPLIER` times
  the configured minimum). Reads the clamp counter filtered to the `maximum`
  bound, so it carries no threshold of its own and inherits whatever bound the
  node enforces.
- P4 (`AlertSeverity::WorkingHours`) `snip35_fee_target_above_maximum`, when the
  oracle-derived `fee_target` exceeds the ceiling. Separate from the P2 because it
  names the cause: a STRK/USD feed reporting STRK far too cheap rather than
  congestion, so the remedy is the feed and not the traffic. Its counter has no
  increment site on this lineage, so it is inert until #14946 is ported.
- P3 (`AlertSeverity::DayOnly`) `consensus_l2_gas_price_at_minimum` already
  existed; it moves into the new module byte-identical, which also executes the
  standing TODO in `alert_definitions.rs` to break the remaining alerts out into
  modules. The generated alert JSON diffs as additions only.

An earlier revision also carried
`consensus_l2_gas_price_far_above_minimum`, a P4 gauge-based early warning while
the accepted price sat far above the configured minimum but still inside the band.
The reviewer asked for it to come out pending a decision with Ohad Barta, so this
revision removes the alert, its registration in `alert_definitions.rs`, its three
tests, its entry in the registered-alerts list, and the
`consensus_l2_gas_price_far_above_minimum-comparison_value` key that was left
dangling in `deployments/monitoring/examples/config/alert_overrides_testnet.yaml`.
`grep far_above_minimum` returns nothing.

Removing it also removes the only per-deployment threshold this PR introduced.
The three remaining alerts all compare `GreaterThan 0.0`, so
`validate_config_overrides` needs no new key and the alert sync is not blocked.

Every expression is chosen so a freshly restarted pod stays quiet. The two
counter-driven alerts append `or vector(0)`, which keeps the vector non-empty
when the metric has never been incremented, so the generated rule evaluates to
`0` rather than entering NoData and paging. The gauge-driven P3 reads
`max(consensus_l2_gas_price_at_minimum)` unfiltered, because `max()` already
ignores a restarting pod's `0` whereas a `> 0` filter would empty the vector on a
cold start.

Two panels come with it, `consensus_l2_gas_price_clamped` and
`snip35_fee_target_above_maximum`, so an on-call paged by these has the
underlying series to look at. The clamped panel breaks the counter out by the
`clamp_bound` label rather than filtering to `maximum` like the alert does, so
the `minimum` series is visible alongside it. Its log query matches both bounds'
log lines for the same reason.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
