### PR TITLE
blockifier,starknet_os_flow_tests: accept null empty spans in read_fe…

### DIFF
--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -937,6 +937,12 @@ where
         + From<TryFromBigIntError<BigUint>>,
 {
     let array_size = felt_from_ptr(vm, ptr)?;
+    // An empty array's data pointer may be a felt-zero null (`cast(0, felt*)`) rather than a real
+    // segment.
+    if array_size == Felt::ZERO {
+        *ptr = (*ptr + 1)?;
+        return Ok(vec![]);
+    }
     let array_data_start_ptr = vm.get_relocatable(*ptr)?;
     *ptr = (*ptr + 1)?;
 

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -861,6 +861,15 @@ pub fn read_felt_array<TErr>(vm: &VirtualMachine, ptr: &mut Relocatable) -> Resu
 where
     TErr: From<StarknetApiError> + From<VirtualMachineError> + From<MemoryError> + From<MathError>,
 {
+    // If the start and end pointers are the same, the array is empty.
+    // This check is necessary to handle the case where both pointers are zero, and thus are not
+    // relocatable values.
+    let array_start = vm.get_maybe(&*ptr);
+    if array_start.is_some() && array_start == vm.get_maybe(&(*ptr + 1_usize)?) {
+        *ptr = (*ptr + 2)?;
+        return Ok(vec![]);
+    }
+
     let array_data_start_ptr = vm.get_relocatable(*ptr)?;
     *ptr = (*ptr + 1)?;
     let array_data_end_ptr = vm.get_relocatable(*ptr)?;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/mod.rs
@@ -14,6 +14,7 @@ mod get_execution_info;
 mod keccak;
 mod library_call;
 mod meta_tx;
+mod null_empty_span;
 mod out_of_gas;
 mod replace_class;
 mod secp;

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/null_empty_span.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/null_empty_span.rs
@@ -1,0 +1,103 @@
+use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
+use cairo_vm::vm::vm_core::VirtualMachine;
+use starknet_types_core::felt::Felt;
+
+use crate::execution::deprecated_syscalls::deprecated_syscall_executor::DeprecatedSyscallExecutorBaseError;
+use crate::execution::deprecated_syscalls::hint_processor::read_felt_array as deprecated_read_felt_array;
+use crate::execution::syscalls::hint_processor::read_felt_array;
+use crate::execution::syscalls::vm_syscall_utils::SyscallExecutorBaseError;
+
+fn vm_with_span(start: MaybeRelocatable, end: MaybeRelocatable) -> (VirtualMachine, Relocatable) {
+    vm_with_span_in(VirtualMachine::new(false, false), start, end)
+}
+
+fn vm_with_span_in(
+    mut vm: VirtualMachine,
+    start: MaybeRelocatable,
+    end: MaybeRelocatable,
+) -> (VirtualMachine, Relocatable) {
+    let span_ptr = vm.add_memory_segment();
+    vm.load_data(span_ptr, &[start, end]).unwrap();
+    (vm, span_ptr)
+}
+
+// The deprecated (Cairo0) parser uses a `(size, data_ptr)` layout. STARKNET-96's null span,
+// forwarded from a Cairo1 caller into a Cairo0 contract's syscall, arrives as `(0, felt-zero-ptr)`.
+fn vm_with_deprecated_array(
+    array_size: MaybeRelocatable,
+    data_ptr: MaybeRelocatable,
+) -> (VirtualMachine, Relocatable) {
+    let mut vm = VirtualMachine::new(false, false);
+    let array_ptr = vm.add_memory_segment();
+    vm.load_data(array_ptr, &[array_size, data_ptr]).unwrap();
+    (vm, array_ptr)
+}
+
+#[test]
+fn read_felt_array_accepts_empty_felt_span() {
+    // STARKNET-96: a null empty span arrives as two equal felt-zero endpoints (`cast(0, felt*)`).
+    let (vm, mut span_ptr) = vm_with_span(Felt::ZERO.into(), Felt::ZERO.into());
+
+    let values = read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).unwrap();
+
+    assert!(values.is_empty());
+}
+
+#[test]
+fn read_felt_array_accepts_equal_nonzero_felt_span() {
+    // Any two equal endpoints denote an empty array, regardless of the (non-relocatable) value.
+    let (vm, mut span_ptr) = vm_with_span(Felt::ONE.into(), Felt::ONE.into());
+
+    let values = read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).unwrap();
+
+    assert!(values.is_empty());
+}
+
+#[test]
+fn read_felt_array_accepts_real_empty_span() {
+    // A real (segment-backed) empty span has start == end pointing at the same relocatable.
+    let mut vm = VirtualMachine::new(false, false);
+    let data_ptr = vm.add_memory_segment();
+    let (vm, mut span_ptr) = vm_with_span_in(vm, data_ptr.into(), data_ptr.into());
+
+    let values = read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).unwrap();
+
+    assert!(values.is_empty());
+}
+
+#[test]
+fn read_felt_array_rejects_mixed_null_and_pointer_span() {
+    let mut vm = VirtualMachine::new(false, false);
+    let data_ptr = vm.add_memory_segment();
+    let span_ptr = vm.add_memory_segment();
+    vm.load_data(span_ptr, &[Felt::ZERO.into(), data_ptr.into()]).unwrap();
+    let mut span_ptr = span_ptr;
+
+    assert!(read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).is_err());
+}
+
+#[test]
+fn deprecated_read_felt_array_accepts_null_empty_array() {
+    let (vm, mut array_ptr) = vm_with_deprecated_array(Felt::ZERO.into(), Felt::ZERO.into());
+
+    let values =
+        deprecated_read_felt_array::<DeprecatedSyscallExecutorBaseError>(&vm, &mut array_ptr)
+            .unwrap();
+
+    assert!(values.is_empty());
+}
+
+#[test]
+fn deprecated_read_felt_array_accepts_real_empty_array() {
+    let mut vm = VirtualMachine::new(false, false);
+    let data_ptr = vm.add_memory_segment();
+    let array_ptr = vm.add_memory_segment();
+    vm.load_data(array_ptr, &[Felt::ZERO.into(), data_ptr.into()]).unwrap();
+    let mut array_ptr = array_ptr;
+
+    let values =
+        deprecated_read_felt_array::<DeprecatedSyscallExecutorBaseError>(&vm, &mut array_ptr)
+            .unwrap();
+
+    assert!(values.is_empty());
+}

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo0/compiled/delegate_proxy_compiled.json
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo0/compiled/delegate_proxy_compiled.json
@@ -26,6 +26,25 @@
                     "type": "felt*"
                 }
             ],
