### PR TITLE
starknet_transaction_prover: graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/crates/starknet_transaction_prover/Cargo.toml
+++ b/crates/starknet_transaction_prover/Cargo.toml
@@ -44,7 +44,7 @@ starknet_patricia_storage.workspace = true
 starknet_proof_verifier.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "signal", "time"] }
 tokio-rustls.workspace = true
 tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true, features = [

--- a/crates/starknet_transaction_prover/README.md
+++ b/crates/starknet_transaction_prover/README.md
@@ -340,6 +340,18 @@ there was never a status.
 The logging layer never reads request bodies. Transaction calldata is private user data and stays
 out of the logs.
 
+### Shutdown
+
+`SIGTERM` and `SIGINT` start a graceful shutdown. The server stops accepting new requests and lets
+in-flight proofs drain. Two structured events mark the sequence in the log stream:
+`shutdown_started` when the drain begins, carrying the `signal` name, and `shutdown_complete` once
+the server has stopped.
+
+A second termination signal during the drain logs an `event="force_exit"` warning, also carrying
+the `signal` name, and calls `exit(1)`. That way an operator can always reclaim a stuck process.
+Once a handler exists, tokio keeps intercepting the signals process-wide, so without this path a
+follow-up Ctrl+C would do nothing.
+
 ### Panics
 
 A global panic hook catches every panic and logs one `error`-level event with `event="panic"`. The

--- a/crates/starknet_transaction_prover/src/main.rs
+++ b/crates/starknet_transaction_prover/src/main.rs
@@ -25,6 +25,7 @@ async fn main() -> anyhow::Result<()> {
     use starknet_transaction_prover::server::panic::install_panic_hook;
     use starknet_transaction_prover::server::rpc_api::ProvingRpcServer;
     use starknet_transaction_prover::server::rpc_impl::ProvingRpcServerImpl;
+    use starknet_transaction_prover::server::shutdown::spawn_signal_bridge;
     use starknet_transaction_prover::server::{
         start_server,
         OhttpJsonrpseeLayer,
@@ -113,6 +114,9 @@ async fn main() -> anyhow::Result<()> {
         "JSON-RPC proving server is running."
     );
 
+    spawn_signal_bridge(server_handle.clone())?;
+
     server_handle.stopped().await;
+    info!(event = "shutdown_complete", "JSON-RPC server stopped.");
     Ok(())
 }

--- a/crates/starknet_transaction_prover/src/server.rs
+++ b/crates/starknet_transaction_prover/src/server.rs
@@ -77,6 +77,7 @@ pub mod request_log;
 pub mod request_span;
 pub mod rpc_api;
 pub mod rpc_impl;
+pub mod shutdown;
 pub mod tls;
 
 pub use health::{HealthLayer, HEALTH_PATH};

--- a/crates/starknet_transaction_prover/src/server/shutdown.rs
+++ b/crates/starknet_transaction_prover/src/server/shutdown.rs
@@ -1,0 +1,92 @@
+//! Bridges SIGTERM/SIGINT into a graceful jsonrpsee server shutdown.
+//!
+//! The first signal calls `ServerHandle::stop`, which lets in-flight requests
+//! drain. A second signal while the drain is still running calls
+//! `std::process::exit(1)`, so an operator can always reclaim a stuck process.
+//! Once a handler existed, tokio keeps intercepting the signals process-wide
+//! (tokio-rs/tokio#7905), so without the second-signal path a follow-up Ctrl+C
+//! would do nothing.
+
+use std::future::Future;
+
+use anyhow::Context;
+use jsonrpsee::server::ServerHandle;
+use tokio::signal::unix::{signal, Signal, SignalKind};
+use tracing::{info, warn};
+
+#[cfg(test)]
+#[path = "shutdown_test.rs"]
+mod shutdown_test;
+
+/// Spawns the task that bridges termination signals into `server_handle.stop()`.
+///
+/// Returns an error instead of running without handlers. A prover that cannot
+/// receive `SIGTERM` gets killed outright by the scheduler at the end of its
+/// grace period, which loses an in-flight proof and skips the drain. Refusing
+/// to start turns that into a visible deploy failure instead of a surprise on
+/// the first rollout.
+pub fn spawn_signal_bridge(server_handle: ServerHandle) -> anyhow::Result<()> {
+    let sigterm = signal(SignalKind::terminate()).context("Failed to install SIGTERM handler")?;
+    let sigint = signal(SignalKind::interrupt()).context("Failed to install SIGINT handler")?;
+    tokio::spawn(stop_on_termination_signal(server_handle, sigterm, sigint));
+    Ok(())
+}
+
+async fn stop_on_termination_signal(
+    server_handle: ServerHandle,
+    mut sigterm: Signal,
+    mut sigint: Signal,
+) {
+    let signal_name = recv_termination_signal(&mut sigterm, &mut sigint).await;
+    info!(event = "shutdown_started", signal = signal_name, "Shutting down JSON-RPC server.");
+    if let Err(err) = server_handle.stop() {
+        warn!(event = "stop_failed", error = %err, "Failed to stop JSON-RPC server cleanly");
+    }
+
+    let outcome = race_shutdown_against_second_signal(
+        server_handle.stopped(),
+        recv_termination_signal(&mut sigterm, &mut sigint),
+    )
+    .await;
+    if let ShutdownOutcome::ForceExit(second_signal_name) = outcome {
+        warn!(
+            event = "force_exit",
+            signal = second_signal_name,
+            "Received second termination signal; forcing exit."
+        );
+        std::process::exit(1);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ShutdownOutcome {
+    /// The drain finished. A late signal must not flip the exit code.
+    Clean,
+    /// Carries the name of the second signal.
+    ForceExit(&'static str),
+}
+
+/// Races a clean shutdown against a second termination signal.
+///
+/// The `biased` keyword is required. Without it `tokio::select!` picks among
+/// the ready branches at random, so a second signal landing in the same poll
+/// as `stopped` resolving could force-exit a server that already shut down
+/// cleanly. Listing `stopped` first makes it win whenever both are ready.
+async fn race_shutdown_against_second_signal(
+    stopped: impl Future<Output = ()>,
+    second_signal: impl Future<Output = &'static str>,
+) -> ShutdownOutcome {
+    tokio::select! {
+        biased;
+        _ = stopped => ShutdownOutcome::Clean,
+        second_signal_name = second_signal => ShutdownOutcome::ForceExit(second_signal_name),
+    }
+}
+
+/// Borrows both handlers, so a second call waits for a follow-up signal.
+async fn recv_termination_signal(sigterm: &mut Signal, sigint: &mut Signal) -> &'static str {
+    tokio::select! {
+        _ = sigterm.recv() => "SIGTERM",
+        _ = sigint.recv() => "SIGINT",
+    }
+}

--- a/crates/starknet_transaction_prover/src/server/shutdown_test.rs
+++ b/crates/starknet_transaction_prover/src/server/shutdown_test.rs
@@ -1,0 +1,24 @@
+use crate::server::shutdown::{race_shutdown_against_second_signal, ShutdownOutcome};
+
+// Both futures below are ready on the first poll. Looping makes a regression,
+// an unbiased select picking a ready branch at random, fail on nearly every
+// run instead of once in a while.
+#[tokio::test]
+async fn stopped_wins_when_both_futures_are_ready_immediately() {
+    for _ in 0..200 {
+        let outcome = race_shutdown_against_second_signal(
+            std::future::ready(()),
+            std::future::ready("SIGTERM"),
+        )
+        .await;
+        assert_eq!(outcome, ShutdownOutcome::Clean);
+    }
+}
+
+#[tokio::test]
+async fn force_exits_when_only_the_second_signal_is_ready() {
+    let outcome =
+        race_shutdown_against_second_signal(std::future::pending(), std::future::ready("SIGTERM"))
+            .await;
+    assert_eq!(outcome, ShutdownOutcome::ForceExit("SIGTERM"));
+}

--- a/crates/starknet_transaction_prover/tests/graceful_shutdown.rs
+++ b/crates/starknet_transaction_prover/tests/graceful_shutdown.rs
@@ -1,0 +1,44 @@
+//! End-to-end check that a termination signal drains the running server.
+//!
+//! This lives in its own integration-test binary on purpose. The test sends a
+//! real `SIGTERM` to its own process, and a signal is process-wide. Sharing a
+//! process with the unit tests would let the signal reach another test's
+//! server, and would race the handler registration that makes sending it safe
+//! at all.
+
+use std::net::SocketAddr;
+use std::process::Command;
+use std::time::Duration;
+
+use jsonrpsee::server::{ServerBuilder, ServerHandle};
+use jsonrpsee::RpcModule;
+use starknet_transaction_prover::server::shutdown::spawn_signal_bridge;
+
+async fn start_bare_server() -> ServerHandle {
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("valid loopback address");
+    let server =
+        ServerBuilder::default().build(addr).await.expect("failed to bind test JSON-RPC server");
+    let methods: jsonrpsee::Methods = RpcModule::new(()).into();
+    server.start(methods)
+}
+
+/// The first `SIGTERM` must call `stop()` on the server. The unit tests cover
+/// only the inner race helper, so this one covers the path from a real signal
+/// through to a stopped server.
+#[tokio::test]
+async fn sigterm_stops_the_running_server() {
+    let server_handle = start_bare_server().await;
+    // Registers the tokio signal handlers, which also replaces the default
+    // terminate-the-process disposition, so the signal below is safe to send.
+    spawn_signal_bridge(server_handle.clone()).expect("signal handlers must install");
+
+    let status = Command::new("kill")
+        .args(["-TERM", &std::process::id().to_string()])
+        .status()
+        .expect("failed to run kill");
+    assert!(status.success(), "kill -TERM failed: {status}");
+
+    tokio::time::timeout(Duration::from_secs(10), server_handle.stopped())
+        .await
+        .expect("SIGTERM must stop the server");
+}


### PR DESCRIPTION
First signal calls `ServerHandle::stop`, letting in-flight proofs drain, and
logs `shutdown_started`/`shutdown_complete` so deployment events are visible in
the log stream. A second signal during the drain forces `exit(1)`, so an
operator can always reclaim a stuck process -- tokio keeps intercepting signals
process-wide once a handler existed, so without that path a follow-up Ctrl+C is
silently swallowed.

Handler registration failure now aborts startup instead of warning and
continuing: a prover that cannot receive SIGTERM is killed outright by the
scheduler at the end of its grace period, losing an in-flight proof and skipping
the drain, and that is better surfaced as a failed deploy than discovered on the
first rollout. Dropping the degraded path also removes the `Option<Signal>`
threading and collapses the four-arm match.

Covered by an integration test in its own binary that sends a real SIGTERM and
asserts the server stops; removing the `stop()` call makes it fail.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>