### PR TITLE
starknet_patricia_storage: split RocksDB multi-key reads across blocking tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13145,6 +13145,7 @@ dependencies = [
  "serde_json",
  "starknet-types-core",
  "starknet_api",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "validator",

--- a/crates/apollo_deployments/resources/app_configs/committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/committer_config.json
@@ -12,6 +12,7 @@
     "committer_config.storage_config.inner_storage_config.max_background_jobs": 8,
     "committer_config.storage_config.inner_storage_config.use_mmap_reads": false,
     "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": true,
+    "committer_config.storage_config.inner_storage_config.max_read_tasks": 32,
     "committer_config.storage_config.inner_storage_config.max_subcompactions": 8,
     "committer_config.storage_config.inner_storage_config.max_write_buffers": 4,
     "committer_config.storage_config.inner_storage_config.num_threads": 8,

--- a/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_committer_config.json
@@ -14,6 +14,7 @@
   "committer_config.storage_config.inner_storage_config.max_write_buffers": 4,
   "committer_config.storage_config.inner_storage_config.num_threads": 8,
   "committer_config.storage_config.inner_storage_config.spawn_blocking_reads": true,
+  "committer_config.storage_config.inner_storage_config.max_read_tasks": 32,
   "committer_config.storage_config.inner_storage_config.use_mmap_reads": false,
   "committer_config.storage_config.inner_storage_config.write_buffer_size": 134217728,
   "committer_config.verify_state_diff_hash": "$$$_COMMITTER_CONFIG-VERIFY_STATE_DIFF_HASH_$$$"

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -604,6 +604,11 @@
     "privacy": "Public",
     "value": 8
   },
+  "committer_config.storage_config.inner_storage_config.max_read_tasks": {
+    "description": "Max parallel disk reads per multi-key batch (disk queue depth). Higher trades provisioned IOPS for faster large batches; 1 disables splitting. Small batches use fewer tasks.",
+    "privacy": "Public",
+    "value": 32
+  },
   "committer_config.storage_config.inner_storage_config.max_subcompactions": {
     "description": "Maximum number of subcompactions for parallel compaction",
     "privacy": "Public",

--- a/crates/starknet_patricia_storage/Cargo.toml
+++ b/crates/starknet_patricia_storage/Cargo.toml
@@ -41,4 +41,5 @@ libmdbx.workspace = true
 page_size.workspace = true
 rstest.workspace = true
 rust-rocksdb.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -58,6 +59,14 @@ const MAX_WRITE_BUFFERS: i32 = 4;
 const NUM_THREADS: i32 = 8;
 // Maximum number of background compactions (STT files merge and rewrite) and flushes.
 const MAX_BACKGROUND_JOBS: i32 = 8;
+// `multi_get` issues its reads one at a time, so an unsplit batch is bound by read latency rather
+// than by IOPS. Raising this only shifts the wait into the disk and blocking-pool queues; lowering
+// it leaves IOPS idle on large batches. Binds only above TARGET_KEYS_PER_READ_TASK keys per task.
+const MAX_READ_TASKS: usize = 32;
+// Keys per task. Each task reads its chunk serially, so wall time grows with this times the
+// per-read latency; lower buys parallelism, higher only amortizes the task spawn, which is
+// negligible beside a disk read. Chunks are balanced, so the smallest is about half this.
+const TARGET_KEYS_PER_READ_TASK: usize = 32;
 
 pub struct RocksDbOptions {
     pub db_options: Options,
@@ -156,6 +165,9 @@ pub struct RocksDbStorageConfig {
     pub use_mmap_reads: bool,
     /// Whether to spawn blocking tasks for read operations.
     pub spawn_blocking_reads: bool,
+    /// Max parallel disk reads per multi-key batch (disk queue depth). Higher trades provisioned
+    /// IOPS for faster large batches; 1 disables splitting. Small batches use fewer tasks.
+    pub max_read_tasks: NonZeroUsize,
 }
 
 impl Default for RocksDbStorageConfig {
@@ -176,6 +188,8 @@ impl Default for RocksDbStorageConfig {
             enable_statistics: true,
             use_mmap_reads: false,
             spawn_blocking_reads: true,
+            max_read_tasks: NonZeroUsize::new(MAX_READ_TASKS)
+                .expect("MAX_READ_TASKS should be nonzero"),
         }
     }
 }
@@ -255,6 +269,14 @@ impl SerializeConfig for RocksDbStorageConfig {
                 "Whether to spawn blocking tasks for read operations",
                 ParamPrivacyInput::Public,
             ),
+            ser_param(
+                "max_read_tasks",
+                &self.max_read_tasks,
+                "Max parallel disk reads per multi-key batch (disk queue depth). Higher trades \
+                 provisioned IOPS for faster large batches; 1 disables splitting. Small batches \
+                 use fewer tasks.",
+                ParamPrivacyInput::Public,
+            ),
         ])
     }
 }