+            "name": "emit_event_raw",
+            "outputs": [],
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "selector",
+                    "type": "felt"
+                },
+                {
+                    "name": "calldata_size",
+                    "type": "felt"
+                },
+                {
+                    "name": "calldata",
+                    "type": "felt*"
+                }
+            ],
             "name": "__default__",
             "outputs": [
                 {
@@ -63,17 +82,21 @@
         "CONSTRUCTOR": [],
         "EXTERNAL": [
             {
-                "offset": 114,
+                "offset": 152,
                 "selector": "0x0"
             },
             {
-                "offset": 77,
+                "offset": 116,
+                "selector": "0x11588788d88e47ab2d3ee2758485e030ff0cdf78d3f49db3b964c27cef0b91d"
+            },
+            {
+                "offset": 87,
                 "selector": "0x1679fae2e055e520e40aa3151502bc246034020f987623497fa9bd662846fa7"
             }
         ],
         "L1_HANDLER": [
             {
-                "offset": 145,
+                "offset": 183,
                 "selector": "0x0"
             }
         ]
@@ -127,6 +150,16 @@
             "0x482680017ffb8000",
             "0x3",
             "0x208b7fff7fff7ffe",
+            "0x480680017fff8000",
+            "0x456d69744576656e74",
+            "0x400280007ff97fff",
+            "0x400380017ff97ffa",
+            "0x400380027ff97ffb",
+            "0x400380037ff97ffc",
+            "0x400380047ff97ffd",
+            "0x482680017ff98000",
+            "0x5",
+            "0x208b7fff7fff7ffe",
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x480680017fff8000",
@@ -139,7 +172,7 @@
             "0x480a7ffb7fff8000",
             "0x48127ffe7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe6",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdc",
             "0x48127ffe7fff8000",
             "0x48127ff57fff8000",
             "0x48127ff57fff8000",
@@ -153,7 +186,7 @@
             "0x48127ffe7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe0",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd6",
             "0x48127ff67fff8000",
             "0x48127ff67fff8000",
             "0x208b7fff7fff7ffe",
@@ -184,17 +217,45 @@
             "0x48127ffa7fff8000",
             "0x208b7fff7fff7ffe",
             "0x480a7ff87fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffba",
+            "0x480a7ff97fff8000",
+            "0x480a7ffa7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff1",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x480280037ffb8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x48127ffa7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ff87fff8000",
             "0x480a7ff97fff8000",
             "0x480a7ffa7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcb",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffaf",
             "0x48127ffc7fff8000",
             "0x48127ffe7fff8000",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff97",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff71",
             "0x48127ffd7fff8000",
             "0x48127ff17fff8000",
             "0x48127ff17fff8000",
@@ -220,14 +281,14 @@
             "0x480a7ff97fff8000",
             "0x480a7ffa7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffaa",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff8e",
             "0x48127ffc7fff8000",
             "0x48127ffe7fff8000",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff82",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff5c",
             "0x48127ffd7fff8000",
             "0x48127ff17fff8000",
             "0x48127ff17fff8000",
@@ -325,7 +386,25 @@
                     }
                 }
             ],
