### PR TITLE
apollo_starknet_client: add request and connect timeouts to the http client

### DIFF
--- a/crates/apollo_starknet_client/src/lib.rs
+++ b/crates/apollo_starknet_client/src/lib.rs
@@ -18,6 +18,7 @@ mod test_utils;
 pub mod writer;
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use apollo_config::secrets::Sensitive;
 use reqwest::header::HeaderMap;
@@ -30,6 +31,11 @@ pub use self::starknet_error::{KnownStarknetErrorCode, StarknetError, StarknetEr
 
 /// A [`Result`] in which the error is a [`ClientError`].
 type ClientResult<T> = Result<T, ClientError>;
+
+// Bound every request so a hung connection surfaces as a retryable timeout error instead of
+// stalling the caller indefinitely.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A starknet client.
 struct StarknetClient {
@@ -112,7 +118,11 @@ impl StarknetClient {
         );
         Ok(StarknetClient {
             http_headers: header_map,
-            internal_client: Client::builder().user_agent(app_user_agent).build()?,
+            internal_client: Client::builder()
+                .user_agent(app_user_agent)
+                .timeout(REQUEST_TIMEOUT)
+                .connect_timeout(CONNECT_TIMEOUT)
+                .build()?,
             retry_config,
         })
     }


### PR DESCRIPTION
## Why

RCA of the Testnet node-3 "Consensus Height Diff From Sync" spike to ~335 on Aug 12 (00:24–00:33 UTC): a single `get_block?blockNumber=latest` request from central sync got wedged inside the GCLB front end for 612s (logged as 502 `internal_error` with no `serverIp`, 20× the backend's 30s `timeoutSec`). The reqwest client is built with no timeout at all, so the call hung until central sync's no-progress watchdog fired on its 5-minute granularity — a 9m17s sync stall (~335 blocks) from one dead request.

The retry layer already classifies reqwest timeout errors as retryable (`RetryErrorCode::Timeout`), but reqwest never produces one without a configured timeout, so it could never engage.

## What

Add a 60s total request timeout and a 10s connect timeout to the shared `StarknetClient` reqwest client (feeder + gateway clients). A hung connection now surfaces as a retryable timeout and `request_with_retry` re-issues the request on a fresh connection, bounding the stall at seconds instead of ~10 minutes. 60s is far above feeder p99 even for multi-MB class-definition responses.

## Verification

- `cargo build -p apollo_starknet_client` — clean
- `SEED=0 cargo test -p apollo_starknet_client` — 76 passed, 0 failed
- `cargo clippy -p apollo_starknet_client --all-targets --all-features` — clean
- `scripts/rust_fmt.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)