### PR TITLE
apollo_l1_gas_price_types: currency pair and rate kind

### DIFF
--- a/crates/apollo_l1_gas_price_types/src/lib.rs
+++ b/crates/apollo_l1_gas_price_types/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod errors;
+#[cfg(test)]
+mod test;
+
 use std::fmt::Debug;
 use std::iter::Sum;
 use std::sync::Arc;
@@ -25,6 +28,35 @@ pub const DEFAULT_ETH_TO_FRI_RATE: ExchangeRate = 10_u128.pow(21);
 
 /// A currency conversion rate, as an 18-decimal fixed-point integer.
 pub type ExchangeRate = u128;
+
+/// Currency pair a reading or rate belongs to.
+pub const LABEL_NAME_CURRENCY_PAIR: &str = "currency_pair";
+
+/// The pair a reading or rate quotes.
+// [Temporary comment] No consumer yet: `labels()` lands with the oracle metrics PR, `pair_name()`
+// with the rate-bounds PR.
+#[derive(Clone, Copy, Debug, EnumIter, IntoStaticStr, PartialEq, Eq, VariantNames)]
+#[strum(serialize_all = "snake_case")]
+pub enum CurrencyPair {
+    EthUsd,
+    StrkUsd,
+    /// Derived from the two USD pairs: no Chainlink feed on Starknet quotes ETH in STRK.
+    EthStrk,
+}
+
+impl CurrencyPair {
+    pub fn pair_name(self) -> &'static str {
+        match self {
+            CurrencyPair::EthUsd => "ETH/USD",
+            CurrencyPair::StrkUsd => "STRK/USD",
+            CurrencyPair::EthStrk => "ETH/STRK",
+        }
+    }
+
+    pub fn labels(self) -> [(&'static str, &'static str); 1] {
+        [(LABEL_NAME_CURRENCY_PAIR, self.into())]
+    }
+}
 
 pub type SharedL1GasPriceClient = Arc<dyn L1GasPriceProviderClient>;
 pub type L1GasPriceProviderResult<T> = Result<T, L1GasPriceProviderError>;
@@ -123,6 +155,29 @@ pub trait ExchangeRateOracleClientTrait: Send + Sync + Debug {
         &self,
         timestamp: u64,
     ) -> Result<ExchangeRate, ExchangeRateOracleClientError>;
+}
+
+/// The rate an oracle client instance produces.
+// [Temporary comment] No implementors outside this module yet: the rate arithmetic and Chainlink
+// client PRs add them.
+pub trait RateKind: Send + Sync + Debug + 'static {
+    const PAIR: CurrencyPair;
+}
+
+/// FRI per ETH, derived from the ETH/USD and STRK/USD pairs.
+#[derive(Clone, Copy, Debug)]
+pub struct EthToFri;
+
+impl RateKind for EthToFri {
+    const PAIR: CurrencyPair = CurrencyPair::EthStrk;
+}
+
+/// USD per STRK.
+#[derive(Clone, Copy, Debug)]
+pub struct StrkToUsd;
+
+impl RateKind for StrkToUsd {
+    const PAIR: CurrencyPair = CurrencyPair::StrkUsd;
 }
 
 #[async_trait]

--- a/crates/apollo_l1_gas_price_types/src/test.rs
+++ b/crates/apollo_l1_gas_price_types/src/test.rs
@@ -1,0 +1,39 @@
+use std::collections::HashSet;
+
+use strum::{IntoEnumIterator, VariantNames};
+
+use crate::{CurrencyPair, EthToFri, RateKind, StrkToUsd, LABEL_NAME_CURRENCY_PAIR};
+
+/// Copy-pasted `pair_name` arms compile, so only a distinctness check catches them.
+#[test]
+fn pair_name_is_distinct_per_variant() {
+    let pair_names: HashSet<&str> = CurrencyPair::iter().map(CurrencyPair::pair_name).collect();
+    assert_eq!(pair_names.len(), CurrencyPair::VARIANTS.len());
+}
+
+#[test]
+fn labels_yield_snake_case_variant_name() {
+    for (currency_pair, snake_case_name) in [
+        (CurrencyPair::EthUsd, "eth_usd"),
+        (CurrencyPair::StrkUsd, "strk_usd"),
+        (CurrencyPair::EthStrk, "eth_strk"),
+    ] {
+        assert_eq!(currency_pair.labels(), [(LABEL_NAME_CURRENCY_PAIR, snake_case_name)]);
+    }
+}
+
+#[test]
+fn enum_iter_and_variant_names_cover_all_variants() {
+    assert_eq!(
+        CurrencyPair::iter().collect::<Vec<CurrencyPair>>(),
+        vec![CurrencyPair::EthUsd, CurrencyPair::StrkUsd, CurrencyPair::EthStrk]
+    );
+    assert_eq!(CurrencyPair::VARIANTS, ["eth_usd", "strk_usd", "eth_strk"]);
+}
+
+/// A transposed `RateKind::PAIR` compiles, since both markers map to a valid `CurrencyPair`.
+#[test]
+fn rate_kind_markers_map_to_their_pair() {
+    assert_eq!(EthToFri::PAIR, CurrencyPair::EthStrk);
+    assert_eq!(StrkToUsd::PAIR, CurrencyPair::StrkUsd);
+}


