### PR TITLE
apollo_versioned_constants,apollo_consensus_orchestrator: version the L2 gas price multiplier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ version = "0.20.0-rc.0"
 dependencies = [
  "serde",
  "starknet_api",
+ "strum",
  "thiserror 1.0.69",
 ]
 

--- a/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
+++ b/crates/apollo_consensus_orchestrator/src/fee_market/mod.rs
@@ -22,12 +22,6 @@ mod test;
 // in approximately 10 minutes.
 const MIN_GAS_PRICE_INCREASE_DENOMINATOR: u128 = 333;
 
-// Ceiling on the L2 gas price, as a multiple of the minimum gas price in force for the height.
-// TODO(asaf-sw): Move to versioned constants in 0.14.4.
-const MAX_GAS_PRICE_MULTIPLIER: u128 = 10;
-// A multiplier of 0 or 1 pins the L2 gas price at 0 or at the minimum.
-const _: () = assert!(MAX_GAS_PRICE_MULTIPLIER > 1);
-
 /// Fee market information for the next block.
 #[cfg_attr(any(feature = "testing", test), derive(serde::Deserialize, PartialEq))]
 #[derive(Debug, Default, Serialize)]
@@ -59,11 +53,12 @@ pub fn get_min_gas_price_for_height(
         .unwrap_or(fallback_min_gas_price)
 }
 
-/// The ceiling on the L2 gas price: `MAX_GAS_PRICE_MULTIPLIER` times `min_gas_price`. Applies to
+/// The ceiling on the L2 gas price: `max_gas_price_multiplier` times `min_gas_price`. Applies to
 /// every block regardless of its `starknet_version`. Proposer and validator reach the ceiling
 /// through this function, so they cannot disagree on it.
 pub fn l2_gas_price_cap(min_gas_price: GasPrice) -> GasPrice {
-    GasPrice(min_gas_price.0.saturating_mul(MAX_GAS_PRICE_MULTIPLIER))
+    let max_gas_price_multiplier = VersionedConstants::latest_constants().max_gas_price_multiplier;
+    GasPrice(min_gas_price.0.saturating_mul(max_gas_price_multiplier))
 }
 
 /// The ceiling in force at `height`: the cap over the minimum configured for that height. The

--- a/crates/apollo_consensus_orchestrator/src/fee_market/test.rs
+++ b/crates/apollo_consensus_orchestrator/src/fee_market/test.rs
@@ -13,7 +13,6 @@ use crate::fee_market::{
     calculate_next_l2_gas_price_for_fin,
     get_min_gas_price_for_height,
     l2_gas_price_cap,
-    MAX_GAS_PRICE_MULTIPLIER,
     MIN_GAS_PRICE_INCREASE_DENOMINATOR,
 };
 use crate::metrics::{CONSENSUS_L2_GAS_PRICE_CLAMPED, LABEL_L2_GAS_PRICE_CLAMP_BOUND};
@@ -244,7 +243,10 @@ fn test_price_constants_match_the_shipped_values() {
     // Tests that leave `min_l2_gas_price_per_height` empty get this fallback as their minimum, and
     // `TEST_MAX_L2_GAS_PRICE` as the ceiling it implies.
     assert_eq!(TEST_MIN_L2_GAS_PRICE, VERSIONED_CONSTANTS.min_gas_price);
-    assert_eq!(TEST_MAX_L2_GAS_PRICE.0, TEST_MIN_L2_GAS_PRICE.0 * MAX_GAS_PRICE_MULTIPLIER);
+    assert_eq!(
+        TEST_MAX_L2_GAS_PRICE.0,
+        TEST_MIN_L2_GAS_PRICE.0 * VERSIONED_CONSTANTS.max_gas_price_multiplier
+    );
 }
 
 #[test]

--- a/crates/apollo_dashboard/src/alert_scenarios/l2_gas_price.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/l2_gas_price.rs
@@ -47,7 +47,7 @@ pub(crate) fn get_l2_gas_price_at_minimum_alert() -> Alert {
 }
 
 /// Alert while the computed L2 gas price keeps running into the ceiling
-/// (`MAX_GAS_PRICE_MULTIPLIER` times the configured minimum): either the price itself is capped
+/// (`max_gas_price_multiplier` times the configured minimum): either the price itself is capped
 /// there, or the SNIP-35 floor alone has risen above it while the published price ramps up to
 /// match.
 ///

--- a/crates/apollo_versioned_constants/Cargo.toml
+++ b/crates/apollo_versioned_constants/Cargo.toml
@@ -13,6 +13,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 starknet_api = { workspace = true, features = ["testing"] }
+strum.workspace = true
 
 [lints]
 workspace = true

--- a/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_0.json
+++ b/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_0.json
@@ -4,6 +4,7 @@
     "gas_price_max_change_denominator": 48,
     "gas_target": 3200000000,
     "max_block_size": 4000000000,
+    "max_gas_price_multiplier": 10,
     "min_gas_price": "0xb2d05e00",
     "l1_gas_price_margin_percent": 10
 }

--- a/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_1.json
+++ b/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_1.json
@@ -4,6 +4,7 @@
     "gas_price_max_change_denominator": 48,
     "gas_target": 4000000000,
     "max_block_size": 5000000000,
+    "max_gas_price_multiplier": 10,
     "min_gas_price": "0x1dcd65000",
     "l1_gas_price_margin_percent": 10
 }

--- a/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_2.json
+++ b/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_2.json
@@ -4,6 +4,7 @@
     "gas_price_max_change_denominator": 48,
     "gas_target": 1500000000,
     "max_block_size": 5800000000,
+    "max_gas_price_multiplier": 10,
     "min_gas_price": "0x1dcd65000",
     "l1_gas_price_margin_percent": 10
 }

