### PR TITLE
⛔ DO NOT MERGE — apollo_versioned_constants: raise l1_gas_price_margin_percent to 500

### DIFF
--- a/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_3.json
+++ b/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_3.json
@@ -5,5 +5,5 @@
     "gas_target": 1040000000,
     "max_block_size": 5800000000,
     "min_gas_price": "0x1dcd65000",
-    "l1_gas_price_margin_percent": 10
+    "l1_gas_price_margin_percent": 500
 }

--- a/crates/apollo_versioned_constants/resources/versioned_constants_diff_regression/0.14.2_0.14.3.txt
+++ b/crates/apollo_versioned_constants/resources/versioned_constants_diff_regression/0.14.2_0.14.3.txt
@@ -1,1 +1,2 @@
 ~ /gas_target: 1040000000
+~ /l1_gas_price_margin_percent: 500


### PR DESCRIPTION
## ⛔ DO NOT MERGE

Opened as a **draft** deliberately and must stay that way. This is a temporary
operational bridge for a live mainnet incident, built so an image can be tagged from
it. It is not a product change and must never reach `main-v0.14.3`.

Anyone who finds this PR: leave it in draft, do not approve, do not queue.

## What it does

`l1_gas_price_margin_percent`: `10` → `500` in
`orchestrator_versioned_constants_0_14_3.json`, plus the regenerated
`versioned_constants_diff_regression/0.14.2_0.14.3.txt` snapshot.

## Why

Since `2026-08-25T17:59:59Z` the Pragma `eth/strk` HTTP endpoint has been unreachable
from every mainnet node (`RequestError`, transport-level, no HTTP status). Nodes 1-5
therefore take the `previous_proposal_init` fallback on every block, which discards the
healthy live wei prices along with the failed rate and re-freezes itself each block —
so the fleet has been pricing off an ~18-hour-old sample.

Node-0 was deployed on `APOLLO-0.14.3-RC.16`, which reads the rate from Chainlink
on-chain instead. It succeeds, computes live prices, and consequently rejects every
proposal with `L1 gas price mismatch` (166 per 5 minutes). Node-0 is
`validator_id = 0x1`, outside the committee `0x64`–`0x68`, so mainnet block production
is unaffected — but no committee node can be rolled the same way without splitting it.

The divergence is carried almost entirely by the **L1 data gas price**: the flat
`l1_gas_tip_wei = 1 gwei` damps the L1 gas price move to ~1.09×, while
`min_l1_data_gas_price_wei = 1` leaves the data gas price showing the full ~2.79×.

Widening the validator-side margin lets the frozen and live camps accept each other's
proposals, so the fleet can be rolled without a committee split. Widening is
**monotonic** — it only ever turns a reject into an accept, never the reverse — so every
intermediate state of the rollout is safe, unlike a config-pin or a price override, both
of which traverse a no-quorum window.

## Blast radius of the constant itself

- **Not in the block hash.** Inputs are `block_hash_version, block_number, state_root, sequencer, timestamp, concatenated_counts, state_diff_commitment, transaction_commitment, event_commitment, receipt_commitment, gas_prices, starknet_version, 0, parent_block_hash`. The *agreed* gas prices are hashed; the acceptance threshold is not.
- **Single consumer**: `apollo_consensus_orchestrator/src/validate_proposal.rs`. Absent from `build_proposal`, the batcher, and every execution path.
- **No commitment coupling.** `version_constant_commitment` is `Default::default()` in `build_proposal.rs:183` and is never checked in `is_proposal_init_valid`.
- **Blockifier VC untouched** — separate crate, separate `define_versioned_constants!` invocation, separate diff fixture. Nothing here can move `state_diff_commitment`.

So mixed VC across nodes cannot produce divergent block hashes.

## Sizing

The check tolerates `|proposed − expected| ≤ proposed × m/100`. Today's gap needs 65% in
the direction currently firing (frozen node proposing) and 180% in the reverse (a rolled
node proposing to a frozen validator). At `m = 500` the frozen value may be up to 6× the
live one; it is 2.79× now, so live blob fee could fall a further ~53% before failing
again. Generous on purpose — blob fee moved 25% in three hours today.

## Rollout notes

1. Tag an image from this branch and deploy to **node-0 first**. It is an observer, so
   nothing it does can affect consensus, and its `PROPOSAL_FAILED` rate dropping to zero
   proves the value is sufficient against live prices at no risk.
2. Then roll nodes 1-5 one at a time. Quorum is exactly 4 of 5, so each pod restart runs
   at zero fault tolerance — confirm each node is back and voting before the next.
3. A restarted node briefly has `previous_proposal_init = None` and falls back to default
   min prices; at `m = 500` those are still accepted, so the wide margin smooths its own
   rollout.
4. Revert to `10` once the fleet is fresh and converged. While this is deployed, mainnet
   has effectively no L1 price validation — a bridge, not a resting state.

## Testing

`cargo test -p apollo_versioned_constants test_vc_diffs_regression` passes with the
regenerated snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)