### PR TITLE
apollo_l1_gas_price_config,apollo_deployments,apollo_node: add ExchangeRateOracleSource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ dependencies = [
  "apollo_l1_gas_price_types",
  "rstest",
  "serde",
+ "serde_json",
  "starknet-types-core",
  "starknet_api",
  "url",

--- a/crates/apollo_deployments/resources/app_configs/l1_gas_price_provider_config.json
+++ b/crates/apollo_deployments/resources/app_configs/l1_gas_price_provider_config.json
@@ -5,6 +5,8 @@
   "l1_gas_price_provider_config.strk_to_usd_oracle_config.lag_interval_seconds": 900,
   "l1_gas_price_provider_config.strk_to_usd_oracle_config.max_cache_size": 100,
   "l1_gas_price_provider_config.strk_to_usd_oracle_config.query_timeout_sec": 10,
+  "l1_gas_price_provider_config.eth_to_strk_oracle_source": "Http",
+  "l1_gas_price_provider_config.strk_to_usd_oracle_source": "Http",
   "l1_gas_price_provider_config.rate_bounds_config.eth_usd.minimum_micro_units": 20000000,
   "l1_gas_price_provider_config.rate_bounds_config.eth_usd.maximum_micro_units": 50000000000,
   "l1_gas_price_provider_config.rate_bounds_config.strk_usd.minimum_micro_units": 100,

--- a/crates/apollo_deployments/resources/app_configs/replacer_l1_gas_price_provider_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_l1_gas_price_provider_config.json
@@ -8,6 +8,7 @@
   "l1_gas_price_provider_config.eth_to_strk_oracle_config.lag_interval_seconds": 900,
   "l1_gas_price_provider_config.eth_to_strk_oracle_config.max_cache_size": 100,
   "l1_gas_price_provider_config.eth_to_strk_oracle_config.query_timeout_sec": 10,
+  "l1_gas_price_provider_config.eth_to_strk_oracle_source": "$$$_L1_GAS_PRICE_PROVIDER_CONFIG-ETH_TO_STRK_ORACLE_SOURCE_$$$",
   "l1_gas_price_provider_config.lag_margin_seconds": 600,
   "l1_gas_price_provider_config.max_time_gap_seconds": 900,
   "l1_gas_price_provider_config.number_of_blocks_for_mean": 300,
@@ -20,5 +21,6 @@
   "l1_gas_price_provider_config.storage_limit": 3000,
   "l1_gas_price_provider_config.strk_to_usd_oracle_config.lag_interval_seconds": 900,
   "l1_gas_price_provider_config.strk_to_usd_oracle_config.max_cache_size": 100,
-  "l1_gas_price_provider_config.strk_to_usd_oracle_config.query_timeout_sec": 10
+  "l1_gas_price_provider_config.strk_to_usd_oracle_config.query_timeout_sec": 10,
+  "l1_gas_price_provider_config.strk_to_usd_oracle_source": "$$$_L1_GAS_PRICE_PROVIDER_CONFIG-STRK_TO_USD_ORACLE_SOURCE_$$$"
 }

--- a/crates/apollo_deployments/src/service.rs
+++ b/crates/apollo_deployments/src/service.rs
@@ -87,6 +87,8 @@ pub static KEYS_TO_BE_REPLACED: phf::Set<&'static str> = phf_set! {
     "http_server_config.static_config.port",
     "l1_gas_price_provider_config.chainlink_oracle_config.eth_usd_feed_address",
     "l1_gas_price_provider_config.chainlink_oracle_config.strk_usd_feed_address",
+    "l1_gas_price_provider_config.eth_to_strk_oracle_source",
+    "l1_gas_price_provider_config.strk_to_usd_oracle_source",
     "mempool_config.dynamic_config.transaction_ttl",
     "mempool_p2p_config.network_config.advertised_multiaddr.#is_none",
     "mempool_p2p_config.network_config.advertised_multiaddr",

--- a/crates/apollo_l1_gas_price_config/Cargo.toml
+++ b/crates/apollo_l1_gas_price_config/Cargo.toml
@@ -20,3 +20,4 @@ validator.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+serde_json.workspace = true