-            "86": [
+            "47": [
+                {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.emit_event"
+                    ],
+                    "code": "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 4,
+                            "offset": 1
+                        },
+                        "reference_ids": {
+                            "starkware.starknet.common.syscalls.emit_event.syscall_ptr": 4
+                        }
+                    }
+                }
+            ],
+            "96": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -336,14 +415,32 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 8,
+                            "group": 9,
                             "offset": 29
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "153": [
+            "124": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.emit_event_raw"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 11,
+                            "offset": 19
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "191": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -354,7 +451,7 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 12,
+                            "group": 15,
                             "offset": 45
                         },
                         "reference_ids": {}
@@ -373,7 +470,7 @@
                     "raw_input",
                     "raw_output"
                 ],
-                "pc": 96,
+                "pc": 134,
                 "type": "function"
             },
             "__main__.__default__.Args": {
@@ -427,7 +524,7 @@
                     "l1_handler",
                     "raw_input"
                 ],
-                "pc": 129,
+                "pc": 167,
                 "type": "function"
             },
             "__main__.__l1_default__.Args": {
@@ -476,6 +573,64 @@
                 "type": "const",
                 "value": 0
             },
+            "__main__.emit_event": {
+                "destination": "starkware.starknet.common.syscalls.emit_event",
+                "type": "alias"
+            },
+            "__main__.emit_event_raw": {
+                "decorators": [
+                    "external",
+                    "raw_input"
+                ],
+                "pc": 106,
+                "type": "function"
+            },
+            "__main__.emit_event_raw.Args": {
+                "full_name": "__main__.emit_event_raw.Args",
+                "members": {
+                    "calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 2
+                    },
+                    "calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.emit_event_raw.ImplicitArgs": {
+                "full_name": "__main__.emit_event_raw.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.emit_event_raw.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.emit_event_raw.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
             "__main__.implementation_hash": {
                 "type": "namespace"
             },
@@ -505,7 +660,7 @@
             },
             "__main__.implementation_hash.addr": {
                 "decorators": [],
-                "pc": 40,
+                "pc": 50,
                 "type": "function"
             },
             "__main__.implementation_hash.addr.Args": {
@@ -547,7 +702,7 @@
             },
             "__main__.implementation_hash.read": {
                 "decorators": [],
-                "pc": 45,
+                "pc": 55,
                 "type": "function"
             },
             "__main__.implementation_hash.read.Args": {
@@ -593,7 +748,7 @@
             },
             "__main__.implementation_hash.write": {
                 "decorators": [],
-                "pc": 58,
+                "pc": 68,
                 "type": "function"
             },
             "__main__.implementation_hash.write.Args": {
@@ -646,7 +801,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 70,
+                "pc": 80,
                 "type": "function"
             },
             "__main__.set_implementation_hash.Args": {
@@ -693,7 +848,7 @@
                     "raw_input",
                     "raw_output"
                 ],
-                "pc": 114,
+                "pc": 152,
                 "type": "function"
             },
             "__wrappers__.__default__.Args": {
@@ -729,7 +884,7 @@
                     "l1_handler",
                     "raw_input"
                 ],