@@ -312,14 +334,33 @@ impl ImmutableReadOnlyStorage for RocksDbStorage {
     }
 
     async fn mget(&self, keys: &[&DbKey]) -> PatriciaStorageResult<Vec<Option<DbValue>>> {
-        if self.config.spawn_blocking_reads {
-            let db = self.db.clone();
-            let keys: Vec<Vec<u8>> = keys.iter().map(|k| k.0.clone()).collect();
-            Ok(spawn_blocking(move || Self::mget_from_raw_keys(keys, &db)).await??)
-        } else {
-            let raw_keys = keys.iter().map(|k| k.0.as_slice());
-            Ok(Self::mget_from_raw_keys(raw_keys, &self.db)?)
+        // Reached whenever every key hit the cache above; `chunks` would panic on a zero size.
+        if keys.is_empty() {
+            return Ok(Vec::new());
         }
+        if !self.config.spawn_blocking_reads {
+            let raw_keys = keys.iter().map(|k| k.0.as_slice());
+            return Self::mget_from_raw_keys(raw_keys, &self.db);
+        }
+
+        // All spawned before any await, so they overlap; in-order await keeps values aligned.
+        let n_tasks =
+            keys.len().div_ceil(TARGET_KEYS_PER_READ_TASK).min(self.config.max_read_tasks.get());
+        let keys_per_task = keys.len().div_ceil(n_tasks);
+        let handles: Vec<_> = keys
+            .chunks(keys_per_task)
+            .map(|chunk| {
+                let db = self.db.clone();
+                let raw_keys: Vec<Vec<u8>> = chunk.iter().map(|key| key.0.clone()).collect();
+                spawn_blocking(move || Self::mget_from_raw_keys(raw_keys, &db))
+            })
+            .collect();
+
+        let mut values = Vec::with_capacity(keys.len());
+        for handle in handles {
+            values.extend(handle.await??);
+        }
+        Ok(values)
     }
 }
 

--- a/crates/starknet_patricia_storage/src/storage_test.rs
+++ b/crates/starknet_patricia_storage/src/storage_test.rs
@@ -1,11 +1,13 @@
+use std::num::NonZeroUsize;
 use std::path::Path;
 
 use rstest::rstest;
+use tempfile::TempDir;
 use tokio::task::JoinSet;
 
 use crate::mdbx_storage::MdbxStorage;
 use crate::rocksdb_storage::{RocksDbStorage, RocksDbStorageConfig};
-use crate::storage_trait::{AsyncStorage, DbKey, DbValue};
+use crate::storage_trait::{AsyncStorage, DbKey, DbValue, ImmutableReadOnlyStorage, Storage};
 
 /// Tests the concurrent access to the storage. Explicitly uses 11 worker threads to get actual
 /// parallelism (one thread for main test, 10 worker threads for concurrent operations).
@@ -49,4 +51,48 @@ async fn test_storage_concurrent_access(#[case] mut storage: impl AsyncStorage) 
     }
 
     tasks.join_all().await;
+}
+
+/// Values must stay aligned with the requested keys however the batch is split.
+#[rstest]
+#[case::split_across_tasks(32)]
+#[case::single_task(1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_mget_preserves_key_order(#[case] max_read_tasks: usize) {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = RocksDbStorage::new(
+        temp_dir.path(),
+        RocksDbStorageConfig {
+            max_read_tasks: NonZeroUsize::new(max_read_tasks).unwrap(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    const N_KEYS: u32 = 200;
+    let value_of = |key: u32| DbValue(key.to_be_bytes().to_vec());
+    // Only even keys exist; a misaligned chunk shows up as a `None` in the wrong slot.
+    for key in (0..N_KEYS).step_by(2) {
+        storage.set(DbKey(key.to_be_bytes().to_vec()), value_of(key)).await.unwrap();
+    }
+
+    let keys: Vec<DbKey> = (0..N_KEYS).map(|key| DbKey(key.to_be_bytes().to_vec())).collect();
+    let borrowed_keys: Vec<&DbKey> = keys.iter().collect();
+    let values = ImmutableReadOnlyStorage::mget(&storage, &borrowed_keys).await.unwrap();
+
+    assert_eq!(values.len(), keys.len());
+    for (index, value) in values.iter().enumerate() {
+        let key = u32::try_from(index).unwrap();
+        let expected = if key % 2 == 0 { Some(value_of(key)) } else { None };
+        assert_eq!(*value, expected, "wrong value at index {index}");
+    }
+}
+
+/// An empty batch must not reach `chunks`, which panics on a zero chunk size. Reachable in
+/// production: `CachedStorage::mget` forwards an empty miss list when every key was cached.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mget_empty_batch() {
+    let temp_dir = TempDir::new().unwrap();
+    let storage = RocksDbStorage::new(temp_dir.path(), RocksDbStorageConfig::default()).unwrap();
+    assert!(ImmutableReadOnlyStorage::mget(&storage, &[]).await.unwrap().is_empty());
 }


