### PR TITLE
apollo_cairo_utils: deserialize retdata rejecting leftover felts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ name = "apollo_cairo_utils"
 version = "0.19.0-rc.2"
 dependencies = [
  "blockifier",
+ "rstest",
  "starknet-types-core",
  "thiserror 1.0.69",
 ]

--- a/crates/apollo_cairo_utils/Cargo.toml
+++ b/crates/apollo_cairo_utils/Cargo.toml
@@ -11,5 +11,8 @@ blockifier.workspace = true
 starknet-types-core.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+rstest.workspace = true
+
 [lints]
 workspace = true

--- a/crates/apollo_cairo_utils/src/lib.rs
+++ b/crates/apollo_cairo_utils/src/lib.rs
@@ -2,6 +2,10 @@ use blockifier::execution::call_info::Retdata;
 use starknet_types_core::felt::Felt;
 use thiserror::Error;
 
+#[cfg(test)]
+#[path = "test.rs"]
+mod test;
+
 /// Conversion from an [`Iterator`].
 ///
 /// By implementing `TryFromIterator` for a type, you define how it will be
@@ -12,6 +16,26 @@ pub trait TryFromIterator<Item>: Sized {
     type Error;
 
     fn try_from_iter<T: Iterator<Item = Item>>(iter: &mut T) -> Result<Self, Self::Error>;
+}
+
+// [Temporary comment] No production caller yet; the first one arrives with the Chainlink feed-math
+// PR (A7).
+/// Deserializes a whole retdata into `T`, rejecting felts left over after `T` is decoded.
+///
+/// TODO(Asaf): route `CairoArray`, `CairoOption` and `apollo_staking`'s `Epoch` through this, and
+/// drop their `TryFrom<Retdata>` impls.
+pub fn deserialize_retdata<T>(retdata: Vec<Felt>) -> Result<T, RetdataDeserializationError>
+where
+    T: TryFromIterator<Felt, Error = RetdataDeserializationError>,
+{
+    let mut felt_iterator = retdata.into_iter();
+    let deserialized = T::try_from_iter(&mut felt_iterator)?;
+    if felt_iterator.next().is_some() {
+        return Err(RetdataDeserializationError::InvalidObjectLength {
+            message: "unconsumed elements in retdata".to_string(),
+        });
+    }
+    Ok(deserialized)
 }
 
 // Represents a Cairo1 `Array` containing elements that can be deserialized to `T`.

--- a/crates/apollo_cairo_utils/src/test.rs
+++ b/crates/apollo_cairo_utils/src/test.rs
@@ -1,0 +1,50 @@
+use rstest::rstest;
+use starknet_types_core::felt::Felt;
+
+use super::{deserialize_retdata, RetdataDeserializationError, TryFromIterator};
+
+// Consumes exactly two felts, so retdata length mismatches are observable in both directions.
+#[derive(Debug, PartialEq, Eq)]
+struct FeltPair {
+    first: Felt,
+    second: Felt,
+}
+
+impl TryFromIterator<Felt> for FeltPair {
+    type Error = RetdataDeserializationError;
+
+    fn try_from_iter<T: Iterator<Item = Felt>>(iter: &mut T) -> Result<Self, Self::Error> {
+        Ok(Self { first: Felt::try_from_iter(iter)?, second: Felt::try_from_iter(iter)? })
+    }
+}
+
+#[test]
+fn deserialize_retdata_accepts_exact_length() {
+    assert_eq!(
+        deserialize_retdata::<FeltPair>(vec![Felt::ONE, Felt::TWO]).unwrap(),
+        FeltPair { first: Felt::ONE, second: Felt::TWO }
+    );
+}
+
+#[rstest]
+#[case::one_leftover_felt(vec![Felt::ONE, Felt::TWO, Felt::THREE])]
+#[case::two_leftover_felts(vec![Felt::ONE, Felt::TWO, Felt::THREE, Felt::ZERO])]
+fn deserialize_retdata_rejects_leftover_felts(#[case] retdata: Vec<Felt>) {
+    let error = deserialize_retdata::<FeltPair>(retdata).unwrap_err();
+    assert_eq!(error.to_string(), "Invalid object length: unconsumed elements in retdata.");
+}
+
+#[rstest]
+#[case::empty_retdata(vec![])]
+#[case::one_felt_short(vec![Felt::ONE])]
+fn deserialize_retdata_rejects_short_retdata(#[case] retdata: Vec<Felt>) {
+    let error = deserialize_retdata::<FeltPair>(retdata).unwrap_err();
+    assert!(
+        matches!(
+            &error,
+            RetdataDeserializationError::InvalidObjectLength { message }
+                if message.contains("missing felt value")
+        ),
+        "unexpected error: {error}"
+    );
+}


### PR DESCRIPTION
Adds `deserialize_retdata` to `apollo_cairo_utils`: it decodes a full retdata into `T` via `TryFromIterator<Felt>` and returns `InvalidObjectLength` when felts remain after `T` is decoded. A contract returning more felts than the caller's type accounts for is a protocol mismatch, so silently ignoring the tail is not safe.

Based on `main-v0.14.3` so it sits on the release lineage.

The first production caller arrives with the Chainlink feed-math PR (A7), which needs the leftover-felt rejection when parsing oracle round data. This PR is the utility plus its unit tests only.

The `TODO(Asaf)` in the function doc proposes routing `CairoArray`, `CairoOption` and `apollo_staking`'s `Epoch` through this function and dropping their `TryFrom<Retdata>` impls. That migration is deliberately out of scope here: it touches unrelated crates and belongs in its own PR.

Tests cover exact-length retdata, leftover felts (one and two extra), and short retdata (empty and one felt short). `rstest` is added to `[dev-dependencies]` for the new test file; the crate had none before.
