### PR TITLE
apollo_consensus_orchestrator: cap the L2 gas price at 10x the minimum

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/build_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal.rs
@@ -327,7 +327,8 @@ async fn get_proposal_content(
                     args.override_l2_gas_price_fri,
                     &args.min_l2_gas_price_per_height,
                     args.fee_actual,
-                );
+                )
+                .published_price;
                 let fin_payload = ProposalFinPayload {
                     commitment_parts: CommitmentParts::from(&info),
                     l2_gas_info: L2GasInfo {

--- a/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp::max;
+use std::cmp::{max, min};
 
 use apollo_consensus_orchestrator_config::config::PricePerHeight;
 use apollo_versioned_constants::VersionedConstants;
@@ -8,6 +8,8 @@ use starknet_api::block::{BlockNumber, GasPrice};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use tracing::info;
+
+use crate::metrics::{record_l2_gas_price_clamped, L2GasPriceClampBound};
 
 #[cfg(test)]
 mod test;
@@ -19,6 +21,12 @@ mod test;
 // double the price takes approximately 230 blocks (at 2.6 seconds per block), this means doubling
 // in approximately 10 minutes.
 const MIN_GAS_PRICE_INCREASE_DENOMINATOR: u128 = 333;
+
+// Ceiling on the L2 gas price, as a multiple of the minimum gas price in force for the height.
+// TODO(asaf-sw): Move to versioned constants in 0.14.4.
+const MAX_GAS_PRICE_MULTIPLIER: u128 = 10;
+// A multiplier of 0 or 1 pins the L2 gas price at 0 or at the minimum.
+const _: () = assert!(MAX_GAS_PRICE_MULTIPLIER > 1);
 
 /// Fee market information for the next block.
 #[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize, PartialEq))]
@@ -51,7 +59,17 @@ pub fn get_min_gas_price_for_height(
         .unwrap_or(fallback_min_gas_price)
 }
 
+/// The ceiling on the L2 gas price: `MAX_GAS_PRICE_MULTIPLIER` times `min_gas_price`. Applies to
+/// every block regardless of its `starknet_version`. Proposer and validator reach the ceiling
+/// through this function, so they cannot disagree on it.
+// [Temporary comment] Single caller on this lineage. The fee-proposal band clamp, which is its
+// second caller, is deferred to `main`.
+pub fn l2_gas_price_cap(min_gas_price: GasPrice) -> GasPrice {
+    GasPrice(min_gas_price.0.saturating_mul(MAX_GAS_PRICE_MULTIPLIER))
+}
+
 /// Compute the next L2 gas price (for the fin or for updating state). Respects override when set.
+/// Reporting the bounds is the caller's job, through `NextL2GasPrice::record_clamping`.
 pub fn calculate_next_l2_gas_price_for_fin(
     current_l2_gas_price: GasPrice,
     height: BlockNumber,
@@ -59,21 +77,90 @@ pub fn calculate_next_l2_gas_price_for_fin(
     override_l2_gas_price_fri: Option<u128>,
     min_l2_gas_price_per_height: &[PricePerHeight],
     fee_actual: Option<GasPrice>,
-) -> GasPrice {
+) -> NextL2GasPrice {
     if let Some(override_value) = override_l2_gas_price_fri {
+        // Operator pin: escapes both bounds by design; each side substitutes its own override.
         info!(
             "L2 gas price ({}) is not updated, remains on override value of {override_value} fri",
             current_l2_gas_price.0
         );
-        return GasPrice(override_value);
+        return NextL2GasPrice { published_price: GasPrice(override_value), bounds: None };
     }
     let gas_target = VersionedConstants::latest_constants().gas_target;
     let config_min = get_min_gas_price_for_height(height, min_l2_gas_price_per_height);
-    let effective_min = match fee_actual {
-        Some(fa) => GasPrice(max(config_min.0, fa.0)),
-        None => config_min,
-    };
-    calculate_next_base_gas_price(current_l2_gas_price, l2_gas_used, gas_target, effective_min)
+    let cap = l2_gas_price_cap(config_min);
+
+    let snip35_min = fee_actual.map_or(config_min, |fee_actual| max(config_min, fee_actual));
+    let effective_min = min(snip35_min, cap);
+
+    let raw_price =
+        calculate_next_base_gas_price(current_l2_gas_price, l2_gas_used, gas_target, effective_min);
+
+    NextL2GasPrice {
+        published_price: min(raw_price, cap),
+        bounds: Some(L2GasPriceBounds {
+            current_price: current_l2_gas_price,
+            raw_price,
+            snip35_min,
+            effective_min,
+            cap,
+        }),
+    }
+}
+
+/// The next L2 gas price, and the bounds that produced it.
+#[derive(Debug)]
+pub struct NextL2GasPrice {
+    /// The price to publish in the fin and to carry into the next block.
+    pub published_price: GasPrice,
+    // `None` for an operator override, which escapes both bounds.
+    bounds: Option<L2GasPriceBounds>,
+}
+
+// The bounds in force for a block, and the prices compared against them.
+#[derive(Debug)]
+struct L2GasPriceBounds {
+    current_price: GasPrice,
+    raw_price: GasPrice,
+    snip35_min: GasPrice,
+    effective_min: GasPrice,
+    cap: GasPrice,
+}
+
+impl NextL2GasPrice {
+    /// Logs and counts the bounds that shaped `published_price`. Call once per decided block;
+    /// blocks obtained through sync are not counted.
+    pub(crate) fn record_clamping(&self) {
+        let Some(bounds) = &self.bounds else {
+            return;
+        };
+        // The current price, not `raw_price`: the last block of the ramp toward the minimum reaches
+        // the minimum exactly, and the minimum is what stopped it there.
+        if bounds.current_price < bounds.effective_min {
+            info!(
+                "Fee Market: minimum gas price {} applied (price {} below it), published price: {}",
+                bounds.effective_min.0, bounds.current_price.0, self.published_price.0
+            );
+            record_l2_gas_price_clamped(L2GasPriceClampBound::Minimum);
+        }
+        // A SNIP-35 floor above the ceiling is a ceiling hit too: `effective_min` clipped the floor
+        // down before the EIP-1559 step, so `raw_price` cannot show it.
+        let raw_price_above_cap = bounds.raw_price > bounds.cap;
+        let snip35_min_above_cap = bounds.snip35_min > bounds.cap;
+        if raw_price_above_cap || snip35_min_above_cap {
+            info!(
+                "Fee Market: maximum gas price {} applied (price {} above it: {}, SNIP-35 floor \
+                 {} above it: {}), published price: {}",
+                bounds.cap.0,
+                bounds.raw_price.0,
+                raw_price_above_cap,
+                bounds.snip35_min.0,
+                snip35_min_above_cap,
+                self.published_price.0
+            );
+            record_l2_gas_price_clamped(L2GasPriceClampBound::Maximum);
+        }
+    }
 }
 
 /// Calculate the base gas price for the next block according to EIP-1559.

--- a/crates/apollo_consensus_orchestrator/src/fee_market/test.rs
+++ b/crates/apollo_consensus_orchestrator/src/fee_market/test.rs
@@ -2,22 +2,46 @@ use std::sync::LazyLock;
 
 use apollo_consensus_orchestrator_config::config::PricePerHeight;
 use apollo_versioned_constants::VersionedConstants;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use rstest::rstest;
 use starknet_api::block::{BlockNumber, GasPrice};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 
 use crate::fee_market::{
     calculate_next_base_gas_price,
+    calculate_next_l2_gas_price_for_fin,
     get_min_gas_price_for_height,
+    l2_gas_price_cap,
+    MAX_GAS_PRICE_MULTIPLIER,
     MIN_GAS_PRICE_INCREASE_DENOMINATOR,
 };
+use crate::metrics::{CONSENSUS_L2_GAS_PRICE_CLAMPED, LABEL_L2_GAS_PRICE_CLAMP_BOUND};
+use crate::test_utils::{TEST_MAX_L2_GAS_PRICE, TEST_MIN_L2_GAS_PRICE};
 
 static VERSIONED_CONSTANTS: LazyLock<&VersionedConstants> =
     LazyLock::new(VersionedConstants::latest_constants);
 
-use rstest::rstest;
-
 const INIT_PRICE: GasPrice = GasPrice(30_000_000_000);
+
+// One entry from genesis, so the ceiling is `TEST_MAX_L2_GAS_PRICE` at every height.
+fn flat_min_gas_price_config() -> Vec<PricePerHeight> {
+    vec![PricePerHeight { height: 0, price: TEST_MIN_L2_GAS_PRICE.0 }]
+}
+
+// Label values are the dashboard and alert contract, so assert them literally.
+fn assert_clamp_counts(metrics: &str, minimum_count: u64, maximum_count: u64) {
+    CONSENSUS_L2_GAS_PRICE_CLAMPED.assert_eq(
+        metrics,
+        minimum_count,
+        &[(LABEL_L2_GAS_PRICE_CLAMP_BOUND, "minimum")],
+    );
+    CONSENSUS_L2_GAS_PRICE_CLAMPED.assert_eq(
+        metrics,
+        maximum_count,
+        &[(LABEL_L2_GAS_PRICE_CLAMP_BOUND, "maximum")],
+    );
+}
 
 #[rstest]
 #[case::high_congestion(
@@ -213,4 +237,206 @@ fn test_calculate_with_price_close_to_minimum() {
 
     // When price is close to minimum, should cap at min_gas_price to avoid overshooting
     assert_eq!(result, min_gas_price);
+}
+
+#[test]
+fn test_price_constants_match_the_shipped_values() {
+    // Tests that leave `min_l2_gas_price_per_height` empty get this fallback as their minimum, and
+    // `TEST_MAX_L2_GAS_PRICE` as the ceiling it implies.
+    assert_eq!(TEST_MIN_L2_GAS_PRICE, VERSIONED_CONSTANTS.min_gas_price);
+    assert_eq!(TEST_MAX_L2_GAS_PRICE.0, TEST_MIN_L2_GAS_PRICE.0 * MAX_GAS_PRICE_MULTIPLIER);
+}
+
+#[test]
+fn test_l2_gas_price_cap_tracks_the_minimum() {
+    assert_eq!(l2_gas_price_cap(GasPrice(10_000_000_000)), GasPrice(100_000_000_000));
+    assert_eq!(l2_gas_price_cap(GasPrice(20_000_000_000)), GasPrice(200_000_000_000));
+}
+
+#[test]
+fn test_l2_gas_price_cap_saturates_at_an_extreme_configured_minimum() {
+    // The minimum is deployment-configured, so an extreme value must saturate, not overflow.
+    assert_eq!(l2_gas_price_cap(GasPrice(u128::MAX)), GasPrice(u128::MAX));
+}
+
+#[test]
+fn test_price_pinned_at_the_ceiling_follows_the_ceiling_down() {
+    const STEP_HEIGHT: u64 = 500;
+    let min_l2_gas_price_per_height = vec![
+        PricePerHeight { height: 0, price: TEST_MIN_L2_GAS_PRICE.0 },
+        PricePerHeight { height: STEP_HEIGHT, price: TEST_MIN_L2_GAS_PRICE.0 / 4 },
+    ];
+    let lowered_ceiling = GasPrice(TEST_MAX_L2_GAS_PRICE.0 / 4);
+
+    // Just before the step the old ceiling still holds a congested price at 80 gwei.
+    let before_the_step = calculate_next_l2_gas_price_for_fin(
+        TEST_MAX_L2_GAS_PRICE,
+        BlockNumber(STEP_HEIGHT - 1),
+        VERSIONED_CONSTANTS.max_block_size,
+        None,
+        &min_l2_gas_price_per_height,
+        None,
+    )
+    .published_price;
+    assert_eq!(before_the_step, TEST_MAX_L2_GAS_PRICE);
+
+    let at_the_step = calculate_next_l2_gas_price_for_fin(
+        TEST_MAX_L2_GAS_PRICE,
+        BlockNumber(STEP_HEIGHT),
+        VERSIONED_CONSTANTS.max_block_size,
+        None,
+        &min_l2_gas_price_per_height,
+        None,
+    )
+    .published_price;
+    assert_eq!(at_the_step, lowered_ceiling);
+}
+
+#[rstest]
+// Ordinary price inside the band: the counters must read 0, not "no data".
+#[case::no_clamp(GasPrice(TEST_MIN_L2_GAS_PRICE.0 * 2), VERSIONED_CONSTANTS.gas_target, None, 0, 0)]
+// Below the configured minimum: the floor binds and only the floor is counted.
+#[case::below_the_minimum(
+    GasPrice(TEST_MIN_L2_GAS_PRICE.0 / 2),
+    VERSIONED_CONSTANTS.gas_target,
+    None,
+    1,
+    0
+)]
+// A full block at the ceiling drives the EIP-1559 result above it: only the ceiling is counted.
+#[case::above_the_ceiling(TEST_MAX_L2_GAS_PRICE, VERSIONED_CONSTANTS.max_block_size, None, 0, 1)]
+// The SNIP-35 floor alone is above the ceiling: only the ceiling is counted.
+#[case::snip35_floor_above_the_ceiling(
+    TEST_MAX_L2_GAS_PRICE,
+    VERSIONED_CONSTANTS.gas_target,
+    Some(GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 25)),
+    0,
+    1
+)]
+// Below the ceiling-clamped SNIP-35 floor: one block counts both bounds.
+#[case::both_bounds_on_one_block(
+    GasPrice(TEST_MIN_L2_GAS_PRICE.0 / 2),
+    VERSIONED_CONSTANTS.gas_target,
+    Some(GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 25)),
+    1,
+    1
+)]
+fn test_l2_gas_price_clamp_counters_record_once_per_committed_block(
+    #[case] current_l2_gas_price: GasPrice,
+    #[case] l2_gas_used: GasAmount,
+    #[case] fee_actual: Option<GasPrice>,
+    #[case] expected_minimum_count: u64,
+    #[case] expected_maximum_count: u64,
+) {
+    // The proposer's fin and every reproposal round compute the same price for the same block.
+    const N_UNCOMMITTED_COMPUTATIONS: usize = 3;
+
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    CONSENSUS_L2_GAS_PRICE_CLAMPED.register();
+
+    let next_l2_gas_price = || {
+        calculate_next_l2_gas_price_for_fin(
+            current_l2_gas_price,
+            BlockNumber(0),
+            l2_gas_used,
+            None,
+            &flat_min_gas_price_config(),
+            fee_actual,
+        )
+    };
+
+    for _ in 0..N_UNCOMMITTED_COMPUTATIONS {
+        next_l2_gas_price();
+    }
+    assert_clamp_counts(&recorder.handle().render(), 0, 0);
+
+    next_l2_gas_price().record_clamping();
+    assert_clamp_counts(
+        &recorder.handle().render(),
+        expected_minimum_count,
+        expected_maximum_count,
+    );
+}
+
+#[test]
+fn test_sustained_congestion_stops_at_the_ceiling() {
+    // A full block drives the EIP-1559 price up ~9.5%, independently of the oracle.
+    let mut price = TEST_MIN_L2_GAS_PRICE;
+
+    for height in 0..100 {
+        price = calculate_next_l2_gas_price_for_fin(
+            price,
+            BlockNumber(height),
+            VERSIONED_CONSTANTS.max_block_size,
+            None,
+            &flat_min_gas_price_config(),
+            None,
+        )
+        .published_price;
+    }
+
+    // Exact equality, not `price <= cap`, which would also pass for a price that never rose.
+    assert_eq!(price, TEST_MAX_L2_GAS_PRICE);
+}
+
+#[test]
+fn test_fee_actual_above_the_ceiling_publishes_the_ceiling() {
+    // `fee_actual` enters as a floor, and the floor is itself clamped to the ceiling.
+    let price = calculate_next_l2_gas_price_for_fin(
+        TEST_MAX_L2_GAS_PRICE,
+        BlockNumber(0),
+        VERSIONED_CONSTANTS.gas_target,
+        None,
+        &flat_min_gas_price_config(),
+        Some(GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 25)),
+    )
+    .published_price;
+
+    assert_eq!(price, TEST_MAX_L2_GAS_PRICE);
+}
+
+#[rstest]
+#[case::override_above_the_ceiling(GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 100))]
+#[case::override_below_the_floor(GasPrice(TEST_MIN_L2_GAS_PRICE.0 / 100))]
+fn test_override_bypasses_both_bounds(#[case] override_l2_gas_price_fri: GasPrice) {
+    assert_eq!(
+        calculate_next_l2_gas_price_for_fin(
+            TEST_MIN_L2_GAS_PRICE,
+            BlockNumber(0),
+            VERSIONED_CONSTANTS.gas_target,
+            Some(override_l2_gas_price_fri.0),
+            &flat_min_gas_price_config(),
+            None,
+        )
+        .published_price,
+        override_l2_gas_price_fri
+    );
+}
+
+#[test]
+fn test_ceiling_leaves_ordinary_prices_untouched() {
+    let price = GasPrice(TEST_MIN_L2_GAS_PRICE.0 * 2);
+    let gas_used = GasAmount(VERSIONED_CONSTANTS.gas_target.0 * 3 / 2);
+
+    let capped = calculate_next_l2_gas_price_for_fin(
+        price,
+        BlockNumber(0),
+        gas_used,
+        None,
+        &flat_min_gas_price_config(),
+        None,
+    )
+    .published_price;
+
+    assert_eq!(
+        capped,
+        calculate_next_base_gas_price(
+            price,
+            gas_used,
+            VERSIONED_CONSTANTS.gas_target,
+            TEST_MIN_L2_GAS_PRICE
+        )
+    );
+    assert!(capped > price);
 }

