### PR TITLE
apollo_metrics: labeled gauge lossy and unix-now setters

### DIFF
--- a/crates/apollo_metrics/src/metrics.rs
+++ b/crates/apollo_metrics/src/metrics.rs
@@ -12,7 +12,12 @@ mod histograms;
 
 // re exports
 pub use crate::metrics::counters::{LabeledMetricCounter, MetricCounter};
-pub use crate::metrics::gauges::{set_unix_now_seconds, LabeledMetricGauge, MetricGauge};
+pub use crate::metrics::gauges::{
+    set_unix_now_seconds,
+    set_unix_now_seconds_with_labels,
+    LabeledMetricGauge,
+    MetricGauge,
+};
 pub use crate::metrics::histograms::{HistogramValue, LabeledMetricHistogram, MetricHistogram};
 
 /// Global variable set by the main config to enable collecting profiling metrics.

--- a/crates/apollo_metrics/src/metrics/gauges.rs
+++ b/crates/apollo_metrics/src/metrics/gauges.rs
@@ -36,6 +36,13 @@ pub fn set_unix_now_seconds(gauge: &MetricGauge) {
     gauge.set_lossy(Clock::unix_now(&DefaultClock));
 }
 
+pub fn set_unix_now_seconds_with_labels(
+    gauge: &LabeledMetricGauge,
+    label: &[(&'static str, &'static str)],
+) {
+    gauge.set_lossy(Clock::unix_now(&DefaultClock), label);
+}
+
 impl MetricGauge {
     pub const fn new(scope: MetricScope, name: &'static str, description: &'static str) -> Self {
         Self { metric: Metric::new(scope, name, description) }
@@ -146,6 +153,10 @@ impl LabeledMetricGauge {
     }
 
     pub fn set<T: IntoF64>(&self, value: T, label: &[(&'static str, &'static str)]) {
+        gauge!(self.get_name(), label).set(value.into_f64());
+    }
+
+    pub fn set_lossy<T: LossyIntoF64>(&self, value: T, label: &[(&'static str, &'static str)]) {
         gauge!(self.get_name(), label).set(value.into_f64());
     }
 


### PR DESCRIPTION
Adds the two setters `LabeledMetricGauge` was missing, so a labeled gauge can be written the same ways an unlabeled one already could:

- `LabeledMetricGauge::set_lossy(value, labels)`, the labeled counterpart of `MetricGauge::set_lossy`.
- `set_unix_now_seconds_with_labels(gauge, labels)`, the labeled counterpart of `set_unix_now_seconds`.

17 lines in `apollo_metrics`, no behavior change to anything existing. Nothing in this PR calls either function.

The caller arrives in #14981, which folds the oracle's thirteen unlabeled metrics into four labeled ones. Two of those four are gauges (`exchange_rate_oracle_rate` and `exchange_rate_oracle_last_success_timestamp_seconds`), and both need a labeled write that did not exist. Split out of #14981 rather than bundled into it, so a change to shared metrics infrastructure is reviewable on its own instead of inside an oracle PR.

---

## Detailed Summary for AI Bots

### Why this is a separate PR

`ExchangeRateOracleMetrics` in `apollo_l1_gas_price` previously held four unlabeled metrics per currency pair, eight in total across ETH/STRK and STRK/USD, plus five unlabeled `CHAINLINK_ORACLE_*_COUNT` guard counters. Review of #14981 replaced all thirteen with four labeled metrics keyed on `currency_pair`, and on `currency_pair` x `error_type` for the error counter.

Two of the four are gauges. Writing them requires setting a value with labels, and `LabeledMetricGauge` exposed no way to do it: `set_lossy` existed only on `MetricGauge`, and the `set_unix_now_seconds` helper took `&MetricGauge`. So the fold was blocked on an `apollo_metrics` gap.

That gap is shared infrastructure used well beyond the oracle, so it is carried here rather than inside an `apollo_l1_gas_price` PR. It keeps #14981's diff to the oracle change, and it keeps a change to a crate every component depends on in a diff a reviewer can read in full.

### What changed

`crates/apollo_metrics/src/metrics/gauges.rs`:

```rust
pub fn set_unix_now_seconds_with_labels(
    gauge: &LabeledMetricGauge,
    label: &[(&'static str, &'static str)],
) {
    gauge.set_lossy(Clock::unix_now(&DefaultClock), label);
}
```

and on `impl LabeledMetricGauge`:

```rust
pub fn set_lossy<T: LossyIntoF64>(&self, value: T, label: &[(&'static str, &'static str)]) {
    gauge!(self.get_name(), label).set(value.into_f64());
}
```

`crates/apollo_metrics/src/metrics.rs` re-exports the new free function alongside the existing `set_unix_now_seconds`.

Both mirror their unlabeled equivalents exactly, including the `LossyIntoF64` bound and the use of `DefaultClock` for the timestamp, so the labeled and unlabeled paths cannot drift in rounding or clock source.

### Deferred by design, and what resolves it

Neither function has a caller in this PR. `#14981` is the first consumer, and it is the PR directly above this one in the stack. A dead-code warning does not arise because both are `pub` in a library crate.

### Scope

Two files, 17 insertions, 1 deletion. No existing signature, metric name, or behavior changes; both additions are new surface. No config, no schema, no dashboard, no test changes: the functions are exercised through #14981's tests, which assert on the labeled series the oracle publishes.
