### PR TITLE
apollo_dashboard,deployment: page on a stale oracle rate instead of on guard trips

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -951,17 +951,43 @@
       "severity": "$$$eth_to_strk_rate_frozen-severity$$$"
     },
     {
-      "name": "eth_to_strk_success_count",
-      "title": "Eth to Strk success count",
+      "name": "eth_to_strk_rate_out_of_bounds",
+      "title": "Eth to Strk rate outside the configured bounds",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(exchange_rate_oracle_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"eth_strk\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "sum(increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"eth_strk\", error_type=\"rate_out_of_bounds_error\"}[1h])) or vector(0)",
       "conditions": [
         {
           "evaluator": {
             "params": [
-              1.0
+              0.0
             ],
-            "type": "lt"
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "$$$eth_to_strk_rate_out_of_bounds-severity$$$"
+    },
+    {
+      "name": "eth_to_strk_success_count",
+      "title": "Eth to Strk oracle produced no rate",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(max((time() - exchange_rate_oracle_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"eth_strk\"}) and (exchange_rate_oracle_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"eth_strk\"} > 0))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              2700.0
+            ],
+            "type": "gt"
           },
           "operator": {
             "type": "and"
@@ -2225,17 +2251,43 @@
       "severity": "$$$strk_to_usd_rate_frozen-severity$$$"
     },
     {
-      "name": "strk_to_usd_success_count",
-      "title": "Strk to Usd success count",
+      "name": "strk_to_usd_rate_out_of_bounds",
+      "title": "Strk to Usd rate outside the configured bounds",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(exchange_rate_oracle_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"strk_usd\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "sum(increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"strk_usd\", error_type=\"rate_out_of_bounds_error\"}[1h])) or vector(0)",
       "conditions": [
         {
           "evaluator": {
             "params": [
-              1.0
+              0.0
             ],
-            "type": "lt"
+            "type": "gt"
+          },
+          "operator": {
+            "type": "and"
+          },
+          "reducer": {
+            "params": [],
+            "type": "avg"
+          },
+          "type": "query"
+        }
+      ],
+      "for": "30s",
+      "severity": "$$$strk_to_usd_rate_out_of_bounds-severity$$$"
+    },
+    {
+      "name": "strk_to_usd_success_count",
+      "title": "Strk to Usd oracle produced no rate",
+      "ruleGroup": "evaluation_rate_default",
+      "expr": "(max((time() - exchange_rate_oracle_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"strk_usd\"}) and (exchange_rate_oracle_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"strk_usd\"} > 0))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "conditions": [
+        {
+          "evaluator": {
+            "params": [
+              2700.0
+            ],
+            "type": "gt"
           },
           "operator": {
             "type": "and"

--- a/crates/apollo_dashboard/src/alert_definitions.rs
+++ b/crates/apollo_dashboard/src/alert_definitions.rs
@@ -71,14 +71,16 @@ use crate::alert_scenarios::infra_alerts::{
 use crate::alert_scenarios::l1_endpoints::get_primary_l1_endpoint_down_too_long_alerts;
 use crate::alert_scenarios::l1_gas_prices::{
     get_eth_to_strk_error_count_alert,
+    get_eth_to_strk_oracle_stale_alert,
     get_eth_to_strk_rate_frozen_alert,
-    get_eth_to_strk_success_count_alert,
+    get_eth_to_strk_rate_out_of_bounds_alert,
     get_l1_gas_price_provider_insufficient_history_alert,
     get_l1_gas_price_scraper_success_count_alert,
     get_l2_gas_price_at_minimum_alert,
     get_strk_to_usd_error_count_alert,
+    get_strk_to_usd_oracle_stale_alert,
     get_strk_to_usd_rate_frozen_alert,
-    get_strk_to_usd_success_count_alert,
+    get_strk_to_usd_rate_out_of_bounds_alert,
 };
 use crate::alert_scenarios::l1_handlers::{
     get_l1_handler_transaction_waiting_in_l1_alert,
@@ -621,6 +623,8 @@ pub fn get_apollo_alerts() -> Alerts {
         get_consensus_retrospective_block_hash_mismatch(),
         get_consensus_round_above_zero(),
         get_consensus_votes_num_sent_messages_alert(),
+        get_eth_to_strk_rate_out_of_bounds_alert(),
+        get_strk_to_usd_rate_out_of_bounds_alert(),
         get_eth_to_strk_error_count_alert(),
         get_strk_to_usd_error_count_alert(),
         get_gateway_add_tx_idle(),
@@ -652,8 +656,8 @@ pub fn get_apollo_alerts() -> Alerts {
     alerts.push(get_consensus_p2p_peer_down());
     alerts.push(get_consensus_round_above_zero_multiple_times());
     alerts.push(get_consensus_round_high());
-    alerts.push(get_eth_to_strk_success_count_alert());
-    alerts.push(get_strk_to_usd_success_count_alert());
+    alerts.push(get_eth_to_strk_oracle_stale_alert());
+    alerts.push(get_strk_to_usd_oracle_stale_alert());
     alerts.push(get_eth_to_strk_rate_frozen_alert());
     alerts.push(get_strk_to_usd_rate_frozen_alert());
     alerts.append(&mut get_general_pod_memory_utilization_vec());

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -1,12 +1,13 @@
 use apollo_consensus_orchestrator::metrics::CONSENSUS_L2_GAS_PRICE_AT_MINIMUM;
 use apollo_l1_gas_price::metrics::{
     EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+    EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
     EXCHANGE_RATE_ORACLE_RATE,
-    EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT,
 };
-use apollo_l1_gas_price_types::{CurrencyPair, LABEL_NAME_CURRENCY_PAIR};
+use apollo_l1_gas_price_types::errors::ExchangeRateOracleErrorType;
+use apollo_l1_gas_price_types::{CurrencyPair, LABEL_NAME_CURRENCY_PAIR, LABEL_NAME_ERROR_TYPE};
 use apollo_metrics::metrics::MetricQueryName;
 
 use crate::alert_placeholders::SeverityValueOrPlaceholder;
@@ -20,13 +21,38 @@ use crate::alerts::{
     ObserverApplicability,
     PENDING_DURATION_DEFAULT,
 };
-use crate::query_builder::{sum_increase, sum_increase_with_label, with_label};
+use crate::query_builder::{
+    sum_increase,
+    sum_increase_with_label,
+    sum_increase_with_labels,
+    with_label,
+};
 
-pub(crate) fn get_eth_to_strk_success_count_alert() -> Alert {
+#[cfg(test)]
+#[path = "l1_gas_prices_test.rs"]
+mod l1_gas_prices_test;
+
+/// How long a pair may go without a successful oracle query before paging: three refreshes at the
+/// 900s cadence both oracles use in production. Raising either refresh interval past 900s without
+/// raising this makes a healthy oracle look stale.
+const ORACLE_STALENESS_THRESHOLD_SECONDS: f64 = 2700.0;
+
+pub(crate) fn get_eth_to_strk_oracle_stale_alert() -> Alert {
+    // Kept as `eth_to_strk_success_count`: the name is the key the per-env severity overrides set.
     const ALERT_NAME: &str = "eth_to_strk_success_count";
-    oracle_success_count_alert(
+    oracle_stale_alert(
         ALERT_NAME,
-        "Eth to Strk success count",
+        "Eth to Strk oracle produced no rate",
+        CurrencyPair::EthStrk,
+        SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+    )
+}
+
+pub(crate) fn get_eth_to_strk_rate_out_of_bounds_alert() -> Alert {
+    const ALERT_NAME: &str = "eth_to_strk_rate_out_of_bounds";
+    oracle_rate_out_of_bounds_alert(
+        ALERT_NAME,
+        "Eth to Strk rate outside the configured bounds",
         CurrencyPair::EthStrk,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
     )
@@ -41,11 +67,22 @@ pub(crate) fn get_eth_to_strk_error_count_alert() -> Alert {
     )
 }
 
-pub(crate) fn get_strk_to_usd_success_count_alert() -> Alert {
+pub(crate) fn get_strk_to_usd_oracle_stale_alert() -> Alert {
+    // Kept as `strk_to_usd_success_count`: the name is the key the per-env severity overrides set.
     const ALERT_NAME: &str = "strk_to_usd_success_count";
-    oracle_success_count_alert(
+    oracle_stale_alert(
         ALERT_NAME,
-        "Strk to Usd success count",
+        "Strk to Usd oracle produced no rate",
+        CurrencyPair::StrkUsd,
+        SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
+    )
+}
+
+pub(crate) fn get_strk_to_usd_rate_out_of_bounds_alert() -> Alert {
+    const ALERT_NAME: &str = "strk_to_usd_rate_out_of_bounds";
+    oracle_rate_out_of_bounds_alert(
+        ALERT_NAME,
+        "Strk to Usd rate outside the configured bounds",
         CurrencyPair::StrkUsd,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
     )
@@ -82,7 +119,8 @@ pub(crate) fn get_strk_to_usd_rate_frozen_alert() -> Alert {
 
 /// Alert if had no successful l1 gas price scrape in the last hour.
 ///
-/// Uses `sum_increase` for the same spot-eviction reason as `get_eth_to_strk_success_count_alert`.
+/// `sum_increase` rather than bare `increase`: a rescheduled pod's counter restarts at 0, and
+/// summing across the pod series keeps the evicted pod's samples counted for the full window.
 pub(crate) fn get_l1_gas_price_scraper_success_count_alert() -> Alert {
     const ALERT_NAME: &str = "l1_gas_price_scraper_success_count";
     Alert::new(
@@ -135,13 +173,56 @@ pub(crate) fn get_l2_gas_price_at_minimum_alert() -> Alert {
     )
 }
 
-/// Alert if an exchange-rate oracle had no successful query in the last hour.
+/// Alert if a pair has had no successful oracle query for
+/// [`ORACLE_STALENESS_THRESHOLD_SECONDS`].
 ///
-/// Uses `sum_increase` instead of bare `increase` to avoid false positives on spot eviction: when
-/// a pod is evicted and rescheduled, the new pod's counter resets to 0, so a bare `increase([1h])`
-/// would return 0 until the first success. `sum` aggregates across all pod series, and the
-/// evicted pod's data points remain in the TSDB for the full 1h window, keeping the sum ≥ 1.
-fn oracle_success_count_alert(
+/// Reads the last-success gauge rather than counting successes, so the alert does not depend on how
+/// often the client queries: any cadence below the threshold satisfies it, and a cadence that slows
+/// past the threshold pages instead of going silent.
+///
+/// `max` is over ages, so the stalest replica governs rather than the freshest: every node serves
+/// proposals from the rate its own client produced, and one node stuck on a fallback rate is worth
+/// paging for.
+///
+/// `and (... > 0)` drops a series that never recorded a success, including the pairs no client
+/// serves: registration publishes every label permutation at 0, and `time() - 0` would page
+/// forever.
+fn oracle_stale_alert(
+    name: &str,
+    title: &str,
+    pair: CurrencyPair,
+    severity: impl Into<SeverityValueOrPlaceholder>,
+) -> Alert {
+    let last_success = with_label(
+        &EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
+        LABEL_NAME_CURRENCY_PAIR,
+        pair.into(),
+    );
+    Alert::new(
+        name,
+        title,
+        EvaluationRate::Default,
+        format!("max((time() - {last_success}) and ({last_success} > 0))"),
+        vec![AlertCondition::new(
+            AlertComparisonOp::GreaterThan,
+            ORACLE_STALENESS_THRESHOLD_SECONDS,
+            AlertLogicalOp::And,
+        )],
+        PENDING_DURATION_DEFAULT,
+        severity,
+        ObserverApplicability::NotApplicable,
+    )
+}
+
+/// Alert if a rate was rejected for falling outside the configured absolute bounds.
+///
+/// The wrong-feed-wiring and poisoned-answer detector, and the one rejection consensus cannot
+/// substitute for: validators check that they agree with each other, never that the agreed value is
+/// sane. A single trip is worth paging for, so this deliberately keeps firing for the rest of the
+/// window after one increment.
+///
+/// Applies to observers, which read the same feeds, so a trip is environment-wide either way.
+fn oracle_rate_out_of_bounds_alert(
     name: &str,
     title: &str,
     pair: CurrencyPair,
@@ -151,16 +232,24 @@ fn oracle_success_count_alert(
         name,
         title,
         EvaluationRate::Default,
-        sum_increase_with_label(
-            &EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
-            LABEL_NAME_CURRENCY_PAIR,
-            pair.into(),
-            "1h",
+        format!(
+            "{} or vector(0)",
+            sum_increase_with_labels(
+                &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+                &[
+                    (LABEL_NAME_CURRENCY_PAIR, pair.into()),
+                    (
+                        LABEL_NAME_ERROR_TYPE,
+                        ExchangeRateOracleErrorType::RateOutOfBoundsError.into()
+                    ),
+                ],
+                "1h",
+            )
         ),
-        vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
+        vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 0.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         severity,
-        ObserverApplicability::NotApplicable,
+        ObserverApplicability::Applicable,
     )
 }
 

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices_test.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices_test.rs
@@ -1,0 +1,57 @@
+use apollo_l1_gas_price_types::errors::ExchangeRateOracleErrorType;
+use apollo_l1_gas_price_types::{CurrencyPair, LABEL_NAME_CURRENCY_PAIR, LABEL_NAME_ERROR_TYPE};
+use serde_json::Value;
+
+use super::{
+    get_eth_to_strk_oracle_stale_alert,
+    get_eth_to_strk_rate_out_of_bounds_alert,
+    get_strk_to_usd_oracle_stale_alert,
+    get_strk_to_usd_rate_out_of_bounds_alert,
+};
+use crate::alerts::Alert;
+
+fn alert_expression(alert: &Alert) -> String {
+    let alert_json: Value = serde_json::to_value(alert).expect("Alert should serialize.");
+    alert_json["expr"].as_str().expect("Alert should carry an expression.").to_string()
+}
+
+/// Registration publishes every label permutation at 0, so without the `> 0` guard the staleness
+/// alert would read `time() - 0` and fire forever, including for a pair no client serves.
+#[test]
+fn stale_alerts_ignore_a_gauge_that_never_recorded_a_success() {
+    for (alert, currency_pair) in [
+        (get_eth_to_strk_oracle_stale_alert(), CurrencyPair::EthStrk),
+        (get_strk_to_usd_oracle_stale_alert(), CurrencyPair::StrkUsd),
+    ] {
+        let expression = alert_expression(&alert);
+        let pair_filter = format!("{LABEL_NAME_CURRENCY_PAIR}=\"{}\"", <&str>::from(currency_pair));
+        assert!(expression.contains(&pair_filter), "{expression} should select one pair.");
+        assert!(expression.contains("> 0)"), "{expression} should drop an unset gauge.");
+    }
+}
+
+/// The pair alone would also match the other guards, which the aggregate error-count alert already
+/// covers at a threshold; this alert pages on a single rejection, so it must select one error type.
+#[test]
+fn rate_out_of_bounds_alerts_select_one_pair_and_one_error_type() {
+    for (alert, currency_pair) in [
+        (get_eth_to_strk_rate_out_of_bounds_alert(), CurrencyPair::EthStrk),
+        (get_strk_to_usd_rate_out_of_bounds_alert(), CurrencyPair::StrkUsd),
+    ] {
+        let expression = alert_expression(&alert);
+        assert!(
+            expression.contains(&format!(
+                "{LABEL_NAME_CURRENCY_PAIR}=\"{}\"",
+                <&str>::from(currency_pair)
+            )),
+            "{expression} should select one pair."
+        );
+        assert!(
+            expression.contains(&format!(
+                "{LABEL_NAME_ERROR_TYPE}=\"{}\"",
+                <&str>::from(ExchangeRateOracleErrorType::RateOutOfBoundsError)
+            )),
+            "{expression} should select the rate-out-of-bounds error type."
+        );
+    }
+}

--- a/crates/apollo_dashboard/src/query_builder.rs
+++ b/crates/apollo_dashboard/src/query_builder.rs
@@ -36,7 +36,26 @@ pub(crate) fn seconds_since_last_timestamp(metric: &dyn MetricQueryName) -> Stri
 ///
 /// Example: `with_label(&m, "currency_pair", "eth_strk")` → `m{..., currency_pair="eth_strk"}`
 pub(crate) fn with_label(metric: &dyn MetricQueryName, label: &str, value: &str) -> String {
-    metric.get_name_with_filer_and_additional_fields(&format!("{label}=\"{value}\""))
+    with_labels(metric, &[(label, value)])
+}
+
+/// Narrows a multi-dimensional labeled metric to one value per label.
+pub(crate) fn with_labels(metric: &dyn MetricQueryName, labels: &[(&str, &str)]) -> String {
+    let filters = labels
+        .iter()
+        .map(|(label, value)| format!("{label}=\"{value}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    metric.get_name_with_filer_and_additional_fields(&filters)
+}
+
+/// `sum(increase())` of one series of a multi-dimensional labeled metric.
+pub(crate) fn sum_increase_with_labels(
+    metric: &dyn MetricQueryName,
+    labels: &[(&str, &str)],
+    duration: &str,
+) -> String {
+    format!("sum(increase({}[{}]))", with_labels(metric, labels), duration)
 }
 
 /// `increase()` of one label value of a labeled metric.

--- a/deployments/monitoring/examples/config/alert_overrides_testnet.yaml
+++ b/deployments/monitoring/examples/config/alert_overrides_testnet.yaml
@@ -31,6 +31,7 @@ consensus_round_above_zero_multiple_times-sampling_window_secs-expression: 600
 consensus_round_above_zero_multiple_times-severity: "p4"
 consensus_round_high-comparison_value: 13.333333333333334
 consensus_round_high-severity: "p4"
+eth_to_strk_rate_out_of_bounds-severity: "p2"
 eth_to_strk_success_count-severity: "p4"
 gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression: 120
 gateway_low_successful_transaction_rate-severity: "p4"
@@ -52,3 +53,4 @@ mempool_pool_size_increase-severity: "p4"
 mempool_transaction_drop_ratio-severity: "p4"
 preconfirmed_block_not_written-severity: "p4"
 state_sync_lag-severity: "p3"
+strk_to_usd_rate_out_of_bounds-severity: "p2"


### PR DESCRIPTION
Pages when an oracle stops producing a rate for a pair, measured as `time() - exchange_rate_oracle_last_success_timestamp_seconds`, instead of trying to page on guard trips. No retry cadence can silence it.

`rate_out_of_bounds` keeps a dedicated alert per pair, since a single rejection means someone is publishing a price the deployment considers impossible. The two freshness guards no longer get their own alert.

The two new severity keys are added to the example testnet overrides; the deployed override configs need them before this reaches an environment.

---

## Detailed Summary for AI Bots

### Why the previous mechanism could not fire

The guard alerts needed `retry_interval < sampling_window < pending_duration`: a 5m window so a lone trip released the condition before the 10m pending timer elapsed, and trips frequent enough to re-satisfy the window continuously. That inequality is not something an alert can hold, because the retry interval is config. At `failure_retry_interval_seconds: 60` it happened to work; at anything above 5m the alert silently became unable to fire, and the justification comment named the wrong knob (`lag_interval_seconds`, 900s), which is what Bugbot picked up.

The staleness alert has a one-sided constraint instead, `threshold > refresh_gap`, and it fails safe: a cadence slower than assumed produces a false page, which gets noticed, rather than a silent rule.

### Alerts

- `eth_to_strk_success_count` / `strk_to_usd_success_count` (names kept so the per-env severity override keys still resolve, titles now "… oracle produced no rate"): `max((time() - <gauge>) and (<gauge> > 0)) > 2700`, per pair. 2700s is three refreshes at the slowest supported cadence, 900s for both the HTTP oracle's `lag_interval_seconds` and the Chainlink client's `sampling_interval_seconds`. The `> 0` guard drops a pair whose gauge was registered but never set, including `eth_usd`, which no client serves; without it `time() - 0` would page forever.
- `eth_to_strk_rate_out_of_bounds` / `strk_to_usd_rate_out_of_bounds`: `sum(increase(exchange_rate_oracle_error_count{currency_pair="…", error_type="rate_out_of_bounds_error"}[1h])) or vector(0) > 0`. Deliberately keeps firing for the rest of the window after one increment. Applies to observers, which read the same feeds.
- Deleted: `alert_scenarios/chainlink_oracle.rs` and its test, along with `GUARD_SAMPLING_WINDOW`, `GUARD_PENDING_DURATION` and the three `get_chainlink_oracle_*` alerts. Everything now lives in `alert_scenarios/l1_gas_prices.rs`, per Matan's request to consolidate the oracle alerts into one file.

The two freshness guards are covered without their own alert: a feed that stopped publishing stops producing rates, which the staleness alert catches, and every guard trip also increments the pair's `error_count`, which the existing threshold alert watches.

### Tests

`l1_gas_prices_test.rs` pins the two properties that a simplification would quietly break: the staleness expression carries the `> 0` guard, and the out-of-bounds expression selects both the pair and the error type rather than the pair alone.