-                "pc": 145,
+                "pc": 183,
                 "type": "function"
             },
             "__wrappers__.__l1_default__.Args": {
@@ -760,11 +915,47 @@
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
+            "__wrappers__.emit_event_raw": {
+                "decorators": [
+                    "external",
+                    "raw_input"
+                ],
+                "pc": 116,
+                "type": "function"
+            },
+            "__wrappers__.emit_event_raw.Args": {
+                "full_name": "__wrappers__.emit_event_raw.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.emit_event_raw.ImplicitArgs": {
+                "full_name": "__wrappers__.emit_event_raw.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.emit_event_raw.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, bitwise_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.emit_event_raw.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.emit_event_raw.__wrapped_func": {
+                "destination": "__main__.emit_event_raw",
+                "type": "alias"
+            },
+            "__wrappers__.emit_event_raw_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
             "__wrappers__.set_implementation_hash": {
                 "decorators": [
                     "external"
                 ],
-                "pc": 77,
+                "pc": 87,
                 "type": "function"
             },
             "__wrappers__.set_implementation_hash.Args": {
@@ -1758,6 +1949,76 @@
                 "size": 8,
                 "type": "struct"
             },
+            "starkware.starknet.common.syscalls.emit_event": {
+                "decorators": [],
+                "pc": 40,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.emit_event.Args": {
+                "full_name": "starkware.starknet.common.syscalls.emit_event.Args",
+                "members": {
+                    "data": {
+                        "cairo_type": "felt*",
+                        "offset": 3
+                    },
+                    "data_len": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "keys": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "keys_len": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 4,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.emit_event.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.emit_event.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.emit_event.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.emit_event.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.emit_event.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.emit_event.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 0
+                        },
+                        "pc": 40,
+                        "value": "[cast(fp + (-7), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 1
+                        },
+                        "pc": 47,
+                        "value": "cast([fp + (-7)] + 5, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
             "starkware.starknet.common.syscalls.library_call": {
                 "decorators": [],
                 "pc": 0,
@@ -2054,6 +2315,14 @@
                     },
                     "pc": 32,
                     "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 40,
+                    "value": "[cast(fp + (-7), felt**)]"
                 }
             ]
         }

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo0/delegate_proxy.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo0/delegate_proxy.cairo
@@ -4,7 +4,7 @@
 %builtins pedersen range_check bitwise
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.syscalls import library_call, library_call_l1_handler
+from starkware.starknet.common.syscalls import emit_event, library_call, library_call_l1_handler
 
 // The hash of the implementation contract class.
 @storage_var
