### PR TITLE
apollo_consensus_orchestrator: clamp the fee proposal band to the L2 gas price cap

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/dynamic_gas_price/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/dynamic_gas_price/mod.rs
@@ -7,7 +7,8 @@
 //! - `compute_fee_target`: the fee we'd *like* for this block, derived from the STRK/USD oracle
 //!   quote and a configurable USD-cost target.
 //! - `compute_fee_proposal`: the target, clamped within a fixed multiplicative margin of
-//!   `fee_actual` (so a proposer cannot move the fee too far per round).
+//!   `fee_actual` (so a proposer cannot move the fee too far per round) and capped at the L2 gas
+//!   price ceiling (so a malicious oracle cannot raise the fee without limit).
 //!
 //! See also: `fee_market` for EIP-1559-style base-fee adjustment, which receives
 //! `fee_actual` as a floor.
@@ -41,7 +42,7 @@ pub struct FeeProposalInfo {
 /// Scale factor for 18-decimal fixed-point conversion (1 STRK = 10^18 FRI).
 const FRI_DECIMALS_SCALE: u128 = 10u128.pow(18);
 
-/// Denominator for parts-per-thousand calculations in fee_proposal bounds.
+/// Denominator for parts-per-thousand config and versioned-constants values, e.g. `2` = 0.2%.
 pub(crate) const PPT_DENOMINATOR: u128 = 1000;
 
 /// Compute fee_actual for `height` as the median of the `fee_proposal` values
@@ -114,40 +115,50 @@ pub fn compute_fee_target(
 
 /// Compute the fee_proposal an honest proposer should publish.
 /// - If oracle failed (`fee_target` is `None`): freeze at `fee_actual`.
-/// - Otherwise: clamp `fee_target` into the geometric bounds returned by `fee_proposal_bounds`.
+/// - Otherwise: aim at `fee_target`.
+///
+/// Either way the result is clamped into the bounds from `fee_proposal_bounds`, since a frozen
+/// `fee_actual` can itself sit above `max_l2_gas_price`, the ceiling from
+/// [`l2_gas_price_cap`](crate::fee_market::l2_gas_price_cap).
 pub fn compute_fee_proposal(
     fee_target: Option<GasPrice>,
     fee_actual: GasPrice,
     margin_ppt: u128,
+    max_l2_gas_price: GasPrice,
 ) -> GasPrice {
-    let Some(fee_target) = fee_target else {
-        return fee_actual;
-    };
-    let (lower, upper) = fee_proposal_bounds(fee_actual, margin_ppt);
-    GasPrice(fee_target.0.clamp(lower, upper))
+    let (lower, upper) = fee_proposal_bounds(fee_actual, margin_ppt, max_l2_gas_price);
+    GasPrice(fee_target.unwrap_or(fee_actual).0.clamp(lower, upper))
 }
 
 /// Geometric bounds for fee_proposal: returns `(lower, upper)` where
 /// - `upper = fee_actual * (1 + margin)` (multiplicative widening), and
 /// - `lower = fee_actual / (1 + margin)` (the reciprocal — multiplicative narrowing),
 ///
-/// with `margin = margin_ppt / PPT_DENOMINATOR`.
+/// with `margin = margin_ppt / PPT_DENOMINATOR`, both then capped at `max_l2_gas_price`, from
+/// [`l2_gas_price_cap`](crate::fee_market::l2_gas_price_cap).
 ///
 /// The asymmetry is intentional: bounds are geometrically symmetric (the same
 /// multiplicative factor in either direction), so a sequence of consecutive proposals
 /// can grow by `(1 + margin)` per round or shrink by the same factor per round. Both
 /// proposer and validator use this helper to ensure they agree on what's in-range.
 ///
+/// The ceiling caps both bounds, not just `upper`: capping only `upper` could leave `lower` above
+/// it, rejecting an honest proposer pinned at the ceiling.
+///
 /// Uses `U256` internally to keep the arithmetic mathematically correct regardless of
 /// `fee_actual` and `margin_ppt`. On the practically-unreachable overflow, the upper
 /// bound saturates to `u128::MAX` and the lower bound saturates to `0`.
-pub(crate) fn fee_proposal_bounds(fee_actual: GasPrice, margin_ppt: u128) -> (u128, u128) {
+pub(crate) fn fee_proposal_bounds(
+    fee_actual: GasPrice,
+    margin_ppt: u128,
+    max_l2_gas_price: GasPrice,
+) -> (u128, u128) {
     let denom = U256::from(PPT_DENOMINATOR);
     let scaled = denom + U256::from(margin_ppt);
     let fee_actual_u256 = U256::from(fee_actual.0);
     let upper = u128::try_from(fee_actual_u256 * scaled / denom).unwrap_or(u128::MAX);
     let lower = u128::try_from(fee_actual_u256 * denom / scaled).unwrap_or(0);
-    (lower, upper)
+    (lower.min(max_l2_gas_price.0), upper.min(max_l2_gas_price.0))
 }
 
 /// Bind `fee_proposal_fri` to the proposal commitment hash.

--- a/crates/apollo_consensus_orchestrator/src/dynamic_gas_price/test.rs
+++ b/crates/apollo_consensus_orchestrator/src/dynamic_gas_price/test.rs
@@ -12,9 +12,11 @@ use crate::dynamic_gas_price::{
     compute_fee_actual,
     compute_fee_proposal,
     compute_fee_target,
+    fee_proposal_bounds,
     FeeProposalInfo,
     PPT_DENOMINATOR,
 };
+use crate::test_utils::{INERT_MAX_L2_GAS_PRICE, TEST_MAX_L2_GAS_PRICE, TEST_MIN_L2_GAS_PRICE};
 
 const TEST_FEE_PROPOSAL_WINDOW_SIZE: u64 = 10;
 
@@ -139,7 +141,10 @@ fn test_compute_fee_proposal(
     #[case] margin_ppt: u128,
     #[case] expected: GasPrice,
 ) {
-    assert_eq!(compute_fee_proposal(fee_target, fee_actual, margin_ppt), expected);
+    assert_eq!(
+        compute_fee_proposal(fee_target, fee_actual, margin_ppt, INERT_MAX_L2_GAS_PRICE),
+        expected
+    );
 }
 
 #[test]
@@ -163,8 +168,18 @@ fn test_compute_fee_target_extreme_values_do_not_panic() {
 #[test]
 fn test_compute_fee_proposal_saturating_on_extreme_actual() {
     // actual near u128::MAX: saturating_mul must prevent overflow.
-    let _ = compute_fee_proposal(Some(GasPrice(1)), GasPrice(u128::MAX), 2);
-    let _ = compute_fee_proposal(Some(GasPrice(u128::MAX)), GasPrice(u128::MAX), 2);
+    let _ = compute_fee_proposal(Some(GasPrice(1)), GasPrice(u128::MAX), 2, INERT_MAX_L2_GAS_PRICE);
+    let _ = compute_fee_proposal(
+        Some(GasPrice(u128::MAX)),
+        GasPrice(u128::MAX),
+        2,
+        INERT_MAX_L2_GAS_PRICE,
+    );
+    // A ceiling of 1 against the widest possible band: both edges collapse onto it.
+    assert_eq!(
+        compute_fee_proposal(Some(GasPrice(u128::MAX)), GasPrice(u128::MAX), 2, GasPrice(1)),
+        GasPrice(1)
+    );
 }
 
 #[test]
@@ -193,9 +208,19 @@ fn test_compute_fee_actual_lone_adversary_cannot_skew_median() {
 
 /// The validator's accept predicate. Must stay in sync with
 /// `validate_proposal::is_proposal_init_valid` fee_proposal bounds check.
-fn validator_accepts(fee_actual: GasPrice, fee_proposal: GasPrice, margin_ppt: u128) -> bool {
+///
+/// Recomputes the band instead of calling `fee_proposal_bounds`, so that a proposal produced by
+/// `compute_fee_proposal` is checked against an independent formula rather than against the very
+/// bounds it was clamped into.
+fn validator_accepts(
+    fee_actual: GasPrice,
+    fee_proposal: GasPrice,
+    margin_ppt: u128,
+    max_l2_gas_price: GasPrice,
+) -> bool {
     let lower = fee_actual.0.saturating_mul(PPT_DENOMINATOR) / (PPT_DENOMINATOR + margin_ppt);
     let upper = fee_actual.0.saturating_mul(PPT_DENOMINATOR + margin_ppt) / PPT_DENOMINATOR;
+    let (lower, upper) = (lower.min(max_l2_gas_price.0), upper.min(max_l2_gas_price.0));
     fee_proposal.0 >= lower && fee_proposal.0 <= upper
 }
 
@@ -203,9 +228,12 @@ fn validator_accepts(fee_actual: GasPrice, fee_proposal: GasPrice, margin_ppt: u
 fn test_malicious_high_fee_proposal_rejected() {
     // Upper bound for fee_actual=1_000_000 with margin=2ppt is 1_002_000.
     let fee_actual = GasPrice(1_000_000);
-    assert!(validator_accepts(fee_actual, GasPrice(1_002_000), 2));
+    assert!(validator_accepts(fee_actual, GasPrice(1_002_000), 2, INERT_MAX_L2_GAS_PRICE));
     for proposal in [1_002_001u128, 1_003_000, 2_000_000, u128::MAX] {
-        assert!(!validator_accepts(fee_actual, GasPrice(proposal), 2), "accepted {proposal}");
+        assert!(
+            !validator_accepts(fee_actual, GasPrice(proposal), 2, INERT_MAX_L2_GAS_PRICE),
+            "accepted {proposal}"
+        );
     }
 }
 
@@ -213,15 +241,132 @@ fn test_malicious_high_fee_proposal_rejected() {
 fn test_malicious_low_fee_proposal_rejected() {
     // Lower bound for fee_actual=1_000_000 with margin=2ppt is 998_003.
     let fee_actual = GasPrice(1_000_000);
-    assert!(validator_accepts(fee_actual, GasPrice(998_003), 2));
+    assert!(validator_accepts(fee_actual, GasPrice(998_003), 2, INERT_MAX_L2_GAS_PRICE));
     for proposal in [998_002u128, 500_000, 1, 0] {
-        assert!(!validator_accepts(fee_actual, GasPrice(proposal), 2), "accepted {proposal}");
+        assert!(
+            !validator_accepts(fee_actual, GasPrice(proposal), 2, INERT_MAX_L2_GAS_PRICE),
+            "accepted {proposal}"
+        );
     }
+}
+
+#[rstest]
+// Well below the cap: the plain margin band.
+#[case::band_untouched_below_cap(GasPrice(1_000_000), (998_003, 1_002_000))]
+// Just below the cap, so only the upper edge is pulled in.
+#[case::upper_edge_capped(
+    GasPrice(TEST_MAX_L2_GAS_PRICE.0 - 1_000_000),
+    (79_839_321_357, TEST_MAX_L2_GAS_PRICE.0)
+)]
+// Exactly at the cap: `upper` is capped, `lower` is still below it.
+#[case::at_cap(TEST_MAX_L2_GAS_PRICE, (79_840_319_361, TEST_MAX_L2_GAS_PRICE.0))]
+// Ten times the cap: both edges collapse to a point.
+#[case::band_collapses_above_cap(
+    GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 10),
+    (TEST_MAX_L2_GAS_PRICE.0, TEST_MAX_L2_GAS_PRICE.0)
+)]
+fn test_fee_proposal_bounds_capped(
+    #[case] fee_actual: GasPrice,
+    #[case] expected_bounds: (u128, u128),
+) {
+    assert_eq!(fee_proposal_bounds(fee_actual, 2, TEST_MAX_L2_GAS_PRICE), expected_bounds);
+}
+
+#[test]
+fn test_honest_proposal_accepted_when_fee_actual_above_cap() {
+    // `fee_actual` can exceed the cap when STRK collapses by more than the multiplier.
+    let margin_ppt = VersionedConstants::latest_constants().fee_proposal_margin_ppt;
+    let fee_actual = GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 10);
+    let fee_target = Some(GasPrice(u128::MAX));
+
+    let proposal = compute_fee_proposal(fee_target, fee_actual, margin_ppt, TEST_MAX_L2_GAS_PRICE);
+
+    assert_eq!(proposal, TEST_MAX_L2_GAS_PRICE);
+    assert!(validator_accepts(fee_actual, proposal, margin_ppt, TEST_MAX_L2_GAS_PRICE));
+}
+
+#[test]
+fn test_oracle_failure_above_the_cap_publishes_the_cap() {
+    // The frozen `fee_actual` must still be clamped: every validator's band has already
+    // collapsed to the single point `max_l2_gas_price`.
+    let margin_ppt = VersionedConstants::latest_constants().fee_proposal_margin_ppt;
+    let fee_actual = GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 25);
+
+    let proposal = compute_fee_proposal(None, fee_actual, margin_ppt, TEST_MAX_L2_GAS_PRICE);
+
+    assert_eq!(proposal, TEST_MAX_L2_GAS_PRICE);
+    assert!(
+        validator_accepts(fee_actual, proposal, margin_ppt, TEST_MAX_L2_GAS_PRICE),
+        "frozen fee_actual was published above the ceiling and would halt the chain"
+    );
+}
+
+#[test]
+fn test_fee_actual_converges_to_cap_within_one_window() {
+    // Once the window holds only capped proposals, their median is at most the cap too.
+    let margin_ppt = VersionedConstants::latest_constants().fee_proposal_margin_ppt;
+    let mut window = window_from(
+        (0..TEST_FEE_PROPOSAL_WINDOW_SIZE)
+            .map(|height| (height, Some(GasPrice(TEST_MAX_L2_GAS_PRICE.0.saturating_mul(10))))),
+    );
+
+    for height in TEST_FEE_PROPOSAL_WINDOW_SIZE..2 * TEST_FEE_PROPOSAL_WINDOW_SIZE {
+        let fee_actual =
+            compute_fee_actual(&window, BlockNumber(height), TEST_FEE_PROPOSAL_WINDOW_SIZE)
+                .expect("window is fully populated");
+        let proposal = compute_fee_proposal(
+            Some(GasPrice(u128::MAX)),
+            fee_actual,
+            margin_ppt,
+            TEST_MAX_L2_GAS_PRICE,
+        );
+        assert_eq!(
+            proposal, TEST_MAX_L2_GAS_PRICE,
+            "proposal drifted off the cap at height {height}"
+        );
+        assert!(
+            validator_accepts(fee_actual, proposal, margin_ppt, TEST_MAX_L2_GAS_PRICE),
+            "honest proposal rejected at height {height}"
+        );
+        window.insert(BlockNumber(height), Some(proposal));
+    }
+
+    let converged_fee_actual = compute_fee_actual(
+        &window,
+        BlockNumber(2 * TEST_FEE_PROPOSAL_WINDOW_SIZE),
+        TEST_FEE_PROPOSAL_WINDOW_SIZE,
+    );
+    assert_eq!(converged_fee_actual, Some(TEST_MAX_L2_GAS_PRICE));
+
+    // Once converged the band reopens below the cap, so the fee can fall again.
+    let (lower, upper) =
+        fee_proposal_bounds(TEST_MAX_L2_GAS_PRICE, margin_ppt, TEST_MAX_L2_GAS_PRICE);
+    assert!(lower < upper);
+    assert_eq!(upper, TEST_MAX_L2_GAS_PRICE.0);
+}
+
+#[test]
+fn test_malicious_strk_usd_rate_cannot_push_fee_proposal_above_cap() {
+    // A rate of 1 atto-USD per STRK drives `compute_fee_target` far above the cap.
+    let margin_ppt = VersionedConstants::latest_constants().fee_proposal_margin_ppt;
+    let fee_target = compute_fee_target(DEFAULT_SNIP35_TARGET_ATTO_USD_PER_L2_GAS, 1);
+    assert!(fee_target.unwrap() > TEST_MAX_L2_GAS_PRICE);
+
+    // Walk the band up from an honest starting point.
+    let mut fee_actual = TEST_MIN_L2_GAS_PRICE;
+    for _ in 0..10_000 {
+        let proposal =
+            compute_fee_proposal(fee_target, fee_actual, margin_ppt, TEST_MAX_L2_GAS_PRICE);
+        assert!(proposal <= TEST_MAX_L2_GAS_PRICE, "proposal {} exceeded the cap", proposal.0);
+        fee_actual = proposal;
+    }
+    assert_eq!(fee_actual, TEST_MAX_L2_GAS_PRICE);
 }
 
 #[test]
 fn test_honest_proposer_always_passes_validation_fuzzed() {
     // Consensus safety: whatever compute_fee_proposal produces, the validator accepts.
+    // Fuzzes both an out-of-reach ceiling and a binding one, including `fee_actual` above it.
     let margin_ppt = VersionedConstants::latest_constants().fee_proposal_margin_ppt;
     let mut rng = ChaCha8Rng::seed_from_u64(0xDEADBEEF);
     for _ in 0..10_000 {
@@ -230,10 +375,17 @@ fn test_honest_proposer_always_passes_validation_fuzzed() {
         let fee_actual = GasPrice(fee_actual_value);
         let target = compute_fee_target(DEFAULT_SNIP35_TARGET_ATTO_USD_PER_L2_GAS, strk_usd_rate);
         let oracle_result = if rng.random_bool(0.1) { None } else { target };
-        let proposal = compute_fee_proposal(oracle_result, fee_actual, margin_ppt);
+        let max_l2_gas_price = if rng.random_bool(0.5) {
+            INERT_MAX_L2_GAS_PRICE
+        } else {
+            GasPrice(rng.random_range(1u128..2_000_000_000_000_000_000))
+        };
+        let proposal =
+            compute_fee_proposal(oracle_result, fee_actual, margin_ppt, max_l2_gas_price);
         assert!(
-            validator_accepts(fee_actual, proposal, margin_ppt),
-            "fee_actual={fee_actual_value} rate={strk_usd_rate} proposal={}",
+            validator_accepts(fee_actual, proposal, margin_ppt, max_l2_gas_price),
+            "fee_actual={fee_actual_value} rate={strk_usd_rate} max_l2_gas_price={} proposal={}",
+            max_l2_gas_price.0,
             proposal.0
         );
     }

--- a/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
@@ -62,10 +62,19 @@ pub fn get_min_gas_price_for_height(
 /// The ceiling on the L2 gas price: `MAX_GAS_PRICE_MULTIPLIER` times `min_gas_price`. Applies to
 /// every block regardless of its `starknet_version`. Proposer and validator reach the ceiling
 /// through this function, so they cannot disagree on it.
-// [Temporary comment] Single caller on this lineage. The fee-proposal band clamp, which is its
-// second caller, is deferred to `main`.
 pub fn l2_gas_price_cap(min_gas_price: GasPrice) -> GasPrice {
     GasPrice(min_gas_price.0.saturating_mul(MAX_GAS_PRICE_MULTIPLIER))
+}
+
+/// The ceiling in force at `height`: the cap over the minimum configured for that height. The
+/// proposer's fee_proposal band and the validator's band compose it here, so they cannot disagree
+/// on it. `calculate_next_l2_gas_price_for_fin` composes `l2_gas_price_cap` directly, because it
+/// needs the height's minimum in its own right.
+pub fn l2_gas_price_cap_for_height(
+    height: BlockNumber,
+    min_l2_gas_price_per_height: &[PricePerHeight],
+) -> GasPrice {
+    l2_gas_price_cap(get_min_gas_price_for_height(height, min_l2_gas_price_per_height))
 }
 
 /// Compute the next L2 gas price (for the fin or for updating state). Respects override when set.

--- a/crates/apollo_consensus_orchestrator/src/metrics.rs
+++ b/crates/apollo_consensus_orchestrator/src/metrics.rs
@@ -43,8 +43,6 @@ define_metrics!(
         MetricGauge { SNIP35_FEE_PROPOSAL_FRI, "snip35_fee_proposal_fri", "The fee_proposal this node published in the latest block, in Fri" },
         MetricGauge { SNIP35_FEE_TARGET_FRI, "snip35_fee_target_fri", "The fee_target computed from the STRK/USD oracle, in Fri" },
         MetricGauge { SNIP35_FEE_TARGET_ATTO_USD, "snip35_fee_target_atto_usd", "Configured target USD cost per L2 gas unit, in atto-USD" },
-        // [Temporary comment] The increment site arrives with the fee-proposal band clamp, which
-        // is deferred to `main`, so this counter stays at zero on this lineage.
         MetricCounter { SNIP35_FEE_TARGET_ABOVE_MAXIMUM, "snip35_fee_target_above_maximum", "Number of blocks whose oracle-derived fee_target exceeded the L2 gas price maximum. Excludes targets from the override_l2_gas_price_fri operator pin", init = 0 },
     }
 );

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -101,6 +101,7 @@ use crate::dynamic_gas_price::{
 use crate::fee_market::{
     calculate_next_l2_gas_price_for_fin,
     get_min_gas_price_for_height,
+    l2_gas_price_cap_for_height,
     FeeMarketInfo,
     NextL2GasPrice,
 };
@@ -112,6 +113,7 @@ use crate::metrics::{
     CONSENSUS_L2_GAS_PRICE_AT_MINIMUM,
     SNIP35_FEE_ACTUAL_FRI,
     SNIP35_FEE_PROPOSAL_FRI,
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM,
     SNIP35_FEE_TARGET_ATTO_USD,
     SNIP35_FEE_TARGET_FRI,
 };
@@ -480,10 +482,13 @@ impl SequencerConsensusContext {
     }
 
     /// Compute the proposer's fee_proposal: clamp the oracle's `fee_target` to a margin around
-    /// `fee_actual`. When `fee_actual` is `None` (window incomplete), freeze at `l2_gas_price`; the
-    /// validator derives the same fallback so both sides agree.
+    /// `fee_actual`, capped at the L2 gas price ceiling for `height`. When `fee_actual` is `None`
+    /// (window incomplete), freeze at `l2_gas_price`, uncapped: the validator skips the band check
+    /// without `fee_actual`, so both sides agree on the fallback, and the price users pay is capped
+    /// in `calculate_next_l2_gas_price_for_fin`.
     async fn compute_proposer_fee_proposal(
         &self,
+        height: BlockNumber,
         fee_actual: Option<GasPrice>,
         timestamp: u64,
         target_atto_usd_per_l2_gas: u128,
@@ -497,14 +502,64 @@ impl SequencerConsensusContext {
         SNIP35_FEE_ACTUAL_FRI.set_lossy(fee_actual.0);
 
         let fee_target = self.resolve_fee_target(timestamp, target_atto_usd_per_l2_gas).await;
+        let max_l2_gas_price = l2_gas_price_cap_for_height(
+            height,
+            &self.config.dynamic_config.min_l2_gas_price_per_height,
+        );
+        // `resolve_fee_target` returns the operator pin when `override_l2_gas_price_fri` is set;
+        // a pin above the ceiling is deliberate, not oracle drift.
+        let fee_target_is_from_oracle =
+            self.config.dynamic_config.override_l2_gas_price_fri.is_none();
+        let oracle_target_above_maximum =
+            fee_target.filter(|target| fee_target_is_from_oracle && *target > max_l2_gas_price);
+        if let Some(oracle_target) = oracle_target_above_maximum {
+            warn!(
+                "Oracle-derived fee_target {} exceeds the L2 gas price maximum {}, capping the \
+                 fee_proposal band at the maximum",
+                oracle_target.0, max_l2_gas_price.0
+            );
+            SNIP35_FEE_TARGET_ABOVE_MAXIMUM.increment(1);
+        }
 
         let proposal = compute_fee_proposal(
             fee_target,
             fee_actual,
             VersionedConstants::latest_constants().fee_proposal_margin_ppt,
+            max_l2_gas_price,
         );
         SNIP35_FEE_PROPOSAL_FRI.set_lossy(proposal.0);
         proposal
+    }
+
+    /// The values a proposal for `height` is validated against, all derived from this node's own
+    /// state and config, never from the proposal. Both validation paths, the current round and a
+    /// proposal dequeued on a round change, build it here so they judge the same proposal alike.
+    fn proposal_init_validation(&self, height: BlockNumber) -> ProposalInitValidation {
+        ProposalInitValidation {
+            height,
+            block_timestamp_window_seconds: self
+                .config
+                .static_config
+                .block_timestamp_window_seconds,
+            previous_proposal_init: self.previous_proposal_init.clone(),
+            l1_da_mode: self.l1_da_mode,
+            l2_gas_price_fri: self
+                .config
+                .dynamic_config
+                .override_l2_gas_price_fri
+                .map(GasPrice)
+                .unwrap_or(self.l2_gas_price),
+            starknet_version: StarknetVersion::LATEST,
+            fee_actual: compute_fee_actual(
+                &self.fee_proposals_window,
+                height,
+                VersionedConstants::latest_constants().fee_proposal_window_size,
+            ),
+            max_l2_gas_price: l2_gas_price_cap_for_height(
+                height,
+                &self.config.dynamic_config.min_l2_gas_price_per_height,
+            ),
+        }
     }
 
     fn update_l2_gas_price(&mut self, height: BlockNumber, l2_gas_used: GasAmount) {
@@ -873,6 +928,7 @@ impl ConsensusContext for SequencerConsensusContext {
         );
         let fee_proposal = self
             .compute_proposer_fee_proposal(
+                build_param.height,
                 fee_actual,
                 self.deps.clock.unix_now(),
                 self.config.dynamic_config.snip35_target_atto_usd_per_l2_gas,
@@ -964,27 +1020,7 @@ impl ConsensusContext for SequencerConsensusContext {
                 fin_receiver
             }
             std::cmp::Ordering::Equal => {
-                let proposal_init_validation = ProposalInitValidation {
-                    height: init.height,
-                    block_timestamp_window_seconds: self
-                        .config
-                        .static_config
-                        .block_timestamp_window_seconds,
-                    previous_proposal_init: self.previous_proposal_init.clone(),
-                    l1_da_mode: self.l1_da_mode,
-                    l2_gas_price_fri: self
-                        .config
-                        .dynamic_config
-                        .override_l2_gas_price_fri
-                        .map(GasPrice)
-                        .unwrap_or(self.l2_gas_price),
-                    starknet_version: StarknetVersion::LATEST,
-                    fee_actual: compute_fee_actual(
-                        &self.fee_proposals_window,
-                        init.height,
-                        VersionedConstants::latest_constants().fee_proposal_window_size,
-                    ),
-                };
+                let proposal_init_validation = self.proposal_init_validation(init.height);
                 self.validate_current_round_proposal(
                     init,
                     proposal_init_validation,
@@ -1293,27 +1329,7 @@ impl ConsensusContext for SequencerConsensusContext {
         let Some(((init, timeout, content), fin_sender)) = to_process else {
             return Ok(());
         };
-        let proposal_init_validation = ProposalInitValidation {
-            height: init.height,
-            block_timestamp_window_seconds: self
-                .config
-                .static_config
-                .block_timestamp_window_seconds,
-            previous_proposal_init: self.previous_proposal_init.clone(),
-            l1_da_mode: self.l1_da_mode,
-            l2_gas_price_fri: self
-                .config
-                .dynamic_config
-                .override_l2_gas_price_fri
-                .map(GasPrice)
-                .unwrap_or(self.l2_gas_price),
-            starknet_version: StarknetVersion::LATEST,
-            fee_actual: compute_fee_actual(
-                &self.fee_proposals_window,
-                init.height,
-                VersionedConstants::latest_constants().fee_proposal_window_size,
-            ),
-        };
+        let proposal_init_validation = self.proposal_init_validation(init.height);
         self.validate_current_round_proposal(
             init,
             proposal_init_validation,

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -81,6 +81,7 @@ use crate::metrics::{
     CONSENSUS_L2_GAS_PRICE_AT_MINIMUM,
     CONSENSUS_L2_GAS_PRICE_CLAMPED,
     LABEL_L2_GAS_PRICE_CLAMP_BOUND,
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM,
 };
 use crate::sequencer_consensus_context::{
     SequencerConsensusContext,
@@ -97,6 +98,7 @@ use crate::test_utils::{
     INTERNAL_TX_BATCH,
     PARTIAL_BLOCK_HASH,
     TEST_MAX_L2_GAS_PRICE,
+    TEST_MIN_L2_GAS_PRICE,
     TIMEOUT,
     TX_BATCH,
 };
@@ -2100,9 +2102,84 @@ async fn test_compute_proposer_fee_proposal(
 
     let mut context = deps.build_context();
     context.l2_gas_price = l2_gas_price;
-    let proposal =
-        context.compute_proposer_fee_proposal(fee_actual, 0, TARGET_ATTO_USD_PER_L2_GAS).await;
+    let proposal = context
+        .compute_proposer_fee_proposal(BlockNumber(0), fee_actual, 0, TARGET_ATTO_USD_PER_L2_GAS)
+        .await;
     assert_eq!(proposal, expected_fee_proposal);
+}
+
+#[tokio::test]
+async fn test_oracle_target_above_the_ceiling_caps_the_band_and_counts() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM.register();
+
+    let (mut deps, _network) = create_test_and_network_deps();
+    // A rate of 1 atto-USD per STRK drives the oracle-derived target far above the ceiling.
+    // Registered before `setup_default_expectations` so the catch-all default does not shadow it.
+    deps.l1_gas_price_provider.expect_get_strk_to_usd_rate().returning(|_| Ok(1));
+    deps.setup_default_expectations();
+    let mut context = deps.build_context();
+    context.config.dynamic_config.min_l2_gas_price_per_height =
+        vec![PricePerHeight { height: 0, price: TEST_MIN_L2_GAS_PRICE.0 }];
+
+    let proposal = context
+        .compute_proposer_fee_proposal(
+            BlockNumber(0),
+            Some(TEST_MAX_L2_GAS_PRICE),
+            0,
+            TARGET_ATTO_USD_PER_L2_GAS,
+        )
+        .await;
+
+    // The margin band's upper edge before capping is 80_160_000_000.
+    assert_eq!(proposal, TEST_MAX_L2_GAS_PRICE);
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM.assert_eq(&recorder.handle().render(), 1);
+}
+
+#[tokio::test]
+async fn test_operator_override_above_the_ceiling_is_not_oracle_drift() {
+    // The pin is excluded from `snip35_fee_target_above_maximum`.
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM.register();
+
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.setup_default_expectations();
+    let mut context = deps.build_context();
+    context.config.dynamic_config.min_l2_gas_price_per_height =
+        vec![PricePerHeight { height: 0, price: TEST_MIN_L2_GAS_PRICE.0 }];
+    context.config.dynamic_config.override_l2_gas_price_fri = Some(TEST_MAX_L2_GAS_PRICE.0 * 2);
+
+    let proposal = context
+        .compute_proposer_fee_proposal(
+            BlockNumber(0),
+            Some(TEST_MAX_L2_GAS_PRICE),
+            0,
+            TARGET_ATTO_USD_PER_L2_GAS,
+        )
+        .await;
+
+    // The ceiling still caps the published proposal; only the attribution changes.
+    assert_eq!(proposal, TEST_MAX_L2_GAS_PRICE);
+    SNIP35_FEE_TARGET_ABOVE_MAXIMUM.assert_eq(&recorder.handle().render(), 0);
+}
+
+#[tokio::test]
+async fn test_partial_window_freezes_at_an_uncapped_l2_gas_price() {
+    // Pins the deliberate exclusion of the `fee_actual == None` path from the cap: the validator
+    // skips the band check without `fee_actual`, so this is not coverage of the cap itself.
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.setup_default_expectations();
+    let mut context = deps.build_context();
+    let above_the_ceiling = GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 2);
+    context.l2_gas_price = above_the_ceiling;
+
+    let proposal = context
+        .compute_proposer_fee_proposal(BlockNumber(0), None, 0, TARGET_ATTO_USD_PER_L2_GAS)
+        .await;
+
+    assert_eq!(proposal, above_the_ceiling);
 }
 
 #[tokio::test]
@@ -2128,6 +2205,10 @@ async fn test_compute_proposer_fee_proposal_converges_to_oracle_target() {
     }
     deps.setup_default_expectations();
     let mut context = deps.build_context();
+    // Mainnet's configured minimum puts the cap at 150 gwei; the 8 gwei fallback would cap below
+    // this scenario's targets.
+    context.config.dynamic_config.min_l2_gas_price_per_height =
+        vec![PricePerHeight { height: 0, price: 15_000_000_000 }];
 
     // Bootstrap the window with 75 gwei (the $0.04 target).
     let window_size = VersionedConstants::latest_constants().fee_proposal_window_size;
@@ -2142,7 +2223,7 @@ async fn test_compute_proposer_fee_proposal_converges_to_oracle_target() {
             let fee_actual = compute_fee_actual(&context.fee_proposals_window, h, window_size)
                 .expect("window stays complete across the loop");
             let proposal = context
-                .compute_proposer_fee_proposal(Some(fee_actual), 0, TARGET_ATTO_USD_PER_L2_GAS)
+                .compute_proposer_fee_proposal(h, Some(fee_actual), 0, TARGET_ATTO_USD_PER_L2_GAS)
                 .await;
             context.record_fee_proposal(h, Some(proposal));
             height += 1;

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -103,6 +103,9 @@ pub(crate) const DEFAULT_STRK_TO_USD_RATE: u128 = 300_000_000_000_000_000;
 pub(crate) const TEST_MIN_L2_GAS_PRICE: GasPrice = GasPrice(8_000_000_000);
 pub(crate) const TEST_MAX_L2_GAS_PRICE: GasPrice = GasPrice(80_000_000_000);
 
+// A ceiling no band can reach, for cases where the cap is not under test.
+pub(crate) const INERT_MAX_L2_GAS_PRICE: GasPrice = GasPrice(u128::MAX);
+
 pub(crate) static TX_BATCH: LazyLock<Vec<ConsensusTransaction>> =
     LazyLock::new(|| (0..3).map(generate_invoke_tx).collect());
 

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal.rs
@@ -83,6 +83,9 @@ pub(crate) struct ProposalInitValidation {
     /// fee_actual from the sliding window. `None` until the window has accumulated
     /// `fee_proposal_window_size` entries (startup / near-genesis).
     pub fee_actual: Option<GasPrice>,
+    /// L2 gas price ceiling for this height, derived from this validator's own
+    /// `min_l2_gas_price_per_height`, never from the proposal.
+    pub max_l2_gas_price: GasPrice,
 }
 
 /// Parameters for deadline and cancellation handling during proposal finalization.
@@ -404,6 +407,7 @@ async fn is_proposal_init_valid(
         let (lower_bound, upper_bound) = fee_proposal_bounds(
             fee_actual,
             VersionedConstants::latest_constants().fee_proposal_margin_ppt,
+            proposal_init_validation.max_l2_gas_price,
         );
         if fee_proposal.0 < lower_bound || fee_proposal.0 > upper_bound {
             return Err(ValidateProposalError::InvalidProposalInit(

--- a/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/validate_proposal_test.rs
@@ -33,7 +33,7 @@ use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_types_core::felt::Felt;
 use tokio_util::sync::CancellationToken;
 
-use crate::dynamic_gas_price::{proposal_commitment_from, PPT_DENOMINATOR};
+use crate::dynamic_gas_price::{compute_fee_proposal, proposal_commitment_from, PPT_DENOMINATOR};
 use crate::sequencer_consensus_context::BuiltProposals;
 
 fn fee_proposal_margin_ppt() -> u128 {
@@ -45,6 +45,8 @@ use crate::test_utils::{
     SetupDepsArgs,
     TestDeps,
     CHANNEL_SIZE,
+    INERT_MAX_L2_GAS_PRICE,
+    TEST_MAX_L2_GAS_PRICE,
     TIMEOUT,
     TX_BATCH,
 };
@@ -110,6 +112,7 @@ fn create_proposal_validate_arguments()
         l2_gas_price_fri: VersionedConstants::latest_constants().min_gas_price,
         starknet_version: StarknetVersion::LATEST,
         fee_actual: None,
+        max_l2_gas_price: INERT_MAX_L2_GAS_PRICE,
     };
     let proposal_id = ProposalId(1);
     let timeout = TIMEOUT;
@@ -478,6 +481,75 @@ async fn validates_version_constant_commitment(
                 if msg.contains("version_constant_commitment mismatch")
         );
     }
+}
+
+#[rstest]
+// `fee_actual` far above the ceiling collapses the band onto `TEST_MAX_L2_GAS_PRICE`.
+#[case::at_the_cap(TEST_MAX_L2_GAS_PRICE.0, true)]
+#[case::just_below_the_cap(TEST_MAX_L2_GAS_PRICE.0 - 1, false)]
+#[case::just_above_the_cap(TEST_MAX_L2_GAS_PRICE.0 + 1, false)]
+#[tokio::test]
+async fn fee_proposal_band_collapses_to_the_cap(
+    #[case] fee_proposal_fri: u128,
+    #[case] should_accept: bool,
+) {
+    let (proposal_args, _content_sender) = create_proposal_validate_arguments();
+    let TestProposalValidateArguments {
+        deps,
+        mut init,
+        mut proposal_init_validation,
+        gas_price_params,
+        ..
+    } = proposal_args;
+    proposal_init_validation.fee_actual = Some(GasPrice(TEST_MAX_L2_GAS_PRICE.0 * 10));
+    proposal_init_validation.max_l2_gas_price = TEST_MAX_L2_GAS_PRICE;
+    init.fee_proposal_fri = Some(GasPrice(fee_proposal_fri));
+
+    let res = is_proposal_init_valid(
+        &proposal_init_validation,
+        &init,
+        deps.clock.as_ref(),
+        Arc::new(deps.l1_gas_price_provider),
+        &gas_price_params,
+    )
+    .await;
+
+    assert_eq!(res.is_ok(), should_accept, "got {res:?}");
+}
+
+#[tokio::test]
+async fn proposer_and_validator_agree_on_the_capped_band() {
+    let (proposal_args, _content_sender) = create_proposal_validate_arguments();
+    let TestProposalValidateArguments {
+        deps,
+        mut init,
+        mut proposal_init_validation,
+        gas_price_params,
+        ..
+    } = proposal_args;
+    // A malicious oracle reporting STRK as nearly worthless drives the target to the maximum.
+    let fee_actual = TEST_MAX_L2_GAS_PRICE;
+    let fee_proposal = compute_fee_proposal(
+        Some(GasPrice(u128::MAX)),
+        fee_actual,
+        fee_proposal_margin_ppt(),
+        TEST_MAX_L2_GAS_PRICE,
+    );
+    proposal_init_validation.fee_actual = Some(fee_actual);
+    proposal_init_validation.max_l2_gas_price = TEST_MAX_L2_GAS_PRICE;
+    init.fee_proposal_fri = Some(fee_proposal);
+
+    let res = is_proposal_init_valid(
+        &proposal_init_validation,
+        &init,
+        deps.clock.as_ref(),
+        Arc::new(deps.l1_gas_price_provider),
+        &gas_price_params,
+    )
+    .await;
+
+    assert!(res.is_ok(), "honest proposal rejected: {res:?}");
+    assert_eq!(fee_proposal, TEST_MAX_L2_GAS_PRICE);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Ports #14946 onto `main-v0.14.4`. The fee proposal band is now clamped to the L2 gas price ceiling, and this adds the **only increment site in the codebase** for `SNIP35_FEE_TARGET_ABOVE_MAXIMUM`.

That second part closes a live gap. The metric is already defined and registered on trunk (from #14978), and both an alert and a dashboard panel read it, but nothing increments it. The alert is deployed on all six mainnet nodes today and is permanently silent until this lands.

Deferred from 0.14.3 at Matan's request, so the metric would be rehomed into the PR that actually enforces the cap rather than sitting unused in #14978.

---

# Detailed Summary for AI Bots

## What changed

- `compute_fee_proposal` and `fee_proposal_bounds` take a `max_gas_price` and cap **both** band edges at it.
- The oracle-failure path (`fee_target == None`) now goes through the same clamp instead of returning `fee_actual` raw.
- `ProposalInitValidation` gains `max_l2_gas_price`. The validator derives it from its **own** `min_l2_gas_price_per_height` via `l2_gas_price_cap(get_min_gas_price_for_height(..))` at both validate call sites, never from the proposal. A malicious proposer therefore cannot widen the band it is checked against.
- `SNIP35_FEE_TARGET_ABOVE_MAXIMUM` is incremented in `compute_proposer_fee_proposal`, guarded by `override_l2_gas_price_fri.is_none()` so that targets originating from the operator pin are excluded, per the metric's own description. Reachable from `ConsensusContext::build_proposal`.

## Port notes

The source branch also added the metric definition and its `register_metrics()` line. Those were **deliberately not ported**, because `main-v0.14.4` already carries both from #14978. Verified there is no duplicate definition or registration.

The predecessor commit on the source branch (`l2_gas_price_cap`, `MAX_GAS_PRICE_MULTIPLIER`, `NextL2GasPrice`, `CONSENSUS_L2_GAS_PRICE_CLAMPED`) is already on `main-v0.14.4`, so only the second commit needed porting.

## Verification

`rust_fmt`, `cargo clippy -p apollo_consensus_orchestrator --all-features --all-targets -- -D warnings`, and `SEED=0 cargo nextest run -p apollo_consensus_orchestrator --all-features` (238 tests) all pass. `apollo_dashboard` is untouched, so no dashboard regeneration was needed.

Note for reviewers: `cargo build -p apollo_consensus_orchestrator --all-features` fails at `cende/python_compat.rs:13` on this base already, unrelated to this change. `cargo nextest run --all-features`, which is what CI runs, compiles fine.
