### PR TITLE
apollo_infra_utils: probe test ports on the interface servers actually bind

### DIFF
--- a/crates/apollo_infra_utils/src/test_utils.rs
+++ b/crates/apollo_infra_utils/src/test_utils.rs
@@ -7,11 +7,27 @@ use socket2::{Domain, Socket, Type};
 use strum::EnumCount;
 use tracing::instrument;
 
+#[cfg(test)]
+#[path = "test_utils_test.rs"]
+mod test_utils_test;
+
 const PORTS_PER_INSTANCE: u16 = 80;
 pub const MAX_NUMBER_OF_INSTANCES_PER_TEST: u16 = 26;
 #[allow(clippy::as_conversions)]
 const MAX_NUMBER_OF_TESTS: u16 = TestIdentifier::COUNT as u16;
 const BASE_PORT: u16 = 11000;
+
+// A port between `is_port_in_use` returning false and the child process binding it can be handed
+// to an outbound connection by the kernel, surfacing as `Os { code: 98, kind: AddrInUse }`. The
+// allocated range (11000..63000) overlaps the ephemeral range that governs this
+// (`/proc/sys/net/ipv4/ip_local_port_range`, 32768..60999 by default), and one integration test
+// run allocated 40 of its 203 ports inside it.
+//
+// Moving the range below 32768 leaves 21768 usable ports, and the budget needs
+// MAX_NUMBER_OF_TESTS * MAX_NUMBER_OF_INSTANCES_PER_TEST * PORTS_PER_INSTANCE = 52000. Shrinking
+// PORTS_PER_INSTANCE is not the way out either: `integration_test_manager` draws
+// 5 * <services in the node> ports from a single instance, which is 60 for a distributed node and
+// 35 for a hybrid one. Fixing this needs a different allocation scheme, not a smaller constant.
 
 // Ensure available ports don't exceed u16::MAX.
 const _: () = {
@@ -111,8 +127,13 @@ impl AvailablePorts {
 }
 
 // Checks if a port is occupied, without side effects.
+//
+// Probes the unspecified address, which is what the servers under test bind. Probing
+// `127.0.0.1` only reports a conflict with a holder on the loopback interface, so a port held on
+// any other interface passes the probe and then collides on bind with
+// `Os { code: 98, kind: AddrInUse }`. CI runners have several interfaces.
 fn is_port_in_use(port: u16) -> bool {
-    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
+    let addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), port);
     let socket =
         Socket::new(Domain::IPV4, Type::STREAM, None).expect("Should be able to create a socket.");
     // Enable SO_REUSEADDR, which enables later binding to the address

--- a/crates/apollo_infra_utils/src/test_utils_test.rs
+++ b/crates/apollo_infra_utils/src/test_utils_test.rs
@@ -1,0 +1,51 @@
+use std::io::ErrorKind;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+
+use super::is_port_in_use;
+
+/// A free port, taken from the ephemeral range so it cannot collide with the ranges
+/// `AvailablePorts` hands out.
+fn free_port() -> u16 {
+    TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap().local_addr().unwrap().port()
+}
+
+#[test]
+fn unheld_port_is_reported_free() {
+    assert!(!is_port_in_use(free_port()));
+}
+
+#[test]
+fn port_held_on_the_unspecified_address_is_reported_in_use() {
+    let port = free_port();
+    let _holder = TcpListener::bind((Ipv4Addr::UNSPECIFIED, port)).unwrap();
+
+    assert!(is_port_in_use(port));
+}
+
+/// A holder on an interface other than `127.0.0.1` still blocks a later bind on the unspecified
+/// address, so the probe must report the port as in use. `127.0.0.2` stands in for the non-loopback
+/// interfaces a CI runner has, and a probe limited to `127.0.0.1` would report this port as free.
+///
+/// Linux assigns all of `127.0.0.0/8` to loopback, so the holder binds there. macOS assigns only
+/// `127.0.0.1` unless an alias was added, and this scenario cannot be expressed without a second
+/// local address, so the test reports that and returns rather than failing on the environment. CI
+/// runs on Linux, where the assertion always executes.
+#[test]
+fn port_held_on_another_interface_is_reported_in_use() {
+    let port = free_port();
+    let holder_address = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 2).into(), port);
+    let holder = match TcpListener::bind(holder_address) {
+        Ok(holder) => holder,
+        Err(error) if error.kind() == ErrorKind::AddrNotAvailable => {
+            println!(
+                "Skipping: {holder_address} is not a local address on this host, so a second \
+                 interface cannot be simulated."
+            );
+            return;
+        }
+        Err(error) => panic!("Failed to bind {holder_address}: {error}"),
+    };
+
+    assert!(is_port_in_use(port));
+    drop(holder);
+}


### PR DESCRIPTION
Fixes the test port probe to use the interface the servers actually bind. `run-integration-tests` has been red on main's nightly for 6+ consecutive nights with `AddrInUse`, because a holder on any non-loopback interface passed the old probe and then collided on bind.

This closes the interface half of the problem. The remaining TOCTOU window is closed by #14964.

---

# Detailed Summary for AI Bots

## Problem

```
Failed to start MonitoringEndpoint: Os { code: 98, kind: AddrInUse }
```

`is_port_in_use` probed `127.0.0.1` while the servers under test bind `0.0.0.0`. CI runners have several interfaces.

## Change

Probe the unspecified address, so the probe conflicts with exactly what a later bind would.

`port_held_on_another_interface_is_reported_in_use` binds a holder on `127.0.0.2` and fails on the old code. It reports and returns on macOS, which assigns only `127.0.0.1` to loopback unless an alias was added.
