### PR TITLE
echonet: throttle tx forwarding on block lead instead of pending tx count

### DIFF
--- a/echonet/echonet_types.py
+++ b/echonet/echonet_types.py
@@ -162,7 +162,8 @@ class SleepConfig:
 class TxSenderTuning:
     """Tuning parameters for transaction_sender consumer."""
 
-    max_pending_txs_before_pausing: int = 15
+    # Max blocks a forwarded tx's source block may run ahead of the committed tip.
+    max_block_lead_before_pausing: int = 10
     poll_interval_seconds: float = 0.25
 
 
@@ -263,7 +264,7 @@ class EchonetConfig:
 
         start_block = int(keys["start_block"])
         blocked_senders_csv = str(keys.get("blocked_senders", ""))
-        max_pending_txs_before_pausing = int(keys.get("max_pending_txs_before_pausing", 15))
+        max_block_lead_before_pausing = int(keys.get("max_block_lead_before_pausing", 10))
 
         feeder_bypass = str(secrets.get("feeder_x_throttling_bypass", "")).strip()
         feeder_headers = MappingProxyType(
@@ -298,12 +299,12 @@ class EchonetConfig:
             ),
             sleep=SleepConfig(),
             tx_sender=TxSenderTuning(
-                max_pending_txs_before_pausing=max_pending_txs_before_pausing,
+                max_block_lead_before_pausing=max_block_lead_before_pausing,
             ),
             block_store=BlockStoreTuning(
                 max_blocks_to_keep_in_memory=max(
                     BlockStoreTuning.max_blocks_to_keep_in_memory,
-                    max_pending_txs_before_pausing // 2,
+                    max_block_lead_before_pausing * 2,
                 ),
             ),
             severity=SeverityConfig(),

--- a/echonet/transaction_sender.py
+++ b/echonet/transaction_sender.py
@@ -51,6 +51,19 @@ def _extract_revert_errors_by_tx_hash(block: JsonObject) -> Dict[str, str]:
     return out
 
 