--- a/crates/apollo_consensus_orchestrator/src/metrics.rs
+++ b/crates/apollo_consensus_orchestrator/src/metrics.rs
@@ -16,6 +16,9 @@ define_metrics!(
         MetricCounter { CONSENSUS_L1_DATA_GAS_MISMATCH, "consensus_l1_data_gas_mismatch", "The number of times the L1 data gas in a proposal does not match the value expected by this validator", init = 0 },
         MetricGauge { CONSENSUS_L2_GAS_PRICE, "consensus_l2_gas_price", "The L2 gas price calculated in an accepted proposal" },
         MetricGauge { CONSENSUS_L2_GAS_PRICE_AT_MINIMUM, "consensus_l2_gas_price_at_minimum", "1 when the accepted L2 gas price is clamped at the configured minimum (min_l2_gas_price_per_height, or the versioned-constants min_gas_price fallback), else 0" },
+        // Counter, not gauge: a gauge resets to 0 on restart, hiding clamps that already occurred.
+        // [Temporary comment] Panel and alerts arrive in #14947.
+        LabeledMetricCounter { CONSENSUS_L2_GAS_PRICE_CLAMPED, "consensus_l2_gas_price_clamped", "Number of times a clamp bound the computed next L2 gas price. `minimum`: the previous price was below the effective minimum, i.e. still ramping up towards the floor. A price at or above the floor is not counted, even when the floor raised it; see consensus_l2_gas_price_at_minimum. `maximum`: bound by the ceiling, including when only the SNIP-35 floor was clipped, in which case the published price can be below the ceiling", init = 0, labels = L2_GAS_PRICE_CLAMP_BOUND },
         MetricCounter { CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR, "consensus_l1_gas_price_provider_error", "Number of times the context got an error when querying the L1 gas price provider", init=0},
         MetricCounter { CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH, "consensus_retrospective_block_hash_mismatch", "Number of times the retrospective block hashes of the state sync and the batcher mismatched", init=0},
 
@@ -40,8 +43,30 @@ define_metrics!(
         MetricGauge { SNIP35_FEE_PROPOSAL_FRI, "snip35_fee_proposal_fri", "The fee_proposal this node published in the latest block, in Fri" },
         MetricGauge { SNIP35_FEE_TARGET_FRI, "snip35_fee_target_fri", "The fee_target computed from the STRK/USD oracle, in Fri" },
         MetricGauge { SNIP35_FEE_TARGET_ATTO_USD, "snip35_fee_target_atto_usd", "Configured target USD cost per L2 gas unit, in atto-USD" },
+        // [Temporary comment] Registered here so the alert in #14947 has a series to read. The
+        // increment site arrives with the fee-proposal band clamp, which is deferred to `main`.
+        MetricCounter { SNIP35_FEE_TARGET_ABOVE_MAXIMUM, "snip35_fee_target_above_maximum", "Number of blocks whose oracle-derived fee_target exceeded the L2 gas price maximum. Excludes targets from the override_l2_gas_price_fri operator pin", init = 0 },
     }
 );
