### PR TITLE
apollo_batcher: remove stale allow(dead_code)

### DIFF
--- a/crates/apollo_batcher/src/commitment_manager/types.rs
+++ b/crates/apollo_batcher/src/commitment_manager/types.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::time::Instant;


### PR DESCRIPTION
## Description

Remove the stale module-level `#[allow(dead_code)]` from `crates/apollo_batcher/src/commitment_manager/types.rs`.

### Why it is stale (live code, not dead)

The annotation was scaffolding. It was added when the `ReadPathsAndCommitBlock` committer task types were introduced in #14385, whose commit message notes *"Nothing constructs the task yet."* Since then:

- the task input/output types (`CommitterTaskInput`, `CommitterTaskOutput`, `CommitmentTaskOutput`, `FinalBlockCommitment`, `TaskTimer`, …) were wired into production paths (#14534, #14884), and
- #14902 removed the `os_input` feature gate, so the `commitment_manager` code is now compiled unconditionally.

As a result every item in `types.rs` is reachable from non-test code, and the module-level allow no longer suppresses any real warning.

### Verification (`RUSTC_WRAPPER="" CARGO_INCREMENTAL=0`)

- `cargo check -p apollo_batcher` — **zero** dead_code warnings without the annotation.
- `cargo check -p apollo_batcher --tests` — **zero** dead_code warnings.
- `cargo clippy -p apollo_batcher --all-targets` — clean.
- `SEED=0 cargo test -p apollo_batcher` — **119 passed, 0 failed**.

### Scope note

The field-level `#[allow(dead_code)]` attributes elsewhere in the module — `StateCommitter::task_performer_handle`, `StateCommitter::get_handle`, and `CommitmentManager::state_committer` — were individually re-checked and are **load-bearing** (removing them reintroduces `never read`/`never used` warnings, as they are RAII/scaffolding handles not yet consumed). They are intentionally kept; this PR only removes the stale module-level allow.

---
_Generated by [Claude Code](https://claude.ai/code/session_017mBUsQzHrb8vzRciYtaQtX)_