@@ -16,6 +16,15 @@ func set_implementation_hash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ran
     implementation_hash_: felt
 ) {
     implementation_hash.write(value=implementation_hash_);
+    return ();
+}
+
+@external
+@raw_input
+func emit_event_raw{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    selector: felt, calldata_size: felt, calldata: felt*
+) {
+    emit_event(keys_len=calldata_size, keys=calldata, data_len=calldata_size, data=calldata);
     return ();
 }
 

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo1/empty_span_emitting_account.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo1/empty_span_emitting_account.cairo
@@ -1,0 +1,74 @@
+// A minimal account whose constructor forwards the (logically empty)
+// `account_deployment_data` span from the current transaction info into syscalls.
+//
+// DeployAccount V3 has no account-deployment data, so the OS builds that span with felt-zero
+// endpoints. Re-emitting the span forces the syscall decoder to dereference those endpoints:
+// native Blockifier (relocatable endpoints) succeeds, while an OS that uses `cast(0, felt*)`
+// aborts with "Expected relocatable" (STARKNET-96). The constructor exercises both the modern and
+// deprecated syscall parsers through the shared Cairo0 DelegateProxy.
+#[starknet::contract(account)]
+mod Account {
+    use core::array::ArrayTrait;
+    use core::box::BoxTrait;
+    use core::traits::TryInto;
+    use starknet::class_hash::ClassHash;
+    use starknet::syscalls::{emit_event_syscall, library_call_syscall};
+    use starknet::{ContractAddress, SyscallResultTrait};
+
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, proxy_class_hash: felt252) {
+        let execution_info = starknet::get_execution_info().unbox();
+        let tx_info = execution_info.tx_info.unbox();
+        let mut event_data: Array<felt252> = ArrayTrait::new();
+        event_data.append(1);
+        emit_event_syscall(tx_info.account_deployment_data, event_data.span()).unwrap_syscall();
+
+        let class_hash: ClassHash = proxy_class_hash.try_into().unwrap();
+        library_call_syscall(
+            class_hash,
+            selector!("emit_event_raw"),
+            tx_info.account_deployment_data,
+        )
+        .unwrap_syscall();
+    }
+
+    #[external(v0)]
+    fn __validate_deploy__(
+        self: @ContractState,
+        class_hash: felt252,
+        contract_address_salt: felt252,
+        proxy_class_hash: felt252,
+    ) -> felt252 {
+        starknet::VALIDATED
+    }
+
+    #[external(v0)]
+    fn __validate_declare__(self: @ContractState, class_hash: felt252) -> felt252 {
+        starknet::VALIDATED
+    }
+
+    #[external(v0)]
+    fn __validate__(
+        self: @ContractState,
+        contract_address: ContractAddress,
+        selector: felt252,
+        calldata: Array<felt252>,
+    ) -> felt252 {
+        starknet::VALIDATED
+    }
+
+    #[external(v0)]
+    #[raw_output]
+    fn __execute__(
+        self: @ContractState,
+        contract_address: ContractAddress,
+        selector: felt252,
+        calldata: Array<felt252>,
+    ) -> Span<felt252> {
+        let empty: Array<felt252> = ArrayTrait::new();
+        empty.span()
+    }
+}

--- a/crates/blockifier_test_utils/src/contracts.rs
+++ b/crates/blockifier_test_utils/src/contracts.rs
@@ -78,6 +78,7 @@ const FUZZ_TEST_ORCHESTRATOR_BASE: u32 = 21 * CLASS_HASH_BASE;
 const ACCOUNT_WITH_REAL_VALIDATE_BASE: u32 = 22 * CLASS_HASH_BASE;
 const OS_RESOURCES_TEST_CONTRACT_BASE: u32 = 23 * CLASS_HASH_BASE;
 const CENDE_TEST_CONTRACT_BASE: u32 = 24 * CLASS_HASH_BASE;
+const EMPTY_SPAN_EMITTING_ACCOUNT_BASE: u32 = 25 * CLASS_HASH_BASE;
 
 // Contract names.
 const ACCOUNT_LONG_VALIDATE_NAME: &str = "account_with_long_validate";
