### PR TITLE
deployment,ci: substitute alert cluster and namespace matchers in selectors with extra labels

### DIFF
--- a/.github/workflows/sequencer_cdk8s-test.yml
+++ b/.github/workflows/sequencer_cdk8s-test.yml
@@ -13,6 +13,8 @@ on:
       - "deployments/anvil/**"
       - "deployments/dummy_eth2strk_oracle/**"
       - "deployments/dummy_recorder/**"
+      - "deployments/monitoring/**"
+      - "crates/apollo_dashboard/resources/dev_grafana_alerts.json"
 
 jobs:
   # https://graphite.com/docs/stacking-and-ci
@@ -27,6 +29,27 @@ jobs:
         uses: withgraphite/graphite-ci-action@v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
+  monitoring-tests:
+    runs-on: ubuntu-24.04
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
+    timeout-minutes: 60
+    steps:
+      - name: Checkout sequencer
+        uses: actions/checkout@v6
+
+      - name: Setup python
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install pip dependencies
+        run: python3 -m pip install pytest -r deployments/monitoring/src/requirements.txt
+
+      - name: Run monitoring builder tests
+        run: python3 -m pytest deployments/monitoring/test -v
 
   prepare:
     runs-on: ubuntu-24.04

--- a/deployments/monitoring/conftest.py
+++ b/deployments/monitoring/conftest.py
@@ -1,0 +1,6 @@
+import pathlib
+import sys
+
+# Puts deployments/monitoring/src on sys.path, so tests import the builder modules by the same
+# names the app uses when run as `python -m main` from that directory.
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "src"))

--- a/deployments/monitoring/src/builders/alert_builder.py
+++ b/deployments/monitoring/src/builders/alert_builder.py
@@ -4,6 +4,7 @@ import argparse
 import collections
 import json
 import os
+import re
 import sys
 from typing import Optional
 