+
+pub const LABEL_L2_GAS_PRICE_CLAMP_BOUND: &str = "l2_gas_price_clamp_bound";
+
+// Which bound a clamp applied: the effective minimum in force, or the `l2_gas_price_cap` ceiling.
+#[derive(IntoStaticStr, EnumIter, VariantNames)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum L2GasPriceClampBound {
+    Minimum,
+    Maximum,
+}
+
+generate_permutation_labels! {
+    L2_GAS_PRICE_CLAMP_BOUND,
+    (LABEL_L2_GAS_PRICE_CLAMP_BOUND, L2GasPriceClampBound),
+}
+
+pub(crate) fn record_l2_gas_price_clamped(bound: L2GasPriceClampBound) {
+    CONSENSUS_L2_GAS_PRICE_CLAMPED.increment(1, &[(LABEL_L2_GAS_PRICE_CLAMP_BOUND, bound.into())]);
+}
 
 pub const LABEL_CENDE_FAILURE_REASON: &str = "cende_write_failure_reason";
 
@@ -99,6 +124,7 @@ pub(crate) fn register_metrics() {
     CONSENSUS_L1_DATA_GAS_MISMATCH.register();
     CONSENSUS_L2_GAS_PRICE.register();
     CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.register();
+    CONSENSUS_L2_GAS_PRICE_CLAMPED.register();
     CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR.register();
     CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH.register();
     CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER.register();
@@ -113,4 +139,5 @@ pub(crate) fn register_metrics() {
     SNIP35_FEE_PROPOSAL_FRI.register();
     SNIP35_FEE_TARGET_FRI.register();
     SNIP35_FEE_TARGET_ATTO_USD.register();
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM.register();
 }

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -95,6 +95,7 @@ use crate::fee_market::{
     calculate_next_l2_gas_price_for_fin,
     get_min_gas_price_for_height,
     FeeMarketInfo,
+    NextL2GasPrice,
 };
 use crate::metrics::{
     record_build_proposal_failure,
@@ -423,7 +424,11 @@ impl SequencerConsensusContext {
 
     /// Returns the next L2 gas price without mutating context. Used when building the fin and when
     /// updating at decision time.
-    fn calculate_next_l2_gas_price(&self, height: BlockNumber, l2_gas_used: GasAmount) -> GasPrice {
+    fn calculate_next_l2_gas_price(
+        &self,
+        height: BlockNumber,
+        l2_gas_used: GasAmount,
+    ) -> NextL2GasPrice {
         let fee_actual = compute_fee_actual(
             &self.fee_proposals_window,
             height,
@@ -493,7 +498,11 @@ impl SequencerConsensusContext {
     }
 
     fn update_l2_gas_price(&mut self, height: BlockNumber, l2_gas_used: GasAmount) {
-        self.l2_gas_price = self.calculate_next_l2_gas_price(height, l2_gas_used);
+        let next_l2_gas_price = self.calculate_next_l2_gas_price(height, l2_gas_used);
+        // Only this path runs once per decided block, so the clamp counter is reported here rather
+        // than inside the shared computation.
+        next_l2_gas_price.record_clamping();
+        self.l2_gas_price = next_l2_gas_price.published_price;
         let gas_price_u64 = u64::try_from(self.l2_gas_price.0).unwrap_or(u64::MAX);
         CONSENSUS_L2_GAS_PRICE.set_lossy(gas_price_u64);
         let config_min = get_min_gas_price_for_height(
@@ -887,8 +896,9 @@ impl ConsensusContext for SequencerConsensusContext {
             .expect("Lock on active proposals was poisoned due to a previous panic")
             .update_for_reproposal(&height, &proposal_commitment, &build_param);
 
-        let next_l2_gas_price =
-            self.calculate_next_l2_gas_price(init.height, finished_info.l2_gas_used);
+        let next_l2_gas_price = self
+            .calculate_next_l2_gas_price(init.height, finished_info.l2_gas_used)
+            .published_price;
         let transaction_converter = self.deps.transaction_converter.clone();
         let mut stream_sender =
             self.start_stream(HeightAndRound(height.0, build_param.round)).await;

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -64,7 +64,12 @@ use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 
 use crate::cende::{MockCendeContext, N_BLOCK_HASHES_BACK_IN_BLOB};
 use crate::dynamic_gas_price::proposal_commitment_from;
-use crate::metrics::{CONSENSUS_L2_GAS_PRICE, CONSENSUS_L2_GAS_PRICE_AT_MINIMUM};
+use crate::metrics::{
+    CONSENSUS_L2_GAS_PRICE,
+    CONSENSUS_L2_GAS_PRICE_AT_MINIMUM,
+    CONSENSUS_L2_GAS_PRICE_CLAMPED,
+    LABEL_L2_GAS_PRICE_CLAMP_BOUND,
+};
 use crate::sequencer_consensus_context::{
     SequencerConsensusContext,
     SequencerConsensusContextDeps,
@@ -79,6 +84,7 @@ use crate::test_utils::{
     ETH_TO_FRI_RATE,
     INTERNAL_TX_BATCH,
     PARTIAL_BLOCK_HASH,
+    TEST_MAX_L2_GAS_PRICE,
     TIMEOUT,
     TX_BATCH,
 };
@@ -793,6 +799,45 @@ async fn decision_reached_sends_correct_values() {
     // The price landed at the configured minimum (empty `min_l2_gas_price_per_height` → the
     // versioned-constants fallback), so the "at minimum" gauge must report 1.
     CONSENSUS_L2_GAS_PRICE_AT_MINIMUM.assert_eq(&metrics, 1);
+}
+
+// A proposer computes the next price twice for the same block, once for the fin and once at
+// decision time. The clamp counter must move once, so that it stays comparable with a validator's.
+#[tokio::test]
+async fn clamped_l2_gas_price_counts_once_per_committed_block() {
+    let (mut deps, _network) = create_test_and_network_deps();
+
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    CONSENSUS_L2_GAS_PRICE_CLAMPED.register();
+
+    // A full block at the ceiling drives the EIP-1559 result above it.
+    deps.setup_deps_for_build(SetupDepsArgs {
+        l2_gas_used: Some(VersionedConstants::latest_constants().max_block_size),
+        ..Default::default()
+    });
+    deps.batcher
+        .expect_decision_reached()
+        .times(1)
+        .return_once(move |_| Ok(DecisionReachedResponse::default()));
+    deps.state_sync_client.expect_add_new_block().times(1).return_once(|_| Ok(()));
+    deps.cende_ambassador.expect_prepare_blob_for_next_height().return_once(|_height| Ok(()));
+
+    let mut context = deps.build_context();
+    context.l2_gas_price = TEST_MAX_L2_GAS_PRICE;
+    // `fee_proposals_window` is empty, so the proposer's `fee_proposal_fri` is `l2_gas_price`.
+    let proposal_commitment =
+        proposal_commitment_from(PARTIAL_BLOCK_HASH, Some(TEST_MAX_L2_GAS_PRICE));
+
+    let _fin = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap().await;
+    context.decision_reached(HEIGHT_0, ROUND_0, proposal_commitment, false).await.unwrap();
+
+    assert_eq!(context.l2_gas_price, TEST_MAX_L2_GAS_PRICE);
+    CONSENSUS_L2_GAS_PRICE_CLAMPED.assert_eq(
+        &recorder.handle().render(),
+        1,
+        &[(LABEL_L2_GAS_PRICE_CLAMP_BOUND, "maximum")],
+    );
 }
 
 // The blob's `parent_proposal_commitment` must bind the parent block's `fee_proposal_fri`, which

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -97,6 +97,12 @@ pub(crate) const ETH_TO_FRI_RATE: u128 = 2 * u128::pow(10, 18);
 // where the specific value doesn't matter.
 pub(crate) const DEFAULT_STRK_TO_USD_RATE: u128 = 300_000_000_000_000_000;
 
+// L2 gas price minimum for the ceiling tests, and the ceiling it implies. Spelled out rather than
+// derived, so `test_price_constants_match_the_shipped_values` catches a change in the shipped
+// minimum or multiplier.
+pub(crate) const TEST_MIN_L2_GAS_PRICE: GasPrice = GasPrice(8_000_000_000);
+pub(crate) const TEST_MAX_L2_GAS_PRICE: GasPrice = GasPrice(80_000_000_000);
+
 pub(crate) static TX_BATCH: LazyLock<Vec<ConsensusTransaction>> =
     LazyLock::new(|| (0..3).map(generate_invoke_tx).collect());
 


### PR DESCRIPTION
Caps the published L2 gas price at 10x the minimum in force for the height, so congestion or a bad oracle cannot charge a user an unbounded price. The published price is what users pay, and this PR bounds it on its own.

`calculate_next_l2_gas_price_for_fin` now clamps **both** ways: an oracle-driven `fee_actual` floor above the ceiling would otherwise silently win over it. Adds `l2_gas_price_cap`, the single function proposer and validator both reach, and the `CONSENSUS_L2_GAS_PRICE_CLAMPED` counter labeled `minimum` / `maximum`.

The cap is **ungated** and applies to every block. The multiplier is a plain Rust `const`, not a versioned constant, moving to versioned constants in 0.14.4.

D1, first of the two-PR cap chain, parallel to the oracle stack. Consensus-critical.

---

## Detailed Summary for AI Bots

### What

Adds a ceiling to the L2 gas price the fee market publishes: `MAX_GAS_PRICE_MULTIPLIER` (10) times the minimum gas price in force for the height. The ceiling bounds what sustained congestion, or a broken STRK/USD oracle, can charge for a transaction.

- `fee_market/mod.rs`: `const MAX_GAS_PRICE_MULTIPLIER: u128 = 10`, guarded by `const _: () = assert!(MAX_GAS_PRICE_MULTIPLIER > 1)`, with `TODO(asaf-sw)` to move it to versioned constants in 0.14.4. No file under `apollo_versioned_constants` is touched: changing versioned constants mid-version was raised in review, and a JSON-loaded value cannot carry a compile-time assert.
- `l2_gas_price_cap(min_gas_price)` takes the already-resolved minimum, so `get_min_gas_price_for_height` is called once per height. Saturating, so a fat-fingered configured minimum cannot overflow.
- `calculate_next_l2_gas_price_for_fin`: `effective_min = min(max(config_min, fee_actual), cap)`, then `raw_price.clamp(effective_min, cap)`. The operator override bypasses both bounds.
- `NextL2GasPrice::record_clamping` logs and counts the bounds that shaped the published price. Called from one site, `sequencer_consensus_context.rs`'s post-decision `update_l2_gas_price`, which every node runs exactly once per committed block. Recording inside `calculate_next_l2_gas_price_for_fin` would double-count on every height a node proposes and count rounds that never commit.

### Why both bounds

`fee_actual`, the SNIP-35 oracle-derived median, enters the fin path as a *floor*, and the oracle can only push it up. A floor above the ceiling would win over the ceiling, so the floor is clamped to the ceiling before it is applied. There is no representable price between a floor above the ceiling and the ceiling itself, so collapsing them is the only consistent resolution.

The clamp must also be identical on both sides of consensus: the validator checks `next_l2_gas_price` by exact equality, so proposer and validator must reach the ceiling through the same function. That is why `l2_gas_price_cap` is a named function rather than an inline `min`.

### Clamp counter semantics

Two deliberate choices in `CONSENSUS_L2_GAS_PRICE_CLAMPED`:

- **Counter, not gauge**, unlike the neighbouring `consensus_l2_gas_price_at_minimum`. A gauge resets to 0 on restart and reads 0 until the first block of the new process, indistinguishable from a genuine "not clamped" reading, which would false-trigger a below-minimum alert. A counter's initial 0 is a true "no clamp yet", and #14947's alerts read a rate over it.
- **Both branches compare pre-clamp values.** The returned price no longer shows how far the computation drifted before being bound, so the branches test `current_price < effective_min` for the floor, and `raw_price > cap` or `snip35_min > cap` for the ceiling. `snip35_min > cap` counts as drift too: `effective_min` has already clipped it down by that point, which hides it from `raw_price`.

Per-label semantics:

- `minimum`: the price was raised to the effective minimum in force, that being the configured minimum or the SNIP-35 `fee_actual` floor when higher. It therefore also counts blocks ramping up towards a floor that has just risen.
- `maximum`: the ceiling bound the result. Two shapes count: the computed price capped down to the ceiling, and the SNIP-35 floor alone being clipped to it. In the second shape the published price can end up *below* the ceiling, because a price under the effective minimum is raised gradually (at most 1/`MIN_GAS_PRICE_INCREASE_DENOMINATOR` per block) rather than jumped to it. Both branches are independent, so a single block can count both labels.
- The steady state at the configured minimum, price already at the floor and nothing clamped, is **not** counted. `consensus_l2_gas_price_at_minimum` is the gauge for that state.

### Congestion reaches the ceiling with no oracle involved

With the v0.14.3 constants (`max_block_size` 5.8e9, `gas_target` 1.04e9, `gas_price_max_change_denominator` 48) a full block multiplies the EIP-1559 price by

```
1 + (5.8e9 - 1.04e9) / (1.04e9 * 48) = 1.0954
```

per block. From the configured minimum, sustained full blocks reach 10x in **26 blocks** (~68s at 2.6s blocks), with the oracle playing no part. This is why the published price needs its own ceiling and not just a bounded `fee_proposal` band. `test_sustained_congestion_stops_at_the_ceiling` covers it.

### No version gate

#14946 gated the cap on `starknet_version >= V0_14_3`. That gate cannot distinguish a pre-patch `V0_14_3` block from a post-patch one, so it fails at the only job a version gate has: marking a clean cutover at the cap's introduction. This PR drops it entirely, along with `L2_GAS_PRICE_CAP_VERSION`, `PRE_CAP_VERSION`, the `starknet_version` threading that existed only to feed it, the gate test, and the gate cases from three other tests (kept here in de-gated form).

Two claims from #14946's description are therefore **void** and do not apply here: the `V0_14_4` gate claim, and the "bit-identical replay" claim.

The compile-time `const _: () = assert!(MAX_GAS_PRICE_MULTIPLIER > 1)` replaces the removed gate tests: a multiplier of 0 or 1 would pin the published price at 0 or at the minimum, and the build now fails rather than a runtime assert firing during block production. With the multiplier a single Rust const there is no per-version JSON that can drift, so no version escapes the ceiling.

Rollout and replay exposure is theoretical: the L2 gas price has never exceeded this ceiling, so no recorded block replays differently and no proposer/validator skew is reachable in practice.

### Follow-ups

- `CONSENSUS_L2_GAS_PRICE_CLAMPED` has no dashboard panel or alert yet; both arrive in #14947. Marked in-code with a `[Temporary comment]`.
- `l2_gas_price_cap` has a single caller here and gains its second in D2 (#14946), which clamps the SNIP-35 `fee_proposal` band against the same ceiling. Also marked `[Temporary comment]`.

### Review round

- `record_clamping` no longer binds a `published_price` local; the log reads `self.published_price.0` as a positional argument alongside the other five.
- Fixed a pre-existing `code_style` failure that blocked this PR and its two descendants: the public doc on `calculate_next_l2_gas_price_for_fin` used an intra-doc link to the `pub(crate)` `NextL2GasPrice::record_clamping`, which `cargo doc --document-private-items` rejects. It is plain backticks now.

### Testing

In `crates/apollo_consensus_orchestrator/src/fee_market/test.rs`:

| test | covers |
| --- | --- |
| `test_price_constants_match_the_shipped_values` | the ceiling constants match the shipped multiplier |
| `test_l2_gas_price_cap_tracks_the_minimum` | the ceiling follows the per-height minimum |
| `test_price_pinned_at_the_ceiling_follows_the_ceiling_down` | a minimum that steps down mid-chain |
| `test_l2_gas_price_cap_saturates_at_an_extreme_configured_minimum` | no overflow on a fat-fingered minimum |
| `test_l2_gas_price_clamp_counters_record_once_per_committed_block` | the counters and their label values, once per committed block |
| `test_sustained_congestion_stops_at_the_ceiling` | the 26-block ramp stopping exactly at the ceiling |
| `test_fee_actual_above_the_ceiling_publishes_the_ceiling` | an oracle floor above the ceiling still publishing the ceiling |
| `test_override_bypasses_both_bounds` | the operator pin escaping both bounds |
| `test_ceiling_leaves_ordinary_prices_untouched` | in-band prices bit-identical to the uncapped EIP-1559 result |

The four version-gate tests and `PRE_CAP_VERSION` are dropped with the gate; the compile-time assert on the multiplier replaces what they guarded.
