### PR TITLE
apollo_committer: avoid redundant clone/compression of commitment infos on block commit

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -580,13 +580,6 @@ where
                 let (metadata, next_offset) =
                     commit_tip_metadata_bundle(height, global_root, state_diff_commitment);
 
-                let commitment_infos_updates =
-                    vec![CommitmentInfosUpdate::Write(CommitmentInfosWrite {
-                        block_number: height,
-                        keys_digest: digest,
-                        commitment_infos: state_commitment_infos.clone(),
-                    })];
-
                 info!(
                     "For block number {height}, writing filled forest and \
                      {commitment_facts_count} commitment facts to storage with metadata: \
@@ -594,6 +587,17 @@ where
                     commitment_facts_count = state_commitment_infos.n_commitment_facts(),
                     deleted_nodes_count = deleted_nodes.len(),
                 );
+                // Compress before moving `state_commitment_infos` into the write below:
+                // `compress` only needs a reference, so computing it first avoids cloning the
+                // whole commitment-facts structure just to satisfy the owned `commitment_infos`
+                // field.
+                let compressed_state_commitment_infos = state_commitment_infos.compress()?;
+                let commitment_infos_updates =
+                    vec![CommitmentInfosUpdate::Write(CommitmentInfosWrite {
+                        block_number: height,
+                        keys_digest: digest,
+                        commitment_infos: state_commitment_infos,
+                    })];
                 block_measurements.start_measurement(Action::Write);
                 let n_write_entries = self
                     .forest_storage
@@ -615,7 +619,7 @@ where
                 self.update_offset(next_offset);
                 Ok(ReadPathsAndCommitBlockResponse {
                     global_root,
-                    state_commitment_infos: state_commitment_infos.compress()?,
+                    state_commitment_infos: compressed_state_commitment_infos,
                 })
             }
         }

--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -587,16 +587,15 @@ where
                     commitment_facts_count = state_commitment_infos.n_commitment_facts(),
                     deleted_nodes_count = deleted_nodes.len(),
                 );
-                // Compress before moving `state_commitment_infos` into the write below:
-                // `compress` only needs a reference, so computing it first avoids cloning the
-                // whole commitment-facts structure just to satisfy the owned `commitment_infos`
-                // field.
+                // Compress once and reuse the (small) compressed bytes for both the DB write and
+                // the RPC response, rather than compressing the commitment facts a second time
+                // inside the write path.
                 let compressed_state_commitment_infos = state_commitment_infos.compress()?;
                 let commitment_infos_updates =
                     vec![CommitmentInfosUpdate::Write(CommitmentInfosWrite {
                         block_number: height,
                         keys_digest: digest,
-                        commitment_infos: state_commitment_infos,
+                        commitment_infos: compressed_state_commitment_infos.clone(),
                     })];
                 block_measurements.start_measurement(Action::Write);
                 let n_write_entries = self

--- a/crates/starknet_committer/src/db/forest_trait_witnesses.rs
+++ b/crates/starknet_committer/src/db/forest_trait_witnesses.rs
@@ -19,13 +19,20 @@ use crate::forest::deleted_nodes::DeletedNodes;
 use crate::forest::filled_forest::FilledForest;
 use crate::forest::forest_errors::ForestResult;
 use crate::patricia_merkle_tree::tree::SortedLeafIndices;
