### PR TITLE
Merge main-v0.14.3 into main (#14919)

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/build_proposal_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/build_proposal_test.rs
@@ -11,15 +11,18 @@ use apollo_batcher_types::communication::BatcherClientError;
 use apollo_infra::component_client::ClientError;
 use apollo_transaction_converter::{MockTransactionConverterTrait, TransactionConverterError};
 use assert_matches::assert_matches;
-use starknet_api::block::GasPrice;
+use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
+use starknet_api::block::{BlockHash, BlockNumber, GasPrice};
 use starknet_api::block_hash::block_hash_calculator::BlockHeaderCommitments;
 use starknet_api::core::ClassHash;
 use starknet_api::execution_resources::GasAmount;
 use tokio_util::task::AbortOnDropHandle;
 
 use crate::build_proposal::{build_proposal, BuildProposalError};
+use crate::cende::MockCendeContext;
 use crate::dynamic_gas_price::proposal_commitment_from;
 use crate::test_utils::{create_proposal_build_arguments, INTERNAL_TX_BATCH, PARTIAL_BLOCK_HASH};
+use crate::utils::RetrospectiveStateCommitmentInfosError;
 
 #[tokio::test]
 async fn build_proposal_succeed() {
@@ -137,4 +140,47 @@ async fn cende_fail() {
 
     let res = build_proposal(proposal_args.into()).await;
     assert!(matches!(res, Err(BuildProposalError::CendeWriteError(_))));
+}
+
+/// The blob of height H must carry the state commitment infos (witnesses) of the next height's
+/// retrospective block, H + 1 - STORED_BLOCK_HASH_BUFFER. When neither the batcher nor the cende
+/// recorder has stored them, the round fails before the block is even proposed.
+#[tokio::test]
+async fn missing_retrospective_state_commitment_infos_fail() {
+    let (mut proposal_args, _proposal_receiver) = create_proposal_build_arguments();
+    proposal_args.build_param.height = BlockNumber(STORED_BLOCK_HASH_BUFFER);
+    let next_height_retro_block_number =
+        BlockNumber(proposal_args.build_param.height.0 + 1 - STORED_BLOCK_HASH_BUFFER);
+
+    // Setup the retrospective block hash check to pass.
+    proposal_args.deps.batcher.expect_get_block_hash().returning(|_| Ok(BlockHash::default()));
+    proposal_args
+        .deps
+        .state_sync_client
+        .expect_get_block_hash()
+        .returning(|_| Ok(BlockHash::default()));
+
+    // The batcher doesn't have the retrospective block's state commitment infos, and the cende
+    // recorder's height offset shows it hasn't stored them either.
+    proposal_args
+        .deps
+        .batcher
+        .expect_has_state_commitment_infos()
+        .withf(move |block_number| *block_number == next_height_retro_block_number)
+        .returning(|_| Ok(false));
+    let mut cende_ambassador = MockCendeContext::new();
+    cende_ambassador
+        .expect_commitment_infos_height_offset()
+        .returning(move || Ok(Some(next_height_retro_block_number)));
+    proposal_args.deps.cende_ambassador = cende_ambassador;
+
+    // No `propose_block` expectation is set: reaching the batcher would panic, proving the build
+    // fails before proposing.
+    let res = build_proposal(proposal_args.into()).await;
+    assert_matches!(
+        res,
+        Err(BuildProposalError::RetrospectiveStateCommitmentInfosError(
+            RetrospectiveStateCommitmentInfosError::NotStored { retrospective_block_number, .. }
+        )) if retrospective_block_number == next_height_retro_block_number
+    );
 }


### PR DESCRIPTION
Merge main-v0.14.3 into main (#14919)

* workspace: emit line-tables-only debuginfo in dev profile (#14877)

Adds `[profile.dev] debug = "line-tables-only"` to keep panic/backtrace
file:line and tracing call-site info while dropping the full DWARF
variable/type info that dominates codegen time, linker memory, and
target/ disk. A `dev-debug` profile (`cargo build --profile dev-debug`)
restores full debug info on demand.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* apollo_gateway: stop auto-discovering bench helper as a bench target (#14878)

benches/utils.rs is a helper module included by benches/main.rs (the explicit
[[bench]], gated on the `testing` feature). Cargo's bench auto-discovery also
picked utils.rs up as a standalone, feature-less bench target, so
`cargo bench`/`cargo clippy --benches` failed to compile it without
`--features testing` (it references apollo_gateway::test_utils). Set
autobenches = false so only the explicit [[bench]] is a bench target.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

* No conflicts in main-v0.14.3 -> main merge, this commit is for any change needed to pass the CI.

---------

Co-authored-by: Avi Cohen <avi.cohen@starkware.co>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

workspace: stop taplo from scrambling the darwin rustflags (#14955)

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

apollo_consensus_orchestrator: include block hash commitments in the cende blob (#14980)

apollo_consensus_orchestrator: rename cende python_test module to python_compat (#14985)

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>

apollo_starknet_client: add request and connect timeouts to the http client (#14966)

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>

blockifier,apollo_gateway,apollo_p2p_sync: keep test-utils out of production build graphs (#14795)

Three vectors pulled workspace test-utils crates and testing features into
the production apollo_node and blockifier_reexecution images via Cargo
feature unification:
- blockifier's cairo_native feature spec was missing a ? on
  blockifier_test_utils/cairo_native, force-enabling the optional test-only
  dep in every cairo_native build.
- apollo_gateway carried mempool_test_utils as a normal dependency for one
  cfg(test) import, dragging papyrus_base_layer/testing (Anvil node
  bindings) into the node.
- apollo_p2p_sync carried apollo_test_utils as a normal dependency for
  cfg(test)-only imports.

apollo_p2p_sync's placeholder sync transactions (client/transaction.rs)
turn out to genuinely use testing-gated starknet_api constructors and only
compiled through the unification leak. They are now built by a local
empty_invoke_transaction helper: the sync block carries only transaction
hashes, so these bodies exist to pad the block body to the reported
transaction count and are never executed or fee-checked. The one value that
changes is the placeholder's resource bounds, which drop from the testing
helper's max_price_per_unit of 1 to zero.

Note: dropping papyrus_base_layer/testing from the node graph also flips
the compiled L1 Starknet contract ABI from the testing mock
(StarknetForSequencerTesting.json) to the real Starknet-0.10.3.4.json in
ethereum_base_layer_contract.rs. The production-used ABI surface (message
events, stateBlockNumber/stateBlockHash) is identical in both files.

After: apollo_node's cairo_native graph has no workspace test-utils crates
and no workspace testing features; apollo_gateway drops from 709 to 642
unique normal deps; testing + cairo_native builds still resolve
blockifier_test_utils/cairo_native.

apollo_mempool_p2p: log tx identifiers instead of the full received batch (#14930)

Debug-formatting every received transaction batch made this the largest log
site in sequencer-mempool: 30% of the container's log bytes.

Logs the batch size and the (sender_address, nonce) pair per transaction
instead, which is what identifies a transaction at this point in the flow.
Resolves the existing TODO only partially on purpose: the tx_hash would be a
better identifier, but computing it needs a ChainId the runner does not hold.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

starknet_os: preallocate decompress result vectors to avoid reallocation (#14779)

`decompress` runs once per block over the full state diff. Both
`unique_values` and `result` grow via push/extend from `Vec::new()`
even though their final lengths are already known from the decoded
header (sum of unique-value bucket lengths, and data_len,
respectively), causing avoidable reallocations for large state diffs.


Claude-Session: https://claude.ai/code/session_01YHx5w4Xp5DBX5oBBTTFEvt

Co-authored-by: Claude <noreply@anthropic.com>

papyrus_base_layer,apollo_l1_events: resolve L1 event timestamps once per block (#14999)

events() fetched the block header once per matching log, only to read the block
timestamp, issuing many redundant eth_getBlockByNumber calls for logs that share
a block. Resolve the timestamp once per distinct block, reuse the block_timestamp
returned on the log when present (skipping the header fetch entirely), and fetch
the remainder with bounded concurrency.

Reduces redundant RPC load and latency when a range contains many logs.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

apollo_class_manager_types,apollo_batcher_types,apollo_mempool,apollo_gateway: drop unused dev-deps (#14796)

All deleted entries have zero references in their crates:
- apollo_class_manager_types: six stale dev-dependencies survived the
  removal of this crate's tests (the crate has no test code at all);
  mockall stays for the testing-gated automock in lib.rs.
- apollo_batcher_types: apollo_storage (MDBX stack) compiled for every
  test build of this widely-built types crate, for nothing.
- apollo_mempool: apollo_network dev-dependency and the
  apollo_network/testing entry in its own testing feature. A feature
  entry that names a dev-dependency only affects the package's own test
  builds, so the forward never propagated to apollo_mempool/testing
  consumers; mempool's own tests pass without it.
- apollo_gateway: apollo_mempool dev-dependency.

CI compile-time cost only; none of these edges ship in any binary.

apollo_cairo_utils,apollo_staking: drop blockifier dep, take Vec<Felt> instead of Retdata (#14782)

apollo_cairo_utils imported blockifier solely for Retdata, a newtype over
Vec<Felt>, dragging the full execution stack into its dependency tree
(352 -> 17 unique normal deps). Take Vec<Felt> directly and let callers
unwrap the newtype. apollo_staking, the only current consumer, already
depends on blockifier for its own Retdata handling, so this does not
shrink any shipped binary today; it makes apollo_cairo_utils cheap for
future consumers and shrinks its rebuild cone.

apollo_transaction_converter,blockifier: drop test-only blockifier dep and dead build-deps section (#14797)

apollo_transaction_converter's tests used blockifier only for
ChainInfo::create_for_testing().chain_id, which is CHAIN_ID_FOR_TESTS from
starknet_api::test_utils — already a dev-dependency here. Swapping the two
call sites removes the whole blockifier stack from this crate's test builds.

blockifier's [build-dependencies] section is dead config: the crate has no
build script (build.rs was removed), so cargo never compiles it.

starknet_patricia_storage: split RocksDB multi-key reads across blocking tasks (#15000)

`multi_get` batches at the API level but issues the underlying file reads one at a
time, so a large batch runs at queue depth ~1 and costs `n_keys * read_latency`
however many IOPS the device can serve. On a committer replaying mainnet traffic, a
single block's witness fetch measured 101,639 reads in 50.9s -- 2,008 reads/sec at
0.65ms each, using 12% of the disk's provisioned IOPS and 2% of its bandwidth.

Split the batch across blocking tasks so several reads are in flight at once. Every
task is spawned before any is awaited, so they run concurrently, and awaiting them in
order keeps the values aligned with the requested keys.

Measured on that same block after the change: witness fetch 50.9s -> 2.7s, with queue
depth 1.3 -> 24.4 and read latency unchanged, confirming the reads were always
concurrent-capable and simply were not being issued concurrently.

`max_read_tasks` is configurable; 1 restores the previous behaviour. It is added to
the committer app configs too, since node loading discards schema defaults and would
otherwise fail on the missing key.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

apollo_consensus_orchestrator: demote batcher dep to dev (#14798)

The orchestrator's only apollo_batcher usage is a cfg(test) module
(src/cende/central_objects_test.rs), and a dev-dependencies twin already
existed — the normal edge dragged apollo_batcher (and its
apollo_state_reader/apollo_starknet_client chain) into
apollo_consensus_manager's graph for nothing.

apollo_consensus_orchestrator: test round fails when retrospective witnesses are missing