### PR TITLE
papyrus_base_layer,apollo_l1_events: resolve L1 event timestamps once per block

### DIFF
--- a/crates/apollo_l1_events/tests/flow_test_event_filters.rs
+++ b/crates/apollo_l1_events/tests/flow_test_event_filters.rs
@@ -28,7 +28,7 @@ use papyrus_base_layer::test_utils::{
     DEFAULT_ANVIL_L1_ACCOUNT_ADDRESS,
     DEFAULT_ANVIL_L1_DEPLOYED_ADDRESS,
 };
-use papyrus_base_layer::BaseLayerContract;
+use papyrus_base_layer::{BaseLayerContract, L1Event};
 use utils::{L1_CONTRACT_ADDRESS, L2_ENTRY_POINT};
 
 // This test requires that we do some manual work to produce the logs we expect to get from the
@@ -162,6 +162,80 @@ async fn cannot_parse_log_message_to_l1() {
     assert_matches!(
         result,
         Err(EthereumBaseLayerError::TypeError(alloy::sol_types::Error::InvalidLog { .. }))
+    );
+}
+
+// Logs that share a block resolve their timestamp with a single block-header fetch, not one per
+// log. The mock is given exactly one block response for three same-block logs, so a per-log fetch
+// would exhaust the queue and fail.
+#[tokio::test]
+async fn many_logs_in_one_block_fetch_the_block_header_once() {
+    let asserter = Asserter::new();
+    let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+    let mut base_layer = EthereumBaseLayerContract::new_with_provider(
+        EthereumBaseLayerConfig::default(),
+        provider.root().clone(),
+    );
+
+    let filters = event_identifiers_to_track();
+    let shared_block_number = 5;
+    let logs: Vec<Log> = (0..3)
+        .map(|nonce| {
+            encode_message_into_log(
+                filters[0],
+                shared_block_number,
+                &[U256::from(15), U256::from(202)],
+                U256::from(nonce),
+                Some(U256::from(420)),
+            )
+        })
+        .collect();
+
+    asserter.push_success(&logs);
+    // Exactly one block response for the three same-block logs.
+    asserter.push_success(&dummy_block::<B256>());
+
+    let events = base_layer
+        .events(0..=shared_block_number, &[filters[0]])
+        .await
+        .expect("one block fetch should satisfy all same-block logs");
+    assert_eq!(events.len(), 3);
+}
+
+// When the log carries `blockTimestamp`, no block-header fetch is issued at all: no block response
+// is queued, so any fetch would exhaust the queue and fail. The event carries the log's own
+// timestamp.
+#[tokio::test]
+async fn log_block_timestamp_skips_the_block_header_fetch() {
+    let asserter = Asserter::new();
+    let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+    let mut base_layer = EthereumBaseLayerContract::new_with_provider(
+        EthereumBaseLayerConfig::default(),
+        provider.root().clone(),
+    );
+
+    let filters = event_identifiers_to_track();
+    let block_number = 7;
+    let expected_timestamp = 987654321;
+    let mut log = encode_message_into_log(
+        filters[0],
+        block_number,
+        &[U256::from(15), U256::from(202)],
+        U256::from(127),
+        Some(U256::from(420)),
+    );
+    log.block_timestamp = Some(expected_timestamp);
+
+    asserter.push_success(&vec![log]);
+    // Deliberately no block response queued.
+
+    let events = base_layer
+        .events(0..=block_number, &[filters[0]])
+        .await
+        .expect("timestamp on the log should avoid any block fetch");
+    assert_matches!(
+        &events[0],
+        L1Event::LogMessageToL2 { block_timestamp, .. } if block_timestamp.0 == expected_timestamp
     );
 }
 

--- a/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
+++ b/crates/papyrus_base_layer/src/ethereum_base_layer_contract.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::IntoFuture;
 use std::ops::RangeInclusive;
 use std::time::Duration;
@@ -23,8 +23,9 @@ use apollo_config::dumping::{ser_param, SerializeConfig};
 use apollo_config::secrets::Sensitive;
 use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 use async_trait::async_trait;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
+use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber, BlockTimestamp};
 use starknet_api::hash::StarkHash;
 use starknet_api::StarknetApiError;
 use tokio::time::error::Elapsed;