--- a/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_3.json
+++ b/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_3.json
@@ -4,6 +4,7 @@
     "gas_price_max_change_denominator": 48,
     "gas_target": 1040000000,
     "max_block_size": 5800000000,
+    "max_gas_price_multiplier": 10,
     "min_gas_price": "0x1dcd65000",
     "l1_gas_price_margin_percent": 10
 }

--- a/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_4.json
+++ b/crates/apollo_versioned_constants/resources/orchestrator_versioned_constants_0_14_4.json
@@ -4,6 +4,7 @@
     "gas_price_max_change_denominator": 48,
     "gas_target": 1040000000,
     "max_block_size": 5800000000,
+    "max_gas_price_multiplier": 10,
     "min_gas_price": "0x1dcd65000",
     "l1_gas_price_margin_percent": 10
 }

--- a/crates/apollo_versioned_constants/src/lib.rs
+++ b/crates/apollo_versioned_constants/src/lib.rs
@@ -5,6 +5,10 @@ use starknet_api::execution_resources::GasAmount;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use thiserror::Error;
 
+#[cfg(test)]
+#[path = "test.rs"]
+mod test;
+
 /// Versioned constants for the Consensus.
 #[derive(Clone, Debug, Deserialize)]
 pub struct VersionedConstants {
@@ -14,6 +18,9 @@ pub struct VersionedConstants {
     pub gas_price_max_change_denominator: u128,
     /// The minimum gas price in fri.
     pub min_gas_price: GasPrice,
+    /// Ceiling on the L2 gas price, as a multiple of the minimum gas price in force for the
+    /// height. Must be greater than one. Every version's resource states it explicitly.
+    pub max_gas_price_multiplier: u128,
     /// The maximum block size in gas units.
     // NOTE: Must stay in sync with BouncerWeights receipt_l2_gas.
     // NOTE: When max_block_size is changed, update `gas_target` accordingly to maintain the ratio.

--- a/crates/apollo_versioned_constants/src/test.rs
+++ b/crates/apollo_versioned_constants/src/test.rs
@@ -1,0 +1,24 @@
+use starknet_api::block::StarknetVersion;
+use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
+use strum::IntoEnumIterator;
+
+use super::VersionedConstants;
+
+#[test]
+fn max_gas_price_multiplier_is_above_one_in_every_version() {
+    let supported_constants: Vec<_> = StarknetVersion::iter()
+        .filter_map(|version| {
+            VersionedConstants::get(&version)
+                .ok()
+                .map(|versioned_constants| (version, versioned_constants))
+        })
+        .collect();
+    assert!(!supported_constants.is_empty());
+    for (version, versioned_constants) in supported_constants {
+        assert!(
+            versioned_constants.max_gas_price_multiplier > 1,
+            "max_gas_price_multiplier of {version} must be greater than one, got {}.",
+            versioned_constants.max_gas_price_multiplier
+        );
+    }
+}


### PR DESCRIPTION
Moves the L2 gas price ceiling multiplier from a compile-time constant into `VersionedConstants`, so changing the ceiling no longer needs a release. Resolves the `TODO(asaf-sw)` in `fee_market/mod.rs`.

Every version's resource states the value explicitly as 10, which is what `MAX_GAS_PRICE_MULTIPLIER` was as a compile-time constant applied to all versions, so no version's pricing changes.

Stacked on #15050.

---

# Detailed Summary for AI Bots

## What changed

- `VersionedConstants` (`apollo_versioned_constants`) gains `max_gas_price_multiplier: u128`.
- `"max_gas_price_multiplier": 10` added to all five `orchestrator_versioned_constants_0_14_{0..4}.json`. All five carry an identical key set, matching the convention across `blockifier`'s 17 resources: every version's JSON states every field, and neither VC struct uses a serde default.
- `l2_gas_price_cap` reads the value from `VersionedConstants::latest_constants()` and keeps `saturating_mul`.
- The deleted `const _: () = assert!(MAX_GAS_PRICE_MULTIPLIER > 1)` is replaced by a test, `max_gas_price_multiplier_is_above_one_in_every_version` in `apollo_versioned_constants`, which asserts the invariant for every version the crate ships. There is no runtime check: the value is compiled in via `include_str!` behind a `LazyLock`, so it cannot vary at runtime, and a per-block assert on the fee path would only turn a CI failure into a node panic.

## Required step for the forward merge to main

**Mandatory.** `main` carries `orchestrator_versioned_constants_0_14_5.json`, which this branch cannot touch because that file does not exist on the `main-v0.14.4` lineage. Add `"max_gas_price_multiplier": 10` to it during the merge.

Without it, `serde_json::from_str` on that resource fails with `missing field max_gas_price_multiplier`, and the first `VersionedConstants::latest_constants()` call panics, since `V0_14_5` is `LATEST` on main. That is a crash on the first block proposal or validation after startup.

Both `max_gas_price_multiplier_is_above_one_in_every_version` and `test_vc_diffs_regression` catch the omission in CI. Verified by negative control: stripping the key from `orchestrator_versioned_constants_0_14_2.json` fails the former with exactly that `missing field` panic.

## Not affected

The `consensus_l2_gas_price_above_maximum` alert reads the node's own clamp counter and carries no threshold of its own, so it follows the constant automatically. Only its doc comment mentioned the old identifier, and that is updated.

## Verification

`rust_fmt`, clippy on `apollo_versioned_constants` / `apollo_consensus_orchestrator` / `apollo_dashboard` with `-D warnings`, 262 tests across those three packages, and `apollo_versioned_constants` standalone (feature unification differs, and standalone is the shape of CI's per-package job).
