### PR TITLE
apollo_l1_gas_price_config: Chainlink oracle config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,7 @@ dependencies = [
  "apollo_l1_gas_price_types",
  "rstest",
  "serde",
+ "starknet-types-core",
  "starknet_api",
  "url",
  "validator",

--- a/crates/apollo_l1_gas_price_config/Cargo.toml
+++ b/crates/apollo_l1_gas_price_config/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 apollo_config.workspace = true
 apollo_l1_gas_price_types.workspace = true
 serde = { workspace = true, features = ["derive"] }
+starknet-types-core.workspace = true
 starknet_api.workspace = true
 url.workspace = true
 validator.workspace = true

--- a/crates/apollo_l1_gas_price_config/src/config.rs
+++ b/crates/apollo_l1_gas_price_config/src/config.rs
@@ -18,7 +18,8 @@ use apollo_config::validators::{create_validation_error, validate_ascii};
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use apollo_l1_gas_price_types::{CurrencyPair, ExchangeRate, EXCHANGE_RATE_DECIMALS};
 use serde::{Deserialize, Serialize};
-use starknet_api::core::ChainId;
+use starknet_api::core::{ChainId, ContractAddress};
+use starknet_types_core::felt::Felt;
 use url::Url;
 use validator::{Validate, ValidationError};
 
@@ -243,6 +244,145 @@ impl SerializeConfig for AllRateBoundsConfig {
         let mut config = prepend_sub_config_name(self.eth_usd.dump(), "eth_usd");
         config.extend(prepend_sub_config_name(self.strk_usd.dump(), "strk_usd"));
         config.extend(prepend_sub_config_name(self.eth_strk.dump(), "eth_strk"));
+        config
+    }
+}
+
+/// The window a feed round's `updated_at` must fall in, relative to the block being priced.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Validate)]
+#[validate(schema(function = "validate_freshness_window"))]
+pub struct FreshnessWindow {
+    #[validate(range(min = 1))]
+    pub max_staleness_seconds: u64,
+    pub max_future_updated_at_seconds: u64,
+}
+
+/// Rejects a window whose two bounds are swapped: `max_future_updated_at_seconds` covers clock
+/// skew, so it must sit strictly below `max_staleness_seconds`, which covers a full feed heartbeat.
+fn validate_freshness_window(freshness: &FreshnessWindow) -> Result<(), ValidationError> {
+    if freshness.max_future_updated_at_seconds >= freshness.max_staleness_seconds {
+        return Err(create_validation_error(
+            format!(
+                "max_future_updated_at_seconds ({}) is not below max_staleness_seconds ({})",
+                freshness.max_future_updated_at_seconds, freshness.max_staleness_seconds
+            ),
+            "inverted freshness window",
+            "Keep max_future_updated_at_seconds, which covers clock skew, below \
+             max_staleness_seconds, which covers the feed's heartbeat.",
+        ));
+    }
+    Ok(())
+}
+
+impl SerializeConfig for FreshnessWindow {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
+            ser_param(
+                "max_staleness_seconds",
+                &self.max_staleness_seconds,
+                "Maximum age (seconds) of a feed's `updated_at` relative to the block timestamp \
+                 being priced. An older reading is rejected, and for the derived ETH/STRK rate a \
+                 single stale leg rejects the whole rate.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "max_future_updated_at_seconds",
+                &self.max_future_updated_at_seconds,
+                "Maximum amount (seconds) by which a feed's `updated_at` may lead the block \
+                 timestamp being priced. Covers the clock skew between the sequencer that wrote \
+                 the round and this node.",
+                ParamPrivacyInput::Public,
+            ),
+        ])
+    }
+}
+
+/// Configuration for reading Chainlink's on-chain Starknet price feeds through the batcher. Holds
+/// only what is Chainlink-specific: the bounds a feed's answer is judged against describe the rate
+/// rather than the source, so they live in `AllRateBoundsConfig`, which also bounds the derived
+/// ETH/STRK pair that has no feed of its own.
+// [Temporary comment] No reader yet: A8 reads the feeds through these fields and A9 wires the
+// source in, and B2 nests this under `L1GasPriceProviderConfig`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Validate)]
+pub struct ChainlinkOracleConfig {
+    /// Quotes USD per ETH.
+    pub eth_usd_feed_address: ContractAddress,
+    /// Quotes USD per STRK.
+    pub strk_usd_feed_address: ContractAddress,
+    #[validate(nested)]
+    pub freshness: FreshnessWindow,
+    #[validate(range(min = 1))]
+    pub sampling_interval_seconds: u64,
+    #[validate(range(min = 1))]
+    pub failure_retry_interval_seconds: u64,
+}
+
+impl Default for ChainlinkOracleConfig {
+    fn default() -> Self {
+        // Chainlink proxy addresses on Starknet mainnet. The proxies are used rather than the
+        // aggregators behind them, because aggregators are rotated without notice.
+        const ETH_USD_PROXY_ADDRESS: &str =
+            "0x06b2ef9b416ad0f996b2a8ac0dd771b1788196f51c96f5b000df2e47ac756d26";
+        const STRK_USD_PROXY_ADDRESS: &str =
+            "0x076a0254cdadb59b86da3b5960bf8d73779cac88edc5ae587cab3cedf03226ec";
+        // The feeds guarantee an update at least once per 24h heartbeat; the extra hour absorbs
+        // the delay between the heartbeat deadline and the update landing on-chain.
+        const HEARTBEAT_PLUS_MARGIN_SECONDS: u64 = (24 + 1) * 3600;
+        // `updated_at` and the block timestamp it is checked against both come from a
+        // sequencer's clock, so this only covers the skew between them.
+        const MAX_FUTURE_UPDATED_AT_SECONDS: u64 = 300;
+
+        Self {
+            eth_usd_feed_address: parse_feed_address(ETH_USD_PROXY_ADDRESS),
+            strk_usd_feed_address: parse_feed_address(STRK_USD_PROXY_ADDRESS),
+            freshness: FreshnessWindow {
+                max_staleness_seconds: HEARTBEAT_PLUS_MARGIN_SECONDS,
+                max_future_updated_at_seconds: MAX_FUTURE_UPDATED_AT_SECONDS,
+            },
+            sampling_interval_seconds: 900, // 15 minutes
+            // Successful reads are sampled once per sampling interval, so a failure that waited
+            // for the next sample would freeze the price for that long.
+            failure_retry_interval_seconds: 60,
+        }
+    }
+}
+
+fn parse_feed_address(hex_address: &str) -> ContractAddress {
+    ContractAddress::try_from(Felt::from_hex(hex_address).expect("Invalid feed address felt"))
+        .expect("Invalid feed contract address")
+}
+
+impl SerializeConfig for ChainlinkOracleConfig {
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        let mut config = BTreeMap::from_iter([
+            ser_param(
+                "eth_usd_feed_address",
+                &self.eth_usd_feed_address,
+                "Address of the Chainlink proxy feed quoting ETH/USD on Starknet.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "strk_usd_feed_address",
+                &self.strk_usd_feed_address,
+                "Address of the Chainlink proxy feed quoting STRK/USD on Starknet.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "sampling_interval_seconds",
+                &self.sampling_interval_seconds,
+                "The size of the interval (seconds) a successful feed reading is sampled on, so \
+                 that every block priced within one interval shares a single reading.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "failure_retry_interval_seconds",
+                &self.failure_retry_interval_seconds,
+                "How long (seconds) after a failed read the feed is read again. Successful reads \
+                 are governed by `sampling_interval_seconds` instead.",
+                ParamPrivacyInput::Public,
+            ),
+        ]);
+        config.extend(prepend_sub_config_name(self.freshness.dump(), "freshness"));
         config
     }
 }

