### PR TITLE
apollo_propeller: bound inbound read loop to one batch per poll

### DIFF
--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -182,8 +182,23 @@ impl Handler {
             Poll::Ready(Some(Ok(batch))) => {
                 *inbound_substream = Some(InboundSubstreamState::WaitingInput(substream));
                 Self::handle_received_batch(batch, unsent_units);
-                // Continue the loop in case there are more messages ready
-                ControlFlow::Continue(())
+                if unsent_units.is_empty() {
+                    // The batch decoded to zero valid units (e.g. all failed conversion):
+                    // keep draining, since no back-pressure has been buffered yet.
+                    ControlFlow::Continue(())
+                } else {
+                    // Stop after one batch's worth of units, even though the underlying
+                    // stream may already have further batches buffered and ready. Without
+                    // this, a peer that keeps the socket's read buffer full can have every
+                    // already-buffered batch decoded in a single `poll_inner` call, which
+                    // defeats the `unsent_units.is_empty()` gate in `poll_inner` that is
+                    // supposed to cap buffering at one batch. Wake ourselves so the reactor
+                    // re-polls promptly and drains the rest once the engine channel has
+                    // consumed this batch, instead of relying on a fresh I/O readiness event
+                    // that may never arrive if the peer already sent everything.
+                    cx.waker().wake_by_ref();
+                    ControlFlow::Break(())
+                }
             }
             Poll::Ready(Some(Err(error))) => {
                 trace!("Failed to read from inbound stream: {error}");
@@ -526,6 +541,13 @@ impl Handler {
         if self.unsent_units.is_empty() {
             for inbound_substream in self.inbound_substream.iter_mut() {
                 Self::poll_single_inbound_substream(inbound_substream, &mut self.unsent_units, cx);
+                // Stop at the first slot that buffered a batch: with more than one concurrent
+                // inbound substream, continuing here would let each remaining slot add its own
+                // batch on top, one poll_single_inbound_substream call per slot, defeating this
+                // same one-batch bound across slots instead of just within a slot.
+                if !self.unsent_units.is_empty() {
+                    break;
+                }
             }
         }
 

--- a/crates/apollo_propeller/src/handler.rs
+++ b/crates/apollo_propeller/src/handler.rs
@@ -172,6 +172,11 @@ impl Handler {
     }
 
     /// Polls a single inbound substream that is waiting for input.
+    ///
+    /// Expects `unsent_units` to be empty on entry: that precondition is what lets a non-empty
+    /// `unsent_units` after decoding mean "this batch produced units". Returns
+    /// `ControlFlow::Break` once a batch has been buffered, or once the substream has no more
+    /// data ready, and `ControlFlow::Continue` while the caller should keep polling it.
     fn poll_single_inbound_substream_waiting_input(
         inbound_substream: &mut Option<InboundSubstreamState>,
         mut substream: Framed<Stream, PropellerCodec>,
@@ -541,10 +546,15 @@ impl Handler {
         if self.unsent_units.is_empty() {
             for inbound_substream in self.inbound_substream.iter_mut() {
                 Self::poll_single_inbound_substream(inbound_substream, &mut self.unsent_units, cx);
-                // Stop at the first slot that buffered a batch: with more than one concurrent
-                // inbound substream, continuing here would let each remaining slot add its own
-                // batch on top, one poll_single_inbound_substream call per slot, defeating this
-                // same one-batch bound across slots instead of just within a slot.
+                // Stop at the first slot that buffered a batch, so `unsent_units` holds at most one
+                // batch worth of units exactly as its documentation claims. Continuing would let
+                // each remaining slot add a batch on top, bounding the buffer at
+                // CONCURRENT_STREAMS batches instead -- still O(1), so not a memory-exhaustion
+                // risk, but it would silently invalidate that invariant as the constant grows.
+                // TODO(AndrewL): This scan always restarts at index 0, so once CONCURRENT_STREAMS
+                // exceeds 1, a peer keeping a low-indexed substream constantly readable starves
+                // the higher-indexed ones. Resume from the slot after the last one served
+                // (round-robin) when making the substream count dynamic.
                 if !self.unsent_units.is_empty() {
                     break;
                 }

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::time::Duration;
 
 use apollo_protobuf::protobuf::PropellerUnit as ProtoUnit;
 use futures::StreamExt;
@@ -10,7 +11,7 @@ use prost::Message;
 use starknet_api::staking::StakingWeight;
 use tracing_test::traced_test;
 
-use super::Handler;
+use super::{Handler, QUEUE_WARNING_THRESHOLD};
 use crate::types::{CommitteeId, Event};
 use crate::{Behaviour, Config};
 
@@ -102,16 +103,35 @@ fn test_create_message_batch_stops_at_size_limit() {
 /// `apollo_propeller`'s own log output (including the `warn_every_n_ms!` backlog warning this
 /// test relies on).
 ///
-/// `max_wire_message_size` is kept small so many batches are needed for `NUM_MESSAGES` units.
+/// The signal is `poll_inner`'s backlog warning, which fires once any of its queues exceeds
+/// `QUEUE_WARNING_THRESHOLD`. In this scenario only `unsent_units` can reach that size, so the
+/// warning is unambiguous: the sender's `send_queue` is fed over libp2p's bounded per-connection
+/// command channel and drained on every poll, and `events_to_emit` stays empty while no send fails.
+///
+/// `MAX_WIRE_MESSAGE_SIZE` is load-bearing in both directions: small enough that `NUM_MESSAGES`
+/// units span many wire batches (so an unbounded read pass has plenty to over-consume), yet large
+/// enough that one batch holds far fewer than `QUEUE_WARNING_THRESHOLD` units -- otherwise a single
+/// legitimate batch would trip the warning and fail the test even with the bound in place.
+///
 /// Every broadcast is queued before `sender`'s swarm is ever polled, so once `sender` starts
 /// running, it drains its whole backlog and pushes every batch onto the wire before `receiver`
-/// is polled even once -- exactly the condition the one-batch bound must survive.
+/// is polled even once -- exactly the condition the one-batch bound must survive. Requiring all
+/// `NUM_MESSAGES` to arrive also covers the liveness half of the fix: dropping the self-wake in
+/// `poll_single_inbound_substream_waiting_input` leaves the already-buffered data undrained and
+/// delivery stalls partway, tripping the timeout below.
 #[traced_test]
 #[tokio::test(flavor = "current_thread")]
 async fn poll_inner_bounds_inbound_backlog_to_one_batch() {
-    const NUM_MESSAGES: usize = 220;
+    // Enough units in flight that an unbounded read pass buffers well past
+    // QUEUE_WARNING_THRESHOLD in a single pass. Derived from the threshold rather than hardcoded
+    // so that raising the threshold cannot silently turn this into a test that always passes.
+    const NUM_MESSAGES: usize = 3 * QUEUE_WARNING_THRESHOLD;
+    const MAX_WIRE_MESSAGE_SIZE: usize = 2048;
+    // Generous relative to the ~1s this takes locally: the timeout only has to distinguish
+    // "delivery stalled" from "slow", so err towards a loaded CI machine rather than a flake.
+    const DELIVERY_TIMEOUT: Duration = Duration::from_secs(30);
 
-    let config = Config { max_wire_message_size: 2048, ..Config::default() };
+    let config = Config { max_wire_message_size: MAX_WIRE_MESSAGE_SIZE, ..Config::default() };
     let mut sender = Swarm::new_ephemeral_tokio(|keypair| Behaviour::new(keypair, config.clone()));
     let mut receiver =
         Swarm::new_ephemeral_tokio(|keypair| Behaviour::new(keypair, config.clone()));
@@ -135,8 +155,8 @@ async fn poll_inner_bounds_inbound_backlog_to_one_batch() {
 
     // Queue every broadcast before the sender's swarm is polled even once, so none of this
     // reaches the handler's send queue or the wire yet.
-    for i in 0..NUM_MESSAGES {
-        let message = vec![u8::try_from(i % 256).unwrap()];
+    for message_index in 0..NUM_MESSAGES {
+        let message = vec![u8::try_from(message_index % 256).unwrap()];
         sender
             .behaviour_mut()
             .broadcast(committee_id, message)
@@ -151,7 +171,7 @@ async fn poll_inner_bounds_inbound_backlog_to_one_batch() {
     tokio::spawn(sender.loop_on_next());
 
     let mut num_received = 0;
-    let result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+    let result = tokio::time::timeout(DELIVERY_TIMEOUT, async {
         while num_received < NUM_MESSAGES {
             if let SwarmEvent::Behaviour(Event::MessageReceived { .. }) =
                 receiver.select_next_some().await

--- a/crates/apollo_propeller/src/handler_test.rs
+++ b/crates/apollo_propeller/src/handler_test.rs
@@ -1,10 +1,18 @@
 use std::collections::VecDeque;
 
 use apollo_protobuf::protobuf::PropellerUnit as ProtoUnit;
+use futures::StreamExt;
+use libp2p::swarm::SwarmEvent;
+use libp2p::Swarm;
+use libp2p_swarm_test::SwarmExt as _;
 use prost::encoding::encoded_len_varint;
 use prost::Message;
+use starknet_api::staking::StakingWeight;
+use tracing_test::traced_test;
 
 use super::Handler;
+use crate::types::{CommitteeId, Event};
+use crate::{Behaviour, Config};
 
 /// Build a `ProtoUnit` whose `signature` field is `payload_bytes` bytes long, giving
 /// predictable and controllable encoded sizes.
@@ -79,4 +87,85 @@ fn test_create_message_batch_stops_at_size_limit() {
     assert_eq!(batch.batch.len(), 2, "should pack exactly 2 items");
     assert_eq!(queue.len(), 3, "3 items should remain in the queue");
     assert!(batch.encoded_len() <= max_size);
+}
+
+/// Regression test for an inbound backlog bound bypass: `Handler::unsent_units` is documented
+/// to hold "at most one batch worth of units", and `poll_inner` only starts a new read pass
+/// while it is empty. But `poll_single_inbound_substream_waiting_input` kept decoding every
+/// already-buffered batch in a single call regardless of that gate, so a peer whose batches are
+/// all already sitting in the transport by the time it's first polled could have every one of
+/// them decoded -- and buffered in `unsent_units` -- in one shot, well past the one-batch bound.
+///
+/// This lives here (a unit test, same crate as `Handler`) rather than in `tests/e2e_test.rs`
+/// because `tracing-test`'s default per-crate log filter only captures logs from the crate under
+/// test; an integration test in `tests/` is a separate crate and would silently see none of
+/// `apollo_propeller`'s own log output (including the `warn_every_n_ms!` backlog warning this
+/// test relies on).
+///
+/// `max_wire_message_size` is kept small so many batches are needed for `NUM_MESSAGES` units.
+/// Every broadcast is queued before `sender`'s swarm is ever polled, so once `sender` starts
+/// running, it drains its whole backlog and pushes every batch onto the wire before `receiver`
+/// is polled even once -- exactly the condition the one-batch bound must survive.
+#[traced_test]
+#[tokio::test(flavor = "current_thread")]
+async fn poll_inner_bounds_inbound_backlog_to_one_batch() {
+    const NUM_MESSAGES: usize = 220;
+
+    let config = Config { max_wire_message_size: 2048, ..Config::default() };
+    let mut sender = Swarm::new_ephemeral_tokio(|keypair| Behaviour::new(keypair, config.clone()));
+    let mut receiver =
+        Swarm::new_ephemeral_tokio(|keypair| Behaviour::new(keypair, config.clone()));
+    sender.listen().with_memory_addr_external().await;
+    receiver.listen().with_memory_addr_external().await;
+    sender.connect(&mut receiver).await;
+
+    let committee_id = CommitteeId([0u8; 32]);
+    let peers = vec![
+        (*sender.local_peer_id(), StakingWeight(1)),
+        (*receiver.local_peer_id(), StakingWeight(1)),
+    ];
+    for swarm in [&mut sender, &mut receiver] {
+        swarm
+            .behaviour_mut()
+            .register_committee_peers(committee_id, peers.clone())
+            .await
+            .unwrap()
+            .expect("Failed to register committee");
+    }
+
+    // Queue every broadcast before the sender's swarm is polled even once, so none of this
+    // reaches the handler's send queue or the wire yet.
+    for i in 0..NUM_MESSAGES {
+        let message = vec![u8::try_from(i % 256).unwrap()];
+        sender
+            .behaviour_mut()
+            .broadcast(committee_id, message)
+            .await
+            .unwrap()
+            .expect("Broadcast should succeed");
+    }
+
+    // Drive the sender in the background. With nothing else runnable yet, it drains its entire
+    // backlog -- queueing all NUM_MESSAGES units' worth of batches on the wire -- before
+    // yielding, so they are all already buffered by the time `receiver` is polled below.
+    tokio::spawn(sender.loop_on_next());
+
+    let mut num_received = 0;
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while num_received < NUM_MESSAGES {
+            if let SwarmEvent::Behaviour(Event::MessageReceived { .. }) =
+                receiver.select_next_some().await
+            {
+                num_received += 1;
+            }
+        }
+    })
+    .await;
+    assert!(result.is_ok(), "Timed out: received {num_received}/{NUM_MESSAGES} messages");
+
+    assert!(
+        !logs_contain("Backlog in propeller handler"),
+        "receiver's unsent_units backlog exceeded the warning threshold, meaning far more than \
+         one batch worth of units was buffered from a single already-queued burst"
+    );
 }


### PR DESCRIPTION
## Security scan of #14642

Automated security scan of #14642 (merged) found a resource-exhaustion gap in the fix it shipped, in `crates/apollo_propeller/src/handler.rs`.

### Vulnerability

#14642 added `unsent_units` as a buffer meant to hold "at most one batch worth of units" (see the field doc on `Handler::unsent_units`), and gated new wire reads on `unsent_units.is_empty()` in `poll_inner` specifically to stop a fast/malicious peer from growing that buffer without bound.

That gate is only checked *before starting* a read pass. Inside a pass, `poll_single_inbound_substream_waiting_input` (called in a loop by `poll_single_inbound_substream`) kept decoding **every** already-buffered batch in a single call, unconditionally returning `ControlFlow::Continue`. If a peer's batches are all already sitting in the transport by the time the handler is first polled (e.g. it queued everything before ever being polled, or simply pushed faster than the local task got scheduled), every one of them gets decoded — and buffered in `unsent_units` — in one shot, defeating the one-batch bound the gate is supposed to enforce.

### Proof

`handler_test.rs::poll_inner_bounds_inbound_backlog_to_one_batch` connects two real swarms over the in-memory transport, queues 220 broadcasts on the sender before its swarm is ever polled, then drives the sender in the background so its whole backlog reaches the wire before the receiver is polled even once. Against #14642's code, `unsent_units` reaches **118** in one pass (tripping the crate's own `Backlog in propeller handler` warning, threshold 100); with the fix, it never exceeds one batch (~10 units at the configured `max_wire_message_size`).

### Fix

- `poll_single_inbound_substream_waiting_input`: after decoding a batch, stop (`ControlFlow::Break`) once `unsent_units` is non-empty instead of always continuing. Self-wakes via `cx.waker().wake_by_ref()` so the reactor promptly resumes draining once the engine channel has consumed the batch, rather than relying on a fresh I/O readiness event that may never arrive if the peer already sent everything.
- `poll_inner`'s loop over `inbound_substream` slots: stop at the first slot that buffers a batch, so the same one-batch bound holds once `CONCURRENT_STREAMS` grows past 1 (currently 1, per a `TODO(AndrewL)` in the file).

### Testing

- New regression test added; verified it fails against #14642's code (`Unsent units queue length: 118`) and passes with the fix.
- `cargo test -p apollo_propeller`: 167 unit tests + 4 e2e tests pass.
- `scripts/clippy.sh` / `cargo clippy -p apollo_propeller --all-targets --all-features -- -D warnings`: clean.
- `scripts/rust_fmt.sh --check`: clean.

Note: I could not apply the Rust style guide linked in my scan instructions (`starkware-industries/code-quality`) — that repo is outside this session's authorized scope, so I followed this repo's own `.claude/CLAUDE.md` and `code-style.md` conventions instead.

cc @gkaempfer as author of the original PR.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrwSiNVqapZDsJ44DGc92v)_