### PR TITLE
echonet: serve the recorder's witness height offset

### DIFF
--- a/echonet/echo_center.py
+++ b/echonet/echo_center.py
@@ -1167,6 +1167,17 @@ class EchoCenterService:
         last = self.shared.get_last_stored_commitment_height()
         return self._json_response({"block_number": last}, requests.codes.ok)
 
+    def handle_get_witness_height_offset(self) -> flask.Response:
+        """
+        GET /cende_recorder/get_witness_height_offset
+
+        Returns one past the last contiguously-stored commitment-info height (or null);
+        the sequencer skips its retrospective check entirely on null.
+        """
+        last = self.shared.get_last_stored_commitment_height()
+        offset = None if last is None else last + 1
+        return self._json_response({"block_number": offset}, requests.codes.ok)
+
     def handle_report_snapshot(self) -> flask.Response:
         """Return current in-memory tx tracking snapshot."""
         snap = self.shared.get_report_snapshot()
@@ -1481,6 +1492,11 @@ def get_latest_received_block() -> flask.Response:
 @app.route("/cende_recorder/get_last_stored_commitment_height", methods=["GET"])
 def get_last_stored_commitment_height() -> flask.Response:
     return service.handle_get_last_stored_commitment_height()
+
+
+@app.route("/cende_recorder/get_witness_height_offset", methods=["GET"])
+def get_witness_height_offset() -> flask.Response:
+    return service.handle_get_witness_height_offset()
 
 
 @app.route("/echonet/report", methods=["GET"])


### PR DESCRIPTION
## Problem

Main added `verify_retrospective_state_commitment_infos` (#14895), which calls `GET /cende_recorder/get_witness_height_offset` before every proposal. Echonet's mock recorder never implemented it, so the sequencer got a 404 and **every consensus round failed**:

```
PROPOSAL_FAILED: Proposal failed as proposer. Error: RetrospectiveStateCommitmentInfosError(
  CendeError(RecorderRequestFailed { path: "/cende_recorder/get_witness_height_offset",
  message: "returned error status 404 Not Found" }))
```

The sequencer already handles a recorder with nothing stored — it skips the check when the offset is null:

```rust
if cende_recorder_height_offset.is_none() {
    warn!("...the cende recorder hasn't stored any; skipping the retrospective ... validation.");
    return Ok(());
}
```

It just never got there: a 404 is a transport error and fails before that branch.

## Fix

Serve the offset from the existing commit store — one past the last contiguously-stored height, or `null` when nothing is stored. Wired to `SharedContext.get_last_stored_commitment_height`, so it stays meaningful as blobs accumulate rather than being hardcoded to `null`.

## Note

`/cende_recorder/get_last_stored_commitment_height` is left in place even though current main no longer calls it, because the previous sequencer image still does — removing it would break rollback to that image.