--- a/crates/apollo_l1_gas_price_config/src/config_test.rs
+++ b/crates/apollo_l1_gas_price_config/src/config_test.rs
@@ -3,7 +3,12 @@ use std::mem::swap;
 use rstest::rstest;
 use validator::Validate;
 
-use super::{AllRateBoundsConfig, L1GasPriceProviderConfig};
+use super::{
+    AllRateBoundsConfig,
+    ChainlinkOracleConfig,
+    FreshnessWindow,
+    L1GasPriceProviderConfig,
+};
 
 // A zero mean window would make the provider divide by zero when computing the mean gas price,
 // so it must be rejected at config load instead of panicking later during block production.
@@ -63,5 +68,62 @@ fn rejects_unusable_rate_bounds(
     let mut config = AllRateBoundsConfig::default();
     let (minimum_micro_units, maximum_micro_units) = select_bounds(&mut config);
     break_bounds(minimum_micro_units, maximum_micro_units);
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn accepts_default_chainlink_oracle_config() {
+    assert!(ChainlinkOracleConfig::default().validate().is_ok());
+}
+
+// A zero `max_staleness_seconds` rejects every reading not written in the block's own second;
+// a zero `failure_retry_interval_seconds` re-queries a failing feed on every proposal.
+#[rstest]
+#[case::zero_max_staleness(ChainlinkOracleConfig {
+    freshness: FreshnessWindow {
+        max_staleness_seconds: 0,
+        ..ChainlinkOracleConfig::default().freshness
+    },
+    ..Default::default()
+})]
+#[case::zero_failure_retry_interval(ChainlinkOracleConfig {
+    failure_retry_interval_seconds: 0,
+    ..Default::default()
+})]
+fn rejects_out_of_range_chainlink_fields(#[case] config: ChainlinkOracleConfig) {
+    assert!(config.validate().is_err());
+}
+
+// A zero `sampling_interval_seconds` re-reads the feeds on every proposal, so one second is the
+// smallest accepted interval.
+#[rstest]
+#[case::zero(0, false)]
+#[case::one_second(1, true)]
+fn validates_sampling_interval_seconds_range(
+    #[case] sampling_interval_seconds: u64,
+    #[case] is_accepted: bool,
+) {
+    let config = ChainlinkOracleConfig { sampling_interval_seconds, ..Default::default() };
+
+    assert_eq!(config.validate().is_ok(), is_accepted);
+}
+
+#[test]
+fn default_freshness_window_reaches_further_back_than_forward() {
+    let freshness = ChainlinkOracleConfig::default().freshness;
+
+    assert_eq!(freshness.max_staleness_seconds, (24 + 1) * 3600);
+    assert_eq!(freshness.max_future_updated_at_seconds, 300);
+}
+
+#[rstest]
+#[case::inverted(FreshnessWindow {
+    max_staleness_seconds: 300,
+    max_future_updated_at_seconds: 90_000,
+})]
+#[case::equal(FreshnessWindow { max_staleness_seconds: 300, max_future_updated_at_seconds: 300 })]
+fn rejects_a_forward_bound_at_or_above_the_backward_bound(#[case] freshness: FreshnessWindow) {
+    let config = ChainlinkOracleConfig { freshness, ..Default::default() };
+
     assert!(config.validate().is_err());
 }


