### PR TITLE
starknet_os: preallocate CompressionSet vectors to avoid reallocation

### DIFF
--- a/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
@@ -575,7 +575,7 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
     let unique_value_bucket_lengths: Vec<usize> = header[2..2 + N_UNIQUE_BUCKETS].to_vec();
     let n_repeating_values = &header[2 + N_UNIQUE_BUCKETS];
 
-    let mut unique_values = Vec::new();
+    let mut unique_values = Vec::with_capacity(unique_value_bucket_lengths.iter().sum());
     unique_values.extend(compressed.take(unique_value_bucket_lengths[0])); // 252 bucket.
     unique_values.extend(unpack_chunk::<125>(compressed, unique_value_bucket_lengths[1]));
     unique_values.extend(unpack_chunk::<83>(compressed, unique_value_bucket_lengths[2]));
@@ -605,7 +605,7 @@ pub fn decompress(compressed: &mut impl Iterator<Item = Felt>) -> Vec<Felt> {
 
     let mut bucket_offset_trackers: Vec<_> = bucket_offsets;
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(*data_len);
     for bucket_index in bucket_index_per_elm {
         let offset = &mut bucket_offset_trackers[bucket_index];
         let value = all_values[*offset];

--- a/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
+++ b/crates/starknet_os/src/hints/hint_implementation/stateless_compression/utils.rs
@@ -360,8 +360,8 @@ impl CompressionSet {
     pub fn new(values: &[Felt]) -> Self {
         let mut obj = Self {
             unique_value_buckets: Buckets::new(),
-            repeating_value_bucket: Vec::new(),
-            bucket_index_per_elm: Vec::new(),
+            repeating_value_bucket: Vec::with_capacity(values.len()),
+            bucket_index_per_elm: Vec::with_capacity(values.len()),
         };
         let repeating_values_bucket_index = N_UNIQUE_BUCKETS;
 


### PR DESCRIPTION
## Context

Follow-up to #14779, which preallocated the two `Vec`s inside `stateless_compression::utils::decompress` that grew from `Vec::new()` even though their final length was already known from the decoded header.

That PR's sibling function, `compress()`, has the same pattern and is also on a production hot path: `compress()` is invoked from the `compression_hint` Cairo VM hint (`crates/starknet_os/src/hints/hint_implementation/stateless_compression/implementation.rs`), a hint registered in `crates/starknet_os/src/hints/enum_definition.rs` and executed once per block during OS/Cairo execution — not test-only code.

## Problem

`CompressionSet::new` (called from `compress`) builds two `Vec`s via `Vec::new()` + `push` inside a loop over `values: &[Felt]`, even though both are bounded by `values.len()` before the loop starts:

- `bucket_index_per_elm`: exactly one `push` per loop iteration, so its final length is always exactly `values.len()`.
- `repeating_value_bucket`: pushed only on the "value already seen" branch, so its final length is at most `values.len()`, never more.

Growing both from capacity 0 means ~log2(N) reallocations and O(N) redundant `(usize, usize)`/`usize` copies per block, on a per-block hot path — the same class of inefficiency #14779 fixed on the decompress side.

## Fix

Preallocate both `Vec`s with `values.len()` via `Vec::with_capacity`, mirroring the pattern already used elsewhere in this file (`get_bucket_offsets`, `unpack_felts`, `unpack_felts_to`, and the two call sites `decompress` already uses from #14779).

This is behavior-neutral — `Vec::with_capacity` cannot panic or change output; capacity isn't observable through any of the `Vec` APIs used here (`len`, `iter`, slice deref).

## Verification

With `sequencer_venv` active and `RUSTC_WRAPPER=""` (sccache unavailable in this environment):
- `cargo build -p starknet_os` — clean.
- `SEED=0 cargo test -p starknet_os stateless_compression` — 35 passed, 0 failed.
- `cargo clippy -p starknet_os --all-targets` — clean.
- `scripts/rust_fmt.sh` — no diff beyond this change.

An independent Opus review verified: the capacity for `bucket_index_per_elm` is exact and for `repeating_value_bucket` is a safe upper bound never exceeded; no new panic or observable-behavior surface; the optimization is real (not a no-op) given mainnet block sizes; and the change matches this file's existing `Vec::with_capacity` conventions.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012d2MUgfgFsLLKMTf6vrgf7)_