### PR TITLE
starknet_api: add proof facts version V2

### DIFF
--- a/crates/starknet_api/src/transaction/fields.rs
+++ b/crates/starknet_api/src/transaction/fields.rs
@@ -640,16 +640,22 @@ pub const PROOF_VERSION_V0: Felt = Felt::from_hex_unchecked("0x50524f4f4630");
 // Represent the `PROOF_VERSION_V1` marker as a Felt ('PROOF1').
 pub const PROOF_VERSION_V1: Felt = Felt::from_hex_unchecked("0x50524f4f4631");
 
+// Represent the `PROOF_VERSION_V2` marker as a Felt ('PROOF2').
+pub const PROOF_VERSION_V2: Felt = Felt::from_hex_unchecked("0x50524f4f4632");
+
 /// Supported proof-facts version markers.
 ///
+/// TODO(Einat): Once the OS asserts V2 and the V2 circuit is wired up, update this to state that V1
+/// is replay-only too and that V2 is the only verifiable version.
 /// V0 is retained only so that historical blocks carrying V0 proof facts can be replayed (e.g. via
-/// reexecution). Whether V0 is accepted is gated per protocol version in the blockifier; the proof
-/// verifier no longer supports it.
+/// reexecution). Whether a version is accepted is gated per protocol version in the blockifier.
+/// V2 is defined ahead of the verifier and OS switch, and is not verifiable yet.
 #[cfg_attr(any(test, feature = "testing"), derive(EnumIter))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProofVersion {
     V0,
     V1,
+    V2,
 }
 
 impl ProofVersion {
@@ -658,6 +664,7 @@ impl ProofVersion {
         match self {
             ProofVersion::V0 => PROOF_VERSION_V0,
             ProofVersion::V1 => PROOF_VERSION_V1,
+            ProofVersion::V2 => PROOF_VERSION_V2,
         }
     }
 
@@ -666,6 +673,7 @@ impl ProofVersion {
         match self {
             ProofVersion::V0 => "PROOF0",
             ProofVersion::V1 => "PROOF1",
+            ProofVersion::V2 => "PROOF2",
         }
     }
 }
@@ -677,6 +685,8 @@ impl TryFrom<Felt> for ProofVersion {
             Ok(ProofVersion::V0)
         } else if value == PROOF_VERSION_V1 {
             Ok(ProofVersion::V1)
+        } else if value == PROOF_VERSION_V2 {
+            Ok(ProofVersion::V2)
         } else {
             Err(())
         }
@@ -748,9 +758,10 @@ impl TryFrom<&ProofFacts> for ProofFactsVariant {
         // Validate that the first element is a supported proof version marker.
         let proof_version = ProofVersion::try_from(*proof_version).map_err(|()| {
             StarknetApiError::InvalidProofFacts(format!(
-                "Expected first field to be {} or {}, but got {}",
+                "Expected first field to be one of {}, {}, {}, but got {}",
                 ProofVersion::V0,
                 ProofVersion::V1,
+                ProofVersion::V2,
                 proof_version,
             ))
         })?;

--- a/crates/starknet_proof_verifier/src/proof_verifier.rs
+++ b/crates/starknet_proof_verifier/src/proof_verifier.rs
@@ -138,9 +138,12 @@ pub fn verify_proof(proof_facts: ProofFacts, proof: Proof) -> Result<(), VerifyP
     let proof_bytes = proof.0.to_vec();
 
     match proof_version {
+        // TODO(Einat): Once privacy-circuit-verify exposes the V2 circuit, move V2 to its own arm
+        // that dispatches to it, and reject V1 here instead.
         // V0 proofs are no longer verifiable: the v0 circuit was removed. V0 proof facts are only
         // tolerated by the blockifier (gated per protocol version) for replaying historical blocks.
-        ProofVersion::V0 => {
+        // V2 is defined but not verifiable yet: the v2 circuit is not wired up.
+        ProofVersion::V0 | ProofVersion::V2 => {
             return Err(VerifyProofError::InvalidProofVersion { actual: proof_version_felt });
         }
         ProofVersion::V1 => {


### PR DESCRIPTION
> [!NOTE]
> **Part of a 3-PR stack** moving client-side proving from proof version V1 to V2. Review and merge in order:
> 1. **#15013** — `starknet_api: add proof facts version V2` (additive, independently mergeable)
> 2. **#15014** — `apollo_starknet_os_program,starknet_os,blockifier: switch client-side proving to V2`
> 3. **#15015** — `workspace,starknet_proof_verifier: verify proofs with the V2 circuit`
>
> Targets the **`main-v0.14.4`** release branch, since 0.14.4 is the protocol version whose `allowed_proof_versions` this change flips.

## What

Adds the proof-facts version marker `PROOF_VERSION_V2` (`'PROOF2'`, `0x50524f4f4632`) and the `ProofVersion::V2` variant, so proof facts carrying it parse and round-trip through `ProofFactsVariant`.

This is the additive first step of the V1 → V2 migration, mirroring how V0 → V1 was done (#14432 + #14450) — including the "one supported version at a time" policy: older markers are retained purely so historical blocks stay replayable.

## Why this is safe on its own

Nothing accepts V2 yet:

- `allowed_proof_versions` is unchanged, so the blockifier still rejects V2 proof facts under every protocol version.
- The Cairo OS still asserts `PROOF_VERSION_V1`.
- `verify_proof` rejects V2 up front — the new match arm exists only to keep the match exhaustive, and is what #15015 replaces with the real V2 circuit dispatch.

Both placeholder spots carry a `TODO(Einat)` naming exactly what to change once the OS and the V2 circuit are wired up:

- the `ProofVersion` doc comment → restate V1 as replay-only and V2 as the only verifiable version (done in #15015);
- the `verify_proof` match arm → give V2 its own arm dispatching to the V2 circuit, and reject V1 there instead (done in #15015).

`V0` stays documented as replay-only: it appears in historical blocks under protocol 0.14.2, and acceptance is gated per protocol version in the blockifier.

## Test coverage

`ProofVersion` derives `EnumIter` under `testing`, so the existing `fields_test.rs` tests pick V2 up for free — `proof_facts_variant_accepts_supported_versions` now parses V2-marked facts, and `proof_version_str_encodes_to_felt` checks that `"PROOF2"` encodes to the new felt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
