### PR TITLE
apollo_batcher: bound in-flight view calls so they cannot exhaust the blocking pool

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -117,7 +117,7 @@ use starknet_api::core::{ContractAddress, GlobalRoot, Nonce, StateDiffCommitment
 use starknet_api::state::{StateNumber, ThinStateDiff};
 use starknet_api::transaction::fields::Calldata;
 use starknet_api::transaction::TransactionHash;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 use tokio::task::AbortHandle;
 use tracing::{debug, error, info, instrument, trace, warn, Instrument};
 use validator::Validate;
@@ -152,6 +152,7 @@ use crate::metrics::{
     NUM_TRANSACTION_IN_BLOCK,
     PROVING_GAS_IN_LAST_BLOCK,
     REJECTED_TRANSACTIONS,
+    REJECTED_VIEW_CALLS,
     REVERTED_BLOCKS,
     REVERTED_TRANSACTIONS,
     SIERRA_GAS_IN_LAST_BLOCK,
@@ -186,12 +187,32 @@ type InputStreamSender = tokio::sync::mpsc::Sender<InternalConsensusTransaction>
 /// Bounds the top-level return value only.
 pub(crate) const MAX_VIEW_CALL_RETDATA_LENGTH: usize = 100_000;
 
+/// Maximal number of view calls that may occupy tokio blocking threads at once.
+///
+/// A call whose caller stopped waiting keeps its thread parked until execution ends, so this caps
+/// how many pile up. Uncapped, a wedged class manager parks one more every
+/// `view_call_timeout_millis` for as long as each read keeps retrying, and the blocking pool is
+/// shared with block production.
+///
+/// It also bounds the damage before the cap is reached: the batcher serves one request at a time,
+/// so every stuck call costs block production a full `view_call_timeout_millis`. Once the slots are
+/// gone, view calls fail immediately and the batcher is free again.
+pub(crate) const MAX_CONCURRENT_VIEW_CALLS: usize = 32;
+
+/// Reason returned when all view call slots are taken. Names no internal component, since it
+/// reaches external callers.
+pub(crate) const TOO_MANY_VIEW_CALLS_REASON: &str =
+    "Too many concurrent contract calls. Try again later.";
+
 #[cfg_attr(test, apollo_proc_macros::upgrade_fields_visibility(pub(crate)))]
 pub struct Batcher {
     pub config: BatcherConfig,
     pub storage_reader: Arc<dyn BatcherStorageReader>,
     /// Factory for creating state readers used to execute view calls (e.g. call_contract).
     view_state_reader_factory: Box<dyn ViewStateReaderFactory>,
+    /// Caps how many view calls may occupy tokio blocking threads at once. A permit is held by the
+    /// blocking task itself, so it is returned only when the execution really ends.
+    view_call_semaphore: Arc<Semaphore>,
     pub storage_writer: Box<dyn BatcherStorageWriter>,
     pub committer_client: SharedCommitterClient,
     pub l1_events_provider_client: SharedL1EventsProviderClient,
@@ -268,6 +289,7 @@ impl Batcher {
             config,
             storage_reader,
             view_state_reader_factory,
+            view_call_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_VIEW_CALLS)),
             storage_writer,
             committer_client,
             l1_events_provider_client,
@@ -767,7 +789,21 @@ impl Batcher {
             BouncerConfig::max(),
         );
 
+        let view_call_permit =
+            self.view_call_semaphore.clone().try_acquire_owned().map_err(|_| {
+                REJECTED_VIEW_CALLS.increment(1);
+                warn!(
+                    "Rejecting view call, all {MAX_CONCURRENT_VIEW_CALLS} view call slots are \
+                     taken."
+                );
+                BatcherError::ContractCallFailed { reason: TOO_MANY_VIEW_CALLS_REASON.to_string() }
+            })?;
+
         let call_task = tokio::task::spawn_blocking(move || {
+            // Owned by the blocking task, so the slot is freed only when the execution ends. A
+            // caller that stops waiting (the view call timeout, a dropped connection) must not
+            // free a slot that a still-parked thread occupies.
+            let _view_call_permit = view_call_permit;
             call_view_entry_point(
                 state_reader,
                 Arc::new(block_context),

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::mpsc::{channel, Receiver};
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
 use std::task::Poll;
 use std::time::Duration;
 
@@ -95,6 +95,7 @@ use starknet_api::transaction::TransactionHash;
 use starknet_api::{class_hash, invoke_tx_args, tx_hash};
 use starknet_types_core::felt::Felt;
 use tempfile::TempDir;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use validator::Validate;
 
 use crate::batcher::{
@@ -108,7 +109,9 @@ use crate::batcher::{
     StorageCommitmentBlockHash,
     StorageViewStateReaderFactory,
     ViewStateReaderFactory,
+    MAX_CONCURRENT_VIEW_CALLS,
     MAX_VIEW_CALL_RETDATA_LENGTH,
+    TOO_MANY_VIEW_CALLS_REASON,
 };
 use crate::block_builder::{
     AbortSignalSender,
@@ -128,6 +131,7 @@ use crate::metrics::{
     PROPOSAL_STARTED,
     PROPOSAL_SUCCEEDED,
     REJECTED_TRANSACTIONS,
+    REJECTED_VIEW_CALLS,
     REVERTED_BLOCKS,
     REVERTED_TRANSACTIONS,
     SYNCED_TRANSACTIONS,
@@ -194,6 +198,79 @@ impl ViewStateReaderFactory for TestViewStateReaderFactory {
     ) -> Box<dyn StateReader + Send> {
         assert_eq!(block_number, self.expected_block_number);
         Box::new(self.state.lock().unwrap().clone())
+    }
+}
+
+/// Creates readers that park the blocking thread executing the view call until released,
+/// reproducing a view call that outlives the caller waiting for it. Serves a single view call.
+struct ParkedViewStateReaderFactory {
+    entered_sender: UnboundedSender<()>,
+    release_receiver: Mutex<Option<mpsc::Receiver<()>>>,
+}
+
+impl ViewStateReaderFactory for ParkedViewStateReaderFactory {
+    fn create(
+        &self,
+        _block_number: BlockNumber,
+        _native_classes_whitelist: NativeClassesWhitelist,
+        _runtime: tokio::runtime::Handle,
+    ) -> Box<dyn StateReader + Send> {
+        let release_receiver =
+            self.release_receiver.lock().unwrap().take().expect("Expected a single view call.");
+        Box::new(ParkedViewStateReader {
+            entered_sender: self.entered_sender.clone(),
+            release_receiver: Mutex::new(Some(release_receiver)),
+            state: DictStateReader::default(),
+        })
+    }
+}
+
+/// An empty state whose first access parks the calling thread until released.
+struct ParkedViewStateReader {
+    entered_sender: UnboundedSender<()>,
+    /// Taken by the first state access, so that only that access parks.
+    release_receiver: Mutex<Option<mpsc::Receiver<()>>>,
+    state: DictStateReader,
+}
+
+impl ParkedViewStateReader {
+    fn park_on_first_access(&self) {
+        let release_receiver = self.release_receiver.lock().unwrap().take();
+        if let Some(release_receiver) = release_receiver {
+            self.entered_sender.send(()).unwrap();
+            release_receiver.recv().unwrap();
+        }
+    }
+}
+
+impl StateReader for ParkedViewStateReader {
+    fn get_storage_at(
+        &self,
+        contract_address: ContractAddress,
+        key: StorageKey,
+    ) -> StateResult<Felt> {
+        self.park_on_first_access();
+        self.state.get_storage_at(contract_address, key)
+    }
+
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
+        self.park_on_first_access();
+        self.state.get_nonce_at(contract_address)
+    }
+
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+        self.park_on_first_access();
+        self.state.get_class_hash_at(contract_address)
+    }
+
+    fn get_compiled_class(&self, class_hash: ClassHash) -> StateResult<RunnableCompiledClass> {
+        self.park_on_first_access();
+        self.state.get_compiled_class(class_hash)
+    }
+
+    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+        self.park_on_first_access();
+        self.state.get_compiled_class_hash(class_hash)
     }
 }
 
@@ -2064,27 +2141,101 @@ async fn validation_only_flag_true_with_mempool_panics() {
     new_batcher_with_mempool_override(validation_only_mock_dependencies(), mempool).await;
 }
 
+fn undeployed_contract_call_input() -> CallContractInput {
+    CallContractInput {
+        contract_address: Default::default(),
+        entry_point: "get_stakers".to_string(),
+        calldata: vec![],
+    }
+}
+
+/// Creates a batcher whose view calls run against an empty state with no contracts deployed.
+async fn create_batcher_with_empty_view_state() -> Batcher {
+    create_batcher(MockDependencies {
+        view_state_reader_factory: Box::new(TestViewStateReaderFactory {
+            state: Arc::new(Mutex::new(CachedState::from(DictStateReader::default()))),
+            expected_block_number: INITIAL_HEIGHT,
+        }),
+        ..Default::default()
+    })
+    .await
+}
+
 #[tokio::test]
 async fn call_contract_contract_not_deployed() {
-    // The factory returns an empty state with no contracts deployed.
-    let state = Arc::new(Mutex::new(CachedState::from(DictStateReader::default())));
-    let factory = TestViewStateReaderFactory { state, expected_block_number: INITIAL_HEIGHT };
+    let batcher = create_batcher_with_empty_view_state().await;
 
+    let result = batcher.call_contract(undeployed_contract_call_input()).await;
+
+    assert_matches!(result, Err(BatcherError::ContractCallFailed { .. }));
+}
+
+#[tokio::test]
+async fn call_contract_rejected_when_all_view_call_slots_are_taken() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    let batcher = create_batcher_with_empty_view_state().await;
+
+    let taken_view_call_slots: Vec<_> = (0..MAX_CONCURRENT_VIEW_CALLS)
+        .map(|_| batcher.view_call_semaphore.clone().try_acquire_owned().unwrap())
+        .collect();
+
+    assert_matches!(
+        batcher.call_contract(undeployed_contract_call_input()).await,
+        Err(BatcherError::ContractCallFailed { reason }) if reason == TOO_MANY_VIEW_CALLS_REASON,
+        "The call should be rejected instead of waiting for a slot."
+    );
+    assert_eq!(
+        REJECTED_VIEW_CALLS.parse_numeric_metric::<u64>(&recorder.handle().render()),
+        Some(1)
+    );
+
+    // Freeing the slots lets the next call execute; it then fails on the empty state.
+    drop(taken_view_call_slots);
+    assert_matches!(
+        batcher.call_contract(undeployed_contract_call_input()).await,
+        Err(BatcherError::ContractCallFailed { reason }) if reason != TOO_MANY_VIEW_CALLS_REASON
+    );
+}
+
+/// A view call slot models the occupancy of a tokio blocking thread, which no caller-side timeout
+/// can cancel. It must therefore outlive a caller that gave up waiting.
+#[tokio::test]
+async fn view_call_slot_is_freed_only_when_the_blocking_task_ends() {
+    let (entered_sender, mut entered_receiver) = unbounded_channel();
+    let (release_sender, release_receiver) = mpsc::channel();
     let batcher = create_batcher(MockDependencies {
-        view_state_reader_factory: Box::new(factory),
+        view_state_reader_factory: Box::new(ParkedViewStateReaderFactory {
+            entered_sender,
+            release_receiver: Mutex::new(Some(release_receiver)),
+        }),
         ..Default::default()
     })
     .await;
+    let view_call_semaphore = batcher.view_call_semaphore.clone();
 
-    let result = batcher
-        .call_contract(CallContractInput {
-            contract_address: Default::default(),
-            entry_point: "get_stakers".to_string(),
-            calldata: vec![],
-        })
-        .await;
+    let mut call_future = Box::pin(batcher.call_contract(undeployed_contract_call_input()));
+    assert!(futures::poll!(&mut call_future).is_pending());
+    entered_receiver.recv().await.expect("The view call should reach the state reader.");
+    assert_eq!(view_call_semaphore.available_permits(), MAX_CONCURRENT_VIEW_CALLS - 1);
 
-    assert_matches!(result, Err(BatcherError::ContractCallFailed { .. }));
+    // The caller gives up while the blocking thread is still parked.
+    drop(call_future);
+    assert_eq!(
+        view_call_semaphore.available_permits(),
+        MAX_CONCURRENT_VIEW_CALLS - 1,
+        "The slot must stay taken while the blocking thread is parked."
+    );
+
+    release_sender.send(()).unwrap();
+    // Acquiring every slot succeeds only once the parked thread returns the one it holds.
+    let all_view_call_slots = tokio::time::timeout(
+        Duration::from_secs(5),
+        view_call_semaphore.acquire_many(u32::try_from(MAX_CONCURRENT_VIEW_CALLS).unwrap()),
+    )
+    .await
+    .expect("The slot should be freed once the blocking task ends.");
+    assert!(all_view_call_slots.is_ok());
 }
 
 #[tokio::test]

--- a/crates/apollo_batcher/src/metrics.rs
+++ b/crates/apollo_batcher/src/metrics.rs
@@ -49,6 +49,8 @@ define_metrics!(
         MetricCounter { REVERTED_TRANSACTIONS, "batcher_reverted_transactions", "Counter of reverted transactions across all forks", init = 0 },
         MetricCounter { SYNCED_TRANSACTIONS, "batcher_synced_transactions", "Counter of synced transactions", init = 0 },
         MetricHistogram { NUM_TRANSACTION_IN_BLOCK, "batcher_num_transaction_in_block", "Number of transactions in a block"},
+        // View calls
+        MetricCounter { REJECTED_VIEW_CALLS, "batcher_rejected_view_calls", "Counter of view calls rejected because all concurrent view call slots were taken", init = 0 },
 
         MetricCounter { BATCHER_L1_EVENTS_PROVIDER_ERRORS, "batcher_l1_events_provider_errors", "Counter of L1 provider errors", init = 0 },
         MetricCounter { PRECONFIRMED_BLOCK_WRITTEN, "batcher_preconfirmed_block_written", "Counter of preconfirmed blocks written to storage", init = 0 },
@@ -164,6 +166,8 @@ pub fn register_metrics(storage_height: BlockNumber, global_root_height: BlockNu
     REJECTED_TRANSACTIONS.register();
     REVERTED_TRANSACTIONS.register();
     SYNCED_TRANSACTIONS.register();
+
+    REJECTED_VIEW_CALLS.register();
 
     BATCHER_L1_EVENTS_PROVIDER_ERRORS.register();
     PRECONFIRMED_BLOCK_WRITTEN.register();


### PR DESCRIPTION
A view call runs on a tokio blocking thread, and nothing can cancel that thread once it
starts: a caller that stops waiting (client timeout, dropped connection) leaves the thread
parked until execution ends. The node runs on a bare `#[tokio::main]` runtime, so the
blocking pool is tokio's default of 512 threads shared with block production, the gateway's
stateful validator and the transaction converter, and `spawn_blocking` past that limit
queues rather than fails.

Cap concurrent view calls at 32 with a semaphore whose permit is moved into the blocking
closure, so a slot is returned only when the execution really ends, not when the request
gives up. Over the cap, `try_acquire_owned` rejects the call instead of queueing, and
`batcher_rejected_view_calls` counts the rejections.