@@ -165,12 +166,18 @@ def update_alert_rule_group(
 def inject_expr_placeholders(expr: str, cluster: str, namespace: str) -> str:
     return expr.replace(
         const.ALERT_RULE_EXPRESSION_PLACEHOLDER,
-        '{{namespace="{0}", cluster="{1}"}}'.format(namespace, cluster),
+        'namespace="{0}", cluster="{1}"'.format(namespace, cluster),
     )
 
 
 def remove_expr_placeholder(expr: str) -> str:
-    return expr.replace(const.ALERT_RULE_EXPRESSION_PLACEHOLDER, "")
+    # The separator after the placeholder is consumed too, so a selector that carries further
+    # matchers stays valid PromQL.
+    return re.sub(
+        re.escape(const.ALERT_RULE_EXPRESSION_PLACEHOLDER) + r"(,\s*)?",
+        "",
+        expr,
+    )
 
 
 def _convert_numeric_strings_in_conditions(conditions: list[dict[str, any]]) -> None:

--- a/deployments/monitoring/src/common/const.py
+++ b/deployments/monitoring/src/common/const.py
@@ -1,3 +1,6 @@
+# The cluster/namespace matchers inside a metric selector's brace group, substituted at
+# provisioning time since alert rules carry no dashboard-variable context. Braces are excluded so
+# selectors that carry further matchers still match.
 # fmt: off
-ALERT_RULE_EXPRESSION_PLACEHOLDER = '{cluster=~\"$cluster\", namespace=~\"$namespace\"}'
+ALERT_RULE_EXPRESSION_PLACEHOLDER = 'cluster=~\"$cluster\", namespace=~\"$namespace\"'
 # fmt: on

--- a/deployments/monitoring/test/test_alert_expression_placeholders.py
+++ b/deployments/monitoring/test/test_alert_expression_placeholders.py
@@ -1,0 +1,125 @@
+import json
+import pathlib
+
+import pytest
+from builders.alert_builder import inject_expr_placeholders, remove_expr_placeholder
+
+CLUSTER = "test-cluster"
+NAMESPACE = "test-namespace"
+
+# Grafana substitutes these only where a dashboard supplies them as template variables.
+DASHBOARD_VARIABLES = ("$cluster", "$namespace")
+
+SHIPPED_ALERTS_PATH = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "crates"
+    / "apollo_dashboard"
+    / "resources"
+    / "dev_grafana_alerts.json"
+)
+
+
+def shipped_alerts() -> list[dict]:
+    with open(SHIPPED_ALERTS_PATH) as alerts_file:
+        return json.load(alerts_file)["alerts"]
+
+
+def alert_name(alert: dict) -> str:
+    return alert["name"]
+
+
+@pytest.mark.parametrize("alert", shipped_alerts(), ids=alert_name)
+def test_injection_leaves_no_dashboard_variable_in_shipped_alert(alert: dict):
+    # An alert rule is evaluated without dashboard variables, so a surviving $cluster or $namespace
+    # reaches Prometheus as a literal regex, matches no series, and the rule never fires. Rendering
+    # every shipped expression guards the substitution against selectors this test does not
+    # enumerate, such as any selector carrying matchers beyond cluster and namespace.
+    rendered_expr = inject_expr_placeholders(
+        expr=alert["expr"], cluster=CLUSTER, namespace=NAMESPACE
+    )
+
+    for variable in DASHBOARD_VARIABLES:
+        assert (
+            variable not in rendered_expr
+        ), f"alert '{alert['name']}' still contains {variable} after injection: {rendered_expr}"
+    if any(variable in alert["expr"] for variable in DASHBOARD_VARIABLES):
+        assert NAMESPACE in rendered_expr
+        assert CLUSTER in rendered_expr
+
+
+@pytest.mark.parametrize("alert", shipped_alerts(), ids=alert_name)
+def test_removal_leaves_valid_selector_in_shipped_alert(alert: dict):
+    stripped_expr = remove_expr_placeholder(expr=alert["expr"])
+
+    for variable in DASHBOARD_VARIABLES:
+        assert (
+            variable not in stripped_expr
+        ), f"alert '{alert['name']}' still contains {variable} after removal: {stripped_expr}"
+    for dangling_separator in ("{,", ",}", ", }"):
+        assert dangling_separator not in stripped_expr, (
+            f"alert '{alert['name']}' has a dangling '{dangling_separator}' after removal: "
+            f"{stripped_expr}"
+        )
+
+
+# (case id, expression, expression after injection, expression after removal)
+PLACEHOLDER_CASES = [
+    (
+        "bare_selector",
+        'up{cluster=~"$cluster", namespace=~"$namespace"}',
+        'up{namespace="test-namespace", cluster="test-cluster"}',
+        "up{}",
+    ),
+    (
+        "one_extra_matcher",
+        'exchange_rate_oracle_rate{cluster=~"$cluster", namespace=~"$namespace", '
+        'currency_pair="strk_usd"}',
+        'exchange_rate_oracle_rate{namespace="test-namespace", cluster="test-cluster", '
+        'currency_pair="strk_usd"}',
+        'exchange_rate_oracle_rate{currency_pair="strk_usd"}',
+    ),
+    (
+        "two_extra_matchers",
+        'http_server_add_tx_latency_bucket{cluster=~"$cluster", namespace=~"$namespace", '
+        'le="1.0", scraper="l1_events"}',
+        'http_server_add_tx_latency_bucket{namespace="test-namespace", cluster="test-cluster", '
+        'le="1.0", scraper="l1_events"}',
+        'http_server_add_tx_latency_bucket{le="1.0", scraper="l1_events"}',
+    ),
+    (
+        "two_selectors_one_with_extra_matcher",
+        '(mempool_transactions_dropped{cluster=~"$cluster", namespace=~"$namespace", '
+        'drop_reason="evicted"}) and on() (is_observer{cluster=~"$cluster", '
+        'namespace=~"$namespace"} == 0)',
+        '(mempool_transactions_dropped{namespace="test-namespace", cluster="test-cluster", '
+        'drop_reason="evicted"}) and on() (is_observer{namespace="test-namespace", '
+        'cluster="test-cluster"} == 0)',
+        '(mempool_transactions_dropped{drop_reason="evicted"}) and on() (is_observer{} == 0)',
+    ),
+    (
+        "no_placeholder",
+        "vector(0)",
+        "vector(0)",
+        "vector(0)",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "expr, expected_expr",
+    [(expr, injected_expr) for _, expr, injected_expr, _ in PLACEHOLDER_CASES],
+    ids=[case_id for case_id, _, _, _ in PLACEHOLDER_CASES],
+)
+def test_inject_expr_placeholders(expr: str, expected_expr: str):
+    assert (
+        inject_expr_placeholders(expr=expr, cluster=CLUSTER, namespace=NAMESPACE) == expected_expr
+    )
+
+
+@pytest.mark.parametrize(
+    "expr, expected_expr",
+    [(expr, stripped_expr) for _, expr, _, stripped_expr in PLACEHOLDER_CASES],
+    ids=[case_id for case_id, _, _, _ in PLACEHOLDER_CASES],
+)
+def test_remove_expr_placeholder(expr: str, expected_expr: str):
+    assert remove_expr_placeholder(expr=expr) == expected_expr


### PR DESCRIPTION
15 of our 94 Grafana alert rules have never been able to fire. When alert rules are provisioned, the cluster/namespace selector is substituted into each expression by a literal string replace, and that literal included the selector's closing brace. Any alert whose selector carries an extra matcher, for example `currency_pair="strk_usd"` or `reason="CrashLoopBackOff"`, therefore did not match, and shipped to Prometheus with a literal `$cluster` and `$namespace`. Prometheus treats those as regex literals, they match no series, and the rule sits at Health: nodata / State: Normal forever. Where the expression ends in `or vector(0)` it looks even better: a confident, permanent green 0.

The fix is to drop the braces from the placeholder constant, so trailing matchers survive with no parsing. `remove_expr_placeholder` needs a regex to also swallow the now-dangling comma.

The reason this went unnoticed is that nothing tested it. There were no tests for the monitoring builders at all, and the checked-in examples use a selector with no placeholder in it, so the substitution was never exercised. This adds a test that renders every expression in the shipped `dev_grafana_alerts.json` and asserts no dashboard variable survives, which fails on 15 alerts before the fix and passes after, plus table cases per selector shape. A CI job runs them.

The generated artifacts are untouched: the placeholders in `dev_grafana_alerts.json` and `dev_grafana.json` are correct by design, since substitution happens at provisioning time.

---

# Detailed Summary for AI Bots

## Mechanism

`deployments/monitoring/src/builders/alert_builder.py` substitutes the cluster/namespace selector at provisioning time, because alert rules are evaluated with no dashboard-variable context. Both substitution paths keyed off one constant:

```python
# deployments/monitoring/src/common/const.py, before
ALERT_RULE_EXPRESSION_PLACEHOLDER = '{cluster=~\"$cluster\", namespace=~\"$namespace\"}'
```

`inject_expr_placeholders` (used when `--namespace` and `--cluster` are given) and `remove_expr_placeholder` (used otherwise) both did a literal `str.replace` of that value. Because the constant included the braces, it only matched a selector whose brace group contained nothing else:

- substitutes: `batcher_batched_transactions{cluster=~"$cluster", namespace=~"$namespace"}`
- does not: `exchange_rate_oracle_rate{cluster=~"$cluster", namespace=~"$namespace", currency_pair="eth_strk"}`

Substitution could be partial within one expression. Most of the affected alerts also carry an `is_observer{cluster=~"$cluster", namespace=~"$namespace"}` join, which is a bare selector and did get substituted, so "the placeholder was found" was never a valid check. The only sound invariant is that no placeholder survives anywhere in the rendered expression.

An unsubstituted `$cluster` reaches Prometheus as a literal regex matcher. It matches no series, so the rule reports Health: nodata and State: Normal. For the expressions ending in `or vector(0)`, the fallback evaluates and the rule reports a healthy 0.

## Fix

Drop the braces from the constant, so the substitution operates on the matcher list inside the brace group and any trailing matchers are preserved with no parsing:

```python
ALERT_RULE_EXPRESSION_PLACEHOLDER = 'cluster=~\"$cluster\", namespace=~\"$namespace\"'
```

- `inject_expr_placeholders` now replaces it with `namespace="<ns>", cluster="<cluster>"` (no braces). `metric{cluster=~"$cluster", namespace=~"$namespace", currency_pair="x"}` renders as `metric{namespace="NS", cluster="CL", currency_pair="x"}`.
- `remove_expr_placeholder` is the one path needing a regex, to consume the now-dangling separator: `re.escape(PLACEHOLDER) + r"(,\s*)?"`. The bare case becomes `metric{}` (valid PromQL, previously `metric`), the extra-matcher case becomes `metric{currency_pair="x"}`.

Every other reference to the constant was checked. The only two call sites are the two functions above. The Rust-side `METRIC_LABEL_FILTER` in `crates/apollo_metrics/src/metric_definitions.rs` and the assertion in `crates/apollo_dashboard/src/dashboard_test.rs` describe the generated artifact, which still carries the braces and is unchanged. `dashboard_builder.py` does not use this constant, correctly, since dashboards do have variable context.

## Before and after

Measured against `crates/apollo_dashboard/resources/dev_grafana_alerts.json` on this branch's base (`origin/main-v0.14.3`): 94 expressions, of which 15 retained a placeholder after injection. On `origin/main` the same script reports 95 expressions and the identical 15 alerts.

After the fix: 94 expressions, 0 retaining a placeholder.

## Alerts restored

1. `consensus_l2_gas_price_above_maximum`
2. `eth_to_strk_error_count`
3. `eth_to_strk_rate_frozen`
4. `eth_to_strk_rate_out_of_bounds`
5. `eth_to_strk_success_count`
6. `high_empty_blocks_ratio`
7. `http_server_min_add_tx_latency`
8. `mempool_evictions_count`
9. `pod_state_crashloopbackoff`
10. `primary_l1_endpoint_down_too_long_l1_events`
11. `primary_l1_endpoint_down_too_long_l1_gas_price`
12. `strk_to_usd_error_count`
13. `strk_to_usd_rate_frozen`
14. `strk_to_usd_rate_out_of_bounds`
15. `strk_to_usd_success_count`

## Tests

`deployments/monitoring/test/test_alert_expression_placeholders.py` is new, along with `deployments/monitoring/conftest.py` which puts `deployments/monitoring/src` on `sys.path` so tests import the builder modules under the same names the app uses.

There were no pre-existing assertions to repair. `deployments/monitoring` had no tests, and the checked-in example input (`deployments/monitoring/examples/input/dev_grafana_alerts.json`) uses `mempool_transactions_dropped{job="node"}`, which contains no placeholder, so the substitution was never covered by anything.

- `test_injection_leaves_no_dashboard_variable_in_shipped_alert`, parametrized over every alert in the shipped `dev_grafana_alerts.json` and keyed by alert name. Asserts no `$cluster` or `$namespace` survives injection. This is the invariant test and carries a comment stating what it guards. 15 failures before the fix, exactly the list above; passes after.
- `test_removal_leaves_valid_selector_in_shipped_alert`, same parametrization over the removal path. Asserts no variable survives and no dangling `{,`, `,}` or `, }` is left. 15 failures before the fix; passes after.
- `test_inject_expr_placeholders` and `test_remove_expr_placeholder`, table-driven over five selector shapes: bare selector, one extra matcher, two extra matchers, two selectors in one expression where only one carries extras, and an expression with no placeholder at all (asserted to pass through unchanged).

Verified in both directions with the fix stashed and restored:

- fix stashed, tests present: `37 failed, 161 passed`
- fix applied: `198 passed`

Formatted with `black -l 100 -t py37` and `isort`, matching `scripts/py_code_style.py`.

## CI

`deployments/monitoring` had no CI coverage, so the tests would not have run. A `monitoring-tests` job is added to `.github/workflows/sequencer_cdk8s-test.yml`, the repo's existing home for deployment Python tests, installing `deployments/monitoring/src/requirements.txt` plus pytest and running `pytest deployments/monitoring/test`. The workflow's `paths` filter gains `deployments/monitoring/**` and `crates/apollo_dashboard/resources/dev_grafana_alerts.json`, so a regenerated alert with a new selector shape triggers the invariant test.

## Deliberately out of scope

Alert severities use a different placeholder mechanism (`$$$<alert_name>-severity$$$`, filled per environment from the overrides YAML). This is not the same class of bug. That path is fail-closed: `validate_config_overrides` in `deployments/monitoring/src/common/config_overrides.py` runs over all alerts before any are processed and `sys.exit(1)`s if any `$$$KEY$$$` placeholder has no config entry, and also if the config carries unused keys. An unsubstituted severity cannot reach Grafana, because the provisioner refuses to run. The expression placeholder had no equivalent validation, which is why it failed open and silently.

Possible follow-up, not done here: extend that same fail-closed validation to the expression placeholder, so the provisioner refuses to push a rule that still contains `$cluster` or `$namespace`. That would give runtime defense in depth alongside the test added here. It is not a one-line change in the same function, so it is left out of this PR.