--- a/crates/apollo_l1_gas_price_config/src/config.rs
+++ b/crates/apollo_l1_gas_price_config/src/config.rs
@@ -27,6 +27,20 @@ use validator::{Validate, ValidationError};
 #[path = "config_test.rs"]
 mod config_test;
 
+/// Which implementation serves a single exchange rate feed. The two feeds are selected
+/// independently, so they can be migrated one at a time.
+// TODO(Asaf): remove this enum, both `*_oracle_source` fields and both their params together
+// with the HTTP oracle, once both feeds have run on `Chainlink` on mainnet for a week.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum ExchangeRateOracleSource {
+    /// The off-chain oracle HTTP API, configured by the feed's `ExchangeRateOracleConfig`.
+    #[default]
+    Http,
+    /// Chainlink's on-chain Starknet price feeds, configured by `ChainlinkOracleConfig` and read
+    /// through the batcher.
+    Chainlink,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Validate)]
 pub struct ExchangeRateOracleConfig {
     #[serde(deserialize_with = "deserialize_optional_sensitive_list_with_url_and_headers")]
@@ -138,15 +152,17 @@ impl SerializeConfig for RateBoundsConfig {
             ser_param(
                 "minimum_micro_units",
                 &self.minimum_micro_units,
-                "Lowest accepted rate for this pair, in micro units (1e-6) of the quote currency, \
-                 so a value of 20000000 on ETH/USD means $20.",
+                "Lowest accepted price for this pair, in micro units (1e-6) of the pair's quote \
+                 currency, so a value of 20000000 means 20 units of the quote currency, and a \
+                 value of 100 means 0.0001 units.",
                 ParamPrivacyInput::Public,
             ),
             ser_param(
                 "maximum_micro_units",
                 &self.maximum_micro_units,
-                "Highest accepted rate for this pair, in micro units (1e-6) of the quote \
-                 currency, so a value of 50000000000 on ETH/USD means $50,000.",
+                "Highest accepted price for this pair, in micro units (1e-6) of the pair's quote \
+                 currency, so a value of 50000000000 means 50,000 units of the quote currency, \
+                 and a value of 10000000 means 10 units.",
                 ParamPrivacyInput::Public,
             ),
         ])
