### PR TITLE
starknet_patricia_storage: flatten mget chunk keys into one buffer

### DIFF
--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -300,6 +300,21 @@ impl RocksDbStorage {
             .map(|r| r.map(|opt| opt.map(DbValue)))
             .collect::<Result<_, _>>()?)
     }
+
+    /// Concatenates `chunk`'s key bytes into one buffer and records each key's `(start, end)`
+    /// byte range within it, so the chunk moves into a blocking task as two allocations total
+    /// instead of one per key.
+    fn flatten_keys(chunk: &[&DbKey]) -> (Vec<u8>, Vec<(usize, usize)>) {
+        let total_bytes = chunk.iter().map(|key| key.0.len()).sum();
+        let mut key_bytes = Vec::with_capacity(total_bytes);
+        let mut key_spans = Vec::with_capacity(chunk.len());
+        for key in chunk {
+            let start = key_bytes.len();
+            key_bytes.extend_from_slice(&key.0);
+            key_spans.push((start, key_bytes.len()));
+        }
+        (key_bytes, key_spans)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -351,8 +366,13 @@ impl ImmutableReadOnlyStorage for RocksDbStorage {
             .chunks(keys_per_task)
             .map(|chunk| {
                 let db = self.db.clone();
-                let raw_keys: Vec<Vec<u8>> = chunk.iter().map(|key| key.0.clone()).collect();
-                spawn_blocking(move || Self::mget_from_raw_keys(raw_keys, &db))
+                // One allocation for the bytes and one for the spans, instead of one allocation
+                // per key: a chunk can hold thousands of keys on a large witness fetch.
+                let (key_bytes, key_spans) = Self::flatten_keys(chunk);
+                spawn_blocking(move || {
+                    let raw_keys = key_spans.iter().map(|&(start, end)| &key_bytes[start..end]);
+                    Self::mget_from_raw_keys(raw_keys, &db)
+                })
             })
             .collect();
 

--- a/crates/starknet_patricia_storage/src/rocksdb_storage.rs
+++ b/crates/starknet_patricia_storage/src/rocksdb_storage.rs
@@ -303,7 +303,8 @@ impl RocksDbStorage {
 
     /// Concatenates `chunk`'s key bytes into one buffer and records each key's `(start, end)`
     /// byte range within it, so the chunk moves into a blocking task as two allocations total
-    /// instead of one per key.
+    /// instead of one per key. Ranges are half-open (`end` exclusive) and ordered as in `chunk`;
+    /// a zero-length key yields an empty range.
     fn flatten_keys(chunk: &[&DbKey]) -> (Vec<u8>, Vec<(usize, usize)>) {
         let total_bytes = chunk.iter().map(|key| key.0.len()).sum();
         let mut key_bytes = Vec::with_capacity(total_bytes);

--- a/crates/starknet_patricia_storage/src/storage_test.rs
+++ b/crates/starknet_patricia_storage/src/storage_test.rs
@@ -88,6 +88,48 @@ async fn test_mget_preserves_key_order(#[case] max_read_tasks: usize) {
     }
 }
 
+/// Keys of mixed lengths share one flattened chunk buffer, so a value must still come back for the
+/// key it was requested with, whatever the neighboring keys' lengths are.
+#[rstest]
+#[case::split_across_tasks(32)]
+#[case::single_task(1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_mget_varying_key_lengths(#[case] max_read_tasks: usize) {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = RocksDbStorage::new(
+        temp_dir.path(),
+        RocksDbStorageConfig {
+            max_read_tasks: NonZeroUsize::new(max_read_tasks).unwrap(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Key lengths cycle over 1..=7 bytes so that every chunk mixes lengths, plus one empty key to
+    // cover a zero-length span. Repeating the index as the key's bytes keeps the keys distinct.
+    const N_KEYS: u8 = 200;
+    let key_of = |index: u8| {
+        if index == 0 { DbKey(Vec::new()) } else { DbKey(vec![index; usize::from(index) % 7 + 1]) }
+    };
+    let value_of = |index: u8| DbValue(vec![index; 3]);
+    // Only even keys exist; a span read from the wrong offset shows up as a misplaced `None`.
+    for index in (0..N_KEYS).step_by(2) {
+        storage.set(key_of(index), value_of(index)).await.unwrap();
+    }
+
+    let keys: Vec<DbKey> = (0..N_KEYS).map(key_of).collect();
+    let borrowed_keys: Vec<&DbKey> = keys.iter().collect();
+    let values = ImmutableReadOnlyStorage::mget(&storage, &borrowed_keys).await.unwrap();
+
+    assert_eq!(values.len(), keys.len());
+    for (index, value) in values.iter().enumerate() {
+        let index = u8::try_from(index).unwrap();
+        // The single empty key (index 0) is even, so it is expected to be present.
+        let expected = if index % 2 == 0 { Some(value_of(index)) } else { None };
+        assert_eq!(*value, expected, "wrong value at index {index}");
+    }
+}
+
 /// An empty batch must not reach `chunks`, which panics on a zero chunk size. Reachable in
 /// production: `CachedStorage::mget` forwards an empty miss list when every key was cached.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Problem

Follow-up to #15000, which split `RocksDbStorage::mget` across `spawn_blocking` tasks for read parallelism on the committer's per-block Patricia witness-fetch hot path (sometimes 100,000+ keys in one call).

Each task built its chunk of keys as `Vec<Vec<u8>>` by individually cloning every key's `Vec<u8>`:

```rust
let raw_keys: Vec<Vec<u8>> = chunk.iter().map(|key| key.0.clone()).collect();
```

That's one heap allocation per key, purely to give `spawn_blocking`'s `'static` closure owned data — on a 100k-key witness fetch, tens of thousands of small allocations per `mget` call.

## Fix

`flatten_keys` concatenates a chunk's key bytes into one `Vec<u8>` buffer plus a `Vec<(usize, usize)>` of `(start, end)` byte spans (sized exactly via a single pass, so `Vec::with_capacity` never reallocates). Each `spawn_blocking` task now moves in two allocations total instead of one per key; the byte slices are reconstructed from the buffer inside the closure body, after the move, so there's no self-referential-struct concern.

This only touches how the chunk's keys travel into the blocking task — it doesn't change what's queried or the order values come back in.

## Scope note (from review)

`rust-rocksdb` 0.44.1's `multi_get_opt` still copies each key into its own `Box<[u8]>` internally before calling into the C API, so this change takes per-key allocations from 2 down to 1 (our clone + RocksDB's own), not to zero. Getting rid of the remaining one would mean switching to `batched_multi_get_cf_opt`, which hands RocksDB raw pointers into the caller's buffer instead — a larger change (needs a `ColumnFamily` handle, returns `DBPinnableSlice`) left as a possible follow-up rather than folded in here.

## Testing

`RUSTC_WRAPPER="" cargo test -p starknet_patricia_storage --features rocksdb_storage,mdbx_storage` — 13/13 pass, including the existing `test_mget_preserves_key_order` (both chunked and single-task) and a new `test_mget_varying_key_lengths` covering a chunk that mixes key lengths (1–7 bytes) plus a zero-length key, which would surface any off-by-one in the span bookkeeping. Mutation-checked: corrupting a span's end fails both tests.

Reviewed by an Opus subagent for correctness (span math, closure/lifetime soundness, code-style compliance) before opening this PR; clippy and `rust_fmt.sh` are clean.

Related: #15000


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERBQzeK8gC2C5QUZt7L6ka)_