### PR TITLE
apollo_consensus_orchestrator,apollo_l1_gas_price: bound the per-block eth to fri rate change

### DIFF
--- a/crates/apollo_consensus_manager/src/consensus_manager.rs
+++ b/crates/apollo_consensus_manager/src/consensus_manager.rs
@@ -168,9 +168,9 @@ impl ConsensusManager {
         let current_height =
             self.batcher_client.get_height().await.expect("Failed to get height from batcher");
         consensus_context
-            .initialize_fee_proposals_window(current_height.height)
+            .initialize_from_committed_blocks(current_height.height)
             .await
-            .expect("Failed to bootstrap fee_proposals window");
+            .expect("Failed to bootstrap from committed blocks");
         let run_consensus_args = self.create_run_consensus_args(current_height.height);
 
         let network_task =

--- a/crates/apollo_consensus_orchestrator/Cargo.toml
+++ b/crates/apollo_consensus_orchestrator/Cargo.toml
@@ -83,6 +83,8 @@ rand_chacha.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 shared_execution_objects = { workspace = true, features = ["deserialize", "testing"] }
+# `test-util` for `tokio::test(start_paused = true)`, which skips the state_sync retry sleeps.
+tokio = { workspace = true, features = ["test-util"] }
 tracing-test.workspace = true
 
 [lints]

--- a/crates/apollo_consensus_orchestrator/src/metrics.rs
+++ b/crates/apollo_consensus_orchestrator/src/metrics.rs
@@ -20,6 +20,7 @@ define_metrics!(
         LabeledMetricCounter { CONSENSUS_L2_GAS_PRICE_CLAMPED, "consensus_l2_gas_price_clamped", "Number of times a clamp bound the computed next L2 gas price. `minimum`: the previous price was below the effective minimum, i.e. still ramping up towards the floor. A price at or above the floor is not counted, even when the floor raised it; see consensus_l2_gas_price_at_minimum. `maximum`: bound by the ceiling, including when only the SNIP-35 floor was clipped, in which case the published price can be below the ceiling", init = 0, labels = L2_GAS_PRICE_CLAMP_BOUND },
         MetricCounter { CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR, "consensus_l1_gas_price_provider_error", "Number of times the context got an error when querying the L1 gas price provider", init=0},
         MetricCounter { CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH, "consensus_retrospective_block_hash_mismatch", "Number of times the retrospective block hashes of the state sync and the batcher mismatched", init=0},
+        MetricCounter { CONSENSUS_ETH_TO_FRI_RATE_CLAMPED, "consensus_eth_to_fri_rate_clamped", "Number of times the eth to fri rate from the oracle was clamped to the per-block change bound around the rate implied by the previous block. Not counted when the clamp does not run: the override_eth_to_fri_rate operator pin replaces the rate, or the previous block implies no rate (genesis, or recorded prices that yield no rate)", init=0},
 
 
         // Cende metrics
@@ -125,6 +126,7 @@ pub(crate) fn register_metrics() {
     CONSENSUS_L2_GAS_PRICE_CLAMPED.register();
     CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR.register();
     CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH.register();
+    CONSENSUS_ETH_TO_FRI_RATE_CLAMPED.register();
     CENDE_LAST_PREPARED_BLOB_BLOCK_NUMBER.register();
     CENDE_PREPARE_BLOB_FOR_NEXT_HEIGHT_LATENCY.register();
     CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY.register();

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -6,7 +6,7 @@
 mod sequencer_consensus_context_test;
 
 use std::cmp::max;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -333,39 +333,56 @@ impl SequencerConsensusContext {
         self.fee_proposals_window = self.fee_proposals_window.split_off(&cutoff);
     }
 
-    /// Fill `[start_height - WINDOW, start_height)` from local state_sync storage. Must be
-    /// called before `run_consensus` so the window is populated before voting begins. Blocks
-    /// state_sync has not caught up to yet are pushed to the back of the queue and revisited —
-    /// joining consensus with a partial window would make this node disagree with caught-up
-    /// peers on `fee_actual`. Other state_sync errors propagate.
-    pub async fn initialize_fee_proposals_window(
+    /// Fill `fee_proposals_window` from `[start_height - fee_proposal_window_size, start_height)`
+    /// and `previous_proposal_init` from `start_height - 1`, both read from local state_sync
+    /// storage. Must be called before `run_consensus`: joining consensus with a partial window
+    /// would make this node disagree with caught-up peers on `fee_actual`, and joining with
+    /// `previous_proposal_init` unset would make it propose an eth to fri rate its peers clamp.
+    /// Waits for state_sync to reach each height.
+    ///
+    /// `previous_proposal_init` is also `try_sync`'s lower bound on a synced block's timestamp, so
+    /// seeding it holds the first synced block after a restart to the same monotonicity every
+    /// later one already faced.
+    pub async fn initialize_from_committed_blocks(
         &mut self,
         start_height: BlockNumber,
     ) -> StateSyncClientResult<()> {
-        const STATE_SYNC_RETRY_INTERVAL: Duration = Duration::from_millis(500);
         let window_size = VersionedConstants::latest_constants().fee_proposal_window_size;
-        let window_end_height = start_height.0;
-        let window_start_height = window_end_height.saturating_sub(window_size);
-        let mut pending_heights: VecDeque<BlockNumber> =
-            (window_start_height..window_end_height).map(BlockNumber).collect();
-        while let Some(block_number) = pending_heights.pop_front() {
-            match self.deps.state_sync_client.get_block(block_number).await {
-                Ok(block) => self.record_fee_proposal(
-                    block_number,
-                    block.block_header_without_hash.fee_proposal_fri,
-                ),
-                Err(StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(_))) => {
-                    warn!(
-                        "State sync not ready for height {block_number}; re-queueing after \
-                         {STATE_SYNC_RETRY_INTERVAL:?}"
-                    );
-                    pending_heights.push_back(block_number);
-                    tokio::time::sleep(STATE_SYNC_RETRY_INTERVAL).await;
-                }
-                Err(e) => return Err(e),
-            }
+        let window_start_height = start_height.0.saturating_sub(window_size);
+        for block_number in (window_start_height..start_height.0).map(BlockNumber) {
+            let block_header = self.committed_block_header(block_number).await?;
+            self.record_fee_proposal(block_number, block_header.fee_proposal_fri);
+        }
+        // Genesis has no previous block, so `previous_proposal_init` stays `None` and the first
+        // block's eth to fri rate is unclamped and its timestamp unbounded from below.
+        if let Some(previous_height) = start_height.prev() {
+            let block_header = self.committed_block_header(previous_height).await?;
+            self.previous_proposal_init =
+                Some(previous_proposal_init_from_block_header(&block_header));
         }
         Ok(())
+    }
+
+    /// Reads a committed block's header from local state_sync storage, waiting for state_sync to
+    /// catch up to the height. Other state_sync errors propagate.
+    async fn committed_block_header(
+        &self,
+        block_number: BlockNumber,
+    ) -> StateSyncClientResult<BlockHeaderWithoutHash> {
+        const STATE_SYNC_RETRY_INTERVAL: Duration = Duration::from_millis(500);
+        loop {
+            match self.deps.state_sync_client.get_block(block_number).await {
+                Ok(block) => return Ok(block.block_header_without_hash),
+                Err(StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(_))) => {
+                    warn!(
+                        "State sync not ready for height {block_number}; retrying after \
+                         {STATE_SYNC_RETRY_INTERVAL:?}"
+                    );
+                    tokio::time::sleep(STATE_SYNC_RETRY_INTERVAL).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     async fn start_stream(&mut self, stream_id: HeightAndRound) -> StreamSender {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::future::ready;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
@@ -43,6 +44,7 @@ use apollo_state_sync_types::errors::StateSyncError;
 use apollo_state_sync_types::state_sync_types::SyncBlock;
 use apollo_time::time::MockClock;
 use apollo_versioned_constants::VersionedConstants;
+use assert_matches::assert_matches;
 use chrono::{TimeZone, Utc};
 use futures::channel::mpsc;
 use futures::channel::oneshot::Canceled;
@@ -54,7 +56,9 @@ use starknet_api::block::{
     BlockHash,
     BlockHeaderWithoutHash,
     BlockNumber,
+    BlockTimestamp,
     GasPrice,
+    GasPricePerToken,
     StarknetVersion,
     TEMP_ETH_BLOB_GAS_FEE_IN_WEI,
     TEMP_ETH_GAS_FEE_IN_WEI,
@@ -2064,10 +2068,11 @@ fn test_prune_fee_proposals_window(
     assert_eq!(context.fee_proposals_window, expected_window);
 }
 
-// `initialize_fee_proposals_window` reads `[start_height - WINDOW, start_height)` from state_sync
-// and records each block's `fee_proposal_fri`. `expected_window` is the mapping the test asserts;
-// the mock answers `get_block(h)` from the same map. Genesis case (`start_height < WINDOW_SIZE`)
-// is exercised by a smaller window: the bootstrap range collapses to `[0, start_height)`.
+// `initialize_from_committed_blocks` reads `[start_height - WINDOW, start_height)` from state_sync
+// and records each block's `fee_proposal_fri`, then re-reads `start_height - 1` to seed
+// `previous_proposal_init`. `expected_window` is the mapping the test asserts; the mock answers
+// `get_block(h)` from the same map. Genesis case (`start_height < WINDOW_SIZE`) is exercised by a
+// smaller window: the bootstrap range collapses to `[0, start_height)`.
 #[rstest]
 #[case::all_some(BlockNumber(100), window_of(90..100))]
 // v0.14.2 era: every block recorded with `fee_proposal_fri = None`.
@@ -2081,13 +2086,15 @@ fn test_prune_fee_proposals_window(
 )]
 #[case::genesis_collapses_range(BlockNumber(3), window_of(0..3))]
 #[tokio::test]
-async fn test_initialize_fee_proposals_window(
+async fn test_initialize_from_committed_blocks(
     #[case] start_height: BlockNumber,
     #[case] expected_window: BTreeMap<BlockNumber, Option<GasPrice>>,
 ) {
     let mock_window = expected_window.clone();
     let (mut deps, _network) = create_test_and_network_deps();
-    deps.state_sync_client.expect_get_block().times(expected_window.len()).returning(
+    // One read per window height, plus the re-read of `start_height - 1` that seeds
+    // `previous_proposal_init`.
+    deps.state_sync_client.expect_get_block().times(expected_window.len() + 1).returning(
         move |height| {
             let mut sync_block = SyncBlock::default();
             sync_block.block_header_without_hash.block_number = height;
@@ -2099,8 +2106,128 @@ async fn test_initialize_fee_proposals_window(
     deps.setup_default_expectations();
 
     let mut context = deps.build_context();
-    context.initialize_fee_proposals_window(start_height).await.unwrap();
+    context.initialize_from_committed_blocks(start_height).await.unwrap();
     assert_eq!(context.fee_proposals_window, expected_window);
+}
+
+// `previous_proposal_init` is the band center `clamp_eth_to_fri_rate_change` clamps around, so a
+// node restarted at tip must hold it before it votes.
+#[tokio::test]
+async fn test_initialize_from_committed_blocks_seeds_previous_block() {
+    const START_HEIGHT: BlockNumber = BlockNumber(100);
+    const PREVIOUS_TIMESTAMP: BlockTimestamp = BlockTimestamp(1_700_000_000);
+    const PREVIOUS_L1_GAS_PRICE: GasPricePerToken =
+        GasPricePerToken { price_in_wei: GasPrice(7), price_in_fri: GasPrice(11) };
+    const PREVIOUS_L1_DATA_GAS_PRICE: GasPricePerToken =
+        GasPricePerToken { price_in_wei: GasPrice(13), price_in_fri: GasPrice(17) };
+
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.state_sync_client.expect_get_block().returning(move |height| {
+        let mut sync_block = SyncBlock::default();
+        sync_block.block_header_without_hash.block_number = height;
+        // Only `start_height - 1` carries the prices, so the assertions below cannot pass on a
+        // block read for the fee window.
+        if height == START_HEIGHT.prev().unwrap() {
+            sync_block.block_header_without_hash.timestamp = PREVIOUS_TIMESTAMP;
+            sync_block.block_header_without_hash.l1_gas_price = PREVIOUS_L1_GAS_PRICE;
+            sync_block.block_header_without_hash.l1_data_gas_price = PREVIOUS_L1_DATA_GAS_PRICE;
+        }
+        Ok(sync_block)
+    });
+    deps.setup_default_expectations();
+
+    let mut context = deps.build_context();
+    context.initialize_from_committed_blocks(START_HEIGHT).await.unwrap();
+
+    let previous_proposal_init = context.previous_proposal_init.unwrap();
+    assert_eq!(previous_proposal_init.timestamp, PREVIOUS_TIMESTAMP.0);
+    assert_eq!(
+        previous_proposal_init.l1_prices_wei.l1_gas_price,
+        PREVIOUS_L1_GAS_PRICE.price_in_wei
+    );
+    assert_eq!(
+        previous_proposal_init.l1_prices_wei.l1_data_gas_price,
+        PREVIOUS_L1_DATA_GAS_PRICE.price_in_wei
+    );
+    assert_eq!(
+        previous_proposal_init.l1_prices_fri.l1_gas_price,
+        PREVIOUS_L1_GAS_PRICE.price_in_fri
+    );
+    assert_eq!(
+        previous_proposal_init.l1_prices_fri.l1_data_gas_price,
+        PREVIOUS_L1_DATA_GAS_PRICE.price_in_fri
+    );
+}
+
+// The retry loop that carries a node restarted ahead of state_sync: a height that is not there
+// yet is read again, in place, until it is.
+#[tokio::test(start_paused = true)]
+async fn test_initialize_from_committed_blocks_retries_a_height_state_sync_lacks() {
+    const START_HEIGHT: BlockNumber = BlockNumber(1);
+    const NOT_READY_READS: usize = 3;
+    const RECORDED_FEE_PROPOSAL: GasPrice = GasPrice(9_000_000_000);
+
+    let (mut deps, _network) = create_test_and_network_deps();
+    let n_reads = Arc::new(AtomicUsize::new(0));
+    let n_reads_in_mock = n_reads.clone();
+    deps.state_sync_client.expect_get_block().returning(move |height| {
+        if n_reads_in_mock.fetch_add(1, Ordering::SeqCst) < NOT_READY_READS {
+            return Err(StateSyncClientError::StateSyncError(StateSyncError::BlockNotFound(
+                height,
+            )));
+        }
+        let mut sync_block = SyncBlock::default();
+        sync_block.block_header_without_hash.block_number = height;
+        sync_block.block_header_without_hash.fee_proposal_fri = Some(RECORDED_FEE_PROPOSAL);
+        Ok(sync_block)
+    });
+    deps.setup_default_expectations();
+
+    let mut context = deps.build_context();
+    context.initialize_from_committed_blocks(START_HEIGHT).await.unwrap();
+
+    // The window collapses to `[0, 1)`, so the single window height and the re-read that seeds
+    // `previous_proposal_init` are both height 0: no height is skipped over while state_sync
+    // catches up.
+    assert_eq!(
+        context.fee_proposals_window,
+        BTreeMap::from([(BlockNumber(0), Some(RECORDED_FEE_PROPOSAL))])
+    );
+    assert!(context.previous_proposal_init.is_some());
+    assert_eq!(n_reads.load(Ordering::SeqCst), NOT_READY_READS + 2);
+}
+
+// Only `BlockNotFound` is retried; any other state_sync error aborts the bootstrap rather than
+// looping, so the caller's `expect` stops the node instead of voting on a partial window.
+#[tokio::test]
+async fn test_initialize_from_committed_blocks_propagates_other_state_sync_errors() {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.state_sync_client
+        .expect_get_block()
+        .returning(|_| Err(StateSyncClientError::StateSyncError(StateSyncError::EmptyState)));
+    deps.setup_default_expectations();
+
+    let mut context = deps.build_context();
+    let result = context.initialize_from_committed_blocks(BlockNumber(1)).await;
+
+    assert_matches!(result, Err(StateSyncClientError::StateSyncError(StateSyncError::EmptyState)));
+    assert!(context.fee_proposals_window.is_empty());
+    assert!(context.previous_proposal_init.is_none());
+}
+
+// Genesis has no previous block: `previous_proposal_init` stays `None` and no read is attempted
+// for it.
+#[tokio::test]
+async fn test_initialize_from_committed_blocks_at_genesis_leaves_previous_proposal_init_unset() {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.state_sync_client.expect_get_block().never();
+    deps.setup_default_expectations();
+
+    let mut context = deps.build_context();
+    context.initialize_from_committed_blocks(BlockNumber(0)).await.unwrap();
+
+    assert!(context.previous_proposal_init.is_none());
+    assert!(context.fee_proposals_window.is_empty());
 }
 
 #[derive(Clone)]

--- a/crates/apollo_consensus_orchestrator/src/utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils.rs
@@ -16,6 +16,7 @@ use apollo_state_sync_types::errors::StateSyncError;
 use apollo_time::time::{Clock, DateTime};
 // TODO(Gilad): Define in consensus, either pass to blockifier as config or keep the dup.
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
+use ethnum::U256;
 use futures::channel::mpsc;
 use futures::SinkExt;
 use num_rational::Ratio;
@@ -33,10 +34,12 @@ use starknet_api::block::{
 use starknet_api::consensus_transaction::InternalConsensusTransaction;
 use starknet_api::hash::StarkHash;
 use starknet_api::StarknetApiError;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::cende::{CendeAmbassadorError, CendeContext};
+use crate::dynamic_gas_price::PPT_DENOMINATOR;
 use crate::metrics::{
+    CONSENSUS_ETH_TO_FRI_RATE_CLAMPED,
     CONSENSUS_L1_GAS_PRICE_PROVIDER_ERROR,
     CONSENSUS_RETROSPECTIVE_BLOCK_HASH_MISMATCH,
 };
@@ -101,6 +104,7 @@ pub(crate) struct GasPriceParams {
     pub override_l1_gas_price_fri: Option<GasPrice>,
     pub override_l1_data_gas_price_fri: Option<GasPrice>,
     pub override_eth_to_fri_rate: Option<u128>,
+    pub max_eth_to_fri_rate_change_ppt: u128,
 }
 
 #[derive(Clone, Debug)]
@@ -183,6 +187,18 @@ pub(crate) async fn get_l1_prices_in_fri_and_wei_and_conversion_rate(
             "raw eth_to_fri_rate (from oracle): {eth_to_fri_rate}, raw l1 gas price wei (from \
              provider): {price_info:?}"
         );
+        // `get_l1_prices_in_fri_and_wei` replaces the rate with the operator pin when
+        // `override_eth_to_fri_rate` is set, so clamping it would warn and count a clamp that
+        // shapes no published price. A pin is deliberate, not feed drift.
+        let eth_to_fri_rate = if gas_price_params.override_eth_to_fri_rate.is_some() {
+            eth_to_fri_rate
+        } else {
+            clamp_eth_to_fri_rate_change(
+                eth_to_fri_rate,
+                previous_proposal_init,
+                gas_price_params.max_eth_to_fri_rate_change_ppt,
+            )
+        };
         apply_fee_transformations(&mut price_info, gas_price_params);
         let prices_in_wei = L1PricesInWei {
             l1_gas_price: price_info.base_fee_per_gas,
@@ -557,12 +573,82 @@ pub(crate) fn make_gas_price_params(config: &ContextDynamicConfig) -> GasPricePa
         max_l1_gas_price_wei: GasPrice(config.max_l1_gas_price_wei),
         min_l1_data_gas_price_wei: GasPrice(config.min_l1_data_gas_price_wei),
         max_l1_data_gas_price_wei: GasPrice(config.max_l1_data_gas_price_wei),
-        l1_data_gas_price_multiplier: Ratio::new(config.l1_data_gas_price_multiplier_ppt, 1000),
+        l1_data_gas_price_multiplier: Ratio::new(
+            config.l1_data_gas_price_multiplier_ppt,
+            PPT_DENOMINATOR,
+        ),
         l1_gas_tip_wei: GasPrice(config.l1_gas_tip_wei),
         override_l1_gas_price_fri: config.override_l1_gas_price_fri.map(GasPrice),
         override_l1_data_gas_price_fri: config.override_l1_data_gas_price_fri.map(GasPrice),
         override_eth_to_fri_rate: config.override_eth_to_fri_rate,
+        max_eth_to_fri_rate_change_ppt: config.max_eth_to_fri_rate_change_ppt,
     }
+}
+
+/// Clamp a freshly fetched eth to fri rate into a band of `max_eth_to_fri_rate_change_ppt` parts
+/// per thousand around the rate implied by the previous block, and return the clamped value.
+///
+/// The band's center is recomputed from the previous block's recorded wei and fri prices, so every
+/// validator that holds the previous block derives the same center and maps a given oracle reading
+/// to the same rate. Clamping rather than rejecting bounds the effect of a single manipulated
+/// reading on the rate an honest node publishes.
+///
+/// The band bounds what an honest node publishes, not how far the center can move: a proposal's wei
+/// and fri prices are each checked against `l1_gas_price_margin_percent` on its own
+/// (`validate_proposal::within_margin`), never as a ratio, so an accepted proposal can imply a
+/// center `(1 + margin) / (1 - margin)` away from the rate the validator itself holds.
+///
+/// Only genesis has no previous block: a restarted node seeds `previous_proposal_init` from
+/// state_sync in `SequencerConsensusContext::initialize_from_committed_blocks` before it votes.
+///
+/// Not applied when `override_eth_to_fri_rate` pins the rate, since the pin replaces the clamped
+/// value.
+// TODO(Asaf): bound the rate a proposal implies against this band too, so that a single accepted
+// proposal cannot move the center further than the band allows.
+fn clamp_eth_to_fri_rate_change(
+    oracle_eth_to_fri_rate: u128,
+    previous_proposal_init: Option<&PreviousProposalInitInfo>,
+    max_eth_to_fri_rate_change_ppt: u128,
+) -> u128 {
+    // Genesis: no previous block to center the band on, so the oracle rate is used as is.
+    let Some(previous_proposal_init) = previous_proposal_init else {
+        return oracle_eth_to_fri_rate;
+    };
+    let previous_eth_to_fri_rate = match calculate_eth_to_fri_rate(previous_proposal_init) {
+        Ok(previous_eth_to_fri_rate) => previous_eth_to_fri_rate,
+        // Logged at error, above the clamp's own warning: the clamp is disabled for this block.
+        Err(error) => {
+            error!(
+                "Cannot clamp the eth to fri rate change, the previous block info {:?} implies no \
+                 rate: {:?}",
+                previous_proposal_init, error
+            );
+            return oracle_eth_to_fri_rate;
+        }
+    };
+
+    // Multiply before dividing to avoid the precision loss of dividing first. U256 because the
+    // product of two u128 values overflows u128. The division truncates, which makes the band
+    // marginally tighter, never looser.
+    let previous_rate_u256 = U256::from(previous_eth_to_fri_rate);
+    let max_change = (previous_rate_u256 * U256::from(max_eth_to_fri_rate_change_ppt))
+        / U256::from(PPT_DENOMINATOR);
+    // The rate should not realistically approach `u128::MAX`, clamped to it to avoid a
+    // theoretical overflow.
+    let max_rate = u128::try_from(previous_rate_u256 + max_change).unwrap_or(u128::MAX);
+    let min_rate =
+        previous_eth_to_fri_rate.saturating_sub(u128::try_from(max_change).unwrap_or(u128::MAX));
+
+    let clamped_eth_to_fri_rate = oracle_eth_to_fri_rate.clamp(min_rate, max_rate);
+    if clamped_eth_to_fri_rate != oracle_eth_to_fri_rate {
+        warn!(
+            "Eth to fri rate {oracle_eth_to_fri_rate} from the oracle is more than \
+             {max_eth_to_fri_rate_change_ppt} ppt away from the rate implied by the previous \
+             block ({previous_eth_to_fri_rate}), clamping it to {clamped_eth_to_fri_rate}."
+        );
+        CONSENSUS_ETH_TO_FRI_RATE_CLAMPED.increment(1);
+    }
+    clamped_eth_to_fri_rate
 }
 
 fn calculate_eth_to_fri_rate(

--- a/crates/apollo_consensus_orchestrator/src/utils_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils_test.rs
@@ -1,22 +1,44 @@
+use std::sync::Arc;
+
 use apollo_batcher_types::communication::{BatcherClientError, MockBatcherClient};
 use apollo_batcher_types::errors::BatcherError;
+use apollo_consensus_orchestrator_config::config::{
+    ContextDynamicConfig,
+    DEFAULT_MAX_ETH_TO_FRI_RATE_CHANGE_PPT,
+};
+use apollo_l1_gas_price_types::{MockL1GasPriceProviderClient, PriceInfo};
 use apollo_protobuf::consensus::ProposalInit;
 use apollo_state_sync_types::communication::StateSyncClientError;
 use apollo_state_sync_types::errors::StateSyncError;
 use assert_matches::assert_matches;
 use blockifier::abi::constants::STORED_BLOCK_HASH_BUFFER;
+use metrics_exporter_prometheus::PrometheusBuilder;
 use rstest::rstest;
-use starknet_api::block::{BlockHash, BlockHashAndNumber, BlockNumber};
+use starknet_api::block::{
+    BlockHash,
+    BlockHashAndNumber,
+    BlockNumber,
+    GasPrice,
+    TEMP_ETH_BLOB_GAS_FEE_IN_WEI,
+    TEMP_ETH_GAS_FEE_IN_WEI,
+};
 use starknet_types_core::felt::Felt;
 
 use crate::build_proposal::ProposalBuildArguments;
 use crate::cende::MockCendeContext;
+use crate::dynamic_gas_price::PPT_DENOMINATOR;
+use crate::metrics::{register_metrics, CONSENSUS_ETH_TO_FRI_RATE_CLAMPED};
 use crate::test_utils::create_proposal_build_arguments;
 use crate::utils::{
     get_l1_prices_in_fri_and_wei,
+    get_l1_prices_in_fri_and_wei_and_conversion_rate,
+    make_gas_price_params,
     retrospective_block_hash,
     verify_retrospective_state_commitment_infos,
     wait_for_retrospective_block_hash,
+    L1PricesInFri,
+    L1PricesInWei,
+    PreviousProposalInitInfo,
     RetrospectiveBlockHashError,
     RetrospectiveStateCommitmentInfosError,
 };
@@ -32,6 +54,17 @@ const STORED_HEIGHT_OFFSET: Option<BlockNumber> =
 const BEHIND_HEIGHT_OFFSET: Option<BlockNumber> = Some(NEXT_HEIGHT_RETRO_BLOCK_NUMBER);
 const MUST_HAVE_BLOCK_HASH_FOR: BlockNumber = BlockNumber(1);
 const RETRO_BLOCK_HASH: BlockHash = BlockHash(Felt::from_hex_unchecked("0x1234567890abcdef"));
+
+const PROPOSAL_TIMESTAMP: u64 = 1_700_000_000;
+// A gas price of one gwei keeps the previous block's implied rate exactly equal to the rate it was
+// built with, for the rates used in these tests.
+const PREVIOUS_L1_GAS_PRICE_WEI: GasPrice = GasPrice(u128::pow(10, 9));
+const PREVIOUS_ETH_TO_FRI_RATE: u128 = 2 * u128::pow(10, 18);
+// The band the shipped default puts around `PREVIOUS_ETH_TO_FRI_RATE`.
+const MAX_ETH_TO_FRI_RATE_CHANGE: u128 =
+    PREVIOUS_ETH_TO_FRI_RATE * DEFAULT_MAX_ETH_TO_FRI_RATE_CHANGE_PPT / PPT_DENOMINATOR;
+const MAX_ETH_TO_FRI_RATE: u128 = PREVIOUS_ETH_TO_FRI_RATE + MAX_ETH_TO_FRI_RATE_CHANGE;
+const MIN_ETH_TO_FRI_RATE: u128 = PREVIOUS_ETH_TO_FRI_RATE - MAX_ETH_TO_FRI_RATE_CHANGE;
 
 async fn get_proposal_init(args: &ProposalBuildArguments) -> ProposalInit {
     let timestamp = args.deps.clock.unix_now();
@@ -403,4 +436,177 @@ async fn retrospective_state_commitment_infos_next_height_below_buffer() {
     )
     .await
     .unwrap();
+}
+
+/// Builds the previous block's recorded prices such that they imply `eth_to_fri_rate`.
+fn previous_proposal_init_with_rate(eth_to_fri_rate: u128) -> PreviousProposalInitInfo {
+    let l1_prices_wei = L1PricesInWei {
+        l1_gas_price: PREVIOUS_L1_GAS_PRICE_WEI,
+        l1_data_gas_price: PREVIOUS_L1_GAS_PRICE_WEI,
+    };
+    let l1_prices_fri = L1PricesInFri::convert_from_wei(&l1_prices_wei, eth_to_fri_rate)
+        .expect("Test prices should be convertible to fri.");
+    PreviousProposalInitInfo { timestamp: PROPOSAL_TIMESTAMP, l1_prices_wei, l1_prices_fri }
+}
+
+/// Fetches the eth to fri rate through the full oracle path, with a freshly built provider and a
+/// freshly built config, both independent of any other instance.
+async fn fetch_eth_to_fri_rate(
+    oracle_eth_to_fri_rate: u128,
+    previous_proposal_init: Option<&PreviousProposalInitInfo>,
+) -> u128 {
+    fetch_eth_to_fri_rate_with_config(
+        oracle_eth_to_fri_rate,
+        previous_proposal_init,
+        ContextDynamicConfig::default(),
+    )
+    .await
+}
+
+async fn fetch_eth_to_fri_rate_with_config(
+    oracle_eth_to_fri_rate: u128,
+    previous_proposal_init: Option<&PreviousProposalInitInfo>,
+    dynamic_config: ContextDynamicConfig,
+) -> u128 {
+    let mut l1_gas_price_provider = MockL1GasPriceProviderClient::new();
+    l1_gas_price_provider.expect_get_rate().return_const(Ok(oracle_eth_to_fri_rate));
+    l1_gas_price_provider.expect_get_price_info().return_const(Ok(PriceInfo {
+        base_fee_per_gas: GasPrice(TEMP_ETH_GAS_FEE_IN_WEI),
+        blob_fee: GasPrice(TEMP_ETH_BLOB_GAS_FEE_IN_WEI),
+    }));
+
+    let (_l1_prices_fri, _l1_prices_wei, eth_to_fri_rate) =
+        get_l1_prices_in_fri_and_wei_and_conversion_rate(
+            Arc::new(l1_gas_price_provider),
+            PROPOSAL_TIMESTAMP,
+            previous_proposal_init,
+            &make_gas_price_params(&dynamic_config),
+        )
+        .await;
+    eth_to_fri_rate
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_inside_the_band_is_not_clamped() {
+    let previous_proposal_init = previous_proposal_init_with_rate(PREVIOUS_ETH_TO_FRI_RATE);
+    let oracle_eth_to_fri_rate = PREVIOUS_ETH_TO_FRI_RATE + MAX_ETH_TO_FRI_RATE_CHANGE / 2;
+    assert_eq!(
+        fetch_eth_to_fri_rate(oracle_eth_to_fri_rate, Some(&previous_proposal_init)).await,
+        oracle_eth_to_fri_rate
+    );
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_above_the_band_is_clamped_to_the_maximum() {
+    let previous_proposal_init = previous_proposal_init_with_rate(PREVIOUS_ETH_TO_FRI_RATE);
+    assert_eq!(
+        fetch_eth_to_fri_rate(PREVIOUS_ETH_TO_FRI_RATE * 3, Some(&previous_proposal_init)).await,
+        MAX_ETH_TO_FRI_RATE
+    );
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_below_the_band_is_clamped_to_the_minimum() {
+    let previous_proposal_init = previous_proposal_init_with_rate(PREVIOUS_ETH_TO_FRI_RATE);
+    assert_eq!(
+        fetch_eth_to_fri_rate(PREVIOUS_ETH_TO_FRI_RATE / 3, Some(&previous_proposal_init)).await,
+        MIN_ETH_TO_FRI_RATE
+    );
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_exactly_at_the_band_edge_is_not_clamped() {
+    let previous_proposal_init = previous_proposal_init_with_rate(PREVIOUS_ETH_TO_FRI_RATE);
+    assert_eq!(
+        fetch_eth_to_fri_rate(MAX_ETH_TO_FRI_RATE, Some(&previous_proposal_init)).await,
+        MAX_ETH_TO_FRI_RATE
+    );
+    assert_eq!(
+        fetch_eth_to_fri_rate(MIN_ETH_TO_FRI_RATE, Some(&previous_proposal_init)).await,
+        MIN_ETH_TO_FRI_RATE
+    );
+}
+
+/// Genesis is the only height with no `previous_proposal_init`. A restarted node seeds it from
+/// state_sync, covered by `test_initialize_from_committed_blocks_seeds_previous_block`.
+#[tokio::test]
+async fn eth_to_fri_rate_at_genesis_is_not_clamped() {
+    let oracle_eth_to_fri_rate = PREVIOUS_ETH_TO_FRI_RATE * 100;
+    assert_eq!(fetch_eth_to_fri_rate(oracle_eth_to_fri_rate, None).await, oracle_eth_to_fri_rate);
+}
+
+#[tokio::test]
+async fn eth_to_fri_rate_clamp_metric_increments_only_when_clamping() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    register_metrics();
+
+    let previous_proposal_init = previous_proposal_init_with_rate(PREVIOUS_ETH_TO_FRI_RATE);
+    fetch_eth_to_fri_rate(PREVIOUS_ETH_TO_FRI_RATE, Some(&previous_proposal_init)).await;
+    CONSENSUS_ETH_TO_FRI_RATE_CLAMPED.assert_eq(&recorder.handle().render(), 0);
+
+    fetch_eth_to_fri_rate(PREVIOUS_ETH_TO_FRI_RATE * 3, Some(&previous_proposal_init)).await;
+    CONSENSUS_ETH_TO_FRI_RATE_CLAMPED.assert_eq(&recorder.handle().render(), 1);
+}
+
+/// The operator pin replaces the rate the clamp returns, so a clamp there would shape no published
+/// price. `get_l1_prices_in_fri_and_wei_and_conversion_rate` returns the rate before the pin is
+/// applied, so the assertion is that the oracle rate passed through untouched and uncounted.
+#[tokio::test]
+async fn eth_to_fri_rate_is_not_clamped_when_the_operator_pins_the_rate() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    register_metrics();
+
+    let previous_proposal_init = previous_proposal_init_with_rate(PREVIOUS_ETH_TO_FRI_RATE);
+    let oracle_eth_to_fri_rate = PREVIOUS_ETH_TO_FRI_RATE * 3;
+    let dynamic_config = ContextDynamicConfig {
+        override_eth_to_fri_rate: Some(PREVIOUS_ETH_TO_FRI_RATE),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        fetch_eth_to_fri_rate_with_config(
+            oracle_eth_to_fri_rate,
+            Some(&previous_proposal_init),
+            dynamic_config
+        )
+        .await,
+        oracle_eth_to_fri_rate
+    );
+    CONSENSUS_ETH_TO_FRI_RATE_CLAMPED.assert_eq(&recorder.handle().render(), 0);
+}
+
+/// A previous block whose prices imply no rate leaves the clamp with nothing to center on, so the
+/// oracle rate passes through unclamped and uncounted.
+#[rstest]
+#[case::zero_previous_wei_price(GasPrice(0), GasPrice(u128::pow(10, 9)))]
+#[case::overflowing_previous_fri_price(PREVIOUS_L1_GAS_PRICE_WEI, GasPrice(u128::MAX))]
+#[tokio::test]
+async fn eth_to_fri_rate_is_not_clamped_when_the_previous_block_implies_no_rate(
+    #[case] previous_l1_gas_price_wei: GasPrice,
+    #[case] previous_l1_gas_price_fri: GasPrice,
+) {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+    register_metrics();
+
+    let previous_proposal_init = PreviousProposalInitInfo {
+        timestamp: PROPOSAL_TIMESTAMP,
+        l1_prices_wei: L1PricesInWei {
+            l1_gas_price: previous_l1_gas_price_wei,
+            l1_data_gas_price: previous_l1_gas_price_wei,
+        },
+        l1_prices_fri: L1PricesInFri {
+            l1_gas_price: previous_l1_gas_price_fri,
+            l1_data_gas_price: previous_l1_gas_price_fri,
+        },
+    };
+    let oracle_eth_to_fri_rate = PREVIOUS_ETH_TO_FRI_RATE * 100;
+
+    assert_eq!(
+        fetch_eth_to_fri_rate(oracle_eth_to_fri_rate, Some(&previous_proposal_init)).await,
+        oracle_eth_to_fri_rate
+    );
+    CONSENSUS_ETH_TO_FRI_RATE_CLAMPED.assert_eq(&recorder.handle().render(), 0);
 }

--- a/crates/apollo_consensus_orchestrator_config/src/config.rs
+++ b/crates/apollo_consensus_orchestrator_config/src/config.rs
@@ -22,6 +22,10 @@ use starknet_api::core::{ChainId, ContractAddress};
 use url::Url;
 use validator::Validate;
 
+#[cfg(test)]
+#[path = "config_test.rs"]
+mod config_test;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct CendeConfig {
     pub recorder_url: Url,
@@ -84,6 +88,20 @@ const ETH_FACTOR: u128 = u128::pow(10, 18);
 
 // Default SNIP-35 target USD cost per L2 gas unit: $0.88 per 1e9 L2 gas = 880_000_000 atto-USD.
 pub const DEFAULT_SNIP35_TARGET_ATTO_USD_PER_L2_GAS: u128 = 880_000_000;
+
+// Denominator for parts-per-thousand values. Duplicates
+// `apollo_consensus_orchestrator::dynamic_gas_price::PPT_DENOMINATOR`, which computes the bands
+// these values configure; that crate depends on this one, so the two must stay equal.
+const PPT_DENOMINATOR: u128 = 1000;
+
+// Default per-block bound on the Eth-to-Fri rate change: 5%. Wide enough that a single feed
+// update never trips it (the ETH and STRK feeds update on deviation thresholds of about 0.5% and
+// 1%, so their ratio steps by at most ~1.5% between blocks), tight enough that one manipulated
+// feed reading moves the rate a node publishes by at most 5%, and doubling it requires holding the
+// feed for ~15 consecutive blocks. A malicious proposer reaches further than a manipulated feed
+// does, since the band's center comes from the previous block: see `clamp_eth_to_fri_rate_change`
+// in apollo_consensus_orchestrator.
+pub const DEFAULT_MAX_ETH_TO_FRI_RATE_CHANGE_PPT: u128 = 50;
 
 // This matches the min_gas_price in orchestrator_versioned_constants_0_14_1.json (0x1dcd65000).
 const MIN_ALLOWED_GAS_PRICE: u128 = 8_000_000_000;
@@ -314,6 +332,16 @@ pub struct ContextDynamicConfig {
     /// SNIP-35 target USD cost per L2 gas unit, in atto-USD ($0.88 per 1e9 L2 gas = 880_000_000
     /// atto-USD).
     pub snip35_target_atto_usd_per_l2_gas: u128,
+    /// Maximum change, in parts per thousand, of the Eth-to-Fri rate relative to the rate implied
+    /// by the previous block. A fresh oracle rate outside this band is clamped to the band's edge.
+    /// Must be in `1..1000`: zero pins the rate to the previous block's forever, and a thousand or
+    /// more puts the band's lower edge at zero. The bound does not apply when there is no previous
+    /// block, or when `override_eth_to_fri_rate` pins the rate.
+    ///
+    /// Must hold the same value network-wide. A validator checks a proposal's L1 prices against
+    /// its own clamped rate within `l1_gas_price_margin_percent`, so two honest nodes whose values
+    /// differ by more than that margin reject each other's proposals on a large oracle move.
+    pub max_eth_to_fri_rate_change_ppt: u128,
     /// If given, will override the L2 gas price.
     pub override_l2_gas_price_fri: Option<u128>,
     /// If given, will override the L1 gas price in FRI.
@@ -388,6 +416,14 @@ impl SerializeConfig for ContextDynamicConfig {
                 ParamPrivacyInput::Public,
             ),
             ser_param(
+                "max_eth_to_fri_rate_change_ppt",
+                &self.max_eth_to_fri_rate_change_ppt,
+                "Maximum change, in parts per thousand, of the Eth-to-Fri rate relative to the \
+                 rate implied by the previous block. A fresh oracle rate outside this band is \
+                 clamped to the band's edge. Must be in 1..1000, and the same network-wide.",
+                ParamPrivacyInput::Public,
+            ),
+            ser_param(
                 "compare_retrospective_block_hash",
                 &self.compare_retrospective_block_hash,
                 "Whether to compare the retrospective block hash between the Batcher and the \
@@ -451,6 +487,7 @@ impl Default for ContextDynamicConfig {
             l1_data_gas_price_multiplier_ppt: 135,
             l1_gas_tip_wei: GWEI_FACTOR,
             snip35_target_atto_usd_per_l2_gas: DEFAULT_SNIP35_TARGET_ATTO_USD_PER_L2_GAS,
+            max_eth_to_fri_rate_change_ppt: DEFAULT_MAX_ETH_TO_FRI_RATE_CHANGE_PPT,
             override_l2_gas_price_fri: None,
             override_l1_gas_price_fri: None,
             override_l1_data_gas_price_fri: None,
@@ -502,6 +539,16 @@ fn validate_dynamic_config(
                  fri)",
             ));
         }
+    }
+
+    // Zero freezes the Eth-to-Fri rate at the previous block's, and the denominator or more leaves
+    // the band one-sided, with its lower edge at zero.
+    if config.max_eth_to_fri_rate_change_ppt == 0
+        || config.max_eth_to_fri_rate_change_ppt >= PPT_DENOMINATOR
+    {
+        return Err(validator::ValidationError::new(
+            "max_eth_to_fri_rate_change_ppt must be greater than zero and less than 1000",
+        ));
     }
 
     Ok(())

--- a/crates/apollo_consensus_orchestrator_config/src/config_test.rs
+++ b/crates/apollo_consensus_orchestrator_config/src/config_test.rs
@@ -1,0 +1,28 @@
+use validator::Validate;
+
+use super::{ContextDynamicConfig, DEFAULT_MAX_ETH_TO_FRI_RATE_CHANGE_PPT, PPT_DENOMINATOR};
+
+#[test]
+fn default_dynamic_config_is_valid() {
+    assert!(ContextDynamicConfig::default().validate().is_ok());
+}
+
+#[test]
+fn max_eth_to_fri_rate_change_ppt_outside_the_band_is_rejected() {
+    for max_eth_to_fri_rate_change_ppt in [0, PPT_DENOMINATOR, PPT_DENOMINATOR + 1] {
+        let config = ContextDynamicConfig { max_eth_to_fri_rate_change_ppt, ..Default::default() };
+        assert!(
+            config.validate().is_err(),
+            "accepted max_eth_to_fri_rate_change_ppt={max_eth_to_fri_rate_change_ppt}"
+        );
+    }
+    for max_eth_to_fri_rate_change_ppt in
+        [1, DEFAULT_MAX_ETH_TO_FRI_RATE_CHANGE_PPT, PPT_DENOMINATOR - 1]
+    {
+        let config = ContextDynamicConfig { max_eth_to_fri_rate_change_ppt, ..Default::default() };
+        assert!(
+            config.validate().is_ok(),
+            "rejected max_eth_to_fri_rate_change_ppt={max_eth_to_fri_rate_change_ppt}"
+        );
+    }
+}

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -330,6 +330,17 @@
           "extra_params": {
             "log_query": "\"maximum gas price\" OR \"below minimum gas price\""
           }
+        },
+        {
+          "title": "Eth To Fri Rate Clamped",
+          "description": "The number of blocks whose oracle eth to fri rate was pulled to the per-block change bound around the rate implied by the previous block (10m window). Not counted when the clamp does not run: the override_eth_to_fri_rate operator pin, or a previous block that implies no rate",
+          "type": "timeseries",
+          "exprs": [
+            "increase(consensus_eth_to_fri_rate_clamped{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[10m])"
+          ],
+          "extra_params": {
+            "log_query": "\"away from the rate implied by the previous block\""
+          }
         }
       ],
       "collapsed": true

--- a/crates/apollo_dashboard/src/panels/consensus.rs
+++ b/crates/apollo_dashboard/src/panels/consensus.rs
@@ -52,6 +52,7 @@ use apollo_consensus_orchestrator::metrics::{
     CENDE_WRITE_BLOB_SUCCESS,
     CENDE_WRITE_PREV_HEIGHT_BLOB_LATENCY,
     CONSENSUS_BUILD_PROPOSAL_FAILURE,
+    CONSENSUS_ETH_TO_FRI_RATE_CLAMPED,
     CONSENSUS_L2_GAS_PRICE,
     CONSENSUS_L2_GAS_PRICE_CLAMPED,
     CONSENSUS_VALIDATE_PROPOSAL_FAILURE,
@@ -351,6 +352,21 @@ fn get_panel_consensus_l2_gas_price_clamped() -> Panel {
         PanelType::TimeSeries,
     )
     .with_log_query("\"maximum gas price\" OR \"below minimum gas price\"")
+}
+
+fn get_panel_consensus_eth_to_fri_rate_clamped() -> Panel {
+    Panel::new(
+        "Eth To Fri Rate Clamped",
+        format!(
+            "The number of blocks whose oracle eth to fri rate was pulled to the per-block change \
+             bound around the rate implied by the previous block ({DEFAULT_DURATION} window). Not \
+             counted when the clamp does not run: the override_eth_to_fri_rate operator pin, or a \
+             previous block that implies no rate"
+        ),
+        increase(&CONSENSUS_ETH_TO_FRI_RATE_CLAMPED, DEFAULT_DURATION),
+        PanelType::TimeSeries,
+    )
+    .with_log_query("\"away from the rate implied by the previous block\"")
 }
 
 fn get_panel_cende_last_prepared_blob_block_number() -> Panel {
@@ -748,6 +764,7 @@ pub(crate) fn get_consensus_row() -> Row {
             get_panel_consensus_timeouts_by_type(),
             get_panel_consensus_l2_gas_price(),
             get_panel_consensus_l2_gas_price_clamped(),
+            get_panel_consensus_eth_to_fri_rate_clamped(),
         ],
     )
 }

--- a/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/consensus_manager_config.json
@@ -42,6 +42,7 @@
   "consensus_manager_config.context_config.static_config.l1_da_mode": true,
   "consensus_manager_config.context_config.dynamic_config.l1_data_gas_price_multiplier_ppt": 135,
   "consensus_manager_config.context_config.dynamic_config.l1_gas_tip_wei": 1000000000,
+  "consensus_manager_config.context_config.dynamic_config.max_eth_to_fri_rate_change_ppt": 50,
   "consensus_manager_config.context_config.dynamic_config.max_l1_data_gas_price_wei": 1000000000000,
   "consensus_manager_config.context_config.dynamic_config.max_l1_gas_price_wei": 1000000000000,
   "consensus_manager_config.context_config.dynamic_config.min_l1_data_gas_price_wei": 1,

--- a/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_consensus_manager_config.json
@@ -37,6 +37,7 @@
   "consensus_manager_config.context_config.dynamic_config.compare_retrospective_block_hash": "$$$_CONSENSUS_MANAGER_CONFIG-CONTEXT_CONFIG-DYNAMIC_CONFIG-COMPARE_RETROSPECTIVE_BLOCK_HASH_$$$",
   "consensus_manager_config.context_config.dynamic_config.l1_data_gas_price_multiplier_ppt": 135,
   "consensus_manager_config.context_config.dynamic_config.l1_gas_tip_wei": 1000000000,
+  "consensus_manager_config.context_config.dynamic_config.max_eth_to_fri_rate_change_ppt": 50,
   "consensus_manager_config.context_config.dynamic_config.max_l1_data_gas_price_wei": 1000000000000,
   "consensus_manager_config.context_config.dynamic_config.max_l1_gas_price_wei": 1000000000000,
   "consensus_manager_config.context_config.dynamic_config.min_l1_data_gas_price_wei": 1,

--- a/crates/apollo_l1_gas_price/src/rate_bounds.rs
+++ b/crates/apollo_l1_gas_price/src/rate_bounds.rs
@@ -8,14 +8,14 @@ use apollo_l1_gas_price_types::ExchangeRate;
 #[path = "rate_bounds_test.rs"]
 mod rate_bounds_test;
 
-// TODO(Asaf): bound the rate's change against the previous block's implied rate. The absolute
-// bounds below are wide enough to pass a manipulated but plausible answer, the STRK/USD pair alone
-// accepting anything from $0.0001 to $10, which only a bound relative to the last accepted rate
-// catches. It must be anchored to the block header rather than to node-local history, so that every
-// validator accepts and rejects the same values.
-/// Absolute bounds are the only defense against a feed wired to the wrong asset or a
-/// plausible-but-poisoned answer: consensus checks that validators agree with each other, never
-/// that the agreed value is sane, and every node reads the same chain state.
+/// Absolute bounds catch a feed wired to the wrong asset: consensus checks that validators agree
+/// with each other, never that the agreed value is sane, and every node reads the same chain state.
+/// They are wide enough to pass a manipulated but plausible answer, the STRK/USD pair alone
+/// accepting anything from $0.0001 to $10. The bound relative to the previous block's implied rate,
+/// which limits how fast such an answer moves the rate a node publishes, lives in
+/// `apollo_consensus_orchestrator::utils`, where the previous block is in hand, so that its band is
+/// centered on the block header rather than on this client's own read history and every validator
+/// derives the same clamped rate.
 pub(crate) fn check_rate_bounds(
     rate: ExchangeRate,
     bounds: RateBounds,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -2749,6 +2749,11 @@
     "privacy": "Public",
     "value": 1000000000
   },
+  "consensus_manager_config.context_config.dynamic_config.max_eth_to_fri_rate_change_ppt": {
+    "description": "Maximum change, in parts per thousand, of the Eth-to-Fri rate relative to the rate implied by the previous block. A fresh oracle rate outside this band is clamped to the band's edge. Must be in 1..1000, and the same network-wide.",
+    "privacy": "Public",
+    "value": 50
+  },
   "consensus_manager_config.context_config.dynamic_config.max_l1_data_gas_price_wei": {
     "description": "The maximum L1 data gas price in wei.",
     "privacy": "Public",


### PR DESCRIPTION
Ports #14973 onto `main-v0.14.4`. A fresh oracle rate is now clamped into a band of `max_eth_to_fri_rate_change_ppt` (default 50, i.e. 5%) around the rate implied by the previous block's recorded wei and fri prices.

This closes the gap the absolute `rate_bounds_config` leaves: those bounds ($20k-50k per ETH, $0.0001-10 per STRK, 10k-1M STRK per ETH) are wide enough to admit a manipulated but plausible feed value. #14944 names this bound as a precondition for flipping a feed source.

It also closes the startup gap the original PR left open. Previously there was no anchor at startup, so the first block after a restart went unclamped. Genesis is now the only height without one.

**Please read the "Known limitation" section below before approving.** The bound on how far the band's center can move per accepted proposal is 1.222x, not 5%, and closing that needs a coordinated activation height.

---

# Detailed Summary for AI Bots

## What changed

- `clamp_eth_to_fri_rate_change` in `apollo_consensus_orchestrator/src/utils.rs` clamps the oracle rate into the band and increments `CONSENSUS_ETH_TO_FRI_RATE_CLAMPED`, with a warning log when it bites.
- New config key `max_eth_to_fri_rate_change_ppt` in `ContextDynamicConfig`, default 50. Wired into `config_schema.json` **and** both consensus manager app configs (`consensus_manager_config.json`, `replacer_consensus_manager_config.json`). A key present in the schema but missing from the app configs crash-loops every node, since the node loads configs with `ignore_default_values = true`.
- `initialize_fee_proposals_window` renamed to `initialize_from_committed_blocks`, since it now bootstraps two things. It additionally seeds `previous_proposal_init` from block `start_height - 1`, reusing the existing `previous_proposal_init_from_block_header` helper. Sole caller is `apollo_consensus_manager`.
- The retry-until-state-sync-is-ready fetch is extracted into `committed_block_header`. It retries the same height in place rather than re-queueing to the back of a `VecDeque`. Equivalent, because heights commit in order, and it issues strictly fewer reads.
- Dashboard panel `get_panel_consensus_eth_to_fri_rate_clamped` added, modelled on the SNIP-35 panel and wired into `get_consensus_row()`. `dev_grafana.json` regenerated. **No alert added**, deliberately: an alert here would need a per-deployment threshold override key in every environment, which is a separate decision.
- `tokio` gains the `test-util` dev-dependency feature, required for `start_paused = true`. Without it the crate's tests do not compile standalone, which is the shape of CI's per-package jobs.

## Anchor source: state sync, not the batcher

The original plan was to read the previous block's prices from the batcher via the `get_partial_block_hash_components` path added by #15006. That route needs a new `BatcherRequest`/`BatcherResponse` variant, a new `BatcherClient` trait method, and local plus remote server wiring, because `get_partial_block_hash_components` sits on the batcher-internal `BatcherStorageReaderTrait` and its only consumer is the batcher's own private `get_block_info`.

State sync needs none of that: `SyncBlock.block_header_without_hash` already carries `l1_gas_price` and `l1_data_gas_price` as `GasPricePerToken`, which holds both `price_in_wei` and `price_in_fri`, and the orchestrator already reads blocks from that client in the same startup function. Same anchor pair, zero new APIs.

## Known limitation, and the follow-up it needs

The delivered guarantee is that the band bounds what an **honest node publishes**, not how far the band's center can move.

`PreviousProposalInitInfo::from(&init)` copies `l1_gas_price_wei` and `l1_gas_price_fri` verbatim from the accepted `ProposalInit`, and `calculate_eth_to_fri_rate` divides one by the other. But `validate_proposal` checks the two legs **independently** through `within_margin` at `l1_gas_price_margin_percent = 10`, with nothing checking their ratio. A proposer publishing `0.9 * w` and `1.1 * f` passes both checks, so an accepted proposal can move every node's band center by `(1 + margin) / (1 - margin) = 1.222x`. Since the pull-back is only 5% per block, with roughly one proposal slot in four the center ratchets: `1.222 * 0.95^3 = 1.047 > 1`.

Closing this means rejecting a proposal whose implied fri/wei ratio falls outside the validator's own band. That is a new consensus validity rule: its tolerance must be at least `2 * max_eth_to_fri_rate_change_ppt`, because two honest nodes clamped into the same band can legitimately differ by that much, and it has to activate at a coordinated height or the first node to ship it forks. `TODO(Asaf)` is in place on `clamp_eth_to_fri_rate_change`, and the docs state the delivered guarantee rather than the intended one.

Related open choice: `max_eth_to_fri_rate_change_ppt` currently lives in `ContextDynamicConfig`, so it is per-node and operator-tunable. A spread above roughly 100 ppt between two honest nodes can reject an honest proposal on a large oracle move. The field doc, `ser_param` description and schema now state that the value must match network-wide. Moving it into `VersionedConstants` next to `l1_gas_price_margin_percent` would make that provable rather than documented.

## Verification

`rust_fmt`, clippy with `-D warnings`, and nextest across `apollo_consensus_orchestrator`, `apollo_consensus_manager`, `apollo_consensus_orchestrator_config`, `apollo_l1_gas_price` and `apollo_dashboard` under `--all-features` (358 tests), plus `apollo_node_config` and `apollo_deployments` without `--all-features` (26 tests). `default_config_file_is_up_to_date` and `deployment_files_are_up_to_date` both pass, confirming the schema and app config entries are correct.
