### PR TITLE
ci: install Anvil only where it is used, and retry it

### DIFF
--- a/.github/actions/install_anvil/action.yml
+++ b/.github/actions/install_anvil/action.yml
@@ -1,0 +1,18 @@
+name: Install Anvil
+description: Install Foundry's Anvil.
+
+# Used only by jobs whose tests spawn anvil. Callers wrap it in a retry: a transient upstream 503
+# here fails the job at a setup step and reads like a broken commit, and `continue-on-error` is
+# unavailable inside a composite action.
+inputs:
+  version:
+    description: "Foundry version to install"
+    required: false
+    default: v1.5.1
+
+runs:
+  using: "composite"
+  steps:
+    - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+      with:
+        version: ${{ inputs.version }}

--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -20,9 +20,3 @@ runs:
     - name: Install cargo tools
       shell: bash
       run: ./scripts/install_cargo_tools.sh
-
-    # This installation is _not_ cached, but takes a couple seconds: it's downloading prepackaged binaries.
-    - name: Install Anvil
-      uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
-      with:
-        version: v1.5.1

--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -285,10 +285,16 @@ jobs:
           echo "SENDER_ADDRESS=$SENDER_ADDRESS" >> "$GITHUB_ENV"
           echo "RECEIVER_ADDRESS=$RECEIVER_ADDRESS" >> "$GITHUB_ENV"
 
+      # Retried because a transient upstream 503 in this step previously failed 12+ jobs across
+      # 5 PRs. `continue-on-error` works here but not inside a composite action.
       - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
-        with:
-          version: v1.5.1
+        id: install_anvil
+        continue-on-error: true
+        uses: ./.github/actions/install_anvil
+
+      - name: Retry installing Anvil
+        if: steps.install_anvil.outcome == 'failure'
+        uses: ./.github/actions/install_anvil
 
       - name: Restore executable permissions
         run: chmod +x ./target/debug/sequencer_node_setup ./target/debug/sequencer_simulator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,17 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+
+      # Retried because a transient upstream 503 in this step previously failed 12+ jobs across
+      # 5 PRs. `continue-on-error` works here but not inside a composite action.
+      - name: Install Anvil
+        id: install_anvil
+        continue-on-error: true
+        uses: ./.github/actions/install_anvil
+
+      - name: Retry installing Anvil
+        if: steps.install_anvil.outcome == 'failure'
+        uses: ./.github/actions/install_anvil
       # Setup pypy and link to the location expected by .cargo/config.toml.
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
@@ -159,6 +170,17 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+
+      # Retried because a transient upstream 503 in this step previously failed 12+ jobs across
+      # 5 PRs. `continue-on-error` works here but not inside a composite action.
+      - name: Install Anvil
+        id: install_anvil
+        continue-on-error: true
+        uses: ./.github/actions/install_anvil
+
+      - name: Retry installing Anvil
+        if: steps.install_anvil.outcome == 'failure'
+        uses: ./.github/actions/install_anvil
       # Setup pypy and link to the location expected by .cargo/config.toml.
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy

--- a/.github/workflows/main_nightly.yml
+++ b/.github/workflows/main_nightly.yml
@@ -64,6 +64,17 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+
+      # Retried because a transient upstream 503 in this step previously failed 12+ jobs across
+      # 5 PRs. `continue-on-error` works here but not inside a composite action.
+      - name: Install Anvil
+        id: install_anvil
+        continue-on-error: true
+        uses: ./.github/actions/install_anvil
+
+      - name: Retry installing Anvil
+        if: steps.install_anvil.outcome == 'failure'
+        uses: ./.github/actions/install_anvil
       # Setup pypy and link to the location expected by .cargo/config.toml.
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy

--- a/.github/workflows/verify-deps.yml
+++ b/.github/workflows/verify-deps.yml
@@ -16,6 +16,17 @@ jobs:
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Retried because a transient upstream 503 in this step previously failed 12+ jobs across
+      # 5 PRs. `continue-on-error` works here but not inside a composite action.
+      - name: Install Anvil
+        id: install_anvil
+        continue-on-error: true
+        uses: ./.github/actions/install_anvil
+
+      - name: Retry installing Anvil
+        if: steps.install_anvil.outcome == 'failure'
+        uses: ./.github/actions/install_anvil
       - name: Update Dependencies
         run: cargo update --verbose
       - name: Build


### PR DESCRIPTION
Anvil is installed by `bootstrap`, so all 14 workflows that bootstrap pay for it, while only 4 jobs actually run tests that spawn anvil. When a transient upstream 503 hit that step on 2026-08-12 it took down 12+ jobs across 5 PRs, because every job was fetching it.

This installs it only where it is used, and retries it there. The pinned `foundry-rs/foundry-toolchain` action is kept.

---

# Detailed Summary for AI Bots

## Problem

Two compounding issues:

- The install is in `.github/actions/install_rust/action.yml`, reached by 14 workflows via `bootstrap`. Only 4 jobs need anvil, so ~10 workflows were making a network fetch they never use.
- It had no retry. `continue-on-error` is not supported on steps inside a composite action, so the step could not be retried where it lived.

Because it fails in a setup step, a 503 reads like a broken commit: #14938 changes three doc comments and failed at `Install Anvil`.

## Change

The install moves out of `bootstrap` and into the jobs that need it, where `continue-on-error` works, wrapped in an attempt plus a retry:

```yaml
- name: Install Anvil
  id: install_anvil
  continue-on-error: true
  uses: ./.github/actions/install_anvil

- name: Retry installing Anvil
  if: steps.install_anvil.outcome == 'failure'
  uses: ./.github/actions/install_anvil
```

`.github/actions/install_anvil` is a thin wrapper over the SHA-pinned upstream action, so the pin and the version live in one place rather than at each call site.

## Which jobs need it

Determined from the actual test command each job runs, not from grep over workflow text:

| Job | Command | Needs anvil |
|---|---|---|
| `main.yml` / `run-tests` | `run_tests.py --command test --changes_only` | yes, can select any crate |
| `main.yml` / `run-integration-tests` | `run_tests.py --command integration` | yes |
| `main_nightly.yml` / `run-integration-tests` | `run_tests.py --command integration --is_nightly` | yes |
| `verify-deps.yml` / `latest_deps` | `cargo test --verbose` | yes, workspace-wide |
| `hybrid_system_test.yaml` | already installed anvil separately | yes, now retried |
| `main.yml` / `run-workspace-tests` | `cargo test -p workspace_tests` | no |
| `papyrus_ci.yml`, `papyrus_nightly-tests.yml` | `--test latency_histogram --test feeder_gateway_integration_test`, `-p apollo_storage` | no, neither target references anvil |
| everything else | crate-scoped tests, clippy, docker builds | no |

The four anvil-using crates are `apollo_base_layer_tests`, `apollo_integration_tests`, `apollo_l1_events` and `papyrus_base_layer`.

## What this keeps

The upstream action stays pinned at `b00af27...`, as #15097 set it. That matters beyond reproducibility: the `v1` tag has since moved to `908c5403...`.

It also keeps foundryup's behaviour of fetching a current installer while installing a pinned foundry version. An earlier revision of this PR replaced the action with a script that downloaded the release tarball directly. That removed a hop, but it also gave up the installer's ability to adapt when release layout changes, which this repo has already been bitten by: the comment at `hybrid_system_test.yaml` records that k3d's moving `install.sh` began requiring a `checksums.txt` asset that the pinned older version did not ship.

## Failure mode if a job was missed

A job that needs anvil and no longer installs it fails with the explicit message in `crates/apollo_base_layer_tests/src/anvil_base_layer.rs`, which names the binary and the install command, rather than an obscure error.