### PR DESCRIPTION
## Problem

`RocksDbStorage::mget` calls `db.multi_get`, which batches at the API level but issues the underlying file reads **one at a time**. A large batch therefore runs at queue depth ~1 and costs `n_keys * read_latency`, no matter how many IOPS the device can serve.

This dominates the committer's pre-commit Patricia witness fetch, which is `tokio::join!`ed with the compute phase — so on state-heavy blocks the whole commit is gated on it, the batcher reports "not ready", and consensus stalls for tens of seconds.

Measured on a committer replaying mainnet traffic (block with 101,639 witness entries):

```
Block stats: durations in ms (total/read/compute/write): 58641/2578/154/171,
  witness fetch ms (pre-commit/post-commit): 50883/167, witness entries: 101639
Component Committer took 58641 ms to process "CommitterRequest::ReadPathsAndCommitBlock"
```

101,639 reads in 50.9s = **2,008 reads/sec at 0.65ms each** — that is hyperdisk's single-read latency, i.e. serial round-trips. At the time this used **12% of the disk's provisioned IOPS and 2% of its bandwidth**, on a node at 25% CPU. Disk-level sampling confirmed **queue depth 1.30**.

## Fix

Split the batch across blocking tasks so several reads are in flight. All tasks are spawned before any is awaited, so they run concurrently; awaiting them in order keeps values aligned with the requested keys.

`max_read_tasks` is configurable and `1` restores the previous behaviour exactly, so it can be A/B'd or reverted without a rebuild.

## Results

Same blocks, replayed deterministically — witness-entry counts byte-identical before and after, so this is the same work done faster:

| block | entries | witness fetch before → after | speedup |
|---|---|---|---|
| 11752174 | 101,639 | 50,883 → 2,699 ms | **18.9x** |
| 11752207 | 135,879 | 29,364 → 2,101 ms | **14.0x** |
| 11752175 | 111,824 | 18,374 → 1,695 ms | **10.8x** |
| 11752177 | 82,655 | 9,031 → 1,211 ms | 7.5x |
| 11752176 | 68,349 | 7,738 → 1,059 ms | 7.3x |

Commit-duration distribution over ~320 blocks:

| | before | after |
|---|---|---|
| p50 | 87 ms | 86 ms |
| p99 | 5,792 ms | **1,920 ms** |
| max | **58,641 ms** | **3,696 ms** |
| commits > 10s | 4 | **0** |

p50 is unchanged, as expected — light blocks were never affected.

Mechanism confirmed by disk sampling: **queue depth 1.30 → 24.4**, peak read IOPS 3,612 → 45,140, **read latency unchanged** (0.650 → 0.632 ms). Same disk, same reads, just issued concurrently.

Note the run that produced these numbers also raised the disk from 30k to 60k provisioned IOPS. That cannot explain the gain on its own — the baseline used only 12% of the old ceiling — but peak demand did reach 45,140 IOPS, so the extra headroom is needed to realise the full benefit.

## Notes for review

- `MIN_KEYS_PER_READ_TASK` caps the split as well as flooring it: a batch only reaches `max_read_tasks` tasks once it holds `max_read_tasks * MIN_KEYS_PER_READ_TASK` keys. For a typical ~400-key level that yields 13 tasks regardless of whether `max_read_tasks` is 16 or 32, which is why measured queue depth peaked at 24.4 rather than 32. Happy to tune either constant.
- The split is **per `mget` call**, not global. `fetch_contract_storage_paths_concurrently` already fetches several tries at once, so peak blocking-task demand is (concurrent tries x tasks). It is bounded only by tokio's blocking pool, which queues rather than fails. A global semaphore would be the stricter alternative if reviewers prefer.
- I considered RocksDB's `multi_get_opt` with `ReadOptions::set_async_io`, which the crate exposes; it only parallelises when the build has io_uring, which I could not verify, so this approach does not depend on it.
- **Follow-up, not fixed here:** `MdbxStorage::mget` has the same defect — a `for` loop of `txn.get()`. Its single-RO-transaction/mmap model makes parallelising it a different design. `AerospikeStorage` is fine (real batch API).

## Testing

`cargo test -p starknet_patricia_storage --features rocksdb_storage,mdbx_storage` — 10/10 pass.

New test asserts values stay positionally aligned across chunk boundaries, at `max_read_tasks` of both 32 and 1. Only even keys are written, so a misaligned chunk surfaces immediately as a `None` in the wrong slot.