### PR TITLE
apollo_l1_gas_price,apollo_l1_gas_price_types: name the exchange rate type

### DIFF
--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use apollo_config::secrets::Sensitive;
 use apollo_l1_gas_price_config::config::ExchangeRateOracleConfig;
 use apollo_l1_gas_price_types::errors::ExchangeRateOracleClientError;
-use apollo_l1_gas_price_types::ExchangeRateOracleClientTrait;
+use apollo_l1_gas_price_types::{ExchangeRate, ExchangeRateOracleClientTrait};
 use apollo_metrics::metrics::set_unix_now_seconds;
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -46,7 +46,7 @@ pub struct UrlAndHeaderMap {
     pub headers: Sensitive<HeaderMap>,
 }
 
-type PriceQuery = AbortOnDropHandle<Result<u128, ExchangeRateOracleClientError>>;
+type PriceQuery = AbortOnDropHandle<Result<ExchangeRate, ExchangeRateOracleClientError>>;
 
 /// Client for interacting with an exchange-rate oracle API.
 /// Concrete pair (ETH→STRK, STRK→USD, ...) is determined by `config.url_header_list`
@@ -59,7 +59,7 @@ pub struct ExchangeRateOracleClient {
     index: Arc<AtomicUsize>,
     url_header_list: Arc<Vec<UrlAndHeaderMap>>,
     client: reqwest::Client,
-    cached_prices: Arc<Mutex<LruCache<u64, u128>>>,
+    cached_prices: Arc<Mutex<LruCache<u64, ExchangeRate>>>,
     queries: Arc<Mutex<LruCache<u64, PriceQuery>>>,
     metrics: ExchangeRateOracleMetrics,
 }