### PR DESCRIPTION
Adds the currency-pair vocabulary the Chainlink oracle work is built on: `CurrencyPair` (`EthUsd`, `StrkUsd`, `EthStrk`) with its `labels()` metric label and `pair_name()` display form, plus the `RateKind` trait and the `EthToFri` / `StrkToUsd` markers that carry a rate's pair as a type parameter.

A3, the leaf of the split of #14942. Types only, in `apollo_l1_gas_price_types`.

- Deferred: nothing constructs or reads any of it yet. Each artifact carries a `[Temporary comment]` naming the later PR that consumes it, dropped as those land. `config_schema.json` is untouched and there is no behavior change.
- Worth a look: the four tests exist to catch transposed or copy-pasted mappings. Both `pair_name` arms are string literals and every marker's `PAIR` compiles either way, so nothing else in the stack would notice.

---

## Detailed Summary for AI Bots

Adds the currency-pair vocabulary the Chainlink oracle work is built on, as the leaf of that stack. No behavior change: nothing constructs or reads these types yet, and `config_schema.json` is untouched.

Two artifacts, both `pub` in `apollo_l1_gas_price_types`:

`CurrencyPair` (`EthUsd`, `StrkUsd`, `EthStrk`) names which pair a reading, rate or guard trip belongs to. Without it a stale ETH/USD leg and a stale STRK/USD leg are indistinguishable, since the ETH/STRK rate reads both. `EthStrk` has no Chainlink feed on Starknet, so it is derived from the two USD pairs. It carries two accessors with distinct consumers:
- `labels()` returns the `snake_case` strum name under `LABEL_NAME_CURRENCY_PAIR`, read by the per-pair guard counters in the oracle metrics PR.
- `pair_name()` returns the display form (`ETH/USD`) used in guard error messages and as the per-pair key for the rate bounds in the rate-bounds PR.

`RateKind` with the marker types `EthToFri` and `StrkToUsd` carries the pair a rate quotes as a type parameter rather than a field, so a client cannot be handed another rate's config and a pair with no impl fails to compile rather than at runtime. The rate arithmetic PR is generic over `RateKind`; the Chainlink client PR instantiates it per marker.

Each artifact carries a `[Temporary comment]` naming its consumer, to be dropped as the consumers land.

`strum` with the `derive` feature was already a dependency, so `Cargo.toml` is unchanged.

### Tests

New `crates/apollo_l1_gas_price_types/src/test.rs`, the crate's first tests:
- `pair_name_is_distinct_per_variant`: every `pair_name` arm is a string literal, so a copy-paste between them compiles and passes every other test in the stack. Distinctness is what catches it.
- `labels_yield_snake_case_variant_name`: pins the label values the metrics PR will register permutations against.
- `enum_iter_and_variant_names_cover_all_variants`: pins the `EnumIter` order and the `VariantNames` list, so a new pair added later cannot silently skip a consumer that iterates.
- `rate_kind_markers_map_to_their_pair`: pins each marker's `PAIR`, since a transposed mapping compiles and passes every other test.

### Verification

- `./scripts/rust_fmt.sh`: clean.
- `RUSTFLAGS="-D warnings" cargo clippy -p apollo_l1_gas_price_types --all-targets --all-features`: clean.
- `SEED=0 cargo nextest run -p apollo_l1_gas_price_types`: 4 tests run, 4 passed.