@@ -301,7 +317,7 @@ impl SerializeConfig for FreshnessWindow {
 /// only what is Chainlink-specific: the bounds a feed's answer is judged against describe the rate
 /// rather than the source, so they live in `AllRateBoundsConfig`, which also bounds the derived
 /// ETH/STRK pair that has no feed of its own.
-// [Temporary comment] B3 selects the source per feed and B4 builds the client.
+// [Temporary comment] B4 builds the client that reads this.
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Validate)]
 pub struct ChainlinkOracleConfig {
@@ -405,9 +421,12 @@ pub struct L1GasPriceProviderConfig {
     pub eth_to_strk_oracle_config: ExchangeRateOracleConfig,
     #[validate(nested)]
     pub strk_to_usd_oracle_config: ExchangeRateOracleConfig,
-    // Both apply to every feed, unlike the per-feed HTTP configs above.
-    // [Temporary comment] B3 adds the per-feed source switch and B4 builds the client that reads
-    // these.
+    pub eth_to_strk_oracle_source: ExchangeRateOracleSource,
+    pub strk_to_usd_oracle_source: ExchangeRateOracleSource,
+    // `rate_bounds_config` and `chainlink_oracle_config` apply to every feed, unlike the per-feed
+    // HTTP configs, and both are validated while every feed is still on `Http`, so a bad value is
+    // rejected at config load rather than at the moment an operator flips a source to `Chainlink`.
+    // [Temporary comment] B4 builds the client that reads these.
     #[validate(nested)]
     pub rate_bounds_config: AllRateBoundsConfig,
     #[validate(nested)]
@@ -424,6 +443,8 @@ impl Default for L1GasPriceProviderConfig {
             max_time_gap_seconds: 900, // 15 minutes
             eth_to_strk_oracle_config: ExchangeRateOracleConfig::default(),
             strk_to_usd_oracle_config: ExchangeRateOracleConfig::default(),
+            eth_to_strk_oracle_source: ExchangeRateOracleSource::default(),
+            strk_to_usd_oracle_source: ExchangeRateOracleSource::default(),
             rate_bounds_config: AllRateBoundsConfig::default(),
             chainlink_oracle_config: ChainlinkOracleConfig::default(),
         }
@@ -457,6 +478,28 @@ impl SerializeConfig for L1GasPriceProviderConfig {
                 &self.max_time_gap_seconds,
                 "Maximum valid time gap between the requested timestamp and the last price sample \
                  in seconds",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "eth_to_strk_oracle_source",
+                &self.eth_to_strk_oracle_source,
+                "Which oracle serves the ETH/STRK rate: `Http` reads the API configured in \
+                 `eth_to_strk_oracle_config`, `Chainlink` reads the on-chain feeds configured in \
+                 `chainlink_oracle_config`, which both feeds share, and requires a batcher \
+                 client. Selecting `Chainlink` on a service that has no batcher client is a \
+                 startup failure, not a fallback to `Http`. The feeds exist on Starknet mainnet \
+                 only, so `Chainlink` is mainnet-only until they are deployed elsewhere.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
+                "strk_to_usd_oracle_source",
+                &self.strk_to_usd_oracle_source,
+                "Which oracle serves the STRK/USD rate: `Http` reads the API configured in \
+                 `strk_to_usd_oracle_config`, `Chainlink` reads the on-chain feeds configured in \
+                 `chainlink_oracle_config`, which both feeds share, and requires a batcher \
+                 client. Selecting `Chainlink` on a service that has no batcher client is a \
+                 startup failure, not a fallback to `Http`. The feeds exist on Starknet mainnet \
+                 only, so `Chainlink` is mainnet-only until they are deployed elsewhere.",
                 ParamPrivacyInput::Public,
             ),
         ]);

--- a/crates/apollo_l1_gas_price_config/src/config_test.rs
+++ b/crates/apollo_l1_gas_price_config/src/config_test.rs
@@ -1,14 +1,17 @@
+use std::collections::BTreeMap;
 use std::mem::swap;
 
 use apollo_config::dumping::SerializeConfig;
 use apollo_config::loading::load;
-use apollo_config::SerializedContent;
+use apollo_config::{ParamPath, SerializedContent};
 use rstest::rstest;
