### PR TITLE
workspace: drop unused dev- and build-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,14 +908,12 @@ dependencies = [
  "async-trait",
  "blockifier",
  "blockifier_test_utils",
- "cairo-lang-starknet-classes",
  "cairo-vm",
  "chrono",
  "futures",
  "indexmap 2.14.0",
  "itertools 0.12.1",
  "lru 0.12.5",
- "mempool_test_utils",
  "metrics",
  "metrics-exporter-prometheus",
  "mockall",
@@ -953,25 +951,20 @@ name = "apollo_batcher_types"
 version = "0.0.0"
 dependencies = [
  "apollo_infra",
- "apollo_infra_utils",
  "apollo_metrics",
  "apollo_state_sync_types",
  "async-trait",
- "axum",
  "blockifier",
  "chrono",
  "derive_more",
  "indexmap 2.14.0",
  "mockall",
  "serde",
- "serde_json",
  "starknet-types-core",
  "starknet_api",
  "starknet_committer",
  "strum",
  "thiserror 1.0.69",
- "tokio",
- "tower",
 ]
 
 [[package]]
@@ -1131,8 +1124,6 @@ dependencies = [
 name = "apollo_compilation_utils"
 version = "0.0.0"
 dependencies = [
- "apollo_infra_utils",
- "assert_matches",
  "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
@@ -1198,7 +1189,6 @@ dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-native",
  "mempool_test_utils",
- "rstest",
  "tempfile",
  "toml_test_utils",
 ]
@@ -1217,7 +1207,6 @@ name = "apollo_config"
 version = "0.0.0"
 dependencies = [
  "apollo_infra_utils",
- "apollo_test_utils",
  "assert_matches",
  "clap",
  "colored 3.0.0",
@@ -1313,7 +1302,6 @@ dependencies = [
  "apollo_time",
  "assert_matches",
  "async-trait",
- "enum-as-inner",
  "futures",
  "lazy_static",
  "lru 0.12.5",
@@ -1367,15 +1355,12 @@ dependencies = [
  "apollo_signature_manager_types",
  "apollo_staking",
  "apollo_state_sync_types",
- "apollo_storage",
  "apollo_time",
  "apollo_transaction_converter",
  "async-trait",
  "futures",
  "mockall",
- "rstest",
  "starknet_api",
- "tempfile",
  "tokio",
  "tracing",
 ]
@@ -1416,15 +1401,12 @@ dependencies = [
  "apollo_sizeof",
  "apollo_starknet_client",
  "apollo_state_sync_types",
- "apollo_storage",
- "apollo_test_utils",
  "apollo_time",
  "apollo_transaction_converter",
  "apollo_versioned_constants",
  "assert_matches",
  "async-trait",
  "blockifier",
- "blockifier_test_utils",
  "cairo-lang-casm",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
@@ -1550,7 +1532,6 @@ dependencies = [
  "async-trait",
  "blockifier",
  "blockifier_test_utils",
- "cairo-lang-sierra-to-casm",
  "clap",
  "criterion",
  "expect-test",
@@ -1559,8 +1540,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "mockall",
- "mockito",
- "num-bigint",
  "num-rational",
  "pretty_assertions",
  "reqwest 0.12.24",
@@ -1574,7 +1553,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "tracing-test",
 ]
 
 [[package]]
@@ -1627,7 +1605,6 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.13.1",
- "blockifier",
  "blockifier_test_utils",
  "flate2",
  "futures",
@@ -1669,7 +1646,6 @@ dependencies = [
  "apollo_infra_utils",
  "apollo_metrics",
  "apollo_proc_macros",
- "assert_matches",
  "async-trait",
  "bytes",
  "derive_more",
@@ -1679,8 +1655,6 @@ dependencies = [
  "hyper-util",
  "metrics",
  "metrics-exporter-prometheus",
- "once_cell",
- "pretty_assertions",
  "rand 0.10.1",
  "rstest",
  "serde",
@@ -1791,7 +1765,6 @@ dependencies = [
  "mockall",
  "papyrus_base_layer",
  "pretty_assertions",
- "rstest",
  "serde",
  "serde_json",
  "starknet-types-core",
@@ -1838,7 +1811,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -1887,7 +1859,6 @@ dependencies = [
  "lru 0.12.5",
  "metrics",
  "metrics-exporter-prometheus",
- "mockall",
  "mockito",
  "papyrus_base_layer",
  "reqwest 0.12.24",
@@ -1949,7 +1920,6 @@ dependencies = [
  "apollo_network_types",
  "apollo_test_utils",
  "apollo_time",
- "assert_matches",
  "async-trait",
  "axum",
  "blockifier",
@@ -1958,7 +1928,6 @@ dependencies = [
  "derive_more",
  "expect-test",
  "indexmap 2.14.0",
- "itertools 0.12.1",
  "mempool_test_utils",
  "metrics",
  "metrics-exporter-prometheus",
@@ -2007,7 +1976,6 @@ dependencies = [
  "futures",
  "libp2p",
  "mockall",
- "rand_chacha 0.10.0",
  "starknet_api",
  "tokio",
  "tracing",
@@ -2153,7 +2121,6 @@ dependencies = [
  "anyhow",
  "apollo_metrics",
  "apollo_network",
- "assert_matches",
  "chrono",
  "clap",
  "futures",
@@ -2165,7 +2132,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-metrics",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2224,12 +2190,10 @@ dependencies = [
  "metrics-exporter-prometheus",
  "nix 0.20.2",
  "papyrus_base_layer",
- "pretty_assertions",
  "rstest",
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
  "tracing-test",
 ]
 
@@ -2285,7 +2249,6 @@ dependencies = [
  "apollo_state_sync_types",
  "apollo_storage",
  "apollo_test_utils",
- "assert_matches",
  "async-stream",
  "async-trait",
  "chrono",
@@ -2342,7 +2305,6 @@ dependencies = [
  "apollo_test_utils",
  "metrics",
  "metrics-exporter-prometheus",
- "papyrus_common",
  "prometheus-parse",
  "rstest",
  "static_assertions",
@@ -2413,7 +2375,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-test",
  "tracing",
  "tracing-test",
  "unsigned-varint 0.8.0",
@@ -2479,9 +2440,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.13.1",
- "cairo-lang-casm",
  "cairo-lang-starknet-classes",
- "camelpaste",
  "derive_more",
  "enum-iterator",
  "flate2",
@@ -2504,7 +2463,6 @@ dependencies = [
  "reqwest 0.12.24",
  "serde",
  "serde_json",
- "starknet-core",
  "starknet-types-core",
  "starknet_api",
  "strum",
@@ -2525,14 +2483,12 @@ dependencies = [
  "apollo_test_utils",
  "assert_matches",
  "blockifier",
- "cairo-lang-casm",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "cairo-vm",
  "indexmap 2.14.0",
  "itertools 0.12.1",
  "lazy_static",
- "mockall",
  "papyrus_common",
  "pretty_assertions",
  "rand_chacha 0.10.0",
@@ -2639,7 +2595,6 @@ version = "0.0.0"
 dependencies = [
  "apollo_config",
  "serde",
- "serde_json",
  "starknet-types-core",
  "starknet_api",
  "validator",
@@ -2706,7 +2661,6 @@ dependencies = [
  "blockifier_test_utils",
  "cairo-lang-starknet-classes",
  "indexmap 2.14.0",
- "rstest",
  "starknet-types-core",
  "starknet_api",
  "tokio",
@@ -2738,7 +2692,6 @@ dependencies = [
  "mockall",
  "papyrus_common",
  "rand 0.10.1",
- "rand_chacha 0.10.0",
  "starknet-types-core",
  "starknet_api",
  "tokio",
@@ -2806,9 +2759,7 @@ dependencies = [
  "cairo-lang-casm",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "camelpaste",
  "clap",
- "futures",
  "http 1.3.1",
  "http-body-util",
  "human_bytes",
@@ -2821,7 +2772,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "nix 0.20.2",
  "num-bigint",
- "num-traits",
  "page_size",
  "parity-scale-codec",
  "paste",
@@ -2841,7 +2791,6 @@ dependencies = [
  "starknet_committer",
  "tempfile",
  "test-case",
- "test-log",
  "thiserror 1.0.69",
  "tokio",
  "tower",
@@ -2854,7 +2803,6 @@ dependencies = [
 name = "apollo_task_executor"
 version = "0.0.0"
 dependencies = [
- "futures",
  "rstest",
  "tokio",
  "tokio-test",
@@ -2904,7 +2852,6 @@ dependencies = [
  "mempool_test_utils",
  "mockall",
  "rstest",
- "serde_json",
  "starknet-types-core",
  "starknet_api",
  "starknet_proof_verifier",
@@ -3695,7 +3642,6 @@ dependencies = [
  "apollo_infra_utils",
  "clap",
  "criterion",
- "glob",
  "rstest",
  "serde",
  "serde_json",
@@ -5004,12 +4950,6 @@ dependencies = [
  "tracing",
  "zip",
 ]
-
-[[package]]
-name = "camelpaste"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d88a780e6aa14b75d7be99f374d8b5c315aaf9c12ada1e2b1cb281468584c9"
 
 [[package]]
 name = "caseless"
@@ -6344,27 +6284,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "log",
 ]
 
 [[package]]
@@ -9326,7 +9245,6 @@ dependencies = [
  "apollo_state_reader",
  "apollo_storage",
  "blockifier",
- "cached",
  "cairo-lang-starknet-classes",
  "cairo-vm",
  "indexmap 2.14.0",
@@ -9989,7 +9907,6 @@ dependencies = [
  "apollo_config",
  "apollo_infra_utils",
  "apollo_metrics",
- "assert_matches",
  "async-trait",
  "futures",
  "hex",
@@ -10013,11 +9930,8 @@ dependencies = [
 name = "papyrus_common"
 version = "0.0.0"
 dependencies = [
- "apollo_test_utils",
- "assert_matches",
  "cairo-lang-starknet-classes",
  "indexmap 2.14.0",
- "pretty_assertions",
  "rand 0.10.1",
  "serde",
  "serde_json",
@@ -13021,7 +12935,6 @@ dependencies = [
 name = "starknet_os"
 version = "0.0.0"
 dependencies = [
- "apollo_infra_utils",
  "apollo_starknet_os_program",
  "ark-bls12-381",
  "ark-ff 0.5.0",
@@ -13098,7 +13011,6 @@ dependencies = [
  "starknet_api",
  "starknet_committer",
  "starknet_os",
- "starknet_patricia",
  "starknet_patricia_storage",
  "starknet_proof_verifier",
  "starknet_transaction_prover",
@@ -13173,7 +13085,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "apollo_infra_utils",
- "apollo_starknet_os_program",
  "assert_matches",
  "async-trait",
  "axum",
@@ -13639,28 +13550,6 @@ dependencies = [
  "quote",
  "syn 2.0.110",
  "test-case-core",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
-dependencies = [
- "env_logger",
- "test-log-macros",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
 ]
 
 [[package]]

--- a/crates/apollo_batcher/Cargo.toml
+++ b/crates/apollo_batcher/Cargo.toml
@@ -64,10 +64,8 @@ apollo_transaction_converter = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 blockifier = { workspace = true, features = ["testing"] }
 blockifier_test_utils.workspace = true
-cairo-lang-starknet-classes.workspace = true
 chrono = { workspace = true }
 itertools.workspace = true
-mempool_test_utils.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 mockall.workspace = true

--- a/crates/apollo_batcher_types/Cargo.toml
+++ b/crates/apollo_batcher_types/Cargo.toml
@@ -31,10 +31,5 @@ thiserror.workspace = true
 
 
 [dev-dependencies]
-apollo_infra_utils = { workspace = true, features = ["testing"] }
-axum.workspace = true
 mockall.workspace = true
-serde_json.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
-tokio = { workspace = true, features = ["full", "test-util"] }
-tower.workspace = true

--- a/crates/apollo_compilation_utils/Cargo.toml
+++ b/crates/apollo_compilation_utils/Cargo.toml
@@ -25,6 +25,4 @@ tempfile.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-apollo_infra_utils.workspace = true
-assert_matches.workspace = true
 rstest.workspace = true

--- a/crates/apollo_compile_to_native/Cargo.toml
+++ b/crates/apollo_compile_to_native/Cargo.toml
@@ -21,5 +21,4 @@ apollo_compilation_utils = { workspace = true, features = ["testing"] }
 apollo_infra_utils.workspace = true
 assert_matches.workspace = true
 mempool_test_utils.workspace = true
-rstest.workspace = true
 toml_test_utils.workspace = true

--- a/crates/apollo_config/Cargo.toml
+++ b/crates/apollo_config/Cargo.toml
@@ -22,7 +22,6 @@ validator = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 apollo_infra_utils = { workspace = true, features = ["testing"] }
-apollo_test_utils.workspace = true
 assert_matches.workspace = true
 colored.workspace = true
 itertools.workspace = true

--- a/crates/apollo_consensus/Cargo.toml
+++ b/crates/apollo_consensus/Cargo.toml
@@ -44,7 +44,6 @@ apollo_staking = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
 assert_matches.workspace = true
-enum-as-inner.workspace = true
 mockall.workspace = true
 rand.workspace = true
 rstest.workspace = true

--- a/crates/apollo_consensus_manager/Cargo.toml
+++ b/crates/apollo_consensus_manager/Cargo.toml
@@ -49,8 +49,5 @@ apollo_proof_manager_types = { workspace = true, features = ["testing"] }
 apollo_signature_manager_types = { workspace = true, features = ["testing"] }
 apollo_staking = { workspace = true, features = ["testing"] }
 apollo_state_sync_types = { workspace = true, features = ["testing"] }
-apollo_storage = { workspace = true }
 apollo_transaction_converter = { workspace = true, features = ["testing"] }
 mockall.workspace = true
-rstest.workspace = true
-tempfile.workspace = true

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -63,13 +63,10 @@ apollo_network = { workspace = true, features = ["testing"] }
 apollo_proof_manager_types = { workspace = true, features = ["testing"] }
 apollo_starknet_client.workspace = true
 apollo_state_sync_types = { workspace = true, features = ["testing"] }
-apollo_storage = { workspace = true, features = ["testing"] }
-apollo_test_utils.workspace = true
 apollo_time = { workspace = true, features = ["testing", "tokio"] }
 apollo_transaction_converter = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 blockifier = { workspace = true, features = ["testing"] }
-blockifier_test_utils = { workspace = true }
 cairo-lang-casm.workspace = true
 cairo-lang-utils.workspace = true
 cairo-vm.workspace = true

--- a/crates/apollo_gateway/Cargo.toml
+++ b/crates/apollo_gateway/Cargo.toml
@@ -70,20 +70,16 @@ apollo_transaction_converter = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 blockifier = { workspace = true, features = ["mocks", "testing"] }
 blockifier_test_utils.workspace = true
-cairo-lang-sierra-to-casm.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 expect-test.workspace = true
 mempool_test_utils.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 mockall.workspace = true
-mockito.workspace = true
-num-bigint.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 starknet_proof_verifier.workspace = true
-tracing-test.workspace = true
 
 [[bench]]
 harness = false

--- a/crates/apollo_http_server/Cargo.toml
+++ b/crates/apollo_http_server/Cargo.toml
@@ -51,7 +51,6 @@ apollo_gateway_types = { workspace = true, features = ["testing"] }
 apollo_metrics = { workspace = true, features = ["testing"] }
 assert_matches.workspace = true
 base64.workspace = true
-blockifier = { workspace = true, features = ["testing"] }
 blockifier_test_utils.workspace = true
 flate2.workspace = true
 mempool_test_utils.workspace = true

--- a/crates/apollo_infra/Cargo.toml
+++ b/crates/apollo_infra/Cargo.toml
@@ -45,10 +45,7 @@ validator.workspace = true
 apollo_infra_utils = { workspace = true, features = ["testing"] }
 apollo_metrics = { workspace = true, features = ["testing"] }
 apollo_proc_macros.workspace = true
-assert_matches.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
-once_cell.workspace = true
-pretty_assertions.workspace = true
 starknet-types-core.workspace = true
 strum = { workspace = true, features = ["derive"] }

--- a/crates/apollo_integration_tests/Cargo.toml
+++ b/crates/apollo_integration_tests/Cargo.toml
@@ -92,7 +92,6 @@ apollo_l1_events_types = { workspace = true, features = ["testing"] }
 futures.workspace = true
 metrics.workspace = true
 mockall.workspace = true
-rstest.workspace = true
 starknet_proof_verifier.workspace = true
 
 [[bin]]

--- a/crates/apollo_l1_events/Cargo.toml
+++ b/crates/apollo_l1_events/Cargo.toml
@@ -56,6 +56,5 @@ rstest.workspace = true
 starknet-types-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 tokio = { workspace = true, features = ["test-util"] }
-url.workspace = true
 [lints]
 workspace = true

--- a/crates/apollo_l1_gas_price/Cargo.toml
+++ b/crates/apollo_l1_gas_price/Cargo.toml
@@ -39,7 +39,6 @@ apollo_l1_gas_price_types = { workspace = true, features = ["testing"] }
 apollo_metrics = { workspace = true, features = ["testing"] }
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
-mockall.workspace = true
 mockito.workspace = true
 papyrus_base_layer = { workspace = true, features = ["testing"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/apollo_mempool/Cargo.toml
+++ b/crates/apollo_mempool/Cargo.toml
@@ -51,13 +51,11 @@ apollo_metrics = { workspace = true, features = ["testing"] }
 apollo_network_types = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
 apollo_time = { workspace = true, features = ["testing"] }
-assert_matches.workspace = true
 axum.workspace = true
 blockifier = { workspace = true, features = ["mocks", "testing"] }
 blockifier_test_utils.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 expect-test.workspace = true
-itertools.workspace = true
 mempool_test_utils.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true

--- a/crates/apollo_mempool_p2p/Cargo.toml
+++ b/crates/apollo_mempool_p2p/Cargo.toml
@@ -42,6 +42,5 @@ apollo_transaction_converter = { workspace = true, features = ["testing"] }
 futures.workspace = true
 libp2p.workspace = true
 mockall.workspace = true
-rand_chacha.workspace = true
 starknet_api.workspace = true
 tokio = { workspace = true, features = ["full", "sync", "test-util"] }

--- a/crates/apollo_network_benchmark/Cargo.toml
+++ b/crates/apollo_network_benchmark/Cargo.toml
@@ -29,10 +29,8 @@ tracing-subscriber.workspace = true
 
 
 [dev-dependencies]
-assert_matches.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = ["full", "sync", "test-util"] }
-tokio-stream.workspace = true
 
 [lints]
 workspace = true

--- a/crates/apollo_node/Cargo.toml
+++ b/crates/apollo_node/Cargo.toml
@@ -60,8 +60,6 @@ tracing.workspace = true
 apollo_config = { workspace = true, features = ["testing"] }
 apollo_infra_utils = { workspace = true, features = ["testing"] }
 nix.workspace = true
-pretty_assertions.workspace = true
 rstest.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
-tracing-subscriber.workspace = true
 tracing-test.workspace = true

--- a/crates/apollo_p2p_sync/Cargo.toml
+++ b/crates/apollo_p2p_sync/Cargo.toml
@@ -38,7 +38,6 @@ apollo_network = { workspace = true, features = ["testing"] }
 apollo_protobuf = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
-assert_matches.workspace = true
 lazy_static.workspace = true
 mockall.workspace = true
 static_assertions.workspace = true

--- a/crates/apollo_proc_macros_tests/Cargo.toml
+++ b/crates/apollo_proc_macros_tests/Cargo.toml
@@ -14,7 +14,6 @@ apollo_metrics.workspace = true
 apollo_test_utils.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
-papyrus_common.workspace = true
 prometheus-parse.workspace = true
 rstest.workspace = true
 static_assertions.workspace = true

--- a/crates/apollo_propeller/Cargo.toml
+++ b/crates/apollo_propeller/Cargo.toml
@@ -34,7 +34,6 @@ insta.workspace = true
 libp2p-swarm-test.workspace = true
 rstest.workspace = true
 tokio-stream.workspace = true
-tokio-test.workspace = true
 tracing-test.workspace = true
 
 

--- a/crates/apollo_rpc/Cargo.toml
+++ b/crates/apollo_rpc/Cargo.toml
@@ -39,9 +39,7 @@ apollo_starknet_client = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
 assert_matches.workspace = true
-cairo-lang-casm.workspace = true
 cairo-lang-starknet-classes.workspace = true
-camelpaste.workspace = true
 derive_more = { workspace = true, features = ["display"] }
 enum-iterator.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
@@ -56,7 +54,6 @@ prometheus-parse.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 reqwest.workspace = true
-starknet-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 strum = { workspace = true, features = ["derive"] }
 

--- a/crates/apollo_rpc_execution/Cargo.toml
+++ b/crates/apollo_rpc_execution/Cargo.toml
@@ -36,10 +36,8 @@ apollo_class_manager_types = { workspace = true, features = ["testing"] }
 apollo_storage = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
 assert_matches.workspace = true
-cairo-lang-casm.workspace = true
 cairo-lang-utils.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
-mockall.workspace = true
 pretty_assertions.workspace = true
 rand_chacha.workspace = true
 

--- a/crates/apollo_staking_config/Cargo.toml
+++ b/crates/apollo_staking_config/Cargo.toml
@@ -14,7 +14,6 @@ starknet_api.workspace = true
 validator.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/apollo_state_reader/Cargo.toml
+++ b/crates/apollo_state_reader/Cargo.toml
@@ -29,5 +29,4 @@ async-trait.workspace = true
 blockifier = { workspace = true, features = ["testing"] }
 blockifier_test_utils.workspace = true
 indexmap.workspace = true
-rstest.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/apollo_state_sync/Cargo.toml
+++ b/crates/apollo_state_sync/Cargo.toml
@@ -48,4 +48,3 @@ indexmap = { workspace = true, features = ["serde"] }
 libp2p.workspace = true
 mockall.workspace = true
 rand.workspace = true
-rand_chacha.workspace = true

--- a/crates/apollo_storage/Cargo.toml
+++ b/crates/apollo_storage/Cargo.toml
@@ -55,12 +55,9 @@ apollo_infra_utils = { workspace = true, features = ["testing"] }
 apollo_test_utils.workspace = true
 assert_matches.workspace = true
 cairo-lang-casm = { workspace = true, features = ["parity-scale-codec", "schemars"] }
-camelpaste.workspace = true
-futures.workspace = true
 insta = { workspace = true, features = ["yaml"] }
 metrics-exporter-prometheus.workspace = true
 nix.workspace = true
-num-traits.workspace = true
 paste.workspace = true
 pretty_assertions.workspace = true
 prometheus-parse.workspace = true
@@ -74,7 +71,6 @@ starknet_api = { workspace = true, features = ["testing"] }
 starknet_committer = { workspace = true, features = ["testing"] }
 tempfile = { workspace = true }
 test-case.workspace = true
-test-log.workspace = true
 tokio = { workspace = true, features = ["full", "sync"] }
 tower = { workspace = true, features = ["util"] }
 

--- a/crates/apollo_task_executor/Cargo.toml
+++ b/crates/apollo_task_executor/Cargo.toml
@@ -10,7 +10,6 @@ description = "Task execution utilities for concurrent operations."
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
-futures.workspace = true
 rstest.workspace = true
 tokio-test.workspace = true
 

--- a/crates/apollo_transaction_converter/Cargo.toml
+++ b/crates/apollo_transaction_converter/Cargo.toml
@@ -34,6 +34,5 @@ blockifier_test_utils.workspace = true
 mempool_test_utils.workspace = true
 mockall.workspace = true
 rstest.workspace = true
-serde_json.workspace = true
 starknet-types-core.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }

--- a/crates/bench_tools/Cargo.toml
+++ b/crates/bench_tools/Cargo.toml
@@ -15,7 +15,6 @@ serde_json.workspace = true
 
 [dev-dependencies]
 apollo_infra_utils.workspace = true
-glob.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/crates/native_blockifier/Cargo.toml
+++ b/crates/native_blockifier/Cargo.toml
@@ -47,7 +47,6 @@ thiserror.workspace = true
 [dev-dependencies]
 apollo_storage = { workspace = true, features = ["testing"] }
 blockifier = { workspace = true, features = ["native_blockifier", "testing"] }
-cached.workspace = true
 pretty_assertions.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 tempfile.workspace = true

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -34,7 +34,6 @@ validator.workspace = true
 [dev-dependencies]
 apollo_infra_utils.workspace = true
 apollo_metrics = { workspace = true, features = ["testing"] }
-assert_matches.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 pretty_assertions.workspace = true

--- a/crates/papyrus_common/Cargo.toml
+++ b/crates/papyrus_common/Cargo.toml
@@ -16,9 +16,6 @@ starknet-types-core = { workspace = true, features = ["hash"] }
 starknet_api.workspace = true
 
 [dev-dependencies]
-apollo_test_utils.workspace = true
-assert_matches.workspace = true
-pretty_assertions.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 
 [lints]

--- a/crates/starknet_os/Cargo.toml
+++ b/crates/starknet_os/Cargo.toml
@@ -71,7 +71,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-apollo_infra_utils = { workspace = true, features = ["testing"] }
 apollo_starknet_os_program = { workspace = true, features = ["test_programs"] }
 assert_matches.workspace = true
 blockifier = { workspace = true, features = ["testing"] }

--- a/crates/starknet_os_flow_tests/Cargo.toml
+++ b/crates/starknet_os_flow_tests/Cargo.toml
@@ -34,7 +34,6 @@ starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_committer = { workspace = true, features = ["testing"] }
 starknet_os = { workspace = true, features = ["include_program_output", "testing"] }
-starknet_patricia = { workspace = true, features = ["testing"] }
 starknet_patricia_storage = { workspace = true, features = ["testing"] }
 starknet_proof_verifier.workspace = true
 starknet_transaction_prover.workspace = true

--- a/crates/starknet_transaction_prover/Cargo.toml
+++ b/crates/starknet_transaction_prover/Cargo.toml
@@ -60,7 +60,6 @@ url.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-apollo_starknet_os_program.workspace = true
 assert_matches.workspace = true
 axum.workspace = true
 blockifier = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
## Why these were never caught

CI already runs `cargo machete` (`.github/workflows/main.yml:91`), but it only analyses `[dependencies]`. I verified that empirically rather than assuming — injecting an unused `glob` into `[dependencies]` and an unused `camelpaste` into `[dev-dependencies]` of the same crate, machete flags only the former:

```
cargo-machete found the following unused dependencies in this directory:
apollo_l1_gas_price -- ./crates/apollo_l1_gas_price/Cargo.toml:
	glob
```

So dev- and build-dependencies have never been checked. **62 of them across 36 crates** are unreferenced by any source file in their own crate. They cost test-build time and make manifests misleading about what a crate actually needs.

## Verification

Removal, not inspection:

- `cargo check --workspace --all-targets --keep-going` — compiles clean (`--keep-going` so a single failure doesn't mask the rest).
- `cargo machete` — still clean.
- `Cargo.lock` — deletions only, no version changes. Five packages leave the tree entirely: `camelpaste`, and `test-log` with its `env_logger`/`env_filter`/`test-log-macros` subtree.

## Kept on purpose

Three classes look unused to any source scan but are genuinely required. Each of these actually broke the build before I accounted for it:

- **Named by a feature list** — `apollo_mempool`'s `testing = ["blockifier/testing", ...]` needs `blockifier` as a dependency even though no source file mentions it.
- **Reached only through another crate's macro expansion** — `starknet_api`'s `felt!` and `nonce!` expand to `starknet_types_core` paths, so four crates need it without ever naming it.
- **Linked for side effects or macro-only** — `tikv-jemallocator`, `paste`, and similar.

Also worth knowing: `apollo_starknet_os_program`'s build script lives in `build/`, not `build.rs`, so a naive scan misses its `tempfile` use.

## Limitation

`--all-targets` does not build feature-gated code, so a dev-dependency used only under a `cfg(feature = ...)` test path would not be caught here. CI's feature matrix is the backstop — if something turns up red, the fix is to restore that one line.

## What's removed

  apollo_batcher: cairo-lang-starknet-classes, mempool_test_utils
  apollo_batcher_types: apollo_infra_utils, axum, serde_json, tokio, tower
  apollo_compilation_utils: apollo_infra_utils, assert_matches
  apollo_compile_to_native: rstest
  apollo_config: apollo_test_utils
  apollo_consensus: enum-as-inner
  apollo_consensus_manager: apollo_storage, rstest, tempfile
  apollo_consensus_orchestrator: apollo_storage, apollo_test_utils, blockifier_test_utils
  apollo_gateway: cairo-lang-sierra-to-casm, mockito, num-bigint, tracing-test
  apollo_http_server: blockifier
  apollo_infra: assert_matches, once_cell, pretty_assertions
  apollo_integration_tests: rstest
  apollo_l1_events: url
  apollo_l1_gas_price: mockall
  apollo_mempool: assert_matches, itertools
  apollo_mempool_p2p: rand_chacha
  apollo_network_benchmark: assert_matches, tokio-stream
  apollo_node: pretty_assertions, tracing-subscriber
  apollo_p2p_sync: assert_matches
  apollo_proc_macros_tests: papyrus_common
  apollo_propeller: tokio-test
  apollo_rpc: cairo-lang-casm, camelpaste, starknet-core
  apollo_rpc_execution: cairo-lang-casm, mockall
  apollo_staking_config: serde_json
  apollo_state_reader: rstest
  apollo_state_sync: rand_chacha
  apollo_storage: camelpaste, futures, num-traits, test-log
  apollo_task_executor: futures
  apollo_transaction_converter: serde_json
  bench_tools: glob
  native_blockifier: cached
  papyrus_base_layer: assert_matches
  papyrus_common: apollo_test_utils, assert_matches, pretty_assertions
  starknet_os: apollo_infra_utils
  starknet_os_flow_tests: starknet_patricia
  starknet_transaction_prover: apollo_starknet_os_program

🤖 Generated with [Claude Code](https://claude.com/claude-code)