### PR TITLE
apollo_l1_gas_price: bound Chainlink freshness fallback between blocks

### DIFF
--- a/crates/apollo_l1_gas_price/src/chainlink_oracle/mod.rs
+++ b/crates/apollo_l1_gas_price/src/chainlink_oracle/mod.rs
@@ -41,13 +41,21 @@ mod test;
 #[cfg(test)]
 mod test_utils;
 
+// How many sampling intervals may separate the last valid read's block timestamp from the block
+// timestamp being served, while that read is still served. Three read intervals, 45 minutes at the
+// production 900 second interval. The bound applies in both directions, because a re-proposal can
+// ask for a timestamp earlier than the read the client holds.
+const MAX_FALLBACK_SAMPLING_INTERVALS: u64 = 3;
+
 // A read in flight, resolving to a rate already dated by the block timestamp it was issued for.
 // A plain handle, not an abort-on-drop one: aborting mid-`call_contract` drops the response
 // receiver while the batcher still holds the sender, which panics its local component server. The
 // slot is never reused while occupied, so there is nothing for abort-on-drop to protect.
 type RateQuery = JoinHandle<Result<ValidRead, ExchangeRateOracleClientError>>;
 
-// A rate that passed every guard, and the block timestamp it was read for.
+// A rate that passed every guard, and the block timestamp it was read for. That timestamp is a
+// block timestamp rather than a local one, because the distance a later caller measures against it
+// must come out the same on every node, including on a replay of the same block.
 #[derive(Clone, Copy)]
 struct ValidRead {
     rate: ExchangeRate,
@@ -58,10 +66,11 @@ struct ValidRead {
 /// pair, which caches and refreshes its combined rate independently of the legs it is built from.
 #[derive(Default)]
 struct PairOracleState {
-    // The newest read that passed every guard, served to callers until a newer one replaces it.
+    // The newest read that passed every guard, served to callers while it is within
+    // `MAX_FALLBACK_SAMPLING_INTERVALS` of their own block timestamp.
     last_valid_read: Option<ValidRead>,
     // The newest query's failure, cleared by the next success. Served only when no valid read is
-    // held.
+    // close enough to the caller.
     last_error: Option<ExchangeRateOracleClientError>,
     // The query in flight. A single slot bounds this client to one query at a time.
     query: Option<RateQuery>,
@@ -91,7 +100,8 @@ pub trait ChainlinkRate: RateKind {
 ///
 /// Consensus calls `fetch_rate` on every proposal build and validate, so the call must not block on
 /// the batcher: the feed is read by a background query spawned at most once per
-/// `sampling_interval_seconds`, and every caller is served the last valid read.
+/// `sampling_interval_seconds`, and every caller is served the last valid read while that read is
+/// within `MAX_FALLBACK_SAMPLING_INTERVALS` of the caller's own block timestamp.
 ///
 /// Reads are not deterministic across nodes: `call_contract` executes against the batcher's latest
 /// committed block rather than state pinned to the queried timestamp, so two nodes can read
@@ -107,6 +117,9 @@ pub struct ChainlinkOracleClient<Kind: ChainlinkRate> {
     batcher_client: SharedBatcherClient,
     state: Arc<Mutex<PairOracleState>>,
     metrics: ExchangeRateOracleMetrics,
+    // Distance bound, in both directions, between a caller's block timestamp and the last valid
+    // read's, within which that read is still served.
+    max_fallback_distance_seconds: u64,
     _kind: PhantomData<Kind>,
 }
 
@@ -132,12 +145,15 @@ impl<Kind: ChainlinkRate> ChainlinkOracleClient<Kind> {
         info!("Creating ChainlinkOracleClient for {pair:?} with: {config:?} {bounds_config:?}");
         let metrics = Kind::metrics();
         metrics.register();
+        let max_fallback_distance_seconds =
+            MAX_FALLBACK_SAMPLING_INTERVALS.saturating_mul(config.sampling_interval_seconds);
         Self {
             config: Arc::new(config),
             bounds_config: Arc::new(bounds_config),
             batcher_client,
             state: Arc::new(Mutex::new(PairOracleState::default())),
             metrics,
+            max_fallback_distance_seconds,
             _kind: PhantomData,
         }
     }
@@ -228,10 +244,13 @@ impl<Kind: ChainlinkRate> ExchangeRateOracleClientTrait for ChainlinkOracleClien
             state.last_attempt_instant = Some(Instant::now());
         }
 
-        // A caller whose own read has not resolved is served the read the client already holds,
-        // including the caller that spawned the read in flight. A held failure is served only when
-        // no valid read is held.
-        if let Some(valid_read) = state.last_valid_read {
+        // A caller whose own read has not resolved is served the last valid read while it is close
+        // enough. The distance is measured between block timestamps, in both directions, so a
+        // re-proposal for an earlier timestamp reaches the same decision the proposer did.
+        if let Some(valid_read) = state.last_valid_read.filter(|valid_read| {
+            block_timestamp.abs_diff(valid_read.block_timestamp)
+                <= self.max_fallback_distance_seconds
+        }) {
             return Ok(valid_read.rate);
         }
         match &state.last_error {

--- a/crates/apollo_l1_gas_price/src/chainlink_oracle/test.rs
+++ b/crates/apollo_l1_gas_price/src/chainlink_oracle/test.rs
@@ -95,7 +95,7 @@ async fn wait_for_query_to_finish<Kind: ChainlinkRate>(client: &ChainlinkOracleC
     panic!("Query did not finish within {MAX_POLL_ATTEMPTS} attempts");
 }
 
-/// The failure the client holds, which a held valid read masks.
+/// The failure the client holds, which a valid read close enough to the caller masks.
 fn held_error<Kind: ChainlinkRate>(
     client: &ChainlinkOracleClient<Kind>,
 ) -> Option<ExchangeRateOracleClientError> {
@@ -166,6 +166,23 @@ async fn eth_to_fri_rejects_when_either_leg_is_stale(
         Err(ExchangeRateOracleClientError::StaleFeedError { pair, .. })
             if pair == expected_pair
     );
+}
+
+/// The freshness guards are measured against the block timestamp the caller asks for, so a round
+/// written in that very block is accepted however far it leads the timestamp of the client's
+/// previous read.
+#[tokio::test]
+async fn freshness_is_measured_against_the_block_timestamp() {
+    let config = test_config();
+    let offset_into_the_interval = config.freshness.max_future_updated_at_seconds + 1;
+    assert!(offset_into_the_interval < sampling_interval_seconds());
+    let block_timestamp = TIMESTAMP + offset_into_the_interval;
+
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        block_timestamp,
+    )));
+    assert_eq!(resolve_rate(&client, block_timestamp).await.unwrap(), STRK_TO_USD_RATE);
 }
 
 #[tokio::test]
@@ -457,4 +474,68 @@ async fn no_call_is_denied_a_rate_the_client_holds() {
         tokio::task::yield_now().await;
     }
     assert!(held_error(&client).is_some(), "the failing query was never harvested");
+}
+
+/// The last valid read is served while it is within `MAX_FALLBACK_SAMPLING_INTERVALS` of the block
+/// timestamp asked for, however many intervals passed without a call.
+#[rstest]
+#[case::at_the_allowance(MAX_FALLBACK_SAMPLING_INTERVALS, true)]
+#[case::one_interval_past_the_allowance(MAX_FALLBACK_SAMPLING_INTERVALS + 1, false)]
+#[case::many_intervals_later(60, false)]
+#[tokio::test(start_paused = true)]
+async fn last_valid_rate_is_served_only_within_the_allowance(
+    #[case] num_intervals_ahead: u64,
+    #[case] is_served: bool,
+) {
+    let client = client_with_batcher::<StrkToUsd>(batcher_client_failing_after(
+        strk_usd_responses(FeedFixture::new(STRK_USD_ANSWER, fresh_updated_at())),
+        CALLS_PER_FEED_PER_QUERY,
+    ));
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    // No call is made in between, so nothing refreshes the read the client holds.
+    let elapsed_seconds = num_intervals_ahead * sampling_interval_seconds();
+    tokio::time::advance(Duration::from_secs(elapsed_seconds)).await;
+    let later_timestamp = TIMESTAMP + elapsed_seconds;
+    wait_for_held_error(&client, later_timestamp).await;
+
+    let result = client.fetch_rate(later_timestamp).await;
+    if is_served {
+        assert_eq!(result.unwrap(), rate);
+    } else {
+        assert_matches!(result, Err(ExchangeRateOracleClientError::ContractCallError(_)));
+    }
+}
+
+/// A re-proposal asks for a timestamp the client has already read past, so it is served a read that
+/// leads it.
+#[tokio::test]
+async fn an_earlier_timestamp_is_served_a_held_rate_within_the_allowance() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        fresh_updated_at(),
+    )));
+    let rate = resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    let earlier_timestamp =
+        TIMESTAMP - MAX_FALLBACK_SAMPLING_INTERVALS * sampling_interval_seconds();
+    assert_eq!(client.fetch_rate(earlier_timestamp).await.unwrap(), rate);
+}
+
+/// The allowance bounds the distance in both directions, so a timestamp further back than it is not
+/// priced from a read taken that far ahead of it.
+#[tokio::test]
+async fn an_earlier_timestamp_past_the_allowance_is_not_served_a_held_rate() {
+    let client = make_client::<StrkToUsd>(strk_usd_responses(FeedFixture::new(
+        STRK_USD_ANSWER,
+        fresh_updated_at(),
+    )));
+    resolve_rate(&client, TIMESTAMP).await.unwrap();
+
+    let earlier_timestamp =
+        TIMESTAMP - (MAX_FALLBACK_SAMPLING_INTERVALS + 1) * sampling_interval_seconds();
+    assert_matches!(
+        client.fetch_rate(earlier_timestamp).await,
+        Err(ExchangeRateOracleClientError::QueryNotReadyError(_))
+    );
 }


