### PR TITLE
apollo_consensus_orchestrator: run state commitment infos pruning concurrently with blob prep

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -651,10 +651,9 @@ impl SequencerConsensusContext {
                 block_hash_commitments: block_header_commitments,
             });
 
-        // Pruning touches only storage the cende blob preparation never reads (it works off the
-        // `recent_state_commitment_infos` already collected above), so the two independent
-        // batcher/cende requests run concurrently instead of adding their latencies on this
-        // per-height critical path.
+        // Pruning touches only batcher storage that blob preparation never reads, so the two are
+        // safe to run concurrently instead of adding their latencies on this per-height critical
+        // path.
         let (prepare_blob_result, ()) =
             tokio::join!(prepare_blob_future, self.prune_state_commitment_infos(height));
         if let Err(e) = prepare_blob_result {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -15,6 +15,7 @@ use apollo_batcher_types::batcher_types::{
     DecisionReachedResponse,
     FinishedProposalInfo,
     ProposalId,
+    PruneStateCommitmentInfosInput,
     StartHeightInput,
 };
 use apollo_batcher_types::communication::{BatcherClient, BatcherClientError, BatcherClientResult};
@@ -655,6 +656,8 @@ impl SequencerConsensusContext {
         {
             error!("Failed to prepare blob for next height at height {height}: {e:?}");
         }
+
+        self.prune_state_commitment_infos(height).await;
     }
 
     pub fn get_config(&self) -> &ContextConfig {
@@ -764,6 +767,18 @@ impl SequencerConsensusContext {
             }
         }
         Ok(recent_state_commitment_infos)
+    }
+
+    /// Asks the batcher to prune the state commitment infos that fell out of its retention window.
+    async fn prune_state_commitment_infos(&self, height: BlockNumber) {
+        if let Err(e) = self
+            .deps
+            .batcher
+            .prune_state_commitment_infos(PruneStateCommitmentInfosInput { height })
+            .await
+        {
+            error!("Failed to prune state commitment infos at height {height}: {e:?}");
+        }
     }
 
     /// Returns the state commitment infos of `block_number` to send to the cende recorder, or

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -618,10 +618,8 @@ impl SequencerConsensusContext {
                 Vec::new()
             });
 
