### PR TITLE
apollo_committer,starknet_committer: compress commitment infos once per commit

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -647,10 +647,13 @@ where
 
                 let (new_lower_bound, mut commitment_infos_updates) =
                     self.prune_commitment_infos(next_offset, &mut metadata);
+                // Compressed once and shared between the DB write and the response below, instead
+                // of bincode-serializing and zstd-compressing the same commitment infos twice.
+                let compressed_commitment_infos = state_commitment_infos.compress()?;
                 commitment_infos_updates.push(CommitmentInfosUpdate::Write(CommitmentInfosWrite {
                     block_number: height,
                     keys_digest: digest,
-                    commitment_infos: state_commitment_infos.clone(),
+                    commitment_infos: compressed_commitment_infos.clone(),
                 }));
 
                 info!(
@@ -682,7 +685,7 @@ where
                 self.commitment_infos_lower_bound = new_lower_bound;
                 Ok(ReadPathsAndCommitBlockResponse {
                     global_root,
-                    state_commitment_infos: state_commitment_infos.compress()?,
+                    state_commitment_infos: compressed_commitment_infos,
                 })
             }
         }

--- a/crates/starknet_committer/src/db/forest_trait_witnesses.rs
+++ b/crates/starknet_committer/src/db/forest_trait_witnesses.rs
@@ -19,13 +19,19 @@ use crate::forest::deleted_nodes::DeletedNodes;
 use crate::forest::filled_forest::FilledForest;
 use crate::forest::forest_errors::ForestResult;
 use crate::patricia_merkle_tree::tree::SortedLeafIndices;
-use crate::patricia_merkle_tree::types::{StarknetForestProofs, StateCommitmentInfos};
+use crate::patricia_merkle_tree::types::{
+    CompressedStateCommitmentInfos,
+    StarknetForestProofs,
+    StateCommitmentInfos,
+};
 
 /// The information required to write the OS-input commitment infos to the database.
 pub struct CommitmentInfosWrite {
     pub block_number: BlockNumber,
     pub keys_digest: [u8; 32],
-    pub commitment_infos: StateCommitmentInfos,
+    /// Compressed by the caller so that a value already compressed for another purpose (e.g. an
+    /// RPC response) isn't bincode-serialized and zstd-compressed a second time.
+    pub commitment_infos: CompressedStateCommitmentInfos,
 }
 
 /// Commitment-infos DB operation, which can be either delete or write.

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -433,7 +433,7 @@ impl<S: Storage> IndexDb<S> {
     fn append_commitment_infos_update(
         operations: &mut DbOperationMap,
         commitment_infos_update: CommitmentInfosUpdate,
-    ) -> SerializationResult<()> {
+    ) {
         match commitment_infos_update {
             CommitmentInfosUpdate::Delete(block_number) => {
                 operations.insert(
@@ -455,7 +455,7 @@ impl<S: Storage> IndexDb<S> {
                 keys_digest,
                 commitment_infos,
             }) => {
-                let encoded = DbValue(commitment_infos.compress()?.to_bytes());
+                let encoded = DbValue(commitment_infos.to_bytes());
                 operations.insert(
                     Self::metadata_key(ForestMetadataType::AccessedKeysDigest(DbBlockNumber(
                         block_number,
@@ -471,7 +471,6 @@ impl<S: Storage> IndexDb<S> {
                 );
             }
         }
-        Ok(())
     }
 }
 
@@ -487,7 +486,7 @@ impl<S: Storage + Send> ForestWriterWithMetadataAndWitnesses for IndexDb<S> {
         let mut operations = DbOperationMap::new();
         Self::append_forest_and_metadata(&mut operations, filled_forest, metadata, deleted_nodes)?;
         for commitment_infos_update in commitment_infos_updates {
-            Self::append_commitment_infos_update(&mut operations, commitment_infos_update)?;
+            Self::append_commitment_infos_update(&mut operations, commitment_infos_update);
         }
         Ok(self.write_updates(operations).await)
     }


### PR DESCRIPTION
## Summary

Follow-up performance optimization for #15024 ("apollo_committer: prune old commitment infos from storage"), found while reviewing that merged PR's hot path.

In `Committer::read_paths_and_commit_block`'s `CommitTip` branch (the path taken on every fresh block commit that serves witnesses), the block's `StateCommitmentInfos` — nested `HashMap`s of Patricia witness facts — was cloned and independently bincode-serialized + zstd-compressed **twice** per block:
- once via `CommitmentInfosWrite { commitment_infos: state_commitment_infos.clone() }`, compressed inside `append_commitment_infos_update` for the storage write, and
- once again directly for the RPC response (`state_commitment_infos.compress()?`).

This change compresses once and shares the result:
- `CommitmentInfosWrite.commitment_infos` now carries the already-compressed `CompressedStateCommitmentInfos` instead of the raw `StateCommitmentInfos`, so `append_commitment_infos_update` just calls `.to_bytes()` (its `SerializationResult<()>` return type also simplified to `()`, since it can no longer fail).
- The committer computes `compress()` once, clones the (much cheaper) compressed struct — one `u8` + one `Vec<u8>` zstd frame — for the storage write, and reuses the original for the response.

Net effect per block commit: one fewer full bincode+zstd pass over the block's witness data, and one fewer deep clone of the nested witness `HashMap`s (replaced by a cheap clone of the compressed bytes). The on-disk bytes are unchanged (verified empirically across multiple hash-seed runs, since bincode serialization of `HashMap` fields is iteration-order dependent).

Note: since compression now happens before the `Action::Write` measurement window starts (previously it happened inside the writer, within that window), `WRITE_DURATION_PER_BLOCK` will read a bit lower and no longer includes compression time; `Action::EndToEnd`/overall commit latency metrics are unaffected.

## Test plan
- [x] `cargo check -p apollo_committer -p starknet_committer`
- [x] `cargo clippy -p apollo_committer -p starknet_committer --all-targets` (clean)
- [x] `SEED=0 cargo test -p apollo_committer -p starknet_committer` (all 156 tests pass, including the pruning tests added by #15024, which exercise the storage round trip)
- [x] `scripts/rust_fmt.sh` (no changes needed)
- [x] Independent adversarial review by a second agent, including an empirical check (across 8 process runs with distinct `HashMap` hash seeds) that the new single-compress path produces byte-identical storage output to the old double-compress path


---
_Generated by [Claude Code](https://claude.ai/code/session_01F15NnA1mLZh9b5eVTCkHRq)_