### PR TITLE
apollo_l1_gas_price: register each oracle metric set once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,8 @@ dependencies = [
  "async-trait",
  "futures",
  "lru 0.12.5",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mockall",
  "mockito",
  "papyrus_base_layer",

--- a/crates/apollo_l1_gas_price/Cargo.toml
+++ b/crates/apollo_l1_gas_price/Cargo.toml
@@ -30,6 +30,9 @@ url.workspace = true
 
 [dev-dependencies]
 apollo_l1_gas_price_types = { workspace = true, features = ["testing"] }
+apollo_metrics = { workspace = true, features = ["testing"] }
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 mockall.workspace = true
 mockito.workspace = true
 papyrus_base_layer = { workspace = true, features = ["testing"] }

--- a/crates/apollo_l1_gas_price/src/metrics.rs
+++ b/crates/apollo_l1_gas_price/src/metrics.rs
@@ -1,3 +1,5 @@
+use std::sync::Once;
+
 use apollo_infra::metrics::{
     InfraMetrics,
     LocalClientMetrics,
@@ -8,6 +10,10 @@ use apollo_infra::metrics::{
 use apollo_l1_gas_price_types::L1_GAS_PRICE_REQUEST_LABELS;
 use apollo_metrics::metrics::{MetricCounter, MetricDetails, MetricGauge};
 use apollo_metrics::{define_infra_metrics, define_metrics};
+
+#[cfg(test)]
+#[path = "metrics_test.rs"]
+mod metrics_test;
 
 define_infra_metrics!(l1_gas_price);
 
@@ -41,14 +47,18 @@ pub struct ExchangeRateOracleMetrics {
     pub success_count: &'static MetricCounter,
     pub error_count: &'static MetricCounter,
     pub last_success_timestamp: &'static MetricGauge,
+    /// Guards this set's registration.
+    registration_guard: &'static Once,
 }
 
 impl ExchangeRateOracleMetrics {
     pub fn register(&self) {
-        self.rate.register();
-        self.success_count.register();
-        self.error_count.register();
-        self.last_success_timestamp.register();
+        self.registration_guard.call_once(|| {
+            self.rate.register();
+            self.success_count.register();
+            self.error_count.register();
+            self.last_success_timestamp.register();
+        });
     }
 }
 
@@ -66,11 +76,15 @@ impl std::fmt::Debug for ExchangeRateOracleMetrics {
     }
 }
 
+static ETH_TO_STRK_REGISTRATION: Once = Once::new();
+static STRK_TO_USD_REGISTRATION: Once = Once::new();
+
 pub const ETH_TO_STRK_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOracleMetrics {
     rate: &ETH_TO_STRK_RATE,
     success_count: &ETH_TO_STRK_SUCCESS_COUNT,
     error_count: &ETH_TO_STRK_ERROR_COUNT,
     last_success_timestamp: &ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    registration_guard: &ETH_TO_STRK_REGISTRATION,
 };
 
 pub const STRK_TO_USD_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOracleMetrics {
@@ -78,6 +92,7 @@ pub const STRK_TO_USD_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOr
     success_count: &SNIP35_STRK_USD_SUCCESS_COUNT,
     error_count: &SNIP35_STRK_USD_ERROR_COUNT,
     last_success_timestamp: &SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    registration_guard: &STRK_TO_USD_REGISTRATION,
 };
 
 pub(crate) fn register_provider_metrics() {

--- a/crates/apollo_l1_gas_price/src/metrics_test.rs
+++ b/crates/apollo_l1_gas_price/src/metrics_test.rs
@@ -1,0 +1,47 @@
+use std::collections::BTreeMap;
+use std::sync::Once;
+
+use apollo_config::converters::UrlAndHeaders;
+use apollo_l1_gas_price_config::config::ExchangeRateOracleConfig;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use url::Url;
+
+use super::{ExchangeRateOracleMetrics, ETH_TO_STRK_ORACLE_METRICS};
+use crate::exchange_rate_oracle::ExchangeRateOracleClient;
+
+/// Guard owned by this test, so the assertions on its state do not depend on whether another test
+/// in the process already registered the ETH→STRK set.
+static TEST_REGISTRATION: Once = Once::new();
+
+fn oracle_config() -> ExchangeRateOracleConfig {
+    let url_and_headers =
+        UrlAndHeaders { url: Url::parse("http://localhost:1").unwrap(), headers: BTreeMap::new() };
+    ExchangeRateOracleConfig {
+        url_header_list: Some(vec![url_and_headers.into()]),
+        ..Default::default()
+    }
+}
+
+/// Models `create_node_modules` running once per simulated node inside a single flow-test process
+/// (`apollo_integration_tests/src/flow_test_setup.rs:336`): each node builds its own client for the
+/// same pair against the same static metric set, so a later construction must not re-register the
+/// set or reset the counts recorded for an earlier one.
+#[test]
+fn repeated_client_construction_registers_metrics_once() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+    let oracle_metrics = ExchangeRateOracleMetrics {
+        registration_guard: &TEST_REGISTRATION,
+        ..ETH_TO_STRK_ORACLE_METRICS
+    };
+    assert!(!TEST_REGISTRATION.is_completed());
+
+    let _first_client = ExchangeRateOracleClient::new(oracle_config(), oracle_metrics);
+    assert!(TEST_REGISTRATION.is_completed());
+
+    oracle_metrics.success_count.increment(1);
+    let _second_client = ExchangeRateOracleClient::new(oracle_config(), oracle_metrics);
+
+    oracle_metrics.success_count.assert_eq::<u64>(&recorder.handle().render(), 1);
+}


### PR DESCRIPTION
`ExchangeRateOracleMetrics::register` is called from `ExchangeRateOracleClient::new`, so every constructed client re-registers the static metric bundle for its pair (`ETH_TO_STRK_ORACLE_METRICS`, `STRK_TO_USD_ORACLE_METRICS`). This adds a per-bundle `Once` so each set registers exactly once per process.

### Reachable path

A deployed node constructs one client per pair and never re-registers. The in-process multi-node path does: `create_node_modules`, the production composition function, is called once per simulated node inside a single test process by `crates/apollo_integration_tests/src/flow_test_setup.rs:336`. Each call rebuilds the per-pair clients against the same two static bundles, so node N's construction re-registers what node 1 already registered. The guard is insurance for exactly that in-process repeat construction.

Registering from `ComponentStarter::start()` instead (the way `register_provider_metrics` does) would not help: the flow-test harness starts each in-process node too.

### On the strength of the claim

Worth being precise, because I checked it rather than assuming it. With the metrics stack actually in use, re-registration is **currently harmless**:

- `MetricCounter::register` publishes the initial value via `counter!(name).absolute(init)`, and `CounterFn for AtomicU64` (`metrics-0.24.2/src/atomics.rs:27`) implements `absolute` as `fetch_max`. With `init = 0` for all four oracle counters, a second `register` cannot lower an incremented counter.
- `MetricGauge::register` only creates the handle and calls `describe_gauge!`; it sets no value.

I confirmed this empirically: with the `Once` removed, an incremented counter still survives a second `register`. So this PR is hardening, not a bug fix. What it buys is that `register` no longer depends on `Counter::absolute` being monotonic, which is a backend-defined detail (`metrics` leaves the semantics to the implementation), and it makes "registration happens once per process" an explicit property rather than an accident of the atomic storage backend.

If reviewers would rather not carry a guard for a latent-only issue, the alternative is to drop this PR. Flagging it rather than overselling the justification.

### Changes

- `crates/apollo_l1_gas_price/src/metrics.rs`: private `registration_guard: &'static Once` field on `ExchangeRateOracleMetrics`, `register` wrapped in `call_once`, one distinct `Once` static per bundle. `Debug` keeps `finish()` and omits the guard.
- `crates/apollo_l1_gas_price/src/metrics_test.rs`: constructs two clients for the same pair with an increment between, asserts the set's guard is uncompleted before the first construction and completed after it, and asserts the count survives the second construction. The guard is a test-owned `Once` so the state assertions do not depend on other tests in the process. Deleting the `call_once` wrapper makes the test fail. The test comment names the flow-test path it models.
- `crates/apollo_l1_gas_price/Cargo.toml`: `metrics`, `metrics-exporter-prometheus`, and `apollo_metrics` with `testing` added as dev-dependencies for the new test.

### Verification

- `./scripts/rust_fmt.sh` clean
- `RUSTFLAGS="-D warnings" cargo clippy -p apollo_l1_gas_price --all-targets --all-features` clean
- `SEED=0 cargo nextest run -p apollo_l1_gas_price`: 20 passed, 0 skipped
- Negative control: with the `call_once` wrapper removed, `repeated_client_construction_registers_metrics_once` fails on `assertion failed: TEST_REGISTRATION.is_completed()`
- `scripts/taplo.sh` and `cargo machete` clean
