### PR TITLE
workspace: stop taplo from scrambling the darwin rustflags

### DIFF
--- a/crates/native_blockifier/.cargo/config.toml
+++ b/crates/native_blockifier/.cargo/config.toml
@@ -6,13 +6,7 @@ PYO3_PYTHON = "/usr/local/bin/pypy3.9"
 RUST_MIN_STACK = "4194304" #  4 MiB
 
 [target.x86_64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 
 [target.aarch64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,7 +1,6 @@
 exclude = [
   "ci/**/*.toml",
   "crates/blockifier/cairo_native/**/*.toml",
-  "crates/native_blockifier/.cargo/config.toml",
   "sequencer_venv/**/*.toml",
   "target/**/*.toml",
 ]
@@ -15,5 +14,14 @@ reorder_keys = true
 [[rule]]
 formatting = { reorder_keys = false }
 keys = ["package", "workspace.package"]
+
+# Don't reorder arrays under "target": a `rustflags` array is a flat list of alternating flag and
+# value, so sorting it pairs the flags wrongly, e.g. ["-C", "-C", "link-arg=-undefined",
+# "link-arg=dynamic_lookup"] in crates/native_blockifier/.cargo/config.toml. Excluding that file
+# instead would not hold, because `exclude` globs are matched relative to taplo's working
+# directory, so they stop matching when taplo runs from a subdirectory.
+[[rule]]
+formatting = { reorder_arrays = false }
+keys = ["target.*"]
 
 # Other configs from here: https://taplo.tamasfe.dev/configuration/formatter-options.html.


### PR DESCRIPTION
## Problem

`taplo format` reorders arrays (`reorder_arrays = true`). `rustflags` is a flat list of alternating flag and value, so sorting it pairs the flags wrongly:

```toml
# correct
rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
# after taplo format
rustflags = ["-C", "-C", "link-arg=-undefined", "link-arg=dynamic_lookup"]
```

Anyone who formats and commits everything ships a broken macOS link configuration for `native_blockifier`. It is invisible on Linux CI.

`crates/native_blockifier/.cargo/config.toml` was already in `exclude`, which is why this has not bitten more often. That exclusion does not hold, though: **`exclude` globs are matched relative to taplo's working directory**, not to the config file. Running `taplo format` from inside the crate corrupts the file:

```
$ cd crates/native_blockifier && taplo format
collect_files: found files total=1 excluded=0
$ grep rustflags .cargo/config.toml
rustflags = ["-C", "-C", "link-arg=-undefined", "link-arg=dynamic_lookup"]
```

Config *discovery* does walk up to the repo root, so the file is found from a subdirectory; only the glob matching is relative. No cwd-based glob is robust here, so the fix has to be something that is not path-relative.

## Change

Replace the exclusion with a rule that turns array reordering off under `target`:

```toml
[[rule]]
formatting = { reorder_arrays = false }
keys = ["target.*"]
```

Rules are not path-relative, so this holds from any working directory. It also means the file is now actually checked by `scripts/taplo.sh` instead of being skipped.

The file itself is reformatted once into taplo's canonical form. The flags keep their order and pairing; only the line wrapping changes.

## Verification

`taplo format` from every working directory that previously corrupted the file:

```
cwd=crates/native_blockifier         -> UNCHANGED
cwd=crates                           -> UNCHANGED
cwd=crates/native_blockifier/.cargo  -> UNCHANGED
cwd=.                                -> UNCHANGED
```

`scripts/taplo.sh` (`taplo format --check --diff`) passes, and a full `taplo format` over all 764 TOML files in the repo touches nothing beyond the two files in this PR, so the new rule does not disturb any other `[target...]` section.

## One correction to the original report

This was attributed to `scripts/rust_fmt.sh`. That script only runs `cargo fmt`; it never invokes taplo. The corruption comes from running `taplo format` directly, which `scripts/taplo.sh` tells developers to do and `scripts/local_presubmit.sh` installs the tool for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