+use serde_json::{json, Value};
 use validator::Validate;
 
 use super::{
     AllRateBoundsConfig,
     ChainlinkOracleConfig,
+    ExchangeRateOracleSource,
     FreshnessWindow,
     L1GasPriceProviderConfig,
     RateBoundsConfig,
@@ -166,14 +169,65 @@ fn provider_validation_reaches_the_nested_rate_bounds_config() {
 #[test]
 fn provider_config_round_trips_through_serialize_config() {
     let config = L1GasPriceProviderConfig::default();
-    let dumped_values = config
+
+    assert_eq!(load::<L1GasPriceProviderConfig>(&dumped_values(&config)).unwrap(), config);
+}
+
+#[test]
+fn default_oracle_sources_are_http() {
+    let config = L1GasPriceProviderConfig::default();
+
+    assert_eq!(config.eth_to_strk_oracle_source, ExchangeRateOracleSource::Http);
+    assert_eq!(config.strk_to_usd_oracle_source, ExchangeRateOracleSource::Http);
+}
+
+// Each feed is switched on its own, so all four combinations must survive a dump and load.
+#[rstest]
+#[case::both_http(ExchangeRateOracleSource::Http, ExchangeRateOracleSource::Http)]
+#[case::eth_to_strk_only(ExchangeRateOracleSource::Chainlink, ExchangeRateOracleSource::Http)]
+#[case::strk_to_usd_only(ExchangeRateOracleSource::Http, ExchangeRateOracleSource::Chainlink)]
+#[case::both_chainlink(ExchangeRateOracleSource::Chainlink, ExchangeRateOracleSource::Chainlink)]
+fn oracle_sources_round_trip_through_serialize_config(
+    #[case] eth_to_strk_oracle_source: ExchangeRateOracleSource,
+    #[case] strk_to_usd_oracle_source: ExchangeRateOracleSource,
+) {
+    let config = L1GasPriceProviderConfig {
+        eth_to_strk_oracle_source,
+        strk_to_usd_oracle_source,
+        ..Default::default()
+    };
+
+    assert_eq!(load::<L1GasPriceProviderConfig>(&dumped_values(&config)).unwrap(), config);
+}
+
+// The enum takes no `serde` renaming, so the variant names are matched exactly as written in Rust.
+// An operator who types the source in the casing used everywhere else in the config file must be
+// told, rather than silently left on the `Http` default with a migration that looks complete.
+#[rstest]
+#[case::lowercase("chainlink")]
+#[case::uppercase("CHAINLINK")]
+#[case::feed_name("eth_to_strk")]
+#[case::unknown_source("Coinbase")]
+fn unrecognized_oracle_source_fails_to_load(#[case] source_value: &str) {
+    for param_path in ["eth_to_strk_oracle_source", "strk_to_usd_oracle_source"] {
+        let mut config_values = dumped_values(&L1GasPriceProviderConfig::default());
+        config_values.insert(param_path.to_string(), json!(source_value));
+
+        assert!(
+            load::<L1GasPriceProviderConfig>(&config_values).is_err(),
+            "`{param_path}` accepted the unrecognized value {source_value}"
+        );
+    }
+}
+
+/// The config as an operator's config file holds it: one flat map from param path to value.
+fn dumped_values(config: &L1GasPriceProviderConfig) -> BTreeMap<ParamPath, Value> {
+    config
         .dump()
         .into_iter()
         .map(|(param_path, param)| match param.content {
             SerializedContent::DefaultValue(value) => (param_path, value),
             content => panic!("`{param_path}` was dumped without a default value: {content:?}"),
         })
-        .collect();
-
-    assert_eq!(load::<L1GasPriceProviderConfig>(&dumped_values).unwrap(), config);
+        .collect()
 }

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -3359,6 +3359,11 @@
     "privacy": "Private",
     "value": "https://api.example.com/api"
   },
+  "l1_gas_price_provider_config.eth_to_strk_oracle_source": {
+    "description": "Which oracle serves the ETH/STRK rate: `Http` reads the API configured in `eth_to_strk_oracle_config`, `Chainlink` reads the on-chain feeds configured in `chainlink_oracle_config`, which both feeds share, and requires a batcher client. Selecting `Chainlink` on a service that has no batcher client is a startup failure, not a fallback to `Http`. The feeds exist on Starknet mainnet only, so `Chainlink` is mainnet-only until they are deployed elsewhere.",
+    "privacy": "Public",
+    "value": "Http"
+  },
   "l1_gas_price_provider_config.lag_margin_seconds": {
     "description": "Difference between the time of the block from L1 used to calculate the gas price and the time of the L2 block this price is used in",
     "privacy": "Public",
@@ -3375,32 +3380,32 @@
     "value": 300
   },
   "l1_gas_price_provider_config.rate_bounds_config.eth_strk.maximum_micro_units": {
-    "description": "Highest accepted rate for this pair, in micro units (1e-6) of the quote currency, so a value of 50000000000 on ETH/USD means $50,000.",
+    "description": "Highest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 50000000000 means 50,000 units of the quote currency, and a value of 10000000 means 10 units.",
     "privacy": "Public",
     "value": 1000000000000
   },
   "l1_gas_price_provider_config.rate_bounds_config.eth_strk.minimum_micro_units": {
-    "description": "Lowest accepted rate for this pair, in micro units (1e-6) of the quote currency, so a value of 20000000 on ETH/USD means $20.",
+    "description": "Lowest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 20000000 means 20 units of the quote currency, and a value of 100 means 0.0001 units.",
     "privacy": "Public",
     "value": 10000000000
   },
   "l1_gas_price_provider_config.rate_bounds_config.eth_usd.maximum_micro_units": {
-    "description": "Highest accepted rate for this pair, in micro units (1e-6) of the quote currency, so a value of 50000000000 on ETH/USD means $50,000.",
+    "description": "Highest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 50000000000 means 50,000 units of the quote currency, and a value of 10000000 means 10 units.",
     "privacy": "Public",
     "value": 50000000000
   },
   "l1_gas_price_provider_config.rate_bounds_config.eth_usd.minimum_micro_units": {
-    "description": "Lowest accepted rate for this pair, in micro units (1e-6) of the quote currency, so a value of 20000000 on ETH/USD means $20.",
+    "description": "Lowest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 20000000 means 20 units of the quote currency, and a value of 100 means 0.0001 units.",
     "privacy": "Public",
     "value": 20000000
   },
   "l1_gas_price_provider_config.rate_bounds_config.strk_usd.maximum_micro_units": {
-    "description": "Highest accepted rate for this pair, in micro units (1e-6) of the quote currency, so a value of 50000000000 on ETH/USD means $50,000.",
+    "description": "Highest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 50000000000 means 50,000 units of the quote currency, and a value of 10000000 means 10 units.",
     "privacy": "Public",
     "value": 10000000
   },
   "l1_gas_price_provider_config.rate_bounds_config.strk_usd.minimum_micro_units": {
-    "description": "Lowest accepted rate for this pair, in micro units (1e-6) of the quote currency, so a value of 20000000 on ETH/USD means $20.",
+    "description": "Lowest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 20000000 means 20 units of the quote currency, and a value of 100 means 0.0001 units.",
     "privacy": "Public",
     "value": 100
   },
@@ -3428,6 +3433,11 @@
     "description": "A list of Url+HTTP headers for the exchange rate oracle. The url is followed by a comma and then headers as key^value pairs, separated by commas. For example: `https://api.example.com/api,key1^value1,key2^value2`. Each URL+headers is separated by a pipe `|` character. The `timestamp` parameter is appended dynamically when making requests, in order to have a stable mapping from block timestamp to conversion rate. ",
     "privacy": "Private",
     "value": "https://api.example.com/api"
+  },
+  "l1_gas_price_provider_config.strk_to_usd_oracle_source": {
+    "description": "Which oracle serves the STRK/USD rate: `Http` reads the API configured in `strk_to_usd_oracle_config`, `Chainlink` reads the on-chain feeds configured in `chainlink_oracle_config`, which both feeds share, and requires a batcher client. Selecting `Chainlink` on a service that has no batcher client is a startup failure, not a fallback to `Http`. The feeds exist on Starknet mainnet only, so `Chainlink` is mainnet-only until they are deployed elsewhere.",
+    "privacy": "Public",
+    "value": "Http"
   },
   "l1_gas_price_scraper_config.#is_none": {
     "description": "Flag for an optional field.",

--- a/deployments/sequencer/configs/overlays/hybrid/mainnet/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/mainnet/services/l1.yaml
@@ -2,6 +2,8 @@ include: configs/overlays/hybrid/common/services/l1.yaml
 
 config:
   sequencerConfig:
+    l1_gas_price_provider_config.eth_to_strk_oracle_source: Http
+    l1_gas_price_provider_config.strk_to_usd_oracle_source: Http
     l1_gas_price_provider_config.chainlink_oracle_config.eth_usd_feed_address: '0x06b2ef9b416ad0f996b2a8ac0dd771b1788196f51c96f5b000df2e47ac756d26'
     l1_gas_price_provider_config.chainlink_oracle_config.strk_usd_feed_address: '0x076a0254cdadb59b86da3b5960bf8d73779cac88edc5ae587cab3cedf03226ec'
     base_layer_config.bpo1_start_block_number: 23973546

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-alpha/services/l1.yaml
@@ -2,6 +2,8 @@ include: configs/overlays/hybrid/common/services/l1.yaml
 
 config:
   sequencerConfig:
+    l1_gas_price_provider_config.eth_to_strk_oracle_source: Http
+    l1_gas_price_provider_config.strk_to_usd_oracle_source: Http
     l1_gas_price_provider_config.chainlink_oracle_config.eth_usd_feed_address: '0x06b2ef9b416ad0f996b2a8ac0dd771b1788196f51c96f5b000df2e47ac756d26'
     l1_gas_price_provider_config.chainlink_oracle_config.strk_usd_feed_address: '0x076a0254cdadb59b86da3b5960bf8d73779cac88edc5ae587cab3cedf03226ec'
     base_layer_config.bpo1_start_block_number: 9456501

--- a/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/sepolia-integration/services/l1.yaml
@@ -2,6 +2,8 @@ include: configs/overlays/hybrid/common/services/l1.yaml
 
 config:
   sequencerConfig:
+    l1_gas_price_provider_config.eth_to_strk_oracle_source: Http
+    l1_gas_price_provider_config.strk_to_usd_oracle_source: Http
     l1_gas_price_provider_config.chainlink_oracle_config.eth_usd_feed_address: '0x06b2ef9b416ad0f996b2a8ac0dd771b1788196f51c96f5b000df2e47ac756d26'
     l1_gas_price_provider_config.chainlink_oracle_config.strk_usd_feed_address: '0x076a0254cdadb59b86da3b5960bf8d73779cac88edc5ae587cab3cedf03226ec'
     base_layer_config.bpo1_start_block_number: 9456501

--- a/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/l1.yaml
+++ b/deployments/sequencer/configs/overlays/hybrid/testing/node-0/services/l1.yaml
@@ -8,6 +8,8 @@ replicas: 1
 config:
   configList: crates/apollo_deployments/resources/services/hybrid/replacer_deployment_l1.json
   sequencerConfig:
+    l1_gas_price_provider_config.eth_to_strk_oracle_source: Http
+    l1_gas_price_provider_config.strk_to_usd_oracle_source: Http
     l1_gas_price_provider_config.chainlink_oracle_config.eth_usd_feed_address: '0x06b2ef9b416ad0f996b2a8ac0dd771b1788196f51c96f5b000df2e47ac756d26'
     l1_gas_price_provider_config.chainlink_oracle_config.strk_usd_feed_address: '0x076a0254cdadb59b86da3b5960bf8d73779cac88edc5ae587cab3cedf03226ec'
     base_layer_config.bpo1_start_block_number: 13205504


### PR DESCRIPTION
Adds `ExchangeRateOracleSource` (`Http` default, `Chainlink`) and one `*_oracle_source` field per feed, so a feed moves off the HTTP oracle by editing a config key rather than by deploying code. The two feeds are selected independently so they can be migrated one at a time. Also rewrites the micro-unit bound descriptions, which were written for ETH/USD but served under `strk_usd` too, where the worked example disagreed with the shipped default by five orders of magnitude.

B3 of the split of #14944. 2 new parameters.

- Deferred: both feeds default to `Http` and nothing reads either field. B4 is the first PR whose behavior depends on them, so merging this changes nothing at runtime.
- Scheduled for deletion: the enum, both fields, both `ser_param`s and the three tests all go in C1 with the HTTP oracle. The enum carries a `TODO(asaf-sw)` naming that removal, which is why the switch is deliberately thin. The description rewrite is the part that survives.
- Worth a look: `unrecognized_oracle_source_fails_to_load` pins that the enum takes no `serde(rename_all)`, so a lowercase `"chainlink"` cannot silently fall back to `Http` and produce a node that looks migrated.

---

## Detailed Summary for AI Bots

Stacked on #14994. Part of the [L1 price oracle replacement](https://starkwareindustries.slack.com/archives/D0ACHD9K27N/p1786280310659939) split of #14942.

## What

`ExchangeRateOracleSource` (`Http` default, `Chainlink`) and the two `*_oracle_source` fields that carry it, one per feed, so a feed moves off the HTTP oracle by editing a config key rather than by deploying code. 2 new parameters, no existing parameter's value or privacy touched.

Both feeds default to `Http`, and nothing reads either field yet: B4 builds each feed's client from its source and is the first PR whose behavior depends on these values. Merging this changes nothing at runtime.

The two feeds are selected independently so they can be migrated one at a time, and so the second flip can wait on a week of evidence from the first.

## Every line of the switch has a deletion date

The enum, both fields, both `ser_param`s and the three tests below all go away in C1, together with the HTTP oracle they exist to switch away from. The enum carries a `TODO(asaf-sw)` naming that removal. Nothing here is built to last, so it is deliberately thin: an enum, two `pub` fields, a `Default`, and no accessor, no helper, no validation beyond what serde already rejects.

What survives C1 is the description rewrite in the second half of this PR, which is about micro units rather than about sources.

## `Chainlink` is mainnet-only

The feed addresses B2 shipped are the Chainlink proxies on Starknet mainnet, in every environment, because no other network has the feeds. That restriction is documented where an operator flipping the switch will read it: both `*_oracle_source` descriptions, and therefore both entries in `config_schema.json`, state that `Chainlink` is mainnet-only until the feeds are deployed elsewhere.

The same descriptions state the other precondition: `Chainlink` requires a batcher client, and selecting it on a service that has none is a startup failure rather than a fallback to `Http`. B4 is what enforces that, naming every offending key in one startup instead of one per restart. Every shipped topology gives the L1 service a batcher client, so it is reachable only by misconfiguration.

Flipping a feed also waits on #14973's rate-of-change bound and on the cap chain, for the reasons set out in #14944; those are gates on using the switch, not on merging it.

## The `rename_all` test is the one that has to be here

`unrecognized_oracle_source_fails_to_load` pins that the enum takes no `serde(rename_all)`, so the variants are matched exactly as written in Rust. Without it, a lowercase `"chainlink"` deserializes to nothing, falls back to the `Http` default, and produces a node that looks migrated while reading the same HTTP API it read yesterday. Config loading does reject the unknown value today; the test is what keeps a later convenience `rename_all` from turning that rejection into a silent default.

It earns its place precisely because the window is short. While both sources exist a wrong flip is detectable by comparing the two, but once the HTTP source is gone in C1 there is no comparison left to make, so the only chance to notice is now.

The four cases cover the casings an operator plausibly types (`chainlink`, `CHAINLINK`), a feed name mistaken for a source (`eth_to_strk`), and an unknown source (`Coinbase`), each against both param paths.

## The bound descriptions were pair-specific and served to every pair

`QuotedRateBoundsConfig::dump()` produces the descriptions for both `eth_usd` and `strk_usd`, so its worked conversion, written for ETH/USD, was served under both keys. The schema shipped `rate_bounds_config.strk_usd.minimum_micro_units` described as "a value of 20000000 on ETH/USD means $20" against an actual default of `100`, which is $0.0001. An operator reading the schema had a worked example that disagreed with the value next to it by five orders of magnitude.

Both descriptions are now pair-agnostic and keep a worked conversion, since the schema is all an operator has:

- `minimum_micro_units`: "Lowest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 20000000 means 20 units of the quote currency, and a value of 100 means 0.0001 units."
- `maximum_micro_units`: "Highest accepted price for this pair, in micro units (1e-6) of the pair's quote currency, so a value of 50000000000 means 50,000 units of the quote currency."

The minimum carries both worked examples because the two defaults it is served for are `20000000` and `100`; one example alone leaves whichever key it was not written for looking wrong. Micro units reached the schema for the first time in B2 and were explained only in a Rust doc comment before that, where being wrong by 10^6 either disables the guard or rejects every reading.

`DerivedRateBoundsConfig` is untouched: it serves `eth_to_fri` only, so its ETH/STRK examples are correct for the one key they reach.

## Testing

9 new cases, 32 in the crate. `default_oracle_sources_are_http` on the `Default`, `oracle_sources_round_trip_through_serialize_config` over all four combinations of the two feeds, and `unrecognized_oracle_source_fails_to_load` over four rejected values against both params. The round-trip test shares its dump-to-flat-map helper with B2's `provider_config_round_trips_through_serialize_config`, which is what makes the rejection test meaningful: `Chainlink` loads through the same path the bad values are rejected on, so the failures are about the value and not about the harness.

`default_config_file_is_up_to_date` and `deployment_files_are_up_to_date` are the staleness gates on the regenerated files, and both pass. The 2 new keys were added to both base app configs by hand, as in B2, before regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

