### PR TITLE
ci: cap test parallelism in the prover job to stop the OOM kills

### DIFF
--- a/.github/workflows/starknet_transaction_prover_ci.yml
+++ b/.github/workflows/starknet_transaction_prover_ci.yml
@@ -98,9 +98,12 @@ jobs:
         run: cargo clippy -p starknet_transaction_prover --no-deps --all-targets --all-features
 
       # Running tests in release mode since stwo significantly slower in debug mode.
+      # Capped at 4 threads: in-memory stwo proving is memory intensive, and running the 143 tests
+      # at the runner's default parallelism has been SIGKILLing the test binary with no test
+      # reporting a failure. The tests themselves take about 27 seconds, so the cap costs little.
       - name: Run tests in release mode
         working-directory: crates/starknet_transaction_prover
-        run: cargo test -p starknet_transaction_prover --features stwo_proving --release
+        run: cargo test -p starknet_transaction_prover --features stwo_proving --release -- --test-threads=4
         env:
           STARKNET_SPECS_DIR: /tmp/starknet-specs
 


### PR DESCRIPTION
Caps test parallelism in the prover job, which is OOM-killed roughly 5 times in 100 runs with zero tests reporting FAILED. The tests take about 27 seconds, so the cap costs little against a 30 minute timeout.

---

# Detailed Summary for AI Bots

## Problem

```
process didn't exit successfully: .../starknet_transaction_prover-ef47240dc8809ec4 (signal: 9, SIGKILL: kill)
```

That binary hash is the lib unittest binary from the `Run tests in release mode` step, which ran 143 tests with in-memory stwo proving at the runner's default parallelism. The proving integration step below it already uses `--test-threads=1` for exactly this reason; the same reasoning was never applied here.

Observed on run 31484035403.

## Change

Cap that step at `--test-threads=4`. In a successful run the tests execute in ~27s of a ~3.5 minute step that is nearly all compilation, and recent runs land at 12 to 17 minutes against a 30 minute timeout.