### PR DESCRIPTION
Adds `MAX_FALLBACK_SAMPLING_INTERVALS`, bounding how far a held Chainlink read may be from the block timestamp it is served to: three sampling intervals, 45 minutes at the production 900 seconds. Inside the allowance a held read is still served, which keeps a transient failure from becoming a hard error for a whole interval. Outside it the caller gets the held error or `QueryNotReadyError`, and the degradation ladder above the oracle handles that rather than a stale price entering a proposal. `ValidRead::block_timestamp` becomes a production input rather than something the client only dates and logs.

A9c of the split of #14942, the last of the three client slices.

- The distance is symmetric on purpose. Backward matters because consensus re-proposes: a validator seeing a re-proposal for an earlier timestamp must reach the decision the proposer reached, so a one-sided bound would let two nodes disagree purely on which of them read ahead. It is measured between block timestamps rather than on the local clock, which the refresh cadence keeps using.
- Deferred: the client is constructed only by tests until B4 wires it into the factory.

---

## Detailed Summary for AI Bots

Stacked on #14992. Part of the [L1 price oracle replacement](https://starkwareindustries.slack.com/archives/D0ACHD9K27N/p1786280310659939) split of #14942.

## What

The fallback allowance: `MAX_FALLBACK_SAMPLING_INTERVALS` bounds how far a held read may travel from the block timestamp it is served to. `fetch_rate` filters `last_valid_read` by that distance instead of serving it unconditionally, which makes `ValidRead::block_timestamp` a production input rather than something the client only dates and logs.