@@ -99,7 +99,7 @@ impl ExchangeRateOracleClient {
     fn spawn_query(
         &self,
         quantized_timestamp: u64,
-    ) -> AbortOnDropHandle<Result<u128, ExchangeRateOracleClientError>> {
+    ) -> AbortOnDropHandle<Result<ExchangeRate, ExchangeRateOracleClientError>> {
         assert!(
             self.config.lag_interval_seconds > 0,
             "lag_interval_seconds should be greater than 0"
@@ -166,7 +166,7 @@ impl ExchangeRateOracleClient {
 fn resolve_query(
     body: String,
     metrics: &ExchangeRateOracleMetrics,
-) -> Result<u128, ExchangeRateOracleClientError> {
+) -> Result<ExchangeRate, ExchangeRateOracleClientError> {
     let Ok(json): Result<serde_json::Value, _> = serde_json::from_str(&body) else {
         return Err(ExchangeRateOracleClientError::ParseError(format!(
             "Failed to parse JSON: {body}"
@@ -218,7 +218,10 @@ impl ExchangeRateOracleClientTrait for ExchangeRateOracleClient {
     /// - `price`: a hexadecimal string representing the price.
     /// - `decimals`: a `u64` value, must be equal to `EXCHANGE_RATE_DECIMALS`.
     #[instrument(skip(self))]
-    async fn fetch_rate(&self, timestamp: u64) -> Result<u128, ExchangeRateOracleClientError> {
+    async fn fetch_rate(
+        &self,
+        timestamp: u64,
+    ) -> Result<ExchangeRate, ExchangeRateOracleClientError> {
         const NUMBER_OF_TIMESTAMPS_BACK: u64 = 1;
         let quantized_timestamp = (timestamp - self.config.lag_interval_seconds)
             .checked_div(self.config.lag_interval_seconds)

--- a/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
+++ b/crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs
@@ -7,6 +7,7 @@ use apollo_infra_utils::info_every_n_ms;
 use apollo_l1_gas_price_config::config::L1GasPriceProviderConfig;
 use apollo_l1_gas_price_types::errors::L1GasPriceProviderError;
 use apollo_l1_gas_price_types::{
+    ExchangeRate,
     ExchangeRateOracleClientTrait,
     GasPriceData,
     L1GasPriceProviderResult,
@@ -202,14 +203,14 @@ impl L1GasPriceProvider {
         Ok(price_info_out)
     }
 
-    pub async fn eth_to_fri_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<u128> {
+    pub async fn eth_to_fri_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<ExchangeRate> {
         self.eth_to_strk_oracle_client
             .fetch_rate(timestamp)
             .await
             .map_err(L1GasPriceProviderError::ExchangeRateOracleClientError)
     }
 
-    pub async fn strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<u128> {
+    pub async fn strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderResult<ExchangeRate> {
         self.strk_to_usd_oracle_client
             .fetch_rate(timestamp)
             .await

--- a/crates/apollo_l1_gas_price_types/src/lib.rs
+++ b/crates/apollo_l1_gas_price_types/src/lib.rs
@@ -21,7 +21,10 @@ use starknet_api::block::{BlockTimestamp, GasPrice};
 use strum::{AsRefStr, EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use tracing::instrument;
 
-pub const DEFAULT_ETH_TO_FRI_RATE: u128 = 10_u128.pow(21);
+pub const DEFAULT_ETH_TO_FRI_RATE: ExchangeRate = 10_u128.pow(21);
+
+/// A currency conversion rate, as an 18-decimal fixed-point integer.
+pub type ExchangeRate = u128;
 
 pub type SharedL1GasPriceClient = Arc<dyn L1GasPriceProviderClient>;
 pub type L1GasPriceProviderResult<T> = Result<T, L1GasPriceProviderError>;
@@ -82,8 +85,8 @@ pub enum L1GasPriceResponse {
     Initialize(L1GasPriceProviderResult<()>),
     GetGasPrice(L1GasPriceProviderResult<PriceInfo>),
     AddGasPrice(L1GasPriceProviderResult<()>),
-    GetEthToFriRate(L1GasPriceProviderResult<u128>),
-    GetStrkToUsdRate(L1GasPriceProviderResult<u128>),
+    GetEthToFriRate(L1GasPriceProviderResult<ExchangeRate>),
+    GetStrkToUsdRate(L1GasPriceProviderResult<ExchangeRate>),
 }
 impl_debug_for_infra_requests_and_responses!(L1GasPriceResponse);
 
@@ -101,22 +104,25 @@ pub trait L1GasPriceProviderClient: Send + Sync {
         timestamp: BlockTimestamp,
     ) -> L1GasPriceProviderClientResult<PriceInfo>;
 
-    /// ETH/FRI rate as 18-decimal fixed-point integer, quoted as FRI per ETH
-    /// (e.g. 5000 STRK per ETH → `5000 * 10^18`).
-    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
+    /// ETH/FRI rate, quoted as FRI per ETH (e.g. 5000 STRK per ETH → `5000 * 10^18`).
+    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<ExchangeRate>;
 
-    /// STRK/USD rate as 18-decimal fixed-point integer, quoted as USD per STRK
-    /// (e.g. STRK at $0.50 → `0.5 * 10^18`).
-    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128>;
+    /// STRK/USD rate, quoted as USD per STRK (e.g. STRK at $0.50 → `0.5 * 10^18`).
+    async fn get_strk_to_usd_rate(
+        &self,
+        timestamp: u64,
+    ) -> L1GasPriceProviderClientResult<ExchangeRate>;
 }
 
 #[cfg_attr(any(feature = "testing", test), automock)]
 #[async_trait]
 pub trait ExchangeRateOracleClientTrait: Send + Sync + Debug {
-    /// Fetches a rate as a u128 for the given timestamp. The semantics of the rate (e.g.
-    /// ETH/FRI, STRK/USD) are determined by the URLs the implementation is configured with;
-    /// callers label the per-instance meaning at the field that holds the trait object.
-    async fn fetch_rate(&self, timestamp: u64) -> Result<u128, ExchangeRateOracleClientError>;
+    /// Fetches the rate for the given timestamp. Which pair the rate converts (e.g. ETH/FRI,
+    /// STRK/USD) is fixed per implementation instance by its configuration.
+    async fn fetch_rate(
+        &self,
+        timestamp: u64,
+    ) -> Result<ExchangeRate, ExchangeRateOracleClientError>;
 }
 
 #[async_trait]
@@ -167,7 +173,7 @@ where
         )
     }
     #[instrument(skip(self))]
-    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128> {
+    async fn get_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<ExchangeRate> {
         let request = L1GasPriceRequest::GetEthToFriRate(timestamp);
         handle_all_response_variants!(
             self,
@@ -180,7 +186,10 @@ where
         )
     }
     #[instrument(skip(self))]
-    async fn get_strk_to_usd_rate(&self, timestamp: u64) -> L1GasPriceProviderClientResult<u128> {
+    async fn get_strk_to_usd_rate(
+        &self,
+        timestamp: u64,
+    ) -> L1GasPriceProviderClientResult<ExchangeRate> {
         let request = L1GasPriceRequest::GetStrkToUsdRate(timestamp);
         handle_all_response_variants!(
             self,


### PR DESCRIPTION
Introduces `pub type ExchangeRate = u128;` in `apollo_l1_gas_price_types` and uses it at every signature that already carried a currency conversion rate as a bare `u128`.

This is a transparent rename with no behavior change. `ExchangeRate` is a type alias, not a newtype, so it is interchangeable with `u128` at every call site and no crate outside the two named in the title needs an edit. There are no new tests: the existing `apollo_l1_gas_price` suite covers the touched code paths, and a passing build is what verifies an alias.

## Sites

`crates/apollo_l1_gas_price_types/src/lib.rs`:
- `DEFAULT_ETH_TO_FRI_RATE`
- `L1GasPriceResponse::GetEthToFriRate` and `::GetStrkToUsdRate`
- `L1GasPriceProviderClient::get_rate` and `::get_strk_to_usd_rate`, in both the trait declaration and the blanket impl
- `ExchangeRateOracleClientTrait::fetch_rate`

`crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs`: `PriceQuery`, `cached_prices`, `spawn_query`, `resolve_query`, `fetch_rate`.

`crates/apollo_l1_gas_price/src/l1_gas_price_provider.rs`: `eth_to_fri_rate`, `strk_to_usd_rate`.

The `u128` uses that are not conversion rates are left alone: `PriceInfo::checked_div`'s divisor and the block-count `u128::try_from` in the provider. The `u128::from_str_radix` parse in `resolve_query` does produce the rate, but it is an associated-function call on the primitive rather than a type position, so the primitive name stays.

## Doc rewording

The alias doc states the shared fixed-point encoding once, so the per-method docs that repeated "as 18-decimal fixed-point integer" now state only the quote direction, which is the part that differs per method. `ExchangeRateOracleClientTrait::fetch_rate` is reworded to say the pair is fixed per implementation instance by its configuration.

## Stack

Split out ahead of the L1 oracle stack so the rename never appears as noise inside a behavioral diff. A3 through A9 build on the name and use it in their signatures.