-        if let Err(e) = self
-            .deps
-            .cende_ambassador
-            .prepare_blob_for_next_height(BlobParameters {
+        let prepare_blob_future =
+            self.deps.cende_ambassador.prepare_blob_for_next_height(BlobParameters {
                 block_info: cende_block_info,
                 starknet_version: init.starknet_version,
                 state_diff,
@@ -651,13 +649,17 @@ impl SequencerConsensusContext {
                 recent_state_commitment_infos,
                 initial_reads: central_objects.initial_reads,
                 block_hash_commitments: block_header_commitments,
-            })
-            .await
-        {
+            });
+
+        // Pruning touches only storage the cende blob preparation never reads (it works off the
+        // `recent_state_commitment_infos` already collected above), so the two independent
+        // batcher/cende requests run concurrently instead of adding their latencies on this
+        // per-height critical path.
+        let (prepare_blob_result, ()) =
+            tokio::join!(prepare_blob_future, self.prune_state_commitment_infos(height));
+        if let Err(e) = prepare_blob_result {
             error!("Failed to prepare blob for next height at height {height}: {e:?}");
         }
-
-        self.prune_state_commitment_infos(height).await;
     }
 
     pub fn get_config(&self) -> &ContextConfig {

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -10,6 +10,7 @@ use apollo_batcher_types::batcher_types::{
     FinishedProposalInfo,
     FinishedProposalInfoWithoutParent,
     ProposalCommitment as BatcherProposalCommitment,
+    PruneStateCommitmentInfosInput,
     SendTxsForProposalStatus,
 };
 use apollo_batcher_types::communication::{BatcherClientError, BatcherClientResult};
@@ -1006,6 +1007,35 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let _fin = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap().await;
     context.decision_reached(HEIGHT_0, ROUND_0, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
 }
+#[tokio::test]
+async fn decision_reached_prunes_old_state_commitment_infos() {
+    let (mut deps, _network) = create_test_and_network_deps();
+    deps.cende_ambassador
+        .expect_commitment_infos_height_offset()
+        .times(1)
+        .return_once(|| Ok(Some(HEIGHT_0)));
+    deps.batcher
+        .expect_get_state_commitment_infos()
+        .returning(|_| Ok(Some(default_state_commitment_infos())));
+    deps.batcher
+        .expect_prune_state_commitment_infos()
+        .times(1)
+        .withf(|input| *input == PruneStateCommitmentInfosInput { height: HEIGHT_0 })
+        .return_once(|_| Ok(()));
+
+    deps.setup_deps_for_build(SetupDepsArgs::default());
+    deps.batcher
+        .expect_decision_reached()
+        .times(1)
+        .return_once(|_| Ok(DecisionReachedResponse::default()));
+    deps.state_sync_client.expect_add_new_block().times(1).return_once(|_| Ok(()));
+    deps.cende_ambassador.expect_prepare_blob_for_next_height().times(1).return_once(|_| Ok(()));
+
+    let mut context = deps.build_context();
+    let _fin = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap().await;
+    context.decision_reached(HEIGHT_0, ROUND_0, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
+}
+
 // When `send_empty_state_commitment_infos_only` is enabled, the same heights are sent, each
 // carrying an empty object; the batcher is only asked whether it has the infos, never for their
 // content.

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -350,6 +350,8 @@ impl TestDeps {
         });
         self.batcher.expect_has_state_commitment_infos().returning(|_block_number| Ok(false));
         self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
+        // Every decision prunes; tests that assert on the pruning override this.
+        self.batcher.expect_prune_state_commitment_infos().returning(|_input| Ok(()));
     }
 
     pub(crate) fn build_context(self) -> SequencerConsensusContext {


### PR DESCRIPTION
## Summary

Follow-up performance optimization on top of #15045, which added a call to
`prune_state_commitment_infos(height).await` at the end of
`SequencerConsensusContext::finalize_decision`
(`crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs`).
That call sits on the per-block consensus critical path (`finalize_decision`
runs once per finalized height and is awaited by `decision_reached` before
consensus proceeds), and was placed **after** the existing
`prepare_blob_for_next_height(...)` await, so its latency was added on top
of it every block even though the two calls are independent:

- `prune_state_commitment_infos` only deletes batcher-side storage pointers
  below `height - retention_blocks` (a bounded cursor scan, capped by
  `max_deletions_per_prune`) plus a data-file punch-hole.
- `prepare_blob_for_next_height` never reads that storage — it works off
  `recent_state_commitment_infos`/`recent_block_hashes`, which are already
  collected in memory earlier in `finalize_decision`.

This PR starts both calls as futures and awaits them together with
`tokio::join!` instead of sequentially, so the (bounded, typically fast)
pruning call's latency overlaps with blob preparation instead of adding to
the per-height critical path.

## Verification

- `cargo build -p apollo_consensus_orchestrator` and
  `cargo check -p apollo_consensus_orchestrator`: clean.
- `SEED=0 cargo test -p apollo_consensus_orchestrator`: 224 passed, 0
  failed (including `decision_reached_prunes_old_state_commitment_infos`,
  added by #15045, which asserts the batcher's
  `prune_state_commitment_infos` mock is still called exactly once).
- Reviewed by an independent Opus pass for concurrency safety (no shared
  locks/read-after-delete hazards between the two joined futures) and
  comment accuracy.

## Expected impact

Removes one full sequential batcher round-trip (plus its MDBX write) from
every block's critical path. The win is modest in absolute terms since
pruning is already bounded (at most `max_deletions_per_prune` deletions
plus one `fallocate`-style hole-punch per call), but it is real and
compounds over every finalized block.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JrrdbUSzzaUfzNWzCoQn77)_