### PR TITLE
apollo_consensus_orchestrator: fetch backfill windows from the batcher concurrently

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -674,20 +674,19 @@ impl SequencerConsensusContext {
     /// Collects the recent block hashes from the batcher.
     /// Returns computed block hashes in range [height - N_BLOCK_HASHES_BACK_IN_BLOB, height].
     async fn collect_recent_block_hashes(&self, height: BlockNumber) -> Vec<BlockHashAndNumber> {
-        let window_size = usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
-            .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
-            + 1;
         let lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
+        let block_heights: Vec<u64> = (lowest_height..=height.0).collect();
         // The window is small and bounded, so issue the batcher calls concurrently instead of
-        // paying window_size sequential round trips on this consensus-critical path.
+        // paying one round trip per height on this consensus-critical path.
         let block_hash_results = futures::future::join_all(
-            (lowest_height..=height.0)
-                .map(|block_height| self.deps.batcher.get_block_hash(BlockNumber(block_height))),
+            block_heights
+                .iter()
+                .map(|&block_height| self.deps.batcher.get_block_hash(BlockNumber(block_height))),
         )
         .await;
 
-        let mut recent_block_hashes = Vec::with_capacity(window_size);
-        for (block_height, result) in (lowest_height..=height.0).zip(block_hash_results) {
+        let mut recent_block_hashes = Vec::with_capacity(block_heights.len());
+        for (&block_height, result) in block_heights.iter().zip(block_hash_results) {
             let block_number = BlockNumber(block_height);
             match result {
                 Ok(block_hash) => {
@@ -723,18 +722,20 @@ impl SequencerConsensusContext {
                 // size.
                 None => (height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB), true),
             };
-        // Cap the backfill window before issuing any calls, then fetch it concurrently: the
-        // window is small and bounded, so this pays one round trip instead of up to
-        // max_heights_to_fetch sequential ones on this consensus-critical path. The bound must
-        // cover both the empty-cende-recorder window (N_BLOCK_HASHES_BACK_IN_BLOB + 1, which may
-        // contain a leading gap before any data) and the offset-driven window (capped below at
-        // MAX_COMMITMENT_INFOS_BACKFILL collected entries, with no leading gap to skip past).
-        let max_heights_to_fetch = usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
-            .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
-            .max(MAX_COMMITMENT_INFOS_BACKFILL)
-            + 1;
+        let max_heights_to_fetch = if cende_recorder_is_empty {
+            // A leading gap doesn't count toward the cap below, so the whole fallback window may
+            // need scanning.
+            usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
+                .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
+                + 1
+        } else {
+            // Any gap breaks immediately, so the cap is reached after at most this many results.
+            MAX_COMMITMENT_INFOS_BACKFILL
+        };
         let backfill_heights: Vec<u64> =
             (lowest_height..=height.0).take(max_heights_to_fetch).collect();
+        // The window is small and bounded, so issue the batcher calls concurrently instead of
+        // paying one round trip per height on this consensus-critical path.
         let commitment_infos_results =
             futures::future::join_all(backfill_heights.iter().map(|&block_height| {
                 self.deps.batcher.get_state_commitment_infos(BlockNumber(block_height))

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -674,15 +674,22 @@ impl SequencerConsensusContext {
     /// Collects the recent block hashes from the batcher.
     /// Returns computed block hashes in range [height - N_BLOCK_HASHES_BACK_IN_BLOB, height].
     async fn collect_recent_block_hashes(&self, height: BlockNumber) -> Vec<BlockHashAndNumber> {
-        let mut recent_block_hashes = Vec::with_capacity(
-            usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
-                .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
-                + 1,
-        );
+        let window_size = usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
+            .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
+            + 1;
         let lowest_height = height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB);
-        for height in lowest_height..=height.0 {
-            let block_number = BlockNumber(height);
-            match self.deps.batcher.get_block_hash(block_number).await {
+        // The window is small and bounded, so issue the batcher calls concurrently instead of
+        // paying window_size sequential round trips on this consensus-critical path.
+        let block_hash_results = futures::future::join_all(
+            (lowest_height..=height.0)
+                .map(|block_height| self.deps.batcher.get_block_hash(BlockNumber(block_height))),
+        )
+        .await;
+
+        let mut recent_block_hashes = Vec::with_capacity(window_size);
+        for (block_height, result) in (lowest_height..=height.0).zip(block_hash_results) {
+            let block_number = BlockNumber(block_height);
+            match result {
                 Ok(block_hash) => {
                     recent_block_hashes
                         .push(BlockHashAndNumber { number: block_number, hash: block_hash });
@@ -716,14 +723,32 @@ impl SequencerConsensusContext {
                 // size.
                 None => (height.0.saturating_sub(N_BLOCK_HASHES_BACK_IN_BLOB), true),
             };
+        // Cap the backfill window before issuing any calls, then fetch it concurrently: the
+        // window is small and bounded, so this pays one round trip instead of up to
+        // max_heights_to_fetch sequential ones on this consensus-critical path. The bound must
+        // cover both the empty-cende-recorder window (N_BLOCK_HASHES_BACK_IN_BLOB + 1, which may
+        // contain a leading gap before any data) and the offset-driven window (capped below at
+        // MAX_COMMITMENT_INFOS_BACKFILL collected entries, with no leading gap to skip past).
+        let max_heights_to_fetch = usize::try_from(N_BLOCK_HASHES_BACK_IN_BLOB)
+            .expect("N_BLOCK_HASHES_BACK_IN_BLOB should fit in usize.")
+            .max(MAX_COMMITMENT_INFOS_BACKFILL)
+            + 1;
+        let backfill_heights: Vec<u64> =
+            (lowest_height..=height.0).take(max_heights_to_fetch).collect();
+        let commitment_infos_results =
+            futures::future::join_all(backfill_heights.iter().map(|&block_height| {
+                self.deps.batcher.get_state_commitment_infos(BlockNumber(block_height))
+            }))
+            .await;
+
         let mut recent_state_commitment_infos = Vec::with_capacity(MAX_COMMITMENT_INFOS_BACKFILL);
-        for block_height in lowest_height..=height.0 {
+        for (&block_height, result) in backfill_heights.iter().zip(commitment_infos_results) {
             // Stop at the cap, so sending commitment infos won't stall block production.
             if recent_state_commitment_infos.len() >= MAX_COMMITMENT_INFOS_BACKFILL {
                 break;
             }
             let block_number = BlockNumber(block_height);
-            match self.deps.batcher.get_state_commitment_infos(block_number).await {
+            match result {
                 Ok(Some(state_commitment_infos)) => recent_state_commitment_infos
                     .push(StateCommitmentInfosAndNumber { state_commitment_infos, block_number }),
                 // In the empty-cende-recorder case, the earliest heights in the window may


### PR DESCRIPTION
## Performance follow-up to #14892

Automated performance-review routine, triggered by the merge of #14892, found a
sequential-latency issue in two backfill loops on the consensus-critical
`finalize_decision`/`decision_reached` path.

### Problem

`collect_recent_block_hashes` and `collect_recent_state_commitment_infos` each run
once per block and loop over a small, bounded window of heights (≤ 11 after
#14892's cap), calling the batcher once per height with a sequential `.await`
inside the `for` loop:

```rust
for block_height in lowest_height..=height.0 {
    ...
    self.deps.batcher.get_state_commitment_infos(block_number).await
    ...
}
```

Each iteration pays a full round trip to the batcher component before the next one
starts. In a remote deployment topology (HTTP, per this repo's component-server
model) this means up to ~10-11 sequential round trips in series, on a path that
per the existing code comments "must not stall block production."

### Fix

Fetch each window concurrently with `futures::future::join_all` — the same pattern
already used elsewhere in this file (`send_reproposal`) and in
`build_proposal.rs`/`validate_proposal.rs` — then apply the *exact same*
sequential break/skip/cap decision logic afterward, over the resolved results in
original height order. This preserves identical observable behavior to the
sequential version (including the "skip a leading gap only when the cende
recorder is empty, but break immediately on any gap once it has a real offset"
logic) while collapsing the round trips into a couple of concurrent batches
instead of paying for each one back-to-back.

### Review

An Opus subagent reviewed the diff for correctness against every branch/edge case
(empty ranges, `height = 0`, the exact-11 vs exact-10 window bounds, mock-ordering
assumptions in existing tests, whether the batcher calls are safe to fire
concurrently given the local component server's serial processing loop) and
flagged 4 suggestion-level findings, all addressed in a follow-up commit:
- Made the state-commitment-infos fetch bound branch-aware instead of a generic
  `max()`, so it can't silently under-fetch if either window's size changes later.
- Built the block-hashes height list once and reused it for both the `join_all`
  and the `zip`, instead of relying on two independently-constructed ranges
  staying in lockstep.
- Renamed a local to avoid colliding with an unrelated `window_size` used
  elsewhere in this file.
- Trimmed a comment that described *what* the bound computed rather than *why*.

### Test

- `cargo test -p apollo_consensus_orchestrator` — 200 passed, 0 failed (including
  all 9 `collect_recent_state_commitment_infos_sends_expected_delta` cases and the
  `collect_recent_block_hashes`/`retrospective_*` coverage)
- `cargo clippy -p apollo_consensus_orchestrator --all-targets -- -D warnings` — clean
- `scripts/rust_fmt.sh` — clean

🤖 Generated by an automated performance-review routine (Claude Code), triggered by the merge of #14892.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxoxSasR9EMgRACGnLKpUz)_