@@ -103,6 +104,7 @@ const FUZZ_TEST_ORCHESTRATOR_NAME: &str = "fuzz_revert_orchestrator";
 const ACCOUNT_WITH_REAL_VALIDATE_NAME: &str = "account_with_real_validate";
 const OS_RESOURCES_TEST_CONTRACT_NAME: &str = "os_resources_test_contract";
 const CENDE_TEST_CONTRACT_NAME: &str = "cende_test_contract";
+const EMPTY_SPAN_EMITTING_ACCOUNT_NAME: &str = "empty_span_emitting_account";
 // ERC20 contract is in a unique location.
 const ERC20_CAIRO0_CONTRACT_SOURCE_PATH: &str =
     "./resources/ERC20/ERC20_Cairo0/ERC20_without_some_syscalls/ERC20/ERC20.cairo";
@@ -147,6 +149,7 @@ pub enum FeatureContract {
     AccountWithRealValidate(RunnableCairo1),
     OsResourcesTest(RunnableCairo1),
     CendeTest(RunnableCairo1),
+    EmptySpanEmittingAccount(RunnableCairo1),
 }
 
 impl FeatureContract {
@@ -175,7 +178,10 @@ impl FeatureContract {
             | Self::FuzzTestOrchestrator(runnable_version)
             | Self::AccountWithRealValidate(runnable_version)
             | Self::OsResourcesTest(runnable_version)
-            | Self::CendeTest(runnable_version) => CairoVersion::Cairo1(*runnable_version),
+            | Self::CendeTest(runnable_version)
+            | Self::EmptySpanEmittingAccount(runnable_version) => {
+                CairoVersion::Cairo1(*runnable_version)
+            }
         }
     }
 
@@ -197,7 +203,8 @@ impl FeatureContract {
             | Self::FuzzTestOrchestrator(rv)
             | Self::AccountWithRealValidate(rv)
             | Self::OsResourcesTest(rv)
-            | Self::CendeTest(rv) => match version {
+            | Self::CendeTest(rv)
+            | Self::EmptySpanEmittingAccount(rv) => match version {
                 CairoVersion::Cairo0 => panic!("{self:?} must be Cairo1"),
                 CairoVersion::Cairo1(runnable) => *rv = runnable,
             },
@@ -341,6 +348,7 @@ impl FeatureContract {
                 Self::AccountWithRealValidate(_) => ACCOUNT_WITH_REAL_VALIDATE_BASE,
                 Self::OsResourcesTest(_) => OS_RESOURCES_TEST_CONTRACT_BASE,
                 Self::CendeTest(_) => CENDE_TEST_CONTRACT_BASE,
+                Self::EmptySpanEmittingAccount(_) => EMPTY_SPAN_EMITTING_ACCOUNT_BASE,
             }
     }
 
@@ -377,6 +385,7 @@ impl FeatureContract {
             Self::AccountWithRealValidate(_) => ACCOUNT_WITH_REAL_VALIDATE_NAME,
             Self::OsResourcesTest(_) => OS_RESOURCES_TEST_CONTRACT_NAME,
             Self::CendeTest(_) => CENDE_TEST_CONTRACT_NAME,
+            Self::EmptySpanEmittingAccount(_) => EMPTY_SPAN_EMITTING_ACCOUNT_NAME,
             Self::ERC20(_) => unreachable!(),
         }
     }
@@ -489,7 +498,8 @@ impl FeatureContract {
                     | FeatureContract::FuzzTestOrchestrator(_)
                     | FeatureContract::AccountWithRealValidate(_)
                     | FeatureContract::OsResourcesTest(_)
-                    | FeatureContract::CendeTest(_) => None,
+                    | FeatureContract::CendeTest(_)
+                    | FeatureContract::EmptySpanEmittingAccount(_) => None,
                     FeatureContract::ERC20(_) | FeatureContract::Experimental => unreachable!(),
                 };
                 cairo0_compile(self.get_source_path(), extra_arg, false)
