### PR TITLE
apollo_consensus_orchestrator: fetch recent block-hash/commitment-info backfill concurrently

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -674,15 +674,23 @@ impl SequencerConsensusContext {
     /// Collects the recent block hashes from the batcher.
     /// Returns computed block hashes in range [height - N_BLOCK_HASHES_BACK_IN_BLOB, height].
     async fn collect_recent_block_hashes(&self, height: BlockNumber) -> Vec<BlockHashAndNumber> {
+        let lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
+        // The window is small and fixed in size, so fetching every height concurrently instead
+        // of one round trip at a time is safe and avoids serializing their latency.
+        let block_hash_results = futures::future::join_all(
+            (lowest_height..=height.0)
+                .map(|block_height| self.deps.batcher.get_block_hash(BlockNumber(block_height))),
+        )
+        .await;
+
         let mut recent_block_hashes = Vec::with_capacity(
             usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
                 .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
                 + 1,
         );
-        let lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
-        for height in lowest_height..=height.0 {
-            let block_number = BlockNumber(height);
-            match self.deps.batcher.get_block_hash(block_number).await {
+        for (block_height, result) in (lowest_height..=height.0).zip(block_hash_results) {
+            let block_number = BlockNumber(block_height);
+            match result {
                 Ok(block_hash) => {
                     recent_block_hashes
                         .push(BlockHashAndNumber { number: block_number, hash: block_hash });
@@ -716,14 +724,35 @@ impl SequencerConsensusContext {
                 // size.
                 None => (height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB), true),
             };
+        // The empty-cende-recorder fallback window is already bounded by
+        // N_BLOCK_HASHES_BACK_IN_BLOB; otherwise bound the fetched range by the backfill cap so
+        // a lagging cende recorder can't trigger an unbounded number of round trips.
+        let highest_fetched_height = if cende_recorder_is_empty {
+            height.0
+        } else {
+            let max_backfill_offset = u64::try_from(MAX_COMMITMENT_INFOS_BACKFILL - 1)
+                .expect("MAX_COMMITMENT_INFOS_BACKFILL should fit in u64.");
+            height.0.min(lowest_height.saturating_add(max_backfill_offset))
+        };
+        // The heights are independent lookups; fetch them concurrently instead of one round trip
+        // at a time, then apply the contiguity and backfill-cap logic in height order below.
+        let state_commitment_infos_results = futures::future::join_all(
+            (lowest_height..=highest_fetched_height).map(|block_height| {
+                self.deps.batcher.get_state_commitment_infos(BlockNumber(block_height))
+            }),
+        )
+        .await;
+
         let mut recent_state_commitment_infos = Vec::with_capacity(MAX_COMMITMENT_INFOS_BACKFILL);
-        for block_height in lowest_height..=height.0 {
+        for (block_height, result) in
+            (lowest_height..=highest_fetched_height).zip(state_commitment_infos_results)
+        {
             // Stop at the cap, so sending commitment infos won't stall block production.
             if recent_state_commitment_infos.len() >= MAX_COMMITMENT_INFOS_BACKFILL {
                 break;
             }
             let block_number = BlockNumber(block_height);
-            match self.deps.batcher.get_state_commitment_infos(block_number).await {
+            match result {
                 Ok(Some(state_commitment_infos)) => recent_state_commitment_infos
                     .push(StateCommitmentInfosAndNumber { state_commitment_infos, block_number }),
                 // In the empty-cende-recorder case, the earliest heights in the window may

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -596,12 +596,17 @@ impl SequencerConsensusContext {
             .prev()
             .and_then(|parent_height| self.fee_proposals_window.get(&parent_height).copied())
             .flatten();
-        let recent_state_commitment_infos =
-            self.collect_recent_state_commitment_infos(height).await.unwrap_or_else(|e| {
-                // `finalize_decision` must not fail, so continue with an empty vector.
-                error!("Failed to collect recent state commitment infos at height {height}: {e:?}");
-                Vec::new()
-            });
+        // Independent lookups, keyed only by `height`; run them concurrently rather than one
+        // after the other.
+        let (recent_state_commitment_infos, recent_block_hashes) = tokio::join!(
+            self.collect_recent_state_commitment_infos(height),
+            self.collect_recent_block_hashes(height),
+        );
+        let recent_state_commitment_infos = recent_state_commitment_infos.unwrap_or_else(|e| {
+            // `finalize_decision` must not fail, so continue with an empty vector.
+            error!("Failed to collect recent state commitment infos at height {height}: {e:?}");
+            Vec::new()
+        });
 
         if let Err(e) = self
             .deps
@@ -632,7 +637,7 @@ impl SequencerConsensusContext {
                 parent_proposal_commitment: central_objects
                     .parent_proposal_commitment
                     .map(|c| proposal_commitment_from(c.partial_block_hash, parent_fee_proposal)),
-                recent_block_hashes: self.collect_recent_block_hashes(height).await,
+                recent_block_hashes,
                 recent_state_commitment_infos,
                 initial_reads: central_objects.initial_reads,
             })

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -1000,6 +1000,15 @@ async fn collected_heights_for(
 #[case::non_empty_cende_recorder_breaks_on_first_gap(Some(BlockNumber(90)), (93..=100).collect(), vec![])]
 #[case::empty_cende_recorder_stops_at_middle_gap(None, (93..=95).chain(98..=100).collect(), (93..=95).collect())]
 #[case::non_empty_cende_recorder_stops_at_middle_gap(Some(BlockNumber(90)), (90..=92).chain(95..=100).collect(), (90..=92).collect())]
+// The recorder is behind by exactly the backfill window: the fetched range must be bounded to
+// the cap (rather than growing with the lag) while still returning the capped delta.
+#[case::non_empty_cende_recorder_hits_cap(Some(BlockNumber(90)), (90..=100).collect(), (90..=99).collect())]
+// The recorder is far behind the cap: the range fetched from the batcher must stay bounded to
+// the cap's size instead of spanning the full (much larger) lag.
+#[case::non_empty_cende_recorder_far_behind_hits_cap(Some(BlockNumber(50)), (50..=100).collect(), (50..=59).collect())]
+// The empty-recorder fallback window must still be fetched in full (not truncated to the
+// backfill cap) so that a leading gap doesn't cost a real entry at the top of the window.
+#[case::empty_cende_recorder_leading_gap_reaches_cap(None, (91..=100).collect(), (91..=100).collect())]
 #[tokio::test]
 async fn collect_recent_state_commitment_infos_sends_expected_delta(
     #[case] cende_offset: Option<BlockNumber>,


### PR DESCRIPTION
## Summary

Follow-up performance optimization to #14892, found while doing a routine perf pass over that merged PR.

`collect_recent_block_hashes` and `collect_recent_state_commitment_infos` (in `sequencer_consensus_context.rs`) run once per committed block, on the block-finalization hot path. Each issued a bounded sequence (up to ~10-11) of `self.deps.batcher.get_block_hash(...)` / `get_state_commitment_infos(...)` calls, **awaiting each one before starting the next**. In split/distributed deployments the batcher client can be a real HTTP client (`RemoteComponentClient`), so this serialized up to 10+ network round trips per block; even in a monolith, each call does an LMDB read.

Changes:
1. Both methods now fire their bounded, independent per-height lookups concurrently via `futures::future::join_all` (a pattern already used elsewhere in this file/crate), then apply the exact original contiguity/backfill-cap logic in height order over the results. Behavior/return values are unchanged — verified by the existing `collect_recent_state_commitment_infos_sends_expected_delta` rstest cases, all of which still pass unmodified.
2. `finalize_decision` awaited these two *independent* collect calls one after the other; they're now run concurrently with `tokio::join!`.
3. Added 3 rstest cases (`non_empty_cende_recorder_hits_cap`, `non_empty_cende_recorder_far_behind_hits_cap`, `empty_cende_recorder_leading_gap_reaches_cap`) covering the previously-untested non-empty-recorder backfill-cap branch and the empty-recorder fallback window's leading-gap handling, per code review.

## Expected impact

Primarily benefits split/remote deployment topologies, where each batcher call is a real HTTP round trip: block finalization no longer serializes up to ~20 sequential round trips (10-11 for block hashes + up to 10 for commitment infos), collapsing them to two concurrent batches run in parallel with each other. In an all-local/monolith topology the win is smaller, since the in-process round trip is already cheap.

Known trade-off: if the batcher is fully unreachable, request *volume* increases (each of the ~10-11 heights now retries independently and concurrently, rather than the loop breaking after the first sustained failure) though wall-clock time for that failure case does not get worse, since the retries now happen in parallel rather than serially.

## Test plan
- [x] `cargo build -p apollo_consensus_orchestrator`
- [x] `SEED=0 cargo test -p apollo_consensus_orchestrator` — 203 passed, 0 failed
- [x] `cargo clippy -p apollo_consensus_orchestrator --all-targets` — clean
- [x] `scripts/rust_fmt.sh` — no diff
- [x] Reviewed by an Opus subagent (verdict: nothing blocking; suggestions addressed — added test coverage for the cap-hit branch and joined the two `finalize_decision` calls)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWtMVXb5eNa6eFCVCsivtN)_