-use crate::patricia_merkle_tree::types::{StarknetForestProofs, StateCommitmentInfos};
+use crate::patricia_merkle_tree::types::{
+    CompressedStateCommitmentInfos,
+    StarknetForestProofs,
+    StateCommitmentInfos,
+};
 
 /// The information required to write the OS-input commitment infos to the database.
 pub struct CommitmentInfosWrite {
     pub block_number: BlockNumber,
     pub keys_digest: [u8; 32],
-    pub commitment_infos: StateCommitmentInfos,
+    /// Callers already need a compressed copy for other purposes (e.g. the RPC response), so
+    /// this takes the compressed form directly to avoid compressing the same commitment infos
+    /// twice per block.
+    pub commitment_infos: CompressedStateCommitmentInfos,
 }
 
 /// Commitment-infos DB operation, which can be either delete or write.

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -431,7 +431,7 @@ impl<S: Storage> IndexDb<S> {
     fn append_commitment_infos_update(
         operations: &mut DbOperationMap,
         commitment_infos_update: CommitmentInfosUpdate,
-    ) -> SerializationResult<()> {
+    ) {
         match commitment_infos_update {
             CommitmentInfosUpdate::Delete(block_number) => {
                 operations.insert(
@@ -453,7 +453,6 @@ impl<S: Storage> IndexDb<S> {
                 keys_digest,
                 commitment_infos,
             }) => {
-                let encoded = DbValue(commitment_infos.compress()?.0);
                 operations.insert(
                     Self::metadata_key(ForestMetadataType::AccessedKeysDigest(DbBlockNumber(
                         block_number,
@@ -465,11 +464,10 @@ impl<S: Storage> IndexDb<S> {
                         &PATRICIA_PATHS_PREFIX,
                         DbBlockNumber(block_number),
                     )),
-                    DbOperation::Set(encoded),
+                    DbOperation::Set(DbValue(commitment_infos.0)),
                 );
             }
         }
-        Ok(())
     }
 }
 
@@ -485,7 +483,7 @@ impl<S: Storage + Send> ForestWriterWithMetadataAndWitnesses for IndexDb<S> {
         let mut operations = DbOperationMap::new();
         Self::append_forest_and_metadata(&mut operations, filled_forest, metadata, deleted_nodes)?;
         for commitment_infos_update in commitment_infos_updates {
-            Self::append_commitment_infos_update(&mut operations, commitment_infos_update)?;
+            Self::append_commitment_infos_update(&mut operations, commitment_infos_update);
         }
         Ok(self.write_updates(operations).await)
     }


### PR DESCRIPTION
## Summary

Follow-up performance optimization on top of #15022 (merged), which introduced batched commitment-infos DB updates. This PR removes two redundant, per-block costs in the same code path that #15022 touched:

- **Unnecessary deep clone**: `read_paths_and_commit_block` called `state_commitment_infos.clone()` — a deep copy of a struct holding three `HashMap`s of Patricia commitment facts, sized by the number of accessed/modified keys in the block — purely to satisfy the owned `CommitmentInfosWrite.commitment_infos` field. The only other use of the original value, `.compress()`, only needs `&self`. The fix computes the compressed form once and moves the original instead of cloning it.
- **Double compression**: `CommitmentInfosWrite` carried the raw `StateCommitmentInfos`, so the DB write path (`index_db::append_commitment_infos_update`) bincode-serialized and zstd-compressed it *again*, even though the caller already compresses it once for the RPC response. `CommitmentInfosWrite.commitment_infos` now takes the already-compressed bytes directly, so compression happens exactly once per block instead of twice.

Both call sites are on the committer's per-block commit hot path (`read_paths_and_commit_block`), which runs once for every block the sequencer produces.

## Note on metrics

Because compression must now happen before the DB write (its output is reused there), the single compression pass now falls inside the `Action::Write`/`Action::EndToEnd` measurement window, whereas previously only one of the two (redundant) compressions was counted there and the other was excluded. Reported `COMMITTER_BLOCK_COMMIT_LATENCY`/block-duration metrics may shift slightly as a result, even though actual wall-clock work per block decreases.

## Test plan

- [x] `cargo build -p apollo_committer -p starknet_committer` — succeeds
- [x] `SEED=0 cargo test -p apollo_committer -p starknet_committer` — 148 tests pass (18 + 130), 0 failed
- [x] `cargo clippy -p apollo_committer -p starknet_committer --all-targets --all-features` — clean
- [x] `scripts/rust_fmt.sh` — no additional formatting changes
- [x] Reviewed by an Opus subagent for correctness, ordering/borrow-checker concerns, and style; both suggestion-level findings from that review are addressed in this PR (the double-compression fix, and this metrics note)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx32jmbshyTfDvag3sHCTK)_