@@ -540,7 +550,8 @@ impl FeatureContract {
             | Self::FuzzTestOrchestrator(_)
             | Self::AccountWithRealValidate(_)
             | Self::OsResourcesTest(_)
-            | Self::CendeTest(_) => {
+            | Self::CendeTest(_)
+            | Self::EmptySpanEmittingAccount(_) => {
                 #[cfg(not(feature = "cairo_native"))]
                 {
                     vec![*self]

--- a/crates/starknet_os_flow_tests/src/test_manager.rs
+++ b/crates/starknet_os_flow_tests/src/test_manager.rs
@@ -659,12 +659,23 @@ impl<S: FlowTestState> TestBuilder<S> {
     }
 
     pub(crate) fn add_deploy_account_tx(&mut self, tx: DeployAccountTransaction) {
+        self.add_deploy_account_tx_with_events(tx, Vec::new());
+    }
+
+    /// Like `add_deploy_account_tx`, but registers `event_expectations` (in emission order) for the
+    /// constructor's events; the fee-transfer expectation is appended automatically last.
+    pub(crate) fn add_deploy_account_tx_with_events(
+        &mut self,
+        tx: DeployAccountTransaction,
+        mut event_expectations: Vec<EventPredicateExpectation>,
+    ) {
+        event_expectations.push(expect_fee_token_transfer_to_sequencer_event());
         self.last_block_txs_mut().push(FlowTestTx {
             tx: BlockifierTransaction::new_for_sequencing(ExecutableTransaction::Account(
                 AccountTransaction::DeployAccount(tx),
             )),
             expected_revert_reason: None,
-            event_expectations: vec![expect_fee_token_transfer_to_sequencer_event()],
+            event_expectations,
         });
     }
 

--- a/crates/starknet_os_flow_tests/src/tests.rs
+++ b/crates/starknet_os_flow_tests/src/tests.rs
@@ -1829,6 +1829,106 @@ async fn test_syscalls_with_alternating_inner_calls() {
     test_output.perform_default_validations();
 }
 
+/// Regression for STARKNET-96: a DeployAccount V3 constructor that forwards the (empty)
+/// `account_deployment_data` span into `emit_event`. The OS builds that span for DeployAccount V3,
+/// and if its endpoints are felt-zero (`cast(0, felt*)`) instead of relocatable pointers, the OS
+/// syscall decoder aborts with "Expected relocatable" while native Blockifier accepts the tx —
+/// making the committed block unprovable. Running the OS to completion here exercises the fix.
+#[tokio::test]
+async fn test_deploy_account_v3_empty_deployment_data_span_emit() {
+    let account = FeatureContract::EmptySpanEmittingAccount(RunnableCairo1::Casm);
+    let account_sierra = account.get_sierra();
+    let class_hash = account_sierra.calculate_class_hash();
+    let compiled_class_hash = account.get_compiled_class_hash(&HashVersion::V2);
+    let (mut test_builder, _) = TestBuilder::create_standard([]).await;
+    let chain_id = &test_builder.chain_id();
+
+    // Declare the malicious account class from the funded account.
+    let declare_args = declare_tx_args! {
+        sender_address: *FUNDED_ACCOUNT_ADDRESS,
+        nonce: test_builder.next_nonce(*FUNDED_ACCOUNT_ADDRESS),
+        class_hash,
+        compiled_class_hash,
+        resource_bounds: *NON_TRIVIAL_RESOURCE_BOUNDS,
+    };
+    let class_info = account.get_class_info();
+    let account_declare_tx =
+        DeclareTransaction::create(declare_tx(declare_args), class_info, chain_id).unwrap();
+    test_builder.add_cairo1_declare_tx(account_declare_tx, &account_sierra);
+
+    // Declare the shared Cairo0 delegate proxy used by the deprecated syscall path. Declare V0
+    // skips nonce handling, so it does not consume the funded account's nonce.
+    let proxy = FeatureContract::DelegateProxy;
+    let proxy_class_hash = get_class_hash_of_feature_contract(proxy);
+    let proxy_declare_args = declare_tx_args! {
+        version: TransactionVersion::ZERO,
+        max_fee: Fee(1_000_000_000_000_000),
+        class_hash: proxy_class_hash,
+        sender_address: *FUNDED_ACCOUNT_ADDRESS,
+    };
+    let proxy_class_info = proxy.get_class_info();
+    let proxy_declare_tx =
+        DeclareTransaction::create(declare_tx(proxy_declare_args), proxy_class_info, chain_id)
+            .unwrap();
+    test_builder.add_cairo0_declare_tx(proxy_declare_tx, proxy_class_hash);
+
+    // The constructor emits once through Cairo 1, then library-calls the Cairo0 proxy with the
+    // same empty span. This single deployment covers both syscall parsers.
+    let constructor_calldata = calldata![proxy_class_hash.0];
+
+    // Precompute the counterfactual address and fund it.
+    let salt = ContractAddressSalt(Felt::from(1993));
+    let account_address = calculate_contract_address(
+        salt,
+        class_hash,
+        &constructor_calldata,
+        ContractAddress::default(),
+    )
+    .unwrap();
+    test_builder.add_fund_address_tx_with_default_amount(account_address);
+
+    // DeployAccount V3 — the constructor emits the empty `account_deployment_data` span twice,
+    // once through each syscall parser.
+    let deploy_tx_args = deploy_account_tx_args! {
+        class_hash,
+        resource_bounds: *NON_TRIVIAL_RESOURCE_BOUNDS,
+        contract_address_salt: salt,
+        constructor_calldata,
+    };
+    let deploy_account_tx = DeployAccountTransaction::create(
+        deploy_account_tx(deploy_tx_args, test_builder.next_nonce(account_address)),
+        chain_id,
+    )
+    .unwrap();
+    // The first constructor event comes from the modern syscall: empty keys and data `[1]`.
+    let constructor_event = EventPredicateExpectation {
+        description: "constructor emits the empty account_deployment_data span as event keys"
+            .to_string(),
+        predicate: Box::new(move |event| {
+            event.from_address == account_address
+                && event.content.keys.is_empty()
+                && event.content.data.0 == vec![Felt::ONE]
+        }),
+    };
+    // The second event comes from the Cairo0 proxy: empty keys and empty data.
+    let proxy_event = EventPredicateExpectation {
+        description: "Cairo0 proxy re-emits the empty account_deployment_data span via a \
+                      deprecated emit_event syscall"
+            .to_string(),
+        predicate: Box::new(move |event| {
+            event.from_address == account_address
+                && event.content.keys.is_empty()
+                && event.content.data.0.is_empty()
+        }),
+    };
+    test_builder
+        .add_deploy_account_tx_with_events(deploy_account_tx, vec![constructor_event, proxy_event]);
+
+    // Before the fix, the OS run aborts here with "Expected relocatable".
+    let test_output = test_builder.build_and_run().await;
+    test_output.perform_validations(true, None);
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_deprecated_tx_info() {


### PR DESCRIPTION
…lt_array (STARKNET-96)

An empty Cairo1 span forwarded from the OS as a felt-zero null pointer (`cast(0, felt*)`, e.g. an empty V3 `account_deployment_data`) made `read_felt_array` dereference a non-relocatable and abort ("Expected relocatable") during OS replay, while native execution accepted it — rendering an already-committed block unprovable.

Guard both decoders: the syscall `read_felt_array` treats equal start/end endpoints as empty without dereferencing (Lior's minimal approach, no new type), and the deprecated `(size, ptr)` parser returns empty when size == 0. Keccak is intentionally left unguarded: a null span cannot reach it (its input is `Span<u64>`, the OS nulls are `Span<felt252>` tx-info arrays) and the OS `execute_keccak` uses felt subtraction rather than a dereference.

Adds blockifier unit tests and starknet_os_flow_tests regression tests covering the DeployAccount V3 empty-span emit and the deprecated Cairo0 forwarding path (red->green verified).