Three sampling intervals, 45 minutes at the production 900 second interval. Inside it, a held read is served, which is what keeps a transient failure from becoming a hard error for a whole interval. Outside it, the read is not served: the caller gets the held error, or `QueryNotReadyError` when the client holds none, and the degradation ladder above the oracle handles that rather than a stale price entering a proposal.

## Why the distance is measured in both directions

The distance is measured between block timestamps, and `abs_diff` makes it symmetric.

Forward is the obvious direction: a read taken long ago must stop pricing new blocks. Backward matters because consensus re-proposes. A validator that reads a rate for height N, then sees a re-proposal for an earlier timestamp, must reach the decision the proposer reached: same read, same rate, or the same refusal. A one-sided bound would serve the earlier caller a read taken arbitrarily far ahead of it, so two nodes evaluating the same proposal could disagree purely on which of them happened to have read ahead. `an_earlier_timestamp_past_the_allowance_is_not_served_a_held_rate` pins the backward edge, and `an_earlier_timestamp_is_served_a_held_rate_within_the_allowance` pins that a re-proposal inside the allowance is still served.

The same argument is why the distance is measured between block timestamps and not on the local clock: block timestamps come out the same on every node, including on a replay of the same block. The refresh cadence keeps using the local monotonic clock, since that is this node's own scheduling and a block timestamp arriving from the network must not steer it. The two clocks answer different questions, which is why they stay separate.

## Landing state

- The client is constructed only by tests until B4 wires it into the factory; `metrics().register()` runs under #14977's `Once` guard.
- The module doc names source selection, which arrives in B3/B4.

## Testing

6 new tests and cases (88 total). The allowance trio advances the paused clock without any call in between, so nothing refreshes the held read: at the allowance it is served, one interval past it and sixty intervals later the held failure is. Both earlier-timestamp cases cover the backward edge. `freshness_is_measured_against_the_block_timestamp` covers the other side of the same coordinate: a round written in the caller's own block is fresh however far it leads the client's previous read, because the guards measure against the requested timestamp and not against what the client holds.

`no_call_is_denied_a_rate_the_client_holds` from #14992 is unchanged and still passes: its caller is one sampling interval away from the held read, inside the allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

