### PR TITLE
apollo_batcher,starknet_api: source view call block info from the committed block hash components

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -55,7 +55,6 @@ use apollo_storage::global_root_marker::{
     GlobalRootMarkerStorageReader,
     GlobalRootMarkerStorageWriter,
 };
-use apollo_storage::header::HeaderStorageReader;
 use apollo_storage::metrics::BATCHER_STORAGE_OPEN_READ_TRANSACTIONS;
 use apollo_storage::partial_block_hash::{
     PartialBlockHashComponentsStorageReader,
@@ -100,7 +99,6 @@ use indexmap::{IndexMap, IndexSet};
 use mockall::automock;
 use starknet_api::block::{
     BlockHash,
-    BlockHeaderWithoutHash,
     BlockInfo,
     BlockNumber,
     GasPrice,
@@ -110,6 +108,7 @@ use starknet_api::block::{
     UnixTimestamp,
 };
 use starknet_api::block_hash::block_hash_calculator::{
+    extract_l1_da_mode_from_concatenated_counts,
     PartialBlockHash,
     PartialBlockHashComponents,
 };
@@ -712,38 +711,61 @@ impl Batcher {
         })
     }
 
-    // Returns the block info for the given committed block number.
-    fn get_block_info(&self, block_number: BlockNumber) -> BatcherResult<BlockInfo> {
-        let header = self.storage_reader.get_block_header(block_number).map_err(|err| {
-            warn!("Failed to get block header for committed block {block_number}: {err}");
-            BatcherError::InternalError
-        })?;
-
-        let convert_price = |price: GasPrice| -> BatcherResult<NonzeroGasPrice> {
-            price.try_into().map_err(|e| {
-                warn!("Failed to convert price: {e}");
+    /// Returns the block info of the given committed block. Sourced from its block hash components
+    /// rather than its header, because nothing writes headers to the batcher's storage.
+    pub(crate) fn get_block_info(&self, block_number: BlockNumber) -> BatcherResult<BlockInfo> {
+        let block_hash_components = self
+            .storage_reader
+            .get_partial_block_hash_components(block_number)
+            .map_err(|err| {
+                warn!(
+                    "Failed to get the block hash components of committed block {block_number}: \
+                     {err}"
+                );
                 BatcherError::InternalError
-            })
+            })?
+            .ok_or_else(|| {
+                // Only a block committed before block hash components existed lacks them.
+                warn!("Committed block {block_number} has no block hash components stored.");
+                BatcherError::ContractCallFailed {
+                    reason: format!(
+                        "No block info stored for committed block {block_number}, so no block \
+                         context can be built for it."
+                    ),
+                }
+            })?;
+
+        // A price of zero is floored rather than rejected: it would fail a view call, which charges
+        // no fee, over a price it never spends.
+        let convert_price = |price: GasPrice| -> NonzeroGasPrice {
+            NonzeroGasPrice::new(price).unwrap_or(NonzeroGasPrice::MIN)
         };
 
         Ok(BlockInfo {
-            block_number: header.block_number,
-            block_timestamp: header.timestamp,
-            sequencer_address: header.sequencer.0,
+            block_number: block_hash_components.block_number,
+            block_timestamp: block_hash_components.timestamp,
+            sequencer_address: block_hash_components.sequencer.0,
             gas_prices: GasPrices {
                 eth_gas_prices: GasPriceVector {
-                    l1_gas_price: convert_price(header.l1_gas_price.price_in_wei)?,
-                    l1_data_gas_price: convert_price(header.l1_data_gas_price.price_in_wei)?,
-                    l2_gas_price: convert_price(header.l2_gas_price.price_in_wei)?,
+                    l1_gas_price: convert_price(block_hash_components.l1_gas_price.price_in_wei),
+                    l1_data_gas_price: convert_price(
+                        block_hash_components.l1_data_gas_price.price_in_wei,
+                    ),
+                    l2_gas_price: convert_price(block_hash_components.l2_gas_price.price_in_wei),
                 },
                 strk_gas_prices: GasPriceVector {
-                    l1_gas_price: convert_price(header.l1_gas_price.price_in_fri)?,
-                    l1_data_gas_price: convert_price(header.l1_data_gas_price.price_in_fri)?,
-                    l2_gas_price: convert_price(header.l2_gas_price.price_in_fri)?,
+                    l1_gas_price: convert_price(block_hash_components.l1_gas_price.price_in_fri),
+                    l1_data_gas_price: convert_price(
+                        block_hash_components.l1_data_gas_price.price_in_fri,
+                    ),
+                    l2_gas_price: convert_price(block_hash_components.l2_gas_price.price_in_fri),
                 },
             },
-            use_kzg_da: header.l1_da_mode.is_use_kzg_da(),
-            starknet_version: header.starknet_version,
+            use_kzg_da: extract_l1_da_mode_from_concatenated_counts(
+                &block_hash_components.header_commitments.concatenated_counts,
+            )
+            .is_use_kzg_da(),
+            starknet_version: block_hash_components.starknet_version,
         })
     }
 
@@ -1792,7 +1814,10 @@ pub trait BatcherStorageReader: Send + Sync {
         height: BlockNumber,
     ) -> StorageResult<(Option<BlockHash>, Option<PartialBlockHashComponents>)>;
 
-    fn get_block_header(&self, block_number: BlockNumber) -> StorageResult<BlockHeaderWithoutHash>;
+    fn get_partial_block_hash_components(
+        &self,
+        height: BlockNumber,
+    ) -> StorageResult<Option<PartialBlockHashComponents>>;
 }
 
 impl BatcherStorageReader for StorageReader {
@@ -1891,14 +1916,11 @@ impl BatcherStorageReader for StorageReader {
         Ok((parent_hash, partial_block_hash_components))
     }
 
-    fn get_block_header(&self, block_number: BlockNumber) -> StorageResult<BlockHeaderWithoutHash> {
-        self.begin_ro_txn()?
-            .get_block_header(block_number)?
-            .map(|header| header.block_header_without_hash)
-            .ok_or_else(|| StorageError::NotFound {
-                resource_type: "block header".to_string(),
-                resource_id: block_number.to_string(),
-            })
+    fn get_partial_block_hash_components(
+        &self,
+        height: BlockNumber,
+    ) -> StorageResult<Option<PartialBlockHashComponents>> {
+        self.begin_ro_txn()?.get_partial_block_hash_components(&height)
     }
 }
 

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -41,7 +41,6 @@ use apollo_mempool_types::communication::{
 use apollo_mempool_types::mempool_types::CommitBlockArgs;
 use apollo_state_sync_types::state_sync_types::SyncBlock;
 use apollo_storage::db::DbError;
-use apollo_storage::header::HeaderStorageWriter;
 use apollo_storage::partial_block_hash::PartialBlockHashComponentsStorageWriter;
 use apollo_storage::state::StateStorageWriter;
 use apollo_storage::test_utils::get_test_storage;
@@ -74,22 +73,25 @@ use mockall::predicate::{always, eq};
 use rstest::rstest;
 use starknet_api::block::{
     BlockHash,
-    BlockHeader,
     BlockHeaderWithoutHash,
     BlockInfo,
     BlockNumber,
+    BlockTimestamp,
     GasPrice,
     GasPricePerToken,
     StarknetVersion,
 };
 use starknet_api::block_hash::block_hash_calculator::{
     calculate_block_hash,
+    concat_counts,
+    BlockHeaderCommitments,
     PartialBlockHash,
     PartialBlockHashComponents,
 };
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, GlobalRoot, Nonce};
+use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::state::{SierraContractClass, StorageKey, ThinStateDiff};
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{class_hash, invoke_tx_args, tx_hash};
@@ -183,6 +185,9 @@ const CAIRO_STEPS_RECURSION_DEPTH_EXCEEDING_RESOURCE_BOUNDS: u64 = 400_000;
 /// `state_diff_height()`, one past the last written diff, and takes its block info from the block
 /// before that.
 const LAST_COMMITTED_HEIGHT: BlockNumber = BlockNumber(0);
+/// Distinguishable from the default, so a test can tell a real committed value from a synthesized
+/// one.
+const COMMITTED_BLOCK_TIMESTAMP: BlockTimestamp = BlockTimestamp(1_700_000_000);
 
 struct TestViewStateReaderFactory {
     state: Arc<Mutex<CachedState<DictStateReader>>>,
@@ -2603,27 +2608,38 @@ async fn call_contract_times_out_when_the_state_reader_never_answers() {
 /// The caller states the class manager expectations, so that each test owns the number of reads it
 /// asserts on.
 fn deploy_contract_in_real_storage(contract: FeatureContract) -> MockDependenciesWithRealStorage {
+    deploy_contract_in_real_storage_with_commitment(
+        contract,
+        committed_block_hash_components(GasPrice(1)),
+    )
+}
+
+/// The block-hash components a real commit writes, which is what a view call sources its block info
+/// from. Every price is set to `gas_price`, so a test can state one and assert it survives.
+fn committed_block_hash_components(gas_price: GasPrice) -> PartialBlockHashComponents {
+    let price_per_token = GasPricePerToken { price_in_wei: gas_price, price_in_fri: gas_price };
+    PartialBlockHashComponents {
+        block_number: LAST_COMMITTED_HEIGHT,
+        l1_gas_price: price_per_token,
+        l1_data_gas_price: price_per_token,
+        l2_gas_price: price_per_token,
+        timestamp: COMMITTED_BLOCK_TIMESTAMP,
+        ..Default::default()
+    }
+}
+
+/// Writes no block header: nothing in production writes one to the batcher's storage, so seeding
+/// one would assert against a precondition the node never has.
+fn deploy_contract_in_real_storage_with_commitment(
+    contract: FeatureContract,
+    block_hash_components: PartialBlockHashComponents,
+) -> MockDependenciesWithRealStorage {
     let class_hash = contract.get_class_hash();
     let mut mock_dependencies = MockDependenciesWithRealStorage::default();
 
-    let gas_price = GasPricePerToken { price_in_wei: GasPrice(1), price_in_fri: GasPrice(1) };
     mock_dependencies
         .storage_writer
         .begin_rw_txn()
-        .unwrap()
-        .append_header(
-            LAST_COMMITTED_HEIGHT,
-            &BlockHeader {
-                block_header_without_hash: BlockHeaderWithoutHash {
-                    block_number: LAST_COMMITTED_HEIGHT,
-                    l1_gas_price: gas_price,
-                    l1_data_gas_price: gas_price,
-                    l2_gas_price: gas_price,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        )
         .unwrap()
         .append_state_diff(
             LAST_COMMITTED_HEIGHT,
@@ -2634,10 +2650,7 @@ fn deploy_contract_in_real_storage(contract: FeatureContract) -> MockDependencie
         )
         .unwrap()
         // The commitment manager panics on a committed height with no hash commitment behind it.
-        .set_partial_block_hash_components(
-            &LAST_COMMITTED_HEIGHT,
-            &PartialBlockHashComponents::default(),
-        )
+        .set_partial_block_hash_components(&LAST_COMMITTED_HEIGHT, &block_hash_components)
         .unwrap()
         .commit()
         .unwrap();
@@ -2716,4 +2729,85 @@ async fn repeated_view_calls_fetch_the_class_once() {
             .await
             .unwrap();
     }
+}
+
+/// A committed block may carry a zero gas price, and a view call spends no fee, so it must not be
+/// the reason the call fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn call_contract_over_a_committed_zero_gas_price_succeeds() {
+    let contract = SIERRA_GAS_TRACKED_RECURSIVE_CONTRACT;
+    let mut mock_dependencies = deploy_contract_in_real_storage_with_commitment(
+        contract,
+        committed_block_hash_components(GasPrice(0)),
+    );
+    mock_dependencies
+        .class_manager_client
+        .expect_get_executable()
+        .returning(move |_| Ok(Some(contract.get_class())));
+    mock_dependencies
+        .class_manager_client
+        .expect_get_sierra()
+        .returning(move |_| Ok(Some(contract.get_sierra())));
+    let batcher = create_batcher_with_real_storage(mock_dependencies).await;
+
+    let result = batcher
+        .call_contract(recurse_call_contract_input(
+            contract,
+            RECURSION_DEPTH_WITHIN_RESOURCE_BOUNDS,
+        ))
+        .await;
+
+    assert_eq!(result.unwrap().retdata, vec![]);
+}
+
+/// A block committed before block hash components existed has no block info to build a context
+/// from. The caller is told that, rather than being handed a bare internal error.
+#[tokio::test]
+async fn call_contract_without_stored_block_info_names_what_is_missing() {
+    let mut storage_reader = MockBatcherStorageReader::new();
+    storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
+    storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
+    storage_reader.expect_get_partial_block_hash_components().returning(|_| Ok(None));
+    let batcher = create_batcher(MockDependencies { storage_reader, ..Default::default() }).await;
+
+    let result = batcher
+        .call_contract(CallContractInput {
+            contract_address: Default::default(),
+            entry_point: "get_stakers".to_string(),
+            calldata: vec![],
+        })
+        .await;
+
+    assert_matches!(
+        result,
+        Err(BatcherError::ContractCallFailed { reason }) if reason.contains("No block info stored")
+    );
+}
+
+/// The data availability mode is committed to by the block hash, so the block info reported for a
+/// committed block must be the mode that block was built with.
+#[rstest]
+#[case::calldata(L1DataAvailabilityMode::Calldata)]
+#[case::blob(L1DataAvailabilityMode::Blob)]
+#[tokio::test]
+async fn block_info_reports_the_committed_data_availability_mode(
+    #[case] l1_da_mode: L1DataAvailabilityMode,
+) {
+    let mut storage_reader = MockBatcherStorageReader::new();
+    storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
+    storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
+    storage_reader.expect_get_partial_block_hash_components().returning(move |_| {
+        Ok(Some(PartialBlockHashComponents {
+            header_commitments: BlockHeaderCommitments {
+                concatenated_counts: concat_counts(0, 0, 0, l1_da_mode),
+                ..Default::default()
+            },
+            ..Default::default()
+        }))
+    });
+    let batcher = create_batcher(MockDependencies { storage_reader, ..Default::default() }).await;
+
+    let block_info = batcher.get_block_info(LAST_COMMITTED_HEIGHT).unwrap();
+
+    assert_eq!(block_info.use_kzg_da, l1_da_mode.is_use_kzg_da());
 }

--- a/crates/apollo_batcher/src/test_utils.rs
+++ b/crates/apollo_batcher/src/test_utils.rs
@@ -22,14 +22,7 @@ use blockifier::state::cached_state::CommitmentStateDiff;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use indexmap::{indexmap, IndexMap};
 use mockall::predicate::eq;
-use starknet_api::block::{
-    BlockHash,
-    BlockHeaderWithoutHash,
-    BlockInfo,
-    BlockNumber,
-    GasPrice,
-    GasPricePerToken,
-};
+use starknet_api::block::{BlockHash, BlockInfo, BlockNumber};
 use starknet_api::block_hash::block_hash_calculator::PartialBlockHashComponents;
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::core::{ContractAddress, GlobalRoot, Nonce};
@@ -313,16 +306,9 @@ impl Default for MockDependencies {
         storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
         storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
         storage_reader.expect_get_state_diff().returning(|_| Ok(Some(test_state_diff())));
-        let valid_gas_price =
-            GasPricePerToken { price_in_wei: GasPrice(1), price_in_fri: GasPrice(1) };
-        storage_reader.expect_get_block_header().returning(move |_| {
-            Ok(BlockHeaderWithoutHash {
-                l1_gas_price: valid_gas_price,
-                l1_data_gas_price: valid_gas_price,
-                l2_gas_price: valid_gas_price,
-                ..Default::default()
-            })
-        });
+        storage_reader
+            .expect_get_partial_block_hash_components()
+            .returning(|_| Ok(Some(PartialBlockHashComponents::default())));
         storage_reader
             .expect_get_parent_hash_and_partial_block_hash_components()
             .with(eq(INITIAL_HEIGHT.prev().unwrap()))

--- a/crates/starknet_api/src/block_hash/block_hash_calculator.rs
+++ b/crates/starknet_api/src/block_hash/block_hash_calculator.rs
@@ -406,6 +406,17 @@ pub fn extract_event_count_from_concatenated_counts(concatenated_counts: &Felt) 
     u64::from_be_bytes(event_count_bytes).try_into().expect("Expected event count to fit in usize")
 }
 
+/// Extracts the L1 data availability mode from concatenated_counts.
+pub fn extract_l1_da_mode_from_concatenated_counts(
+    concatenated_counts: &Felt,
+) -> L1DataAvailabilityMode {
+    // Byte 24 is the L1 data availability mode field, whose top bit carries the mode.
+    match concatenated_counts.to_bytes_be()[24] & 0b10000000 {
+        0 => L1DataAvailabilityMode::Calldata,
+        _ => L1DataAvailabilityMode::Blob,
+    }
+}
+
 // For starknet version >= 0.13.3, returns:
 // [Poseidon (
 //     "STARKNET_GAS_PRICES0", gas_price_wei, gas_price_fri, data_gas_price_wei, data_gas_price_fri,

--- a/crates/starknet_api/src/block_hash/block_hash_calculator_test.rs
+++ b/crates/starknet_api/src/block_hash/block_hash_calculator_test.rs
@@ -1,7 +1,11 @@
 use rstest::rstest;
 use starknet_types_core::felt::Felt;
 
-use super::{concat_counts, extract_event_count_from_concatenated_counts};
+use super::{
+    concat_counts,
+    extract_event_count_from_concatenated_counts,
+    extract_l1_da_mode_from_concatenated_counts,
+};
 use crate::block::{BlockHash, BlockNumber, BlockTimestamp, GasPricePerToken, StarknetVersion};
 use crate::block_hash::block_hash_calculator::{
     calculate_block_commitments,
@@ -219,6 +223,16 @@ fn extract_event_count_from_concatenated_counts_test(
     let concatenated =
         concat_counts(tx_count, event_count, state_diff_len, L1DataAvailabilityMode::Blob);
     assert_eq!(extract_event_count_from_concatenated_counts(&concatenated), event_count);
+}
+
+#[rstest]
+#[case(L1DataAvailabilityMode::Calldata)]
+#[case(L1DataAvailabilityMode::Blob)]
+fn extract_l1_da_mode_from_concatenated_counts_test(#[case] l1_da_mode: L1DataAvailabilityMode) {
+    // state_diff_length occupies the bytes just before the mode, so max it out to catch a
+    // bit-offset error. The transaction count stays zero to keep the felt below the prime.
+    let concatenated = concat_counts(0, usize::MAX, usize::MAX, l1_da_mode);
+    assert_eq!(extract_l1_da_mode_from_concatenated_counts(&concatenated), l1_da_mode);
 }
 
 /// Test that if one of the input to block hash changes, the hash changes.


### PR DESCRIPTION
`Batcher::call_contract` cannot serve any height above genesis. `get_block_info` reads the `headers` table, which nothing in the batcher writes, so every non-genesis call fails with a bare `InternalError`.

The two production header writers (`apollo_central_sync`, `apollo_p2p_sync`) write `/data/state_sync`, not `/data/batcher`; `BatcherStorageWriter` has no header method at all. The bug was invisible because `test_utils.rs` mocked `get_block_header` to succeed for any height, and the real-storage test seeded a header itself — a precondition the node never has.

This gates the Chainlink oracle flip, which reads a feed through `call_contract`, and it applies equally to the other consumer, `CairoStakingContract`.

## Fix

Source the block info from `PartialBlockHashComponents`, which every `commit_proposal` already writes and which carries every `BlockInfo` field. No new write, no storage-scope change, no fabricated block hash, and no backfill — only `height.prev()` is ever read, so it works from the first commit after the upgrade.

`use_kzg_da` is not stored directly, but it is recoverable: `l1_da_mode` is packed into the top bit of byte 24 of `concatenated_counts`, so `extract_l1_da_mode_from_concatenated_counts` (added beside the existing `extract_event_count_from_concatenated_counts`) recovers it. It is not defaulted, because the mode is committed to by the block hash — `concatenated_counts` is chained into `calculate_block_hash`, and the commit path runs the same value in reverse via `L1DataAvailabilityMode::from_use_kzg_da`. Assuming it would put wrong data in a `BlockInfo` that a future caller could feed back into a hash.

Two smaller corrections on the same path:

- A committed zero gas price is floored to `NonzeroGasPrice::MIN` rather than failing the call, matching the RPC view-call path (`apollo_rpc_execution/src/lib.rs:382-397`). Both test helpers previously set `GasPrice(1)` specifically to dodge this.
- A block predating block hash components now returns `ContractCallFailed` naming what is missing, instead of a bare `InternalError`.

`get_block_info` is now `pub(crate)` so the sibling test module can assert on it directly — the view call cannot observe the DA mode end to end, since a fee-free call never reaches the cost table. `validate_retdata_length` in the same file is already `pub(crate)` for the same reason.

## Tests

The regression guard is the removal of `append_header` from `deploy_contract_in_real_storage`. Dropping that one call — a precondition production never satisfies — makes both real-storage `call_contract` tests fail with `InternalError`, the exact production symptom, before the fix.

Added: a committed zero gas price case, a missing-record case asserting the error names the problem, a `get_block_info` case per DA mode, and a round-trip test for the extractor with `state_diff_length` maxed out to catch a bit-offset error.

Verified the DA mode test discriminates rather than merely passes: with `use_kzg_da: false` put back, the blob case fails `left: false, right: true` while calldata still passes.

## Verification

- `apollo_batcher` 136/136, `starknet_api` 98/98
- `cargo clippy -p starknet_api --all-targets` under `-D warnings` clean
- `scripts/run_tests.py --command clippy --changes_only` clean
- `cargo build -p apollo_node` succeeds

No integration test exercises `Batcher::call_contract`. The integration harness (`apollo_integration_tests/src/state_reader.rs:489,497`) writes both a header and the block hash components for block 0, so it is compatible either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)