### PR TITLE
ci: stop the merge gatekeeper waiting on Graphite's mergeability check

### DIFF
--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -49,6 +49,10 @@ jobs:
       checks: read
       statuses: read
     steps:
+      # "Graphite / mergeability_check" is ignored because it stays in_progress for the whole life
+      # of a stacked PR: Graphite cannot call a PR mergeable while its base is another open PR. It
+      # is a stack-state indicator rather than a CI signal about the code, and waiting on it burns
+      # the full timeout and reports "context deadline exceeded" with zero failed jobs.
       - name: Run merge-gatekeeper-new on pull request
         if: github.event_name == 'pull_request'
         uses: starkware-libs/merge-gatekeeper@c0535e7c50a3fc70a0f4857afd37ccd6cfcc59de # v1
@@ -56,7 +60,7 @@ jobs:
           self: merge-gatekeeper-new
           timeout: 3600
           interval: 30
-          ignored: "code-review/reviewable,build_docker_images"
+          ignored: "code-review/reviewable,build_docker_images,Graphite / mergeability_check"
 
       - name: Run merge-gatekeeper-new on Merge Queue || push
         if: github.event_name == 'merge_group' || github.event_name == 'push'


### PR DESCRIPTION
Stops the merge gatekeeper timing out on every stacked PR. The cause is `Graphite / mergeability_check`, which never completes while a PR's base is another open PR, so the gate waits out its full hour and dies reporting zero failed jobs.

---

# Detailed Summary for AI Bots

## Problem

```
Failed job count:      0
Error: context deadline exceeded
```

It self-resolves as the stack merges bottom-up, which is worse than a hard failure: it trains reviewers to ignore a red gate.

## Root cause

Diffing the gate's own "All jobs" and "Completed jobs" groups across all 120 polls of run 31624863250 leaves exactly one job that never completes:

```
last All jobs: 16   last Completed: 15
NEVER COMPLETED -> ['Graphite / mergeability_check']
```

The correlation with base branch is exact: #14938 and #14946 (base `main`) pass; #14944, #14947 and #14948 (stacked) time out. Skipped checks were a red herring, since #14944 and #14947 had zero skips.

## Change

Add `Graphite / mergeability_check` to the gate's `ignored` list on the pull_request step. It is a stack-state indicator, not a CI signal about the code, and the list already ignores `code-review/reviewable` for the same reason. The merge_group step is untouched, since Graphite does not post this check against a merge queue ref.

Name matching is substring-based, as the single `build_docker_images` entry covering all three matrix variants shows.
