### PR TITLE
blockifier: avoid redundant memory reads in read_felt_array

### DIFF
--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -861,22 +861,39 @@ pub fn read_felt_array<TErr>(vm: &VirtualMachine, ptr: &mut Relocatable) -> Resu
 where
     TErr: From<StarknetApiError> + From<VirtualMachineError> + From<MemoryError> + From<MathError>,
 {
+    // Read both endpoints once and reuse them below, instead of re-reading the same memory cells
+    // via `get_relocatable`.
+    let array_data_start = vm.get_maybe(&*ptr);
+    let array_data_end = vm.get_maybe(&(*ptr + 1_usize)?);
+
     // If the start and end pointers are the same, the array is empty.
     // This check is necessary to handle the case where both pointers are zero, and thus are not
     // relocatable values.
-    let array_start = vm.get_maybe(&*ptr);
-    if array_start.is_some() && array_start == vm.get_maybe(&(*ptr + 1_usize)?) {
+    if array_data_start.is_some() && array_data_start == array_data_end {
         *ptr = (*ptr + 2)?;
         return Ok(vec![]);
     }
 
-    let array_data_start_ptr = vm.get_relocatable(*ptr)?;
+    let array_data_start_ptr = relocatable_from_memory_value(*ptr, array_data_start)?;
     *ptr = (*ptr + 1)?;
-    let array_data_end_ptr = vm.get_relocatable(*ptr)?;
+    let array_data_end_ptr = relocatable_from_memory_value(*ptr, array_data_end)?;
     *ptr = (*ptr + 1)?;
     let array_size = (array_data_end_ptr - array_data_start_ptr)?;
 
     Ok(felt_range_from_ptr(vm, array_data_start_ptr, array_size)?)
+}
+
+/// Converts a memory value already read via [`VirtualMachine::get_maybe`] into a [`Relocatable`],
+/// matching the error semantics of [`VirtualMachine::get_relocatable`] without re-reading memory.
+fn relocatable_from_memory_value(
+    address: Relocatable,
+    value: Option<MaybeRelocatable>,
+) -> Result<Relocatable, MemoryError> {
+    match value {
+        Some(MaybeRelocatable::RelocatableValue(relocatable)) => Ok(relocatable),
+        Some(MaybeRelocatable::Int(_)) => Err(MemoryError::ExpectedRelocatable(Box::new(address))),
+        None => Err(MemoryError::UnknownMemoryCell(Box::new(address))),
+    }
 }
 
 pub fn write_segment(

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -861,10 +861,13 @@ pub fn read_felt_array<TErr>(vm: &VirtualMachine, ptr: &mut Relocatable) -> Resu
 where
     TErr: From<StarknetApiError> + From<VirtualMachineError> + From<MemoryError> + From<MathError>,
 {
-    // Read both endpoints once and reuse them below, instead of re-reading the same memory cells
-    // via `get_relocatable`.
+    // Read each endpoint once and reuse the value on every path below, instead of reading the
+    // same memory cell again to convert it to a `Relocatable`.
     let array_data_start = vm.get_maybe(&*ptr);
-    let array_data_end = vm.get_maybe(&(*ptr + 1_usize)?);
+    let array_data_end = match array_data_start {
+        Some(_) => vm.get_maybe(&(*ptr + 1_usize)?),
+        None => None,
+    };
 
     // If the start and end pointers are the same, the array is empty.
     // This check is necessary to handle the case where both pointers are zero, and thus are not
@@ -887,9 +890,9 @@ where
 /// matching the error semantics of [`VirtualMachine::get_relocatable`] without re-reading memory.
 fn relocatable_from_memory_value(
     address: Relocatable,
-    value: Option<MaybeRelocatable>,
+    memory_value: Option<MaybeRelocatable>,
 ) -> Result<Relocatable, MemoryError> {
-    match value {
+    match memory_value {
         Some(MaybeRelocatable::RelocatableValue(relocatable)) => Ok(relocatable),
         Some(MaybeRelocatable::Int(_)) => Err(MemoryError::ExpectedRelocatable(Box::new(address))),
         None => Err(MemoryError::UnknownMemoryCell(Box::new(address))),


### PR DESCRIPTION
## Summary

Follow-up performance optimization to #14986 (merged), which added a null-empty-span guard to `read_felt_array` in `crates/blockifier/src/execution/syscalls/hint_processor.rs`.

That guard reads both span endpoints via `vm.get_maybe` to detect an empty span. In the common non-empty case, the code then fell through and re-read the *same two memory cells* via `vm.get_relocatable`, which performs its own independent memory lookup (`Memory::get_relocatable` calls `self.get(&key)` internally, just like `get_maybe` does). So every call to `read_felt_array` for a non-empty array did 4 memory lookups instead of 2 — 2 of them pure redundant re-reads.

`read_felt_array` is a hot path: it decodes every array/`Span` argument passed into a Starknet syscall (calldata, retdata, event keys/data, etc.), so it runs many times per transaction and many times per block.

- Read each endpoint once via `get_maybe` and reuse the already-fetched `Option<MaybeRelocatable>` on every path (empty-array check and non-empty decode), via a new `relocatable_from_memory_value` helper, instead of re-reading memory with `get_relocatable`.
- The end-of-span lookup is only performed when the start lookup actually found something, preserving the original short-circuit behavior for the pathological (unreachable in practice) pointer-overflow edge case.
- Error semantics are unchanged: `MemoryError::UnknownMemoryCell` for a missing cell, `MemoryError::ExpectedRelocatable` for a cell holding an `Int`, verified line-by-line against `cairo-vm`'s `Memory::get_relocatable`.

An independent Opus review pass confirmed the helper produces identical `Result`s to `get_relocatable` for every possible memory state, verified pointer-mutation ordering is preserved, and found no correctness issues (two non-blocking nits were addressed in a follow-up commit).

## Expected impact

Removes 2 of 4 memory lookups per `read_felt_array` call in the common (non-empty array) case — this function runs on essentially every syscall array/`Span` argument, so the redundant lookups were paid many times per transaction across every block.

## Test plan

- [x] `cargo build -p blockifier --lib`
- [x] `cargo clippy -p blockifier --lib -- -D warnings` (clean)
- [x] `scripts/rust_fmt.sh`
- [x] `cargo test -p blockifier --lib execution::syscalls` — 97 passed, including the 6 `null_empty_span` regression tests added by #14986


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm9D5R6p4UNNNa6fZ4nm5r)_