### PR TITLE
apollo_l1_gas_price,apollo_l1_gas_price_types,apollo_dashboard: fold oracle metrics onto labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,7 @@ dependencies = [
  "rstest",
  "serde_json",
  "starknet_api",
+ "strum",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -438,7 +438,7 @@
           "description": "STRK/USD rate from the oracle, in USD (raw value has 18 decimals)",
           "type": "timeseries",
           "exprs": [
-            "snip35_strk_usd_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / 1e18"
+            "exchange_rate_oracle_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"strk_usd\"} / 1e18"
           ],
           "extra_params": {}
         },
@@ -447,29 +447,38 @@
           "description": "Indicates whether the STRK→USD rate query succeeded (1m window)",
           "type": "timeseries",
           "exprs": [
-            "changes(snip35_strk_usd_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[1m])"
+            "changes(exchange_rate_oracle_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"strk_usd\"}[1m])"
           ],
           "extra_params": {
             "log_query": "\"Caching conversion rate for timestamp\""
           }
         },
         {
-          "title": "STRK/USD Rate Query Error Count",
-          "description": "The number of times the STRK→USD rate query failed (10m window)",
+          "title": "STRK/USD Rate Query Error Count by Error Type",
+          "description": "The number of times the STRK→USD rate query failed, split by error type (10m window)",
           "type": "timeseries",
           "exprs": [
-            "increase(snip35_strk_usd_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m])"
+            "increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"strk_usd\"}[10m]) > 0"
           ],
           "extra_params": {
             "log_query": "\"Failed to resolve query to\" OR \"Timeout when resolving query to\" OR \"Query failed to join handle for timestamp\""
           }
         },
         {
+          "title": "STRK/USD Rate Query Total Error Count",
+          "description": "The number of times the STRK→USD rate query failed, summed over error types (10m window). The error count alert thresholds this sum.",
+          "type": "timeseries",
+          "exprs": [
+            "sum(increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"strk_usd\"}[10m]))"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "Seconds Since Last Successful STRK→USD Rate Update",
           "description": "The number of seconds since the last successful STRK→USD rate update (assuming there was an update in the last 12 hours).",
           "type": "timeseries",
           "exprs": [
-            "time() - max(last_over_time(snip35_strk_usd_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h]))"
+            "time() - max(last_over_time(exchange_rate_oracle_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"strk_usd\"}[12h]))"
           ],
           "extra_params": {
             "unit": "s",
@@ -1687,7 +1696,7 @@
           "description": "The number of seconds since the last successful ETH→STRK rate update (assuming there was an update in the last 12 hours). Expected cadence: ~15 minutes.",
           "type": "timeseries",
           "exprs": [
-            "time() - max(last_over_time(eth_to_strk_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[12h]))"
+            "time() - max(last_over_time(exchange_rate_oracle_last_success_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"eth_strk\"}[12h]))"
           ],
           "extra_params": {
             "unit": "s",
@@ -1715,29 +1724,38 @@
           "description": "Indicates whether the ETH→STRK rate query succeeded (1m window) \nExpected to be 1 every 15 minutes.",
           "type": "timeseries",
           "exprs": [
-            "changes(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[1m])"
+            "changes(exchange_rate_oracle_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"eth_strk\"}[1m])"
           ],
           "extra_params": {
             "log_query": "\"Caching conversion rate for timestamp\""
           }
         },
         {
-          "title": "ETH→STRK Rate Query Error Count",
-          "description": "The number of times the ETH→STRK rate query failed (10m window)",
+          "title": "ETH→STRK Rate Query Error Count by Error Type",
+          "description": "The number of times the ETH→STRK rate query failed, split by error type (10m window)",
           "type": "timeseries",
           "exprs": [
-            "increase(eth_to_strk_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m])"
+            "increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"eth_strk\"}[10m]) > 0"
           ],
           "extra_params": {
             "log_query": "\"Failed to resolve query to\" OR \"Timeout when resolving query to\" OR \"Query failed to join handle for timestamp\""
           }
         },
         {
+          "title": "ETH→STRK Rate Query Total Error Count",
+          "description": "The number of times the ETH→STRK rate query failed, summed over error types (10m window). The error count alert thresholds this sum.",
+          "type": "timeseries",
+          "exprs": [
+            "sum(increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"eth_strk\"}[10m]))"
+          ],
+          "extra_params": {}
+        },
+        {
           "title": "ETH→STRK rate",
           "description": "ETH→STRK rate (divided by DEFAULT_ETH_TO_FRI_RATE=1000000000000000000000)",
           "type": "timeseries",
           "exprs": [
-            "eth_to_strk_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"} / 1000000000000000000000"
+            "exchange_rate_oracle_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", currency_pair=\"eth_strk\"} / 1000000000000000000000"
           ],
           "extra_params": {
             "log_query": "\"Caching conversion rate for timestamp\""

--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -902,7 +902,7 @@
       "name": "eth_to_strk_error_count",
       "title": "Eth to Strk error count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(eth_to_strk_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"eth_strk\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -928,7 +928,7 @@
       "name": "eth_to_strk_rate_frozen",
       "title": "Eth to Strk rate frozen",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "sum(changes(eth_to_strk_rate{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))",
+      "expr": "sum(changes(exchange_rate_oracle_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"eth_strk\"}[1h]))",
       "conditions": [
         {
           "evaluator": {
@@ -954,7 +954,7 @@
       "name": "eth_to_strk_success_count",
       "title": "Eth to Strk success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(eth_to_strk_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(exchange_rate_oracle_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"eth_strk\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -2176,7 +2176,7 @@
       "name": "strk_to_usd_error_count",
       "title": "Strk to Usd error count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(snip35_strk_usd_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(exchange_rate_oracle_error_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"strk_usd\"}[1h])) or vector(0)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {
@@ -2202,7 +2202,7 @@
       "name": "strk_to_usd_rate_frozen",
       "title": "Strk to Usd rate frozen",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "sum(changes(snip35_strk_usd_rate{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))",
+      "expr": "sum(changes(exchange_rate_oracle_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"strk_usd\"}[1h]))",
       "conditions": [
         {
           "evaluator": {
@@ -2228,7 +2228,7 @@
       "name": "strk_to_usd_success_count",
       "title": "Strk to Usd success count",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(snip35_strk_usd_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "(sum(increase(exchange_rate_oracle_success_count{cluster=~\"$cluster\", namespace=~\"$namespace\", currency_pair=\"strk_usd\"}[1h]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l1_gas_prices.rs
@@ -1,14 +1,12 @@
 use apollo_consensus_orchestrator::metrics::CONSENSUS_L2_GAS_PRICE_AT_MINIMUM;
 use apollo_l1_gas_price::metrics::{
-    ETH_TO_STRK_ERROR_COUNT,
-    ETH_TO_STRK_RATE,
-    ETH_TO_STRK_SUCCESS_COUNT,
+    EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+    EXCHANGE_RATE_ORACLE_RATE,
+    EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT,
-    SNIP35_STRK_USD_ERROR_COUNT,
-    SNIP35_STRK_USD_RATE,
-    SNIP35_STRK_USD_SUCCESS_COUNT,
 };
+use apollo_l1_gas_price_types::{CurrencyPair, LABEL_NAME_CURRENCY_PAIR};
 use apollo_metrics::metrics::MetricQueryName;
 
 use crate::alert_placeholders::SeverityValueOrPlaceholder;
@@ -22,14 +20,14 @@ use crate::alerts::{
     ObserverApplicability,
     PENDING_DURATION_DEFAULT,
 };
-use crate::query_builder::sum_increase;
+use crate::query_builder::{sum_increase, sum_increase_with_label, with_label};
 
 pub(crate) fn get_eth_to_strk_success_count_alert() -> Alert {
     const ALERT_NAME: &str = "eth_to_strk_success_count";
     oracle_success_count_alert(
         ALERT_NAME,
         "Eth to Strk success count",
-        &ETH_TO_STRK_SUCCESS_COUNT,
+        CurrencyPair::EthStrk,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
     )
 }
@@ -38,7 +36,7 @@ pub(crate) fn get_eth_to_strk_error_count_alert() -> Alert {
     oracle_error_count_alert(
         "eth_to_strk_error_count",
         "Eth to Strk error count",
-        &ETH_TO_STRK_ERROR_COUNT,
+        CurrencyPair::EthStrk,
         AlertSeverity::Informational,
     )
 }
@@ -48,7 +46,7 @@ pub(crate) fn get_strk_to_usd_success_count_alert() -> Alert {
     oracle_success_count_alert(
         ALERT_NAME,
         "Strk to Usd success count",
-        &SNIP35_STRK_USD_SUCCESS_COUNT,
+        CurrencyPair::StrkUsd,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
     )
 }
@@ -57,7 +55,7 @@ pub(crate) fn get_strk_to_usd_error_count_alert() -> Alert {
     oracle_error_count_alert(
         "strk_to_usd_error_count",
         "Strk to Usd error count",
-        &SNIP35_STRK_USD_ERROR_COUNT,
+        CurrencyPair::StrkUsd,
         AlertSeverity::Informational,
     )
 }
@@ -67,7 +65,7 @@ pub(crate) fn get_eth_to_strk_rate_frozen_alert() -> Alert {
     oracle_rate_frozen_alert(
         ALERT_NAME,
         "Eth to Strk rate frozen",
-        &ETH_TO_STRK_RATE,
+        CurrencyPair::EthStrk,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
     )
 }
@@ -77,7 +75,7 @@ pub(crate) fn get_strk_to_usd_rate_frozen_alert() -> Alert {
     oracle_rate_frozen_alert(
         ALERT_NAME,
         "Strk to Usd rate frozen",
-        &SNIP35_STRK_USD_RATE,
+        CurrencyPair::StrkUsd,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
     )
 }
@@ -146,14 +144,19 @@ pub(crate) fn get_l2_gas_price_at_minimum_alert() -> Alert {
 fn oracle_success_count_alert(
     name: &str,
     title: &str,
-    success_count_metric: &dyn MetricQueryName,
+    pair: CurrencyPair,
     severity: impl Into<SeverityValueOrPlaceholder>,
 ) -> Alert {
     Alert::new(
         name,
         title,
         EvaluationRate::Default,
-        sum_increase(success_count_metric, "1h"),
+        sum_increase_with_label(
+            &EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
+            LABEL_NAME_CURRENCY_PAIR,
+            pair.into(),
+            "1h",
+        ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         severity,
@@ -163,19 +166,30 @@ fn oracle_success_count_alert(
 
 /// Alert if an exchange-rate oracle exceeded the failure threshold in the last hour.
 ///
+/// Sums over every `error_type` of the pair: the threshold is about how often the oracle failed,
+/// not about which variant it failed with.
+///
 /// `or vector(0)` keeps the query defined (evaluating to 0) when the metric has no samples yet,
 /// so the alert stays silent instead of going to no-data before the first error is recorded.
 fn oracle_error_count_alert(
     name: &str,
     title: &str,
-    error_count_metric: &dyn MetricQueryName,
+    pair: CurrencyPair,
     severity: impl Into<SeverityValueOrPlaceholder>,
 ) -> Alert {
     Alert::new(
         name,
         title,
         EvaluationRate::Default,
-        format!("{} or vector(0)", sum_increase(error_count_metric, "1h")),
+        format!(
+            "{} or vector(0)",
+            sum_increase_with_label(
+                &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+                LABEL_NAME_CURRENCY_PAIR,
+                pair.into(),
+                "1h",
+            )
+        ),
         vec![AlertCondition::new(AlertComparisonOp::GreaterThan, 10.0, AlertLogicalOp::And)],
         "1m",
         severity,
@@ -197,14 +211,17 @@ fn oracle_error_count_alert(
 fn oracle_rate_frozen_alert(
     name: &str,
     title: &str,
-    rate_metric: &dyn MetricQueryName,
+    pair: CurrencyPair,
     severity: impl Into<SeverityValueOrPlaceholder>,
 ) -> Alert {
     Alert::new(
         name,
         title,
         EvaluationRate::Default,
-        format!("sum(changes({}[1h]))", rate_metric.get_name_with_filter()),
+        format!(
+            "sum(changes({}[1h]))",
+            with_label(&EXCHANGE_RATE_ORACLE_RATE, LABEL_NAME_CURRENCY_PAIR, pair.into())
+        ),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         severity,

--- a/crates/apollo_dashboard/src/panels/consensus.rs
+++ b/crates/apollo_dashboard/src/panels/consensus.rs
@@ -62,11 +62,12 @@ use apollo_consensus_orchestrator::metrics::{
     SNIP35_FEE_TARGET_FRI,
 };
 use apollo_l1_gas_price::metrics::{
-    SNIP35_STRK_USD_ERROR_COUNT,
-    SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS,
-    SNIP35_STRK_USD_RATE,
-    SNIP35_STRK_USD_SUCCESS_COUNT,
+    EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+    EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    EXCHANGE_RATE_ORACLE_RATE,
+    EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
 };
+use apollo_l1_gas_price_types::{CurrencyPair, LABEL_NAME_CURRENCY_PAIR};
 use apollo_metrics::metrics::MetricQueryName;
 use apollo_network::metrics::{LABEL_NAME_BROADCAST_DROP_REASON, LABEL_NAME_EVENT_TYPE};
 use apollo_state_sync_metrics::metrics::STATE_SYNC_CLASS_MANAGER_MARKER;
@@ -76,8 +77,11 @@ use crate::dashboard::Row;
 use crate::panel::{traffic_light_thresholds, Panel, PanelType, Unit};
 use crate::query_builder::{
     increase,
-    seconds_since_last_timestamp,
+    increase_with_label,
+    seconds_since_last_timestamp_with_label,
     sum_by_label,
+    sum_increase_with_label,
+    with_label,
     DisplayMethod,
     DEFAULT_DURATION,
     RANGE_DURATION,
@@ -763,16 +767,32 @@ fn get_panel_snip35_strk_usd_rate() -> Panel {
     Panel::new(
         "STRK/USD Rate (USD)",
         "STRK/USD rate from the oracle, in USD (raw value has 18 decimals)",
-        format!("{} / 1e18", SNIP35_STRK_USD_RATE.get_name_with_filter()),
+        format!(
+            "{} / 1e18",
+            with_label(
+                &EXCHANGE_RATE_ORACLE_RATE,
+                LABEL_NAME_CURRENCY_PAIR,
+                CurrencyPair::StrkUsd.into()
+            )
+        ),
         PanelType::TimeSeries,
     )
 }
 
 fn get_panel_snip35_strk_usd_error_count() -> Panel {
     Panel::new(
-        "STRK/USD Rate Query Error Count",
-        format!("The number of times the STRK→USD rate query failed ({DEFAULT_DURATION} window)"),
-        increase(&SNIP35_STRK_USD_ERROR_COUNT, DEFAULT_DURATION),
+        "STRK/USD Rate Query Error Count by Error Type",
+        format!(
+            "The number of times the STRK→USD rate query failed, split by error type \
+             ({DEFAULT_DURATION} window)"
+        ),
+        increase_with_label(
+            &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+            LABEL_NAME_CURRENCY_PAIR,
+            CurrencyPair::StrkUsd.into(),
+            DEFAULT_DURATION,
+            true,
+        ),
         PanelType::TimeSeries,
     )
     .with_log_query(
@@ -781,11 +801,35 @@ fn get_panel_snip35_strk_usd_error_count() -> Panel {
     )
 }
 
+fn get_panel_snip35_strk_usd_total_error_count() -> Panel {
+    Panel::new(
+        "STRK/USD Rate Query Total Error Count",
+        format!(
+            "The number of times the STRK→USD rate query failed, summed over error types \
+             ({DEFAULT_DURATION} window). The error count alert thresholds this sum."
+        ),
+        sum_increase_with_label(
+            &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+            LABEL_NAME_CURRENCY_PAIR,
+            CurrencyPair::StrkUsd.into(),
+            DEFAULT_DURATION,
+        ),
+        PanelType::TimeSeries,
+    )
+}
+
 fn get_panel_snip35_strk_usd_success_count() -> Panel {
     Panel::new(
         "STRK/USD Rate Query Success (Binary)",
         "Indicates whether the STRK→USD rate query succeeded (1m window)",
-        format!("changes({}[1m])", SNIP35_STRK_USD_SUCCESS_COUNT.get_name_with_filter()),
+        format!(
+            "changes({}[1m])",
+            with_label(
+                &EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
+                LABEL_NAME_CURRENCY_PAIR,
+                CurrencyPair::StrkUsd.into()
+            )
+        ),
         PanelType::TimeSeries,
     )
     .with_log_query("Caching conversion rate for timestamp")
@@ -796,7 +840,11 @@ fn get_panel_snip35_strk_usd_seconds_since_last_successful_update() -> Panel {
         "Seconds Since Last Successful STRK→USD Rate Update",
         "The number of seconds since the last successful STRK→USD rate update (assuming there was \
          an update in the last 12 hours).",
-        seconds_since_last_timestamp(&SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS),
+        seconds_since_last_timestamp_with_label(
+            &EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
+            LABEL_NAME_CURRENCY_PAIR,
+            CurrencyPair::StrkUsd.into(),
+        ),
         PanelType::TimeSeries,
     )
     .with_unit(Unit::Seconds)
@@ -814,6 +862,7 @@ pub(crate) fn get_snip35_row() -> Row {
             get_panel_snip35_strk_usd_rate(),
             get_panel_snip35_strk_usd_success_count(),
             get_panel_snip35_strk_usd_error_count(),
+            get_panel_snip35_strk_usd_total_error_count(),
             get_panel_snip35_strk_usd_seconds_since_last_successful_update(),
         ],
     )

--- a/crates/apollo_dashboard/src/panels/l1_gas_price.rs
+++ b/crates/apollo_dashboard/src/panels/l1_gas_price.rs
@@ -1,8 +1,8 @@
 use apollo_l1_gas_price::metrics::{
-    ETH_TO_STRK_ERROR_COUNT,
-    ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS,
-    ETH_TO_STRK_RATE,
-    ETH_TO_STRK_SUCCESS_COUNT,
+    EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+    EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    EXCHANGE_RATE_ORACLE_RATE,
+    EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
     L1_DATA_GAS_PRICE_LATEST_MEAN_VALUE,
     L1_GAS_PRICE_LATEST_MEAN_VALUE,
     L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY,
@@ -12,18 +12,38 @@ use apollo_l1_gas_price::metrics::{
     L1_GAS_PRICE_SCRAPER_REORG_DETECTED,
     L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT,
 };
-use apollo_l1_gas_price_types::DEFAULT_ETH_TO_FRI_RATE;
+use apollo_l1_gas_price_types::{CurrencyPair, DEFAULT_ETH_TO_FRI_RATE, LABEL_NAME_CURRENCY_PAIR};
 use apollo_metrics::metrics::MetricQueryName;
 
 use crate::dashboard::Row;
 use crate::panel::{traffic_light_thresholds, Panel, PanelType, Unit};
-use crate::query_builder::{increase, seconds_since_last_timestamp, DEFAULT_DURATION};
+use crate::query_builder::{
+    increase,
+    increase_with_label,
+    seconds_since_last_timestamp,
+    seconds_since_last_timestamp_with_label,
+    sum_increase_with_label,
+    with_label,
+    DEFAULT_DURATION,
+};
 
+// TODO(Asaf): extract the ETH/STRK panels here and the STRK/USD panels in `panels/consensus.rs`
+// into shared functions parameterized by `CurrencyPair`. They differ only in the pair they filter
+// on and in their titles.
 fn get_panel_eth_to_strk_error_count() -> Panel {
     Panel::new(
-        "ETH→STRK Rate Query Error Count",
-        format!("The number of times the ETH→STRK rate query failed ({DEFAULT_DURATION} window)"),
-        increase(&ETH_TO_STRK_ERROR_COUNT, DEFAULT_DURATION),
+        "ETH→STRK Rate Query Error Count by Error Type",
+        format!(
+            "The number of times the ETH→STRK rate query failed, split by error type \
+             ({DEFAULT_DURATION} window)"
+        ),
+        increase_with_label(
+            &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+            LABEL_NAME_CURRENCY_PAIR,
+            CurrencyPair::EthStrk.into(),
+            DEFAULT_DURATION,
+            true,
+        ),
         PanelType::TimeSeries,
     )
     .with_log_query(
@@ -32,12 +52,33 @@ fn get_panel_eth_to_strk_error_count() -> Panel {
     )
 }
 
+fn get_panel_eth_to_strk_total_error_count() -> Panel {
+    Panel::new(
+        "ETH→STRK Rate Query Total Error Count",
+        format!(
+            "The number of times the ETH→STRK rate query failed, summed over error types \
+             ({DEFAULT_DURATION} window). The error count alert thresholds this sum."
+        ),
+        sum_increase_with_label(
+            &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+            LABEL_NAME_CURRENCY_PAIR,
+            CurrencyPair::EthStrk.into(),
+            DEFAULT_DURATION,
+        ),
+        PanelType::TimeSeries,
+    )
+}
+
 fn get_panel_eth_to_strk_seconds_since_last_successful_update() -> Panel {
     Panel::new(
         "Seconds Since Last Successful ETH→STRK Rate Update",
         "The number of seconds since the last successful ETH→STRK rate update (assuming there was \
          an update in the last 12 hours). Expected cadence: ~15 minutes.",
-        seconds_since_last_timestamp(&ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS),
+        seconds_since_last_timestamp_with_label(
+            &EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
+            LABEL_NAME_CURRENCY_PAIR,
+            CurrencyPair::EthStrk.into(),
+        ),
         PanelType::TimeSeries,
     )
     .with_unit(Unit::Seconds)
@@ -49,7 +90,14 @@ fn get_panel_eth_to_strk_success_count() -> Panel {
         "ETH→STRK Rate Query Success (binary)",
         "Indicates whether the ETH→STRK rate query succeeded (1m window) \nExpected to be 1 every \
          15 minutes.",
-        format!("changes({}[1m])", ETH_TO_STRK_SUCCESS_COUNT.get_name_with_filter()),
+        format!(
+            "changes({}[1m])",
+            with_label(
+                &EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
+                LABEL_NAME_CURRENCY_PAIR,
+                CurrencyPair::EthStrk.into()
+            )
+        ),
         PanelType::TimeSeries,
     )
     .with_log_query("Caching conversion rate for timestamp")
@@ -59,7 +107,15 @@ fn get_panel_eth_to_strk_rate() -> Panel {
     Panel::new(
         "ETH→STRK rate",
         format!("ETH→STRK rate (divided by DEFAULT_ETH_TO_FRI_RATE={DEFAULT_ETH_TO_FRI_RATE})"),
-        format!("{} / {}", ETH_TO_STRK_RATE.get_name_with_filter(), DEFAULT_ETH_TO_FRI_RATE),
+        format!(
+            "{} / {}",
+            with_label(
+                &EXCHANGE_RATE_ORACLE_RATE,
+                LABEL_NAME_CURRENCY_PAIR,
+                CurrencyPair::EthStrk.into()
+            ),
+            DEFAULT_ETH_TO_FRI_RATE
+        ),
         PanelType::TimeSeries,
     )
     .with_log_query("Caching conversion rate for timestamp")
@@ -165,6 +221,7 @@ pub(crate) fn get_l1_gas_price_row() -> Row {
             get_panel_eth_to_strk_seconds_since_last_successful_update(),
             get_panel_eth_to_strk_success_count(),
             get_panel_eth_to_strk_error_count(),
+            get_panel_eth_to_strk_total_error_count(),
             get_panel_eth_to_strk_rate(),
             get_panel_l1_gas_price_provider_insufficient_history(),
             get_panel_l1_gas_price_scraper_success_count(),

--- a/crates/apollo_dashboard/src/query_builder.rs
+++ b/crates/apollo_dashboard/src/query_builder.rs
@@ -32,6 +32,46 @@ pub(crate) fn seconds_since_last_timestamp(metric: &dyn MetricQueryName) -> Stri
     format!("time() - max(last_over_time({}[12h]))", metric.get_name_with_filter())
 }
 
+/// Narrows a labeled metric to one label value.
+///
+/// Example: `with_label(&m, "currency_pair", "eth_strk")` → `m{..., currency_pair="eth_strk"}`
+pub(crate) fn with_label(metric: &dyn MetricQueryName, label: &str, value: &str) -> String {
+    metric.get_name_with_filer_and_additional_fields(&format!("{label}=\"{value}\""))
+}
+
+/// `increase()` of one label value of a labeled metric.
+///
+/// - `filter_zeros`: if `true`, appends ` > 0`.
+pub(crate) fn increase_with_label(
+    metric: &dyn MetricQueryName,
+    label: &str,
+    value: &str,
+    duration: &str,
+    filter_zeros: bool,
+) -> String {
+    let filter = if filter_zeros { " > 0" } else { "" };
+    format!("increase({}[{}]){}", with_label(metric, label, value), duration, filter)
+}
+
+/// `sum(increase())` of one label value of a labeled metric, aggregating across instances.
+pub(crate) fn sum_increase_with_label(
+    metric: &dyn MetricQueryName,
+    label: &str,
+    value: &str,
+    duration: &str,
+) -> String {
+    format!("sum({})", increase_with_label(metric, label, value, duration, false))
+}
+
+/// Seconds since the last event timestamp recorded for one label value of a labeled gauge.
+pub(crate) fn seconds_since_last_timestamp_with_label(
+    metric: &dyn MetricQueryName,
+    label: &str,
+    value: &str,
+) -> String {
+    format!("time() - max(last_over_time({}[12h]))", with_label(metric, label, value))
+}
+
 /// Builds `sum(increase(<metric>[<duration>]))` for aggregating a counter across all instances.
 ///
 /// Example: `sum_increase(&m, "1h")` → `sum(increase(my_counter{...}[1h]))`

--- a/crates/apollo_l1_gas_price/Cargo.toml
+++ b/crates/apollo_l1_gas_price/Cargo.toml
@@ -22,6 +22,7 @@ reqwest.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 starknet_api.workspace = true
+strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }

--- a/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
+++ b/crates/apollo_l1_gas_price/src/exchange_rate_oracle.rs
@@ -6,9 +6,11 @@ use std::time::Duration;
 
 use apollo_config::secrets::Sensitive;
 use apollo_l1_gas_price_config::config::ExchangeRateOracleConfig;
-use apollo_l1_gas_price_types::errors::ExchangeRateOracleClientError;
+use apollo_l1_gas_price_types::errors::{
+    ExchangeRateOracleClientError,
+    ExchangeRateOracleErrorType,
+};
 use apollo_l1_gas_price_types::{ExchangeRate, ExchangeRateOracleClientTrait};
-use apollo_metrics::metrics::set_unix_now_seconds;
 use async_trait::async_trait;
 use futures::FutureExt;
 use lru::LruCache;
@@ -146,12 +148,15 @@ impl ExchangeRateOracleClient {
                     }
                     Ok(Err(e)) => {
                         warn!("Failed to resolve query to {url}: {e:?}");
+                        metrics.record_error((&e).into());
                     }
                     Err(_) => {
                         warn!("Timeout when resolving query to {url}");
+                        // The enum has no timeout variant: a request that ran out of time is
+                        // counted as a failed request.
+                        metrics.record_error(ExchangeRateOracleErrorType::RequestError);
                     }
                 };
-                metrics.error_count.increment(1);
             }
             warn!("All {list_len} URLs in the list failed for timestamp {adjusted_timestamp}");
             Err(ExchangeRateOracleClientError::AllUrlsFailedError(
@@ -206,9 +211,7 @@ fn resolve_query(
             decimals,
         ));
     }
-    metrics.success_count.increment(1);
-    set_unix_now_seconds(metrics.last_success_timestamp);
-    metrics.rate.set_lossy(rate);
+    metrics.record_success(rate);
     Ok(rate)
 }
 
@@ -265,7 +268,7 @@ impl ExchangeRateOracleClientTrait for ExchangeRateOracleClient {
             }
             Err(e) => {
                 warn!("Query failed to join handle for timestamp {timestamp}: {e:?}");
-                self.metrics.error_count.increment(1);
+                self.metrics.record_error(ExchangeRateOracleErrorType::JoinError);
                 // Must remove failed query from the cache, to avoid re-polling it.
                 queries.pop(&quantized_timestamp);
                 return Err(ExchangeRateOracleClientError::JoinError(e.to_string()));

--- a/crates/apollo_l1_gas_price/src/metrics.rs
+++ b/crates/apollo_l1_gas_price/src/metrics.rs
@@ -7,9 +7,21 @@ use apollo_infra::metrics::{
     RemoteClientMetrics,
     RemoteServerMetrics,
 };
-use apollo_l1_gas_price_types::L1_GAS_PRICE_REQUEST_LABELS;
-use apollo_metrics::metrics::{MetricCounter, MetricDetails, MetricGauge};
-use apollo_metrics::{define_infra_metrics, define_metrics};
+use apollo_l1_gas_price_types::errors::ExchangeRateOracleErrorType;
+use apollo_l1_gas_price_types::{
+    CurrencyPair,
+    ExchangeRate,
+    L1_GAS_PRICE_REQUEST_LABELS,
+    LABEL_NAME_CURRENCY_PAIR,
+    LABEL_NAME_ERROR_TYPE,
+};
+use apollo_metrics::metrics::{
+    set_unix_now_seconds_with_labels,
+    LabeledMetricCounter,
+    LabeledMetricGauge,
+    MetricDetails,
+};
+use apollo_metrics::{define_infra_metrics, define_metrics, generate_permutation_labels};
 
 #[cfg(test)]
 #[path = "metrics_test.rs"]
@@ -17,37 +29,48 @@ mod metrics_test;
 
 define_infra_metrics!(l1_gas_price);
 
+generate_permutation_labels! {
+    CURRENCY_PAIR_LABELS,
+    (LABEL_NAME_CURRENCY_PAIR, CurrencyPair),
+}
+
+generate_permutation_labels! {
+    CURRENCY_PAIR_AND_ERROR_TYPE_LABELS,
+    (LABEL_NAME_CURRENCY_PAIR, CurrencyPair),
+    (LABEL_NAME_ERROR_TYPE, ExchangeRateOracleErrorType),
+}
+
 define_metrics!(
     L1GasPrice => {
         MetricCounter { L1_GAS_PRICE_PROVIDER_INSUFFICIENT_HISTORY, "l1_gas_price_provider_insufficient_history", "Number of times the L1 gas price provider calculated an average with too few blocks", init=0 },
         MetricCounter { L1_GAS_PRICE_SCRAPER_SUCCESS_COUNT, "l1_gas_price_scraper_success_count", "Number of times the L1 gas price scraper successfully scraped and updated gas prices", init=0 },
         MetricCounter { L1_GAS_PRICE_SCRAPER_BASELAYER_ERROR_COUNT, "l1_gas_price_scraper_baselayer_error_count", "Number of times the L1 gas price scraper encountered an error while scraping the base layer", init=0 },
         MetricCounter { L1_GAS_PRICE_SCRAPER_REORG_DETECTED, "l1_gas_price_scraper_reorg_detected", "Number of times the L1 gas price scraper detected a reorganization in the base layer", init=0 },
-        MetricCounter { ETH_TO_STRK_ERROR_COUNT, "eth_to_strk_error_count", "Number of times the query to the Eth to Strk oracle failed due to an error or timeout", init=0 },
-        MetricCounter { ETH_TO_STRK_SUCCESS_COUNT, "eth_to_strk_success_count", "Number of times the query to the Eth to Strk oracle succeeded", init=0 },
-        MetricCounter { SNIP35_STRK_USD_ERROR_COUNT, "snip35_strk_usd_error_count", "Number of times the query to the STRK to USD oracle failed due to an error or timeout", init=0 },
-        MetricCounter { SNIP35_STRK_USD_SUCCESS_COUNT, "snip35_strk_usd_success_count", "Number of times the query to the STRK to USD oracle succeeded", init=0 },
         MetricGauge { L1_GAS_PRICE_SCRAPER_LAST_SUCCESS_TIMESTAMP_SECONDS, "l1_gas_price_scraper_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful L1 gas price scrape" },
-        MetricGauge { ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS, "eth_to_strk_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful ETH→STRK oracle query" },
-        MetricGauge { SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS, "snip35_strk_usd_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful STRK→USD oracle query" },
         MetricGauge { L1_GAS_PRICE_SCRAPER_LATEST_SCRAPED_BLOCK, "l1_gas_price_scraper_latest_scraped_block", "The latest block number that the L1 gas price scraper has scraped" },
-        MetricGauge { ETH_TO_STRK_RATE, "eth_to_strk_rate", "The current rate of ETH to STRK conversion" },
-        MetricGauge { SNIP35_STRK_USD_RATE, "snip35_strk_usd_rate", "The STRK/USD rate from the oracle" },
         MetricGauge { L1_GAS_PRICE_LATEST_MEAN_VALUE, "l1_gas_price_latest_mean_value", "The latest L1 gas price, calculated as an average by the provider client" },
-        MetricGauge { L1_DATA_GAS_PRICE_LATEST_MEAN_VALUE, "l1_data_gas_price_latest_mean_value", "The latest L1 data gas price, calculated as an average by the provider client" }
+        MetricGauge { L1_DATA_GAS_PRICE_LATEST_MEAN_VALUE, "l1_data_gas_price_latest_mean_value", "The latest L1 data gas price, calculated as an average by the provider client" },
+        LabeledMetricCounter { EXCHANGE_RATE_ORACLE_SUCCESS_COUNT, "exchange_rate_oracle_success_count", "Number of times a query to the exchange rate oracle succeeded, per currency pair", init=0, labels = CURRENCY_PAIR_LABELS },
+        LabeledMetricCounter { EXCHANGE_RATE_ORACLE_ERROR_COUNT, "exchange_rate_oracle_error_count", "Number of times a query to the exchange rate oracle failed, per currency pair and error type", init=0, labels = CURRENCY_PAIR_AND_ERROR_TYPE_LABELS },
+        LabeledMetricGauge { EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS, "exchange_rate_oracle_last_success_timestamp_seconds", "Unix timestamp (seconds) of the last successful exchange rate oracle query, per currency pair", labels = CURRENCY_PAIR_LABELS },
+        LabeledMetricGauge { EXCHANGE_RATE_ORACLE_RATE, "exchange_rate_oracle_rate", "The exchange rate the oracle last served, per currency pair", labels = CURRENCY_PAIR_LABELS }
     },
 );
 
-/// Per-pair metric handles owned by an `ExchangeRateOracleClient`.
-/// Each constructed client uses its own set so concurrent ETH→STRK and
-/// STRK→USD clients update disjoint Prometheus series.
+/// The oracle metrics a client records, bound to the pair it serves.
+///
+/// Every pair writes the same metrics and separates its series by the `currency_pair` label, so the
+/// handles are identical in every instance and only `pair` differs.
 #[derive(Copy, Clone)]
 pub struct ExchangeRateOracleMetrics {
-    pub rate: &'static MetricGauge,
-    pub success_count: &'static MetricCounter,
-    pub error_count: &'static MetricCounter,
-    pub last_success_timestamp: &'static MetricGauge,
-    /// Guards this set's registration.
+    rate: &'static LabeledMetricGauge,
+    success_count: &'static LabeledMetricCounter,
+    error_count: &'static LabeledMetricCounter,
+    last_success_timestamp: &'static LabeledMetricGauge,
+    pair: CurrencyPair,
+    /// Guards registration of the metrics above, shared by every pair: registering a labeled
+    /// metric writes every permutation, so a second registration would zero the counts already
+    /// recorded for the other pairs.
     registration_guard: &'static Once,
 }
 
@@ -60,14 +83,32 @@ impl ExchangeRateOracleMetrics {
             self.last_success_timestamp.register();
         });
     }
+
+    /// Records a query that passed every guard: the rate served, when it resolved, and the success.
+    pub fn record_success(&self, rate: ExchangeRate) {
+        let pair_labels = self.pair.labels();
+        self.success_count.increment(1, &pair_labels);
+        set_unix_now_seconds_with_labels(self.last_success_timestamp, &pair_labels);
+        self.rate.set_lossy(rate, &pair_labels);
+    }
+
+    pub fn record_error(&self, error_type: ExchangeRateOracleErrorType) {
+        self.error_count.increment(
+            1,
+            &[
+                (LABEL_NAME_CURRENCY_PAIR, self.pair.into()),
+                (LABEL_NAME_ERROR_TYPE, error_type.into()),
+            ],
+        );
+    }
 }
 
-// Manual impl: `MetricGauge` / `MetricCounter` do not derive `Debug`,
-// but the surrounding `ExchangeRateOracleClient` does. Printing the prom
-// name of each metric is the only useful thing to surface.
+// Manual impl: `LabeledMetricGauge` / `LabeledMetricCounter` do not derive `Debug`, but the
+// surrounding `ExchangeRateOracleClient` does. The pair is what distinguishes one set from another.
 impl std::fmt::Debug for ExchangeRateOracleMetrics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ExchangeRateOracleMetrics")
+            .field("pair", &self.pair)
             .field("rate", &self.rate.get_name())
             .field("success_count", &self.success_count.get_name())
             .field("error_count", &self.error_count.get_name())
@@ -76,23 +117,24 @@ impl std::fmt::Debug for ExchangeRateOracleMetrics {
     }
 }
 
-static ETH_TO_STRK_REGISTRATION: Once = Once::new();
-static STRK_TO_USD_REGISTRATION: Once = Once::new();
+static ORACLE_METRICS_REGISTRATION: Once = Once::new();
 
 pub const ETH_TO_STRK_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOracleMetrics {
-    rate: &ETH_TO_STRK_RATE,
-    success_count: &ETH_TO_STRK_SUCCESS_COUNT,
-    error_count: &ETH_TO_STRK_ERROR_COUNT,
-    last_success_timestamp: &ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS,
-    registration_guard: &ETH_TO_STRK_REGISTRATION,
+    rate: &EXCHANGE_RATE_ORACLE_RATE,
+    success_count: &EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
+    error_count: &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+    last_success_timestamp: &EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    pair: CurrencyPair::EthStrk,
+    registration_guard: &ORACLE_METRICS_REGISTRATION,
 };
 
 pub const STRK_TO_USD_ORACLE_METRICS: ExchangeRateOracleMetrics = ExchangeRateOracleMetrics {
-    rate: &SNIP35_STRK_USD_RATE,
-    success_count: &SNIP35_STRK_USD_SUCCESS_COUNT,
-    error_count: &SNIP35_STRK_USD_ERROR_COUNT,
-    last_success_timestamp: &SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS,
-    registration_guard: &STRK_TO_USD_REGISTRATION,
+    rate: &EXCHANGE_RATE_ORACLE_RATE,
+    success_count: &EXCHANGE_RATE_ORACLE_SUCCESS_COUNT,
+    error_count: &EXCHANGE_RATE_ORACLE_ERROR_COUNT,
+    last_success_timestamp: &EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS,
+    pair: CurrencyPair::StrkUsd,
+    registration_guard: &ORACLE_METRICS_REGISTRATION,
 };
 
 pub(crate) fn register_provider_metrics() {

--- a/crates/apollo_l1_gas_price/src/metrics_test.rs
+++ b/crates/apollo_l1_gas_price/src/metrics_test.rs
@@ -3,15 +3,19 @@ use std::sync::Once;
 
 use apollo_config::converters::UrlAndHeaders;
 use apollo_l1_gas_price_config::config::ExchangeRateOracleConfig;
+use apollo_l1_gas_price_types::errors::ExchangeRateOracleErrorType;
+use apollo_l1_gas_price_types::{CurrencyPair, LABEL_NAME_CURRENCY_PAIR, LABEL_NAME_ERROR_TYPE};
 use metrics_exporter_prometheus::PrometheusBuilder;
+use strum::IntoEnumIterator;
 use url::Url;
 
 use super::{ExchangeRateOracleMetrics, ETH_TO_STRK_ORACLE_METRICS};
 use crate::exchange_rate_oracle::ExchangeRateOracleClient;
 
-/// Guard owned by this test, so the assertions on its state do not depend on whether another test
-/// in the process already registered the ETH→STRK set.
-static TEST_REGISTRATION: Once = Once::new();
+/// Guards owned by the tests, so the assertions on their state do not depend on whether another
+/// test in the process already registered the shared oracle metrics.
+static REPEATED_CONSTRUCTION_REGISTRATION: Once = Once::new();
+static ZERO_SAMPLE_REGISTRATION: Once = Once::new();
 
 fn oracle_config() -> ExchangeRateOracleConfig {
     let url_and_headers =
@@ -32,16 +36,53 @@ fn repeated_client_construction_registers_metrics_once() {
     let _recorder_guard = metrics::set_default_local_recorder(&recorder);
 
     let oracle_metrics = ExchangeRateOracleMetrics {
-        registration_guard: &TEST_REGISTRATION,
+        registration_guard: &REPEATED_CONSTRUCTION_REGISTRATION,
         ..ETH_TO_STRK_ORACLE_METRICS
     };
-    assert!(!TEST_REGISTRATION.is_completed());
+    assert!(!REPEATED_CONSTRUCTION_REGISTRATION.is_completed());
 
     let _first_client = ExchangeRateOracleClient::new(oracle_config(), oracle_metrics);
-    assert!(TEST_REGISTRATION.is_completed());
+    assert!(REPEATED_CONSTRUCTION_REGISTRATION.is_completed());
 
-    oracle_metrics.success_count.increment(1);
+    oracle_metrics.record_success(5);
     let _second_client = ExchangeRateOracleClient::new(oracle_config(), oracle_metrics);
 
-    oracle_metrics.success_count.assert_eq::<u64>(&recorder.handle().render(), 1);
+    oracle_metrics.success_count.assert_eq::<u64>(
+        &recorder.handle().render(),
+        1,
+        &CurrencyPair::EthStrk.labels(),
+    );
+}
+
+/// Registration publishes a zero sample per label permutation, so a pair that never failed renders
+/// as 0 instead of being absent from the scrape.
+#[test]
+fn oracle_metrics_register_at_zero_for_every_permutation() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+    let oracle_metrics = ExchangeRateOracleMetrics {
+        registration_guard: &ZERO_SAMPLE_REGISTRATION,
+        ..ETH_TO_STRK_ORACLE_METRICS
+    };
+    oracle_metrics.register();
+
+    let metrics_as_string = recorder.handle().render();
+    for currency_pair in CurrencyPair::iter() {
+        oracle_metrics.success_count.assert_eq::<u64>(
+            &metrics_as_string,
+            0,
+            &currency_pair.labels(),
+        );
+        for error_type in ExchangeRateOracleErrorType::iter() {
+            oracle_metrics.error_count.assert_eq::<u64>(
+                &metrics_as_string,
+                0,
+                &[
+                    (LABEL_NAME_CURRENCY_PAIR, <&str>::from(currency_pair)),
+                    (LABEL_NAME_ERROR_TYPE, <&str>::from(error_type)),
+                ],
+            );
+        }
+    }
 }

--- a/crates/apollo_l1_gas_price_types/src/errors.rs
+++ b/crates/apollo_l1_gas_price_types/src/errors.rs
@@ -1,6 +1,9 @@
 use apollo_infra::component_client::ClientError;
 use serde::{Deserialize, Serialize};
+use strum::{EnumDiscriminants, EnumIter, IntoStaticStr, VariantNames};
 use thiserror::Error;
+
+use crate::CurrencyPair;
 
 #[derive(Clone, Debug, Error, PartialEq, Eq, Serialize, Deserialize)]
 pub enum L1GasPriceProviderError {
@@ -31,7 +34,12 @@ pub enum L1GasPriceClientError {
     ExchangeRateOracleClientError(#[from] ExchangeRateOracleClientError),
 }
 
-#[derive(Clone, Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Error, Serialize, Deserialize, PartialEq, Eq, EnumDiscriminants)]
+#[strum_discriminants(
+    name(ExchangeRateOracleErrorType),
+    derive(IntoStaticStr, EnumIter, VariantNames),
+    strum(serialize_all = "snake_case")
+)]
 pub enum ExchangeRateOracleClientError {
     #[error("Join error: {0}")]
     JoinError(String),
@@ -49,6 +57,36 @@ pub enum ExchangeRateOracleClientError {
     AllUrlsFailedError(u64, usize),
     #[error("Invalid rate from oracle: {0}")]
     InvalidRateError(String),
+    // [Temporary comment] The five variants below are first returned by the feed guards (A7/A8).
+    // TODO(Asaf): give the remaining variants the same pair context. Not a payload field for all
+    // of them: `From<reqwest::Error>` and the `?` sites have no pair to supply, so this
+    // likely needs a span field on `fetch_rate` instead.
+    #[error(
+        "Stale {pair} price feed: last updated at {updated_at}, priced for block timestamp \
+         {block_timestamp}, maximum accepted staleness is {max_staleness_seconds} seconds"
+    )]
+    StaleFeedError {
+        pair: CurrencyPair,
+        updated_at: u64,
+        block_timestamp: u64,
+        max_staleness_seconds: u64,
+    },
+    #[error(
+        "The {pair} price feed is dated {updated_at}, more than {max_future_updated_at_seconds} \
+         seconds ahead of the block timestamp {block_timestamp}"
+    )]
+    FutureFeedError {
+        pair: CurrencyPair,
+        updated_at: u64,
+        block_timestamp: u64,
+        max_future_updated_at_seconds: u64,
+    },
+    #[error("Rate {rate} for {pair} is outside the accepted range [{min_rate}, {max_rate}]")]
+    RateOutOfBoundsError { pair: CurrencyPair, rate: u128, min_rate: u128, max_rate: u128 },
+    #[error("Contract call to price feed failed: {0}")]
+    ContractCallError(String),
+    #[error("Arithmetic overflow while computing rate: {0}")]
+    ArithmeticError(String),
 }
 
 impl From<reqwest::Error> for ExchangeRateOracleClientError {

--- a/crates/apollo_l1_gas_price_types/src/lib.rs
+++ b/crates/apollo_l1_gas_price_types/src/lib.rs
@@ -2,7 +2,7 @@ pub mod errors;
 #[cfg(test)]
 mod test;
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Display};
 use std::iter::Sum;
 use std::sync::Arc;
 
@@ -32,10 +32,13 @@ pub type ExchangeRate = u128;
 /// Currency pair a reading or rate belongs to.
 pub const LABEL_NAME_CURRENCY_PAIR: &str = "currency_pair";
 
+/// Variant of `ExchangeRateOracleClientError` a failed query returned.
+pub const LABEL_NAME_ERROR_TYPE: &str = "error_type";
+
 /// The pair a reading or rate quotes.
-// [Temporary comment] No consumer yet: `labels()` lands with the oracle metrics PR, `pair_name()`
-// with the rate-bounds PR.
-#[derive(Clone, Copy, Debug, EnumIter, IntoStaticStr, PartialEq, Eq, VariantNames)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, EnumIter, IntoStaticStr, PartialEq, Eq, Serialize, VariantNames,
+)]
 #[strum(serialize_all = "snake_case")]
 pub enum CurrencyPair {
     EthUsd,
@@ -55,6 +58,13 @@ impl CurrencyPair {
 
     pub fn labels(self) -> [(&'static str, &'static str); 1] {
         [(LABEL_NAME_CURRENCY_PAIR, self.into())]
+    }
+}
+
+/// Renders the operator-facing `pair_name`, not the snake_case label value.
+impl Display for CurrencyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.pair_name())
     }
 }
 

--- a/crates/apollo_l1_gas_price_types/src/test.rs
+++ b/crates/apollo_l1_gas_price_types/src/test.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use strum::{IntoEnumIterator, VariantNames};
 
+use crate::errors::{ExchangeRateOracleClientError, ExchangeRateOracleErrorType};
 use crate::{CurrencyPair, EthToFri, RateKind, StrkToUsd, LABEL_NAME_CURRENCY_PAIR};
 
 /// Copy-pasted `pair_name` arms compile, so only a distinctness check catches them.
@@ -31,9 +32,98 @@ fn enum_iter_and_variant_names_cover_all_variants() {
     assert_eq!(CurrencyPair::VARIANTS, ["eth_usd", "strk_usd", "eth_strk"]);
 }
 
+/// The discriminant names are the `error_type` label values, so this pins the metric series a
+/// renamed or reordered variant would silently change.
+#[test]
+fn error_type_variants_are_snake_case_variant_names() {
+    assert_eq!(
+        ExchangeRateOracleErrorType::VARIANTS,
+        [
+            "join_error",
+            "request_error",
+            "parse_error",
+            "missing_field_error",
+            "invalid_decimals_error",
+            "query_not_ready_error",
+            "all_urls_failed_error",
+            "invalid_rate_error",
+            "stale_feed_error",
+            "future_feed_error",
+            "rate_out_of_bounds_error",
+            "contract_call_error",
+            "arithmetic_error",
+        ]
+    );
+}
+
+#[test]
+fn error_maps_to_its_error_type() {
+    let stale_feed = ExchangeRateOracleClientError::StaleFeedError {
+        pair: CurrencyPair::EthUsd,
+        updated_at: 100,
+        block_timestamp: 400,
+        max_staleness_seconds: 120,
+    };
+    assert_eq!(
+        ExchangeRateOracleErrorType::from(&stale_feed),
+        ExchangeRateOracleErrorType::StaleFeedError
+    );
+}
+
 /// A transposed `RateKind::PAIR` compiles, since both markers map to a valid `CurrencyPair`.
 #[test]
 fn rate_kind_markers_map_to_their_pair() {
     assert_eq!(EthToFri::PAIR, CurrencyPair::EthStrk);
     assert_eq!(StrkToUsd::PAIR, CurrencyPair::StrkUsd);
+}
+
+/// Each message names the pair, the values that tripped the guard and the bound they violated.
+#[test]
+fn guard_errors_render_their_operator_facing_fields() {
+    assert_eq!(
+        ExchangeRateOracleClientError::StaleFeedError {
+            pair: CurrencyPair::EthUsd,
+            updated_at: 100,
+            block_timestamp: 400,
+            max_staleness_seconds: 120,
+        }
+        .to_string(),
+        "Stale ETH/USD price feed: last updated at 100, priced for block timestamp 400, maximum \
+         accepted staleness is 120 seconds"
+    );
+    assert_eq!(
+        ExchangeRateOracleClientError::FutureFeedError {
+            pair: CurrencyPair::StrkUsd,
+            updated_at: 500,
+            block_timestamp: 400,
+            max_future_updated_at_seconds: 30,
+        }
+        .to_string(),
+        "The STRK/USD price feed is dated 500, more than 30 seconds ahead of the block timestamp \
+         400"
+    );
+    assert_eq!(
+        ExchangeRateOracleClientError::RateOutOfBoundsError {
+            pair: CurrencyPair::EthStrk,
+            rate: 7,
+            min_rate: 10,
+            max_rate: 20,
+        }
+        .to_string(),
+        "Rate 7 for ETH/STRK is outside the accepted range [10, 20]"
+    );
+    assert_eq!(
+        ExchangeRateOracleClientError::ContractCallError(
+            "retdata has 1 felt, expected 5".to_owned()
+        )
+        .to_string(),
+        "Contract call to price feed failed: retdata has 1 felt, expected 5"
+    );
+    assert_eq!(
+        ExchangeRateOracleClientError::ArithmeticError(
+            "ETH/USD 3000 * 10^18 exceeds u128".to_owned()
+        )
+        .to_string(),
+        "Arithmetic overflow while computing rate: ETH/USD 3000 * 10^18 exceeds u128"
+    );
 }


### PR DESCRIPTION
Folds the oracle metrics onto a `currency_pair` label, per Matan's review. The eight per-pair metrics and the five `chainlink_oracle_*` guard counters become four labeled metrics that are the same whichever oracle serves the pair. The guard errors carry `pair: CurrencyPair` instead of `pair_name: String`.

Existing dashboard series do not carry over: the old metric names are gone.

---

## Detailed Summary for AI Bots

### Metrics

Thirteen metrics become four, all scoped `L1GasPrice`:

| identifier | key | labels |
| --- | --- | --- |
| `EXCHANGE_RATE_ORACLE_SUCCESS_COUNT` | `exchange_rate_oracle_success_count` | `currency_pair` |
| `EXCHANGE_RATE_ORACLE_ERROR_COUNT` | `exchange_rate_oracle_error_count` | `currency_pair`, `error_type` |
| `EXCHANGE_RATE_ORACLE_LAST_SUCCESS_TIMESTAMP_SECONDS` | `exchange_rate_oracle_last_success_timestamp_seconds` | `currency_pair` |
| `EXCHANGE_RATE_ORACLE_RATE` | `exchange_rate_oracle_rate` | `currency_pair` |

Deleted: `ETH_TO_STRK_{SUCCESS,ERROR}_COUNT`, `SNIP35_STRK_USD_{SUCCESS,ERROR}_COUNT`, `ETH_TO_STRK_RATE`, `SNIP35_STRK_USD_RATE`, `ETH_TO_STRK_LAST_SUCCESS_TIMESTAMP_SECONDS`, `SNIP35_STRK_USD_LAST_SUCCESS_TIMESTAMP_SECONDS`, the five `CHAINLINK_ORACLE_*_COUNT` counters, and `register_chainlink_guard_metrics`.

`error_type` values are the `ExchangeRateOracleClientError` discriminants via strum `EnumDiscriminants`, rendered snake_case: `join_error`, `request_error`, `parse_error`, `missing_field_error`, `invalid_decimals_error`, `query_not_ready_error`, `all_urls_failed_error`, `invalid_rate_error`, `stale_feed_error`, `future_feed_error`, `rate_out_of_bounds_error`, `contract_call_error`, `arithmetic_error`. A test pins that list, since the strings are metric series names.

### `ExchangeRateOracleMetrics`

Still the per-pair bundle, now holding the shared handles plus the `CurrencyPair` it stamps, with `record_success(rate)` and `record_error(error_type)` so no call site assembles labels. The registration guard is shared by every pair rather than one per pair: `register()` on a labeled metric writes every permutation, so a second registration would zero the counts already recorded for the other pairs, which is what #14977 fixed for the unlabeled metrics.

A timeout is counted as `request_error`, since the enum has no timeout variant and the old counter folded timeouts into the error count.

### Errors

`StaleFeedError`, `FutureFeedError` and `RateOutOfBoundsError` take `pair: CurrencyPair` in place of `pair_name: String`; `CurrencyPair` gains `Serialize`, `Deserialize` and a `Display` that renders `pair_name()`. The remaining variants keep no pair, with a `TODO` recording why a payload field cannot work uniformly: `From<reqwest::Error>` and the `?` sites have no pair to supply, so that likely wants a span field on `fetch_rate`.

### Dashboard

`apollo_dashboard` alerts and panels select a pair through the label; `query_builder` gains `with_label`, `increase_with_label`, `sum_increase_with_label` and `seconds_since_last_timestamp_with_label`. Alert names are unchanged, so the per-env severity override keys still resolve.

### Elsewhere in the stack

The branches above this one still reference the deleted identifiers and need matching edits, not just a restack: A6a, A8, A9a, A9b and B4.
