### PR TITLE
ci: run only the title check when a PR title or description is edited

### DIFF
--- a/.github/workflows/blockifier_ci.yml
+++ b/.github/workflows/blockifier_ci.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       - ".github/actions/bootstrap/action.yml"

--- a/.github/workflows/blockifier_compiled_cairo.yml
+++ b/.github/workflows/blockifier_compiled_cairo.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       - ".github/workflows/blockifier_compiled_cairo.yml"

--- a/.github/workflows/blockifier_reexecution_ci.yml
+++ b/.github/workflows/blockifier_reexecution_ci.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       # Other than code-related changes, all changes related to the blockifier should trigger the build.

--- a/.github/workflows/committer_and_os_cli_push.yml
+++ b/.github/workflows/committer_and_os_cli_push.yml
@@ -12,7 +12,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       - ".github/workflows/committer_and_os_cli_push.yml"

--- a/.github/workflows/committer_ci.yml
+++ b/.github/workflows/committer_ci.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       - ".github/workflows/committer_ci.yml"

--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
 
 env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
   workflow_dispatch:
 

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -6,7 +6,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
 
 env:
@@ -22,23 +21,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  commitlint:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          fetch-depth: 0
-
-      - name: Install commitlint
-        run: npm install --global @commitlint/cli @commitlint/config-conventional
-
-      - name: Validate PR title with commitlint
-        if: github.event_name != 'merge_group' && github.event_name != 'push' && !(contains(github.event.pull_request.title, 'merge-main') || contains(github.event.pull_request.title, 'merge main'))
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$TITLE" | commitlint --verbose
-
   # This job is used to check if all checks have passed before merging the PR.
   # Uses starkware-libs/merge-gatekeeper as the implementation.
   merge-gatekeeper-new:

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,0 +1,38 @@
+name: PR-Title
+
+# Kept on `edited` so a title fix takes effect without a push. The title is revalidated on every
+# event rather than only when `changes.title` is set: this job reports a conclusion whenever it
+# runs, so short-circuiting it would report success for a title that was never checked.
+on:
+  merge_group:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Install commitlint
+        run: npm install --global @commitlint/cli @commitlint/config-conventional
+
+      - name: Validate PR title with commitlint
+        if: github.event_name != 'merge_group' && github.event_name != 'push' && !(contains(github.event.pull_request.title, 'merge-main') || contains(github.event.pull_request.title, 'merge main'))
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$TITLE" | commitlint --verbose

--- a/.github/workflows/sequencer_cdk8s-test.yml
+++ b/.github/workflows/sequencer_cdk8s-test.yml
@@ -4,7 +4,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       - ".github/workflows/sequencer_cdk8s-test.yml"

--- a/.github/workflows/starknet_transaction_prover_ci.yml
+++ b/.github/workflows/starknet_transaction_prover_ci.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       - ".github/actions/bootstrap/action.yml"

--- a/.github/workflows/upload_artifacts_workflow.yml
+++ b/.github/workflows/upload_artifacts_workflow.yml
@@ -12,7 +12,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
     paths:
       # Other than code-related changes, all changes related to the native-blockifier build-and-push


### PR DESCRIPTION
Editing a PR title or description re-runs the entire CI suite on an unchanged head, because 11 workflows opt into the `edited` trigger and GitHub fires it identically for title, body and base changes.

The title check moves into its own small workflow, which is the only one that still reacts to `edited`. Every other workflow stops opting in, so an edit runs the title check and nothing else.

**Open question before merging: this drops base-retarget revalidation, and the merge queue does not currently cover it. See "Base retargets" below.** Left as a draft until that is decided.

---

# Detailed Summary for AI Bots

## Problem

`on.pull_request.types` includes `edited` in 11 workflows. GitHub fires `edited` for title, body and base changes alike, so a prose-only edit pays a full-suite re-run.

## Change

**`pr_title.yml`** owns the title check. `commitlint` moves there unchanged, keeping its job name so the check context is identical, and keeping `merge_group` so merge queue runs still report it. It keeps `edited` and **revalidates the title on every event**, deliberately without a `changes.title` gate.

**`edited` is removed from the other ten workflows**, with no job gates and no concurrency changes.

## Why there are no `if` gates, after two rejected attempts

Two earlier revisions gated jobs on `github.event.changes`. Both were wrong, and Bugbot caught both.

**Skipped jobs publish check runs, and `skipped` counts as success.** Verified empirically on this PR's own head SHA: 37 check runs currently carry the `skipped` conclusion. GitHub's troubleshooting docs list `success`, `skipped` and `neutral` as successful statuses, and `merge-gatekeeper`'s `isSettledSuccess` agrees. So a gated re-run on an edit would publish `skipped` over an earlier **failing** result and make a red PR look green. That rules out job gating on the heavy workflows entirely.

**The same hazard applies to the title check.** An earlier revision short-circuited `commitlint` on body edits while the job still concluded success, which would have cleared a genuine title failure. Hence no gate there: the check is cheap and simply runs.

Skipping is safe only where no earlier conclusion can be superseded, which is not a property any of these workflows have.

## Base retargets: the open decision

`edited` is the only event fired by a base-branch change; `synchronize` covers head updates only. So the ten workflows no longer revalidate on a bare retarget, and checks computed against the old base stay green.

The merge queue does **not** backstop this today. Only `merge_queue_ci.yml`, `pr_title.yml` and `main_pr.yml` trigger on `merge_group`; `main.yml`, which carries the unit and integration tests, does not. So the queue catches lint and compile breakage, not test failures.

Two ways to close it, both needing a decision:

1. **Add `merge_group` to `main.yml`**, so the queue validates the real merge. This also closes a pre-existing hole, since today a merge-queue merge never runs the test suite. Cost: slower merges for everyone.
2. **A dispatcher workflow using `workflow_call`**, triggered on `edited`, calling the heavy workflows only when `changes.base` is set. Correct and publishes no check runs when not called, but every heavy workflow needs `on: workflow_call`, the dispatcher must replicate their `paths:` filters, and check names become `dispatcher-job / inner-job`, which affects branch protection contexts and the gatekeeper.

A third option is to accept the gap: in the normal Graphite flow a restack force-pushes, which fires `synchronize` and re-runs everything, so only a UI-only retarget is exposed.

## Also affected

`(SKIP COMMITTER BENCH)` now takes effect from the next push rather than immediately on a title edit, since `committer_ci.yml` no longer reacts to edits.

## Result

| Event | Before | After |
|---|---|---|
| Description edit | 11 workflows, full suite | `pr_title.yml` only |
| Title edit | 11 workflows, full suite | `pr_title.yml` only |
| Base retarget | 11 workflows, full suite | `pr_title.yml` only, pending the decision above |

## Verification

All workflows parse. A programmatic check confirms `pr_title.yml` is the only workflow listing `edited`, that it is the sole producer of the `commitlint` check and still carries `merge_group`, that `main_pr.yml` is left with just `merge-gatekeeper-new`, and that no `github.event.changes` gate remains anywhere.
