### PR TITLE
apollo_consensus_orchestrator: avoid cloning the synced block's state diff to compute accessed keys

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -51,6 +51,7 @@ use apollo_transaction_converter::transaction_converter::{
 };
 use apollo_versioned_constants::VersionedConstants;
 use async_trait::async_trait;
+use blockifier::state::cached_state::CommitmentStateDiff;
 use futures::channel::mpsc::SendError;
 use futures::channel::{mpsc, oneshot};
 use futures::SinkExt;
@@ -1096,7 +1097,7 @@ impl ConsensusContext for SequencerConsensusContext {
     }
 
     async fn try_sync(&mut self, height: BlockNumber) -> bool {
-        let sync_block = match self.deps.state_sync_client.get_block(height).await {
+        let mut sync_block = match self.deps.state_sync_client.get_block(height).await {
             Err(StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(_))) => {
                 return false;
             }
@@ -1141,7 +1142,14 @@ impl ConsensusContext for SequencerConsensusContext {
             match self.deps.cende_ambassador.get_accessed_keys_input(block_number).await {
                 Ok(Some(block_data)) => {
                     info!("Fetched accessed-keys data for synced block {block_number}.");
-                    Some(block_data.compute_accessed_keys(&sync_block.state_diff.clone().into()))
+                    // Move the state diff into a `CommitmentStateDiff` (a cheap field rename, no
+                    // cloning) to compute the accessed keys, then move it back so `sync_block`
+                    // still carries its state diff when passed to `add_sync_block` below.
+                    let commitment_state_diff: CommitmentStateDiff =
+                        std::mem::take(&mut sync_block.state_diff).into();
+                    let accessed_keys = block_data.compute_accessed_keys(&commitment_state_diff);
+                    sync_block.state_diff = commitment_state_diff.into();
+                    Some(accessed_keys)
                 }
                 Ok(None) => {
                     panic!(

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -1145,10 +1145,18 @@ impl ConsensusContext for SequencerConsensusContext {
                     // Move the state diff into a `CommitmentStateDiff` (a cheap field rename, no
                     // cloning) to compute the accessed keys, then move it back so `sync_block`
                     // still carries its state diff when passed to `add_sync_block` below.
-                    let commitment_state_diff: CommitmentStateDiff =
-                        std::mem::take(&mut sync_block.state_diff).into();
+                    // `CommitmentStateDiff` has no `deprecated_declared_classes` field, so it is
+                    // set aside and restored, instead of round-tripping through the conversion
+                    // (which would silently replace it with an empty vector).
+                    let mut state_diff = std::mem::take(&mut sync_block.state_diff);
+                    let deprecated_declared_classes =
+                        std::mem::take(&mut state_diff.deprecated_declared_classes);
+                    let commitment_state_diff: CommitmentStateDiff = state_diff.into();
                     let accessed_keys = block_data.compute_accessed_keys(&commitment_state_diff);
-                    sync_block.state_diff = commitment_state_diff.into();
+                    sync_block.state_diff = ThinStateDiff {
+                        deprecated_declared_classes,
+                        ..commitment_state_diff.into()
+                    };
                     Some(accessed_keys)
                 }
                 Ok(None) => {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -57,6 +57,7 @@ use starknet_api::block::{
     WEI_PER_ETH,
 };
 use starknet_api::block_hash::block_hash_calculator::BlockHeaderCommitments;
+use starknet_api::core::ClassHash;
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::hash::StarkHash;
 use starknet_api::state::ThinStateDiff;
@@ -2073,12 +2074,22 @@ async fn test_compute_proposer_fee_proposal_converges_to_oracle_target() {
 async fn try_sync_forwards_accessed_keys_from_centralized() {
     const SYNC_HEIGHT: BlockNumber = BlockNumber(7);
 
+    // A non-empty state diff, including `deprecated_declared_classes` (which has no counterpart
+    // in `CommitmentStateDiff`), to verify `try_sync` forwards the synced block's state diff to
+    // `add_sync_block` unchanged after converting it to compute the accessed keys.
+    let state_diff = ThinStateDiff {
+        deprecated_declared_classes: vec![ClassHash(StarkHash::from(1_u8))],
+        ..Default::default()
+    };
+    let expected_state_diff = state_diff.clone();
+
     let (mut deps, _network) = create_test_and_network_deps();
     // Specific get_block expectation must be registered before setup_default_expectations, which
     // installs a catch-all handler.
-    deps.state_sync_client.expect_get_block().times(1).return_once(|height| {
+    deps.state_sync_client.expect_get_block().times(1).return_once(move |height| {
         let mut sync_block = SyncBlock::default();
         sync_block.block_header_without_hash.block_number = height;
+        sync_block.state_diff = state_diff;
         Ok(sync_block)
     });
     deps.setup_default_expectations();
@@ -2096,7 +2107,9 @@ async fn try_sync_forwards_accessed_keys_from_centralized() {
     deps.batcher
         .expect_add_sync_block()
         .times(1)
-        .withf(|_sync_block, accessed_keys| accessed_keys.is_some())
+        .withf(move |sync_block, accessed_keys| {
+            accessed_keys.is_some() && sync_block.state_diff == expected_state_diff
+        })
         .return_once(|_, _| Ok(()));
 
     let mut context = deps.build_context_with_config(ContextConfig {


### PR DESCRIPTION
## Summary

Follow-up performance optimization on top of #14962 (merged), which added `BlockAccessedKeysData::compute_accessed_keys` and wired it into `try_sync` in `sequencer_consensus_context.rs`.

In `try_sync`, computing the accessed keys for a synced block did:
```rust
Some(block_data.compute_accessed_keys(&sync_block.state_diff.clone().into()))
```
This deep-clones the entire `ThinStateDiff` of the synced block — which can hold thousands of storage/nonce/class-hash entries for a full block — purely to obtain an owned value to convert into a borrowed `CommitmentStateDiff`. The clone exists only because `sync_block` is later moved by value into `self.deps.batcher.add_sync_block(sync_block, accessed_keys)`, so the original state diff had to be preserved.

Since `From<ThinStateDiff> for CommitmentStateDiff` (and the reverse) are cheap field-moves (no allocation) in `blockifier::state::cached_state`, this PR instead moves the state diff into the `CommitmentStateDiff` via `std::mem::take`, computes the accessed keys, and moves it back — avoiding the clone of the block's storage diff on the sync path.

One subtlety: `CommitmentStateDiff` has no `deprecated_declared_classes` field (present on `ThinStateDiff`, used by the state-diff hash and by storage), so that field is carried across the conversion explicitly instead of being silently dropped.

This runs once per synced block height, on the consensus sync path.

## Changes
- `sequencer_consensus_context.rs`: avoid the clone in `try_sync`, preserving `deprecated_declared_classes` across the `ThinStateDiff` ⇄ `CommitmentStateDiff` round-trip.
- `sequencer_consensus_context_test.rs`: extended `try_sync_forwards_accessed_keys_from_centralized` to use a non-empty state diff (including `deprecated_declared_classes`) and assert `add_sync_block` receives it unchanged.

## Test plan
- [x] `cargo build -p apollo_consensus_orchestrator`
- [x] `SEED=0 cargo test -p apollo_consensus_orchestrator` (203 passed)
- [x] `cargo clippy -p apollo_consensus_orchestrator --all-targets` (clean)
- [x] `scripts/rust_fmt.sh`
- [x] Reviewed by an Opus subagent; findings addressed (lossy round-trip of `deprecated_declared_classes`, missing test coverage)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJn1K1NgLztcwQaKCseg7m)_