### PR TITLE
apollo_batcher: acquire view call semaphore permit before storage reads

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -769,6 +769,18 @@ impl Batcher {
         &self,
         input: CallContractInput,
     ) -> BatcherResult<CallContractOutput> {
+        // Acquired before any storage access or state reader setup, so a call rejected under load
+        // costs nothing beyond the semaphore check.
+        let view_call_permit =
+            self.view_call_semaphore.clone().try_acquire_owned().map_err(|_| {
+                REJECTED_VIEW_CALLS.increment(1);
+                warn!(
+                    "Rejecting view call, all {MAX_CONCURRENT_VIEW_CALLS} view call slots are \
+                     taken."
+                );
+                BatcherError::ContractCallFailed { reason: TOO_MANY_VIEW_CALLS_REASON.to_string() }
+            })?;
+
         let height = self.get_height_from_storage()?;
 
         // Get the block info for the latest committed block.
@@ -788,16 +800,6 @@ impl Batcher {
             self.versioned_constants(),
             BouncerConfig::max(),
         );
-
-        let view_call_permit =
-            self.view_call_semaphore.clone().try_acquire_owned().map_err(|_| {
-                REJECTED_VIEW_CALLS.increment(1);
-                warn!(
-                    "Rejecting view call, all {MAX_CONCURRENT_VIEW_CALLS} view call slots are \
-                     taken."
-                );
-                BatcherError::ContractCallFailed { reason: TOO_MANY_VIEW_CALLS_REASON.to_string() }
-            })?;
 
         let call_task = tokio::task::spawn_blocking(move || {
             // Owned by the blocking task, so the slot is freed only when the execution ends. A


### PR DESCRIPTION
## Summary

Follow-up performance optimization on #14972, which added `view_call_semaphore` (capacity `MAX_CONCURRENT_VIEW_CALLS = 32`) to `Batcher::call_contract` to bound how many view calls can occupy tokio blocking-pool threads at once.

The merged code acquired the semaphore permit (`try_acquire_owned()`) *after* two storage reads (`get_height_from_storage`, `get_block_info`) and after constructing the view state reader and `BlockContext` (which clones a storage reader, wraps a class-manager client, and boxes a `StateReaderAndContractManager`).

This moves the permit acquisition to the top of `call_contract`, before any of that setup work.

## Why

The semaphore exists specifically to protect the node when view calls are piling up under load. In exactly that scenario — the slots are exhausted and the call is going to be rejected anyway — the old ordering still paid for two storage reads (DB transactions) and non-trivial allocation work for a request whose result is thrown away. Checking the permit first makes the rejection path near-free, avoiding wasted I/O and allocation precisely when the system is already resource-constrained.

No other behavior changes: on the success path the permit still moves into the `spawn_blocking` closure and is held until the blocking task ends, per #14972's original guarantee. The only observable difference is that if the semaphore is exhausted *and* a storage read would have separately failed, the caller now sees the more informative `ContractCallFailed { "Too many concurrent contract calls..." }` instead of `InternalError` — a strictly better error for a retryable backpressure condition.

## Testing

- `SEED=0 cargo test -p apollo_batcher`: 132 passed, 0 failed (including `call_contract_rejected_when_all_view_call_slots_are_taken` and `view_call_slot_is_freed_only_when_the_blocking_task_ends`).
- Reviewed by an independent agent for correctness (permit lifetime/drop semantics, test coverage, error precedence) — no blocking issues found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqvNB8QammyjvbXeCqYBAp)_