+def _should_pause_forwarding(source_block_number: int) -> bool:
+    """Whether forwarding should wait for the committed tip to catch up."""
+    committed_block_number = shared.get_last_block()
+    if committed_block_number is None:
+        # Before the run's first blob, the tip is the block the sequencer was reverted to.
+        committed_block_number = (
+            shared.get_current_start_block(default_start_block=CONFIG.blocks.start_block) - 1
+        )
+
+    block_lead = source_block_number - committed_block_number
+    return block_lead > CONFIG.tx_sender.max_block_lead_before_pausing
+
+
 def _compress_and_encode_json(value: Any) -> str:
     """
     Mirror the Rust `compress_and_encode` helper used by the node:
@@ -92,6 +105,9 @@ async def fetch_block_transactions(
     raise last_err
 
 
+_TX_QUEUE_SIZE = 30
+
+
 @dataclass(frozen=True, slots=True)
 class SenderConfig:
     feeder_url: str = CONFIG.feeder.base_url
@@ -103,10 +119,15 @@ class SenderConfig:
     access_fgw_attempts: int = 3
     retry_backoff_seconds: float = 0.5
     max_retry_sleep_seconds: float = 30.0
-    sequencer_not_ready_retry_attempts: int = CONFIG.tx_sender.max_pending_txs_before_pausing * 2
+    # At ~0.5s per attempt, 20x the lead is ~5x the wall clock the tip needs to advance it.
+    sequencer_not_ready_retry_attempts: int = CONFIG.tx_sender.max_block_lead_before_pausing * 20
 
-    queue_size: int = 30
-    blocks_to_wait_before_failing_tx: int = CONFIG.tx_sender.max_pending_txs_before_pausing
+    queue_size: int = _TX_QUEUE_SIZE
+    # The producer buffers up to `queue_size` txs past the consumer, so a pending tx's block
+    # legitimately trails `current_block` by the block lead plus that many blocks.
+    blocks_to_wait_before_failing_tx: int = (
+        CONFIG.tx_sender.max_block_lead_before_pausing + _TX_QUEUE_SIZE
+    ) * 2
 
 
 @dataclass(frozen=True, slots=True)
@@ -368,10 +389,7 @@ class TransactionSenderService:
                         if prepared is None:  # L1_HANDLER
                             continue
 
-                        while (
-                            shared.get_pending_tx_count()
-                            >= CONFIG.tx_sender.max_pending_txs_before_pausing
-                        ):
+                        while _should_pause_forwarding(item.source_block_number):
                             await asyncio.sleep(CONFIG.tx_sender.poll_interval_seconds)
 
                         async with forwarding_lock:


### PR DESCRIPTION
## Problem

The tx sender paused only once 500 txs were in flight. Because mainnet blocks average ~3 txs, that let it run **200–280 blocks ahead of the committed tip** (measured live: tip `11894485`, sender `11894695`, pending exactly 500).

The gateway does stateful validation against `state_sync.get_latest_block_number()` — that stale tip — so any tx depending on recent state gets rejected. Over four days that was 916 first-attempt rejections:

| rejection | count | cause |
|---|---|---|
| `Resources bounds … exceed balance (0)` | 436 | counterfactual `DEPLOY_ACCOUNT` whose funding transfer, 6–9 blocks earlier, is not committed yet |
| `proof block number … is too recent` | 382 | needs `tip >= proof_block + 10` |
| `INVALID_TRANSACTION_NONCE` | 26 | nonce gap behind a stuck predecessor |

Four resyncs in one weekend came from the balance case. Each one gave up **45–80 seconds** before the tip would have caught up — the retry budget is `500 * 2` attempts at ~0.5 s, i.e. ~8.4 min, while a 275-block catch-up needs ~9.4 min. Two quantities derived from unrelated units, landing just on the wrong side.

## Change

Pause on the block lead instead: forwarding waits while a tx's source block is more than `max_block_lead_before_pausing` (10) ahead of the tip.

Throughput is unaffected — it is bound by mainnet's block rate either way (Echonet forwards at 1.55 tx/s against mainnet's 1.73 tx/s) and the gateway absorbs ~90 tx/s, so a whole mainnet block can be handed over in ~40 ms. The 200+ block backlog bought nothing; it only added staleness.

The lead becomes the single knob. `max_pending_txs_before_pausing` is removed, and the three settings derived from it — two of which were counting *blocks* and one *attempts* — now derive from the lead:

| setting | derivation | value |
|---|---|---|
| forwarding throttle | the lead | 10 blocks |
| `blocks_to_wait_before_failing_tx` | `(lead + queue_size) * 2` | 80 blocks |
| `sequencer_not_ready_retry_attempts` | `lead * 20` | 200 attempts (~100 s) |
| `max_blocks_to_keep_in_memory` | `max(default, lead * 2)` | 100 blocks |

Two details worth review attention:

- **`+ queue_size` in the stale-pending threshold.** The producer is throttled only by the tx queue, not by the lead, and a full 30-tx queue spans up to **21 blocks** when blocks are sparse (p10 is 1 tx/block). So `current_block` can sit ~31 blocks past the tip while pending txs start at `tip+1`. With a plain `lead * 2 = 20` the threshold lands *above* every pending tx and fires a resync immediately.
- **The unknown-tip fallback.** Before a run's first blob the tip is `None`, so the throttle falls back to `current_start_block - 1` — the height the sequencer was reverted to. Without it the sender races ahead unthrottled during the ~3.5 min the sequencer takes to start producing after a resync (revert confirmed 21:14:30, first block 21:18:06), which is the shape of the Aug 19 incident.

## Testing

Exercised against the loaded config and the real `ResyncPolicy`:

- throttle: lead 0 / lead == cap / lead == cap+1 / a reproduced 28-block lead / unknown tip at run start (forwards, no deadlock) / unknown tip after 94 blocks (pauses).
- resync policy: producer +9, +31 and +40 past the tip with pending txs at `tip+1..tip+10` → no trigger; a genuinely stuck tx 90 blocks old → triggers.
- derived values resolve to 10 / 80 / 200 / 100.
- `py_compile` and `scripts/py_code_style.py` clean.

## Not included

Two other findings from the same investigation are deliberately left out: the `GAS_PRICE_TOO_LOW` deadlock (the gateway's L2 threshold is 100% of the *tip* block's price, so a low-headroom replayed tx can never enter its own block — needs `validate_resource_bounds: false`, a config change), and making the retry loop tip-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)