### PR DESCRIPTION
Adds `ChainlinkOracleConfig`, the mechanics half of the Chainlink feed source: the two mainnet proxy `feed_address`es, the `FreshnessWindow` a round's `updated_at` must fall in, a 900 second `sampling_interval_seconds` and a 60 second `failure_retry_interval_seconds`, with a validator keeping the forward freshness bound strictly below the backward one.

A6b of the split of #14942. The rate bounds that sit alongside these fields on the source branch were extracted into `RateBoundsConfig` in the base PR, so this carries only Chainlink-specific fields.

- `sampling_interval_seconds` is deliberately a new field: the source branch read the HTTP source's `lag_interval_seconds` instead, so the Chainlink path no longer reaches into the HTTP config and deleting that source later stays a pure deletion.
- Deferred: nothing reads this config. The client that reads the feeds arrives in A9 and the source is wired in after that. The config is still un-nested, so `config_schema.json` and the app configs are untouched until B2 (#14994).

---

## Detailed Summary for AI Bots

Adds `ChainlinkOracleConfig`, the mechanics half of the Chainlink price-feed source: the two mainnet proxy `feed_address`es, the `FreshnessWindow` a round's `updated_at` must fall in, and the two intervals the source is read on.

The rate bounds that live alongside these fields in the original branch were already extracted into `RateBoundsConfig` in the base PR, so this one carries only the Chainlink-specific fields.

### Fields

- `eth_usd_feed_address` / `strk_usd_feed_address`: Chainlink proxy addresses on Starknet mainnet. The proxies rather than the aggregators behind them, because aggregators are rotated without notice.
- `freshness`: `max_staleness_seconds` (the 24h feed heartbeat plus an hour of margin) and `max_future_updated_at_seconds` (300s of clock skew). A schema-level validator keeps the forward bound strictly below the backward one, since both are plain second counts and exchanging them would otherwise pass every per-field check.
- `sampling_interval_seconds`: 900 by default, `range(min = 1)`.
- `failure_retry_interval_seconds`: 60 by default, `range(min = 1)`.

### `sampling_interval_seconds` is deliberately new

In the source branch, the Chainlink factory read the sampling interval off the HTTP source's `ExchangeRateOracleConfig::lag_interval_seconds`. This PR replaces that read with a field of its own, for two reasons:

- The Chainlink path never has to reach into the HTTP source's config to learn how often to sample.
- Deleting the HTTP source later stays a pure deletion, with nothing to rehome first.

It is one field on `ChainlinkOracleConfig`, not one per feed, since both feeds are sampled on the same interval.

### Scope

Nothing reads this config yet; the client that reads the feeds arrives in a later PR, and the source is wired in after that. `config_schema.json` and the `apollo_deployments` app configs are untouched here as well: the config is still un-nested, and it reaches the schema and the app configs when it is nested under `L1GasPriceProviderConfig`.

Tests cover the default validating, the two zero-interval rejections, the `sampling_interval_seconds` range at 0 and 1, the default freshness window pinned by direction, and an inverted or equal freshness window.

