### PR TITLE
apollo_consensus_orchestrator: fail sync gracefully instead of panicking on missing recorder data

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1144,10 +1144,11 @@ impl ConsensusContext for SequencerConsensusContext {
                     Some(block_data.compute_accessed_keys(&sync_block.state_diff.clone().into()))
                 }
                 Ok(None) => {
-                    panic!(
-                        "The accessed-keys data for synced block {block_number} is expected to be \
-                         ready."
+                    error!(
+                        "Recorder does not yet have accessed-keys data for synced block \
+                         {block_number}."
                     );
+                    return false;
                 }
                 Err(e) => {
                     error!(

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -2111,11 +2111,12 @@ async fn try_sync_forwards_accessed_keys_from_centralized() {
     assert!(context.try_sync(SYNC_HEIGHT).await);
 }
 
-// When `fetch_accessed_keys_from_centralized` is enabled, the block's accessed keys are required;
-// the data is expected to be ready at sync time, so a missing entry in the recorder is a bug.
+// When `fetch_accessed_keys_from_centralized` is enabled, the recorder may not yet have the
+// synced block's accessed-keys data (e.g. it lags behind state sync, or is unavailable). This is
+// data from a remote, network-reachable service, not a programmer invariant, so `try_sync` must
+// fail the attempt gracefully (allowing the caller to retry) instead of panicking the node.
 #[tokio::test]
-#[should_panic(expected = "The accessed-keys data for synced block 7 is expected to be ready.")]
-async fn try_sync_panics_when_recorder_has_no_accessed_keys() {
+async fn try_sync_fails_gracefully_when_recorder_has_no_accessed_keys() {
     const SYNC_HEIGHT: BlockNumber = BlockNumber(7);
 
     let (mut deps, _network) = create_test_and_network_deps();
@@ -2140,7 +2141,7 @@ async fn try_sync_panics_when_recorder_has_no_accessed_keys() {
         ..Default::default()
     });
 
-    context.try_sync(SYNC_HEIGHT).await;
+    assert!(!context.try_sync(SYNC_HEIGHT).await);
 }
 
 // With the opt-in disabled (the default), `try_sync` must not query the recorder and passes `None`


### PR DESCRIPTION
## Security scan finding

This is a fix for a vulnerability found while scanning #14826 (merged), which introduced fetching accessed-keys data from the centralized recorder in `try_sync`.

### Vulnerability

In `SequencerConsensusContext::try_sync` (`crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs`), when `fetch_accessed_keys_from_centralized` is enabled, a `None` response from `cende_ambassador.get_accessed_keys_input` triggers a `panic!`:

```rust
Ok(None) => {
    panic!(
        "The accessed-keys data for synced block {block_number} is expected to be ready."
    );
}
```

`get_accessed_keys_input` is an HTTP GET to the recorder service, and its own doc comment states plainly: *"Returns `None` when the recorder does not have the block."* That is a documented, normal response from a network-reachable dependency (the recorder can legitimately lag behind state sync, restart, or be temporarily unreachable/partitioned) — not a programmer invariant. Every other failure path in the same function (`Err(e)` from the same call, block-not-found, timestamp validation) is handled by logging and `return false`, letting the caller retry. Only this branch crashes the process instead.

Impact: any node with `fetch_accessed_keys_from_centralized: true` can be crashed during sync whenever the recorder briefly doesn't have accessed-keys data for the block being synced — this can happen from ordinary recorder lag/restarts, and also gives a compromised or misbehaving recorder a trivial, repeatable way to take down every consensus node relying on it. This violates this repo's own mandatory practice ("Never panic on data reachable from requests" in `.claude/rules/code-style.md`).

### Fix

Treat `Ok(None)` the same way as the `Err(e)` branch immediately below it: log and `return false`, so the sync attempt is retried instead of crashing the node.

### Test

Updated `try_sync_panics_when_recorder_has_no_accessed_keys` (previously asserted a panic via `#[should_panic]`) into `try_sync_fails_gracefully_when_recorder_has_no_accessed_keys`, which asserts `try_sync` returns `false` and `add_sync_block` is never called, instead of panicking.

### Verification

- `cargo build -p apollo_consensus_orchestrator --tests` — passes
- `SEED=0 cargo test -p apollo_consensus_orchestrator --lib try_sync` — 3/3 pass (including the new regression test)
- `scripts/rust_fmt.sh --check` — clean
- `cargo clippy -p apollo_consensus_orchestrator --tests --all-features -- -D warnings` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKkGiqjRxqqdU5L4vUM3da)_