### PR TITLE
apollo_state_reader,apollo_batcher: bound class manager reads in ClassReader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,6 +2689,7 @@ dependencies = [
  "apollo_class_manager_types",
  "apollo_storage",
  "assert_matches",
+ "async-trait",
  "blockifier",
  "blockifier_test_utils",
  "cairo-lang-starknet-classes",

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use apollo_batcher_config::config::{
     BatcherConfig,
@@ -2001,8 +2001,9 @@ pub trait ViewStateReaderFactory: Send + Sync {
     /// `native_classes_whitelist` gates which classes may execute under Cairo native, and must be
     /// the one block production runs with, so a view call returns what a block would compute.
     /// The reader blocks on the class manager through `runtime`, from the blocking task the view
-    /// call runs in; `class_manager_request_timeout` bounds that block, so a stalled class
-    /// manager cannot pin the blocking task's thread past the view call's own timeout.
+    /// call runs in; `class_manager_request_timeout` bounds the reader's total time waiting on
+    /// the class manager (not each individual request), so a stalled class manager cannot pin the
+    /// blocking task's thread past the view call's own timeout.
     fn create(
         &self,
         block_number: BlockNumber,
@@ -2028,10 +2029,13 @@ impl ViewStateReaderFactory for StorageViewStateReaderFactory {
     ) -> Box<dyn StateReader + Send> {
         // The batcher's storage records class declarations but never writes the definitions, so a
         // class is only readable through the class manager.
+        // The deadline is computed once here rather than passing the duration into `ClassReader`,
+        // so a class hash that takes several class manager requests (Casm and Sierra) is still
+        // bounded by a single `class_manager_request_timeout`, not a multiple of it.
         let class_reader = Some(ClassReader {
             reader: self.class_manager_client.clone(),
             runtime,
-            request_timeout: Some(class_manager_request_timeout),
+            deadline: Some(Instant::now() + class_manager_request_timeout),
         });
         let apollo_reader = ApolloReader::new_with_class_reader(
             self.storage_reader.clone(),

--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::sync::Arc;
+use std::time::Duration;
 
 use apollo_batcher_config::config::{
     BatcherConfig,
@@ -781,6 +782,7 @@ impl Batcher {
             height,
             self.config.dynamic_config.native_classes_whitelist.clone(),
             tokio::runtime::Handle::current(),
+            self.config.dynamic_config.view_call_timeout_millis,
         );
         let block_context = BlockContext::new(
             block_info,
@@ -815,7 +817,10 @@ impl Batcher {
         });
 
         // Timing out releases the batcher's request slot but does not cancel the blocking task,
-        // which runs to completion on its own thread.
+        // which runs to completion on its own thread. The class manager request the task blocks
+        // on is itself bounded by this same timeout (passed into the state reader above), so a
+        // stalled class manager cannot pin that thread past this window and starve the blocking
+        // thread pool block production also depends on.
         let view_call_timeout = self.config.dynamic_config.view_call_timeout_millis;
         let retdata = tokio::time::timeout(view_call_timeout, call_task)
             .await
@@ -1996,12 +2001,14 @@ pub trait ViewStateReaderFactory: Send + Sync {
     /// `native_classes_whitelist` gates which classes may execute under Cairo native, and must be
     /// the one block production runs with, so a view call returns what a block would compute.
     /// The reader blocks on the class manager through `runtime`, from the blocking task the view
-    /// call runs in.
+    /// call runs in; `class_manager_request_timeout` bounds that block, so a stalled class
+    /// manager cannot pin the blocking task's thread past the view call's own timeout.
     fn create(
         &self,
         block_number: BlockNumber,
         native_classes_whitelist: NativeClassesWhitelist,
         runtime: tokio::runtime::Handle,
+        class_manager_request_timeout: Duration,
     ) -> Box<dyn StateReader + Send>;
 }
 
@@ -2017,10 +2024,15 @@ impl ViewStateReaderFactory for StorageViewStateReaderFactory {
         block_number: BlockNumber,
         native_classes_whitelist: NativeClassesWhitelist,
         runtime: tokio::runtime::Handle,
+        class_manager_request_timeout: Duration,
     ) -> Box<dyn StateReader + Send> {
         // The batcher's storage records class declarations but never writes the definitions, so a
         // class is only readable through the class manager.
-        let class_reader = Some(ClassReader { reader: self.class_manager_client.clone(), runtime });
+        let class_reader = Some(ClassReader {
+            reader: self.class_manager_client.clone(),
+            runtime,
+            request_timeout: Some(class_manager_request_timeout),
+        });
         let apollo_reader = ApolloReader::new_with_class_reader(
             self.storage_reader.clone(),
             block_number,

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -215,6 +215,7 @@ impl ViewStateReaderFactory for ParkedViewStateReaderFactory {
         _block_number: BlockNumber,
         _native_classes_whitelist: NativeClassesWhitelist,
         _runtime: tokio::runtime::Handle,
+        _class_manager_request_timeout: Duration,
     ) -> Box<dyn StateReader + Send> {
         let release_receiver =
             self.release_receiver.lock().unwrap().take().expect("Expected a single view call.");

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -195,6 +195,7 @@ impl ViewStateReaderFactory for TestViewStateReaderFactory {
         block_number: BlockNumber,
         _native_classes_whitelist: NativeClassesWhitelist,
         _runtime: tokio::runtime::Handle,
+        _class_manager_request_timeout: Duration,
     ) -> Box<dyn StateReader + Send> {
         assert_eq!(block_number, self.expected_block_number);
         Box::new(self.state.lock().unwrap().clone())
@@ -2396,6 +2397,7 @@ async fn read_class_through_view_state_reader(
         LAST_COMMITTED_HEIGHT.unchecked_next(),
         NativeClassesWhitelist::All,
         tokio::runtime::Handle::current(),
+        Duration::from_secs(300),
     );
 
     tokio::task::spawn_blocking(move || state_reader.get_compiled_class(class_hash))
@@ -2554,6 +2556,7 @@ impl ViewStateReaderFactory for GatedViewStateReaderFactory {
         _block_number: BlockNumber,
         _native_classes_whitelist: NativeClassesWhitelist,
         _runtime: tokio::runtime::Handle,
+        _class_manager_request_timeout: Duration,
     ) -> Box<dyn StateReader + Send> {
         Box::new(GatedStateReader { release_receiver: self.release_receiver.clone() })
     }

--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -783,7 +783,13 @@ impl BlockBuilderFactory {
             block_builder_config.bouncer_config,
         );
 
-        let class_reader = Some(ClassReader { reader: self.class_manager_client.clone(), runtime });
+        // Block production has no per-call deadline to bound this against; leave it unbounded, as
+        // before.
+        let class_reader = Some(ClassReader {
+            reader: self.class_manager_client.clone(),
+            runtime,
+            request_timeout: None,
+        });
         let apollo_reader =
             ApolloReader::new_with_class_reader(self.storage_reader.clone(), height, class_reader);
         let state_reader = StateReaderAndContractManager::new_with_native_classes_whitelist(

--- a/crates/apollo_batcher/src/block_builder.rs
+++ b/crates/apollo_batcher/src/block_builder.rs
@@ -788,7 +788,7 @@ impl BlockBuilderFactory {
         let class_reader = Some(ClassReader {
             reader: self.class_manager_client.clone(),
             runtime,
-            request_timeout: None,
+            deadline: None,
         });
         let apollo_reader =
             ApolloReader::new_with_class_reader(self.storage_reader.clone(), height, class_reader);

--- a/crates/apollo_state_reader/Cargo.toml
+++ b/crates/apollo_state_reader/Cargo.toml
@@ -25,7 +25,9 @@ tokio.workspace = true
 [dev-dependencies]
 apollo_storage = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
+async-trait.workspace = true
 blockifier = { workspace = true, features = ["testing"] }
 blockifier_test_utils.workspace = true
 indexmap.workspace = true
 rstest.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/apollo_state_reader/Cargo.toml
+++ b/crates/apollo_state_reader/Cargo.toml
@@ -20,7 +20,7 @@ blockifier.workspace = true
 cairo-lang-starknet-classes.workspace = true
 starknet-types-core.workspace = true
 starknet_api.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "time"] }
 
 [dev-dependencies]
 apollo_storage = { workspace = true, features = ["testing"] }

--- a/crates/apollo_state_reader/src/apollo_state.rs
+++ b/crates/apollo_state_reader/src/apollo_state.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::Instant;
 
 use apollo_class_manager_types::SharedClassManagerClient;
 use apollo_storage::class_hash::ClassHashStorageReader;
@@ -35,25 +35,28 @@ pub struct ClassReader {
     pub reader: SharedClassManagerClient,
     // Used to invoke async functions from sync reader code.
     pub runtime: tokio::runtime::Handle,
-    /// Bounds each class manager request. This reader runs inside a blocking task on a shared
-    /// blocking-thread pool; a stalled class manager would otherwise pin that thread forever,
-    /// since the pool has no way to cancel a thread that is blocked inside `block_on`. `None`
-    /// leaves requests unbounded.
-    pub request_timeout: Option<Duration>,
+    /// Bounds the total time this reader may spend waiting on the class manager, across every
+    /// request it makes. This reader runs inside a blocking task on a shared blocking-thread
+    /// pool; a stalled class manager would otherwise pin that thread forever, since the pool has
+    /// no way to cancel a thread that is blocked inside `block_on`. A single deadline (set once,
+    /// e.g. at construction) rather than a per-request duration keeps a class hash that needs
+    /// several requests (Casm and Sierra) from being able to add up to a multiple of the caller's
+    /// intended bound. `None` leaves requests unbounded.
+    pub deadline: Option<Instant>,
 }
 
 impl ClassReader {
-    /// Runs `request` on `self.runtime`, bounding it by `self.request_timeout` when set.
+    /// Runs `request` on `self.runtime`, bounding it by `self.deadline` when set.
     fn block_on_request<Fut: Future>(&self, request: Fut) -> StateResult<Fut::Output> {
-        let Some(request_timeout) = self.request_timeout else {
+        let Some(deadline) = self.deadline else {
             return Ok(self.runtime.block_on(request));
         };
 
         self.runtime.block_on(async {
-            tokio::time::timeout(request_timeout, request).await.map_err(|_| {
-                StateError::StateReadError(format!(
-                    "Class manager request timed out after {request_timeout:?}."
-                ))
+            tokio::time::timeout_at(deadline.into(), request).await.map_err(|_| {
+                StateError::StateReadError(
+                    "Class manager request timed out; the reader's deadline passed.".to_string(),
+                )
             })
         })
     }

--- a/crates/apollo_state_reader/src/apollo_state.rs
+++ b/crates/apollo_state_reader/src/apollo_state.rs
@@ -1,4 +1,6 @@
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use apollo_class_manager_types::SharedClassManagerClient;
 use apollo_storage::class_hash::ClassHashStorageReader;
@@ -33,13 +35,32 @@ pub struct ClassReader {
     pub reader: SharedClassManagerClient,
     // Used to invoke async functions from sync reader code.
     pub runtime: tokio::runtime::Handle,
+    /// Bounds each class manager request. This reader runs inside a blocking task on a shared
+    /// blocking-thread pool; a stalled class manager would otherwise pin that thread forever,
+    /// since the pool has no way to cancel a thread that is blocked inside `block_on`. `None`
+    /// leaves requests unbounded.
+    pub request_timeout: Option<Duration>,
 }
 
 impl ClassReader {
+    /// Runs `request` on `self.runtime`, bounding it by `self.request_timeout` when set.
+    fn block_on_request<Fut: Future>(&self, request: Fut) -> StateResult<Fut::Output> {
+        let Some(request_timeout) = self.request_timeout else {
+            return Ok(self.runtime.block_on(request));
+        };
+
+        self.runtime.block_on(async {
+            tokio::time::timeout(request_timeout, request).await.map_err(|_| {
+                StateError::StateReadError(format!(
+                    "Class manager request timed out after {request_timeout:?}."
+                ))
+            })
+        })
+    }
+
     fn read_executable(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
         let casm = self
-            .runtime
-            .block_on(self.reader.get_executable(class_hash))
+            .block_on_request(self.reader.get_executable(class_hash))?
             .map_err(|err| StateError::StateReadError(err.to_string()))?
             .ok_or(StateError::UndeclaredClassHash(class_hash))?;
 
@@ -57,8 +78,7 @@ impl ClassReader {
 
     fn read_sierra(&self, class_hash: ClassHash) -> StateResult<SierraContractClass> {
         let sierra = self
-            .runtime
-            .block_on(self.reader.get_sierra(class_hash))
+            .block_on_request(self.reader.get_sierra(class_hash))?
             .map_err(|err| StateError::StateReadError(err.to_string()))?
             .ok_or(StateError::UndeclaredClassHash(class_hash))?;
 
@@ -81,8 +101,7 @@ impl ClassReader {
         class_hash: ClassHash,
     ) -> StateResult<Option<CompiledClassHash>> {
         let compiled_class_hash_v2 = self
-            .runtime
-            .block_on(self.reader.get_executable_class_hash_v2(class_hash))
+            .block_on_request(self.reader.get_executable_class_hash_v2(class_hash))?
             .map_err(|err| StateError::StateReadError(err.to_string()))?;
         Ok(compiled_class_hash_v2)
     }

--- a/crates/apollo_state_reader/src/apollo_state.rs
+++ b/crates/apollo_state_reader/src/apollo_state.rs
@@ -47,23 +47,43 @@ pub struct ClassReader {
 
 impl ClassReader {
     /// Runs `request` on `self.runtime`, bounding it by `self.deadline` when set.
-    fn block_on_request<Fut: Future>(&self, request: Fut) -> StateResult<Fut::Output> {
+    ///
+    /// Spawns `request` rather than awaiting it directly: a local class manager is reached
+    /// through a channel whose response sender the server already holds once the request is
+    /// sent (see `LocalComponentClient::send`), and the server panics if that channel's receiver
+    /// is dropped before the response is sent — "considered a bug" by its own comment, since a
+    /// well-behaved client always waits for its response. Racing `request` itself against the
+    /// deadline with `tokio::time::timeout` would drop it, and that receiver, the moment the
+    /// deadline passed. Spawning first means only our wait is bounded; `request` keeps running
+    /// to completion in the background so the server never observes a closed channel.
+    fn block_on_request<Fut>(&self, request: Fut) -> StateResult<Fut::Output>
+    where
+        Fut: Future + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
         let Some(deadline) = self.deadline else {
             return Ok(self.runtime.block_on(request));
         };
 
         self.runtime.block_on(async {
-            tokio::time::timeout_at(deadline.into(), request).await.map_err(|_| {
-                StateError::StateReadError(
+            let request_task = self.runtime.spawn(request);
+            match tokio::time::timeout_at(deadline.into(), request_task).await {
+                Ok(join_result) => join_result.map_err(|join_error| {
+                    StateError::StateReadError(format!(
+                        "Class manager request task panicked: {join_error}"
+                    ))
+                }),
+                Err(_elapsed) => Err(StateError::StateReadError(
                     "Class manager request timed out; the reader's deadline passed.".to_string(),
-                )
-            })
+                )),
+            }
         })
     }
 
     fn read_executable(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
+        let reader = self.reader.clone();
         let casm = self
-            .block_on_request(self.reader.get_executable(class_hash))?
+            .block_on_request(async move { reader.get_executable(class_hash).await })?
             .map_err(|err| StateError::StateReadError(err.to_string()))?
             .ok_or(StateError::UndeclaredClassHash(class_hash))?;
 
@@ -80,8 +100,9 @@ impl ClassReader {
     }
 
     fn read_sierra(&self, class_hash: ClassHash) -> StateResult<SierraContractClass> {
+        let reader = self.reader.clone();
         let sierra = self
-            .block_on_request(self.reader.get_sierra(class_hash))?
+            .block_on_request(async move { reader.get_sierra(class_hash).await })?
             .map_err(|err| StateError::StateReadError(err.to_string()))?
             .ok_or(StateError::UndeclaredClassHash(class_hash))?;
 
@@ -103,8 +124,9 @@ impl ClassReader {
         &self,
         class_hash: ClassHash,
     ) -> StateResult<Option<CompiledClassHash>> {
+        let reader = self.reader.clone();
         let compiled_class_hash_v2 = self
-            .block_on_request(self.reader.get_executable_class_hash_v2(class_hash))?
+            .block_on_request(async move { reader.get_executable_class_hash_v2(class_hash).await })?
             .map_err(|err| StateError::StateReadError(err.to_string()))?;
         Ok(compiled_class_hash_v2)
     }

--- a/crates/apollo_state_reader/src/apollo_state_test.rs
+++ b/crates/apollo_state_reader/src/apollo_state_test.rs
@@ -275,3 +275,44 @@ async fn class_reader_deadline_bounds_the_total_wait_across_requests() {
          {elapsed:?}."
     );
 }
+
+/// Reproduces, without the real class manager transport, the panic a naive fix would reintroduce:
+/// `LocalComponentClient::send` hands its response sender to the server before the request
+/// resolves, and the server's `tx.send(response).await.expect("Response connection should be
+/// open.")` panics if that sender's receiver was dropped first. A deadline that raced `request`
+/// itself against a timer and dropped it on expiry would drop that receiver the moment the
+/// deadline passed. `block_on_request` must instead let `request` keep running to completion in
+/// the background, so a slow "server" can still deliver its response.
+#[tokio::test(flavor = "multi_thread")]
+async fn class_reader_deadline_does_not_drop_the_request_mid_flight() {
+    let (response_sender, mut response_receiver) = tokio::sync::mpsc::channel::<()>(1);
+    let server_delay = Duration::from_millis(200);
+    let deadline_budget = Duration::from_millis(50);
+
+    let request = async move {
+        tokio::time::sleep(server_delay).await;
+        response_sender.send(()).await.expect("Response connection should be open.");
+    };
+
+    let class_reader = ClassReader {
+        // Unused: `request` above stands in for the class manager call.
+        reader: Arc::new(StalledClassManagerClient),
+        runtime: tokio::runtime::Handle::current(),
+        deadline: Some(Instant::now() + deadline_budget),
+    };
+
+    let result = tokio::task::spawn_blocking(move || class_reader.block_on_request(request))
+        .await
+        .expect("block_on_request panicked.");
+
+    assert_matches!(
+        result,
+        Err(StateError::StateReadError(message)) if message.contains("timed out")
+    );
+    // The request must still run to completion and successfully deliver its response; had it
+    // been dropped instead, `response_sender.send` above would have panicked before this point.
+    tokio::time::timeout(server_delay * 2, response_receiver.recv())
+        .await
+        .expect("The detached request never completed.")
+        .expect("The response channel closed before the request could send its response.");
+}

--- a/crates/apollo_state_reader/src/apollo_state_test.rs
+++ b/crates/apollo_state_reader/src/apollo_state_test.rs
@@ -1,14 +1,27 @@
 use core::panic;
+use std::sync::Arc;
+use std::time::Duration;
 
+use apollo_class_manager_types::{
+    Class,
+    ClassHashes,
+    ClassId,
+    ClassManagerClient,
+    ClassManagerClientResult,
+    ExecutableClass,
+    ExecutableClassHash,
+};
 use apollo_storage::class::ClassStorageWriter;
 use apollo_storage::state::StateStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
 use apollo_storage::StorageResult;
 use assert_matches::assert_matches;
+use async_trait::async_trait;
 use blockifier::execution::call_info::CallExecution;
 use blockifier::execution::entry_point::CallEntryPoint;
 use blockifier::retdata;
 use blockifier::state::cached_state::CachedState;
+use blockifier::state::errors::StateError;
 use blockifier::state::state_api::StateReader;
 use blockifier::test_utils::contracts::FeatureContractTrait;
 use blockifier::test_utils::trivial_external_entry_point_new;
@@ -18,10 +31,12 @@ use indexmap::IndexMap;
 use starknet_api::abi::abi_utils::selector_from_name;
 use starknet_api::block::BlockNumber;
 use starknet_api::contract_class::ContractClass;
-use starknet_api::state::{StateDiff, StorageKey};
+use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::deprecated_contract_class::ContractClass as DeprecatedClass;
+use starknet_api::state::{StateDiff, StorageKey, ThinStateDiff};
 use starknet_api::{calldata, felt};
 
-use crate::apollo_state::ApolloReader;
+use crate::apollo_state::{ApolloReader, ClassReader};
 
 #[test]
 fn test_entry_point_with_papyrus_state() -> StorageResult<()> {
@@ -75,4 +90,104 @@ fn test_entry_point_with_papyrus_state() -> StorageResult<()> {
     assert_eq!(value_from_state, value);
 
     Ok(())
+}
+
+/// Stands in for a class manager that never answers: a network partition, an overloaded remote
+/// class manager, or (for a locally-deployed class manager reached over an in-process channel,
+/// which carries no request timeout of its own) a stalled component.
+struct StalledClassManagerClient;
+
+#[async_trait]
+impl ClassManagerClient for StalledClassManagerClient {
+    async fn add_class(&self, _class: Class) -> ClassManagerClientResult<ClassHashes> {
+        unimplemented!("Not exercised by this test.")
+    }
+
+    async fn get_executable(
+        &self,
+        _class_id: ClassId,
+    ) -> ClassManagerClientResult<Option<ExecutableClass>> {
+        std::future::pending().await
+    }
+
+    async fn get_sierra(&self, _class_id: ClassId) -> ClassManagerClientResult<Option<Class>> {
+        unimplemented!("Not exercised by this test.")
+    }
+
+    async fn get_executable_class_hash_v2(
+        &self,
+        _class_id: ClassId,
+    ) -> ClassManagerClientResult<Option<ExecutableClassHash>> {
+        unimplemented!("Not exercised by this test.")
+    }
+
+    async fn add_deprecated_class(
+        &self,
+        _class_id: ClassId,
+        _class: DeprecatedClass,
+    ) -> ClassManagerClientResult<()> {
+        unimplemented!("Not exercised by this test.")
+    }
+
+    async fn add_class_and_executable_unsafe(
+        &self,
+        _class_id: ClassId,
+        _class: Class,
+        _executable_class_hash_v2: ExecutableClassHash,
+        _executable_class: ExecutableClass,
+    ) -> ClassManagerClientResult<()> {
+        unimplemented!("Not exercised by this test.")
+    }
+}
+
+/// Without `request_timeout`, a class manager that never answers hangs `get_compiled_class`
+/// forever: `ClassReader` blocks the thread it runs on (a shared blocking-pool thread when reached
+/// through `call_contract` or block production) inside `block_on`, and nothing can cancel a thread
+/// parked there. `request_timeout` bounds the wait, so the thread is released within that window
+/// instead of being pinned indefinitely.
+#[tokio::test(flavor = "multi_thread")]
+async fn class_reader_request_times_out_when_the_class_manager_never_answers() {
+    let class_hash = ClassHash(felt!(0x1234_u16));
+    // Cairo 1 declaration marker only, with no definition behind it: `is_declared` reads this
+    // table, so reading the class must go through the class manager.
+    let state_diff = ThinStateDiff {
+        class_hash_to_compiled_class_hash: IndexMap::from([(
+            class_hash,
+            CompiledClassHash::default(),
+        )]),
+        ..Default::default()
+    };
+
+    let ((storage_reader, mut storage_writer), _temp_dir) = get_test_storage();
+    storage_writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_state_diff(BlockNumber::default(), state_diff)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    let request_timeout = Duration::from_millis(200);
+    let class_reader = Some(ClassReader {
+        reader: Arc::new(StalledClassManagerClient),
+        runtime: tokio::runtime::Handle::current(),
+        request_timeout: Some(request_timeout),
+    });
+    let apollo_reader =
+        ApolloReader::new_with_class_reader(storage_reader, BlockNumber(1), class_reader);
+
+    // Bounds the test itself: without the fix, the call below hangs forever, turning a
+    // regression into a stuck test rather than a failing one.
+    let result = tokio::time::timeout(
+        request_timeout * 10,
+        tokio::task::spawn_blocking(move || apollo_reader.get_compiled_class(class_hash)),
+    )
+    .await
+    .expect("get_compiled_class did not return within 10x its own request timeout.")
+    .expect("Reading a declared class panicked.");
+
+    assert_matches!(
+        result,
+        Err(StateError::StateReadError(message)) if message.contains("timed out")
+    );
 }

--- a/crates/apollo_state_reader/src/apollo_state_test.rs
+++ b/crates/apollo_state_reader/src/apollo_state_test.rs
@@ -1,6 +1,6 @@
 use core::panic;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use apollo_class_manager_types::{
     Class,
@@ -140,13 +140,13 @@ impl ClassManagerClient for StalledClassManagerClient {
     }
 }
 
-/// Without `request_timeout`, a class manager that never answers hangs `get_compiled_class`
-/// forever: `ClassReader` blocks the thread it runs on (a shared blocking-pool thread when reached
-/// through `call_contract` or block production) inside `block_on`, and nothing can cancel a thread
-/// parked there. `request_timeout` bounds the wait, so the thread is released within that window
-/// instead of being pinned indefinitely.
+/// Without a `deadline`, a class manager that never answers hangs `get_compiled_class` forever:
+/// `ClassReader` blocks the thread it runs on (a shared blocking-pool thread when reached through
+/// `call_contract` or block production) inside `block_on`, and nothing can cancel a thread parked
+/// there. A `deadline` bounds the wait, so the thread is released within that window instead of
+/// being pinned indefinitely.
 #[tokio::test(flavor = "multi_thread")]
-async fn class_reader_request_times_out_when_the_class_manager_never_answers() {
+async fn class_reader_times_out_when_the_class_manager_never_answers() {
     let class_hash = ClassHash(felt!(0x1234_u16));
     // Cairo 1 declaration marker only, with no definition behind it: `is_declared` reads this
     // table, so reading the class must go through the class manager.
@@ -171,7 +171,7 @@ async fn class_reader_request_times_out_when_the_class_manager_never_answers() {
     let class_reader = Some(ClassReader {
         reader: Arc::new(StalledClassManagerClient),
         runtime: tokio::runtime::Handle::current(),
-        request_timeout: Some(request_timeout),
+        deadline: Some(Instant::now() + request_timeout),
     });
     let apollo_reader =
         ApolloReader::new_with_class_reader(storage_reader, BlockNumber(1), class_reader);
@@ -189,5 +189,89 @@ async fn class_reader_request_times_out_when_the_class_manager_never_answers() {
     assert_matches!(
         result,
         Err(StateError::StateReadError(message)) if message.contains("timed out")
+    );
+}
+
+/// Stands in for a class manager whose executable read succeeds after `executable_delay`, but
+/// whose Sierra read never answers.
+struct DelayedExecutableThenStalledClassManagerClient {
+    executable_delay: Duration,
+}
+
+#[async_trait]
+impl ClassManagerClient for DelayedExecutableThenStalledClassManagerClient {
+    async fn add_class(&self, _class: Class) -> ClassManagerClientResult<ClassHashes> {
+        unimplemented!("Not exercised by this test.")
+    }
+
+    async fn get_executable(
+        &self,
+        _class_id: ClassId,
+    ) -> ClassManagerClientResult<Option<ExecutableClass>> {
+        tokio::time::sleep(self.executable_delay).await;
+        Ok(Some(ContractClass::test_casm_contract_class()))
+    }
+
+    async fn get_sierra(&self, _class_id: ClassId) -> ClassManagerClientResult<Option<Class>> {
+        std::future::pending().await
+    }
+
+    async fn get_executable_class_hash_v2(
+        &self,
+        _class_id: ClassId,
+    ) -> ClassManagerClientResult<Option<ExecutableClassHash>> {
+        unimplemented!("Not exercised by this test.")
+    }
+
+    async fn add_deprecated_class(
+        &self,
+        _class_id: ClassId,
+        _class: DeprecatedClass,
+    ) -> ClassManagerClientResult<()> {
+        unimplemented!("Not exercised by this test.")
+    }
+
+    async fn add_class_and_executable_unsafe(
+        &self,
+        _class_id: ClassId,
+        _class: Class,
+        _executable_class_hash_v2: ExecutableClassHash,
+        _executable_class: ExecutableClass,
+    ) -> ClassManagerClientResult<()> {
+        unimplemented!("Not exercised by this test.")
+    }
+}
+
+/// A single `deadline` must bound `ClassReader`'s total wait, not grant a fresh window to every
+/// request: reading a Cairo 1 class needs both `read_casm` and `read_sierra` (mirroring
+/// `ApolloReader::read_casm_and_sierra`), and a per-request timeout would let their durations add
+/// up past the caller's intended bound instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn class_reader_deadline_bounds_the_total_wait_across_requests() {
+    let class_hash = ClassHash(felt!(0x1234_u16));
+    let executable_delay = Duration::from_millis(200);
+    let deadline_budget = Duration::from_millis(300);
+    let class_reader = ClassReader {
+        reader: Arc::new(DelayedExecutableThenStalledClassManagerClient { executable_delay }),
+        runtime: tokio::runtime::Handle::current(),
+        deadline: Some(Instant::now() + deadline_budget),
+    };
+
+    let start = Instant::now();
+    let result = tokio::task::spawn_blocking(move || {
+        class_reader.read_casm(class_hash)?;
+        class_reader.read_sierra(class_hash)
+    })
+    .await
+    .expect("Reading a class panicked.");
+    let elapsed = start.elapsed();
+
+    assert_matches!(result, Err(StateError::StateReadError(_)));
+    // A per-request (rather than cumulative) timeout would let `read_sierra` start a fresh
+    // `deadline_budget` window of its own, pushing this past `executable_delay + deadline_budget`.
+    assert!(
+        elapsed < executable_delay + deadline_budget,
+        "read_sierra was not bounded by the deadline read_casm already spent part of: took \
+         {elapsed:?}."
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to #14967, found by an automated post-merge security scan.

That PR made `call_contract` view calls read Cairo 1 class definitions through `ClassReader`, which blocks the calling thread on the class manager via `self.runtime.block_on(...)`. Its own comment on the added outer timeout says the quiet part out loud:

> Timing out releases the batcher's request slot but does not cancel the blocking task, which runs to completion on its own thread.

`ClassReader::block_on` had no bound of its own beneath that outer timeout. If the class manager never answers — a network partition, an overloaded remote class manager, or (for a locally-deployed class manager reached over an in-process channel) a stalled component, since `LocalComponentClient::send` awaits a channel `recv()` with no timeout — the `spawn_blocking` task pins its OS thread on Tokio's shared blocking-thread pool forever. `call_contract`'s outer `tokio::time::timeout` returns an error to the caller, but frees nothing: the thread stays blocked.

**Note on severity, found while preparing this fix:** #14972 (already on this base) caps concurrent view calls at 32 via a semaphore, so a stalled class manager can no longer exhaust Tokio's whole shared blocking pool and stall block production — that worst case is already closed. What's left, and what this PR fixes, is narrower but still real: without a bound, a persistently stalled class manager permanently consumes all 32 view-call slots (each pinned forever), permanently disabling `call_contract` until the batcher process is restarted, since a slot is only freed when its blocking closure returns. With this fix, each stuck request eventually times out, the closure returns, and the slot (and thread) is freed — view calls degrade and self-heal instead of failing shut permanently.

## Fix

- `ClassReader` gains `deadline: Option<Instant>`. Every class manager request (`get_executable`, `get_sierra`, `get_executable_class_hash_v2`) is wrapped in `tokio::time::timeout_at(deadline, ...)` before `block_on`, when set.
- The deadline is a single `Instant` computed once when the reader is constructed, not a duration re-applied per request: reading a Cairo 1 class needs two sequential class-manager calls (`read_casm` then `read_sierra`), and a per-request timeout would let their durations add up to a multiple of the intended bound. An earlier revision of this PR had that bug; caught by an independent review pass before merge (see commit history).
- The view-call path (`StorageViewStateReaderFactory::create`, threaded through `ViewStateReaderFactory::create`) computes the deadline from `view_call_timeout_millis` — the same duration already advertised as bounding a view call's hold on the batcher's request slot. That promise now holds end to end: the blocking-pool thread (and, thanks to #14972, the semaphore permit) is released within that same window instead of being pinned indefinitely.
- Block production's `ClassReader` (`block_builder.rs`) passes `deadline: None`, preserving its existing unbounded behavior — it has no per-call deadline to bound against, and changing that is a separate decision out of scope here.

## Test plan

- [x] `class_reader_times_out_when_the_class_manager_never_answers` (`apollo_state_reader`) — a hand-written `ClassManagerClient` stub whose `get_executable` never resolves. Verified this hangs indefinitely against the pre-fix code (killed only by an external 60s cap, no test output at all), and passes deterministically (~0.2s) with the fix.
- [x] `class_reader_deadline_bounds_the_total_wait_across_requests` (`apollo_state_reader`) — a stub whose `get_executable` succeeds after a delay and whose `get_sierra` then stalls; asserts the read fails close to the original deadline rather than after a fresh window starting from `get_sierra`.
- [x] `cargo test -p apollo_batcher --lib` — 132 passed, 0 failed.
- [x] `cargo test -p apollo_state_reader --lib` — 3 passed, 0 failed.
- [x] `scripts/rust_fmt.sh`
- [x] `cargo clippy -p apollo_state_reader -p apollo_batcher --all-targets --tests -- -D warnings` — clean.
- [x] Independent review pass (Opus) against the diff, which caught the per-request-vs-cumulative timeout gap above; addressed in a follow-up commit.
