### PR TITLE
blockifier: avoid redundant memory reads in read_felt_array

### DIFF
--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -871,28 +871,15 @@ where
         return Ok(vec![]);
     }
 
-    // Reuse the values already read above instead of re-reading the same memory cells via
-    // `vm.get_relocatable`.
-    let array_data_start_ptr = expect_relocatable(array_data_start, *ptr)?;
+    // This function runs once per array-typed syscall argument, so the endpoints are converted from
+    // the values read above rather than looked up in memory a second time.
+    let array_data_start_ptr = relocatable_from_memory_value(array_data_start, *ptr)?;
     *ptr = (*ptr + 1)?;
-    let array_data_end_ptr = expect_relocatable(array_data_end, *ptr)?;
+    let array_data_end_ptr = relocatable_from_memory_value(array_data_end, *ptr)?;
     *ptr = (*ptr + 1)?;
     let array_size = (array_data_end_ptr - array_data_start_ptr)?;
 
     Ok(felt_range_from_ptr(vm, array_data_start_ptr, array_size)?)
-}
-
-/// Mirrors `VirtualMachine::get_relocatable`'s error semantics for a value already read via
-/// `VirtualMachine::get_maybe`.
-fn expect_relocatable(
-    value: Option<MaybeRelocatable>,
-    address: Relocatable,
-) -> Result<Relocatable, MemoryError> {
-    match value {
-        Some(MaybeRelocatable::RelocatableValue(relocatable)) => Ok(relocatable),
-        Some(MaybeRelocatable::Int(_)) => Err(MemoryError::ExpectedRelocatable(Box::new(address))),
-        None => Err(MemoryError::UnknownMemoryCell(Box::new(address))),
-    }
 }
 
 pub fn write_segment(
@@ -905,4 +892,17 @@ pub fn write_segment(
     write_maybe_relocatable(vm, ptr, segment_end_ptr)?;
 
     Ok(())
+}
+
+/// Converts a value read from `address` via `VirtualMachine::get_maybe` into a `Relocatable`,
+/// reproducing the errors `VirtualMachine::get_relocatable` would have returned for that address.
+fn relocatable_from_memory_value(
+    memory_value: Option<MaybeRelocatable>,
+    address: Relocatable,
+) -> Result<Relocatable, MemoryError> {
+    match memory_value {
+        Some(MaybeRelocatable::RelocatableValue(relocatable)) => Ok(relocatable),
+        Some(MaybeRelocatable::Int(_)) => Err(MemoryError::ExpectedRelocatable(Box::new(address))),
+        None => Err(MemoryError::UnknownMemoryCell(Box::new(address))),
+    }
 }

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -864,19 +864,35 @@ where
     // If the start and end pointers are the same, the array is empty.
     // This check is necessary to handle the case where both pointers are zero, and thus are not
     // relocatable values.
-    let array_start = vm.get_maybe(&*ptr);
-    if array_start.is_some() && array_start == vm.get_maybe(&(*ptr + 1_usize)?) {
+    let array_data_start = vm.get_maybe(&*ptr);
+    let array_data_end = vm.get_maybe(&(*ptr + 1_usize)?);
+    if array_data_start.is_some() && array_data_start == array_data_end {
         *ptr = (*ptr + 2)?;
         return Ok(vec![]);
     }
 
-    let array_data_start_ptr = vm.get_relocatable(*ptr)?;
+    // Reuse the values already read above instead of re-reading the same memory cells via
+    // `vm.get_relocatable`.
+    let array_data_start_ptr = expect_relocatable(array_data_start, *ptr)?;
     *ptr = (*ptr + 1)?;
-    let array_data_end_ptr = vm.get_relocatable(*ptr)?;
+    let array_data_end_ptr = expect_relocatable(array_data_end, *ptr)?;
     *ptr = (*ptr + 1)?;
     let array_size = (array_data_end_ptr - array_data_start_ptr)?;
 
     Ok(felt_range_from_ptr(vm, array_data_start_ptr, array_size)?)
+}
+
+/// Mirrors `VirtualMachine::get_relocatable`'s error semantics for a value already read via
+/// `VirtualMachine::get_maybe`.
+fn expect_relocatable(
+    value: Option<MaybeRelocatable>,
+    address: Relocatable,
+) -> Result<Relocatable, MemoryError> {
+    match value {
+        Some(MaybeRelocatable::RelocatableValue(relocatable)) => Ok(relocatable),
+        Some(MaybeRelocatable::Int(_)) => Err(MemoryError::ExpectedRelocatable(Box::new(address))),
+        None => Err(MemoryError::UnknownMemoryCell(Box::new(address))),
+    }
 }
 
 pub fn write_segment(

--- a/crates/blockifier/src/execution/syscalls/syscall_tests/null_empty_span.rs
+++ b/crates/blockifier/src/execution/syscalls/syscall_tests/null_empty_span.rs
@@ -1,4 +1,6 @@
+use assert_matches::assert_matches;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
+use cairo_vm::vm::errors::memory_errors::MemoryError;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use starknet_types_core::felt::Felt;
 
@@ -69,11 +71,48 @@ fn read_felt_array_accepts_real_empty_span() {
 fn read_felt_array_rejects_mixed_null_and_pointer_span() {
     let mut vm = VirtualMachine::new(false, false);
     let data_ptr = vm.add_memory_segment();
-    let span_ptr = vm.add_memory_segment();
-    vm.load_data(span_ptr, &[Felt::ZERO.into(), data_ptr.into()]).unwrap();
-    let mut span_ptr = span_ptr;
+    let (vm, mut span_ptr) = vm_with_span_in(vm, Felt::ZERO.into(), data_ptr.into());
+    let expected_address = span_ptr;
 
-    assert!(read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).is_err());
+    let error = read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).unwrap_err();
+
+    assert_matches!(
+        error,
+        SyscallExecutorBaseError::Memory(MemoryError::ExpectedRelocatable(address))
+            if *address == expected_address
+    );
+}
+
+#[test]
+fn read_felt_array_rejects_span_with_felt_end_pointer() {
+    // The reported address must be the end pointer's cell, not the span's base.
+    let mut vm = VirtualMachine::new(false, false);
+    let data_ptr = vm.add_memory_segment();
+    let (vm, mut span_ptr) = vm_with_span_in(vm, data_ptr.into(), Felt::ZERO.into());
+    let expected_address = (span_ptr + 1_usize).unwrap();
+
+    let error = read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).unwrap_err();
+
+    assert_matches!(
+        error,
+        SyscallExecutorBaseError::Memory(MemoryError::ExpectedRelocatable(address))
+            if *address == expected_address
+    );
+}
+
+#[test]
+fn read_felt_array_rejects_unwritten_span() {
+    let mut vm = VirtualMachine::new(false, false);
+    let mut span_ptr = vm.add_memory_segment();
+    let expected_address = span_ptr;
+
+    let error = read_felt_array::<SyscallExecutorBaseError>(&vm, &mut span_ptr).unwrap_err();
+
+    assert_matches!(
+        error,
+        SyscallExecutorBaseError::Memory(MemoryError::UnknownMemoryCell(address))
+            if *address == expected_address
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up perf optimization on #15008 ("blockifier: handle null empty spans"), which added an empty-span check to `read_felt_array` in `crates/blockifier/src/execution/syscalls/hint_processor.rs`.

That check reads the array's start and end pointer cells via `vm.get_maybe(...)` to detect the null-empty-span case. In the non-empty (common) path, the function then re-read the *same two memory cells* via `vm.get_relocatable(...)` — a redundant `Memory::get()` lookup for addresses already fetched a few lines earlier.

`read_felt_array` runs on every array-typed syscall argument (calldata, `emit_event` keys/data, etc.), i.e. roughly once per syscall across a block, so the extra lookup is pure overhead in a hot path.

This PR reuses the already-fetched `Option<MaybeRelocatable>` values instead of re-reading memory, via a small helper (`relocatable_from_memory_value`) that reproduces `VirtualMachine::get_relocatable`'s exact error semantics (`MemoryError::UnknownMemoryCell` vs `MemoryError::ExpectedRelocatable`) so behavior is unchanged in every case — empty span (null or real), non-empty span, missing memory cell, wrong-type memory cell.

Also strengthens test coverage: the existing "rejects mixed null/pointer span" test now asserts the exact error variant and address (previously just `is_err()`), and two new tests cover the felt-typed-end-pointer and unwritten-cell error paths, since preserving `get_relocatable`'s error semantics is the main correctness risk of this kind of refactor.

## Expected impact

Cuts the memory-lookup work of `read_felt_array` roughly in half for the non-empty-array case (2 lookups instead of 4), on a function invoked for essentially every array-typed syscall argument in every transaction.

## Test plan

- [x] `SEED=0 cargo test -p blockifier read_felt_array` — 8 passed, 0 failed
- [x] `SEED=0 cargo test -p blockifier --lib` — 985 passed, 0 failed
- [x] `cargo clippy -p blockifier --lib` — clean
- [x] `scripts/rust_fmt.sh` — no changes needed
- [x] Reviewed by an Opus subagent for correctness (verified error-semantics parity against cairo-vm's `Memory::get`/`get_relocatable`) and style; findings applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWCK4e1KbLLvDTcWcrLCXw)_