### PR TITLE
apollo_consensus_orchestrator: cap recorder response size in send_recorder_get

### DIFF
--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -35,7 +35,7 @@ ethnum.workspace = true
 futures.workspace = true
 indexmap.workspace = true
 num-rational.workspace = true
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "stream"] }
 reqwest-middleware = { workspace = true, features = ["json"] }
 reqwest-retry.workspace = true
 serde.workspace = true

--- a/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
@@ -20,7 +20,13 @@ use super::{
     RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH,
     RECORDER_WRITE_BLOB_PATH,
 };
-use crate::cende::{BlobParameters, CendeAmbassadorError, CendeAmbassadorResult, CendeConfig, CendeContext};
+use crate::cende::{
+    BlobParameters,
+    CendeAmbassadorError,
+    CendeAmbassadorResult,
+    CendeConfig,
+    CendeContext,
+};
 use crate::metrics::{
     register_metrics,
     CendeWriteFailureReason,

--- a/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
@@ -16,6 +16,7 @@ use url::Url;
 use super::{
     send_recorder_get_with_limit,
     CendeAmbassador,
+    MAX_RECORDER_ERROR_BODY_BYTES,
     RECORDER_GET_ACCESSED_KEYS_INPUT_PATH,
     RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH,
     RECORDER_WRITE_BLOB_PATH,
@@ -352,28 +353,69 @@ async fn send_recorder_get_rejects_response_over_the_size_limit() {
     let result: CendeAmbassadorResult<String> =
         send_recorder_get_with_limit(request, "/oversized", MAX_RESPONSE_BYTES).await;
 
-    assert_matches!(result, Err(CendeAmbassadorError::RecorderRequestFailed { .. }));
+    // The message is asserted on, and not just the error variant, so that the test cannot pass
+    // because the body was rejected for an unrelated reason (e.g. a JSON parse failure).
+    assert_matches!(
+        result,
+        Err(CendeAmbassadorError::RecorderRequestFailed { message, .. })
+            if message.contains(&format!("exceeded the {MAX_RESPONSE_BYTES}-byte limit"))
+    );
     mock.assert();
 }
 
+/// A JSON string body, used as a well-formed response whose byte length is easy to reason about.
+const WITHIN_LIMIT_BODY: &str = "\"hi\"";
+
+#[rstest]
+// The cap is inclusive: a body whose length is exactly the cap is accepted.
+#[case::body_length_equals_the_limit(WITHIN_LIMIT_BODY.len())]
+#[case::body_shorter_than_the_limit(1024)]
 #[tokio::test]
-async fn send_recorder_get_accepts_response_within_the_size_limit() {
+async fn send_recorder_get_accepts_response_within_the_size_limit(
+    #[case] max_response_bytes: usize,
+) {
     let mut server = mockito::Server::new_async().await;
-    const MAX_RESPONSE_BYTES: usize = 1024;
 
     let mock = server
         .mock("GET", "/ok")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("\"hi\"")
+        .with_body(WITHIN_LIMIT_BODY)
         .create();
 
     let client = ClientBuilder::new(reqwest::Client::new()).build();
     let request = client.get(format!("{}/ok", server.url()));
 
     let result: CendeAmbassadorResult<String> =
-        send_recorder_get_with_limit(request, "/ok", MAX_RESPONSE_BYTES).await;
+        send_recorder_get_with_limit(request, "/ok", max_response_bytes).await;
 
     assert_eq!(result.unwrap(), "hi");
+    mock.assert();
+}
+
+// An error-status body is attacker-influenceable and unbounded just like a success body, so it too
+// is read under a cap (`MAX_RECORDER_ERROR_BODY_BYTES`) instead of being buffered in full.
+#[tokio::test]
+async fn send_recorder_get_truncates_an_oversized_error_status_body() {
+    let mut server = mockito::Server::new_async().await;
+    let oversized_error_body = "e".repeat(MAX_RECORDER_ERROR_BODY_BYTES + 100);
+
+    let mock =
+        server.mock("GET", "/error").with_status(500).with_body(&oversized_error_body).create();
+
+    let client = ClientBuilder::new(reqwest::Client::new()).build();
+    let request = client.get(format!("{}/error", server.url()));
+
+    let result: CendeAmbassadorResult<String> =
+        send_recorder_get_with_limit(request, "/error", 1024).await;
+
+    assert_matches!(
+        result,
+        Err(CendeAmbassadorError::RecorderRequestFailed { message, .. })
+            if message.contains("returned error status 500")
+                && message.ends_with("...(truncated)")
+                // The full body is never buffered; only a bounded prefix of it is reported.
+                && message.len() < oversized_error_body.len()
+    );
     mock.assert();
 }

--- a/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/cende_test.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use apollo_class_manager_types::MockClassManagerClient;
+use assert_matches::assert_matches;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use reqwest::StatusCode;
+use reqwest_middleware::ClientBuilder;
 use rstest::rstest;
 use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
 use starknet_api::block::{BlockInfo, BlockNumber};
@@ -12,12 +14,13 @@ use starknet_api::test_utils::read_json_file;
 use url::Url;
 
 use super::{
+    send_recorder_get_with_limit,
     CendeAmbassador,
     RECORDER_GET_ACCESSED_KEYS_INPUT_PATH,
     RECORDER_GET_LATEST_RECEIVED_BLOCK_PATH,
     RECORDER_WRITE_BLOB_PATH,
 };
-use crate::cende::{BlobParameters, CendeConfig, CendeContext};
+use crate::cende::{BlobParameters, CendeAmbassadorError, CendeAmbassadorResult, CendeConfig, CendeContext};
 use crate::metrics::{
     register_metrics,
     CendeWriteFailureReason,
@@ -316,5 +319,55 @@ async fn get_accessed_keys_input(
     } else {
         assert!(result.unwrap().is_none());
     }
+    mock.assert();
+}
+
+// Demonstrates the fix for an unbounded-memory-allocation DoS: before the response-size cap was
+// added, `send_recorder_get` deserialized a recorder response of any size (via `response.json`),
+// so a malicious or compromised recorder could send an oversized `get_accessed_keys_input`
+// response (whose `transactions`/`execution_infos` vectors are attacker-influenceable in length)
+// and drive the consensus orchestrator to buffer an unbounded amount of memory.
+#[tokio::test]
+async fn send_recorder_get_rejects_response_over_the_size_limit() {
+    let mut server = mockito::Server::new_async().await;
+    const MAX_RESPONSE_BYTES: usize = 10;
+    let oversized_body = "\"01234567890123456789\""; // A 22-byte JSON string, over the limit.
+
+    let mock = server
+        .mock("GET", "/oversized")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(oversized_body)
+        .create();
+
+    let client = ClientBuilder::new(reqwest::Client::new()).build();
+    let request = client.get(format!("{}/oversized", server.url()));
+
+    let result: CendeAmbassadorResult<String> =
+        send_recorder_get_with_limit(request, "/oversized", MAX_RESPONSE_BYTES).await;
+
+    assert_matches!(result, Err(CendeAmbassadorError::RecorderRequestFailed { .. }));
+    mock.assert();
+}
+
+#[tokio::test]
+async fn send_recorder_get_accepts_response_within_the_size_limit() {
+    let mut server = mockito::Server::new_async().await;
+    const MAX_RESPONSE_BYTES: usize = 1024;
+
+    let mock = server
+        .mock("GET", "/ok")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("\"hi\"")
+        .create();
+
+    let client = ClientBuilder::new(reqwest::Client::new()).build();
+    let request = client.get(format!("{}/ok", server.url()));
+
+    let result: CendeAmbassadorResult<String> =
+        send_recorder_get_with_limit(request, "/ok", MAX_RESPONSE_BYTES).await;
+
+    assert_eq!(result.unwrap(), "hi");
     mock.assert();
 }

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -29,6 +29,7 @@ use central_objects::{
     CentralTransactionWritten,
 };
 use const_format::concatcp;
+use futures::StreamExt;
 #[cfg(test)]
 use mockall::automock;
 use reqwest::Response;
@@ -180,6 +181,13 @@ pub const RECORDER_GET_COMMITMENT_INFOS_HEIGHT_OFFSET_PATH: &str =
 pub const RECORDER_GET_ACCESSED_KEYS_INPUT_PATH: &str =
     concatcp!(RECORDER_PREFIX, "/get_accessed_keys_input");
 
+/// Hard cap on how many bytes a single recorder response may buffer before being deserialized.
+/// Recorder endpoints such as `get_accessed_keys_input` return attacker-influenceable,
+/// unbounded-length data (transaction calldata, signatures, etc.); without this cap, an oversized
+/// (malicious or malfunctioning) response would let the recorder drive unbounded memory allocation
+/// in the consensus orchestrator, a liveness-critical process.
+const MAX_RECORDER_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+
 #[derive(Debug, Deserialize)]
 struct BlockNumberResponse {
     block_number: Option<u64>,
@@ -294,10 +302,20 @@ async fn fetch_block_number(
 
 /// Sends `request` to a recorder GET endpoint and deserializes the JSON body into `T`, mapping
 /// transport, non-success status, and parse failures to `RecorderRequestFailed`. `path` is used
-/// only for diagnostics.
+/// only for diagnostics. The response body is capped at `MAX_RECORDER_RESPONSE_BYTES`.
 async fn send_recorder_get<T: DeserializeOwned>(
     request: RequestBuilder,
     path: &str,
+) -> CendeAmbassadorResult<T> {
+    send_recorder_get_with_limit(request, path, MAX_RECORDER_RESPONSE_BYTES).await
+}
+
+/// Like [`send_recorder_get`], but with the response-size cap as an explicit parameter, so tests
+/// can exercise the cap without buffering `MAX_RECORDER_RESPONSE_BYTES` worth of data.
+async fn send_recorder_get_with_limit<T: DeserializeOwned>(
+    request: RequestBuilder,
+    path: &str,
+    max_response_bytes: usize,
 ) -> CendeAmbassadorResult<T> {
     let recorder_error = |message: String| CendeAmbassadorError::RecorderRequestFailed {
         path: path.to_string(),
@@ -313,7 +331,23 @@ async fn send_recorder_get<T: DeserializeOwned>(
         return Err(recorder_error(format!("returned error status {status}: {body}")));
     }
 
-    response.json::<T>().await.map_err(|e| recorder_error(format!("failed to parse response: {e}")))
+    // Stream the body instead of `response.json`/`response.bytes`, which buffer the entire body
+    // regardless of size: the recorder is a network peer, and its response length is not
+    // otherwise bounded (a `Content-Length` header can be absent or understated).
+    let mut body = Vec::new();
+    let mut chunks = response.bytes_stream();
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.map_err(|e| recorder_error(format!("failed to read response: {e}")))?;
+        if body.len() + chunk.len() > max_response_bytes {
+            return Err(recorder_error(format!(
+                "response body exceeded the {max_response_bytes}-byte limit"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    serde_json::from_slice(&body)
+        .map_err(|e| recorder_error(format!("failed to parse response: {e}")))
 }
 
 #[async_trait]

--- a/crates/apollo_consensus_orchestrator/src/cende/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/cende/mod.rs
@@ -188,6 +188,11 @@ pub const RECORDER_GET_ACCESSED_KEYS_INPUT_PATH: &str =
 /// in the consensus orchestrator, a liveness-critical process.
 const MAX_RECORDER_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
 
+/// Hard cap on how many bytes of a non-success recorder response are read. Such a body is only
+/// used as a diagnostic inside an error message, so a short prefix is enough; it is as unbounded
+/// and as attacker-influenceable as a success body, and it additionally ends up in the logs.
+const MAX_RECORDER_ERROR_BODY_BYTES: usize = 4 * 1024;
+
 #[derive(Debug, Deserialize)]
 struct BlockNumberResponse {
     block_number: Option<u64>,
@@ -327,27 +332,57 @@ async fn send_recorder_get_with_limit<T: DeserializeOwned>(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_else(|_| "unparseable".to_string());
+        // The error body is read under a (much smaller) cap of its own: it is attacker-
+        // influenceable and unbounded just like a success body, and `response.text()` would
+        // buffer all of it.
+        let body = match read_response_body_prefix(response, MAX_RECORDER_ERROR_BODY_BYTES).await {
+            Ok((body_prefix, is_truncated)) => {
+                let mut body = String::from_utf8_lossy(&body_prefix).into_owned();
+                if is_truncated {
+                    body.push_str("...(truncated)");
+                }
+                body
+            }
+            Err(_) => "unparseable".to_string(),
+        };
         return Err(recorder_error(format!("returned error status {status}: {body}")));
     }
 
-    // Stream the body instead of `response.json`/`response.bytes`, which buffer the entire body
-    // regardless of size: the recorder is a network peer, and its response length is not
-    // otherwise bounded (a `Content-Length` header can be absent or understated).
-    let mut body = Vec::new();
-    let mut chunks = response.bytes_stream();
-    while let Some(chunk) = chunks.next().await {
-        let chunk = chunk.map_err(|e| recorder_error(format!("failed to read response: {e}")))?;
-        if body.len() + chunk.len() > max_response_bytes {
-            return Err(recorder_error(format!(
-                "response body exceeded the {max_response_bytes}-byte limit"
-            )));
-        }
-        body.extend_from_slice(&chunk);
+    let (body, is_truncated) = read_response_body_prefix(response, max_response_bytes)
+        .await
+        .map_err(|e| recorder_error(format!("failed to read response: {e}")))?;
+    if is_truncated {
+        return Err(recorder_error(format!(
+            "response body exceeded the {max_response_bytes}-byte limit"
+        )));
     }
 
     serde_json::from_slice(&body)
         .map_err(|e| recorder_error(format!("failed to parse response: {e}")))
+}
+
+/// Reads at most `max_body_bytes` bytes of `response`'s body, returning them alongside a flag that
+/// is `true` iff the body was longer than the cap (i.e. the returned bytes are a truncated prefix
+/// of it). The body is streamed rather than read via `Response::json`/`text`/`bytes`, which buffer
+/// the whole body regardless of size: the recorder is a network peer whose response length is not
+/// otherwise bounded (a `Content-Length` header can be absent or understated).
+async fn read_response_body_prefix(
+    response: Response,
+    max_body_bytes: usize,
+) -> reqwest::Result<(Vec<u8>, bool)> {
+    let mut body = Vec::new();
+    let mut chunks = response.bytes_stream();
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk?;
+        let remaining_capacity = max_body_bytes.saturating_sub(body.len());
+        if chunk.len() > remaining_capacity {
+            body.extend_from_slice(&chunk[..remaining_capacity]);
+            return Ok((body, true));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok((body, false))
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

Automated security scan of #14823, which merged `CendeContext::get_accessed_keys_input`.

That endpoint fetches per-block data from the Cende recorder and deserializes the response body directly via `response.json::<T>()` in the shared `send_recorder_get` helper, with no limit on response size. Previously, every caller of this helper only ever deserialized a tiny fixed-shape `BlockNumberResponse { block_number: Option<u64> }`. `get_accessed_keys_input` is the first caller to deserialize into `BlockAccessedKeysData { transactions: Vec<CentralTransactionWritten>, execution_infos: Vec<CentralTransactionExecutionInfo> }` — collections whose length and nested field sizes (calldata, signatures, paymaster data, etc.) are entirely controlled by the response body. The same PR also removed the `#[cfg(feature = "testing")]` gate on `Deserialize` for these central transaction types, so they are now deserializable in production builds, not just tests.

**Vulnerability (CWE-400, Uncontrolled Resource Consumption):** a malicious or compromised recorder (or a response with an absent/understated `Content-Length`) can return an arbitrarily large body. Because `response.json` buffers the entire body before parsing, and the request timeout only bounds wall-clock time (not bytes-per-second), a fast, oversized response can drive unbounded memory allocation in the consensus orchestrator — a liveness-critical process per this repo's own architecture (it orchestrates block production). This matches the project's own documented guidance in `.claude/rules/code-style.md`: *"Any value deserialized from an HTTP request, query parameter, or other external input must be assumed hostile... Cap allocations derived from user input with hard limits."*

## Fix

`send_recorder_get` now streams the response body via `bytes_stream()` and rejects it with `RecorderRequestFailed` as soon as accumulated bytes exceed a fixed `MAX_RECORDER_RESPONSE_BYTES` cap (64 MiB), before ever calling into `serde_json`. The cap is applied uniformly to all recorder GET endpoints through the shared helper. The size limit is parameterized (`send_recorder_get_with_limit`) so it can be exercised in tests without buffering tens of megabytes.

## Test plan

- [x] Added `send_recorder_get_rejects_response_over_the_size_limit`: a response over a configured byte cap is rejected with `RecorderRequestFailed` instead of being parsed.
- [x] Added `send_recorder_get_accepts_response_within_the_size_limit`: a response within the cap still parses correctly (no regression).
- [x] Existing `get_accessed_keys_input` test cases (parses `Some`, `None`, error status) still pass unmodified.
- [x] `cargo test -p apollo_consensus_orchestrator cende::` — 39 passed, 0 failed.
- [x] `scripts/rust_fmt.sh` — clean.
- [x] `cargo clippy -p apollo_consensus_orchestrator --all-targets --features testing -- -D warnings` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANTjUoyz2ak7VdR9wsv2uw)_