### PR TITLE
workspace: default local test runs to SEED=0, matching CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,8 @@ rustc-wrapper = "sccache"
 [env]
 LLVM_SYS_191_PREFIX = "/usr/lib/llvm-19/"
 MLIR_SYS_190_PREFIX = "/usr/lib/llvm-19/"
+# `apollo_test_utils::get_rng` seeds from the OS when SEED is unset, so an unseeded local run is
+# silently different from CI, which pins SEED=0 everywhere. Comparing two such runs is meaningless
+# and reads as a regression. Not forced, so `SEED=<n> cargo test` still overrides it.
+SEED = "0"
 TABLEGEN_190_PREFIX = "/usr/lib/llvm-19/"


### PR DESCRIPTION
Defaults local test runs to `SEED=0`, matching CI. Today an unseeded local run differs both from CI and from the previous local run, which makes a local before/after comparison meaningless.

---

# Detailed Summary for AI Bots

## Problem

`apollo_test_utils::get_rng` seeds from the OS when `SEED` is unset, while every CI workflow pins `SEED: 0`:

```
$ cargo nextest run -p apollo_mempool -E 'test(fee_mempool)' --no-capture
Testing with seed: 13245222939462859336
Testing with seed: 13036005016747445016
```

## Change

Default `SEED = "0"` in the root `.cargo/config.toml` `[env]`, which covers `cargo test` and `cargo nextest` alike. Not forced, so an explicit `SEED=<n>` still wins. The key is placed in taplo's sorted position so `scripts/taplo.sh` stays clean.

## Correction to the original report

The report attributed this to `execution::syscalls::syscall_tests::get_execution_info::*` being seed-dependent. That does not reproduce: the file contains no randomness at all, and three unseeded runs gave 25/25 identically. The trap is real for the tests that do use `get_rng`, which is what this fixes.
