### PR TITLE
echonet: decode bincode-encoded state commitment infos

### DIFF
--- a/echonet/os_input_builder.py
+++ b/echonet/os_input_builder.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import base64
 import io
-import json
 from typing import Any, Dict, List, Optional
 
 import zstandard
@@ -27,20 +26,88 @@ class OsInputBuildError(RuntimeError):
     """Raised when the cende blob lacks a field required to assemble OsHints."""
 
 
+# Felts are length-prefixed and minimally encoded, so a longer length means the layout drifted.
+MAX_FELT_BYTE_LENGTH = 32
+
+
+class _BincodeReader:
+    """Reads the committer's bincode form: u64 little-endian lengths, big-endian felts."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self._pos = 0
+
+    def _take(self, n_bytes: int) -> bytes:
+        end = self._pos + n_bytes
+        if end > len(self._payload):
+            raise OsInputBuildError(f"truncated payload: wanted {n_bytes} bytes at {self._pos}")
+        chunk = self._payload[self._pos : end]
+        self._pos = end
+        return chunk
+
+    def read_byte(self) -> int:
+        return self._take(1)[0]
+
+    def read_u64(self) -> int:
+        return int.from_bytes(self._take(8), "little")
+
+    def read_felt(self) -> str:
+        # Felts drop leading zero bytes, so the length varies from 1 to MAX_FELT_BYTE_LENGTH.
+        length = self.read_u64()
+        if length > MAX_FELT_BYTE_LENGTH:
+            raise OsInputBuildError(f"felt length {length} exceeds {MAX_FELT_BYTE_LENGTH}")
+        return hex(int.from_bytes(self._take(length), "big"))
+
+    def assert_consumed(self) -> None:
+        if self._pos != len(self._payload):
+            raise OsInputBuildError(
+                f"decode consumed {self._pos} of {len(self._payload)} bytes; layout has changed"
+            )
+
+
+def _read_commitment_info(reader: _BincodeReader) -> JsonObject:
+    previous_root = reader.read_felt()
+    updated_root = reader.read_felt()
+    tree_height = reader.read_byte()
+    commitment_facts: Dict[str, List[str]] = {}
+    num_facts = reader.read_u64()
+    for _ in range(num_facts):
+        fact = reader.read_felt()
+        num_values = reader.read_u64()
+        commitment_facts[fact] = [reader.read_felt() for _ in range(num_values)]
+    return {
+        "previous_root": previous_root,
+        "updated_root": updated_root,
+        "tree_height": tree_height,
+        "commitment_facts": commitment_facts,
+    }
+
+
 def decompress_state_commitment_infos(compressed: str) -> JsonObject:
     """
-    Reverse of the committer's `base64(zstd(serde_json(StateCommitmentInfos)))`
-    pipeline. The streaming decompressor is required: the Rust frame omits the
-    content size, which the one-shot `zstandard.decompress()` rejects.
+    Reverse of the committer's `base64(zstd(bincode(StateCommitmentInfos)))` pipeline; see
+    `StateCommitmentInfos::compress` in starknet_committer's `patricia_merkle_tree/types.rs`.
     """
     try:
         raw = base64.b64decode(compressed)
-        decompressed = zstandard.ZstdDecompressor().stream_reader(io.BytesIO(raw)).read()
-        return json.loads(decompressed)
+        payload = zstandard.ZstdDecompressor().stream_reader(io.BytesIO(raw)).read()
     except (ValueError, zstandard.ZstdError) as exc:
-        raise OsInputBuildError(
-            f"failed to decode compressed state_commitment_infos: {exc}"
-        ) from exc
+        raise OsInputBuildError(f"failed to decompress state_commitment_infos: {exc}") from exc
+
+    reader = _BincodeReader(payload)
+    contracts_trie = _read_commitment_info(reader)
+    classes_trie = _read_commitment_info(reader)
+    storage_tries: Dict[str, JsonObject] = {}
+    num_storage_tries = reader.read_u64()
+    for _ in range(num_storage_tries):
+        address = reader.read_felt()
+        storage_tries[address] = _read_commitment_info(reader)
+    reader.assert_consumed()
+    return {
+        "contracts_trie_commitment_info": contracts_trie,
+        "classes_trie_commitment_info": classes_trie,
+        "storage_tries_commitment_infos": storage_tries,
+    }
 
 
 def build_os_cli_input(


### PR DESCRIPTION
## Problem

The committer changed how it ships `state_commitment_infos` (#14884, #14906):

```
before:  base64(zstd(serde_json(StateCommitmentInfos)))
after:   base64(zstd(bincode(StateCommitmentInfos)))
```

Echonet still ran `json.loads` on the decompressed bytes. Decompression *succeeded*, so `json.loads` got bincode binary and Python's `detect_encoding` guessed utf-32-le from the first four bytes — an unhelpful error for what is really a format change:

```
UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 8-11
OsInputBuildError: failed to decode compressed state_commitment_infos
```

Every `write_blob` returned 500, so no block was ever stored, and the sequencer surfaced it only indirectly as `CendeWriteError("Writing blob to Aerospike didn't return in time")`.

## Fix

Decode the bincode form. The encoding is small and fully determined by the Rust types:

| Rust | encoding |
|---|---|
| collection / `Vec` length | u64 little-endian |
| `Felt` | u64 length + big-endian bytes, leading zeros stripped (1..32) |
| `HashOutput`, `PatriciaKey`, `ContractAddress` | derived newtypes, encoded as the bare `Felt` |
| `SubTreeHeight` | single byte |

Two details worth calling out, since both are easy to get wrong:

- `Felt` is **variable length** — leading zero bytes are stripped, so it is not a fixed 32.
- Every read is bounds-checked and the reader asserts the payload is **fully consumed**. bincode is schema-less, so a layout drift would otherwise decode into plausible-looking garbage and feed the OS runner wrong commitment facts. This fails loudly instead.

## Testing

Verified against the real recorder's own `_BincodeReader` (`starkware/starknet/core/os/state_commitments.py`), loaded verbatim and run over the same inputs: **300 generated payloads decode identically**, covering felt 0, one-byte felts, 32-byte felts, and empty maps. Trailing-byte corruption is rejected.

Confirmed end to end in echonet: blob writes succeed and OS runs complete against the new committer.