### PR TITLE
ci: retry the k3d cluster creation on a transient install failure

### DIFF
--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -144,7 +144,14 @@ jobs:
       - name: Build binaries
         run: cargo build --bin sequencer_node_setup --bin sequencer_simulator
 
+      # Attempted twice: the action downloads the k3d binary from GitHub with no retry of its own,
+      # so a transient upstream 503 fails the whole job at a setup step ("curl: (22) The requested
+      # URL returned error: 503" then "Failed to install k3d"). `continue-on-error` is what lets a
+      # `uses:` step be retried, and it is available here because this is a workflow step rather
+      # than a step inside a composite action.
       - name: Create k3d cluster (Local k8s)
+        id: create_k3d_cluster
+        continue-on-error: true
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           # Pin k3d explicitly: the action's default (v5.4.6) predates the checksums.txt release
@@ -154,6 +161,32 @@ jobs:
           # var is overridden by the action's own empty input default.
           k3d-version: v5.5.0
           # Assumption: only one PR can run per machine at a time.
+          cluster-name: ${{ env.cluster_name }}
+          args: >-
+            --verbose
+            --agents 1
+            --no-lb
+            --wait
+            --timeout 120s
+            --registry-config registries.yaml
+
+      # The observed failure is the binary download, which leaves no cluster behind, but a first
+      # attempt that got as far as creating one would make the retry fail on an existing cluster.
+      - name: Discard a partial k3d cluster before retrying
+        if: steps.create_k3d_cluster.outcome == 'failure'
+        env:
+          CLUSTER_NAME: ${{ env.cluster_name }}
+        run: |
+          if command -v k3d > /dev/null; then
+            k3d cluster delete "${CLUSTER_NAME}" || true
+          fi
+          sleep 60
+
+      - name: Retry creating k3d cluster (Local k8s)
+        if: steps.create_k3d_cluster.outcome == 'failure'
+        uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
+        with:
+          k3d-version: v5.5.0
           cluster-name: ${{ env.cluster_name }}
           args: >-
             --verbose


### PR DESCRIPTION
Retries the k3d cluster creation. Same no-retry weakness as #14952 at a different install site: it died on the same 503 wave, immediately after the Anvil retry had saved that run.

---

# Detailed Summary for AI Bots

## Problem

`AbsaOSS/k3d-action` downloads the k3d binary with no retry of its own:

```
Downloading k3d@v5.5.0 see: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh
curl: (22) The requested URL returned error: 503
Failed to install k3d
```

Observed on run 31639041988, where the Anvil install had already failed four times and succeeded on the fifth before the job died here.

## Change

Attempt the step twice. `continue-on-error` is available here because this is a workflow step rather than a step inside a composite action. Between attempts a cleanup step discards a partial cluster, guarded by `command -v k3d` since a failed download leaves no binary, and waits 60 seconds.

The cluster name is passed through `env:` rather than interpolated into the `run:` block, matching the fix Semgrep asked for on #14952.

## Scope

One retry, not five: duplicating the `with:` block is the cost of retrying a `uses:` step, so a sustained multi-minute outage will still fail the job. The alternative is reimplementing the action's install in shell, which is a bigger change affecting the 14 workflows that depend on this job.