@@ -44,6 +45,11 @@ use crate::{
 
 pub type EthereumBaseLayerResult<T> = Result<T, EthereumBaseLayerError>;
 pub type EthereumContractAddress = Address;
+
+/// Upper bound on concurrent `eth_getBlockByNumber` requests issued while resolving block
+/// timestamps, so a range spanning many blocks resolves them in bounded batches rather than all at
+/// once.
+const MAX_CONCURRENT_BLOCK_HEADER_FETCHES: usize = 8;
 
 #[cfg(test)]
 #[path = "ethereum_base_layer_contract_test.rs"]
@@ -188,27 +194,55 @@ impl BaseLayerContract for EthereumBaseLayerContract {
         debug!("Got events in {:?}, L1 tx hashes: {:?}", block_range, hashes);
         debug!("Got events in {:?}, matching_logs: {:?}", block_range, matching_logs);
 
+        // Each event is stamped with its block's timestamp. Logs in the same block share it, so
+        // resolve it once per distinct block, and skip the fetch entirely for blocks whose logs
+        // already carry `block_timestamp` from the provider. The rest are fetched with bounded
+        // concurrency.
+        let blocks_missing_timestamp: BTreeSet<L1BlockNumber> = matching_logs
+            .iter()
+            .filter(|log| log.block_timestamp.is_none())
+            .filter_map(|log| log.block_number)
+            .collect();
+
+        let fetched_headers = futures::stream::iter(blocks_missing_timestamp.into_iter().map(
+            |block_number| async move {
+                (block_number, immutable_self.get_block_header_immutable(block_number).await)
+            },
+        ))
+        .buffer_unordered(MAX_CONCURRENT_BLOCK_HEADER_FETCHES)
+        .collect::<Vec<_>>()
+        .await;
+
+        let mut block_timestamps: BTreeMap<L1BlockNumber, BlockTimestamp> = BTreeMap::new();
+        for (block_number, header) in fetched_headers {
+            // A fetch error fails this range; the caller retries on the next poll. A missing header
+            // leaves the block unresolved, handled below.
+            if let Some(header) = header? {
+                block_timestamps.insert(block_number, header.timestamp);
+            }
+        }
+
+        let mut parsed_events = Vec::with_capacity(matching_logs.len());
         // Note that these errors should never happen... but since we are depending on an external
-        // service to provider the logs, it is not impossible for temporary glitches to cause weird
+        // service to provide the logs, it is not impossible for temporary glitches to cause weird
         // data inconsistencies like a missing number or header.
-        let block_header_futures = matching_logs.into_iter().map(|log| async move {
+        for log in matching_logs {
             let Some(block_number) = log.block_number else {
                 return Err(EthereumBaseLayerError::BlockNumberMissingError(Box::new(log)));
             };
-            let header = immutable_self.get_block_header_immutable(block_number).await?;
-            let Some(header) = header else {
-                return Err(EthereumBaseLayerError::BlockHeaderMissingError(Box::new(log)));
+            let block_timestamp = match log.block_timestamp {
+                Some(timestamp) => BlockTimestamp(timestamp),
+                None => match block_timestamps.get(&block_number) {
+                    Some(timestamp) => *timestamp,
+                    None => {
+                        return Err(EthereumBaseLayerError::BlockHeaderMissingError(Box::new(log)));
+                    }
+                },
             };
-            parse_event(log, header.timestamp)
-        });
-        // TODO(guyn): replace this with try_join_all.
-        let events = futures::future::join_all(block_header_futures).await;
-        let mut parsed_events = Vec::with_capacity(events.len());
-        for event in events {
-            match event {
+            match parse_event(log, block_timestamp) {
                 Ok(event) => parsed_events.push(event),
-                Err(EthereumBaseLayerError::CalldataValueOutOfRange(_)) => {
-                    warn!("Skipping event due to calldata value out of range {:?}", event);
+                Err(error @ EthereumBaseLayerError::CalldataValueOutOfRange(_)) => {
+                    warn!("Skipping event due to calldata value out of range {error:?}");
                 }
                 Err(error) => return Err(error),
             }


### PR DESCRIPTION
## What
`events()` in the Ethereum base layer fetched the block header once per matching log — only to read the block timestamp — so a range containing many logs issued many redundant `eth_getBlockByNumber` calls, several of them for the same block.

This resolves each event's timestamp:
- once per **distinct** block instead of once per log,
- directly from the log's `block_timestamp` when the provider populates it (no header fetch at all),
- and fetches any remaining block headers with bounded concurrency.

## Why
Removes redundant RPC calls and lowers latency when scraping ranges that contain many L1→L2 events. No behavior change — an event's timestamp is its block's timestamp either way.

## Tests
- `many_logs_in_one_block_fetch_the_block_header_once` — logs sharing a block trigger a single header fetch.
- `log_block_timestamp_skips_the_block_header_fetch` — a log carrying `block_timestamp` triggers none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)