### PR TITLE
Revert "apollo_dashboard: panel for pruned state commitment infos (#15046)"

### DIFF
--- a/crates/apollo_batcher/src/batcher.rs
+++ b/crates/apollo_batcher/src/batcher.rs
@@ -27,7 +27,6 @@ use apollo_batcher_types::batcher_types::{
     ProposalId,
     ProposalStatus,
     ProposeBlockInput,
-    PruneStateCommitmentInfosInput,
     RevertBlockInput,
     SendTxsForProposalInput,
     SendTxsForProposalStatus,
@@ -67,7 +66,6 @@ use apollo_storage::partial_block_hash::{
 use apollo_storage::state::{StateStorageReader, StateStorageWriter};
 use apollo_storage::state_commitment_infos::{
     CompressedStateCommitmentInfos,
-    PrunedStateCommitmentInfosPointers,
     StateCommitmentInfosStorageReader,
     StateCommitmentInfosStorageWriter,
 };
@@ -164,7 +162,6 @@ use crate::metrics::{
     REVERTED_BLOCKS,
     REVERTED_TRANSACTIONS,
     SIERRA_GAS_IN_LAST_BLOCK,
-    STATE_COMMITMENT_INFOS_LOWER_BOUND,
     SYNCED_TRANSACTIONS,
 };
 use crate::pre_confirmed_block_writer::{
@@ -1642,43 +1639,6 @@ impl Batcher {
         })
     }
 
-    /// Deletes the pointers to the state commitment infos of the heights that fell out of the
-    /// retention window, at most `max_deletions_per_prune` of them per call, then releases the
-    /// data they pointed at.
-    pub fn prune_state_commitment_infos(
-        &mut self,
-        input: PruneStateCommitmentInfosInput,
-    ) -> BatcherResult<()> {
-        let pruning_config = &self.config.static_config.state_commitment_infos_pruning_config;
-        let retention_blocks = pruning_config.retention_blocks;
-        let max_deletions_per_prune = pruning_config.max_deletions_per_prune;
-        // The requested height may be ahead of this batcher's storage, whose infos are the ones
-        // being pruned. Taking the lower of the two.
-        let height = input.height.min(self.get_height_from_storage()?);
-        let prune_below = BlockNumber(height.0.saturating_sub(retention_blocks));
-        let pruned = self
-            .storage_writer
-            .prune_state_commitment_infos_pointers(prune_below, max_deletions_per_prune)
-            .map_err(|err| {
-                error!(
-                    "Failed to prune the state commitment infos pointers below {prune_below}: \
-                     {err}"
-                );
-                BatcherError::InternalError
-            })?;
-        let Some(PrunedStateCommitmentInfosPointers { new_lower_bound, data_end_offset }) = pruned
-        else {
-            return Ok(());
-        };
-        self.storage_writer.prune_state_commitment_infos_data(data_end_offset).map_err(|err| {
-            error!("Failed to release the disk space of pruned state commitment infos: {err}");
-            BatcherError::InternalError
-        })?;
-        info!("Pruned the state commitment infos below {new_lower_bound}.");
-        STATE_COMMITMENT_INFOS_LOWER_BOUND.set_lossy(new_lower_bound.0);
-        Ok(())
-    }
-
     fn get_commitment_results_and_write_to_storage(&mut self) -> BatcherResult<()> {
         self.commitment_manager
             .get_commitment_results_and_write_to_storage(
@@ -1902,9 +1862,6 @@ pub trait BatcherStorageReader: Send + Sync {
     /// Returns whether the state commitment infos for the given height are stored.
     fn has_state_commitment_infos(&self, height: BlockNumber) -> StorageResult<bool>;
 
-    /// Returns the lowest height whose state commitment infos are stored, or `None` if none are.
-    fn state_commitment_infos_lower_bound(&self) -> StorageResult<Option<BlockNumber>>;
-
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
         height: BlockNumber,
@@ -2012,10 +1969,6 @@ impl BatcherStorageReader for StorageReader {
         self.begin_ro_txn()?.has_state_commitment_infos(height)
     }
 
-    fn state_commitment_infos_lower_bound(&self) -> StorageResult<Option<BlockNumber>> {
-        self.begin_ro_txn()?.state_commitment_infos_lower_bound()
-    }
-
     fn get_parent_hash_and_partial_block_hash_components(
         &self,
         height: BlockNumber,
@@ -2070,17 +2023,6 @@ pub trait BatcherStorageWriter: Send + Sync {
     ) -> StorageResult<()>;
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()>;
-
-    /// Deletes the pointers to the state commitment infos of the lowest stored heights below
-    /// `prune_below`, at most `max_deletions` of them. Returns `None` if nothing was deleted.
-    fn prune_state_commitment_infos_pointers(
-        &mut self,
-        prune_below: BlockNumber,
-        max_deletions: usize,
-    ) -> StorageResult<Option<PrunedStateCommitmentInfosPointers>>;
-
-    /// Releases the disk space of the state commitment infos data file below `end`.
-    fn prune_state_commitment_infos_data(&self, end: usize) -> StorageResult<()>;
 }
 
 impl BatcherStorageWriter for StorageWriter {
@@ -2146,22 +2088,6 @@ impl BatcherStorageWriter for StorageWriter {
 
     fn set_block_hash(&mut self, height: BlockNumber, block_hash: BlockHash) -> StorageResult<()> {
         self.begin_rw_txn()?.set_block_hash(&height, block_hash)?.commit()
-    }
-
-    fn prune_state_commitment_infos_pointers(
-        &mut self,
-        prune_below: BlockNumber,
-        max_deletions: usize,
-    ) -> StorageResult<Option<PrunedStateCommitmentInfosPointers>> {
-        let (txn, pruned) = self
-            .begin_rw_txn()?
-            .prune_state_commitment_infos_pointers(prune_below, max_deletions)?;
-        txn.commit()?;
-        Ok(pruned)
-    }
-
-    fn prune_state_commitment_infos_data(&self, end: usize) -> StorageResult<()> {
-        StorageWriter::prune_state_commitment_infos_data(self, end)
     }
 }
 
@@ -2240,17 +2166,7 @@ impl ComponentStarter for Batcher {
             .global_root_height()
             .expect("Failed to get global roots height from storage during batcher creation.");
 
-        // With no infos stored, none are retained below the storage height, so that is the bound.
-        let state_commitment_infos_lower_bound = self
-            .storage_reader
-            .state_commitment_infos_lower_bound()
-            .expect(
-                "Failed to get the state commitment infos lower bound from storage during batcher \
-                 creation.",
-            )
-            .unwrap_or(storage_height);
-
-        register_metrics(storage_height, global_root_height, state_commitment_infos_lower_bound);
+        register_metrics(storage_height, global_root_height);
 
         self.commitment_manager
             .add_missing_commitment_tasks(

--- a/crates/apollo_batcher/src/batcher_test.rs
+++ b/crates/apollo_batcher/src/batcher_test.rs
@@ -5,12 +5,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::task::Poll;
 use std::time::Duration;
 
-use apollo_batcher_config::config::{
-    BatcherConfig,
-    BatcherDynamicConfig,
-    BatcherStaticConfig,
-    StateCommitmentInfosPruningConfig,
-};
+use apollo_batcher_config::config::{BatcherConfig, BatcherDynamicConfig, BatcherStaticConfig};
 use apollo_batcher_types::batcher_types::{
     CallContractInput,
     DecisionReachedInput,
@@ -24,7 +19,6 @@ use apollo_batcher_types::batcher_types::{
     GetProposalContentResponse,
     ProposalCommitment,
     ProposalId,
-    PruneStateCommitmentInfosInput,
     RevertBlockInput,
     SendTxsForProposalInput,
     SendTxsForProposalStatus,
@@ -50,7 +44,6 @@ use apollo_storage::accessed_keys::AccessedKeys;
 use apollo_storage::db::DbError;
 use apollo_storage::partial_block_hash::PartialBlockHashComponentsStorageWriter;
 use apollo_storage::state::StateStorageWriter;
-use apollo_storage::state_commitment_infos::PrunedStateCommitmentInfosPointers;
 use apollo_storage::test_utils::get_test_storage;
 use apollo_storage::{StorageError, StorageReader, StorageWriter};
 use assert_matches::assert_matches;
@@ -144,12 +137,10 @@ use crate::metrics::{
     REJECTED_VIEW_CALLS,
     REVERTED_BLOCKS,
     REVERTED_TRANSACTIONS,
-    STATE_COMMITMENT_INFOS_LOWER_BOUND,
     SYNCED_TRANSACTIONS,
 };
 use crate::test_utils::{
     get_number_of_items_in_channel_from_receiver,
-    mock_storage_reader,
     propose_block_input,
     test_contract_nonces,
     test_l1_handler_txs,
@@ -169,7 +160,6 @@ use crate::test_utils::{
     INITIAL_HEIGHT,
     LATEST_BLOCK_IN_STORAGE,
     PROPOSAL_ID,
-    STATE_COMMITMENT_INFOS_LOWER_BOUND_HEIGHT,
     STREAMING_CHUNK_SIZE,
 };
 
@@ -568,7 +558,7 @@ fn mock_create_builder_for_validate_block(
 }
 
 fn mock_storage_reader_for_revert() -> MockBatcherStorageReader {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_reversed_state_diff().returning(|_| Ok(test_state_diff()));
     storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_global_root().returning(|_| Ok(Some(GlobalRoot::default())));
@@ -710,29 +700,6 @@ async fn metrics_registered() {
     let _batcher = create_batcher(MockDependencies::default()).await;
     let metrics = recorder.handle().render();
     assert_eq!(BUILDING_HEIGHT.parse_numeric_metric::<u64>(&metrics), Some(INITIAL_HEIGHT.0));
-    assert_eq!(
-        STATE_COMMITMENT_INFOS_LOWER_BOUND.parse_numeric_metric::<u64>(&metrics),
-        Some(STATE_COMMITMENT_INFOS_LOWER_BOUND_HEIGHT.0)
-    );
-}
-
-/// A storage with no state commitment infos retains none below its height, so the bound the
-/// metric reports is that height.
-#[tokio::test]
-async fn state_commitment_infos_lower_bound_metric_defaults_to_the_storage_height() {
-    let recorder = PrometheusBuilder::new().build_recorder();
-    let _recorder_guard = metrics::set_default_local_recorder(&recorder);
-    let mut storage_reader = MockBatcherStorageReader::new();
-    storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
-    storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
-    storage_reader.expect_state_commitment_infos_lower_bound().returning(|| Ok(None));
-    let _batcher = create_batcher(MockDependencies { storage_reader, ..Default::default() }).await;
-
-    let metrics = recorder.handle().render();
-    assert_eq!(
-        STATE_COMMITMENT_INFOS_LOWER_BOUND.parse_numeric_metric::<u64>(&metrics),
-        Some(INITIAL_HEIGHT.0)
-    );
 }
 
 #[rstest]
@@ -826,7 +793,7 @@ async fn ignore_l1_handler_provider_not_ready(#[case] proposer: bool) {
 #[rstest]
 #[tokio::test]
 async fn consecutive_heights_success() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().times(1).returning(|| Ok(INITIAL_HEIGHT)); // batcher start
     storage_reader.expect_state_diff_height().times(1).returning(|| Ok(INITIAL_HEIGHT)); // first start_height
     storage_reader
@@ -1179,7 +1146,7 @@ async fn multiple_proposals_with_l1_every_n_proposals() {
 #[rstest]
 #[tokio::test]
 async fn get_height() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
 
@@ -1192,7 +1159,7 @@ async fn get_height() {
 #[rstest]
 #[tokio::test]
 async fn propose_block_without_retrospective_block_hash() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     let initial_block_height = BlockNumber(constants::STORED_BLOCK_HASH_BUFFER);
     storage_reader.expect_state_diff_height().returning(move || Ok(initial_block_height));
     storage_reader.expect_global_root_height().returning(move || Ok(initial_block_height));
@@ -1389,7 +1356,7 @@ async fn add_sync_block(
 
     let mut mock_clients = MockClients::default();
 
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(move || Ok(block_number));
     storage_reader.expect_global_root_height().returning(move || Ok(block_number));
 
@@ -1495,7 +1462,7 @@ async fn add_sync_block_mismatch_block_number() {
 #[rstest]
 #[tokio::test]
 async fn add_sync_block_missing_block_header_commitments() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
     let mock_dependencies = MockDependencies { storage_reader, ..Default::default() };
@@ -1521,7 +1488,7 @@ async fn add_sync_block_missing_block_header_commitments() {
 #[should_panic(expected = "is at least the first block configured to include a partial hash")]
 async fn add_sync_block_missing_block_header_commitments_for_new_block() {
     let block_number = FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH.unchecked_next();
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(move || Ok(block_number));
     storage_reader.expect_global_root_height().returning(move || Ok(block_number));
     let mock_dependencies = MockDependencies { storage_reader, ..Default::default() };
@@ -1548,7 +1515,7 @@ async fn add_sync_block_missing_block_header_commitments_for_new_block() {
 #[rstest]
 #[tokio::test]
 async fn add_sync_block_for_first_new_block() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader
         .expect_state_diff_height()
         .returning(|| Ok(FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH));
@@ -1606,7 +1573,7 @@ async fn add_sync_block_for_first_new_block() {
 #[tokio::test]
 #[should_panic(expected = "does not match the configured parent block hash")]
 async fn add_sync_block_parent_hash_mismatch() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader
         .expect_state_diff_height()
         .returning(|| Ok(FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH));
@@ -1637,7 +1604,7 @@ async fn add_sync_block_parent_hash_mismatch() {
 #[should_panic(expected = "is a new block but is older than the configured first block with \
                            partial block hash components")]
 async fn add_sync_block_with_partial_block_hash_but_older_than_configured_first_block() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader
         .expect_state_diff_height()
         .returning(|| Ok(FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH.prev().unwrap()));
@@ -1710,7 +1677,7 @@ async fn revert_block_mismatch_block_number() {
 
 #[tokio::test]
 async fn revert_block_empty_storage() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(|| Ok(BlockNumber(0)));
     storage_reader.expect_global_root_height().returning(|| Ok(BlockNumber(0)));
     let mock_dependencies = MockDependencies { storage_reader, ..Default::default() };
@@ -2826,7 +2793,7 @@ async fn call_contract_over_a_committed_zero_gas_price_succeeds() {
 /// from. The caller is told that, rather than being handed a bare internal error.
 #[tokio::test]
 async fn call_contract_without_stored_block_info_names_what_is_missing() {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_get_partial_block_hash_components().returning(|_| Ok(None));
@@ -2855,7 +2822,7 @@ async fn call_contract_without_stored_block_info_names_what_is_missing() {
 async fn block_info_reports_the_committed_data_availability_mode(
     #[case] l1_da_mode: L1DataAvailabilityMode,
 ) {
-    let mut storage_reader = mock_storage_reader();
+    let mut storage_reader = MockBatcherStorageReader::new();
     storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
     storage_reader.expect_get_partial_block_hash_components().returning(move |_| {
@@ -2872,191 +2839,4 @@ async fn block_info_reports_the_committed_data_availability_mode(
     let block_info = batcher.get_block_info(LAST_COMMITTED_HEIGHT).unwrap();
 
     assert_eq!(block_info.use_kzg_da, l1_da_mode.is_use_kzg_da());
-}
-
-const STATE_COMMITMENT_INFOS_RETENTION_BLOCKS: u64 = 10;
-const MAX_STATE_COMMITMENT_INFOS_DELETIONS_PER_PRUNE: usize = 10;
-const PRUNED_STATE_COMMITMENT_INFOS_DATA_END_OFFSET: usize = 4096;
-/// The storage height the batcher reports in the state commitment infos pruning tests.
-const STATE_COMMITMENT_INFOS_PRUNING_STORAGE_HEIGHT: BlockNumber = BlockNumber(30);
-
-fn mock_dependencies_for_state_commitment_infos_pruning() -> MockDependencies {
-    let mut storage_reader = mock_storage_reader();
-    storage_reader
-        .expect_state_diff_height()
-        .returning(|| Ok(STATE_COMMITMENT_INFOS_PRUNING_STORAGE_HEIGHT));
-    storage_reader
-        .expect_global_root_height()
-        .returning(|| Ok(STATE_COMMITMENT_INFOS_PRUNING_STORAGE_HEIGHT));
-    let mut mock_dependencies = MockDependencies { storage_reader, ..Default::default() };
-    mock_dependencies.batcher_config.static_config.state_commitment_infos_pruning_config =
-        StateCommitmentInfosPruningConfig {
-            retention_blocks: STATE_COMMITMENT_INFOS_RETENTION_BLOCKS,
-            max_deletions_per_prune: MAX_STATE_COMMITMENT_INFOS_DELETIONS_PER_PRUNE,
-        };
-    mock_dependencies
-}
-
-fn retention_window_start(height: BlockNumber) -> BlockNumber {
-    BlockNumber(height.0 - STATE_COMMITMENT_INFOS_RETENTION_BLOCKS)
-}
-
-/// Expects a prune up to `prune_below` that advances the lower bound to `new_lower_bound`,
-/// followed by releasing the space of the pruned infos.
-fn expect_prune_state_commitment_infos(
-    storage_writer: &mut MockBatcherStorageWriter,
-    prune_below: BlockNumber,
-    new_lower_bound: BlockNumber,
-) {
-    storage_writer
-        .expect_prune_state_commitment_infos_pointers()
-        .times(1)
-        .with(eq(prune_below), eq(MAX_STATE_COMMITMENT_INFOS_DELETIONS_PER_PRUNE))
-        .returning(move |_, _| {
-            Ok(Some(PrunedStateCommitmentInfosPointers {
-                new_lower_bound,
-                data_end_offset: PRUNED_STATE_COMMITMENT_INFOS_DATA_END_OFFSET,
-            }))
-        });
-    storage_writer
-        .expect_prune_state_commitment_infos_data()
-        .times(1)
-        .with(eq(PRUNED_STATE_COMMITMENT_INFOS_DATA_END_OFFSET))
-        .returning(|_| Ok(()));
-}
-
-fn prune_state_commitment_infos(batcher: &mut Batcher, height: BlockNumber) {
-    batcher.prune_state_commitment_infos(PruneStateCommitmentInfosInput { height }).unwrap();
-}
-
-#[tokio::test]
-async fn prune_state_commitment_infos_below_retention_window_and_release_space() {
-    let mut mock_dependencies = mock_dependencies_for_state_commitment_infos_pruning();
-    let height = BlockNumber(20);
-    let prune_below = retention_window_start(height);
-    expect_prune_state_commitment_infos(
-        &mut mock_dependencies.storage_writer,
-        prune_below,
-        prune_below,
-    );
-
-    let mut batcher = create_batcher(mock_dependencies).await;
-    prune_state_commitment_infos(&mut batcher, height);
-}
-
-/// The requested height may be ahead of the heights this batcher stored, so the retention window
-/// is measured from its storage height instead.
-#[tokio::test]
-async fn prune_state_commitment_infos_below_the_storage_height_retention_window() {
-    let mut mock_dependencies = mock_dependencies_for_state_commitment_infos_pruning();
-    let prune_below = retention_window_start(STATE_COMMITMENT_INFOS_PRUNING_STORAGE_HEIGHT);
-    expect_prune_state_commitment_infos(
-        &mut mock_dependencies.storage_writer,
-        prune_below,
-        prune_below,
-    );
-
-    let mut batcher = create_batcher(mock_dependencies).await;
-    prune_state_commitment_infos(
-        &mut batcher,
-        BlockNumber(STATE_COMMITMENT_INFOS_PRUNING_STORAGE_HEIGHT.0 + 100),
-    );
-}
-
-#[tokio::test]
-async fn prune_state_commitment_infos_releases_no_space_when_nothing_is_pruned() {
-    let mut mock_dependencies = mock_dependencies_for_state_commitment_infos_pruning();
-    mock_dependencies
-        .storage_writer
-        .expect_prune_state_commitment_infos_pointers()
-        .times(1)
-        .returning(|_, _| Ok(None));
-    // No expectation is set for punching a hole: the mock panics if it is called.
-
-    let mut batcher = create_batcher(mock_dependencies).await;
-    prune_state_commitment_infos(&mut batcher, BlockNumber(20));
-}
-
-#[tokio::test]
-async fn prune_state_commitment_infos_storage_failure_is_internal_error() {
-    let mut mock_dependencies = mock_dependencies_for_state_commitment_infos_pruning();
-    mock_dependencies
-        .storage_writer
-        .expect_prune_state_commitment_infos_pointers()
-        .times(1)
-        .returning(|_, _| {
-            Err(apollo_storage::StorageError::DBInconsistency { msg: String::new() })
-        });
-
-    let mut batcher = create_batcher(mock_dependencies).await;
-    let result = batcher
-        .prune_state_commitment_infos(PruneStateCommitmentInfosInput { height: BlockNumber(20) });
-    assert_eq!(result, Err(BatcherError::InternalError));
-}
-
-/// The pointers are deleted in their own transaction and the data they pointed at is released
-/// only afterwards, so a failure in between leaves the data of already-deleted pointers behind.
-/// The next prune releases the data of its own pointers and of those left behind, because
-/// releasing the data below an offset releases everything below it.
-#[tokio::test]
-async fn prune_state_commitment_infos_releases_the_data_of_previously_pruned_pointers() {
-    const FIRST_DATA_END_OFFSET: usize = 4096;
-    const SECOND_DATA_END_OFFSET: usize = 8192;
-    let height = BlockNumber(20);
-    let prune_below = retention_window_start(height);
-
-    let mut mock_dependencies = mock_dependencies_for_state_commitment_infos_pruning();
-    let storage_writer = &mut mock_dependencies.storage_writer;
-    // The first prune deletes the pointers of the lowest stored heights...
-    storage_writer
-        .expect_prune_state_commitment_infos_pointers()
-        .times(1)
-        .with(eq(prune_below), eq(MAX_STATE_COMMITMENT_INFOS_DELETIONS_PER_PRUNE))
-        .returning(|_, _| {
-            Ok(Some(PrunedStateCommitmentInfosPointers {
-                new_lower_bound: BlockNumber(5),
-                data_end_offset: FIRST_DATA_END_OFFSET,
-            }))
-        });
-    // ... but releasing their data fails, so it is left with no pointer into it.
-    storage_writer
-        .expect_prune_state_commitment_infos_data()
-        .times(1)
-        .with(eq(FIRST_DATA_END_OFFSET))
-        .returning(|_| Err(StorageError::DBInconsistency { msg: String::new() }));
-    // The next prune deletes the pointers of the following heights...
-    storage_writer
-        .expect_prune_state_commitment_infos_pointers()
-        .times(1)
-        .with(eq(prune_below), eq(MAX_STATE_COMMITMENT_INFOS_DELETIONS_PER_PRUNE))
-        .returning(move |_, _| {
-            Ok(Some(PrunedStateCommitmentInfosPointers {
-                new_lower_bound: prune_below,
-                data_end_offset: SECOND_DATA_END_OFFSET,
-            }))
-        });
-    // ... and releases their data.
-    let released_up_to = Arc::new(Mutex::new(None));
-    let recorded_released_up_to = released_up_to.clone();
-    storage_writer.expect_prune_state_commitment_infos_data().times(1).returning(move |end| {
-        *recorded_released_up_to.lock().unwrap() = Some(end);
-        Ok(())
-    });
-
-    let mut batcher = create_batcher(mock_dependencies).await;
-    assert_eq!(
-        batcher.prune_state_commitment_infos(PruneStateCommitmentInfosInput { height }),
-        Err(BatcherError::InternalError)
-    );
-    prune_state_commitment_infos(&mut batcher, height);
-
-    let released_up_to =
-        released_up_to.lock().unwrap().expect("The pruned data should have been released.");
-    for pruned_data_end_offset in [FIRST_DATA_END_OFFSET, SECOND_DATA_END_OFFSET] {
-        assert!(
-            released_up_to >= pruned_data_end_offset,
-            "The data of the pointers pruned up to offset {pruned_data_end_offset} was not \
-             released; only the data below {released_up_to} was."
-        );
-    }
 }

--- a/crates/apollo_batcher/src/communication.rs
+++ b/crates/apollo_batcher/src/communication.rs
@@ -35,9 +35,6 @@ impl ComponentRequestHandler<BatcherRequest, BatcherResponse> for Batcher {
                     self.has_state_commitment_infos(block_number),
                 )
             }
-            BatcherRequest::PruneStateCommitmentInfos(input) => {
-                BatcherResponse::PruneStateCommitmentInfos(self.prune_state_commitment_infos(input))
-            }
             BatcherRequest::GetCurrentHeight => {
                 BatcherResponse::GetCurrentHeight(self.get_height().await)
             }

--- a/crates/apollo_batcher/src/metrics.rs
+++ b/crates/apollo_batcher/src/metrics.rs
@@ -35,7 +35,6 @@ define_metrics!(
         MetricGauge { LAST_SYNCED_BLOCK_HEIGHT, "batcher_last_synced_block_height", "The height of the last block received by syncing" },
         MetricGauge { LAST_PROPOSED_BLOCK_HEIGHT, "batcher_last_proposed_block_height", "The height of the last block proposed by this sequencer" },
         MetricCounter { REVERTED_BLOCKS, "batcher_reverted_blocks", "Counter of reverted blocks", init = 0 },
-        MetricGauge { STATE_COMMITMENT_INFOS_LOWER_BOUND, "batcher_state_commitment_infos_lower_bound", "The lowest height whose state commitment infos may be stored in the batcher storage; lower heights were pruned." },
         // Proposals
         MetricCounter { PROPOSAL_STARTED, "batcher_proposal_started", "Counter of proposals started", init = 0 },
         MetricCounter { PROPOSAL_SUCCEEDED, "batcher_proposal_succeeded", "Counter of successful proposals", init = 0 },
@@ -146,11 +145,7 @@ pub const BATCHER_CLASS_CACHE_METRICS: CacheMetrics =
 pub const BATCHER_VIEW_CALL_CLASS_CACHE_METRICS: CacheMetrics =
     CacheMetrics::new(VIEW_CALL_CLASS_CACHE_MISSES, VIEW_CALL_CLASS_CACHE_HITS);
 
-pub fn register_metrics(
-    storage_height: BlockNumber,
-    global_root_height: BlockNumber,
-    state_commitment_infos_lower_bound: BlockNumber,
-) {
+pub fn register_metrics(storage_height: BlockNumber, global_root_height: BlockNumber) {
     BUILDING_HEIGHT.register();
     BUILDING_HEIGHT.set_lossy(storage_height.0);
     GLOBAL_ROOT_HEIGHT.register();
@@ -159,10 +154,6 @@ pub fn register_metrics(
     LAST_SYNCED_BLOCK_HEIGHT.register();
     LAST_PROPOSED_BLOCK_HEIGHT.register();
     REVERTED_BLOCKS.register();
-    STATE_COMMITMENT_INFOS_LOWER_BOUND.register();
-    // Seeded from storage, so that a restart does not read as "nothing was pruned yet" until the
-    // first prune of this run.
-    STATE_COMMITMENT_INFOS_LOWER_BOUND.set_lossy(state_commitment_infos_lower_bound.0);
 
     PROPOSAL_STARTED.register();
     PROPOSAL_SUCCEEDED.register();

--- a/crates/apollo_batcher/src/test_utils.rs
+++ b/crates/apollo_batcher/src/test_utils.rs
@@ -71,8 +71,6 @@ pub const EXECUTION_INFO_LEN: usize = 10;
 pub const DUMMY_FINAL_N_EXECUTED_TXS: usize = 12;
 
 pub(crate) const INITIAL_HEIGHT: BlockNumber = BlockNumber(3);
-/// Below [`INITIAL_HEIGHT`], so that seeding the lower bound metric from it is observable.
-pub(crate) const STATE_COMMITMENT_INFOS_LOWER_BOUND_HEIGHT: BlockNumber = BlockNumber(1);
 pub(crate) const FIRST_BLOCK_NUMBER_WITH_PARTIAL_BLOCK_HASH: BlockNumber =
     INITIAL_HEIGHT.prev().unwrap();
 pub(crate) const DUMMY_BLOCK_HASH: BlockHash = BlockHash(Felt::from_hex_unchecked("0xdeadbeef"));
@@ -324,19 +322,9 @@ impl Default for MockClients {
     }
 }
 
-/// A storage reader mock with the expectations every batcher needs on startup; a test adds the
-/// ones its own flow reads.
-pub(crate) fn mock_storage_reader() -> MockBatcherStorageReader {
-    let mut storage_reader = MockBatcherStorageReader::new();
-    storage_reader
-        .expect_state_commitment_infos_lower_bound()
-        .returning(|| Ok(Some(STATE_COMMITMENT_INFOS_LOWER_BOUND_HEIGHT)));
-    storage_reader
-}
-
 impl Default for MockDependencies {
     fn default() -> Self {
-        let mut storage_reader = mock_storage_reader();
+        let mut storage_reader = MockBatcherStorageReader::new();
         storage_reader.expect_state_diff_height().returning(|| Ok(INITIAL_HEIGHT));
         storage_reader.expect_global_root_height().returning(|| Ok(INITIAL_HEIGHT));
         storage_reader.expect_get_state_diff().returning(|_| Ok(Some(test_state_diff())));

--- a/crates/apollo_batcher_config/src/config.rs
+++ b/crates/apollo_batcher_config/src/config.rs
@@ -32,8 +32,6 @@ use url::Url;
 use validator::{Validate, ValidationError};
 
 pub const DEFAULT_TASKS_CHANNEL_SIZE: usize = 1000;
-pub const DEFAULT_STATE_COMMITMENT_INFOS_RETENTION_BLOCKS: u64 = 1000;
-pub const DEFAULT_MAX_STATE_COMMITMENT_INFOS_DELETIONS_PER_PRUNE: usize = 100;
 pub const DEFAULT_RESULTS_CHANNEL_SIZE: usize = 1000;
 
 /// Configuration for the block builder component of the batcher.
@@ -194,47 +192,6 @@ impl SerializeConfig for FirstBlockWithPartialBlockHash {
     }
 }
 
-/// Configuration of pruning old state commitment infos from the batcher storage.
-#[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
-pub struct StateCommitmentInfosPruningConfig {
-    /// The state commitment infos of the `retention_blocks` heights below the current height are
-    /// kept; those of lower heights are pruned.
-    #[validate(range(min = 10))]
-    pub retention_blocks: u64,
-    /// At most this many heights are pruned per prune request.
-    #[validate(range(min = 2))]
-    pub max_deletions_per_prune: usize,
-}
-
-impl SerializeConfig for StateCommitmentInfosPruningConfig {
-    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
-        BTreeMap::from_iter([
-            ser_param(
-                "retention_blocks",
-                &self.retention_blocks,
-                "The state commitment infos of this many heights below the current height are \
-                 kept in storage; those of lower heights are pruned.",
-                ParamPrivacyInput::Public,
-            ),
-            ser_param(
-                "max_deletions_per_prune",
-                &self.max_deletions_per_prune,
-                "At most this many heights' state commitment infos are pruned per prune request.",
-                ParamPrivacyInput::Public,
-            ),
-        ])
-    }
-}
-
-impl Default for StateCommitmentInfosPruningConfig {
-    fn default() -> Self {
-        Self {
-            retention_blocks: DEFAULT_STATE_COMMITMENT_INFOS_RETENTION_BLOCKS,
-            max_deletions_per_prune: DEFAULT_MAX_STATE_COMMITMENT_INFOS_DELETIONS_PER_PRUNE,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
 pub struct BatcherStaticConfig {
     #[validate(nested)]
@@ -246,8 +203,6 @@ pub struct BatcherStaticConfig {
     #[validate(nested)]
     pub contract_class_manager_config: ContractClassManagerConfig,
     pub commitment_manager_config: CommitmentManagerConfig,
-    #[validate(nested)]
-    pub state_commitment_infos_pruning_config: StateCommitmentInfosPruningConfig,
     pub max_l1_handler_txs_per_block_proposal: usize,
     pub pre_confirmed_cende_config: PreconfirmedCendeConfig,
     pub propose_l1_txs_every: u64,
@@ -307,10 +262,6 @@ impl SerializeConfig for BatcherStaticConfig {
             "commitment_manager_config",
         ));
         dump.append(&mut prepend_sub_config_name(
-            self.state_commitment_infos_pruning_config.dump(),
-            "state_commitment_infos_pruning_config",
-        ));
-        dump.append(&mut prepend_sub_config_name(
             self.pre_confirmed_cende_config.dump(),
             "pre_confirmed_cende_config",
         ));
@@ -352,7 +303,6 @@ impl Default for BatcherStaticConfig {
             pre_confirmed_block_writer_config: PreconfirmedBlockWriterConfig::default(),
             contract_class_manager_config: ContractClassManagerConfig::default(),
             commitment_manager_config: CommitmentManagerConfig::default(),
-            state_commitment_infos_pruning_config: StateCommitmentInfosPruningConfig::default(),
             max_l1_handler_txs_per_block_proposal: 3,
             pre_confirmed_cende_config: PreconfirmedCendeConfig::default(),
             propose_l1_txs_every: 1, // Default is to propose L1 transactions every proposal.

--- a/crates/apollo_batcher_types/src/batcher_types.rs
+++ b/crates/apollo_batcher_types/src/batcher_types.rs
@@ -194,12 +194,6 @@ pub struct RevertBlockInput {
     pub height: BlockNumber,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
-pub struct PruneStateCommitmentInfosInput {
-    /// The height that was just decided; the retention window is measured back from it.
-    pub height: BlockNumber,
-}
-
 /// Input for executing a view (read-only) entry point on a contract against the latest committed
 /// batcher state.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/apollo_batcher_types/src/communication.rs
+++ b/crates/apollo_batcher_types/src/communication.rs
@@ -33,7 +33,6 @@ use crate::batcher_types::{
     GetProposalContentResponse,
     ProposalId,
     ProposeBlockInput,
-    PruneStateCommitmentInfosInput,
     RevertBlockInput,
     SendTxsForProposalInput,
     SendTxsForProposalStatus,
@@ -68,12 +67,6 @@ pub trait BatcherClient: Send + Sync {
         &self,
         block_number: BlockNumber,
     ) -> BatcherClientResult<bool>;
-    /// Deletes stored state commitment infos that fell out of the retention window, freeing their
-    /// disk space.
-    async fn prune_state_commitment_infos(
-        &self,
-        input: PruneStateCommitmentInfosInput,
-    ) -> BatcherClientResult<()>;
     /// Gets the first height that is not written in the storage yet.
     async fn get_height(&self) -> BatcherClientResult<GetHeightResponse>;
     /// Gets the next available content from the proposal stream (only relevant when building a
@@ -138,7 +131,6 @@ pub enum BatcherRequest {
     GetBlockHash(BlockNumber),
     GetStateCommitmentInfos(BlockNumber),
     HasStateCommitmentInfos(BlockNumber),
-    PruneStateCommitmentInfos(PruneStateCommitmentInfosInput),
     GetProposalContent(GetProposalContentInput),
     ValidateBlock(ValidateBlockInput),
     AbortProposal(ProposalId),
@@ -167,7 +159,6 @@ pub enum BatcherResponse {
     GetBlockHash(BatcherResult<BlockHash>),
     GetStateCommitmentInfos(BatcherResult<Option<CompressedStateCommitmentInfos>>),
     HasStateCommitmentInfos(BatcherResult<bool>),
-    PruneStateCommitmentInfos(BatcherResult<()>),
     GetCurrentHeight(BatcherResult<GetHeightResponse>),
     GetProposalContent(BatcherResult<GetProposalContentResponse>),
     ValidateBlock(BatcherResult<()>),
@@ -248,22 +239,6 @@ where
             request,
             BatcherResponse,
             HasStateCommitmentInfos,
-            BatcherClientError,
-            BatcherError,
-            Direct
-        )
-    }
-
-    async fn prune_state_commitment_infos(
-        &self,
-        input: PruneStateCommitmentInfosInput,
-    ) -> BatcherClientResult<()> {
-        let request = BatcherRequest::PruneStateCommitmentInfos(input);
-        handle_all_response_variants!(
-            self,
-            request,
-            BatcherResponse,
-            PruneStateCommitmentInfos,
             BatcherClientError,
             BatcherError,
             Direct

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -15,7 +15,6 @@ use apollo_batcher_types::batcher_types::{
     DecisionReachedResponse,
     FinishedProposalInfo,
     ProposalId,
-    PruneStateCommitmentInfosInput,
     StartHeightInput,
 };
 use apollo_batcher_types::communication::{BatcherClient, BatcherClientError, BatcherClientResult};
@@ -656,8 +655,6 @@ impl SequencerConsensusContext {
         {
             error!("Failed to prepare blob for next height at height {height}: {e:?}");
         }
-
-        self.prune_state_commitment_infos(height).await;
     }
 
     pub fn get_config(&self) -> &ContextConfig {
@@ -767,18 +764,6 @@ impl SequencerConsensusContext {
             }
         }
         Ok(recent_state_commitment_infos)
-    }
-
-    /// Asks the batcher to prune the state commitment infos that fell out of its retention window.
-    async fn prune_state_commitment_infos(&self, height: BlockNumber) {
-        if let Err(e) = self
-            .deps
-            .batcher
-            .prune_state_commitment_infos(PruneStateCommitmentInfosInput { height })
-            .await
-        {
-            error!("Failed to prune state commitment infos at height {height}: {e:?}");
-        }
     }
 
     /// Returns the state commitment infos of `block_number` to send to the cende recorder, or

--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context_test.rs
@@ -10,7 +10,6 @@ use apollo_batcher_types::batcher_types::{
     FinishedProposalInfo,
     FinishedProposalInfoWithoutParent,
     ProposalCommitment as BatcherProposalCommitment,
-    PruneStateCommitmentInfosInput,
     SendTxsForProposalStatus,
 };
 use apollo_batcher_types::communication::{BatcherClientError, BatcherClientResult};
@@ -1007,35 +1006,6 @@ async fn decision_reached_attaches_state_commitment_infos_to_blob() {
     let _fin = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap().await;
     context.decision_reached(HEIGHT_0, ROUND_0, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
 }
-#[tokio::test]
-async fn decision_reached_prunes_old_state_commitment_infos() {
-    let (mut deps, _network) = create_test_and_network_deps();
-    deps.cende_ambassador
-        .expect_commitment_infos_height_offset()
-        .times(1)
-        .return_once(|| Ok(Some(HEIGHT_0)));
-    deps.batcher
-        .expect_get_state_commitment_infos()
-        .returning(|_| Ok(Some(default_state_commitment_infos())));
-    deps.batcher
-        .expect_prune_state_commitment_infos()
-        .times(1)
-        .withf(|input| *input == PruneStateCommitmentInfosInput { height: HEIGHT_0 })
-        .return_once(|_| Ok(()));
-
-    deps.setup_deps_for_build(SetupDepsArgs::default());
-    deps.batcher
-        .expect_decision_reached()
-        .times(1)
-        .return_once(|_| Ok(DecisionReachedResponse::default()));
-    deps.state_sync_client.expect_add_new_block().times(1).return_once(|_| Ok(()));
-    deps.cende_ambassador.expect_prepare_blob_for_next_height().times(1).return_once(|_| Ok(()));
-
-    let mut context = deps.build_context();
-    let _fin = context.build_proposal(BuildParam::default(), TIMEOUT).await.unwrap().await;
-    context.decision_reached(HEIGHT_0, ROUND_0, *TEST_PROPOSAL_COMMITMENT, false).await.unwrap();
-}
-
 // When `send_empty_state_commitment_infos_only` is enabled, the same heights are sent, each
 // carrying an empty object; the batcher is only asked whether it has the infos, never for their
 // content.

--- a/crates/apollo_consensus_orchestrator/src/test_utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/test_utils.rs
@@ -350,8 +350,6 @@ impl TestDeps {
         });
         self.batcher.expect_has_state_commitment_infos().returning(|_block_number| Ok(false));
         self.batcher.expect_get_state_commitment_infos().returning(|_block_number| Ok(None));
-        // Every decision prunes; tests that assert on the pruning override this.
-        self.batcher.expect_prune_state_commitment_infos().returning(|_input| Ok(()));
     }
 
     pub(crate) fn build_context(self) -> SequencerConsensusContext {

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -1042,17 +1042,6 @@
           }
         },
         {
-          "title": "State Commitment Infos Lower Bound",
-          "description": "The lowest height whose state commitment infos may be stored in the batcher storage; lower heights were pruned.",
-          "type": "stat",
-          "exprs": [
-            "batcher_state_commitment_infos_lower_bound{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}"
-          ],
-          "extra_params": {
-            "log_query": "\"Pruned the state commitment infos below\""
-          }
-        },
-        {
           "title": "Average Block Time",
           "description": "Average block time (1m window)",
           "type": "timeseries",

--- a/crates/apollo_dashboard/resources/dev_grafana.json
+++ b/crates/apollo_dashboard/resources/dev_grafana.json
@@ -2768,32 +2768,6 @@
           "extra_params": {}
         },
         {
-          "title": "prune_state_commitment_infos (client-side)",
-          "description": "client-side infra metrics for request type prune_state_commitment_infos",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_local_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_local_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_response_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_remote_response_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_remote_client_communication_failure_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_remote_client_communication_failure_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
-          "title": "prune_state_commitment_infos (server-side)",
-          "description": "server-side infra metrics for request type prune_state_commitment_infos",
-          "type": "timeseries",
-          "exprs": [
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_processing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_processing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.50,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.50 batcher_queueing_times_secs\", \"le\", \".*\"))",
-            "histogram_quantile(0.95,label_replace(sum by (le) (rate(batcher_queueing_times_secs_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", request_variant=\"prune_state_commitment_infos\"}[5m])), \"label_name\", \"0.95 batcher_queueing_times_secs\", \"le\", \".*\"))"
-          ],
-          "extra_params": {}
-        },
-        {
           "title": "revert_block (client-side)",
           "description": "client-side infra metrics for request type revert_block",
           "type": "timeseries",

--- a/crates/apollo_dashboard/src/panels/batcher.rs
+++ b/crates/apollo_dashboard/src/panels/batcher.rs
@@ -17,7 +17,6 @@ use apollo_batcher::metrics::{
     RECEIPT_COMMITMENT_LATENCY,
     REJECTED_TRANSACTIONS,
     REVERTED_TRANSACTIONS,
-    STATE_COMMITMENT_INFOS_LOWER_BOUND,
     STATE_DIFF_COMMITMENT_LATENCY,
     STATE_DIFF_LENGTH,
     TX_COMMITMENT_COUNT,
@@ -109,17 +108,6 @@ fn get_panel_global_root_height() -> Panel {
         PanelType::Stat,
     )
     .with_log_query("Committing block at height")
-}
-
-fn get_panel_state_commitment_infos_lower_bound() -> Panel {
-    Panel::new(
-        "State Commitment Infos Lower Bound",
-        "The lowest height whose state commitment infos may be stored in the batcher storage; \
-         lower heights were pruned.",
-        STATE_COMMITMENT_INFOS_LOWER_BOUND.get_name_with_filter().to_string(),
-        PanelType::Stat,
-    )
-    .with_log_query("Pruned the state commitment infos below")
 }
 
 fn get_panel_rejection_reverted_ratio() -> Panel {
@@ -307,7 +295,6 @@ pub(crate) fn get_batcher_row() -> Row {
         vec![
             get_panel_building_height(),
             get_panel_global_root_height(),
-            get_panel_state_commitment_infos_lower_bound(),
             get_panel_consensus_block_time_avg(),
             get_panel_batched_transactions_rate(),
             get_panel_proposer_deferred_txs(),

--- a/crates/apollo_deployments/resources/app_configs/batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/batcher_config.json
@@ -50,8 +50,6 @@
   "batcher_config.static_config.pre_confirmed_block_writer_config.channel_buffer_capacity": 1000,
   "batcher_config.static_config.pre_confirmed_block_writer_config.write_block_interval_millis": 50,
   "batcher_config.static_config.propose_l1_txs_every": 10,
-  "batcher_config.static_config.state_commitment_infos_pruning_config.max_deletions_per_prune": 100,
-  "batcher_config.static_config.state_commitment_infos_pruning_config.retention_blocks": 1000,
   "batcher_config.static_config.storage.db_config.enforce_file_exists": false,
   "batcher_config.static_config.storage.db_config.growth_step": 67108864,
   "batcher_config.static_config.storage.db_config.max_readers": 8192,

--- a/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
+++ b/crates/apollo_deployments/resources/app_configs/replacer_batcher_config.json
@@ -50,8 +50,6 @@
   "batcher_config.static_config.pre_confirmed_block_writer_config.channel_buffer_capacity": 1000,
   "batcher_config.static_config.pre_confirmed_block_writer_config.write_block_interval_millis": 50,
   "batcher_config.static_config.propose_l1_txs_every": 10,
-  "batcher_config.static_config.state_commitment_infos_pruning_config.max_deletions_per_prune": 100,
-  "batcher_config.static_config.state_commitment_infos_pruning_config.retention_blocks": 1000,
   "batcher_config.static_config.storage.db_config.enforce_file_exists": false,
   "batcher_config.static_config.storage.db_config.growth_step": 67108864,
   "batcher_config.static_config.storage.db_config.max_readers": 8192,

--- a/crates/apollo_node/resources/config_schema.json
+++ b/crates/apollo_node/resources/config_schema.json
@@ -354,16 +354,6 @@
     "privacy": "Public",
     "value": 1
   },
-  "batcher_config.static_config.state_commitment_infos_pruning_config.max_deletions_per_prune": {
-    "description": "At most this many heights' state commitment infos are pruned per prune request.",
-    "privacy": "Public",
-    "value": 100
-  },
-  "batcher_config.static_config.state_commitment_infos_pruning_config.retention_blocks": {
-    "description": "The state commitment infos of this many heights below the current height are kept in storage; those of lower heights are pruned.",
-    "privacy": "Public",
-    "value": 1000
-  },
   "batcher_config.static_config.storage.batch_config.batch_size": {
     "description": "Number of logical commits before actual MDBX commit.",
     "privacy": "Public",

--- a/crates/apollo_storage/Cargo.toml
+++ b/crates/apollo_storage/Cargo.toml
@@ -32,7 +32,6 @@ integer-encoding.workspace = true
 libmdbx = { workspace = true, features = ["lifetimed-bytes"] }
 memmap2.workspace = true
 metrics.workspace = true
-nix.workspace = true
 num-bigint.workspace = true
 page_size.workspace = true
 parity-scale-codec.workspace = true
@@ -60,6 +59,7 @@ camelpaste.workspace = true
 futures.workspace = true
 insta = { workspace = true, features = ["yaml"] }
 metrics-exporter-prometheus.workspace = true
+nix.workspace = true
 num-traits.workspace = true
 paste.workspace = true
 pretty_assertions.workspace = true

--- a/crates/apollo_storage/src/lib.rs
+++ b/crates/apollo_storage/src/lib.rs
@@ -1212,11 +1212,6 @@ impl FileHandlers<RW> {
         self.clone().state_commitment_infos.append(state_commitment_infos)
     }
 
-    // Releases the disk blocks of the state commitment infos file below `end`.
-    fn punch_state_commitment_infos_hole_up_to(&self, end: usize) -> StorageResult<()> {
-        Ok(self.state_commitment_infos.punch_hole_up_to(end)?)
-    }
-
     // TODO(dan): Consider 1. flushing only the relevant files, 2. flushing concurrently.
     #[latency_histogram("storage_file_handler_flush_latency_seconds", false)]
     fn flush(&self) {

--- a/crates/apollo_storage/src/mmap_file/mmap_file_test.rs
+++ b/crates/apollo_storage/src/mmap_file/mmap_file_test.rs
@@ -1,4 +1,3 @@
-use std::os::unix::fs::MetadataExt;
 use std::sync::Arc;
 
 use apollo_test_utils::get_rng;
@@ -302,38 +301,4 @@ fn location_in_file_serialization_order() {
     let mut serialized_256 = Vec::new();
     location_256.serialize_into(&mut serialized_256).unwrap();
     assert!(serialized_256 > serialized_1);
-}
-
-#[test]
-fn punch_hole_up_to() {
-    let dir = tempdir().unwrap();
-    let path = dir.path().to_path_buf().join("test_punch_hole_up_to");
-    let (mut writer, reader) =
-        open_file::<NoVersionValueWrapper<Vec<u8>>>(get_mmap_file_test_config(), path.clone(), 0)
-            .unwrap();
-    let allocated_bytes =
-        || usize::try_from(std::fs::metadata(&path).unwrap().blocks() * 512).unwrap();
-    let data = vec![1; 32 * 1024];
-    let locations: Vec<_> = (0..3).map(|_| writer.append(&data)).collect();
-    writer.flush();
-    let before = allocated_bytes();
-
-    // Releases whole pages below `end` only.
-    writer.punch_hole_up_to(locations[2].offset()).unwrap();
-    let released = before - allocated_bytes();
-    let page_size = page_size::get();
-    assert!(released >= 2 * data.len() - page_size, "released only {released} bytes");
-    assert_eq!(reader.get(locations[2]).unwrap().unwrap(), data);
-
-    // Punching again, or below a page, changes nothing.
-    let after = allocated_bytes();
-    writer.punch_hole_up_to(locations[2].offset()).unwrap();
-    writer.punch_hole_up_to(page_size - 1).unwrap();
-    assert_eq!(allocated_bytes(), after);
-
-    // Appending afterwards is unaffected.
-    let location = writer.append(&data);
-    assert_eq!(reader.get(location).unwrap().unwrap(), data);
-
-    dir.close().unwrap();
 }

--- a/crates/apollo_storage/src/mmap_file/mod.rs
+++ b/crates/apollo_storage/src/mmap_file/mod.rs
@@ -11,8 +11,6 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fs::{File, OpenOptions};
 use std::marker::PhantomData;
-#[cfg(target_os = "linux")]
-use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::result;
 use std::sync::{Arc, Mutex};
@@ -22,8 +20,6 @@ use apollo_config::{ParamPath, ParamPrivacyInput, SerializedParam};
 #[cfg(test)]
 use apollo_test_utils::GetTestInstance;
 use memmap2::{MmapMut, MmapOptions};
-#[cfg(target_os = "linux")]
-use nix::fcntl::{fallocate, FallocateFlags};
 #[cfg(test)]
 use rand_chacha::ChaCha8Rng;
 use serde::{Deserialize, Serialize};
@@ -104,11 +100,6 @@ pub enum MMapFileError {
     /// Number conversion error.
     #[error(transparent)]
     TryFromInt(#[from] std::num::TryFromIntError),
-
-    /// Error from a system call.
-    #[cfg(target_os = "linux")]
-    #[error(transparent)]
-    Nix(#[from] nix::Error),
 }
 
 /// A trait for writing to a memory mapped file.
@@ -136,11 +127,6 @@ pub struct LocationInFile {
 }
 
 impl LocationInFile {
-    /// returns the offset of the object in the file.
-    pub fn offset(&self) -> usize {
-        self.offset
-    }
-
     /// returns the next offset in the file.
     pub fn next_offset(&self) -> usize {
         self.offset + self.len
@@ -232,37 +218,6 @@ unsafe impl<V: ValueSerde, Mode: TransactionKind> Send for FileHandler<V, Mode> 
 unsafe impl<V: ValueSerde, Mode: TransactionKind> Sync for FileHandler<V, Mode> {}
 
 impl<V: ValueSerde> FileHandler<V, RW> {
-    /// Releases the disk blocks of the file range `[0, end)`, rounded down to a whole page, so the
-    /// bytes read back as zeros. The file size and all offsets are unchanged; the caller must
-    /// ensure no live object resides in the range. Idempotent: re-releasing a released range is a
-    /// no-op. Only supported on Linux; elsewhere this logs an error and does nothing.
-    pub(crate) fn punch_hole_up_to(&self, end: usize) -> MmapFileResult<()> {
-        let end = end - end % page_size::get();
-        if end == 0 {
-            return Ok(());
-        }
-        #[cfg(not(target_os = "linux"))]
-        tracing::error!(
-            "Cannot punch a hole in the file range [0, {end}): unsupported on this OS, so the \
-             disk space is not released."
-        );
-        #[cfg(target_os = "linux")]
-        {
-            debug!("Punching a hole in the file range [0, {end}).");
-            let mmap_file = self.mmap_file.lock().expect("Lock should not be poisoned");
-            // `PUNCH_HOLE` deallocates the range's blocks, turning it into a hole that reads as
-            // zeros; `KEEP_SIZE`, which it must be paired with, leaves the file's size as is, so
-            // the offsets of the objects above the range stay valid.
-            fallocate(
-                mmap_file.file.as_raw_fd(),
-                FallocateFlags::FALLOC_FL_PUNCH_HOLE | FallocateFlags::FALLOC_FL_KEEP_SIZE,
-                0,
-                end.try_into()?,
-            )?;
-        }
-        Ok(())
-    }
-
     fn grow_file_if_needed(&mut self, offset: usize) {
         let mut mmap_file = self.mmap_file.lock().expect("Lock should not be poisoned");
         if mmap_file.size < offset + mmap_file.config.max_object_size {

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -57,10 +57,6 @@ pub trait StateCommitmentInfosStorageReader<Mode: TransactionKind> {
     /// Returns whether the compressed commitment infos for the given block are stored, without
     /// reading the stored blob.
     fn has_state_commitment_infos(&self, block_number: BlockNumber) -> StorageResult<bool>;
-
-    /// Returns the lowest block whose commitment infos are stored, which is where pruning
-    /// resumes, or `None` if no infos are stored at all.
-    fn state_commitment_infos_lower_bound(&self) -> StorageResult<Option<BlockNumber>>;
 }
 
 /// Interface for writing the OS-input commitment infos to storage.
@@ -105,12 +101,6 @@ impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTrans
 
     fn has_state_commitment_infos(&self, block_number: BlockNumber) -> StorageResult<bool> {
         Ok(self.state_commitment_infos_location(block_number)?.is_some())
-    }
-
-    fn state_commitment_infos_lower_bound(&self) -> StorageResult<Option<BlockNumber>> {
-        let table = self.open_table(&self.tables().state_commitment_infos)?;
-        let mut cursor = table.cursor(self.txn())?;
-        Ok(cursor.lower_bound(&BlockNumber(0))?.map(|(block_number, _location)| block_number))
     }
 }
 

--- a/crates/apollo_storage/src/state_commitment_infos.rs
+++ b/crates/apollo_storage/src/state_commitment_infos.rs
@@ -1,9 +1,6 @@
 //! Storage for the per-block OS-input commitment infos (state-trie commitment data for the OS).
 //!
-//! Persists the already-compressed `CompressedStateCommitmentInfos` the committer produces. The
-//! compressed bytes are appended to the commitment infos data file, and the pointers table maps
-//! each block to the location of its infos in that file. Pruning removes a block's pointer, then
-//! releases the data its pointer pointed at.
+//! Persists the already-compressed `CompressedStateCommitmentInfos` the committer produces.
 
 use starknet_api::block::BlockNumber;
 pub use starknet_committer::patricia_merkle_tree::types::{
@@ -17,20 +14,10 @@ pub use starknet_committer::patricia_merkle_tree::types::{
 mod state_commitment_infos_test;
 
 use crate::db::serialization::{StorageSerde, StorageSerdeError};
-use crate::db::table_types::{DbCursorTrait, Table};
+use crate::db::table_types::Table;
 use crate::db::{TransactionKind, RW};
 use crate::mmap_file::LocationInFile;
-use crate::{OffsetKind, StorageResult, StorageTransaction, StorageWriter};
-
-/// The outcome of pruning state commitment infos pointers.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PrunedStateCommitmentInfosPointers {
-    /// One past the last removed height; no infos are stored below it.
-    pub new_lower_bound: BlockNumber,
-    /// The data file offset just past the infos of the last removed pointer; the data below it is
-    /// pointed at by no pointer, and can be released.
-    pub data_end_offset: usize,
-}
+use crate::{OffsetKind, StorageResult, StorageTransaction};
 
 impl StorageSerde for CompressedStateCommitmentInfos {
     fn serialize_into(&self, res: &mut impl std::io::Write) -> Result<(), StorageSerdeError> {
@@ -74,16 +61,6 @@ where
     /// Removes the commitment infos for the given block from storage.
     /// If no entry exists for the block, returns without error.
     fn revert_state_commitment_infos(self, block_number: BlockNumber) -> StorageResult<Self>;
-
-    /// Removes the pointers to the commitment infos of the lowest stored heights below
-    /// `prune_below`, at most `max_deletions` of them. Returns `None` if nothing was removed. The
-    /// data they pointed at stays in the data file until released with
-    /// [`StorageWriter::prune_state_commitment_infos_data`].
-    fn prune_state_commitment_infos_pointers(
-        self,
-        prune_below: BlockNumber,
-        max_deletions: usize,
-    ) -> StorageResult<(Self, Option<PrunedStateCommitmentInfosPointers>)>;
 }
 
 impl<T: StorageTransaction> StateCommitmentInfosStorageReader<<T as StorageTransaction>::Mode>
@@ -149,47 +126,5 @@ impl<T: StorageTransaction<Mode = RW>> StateCommitmentInfosStorageWriter for T {
             self.open_table(&self.tables().state_commitment_infos)?;
         state_commitment_infos_table.delete(self.txn(), &block_number)?;
         Ok(self)
-    }
-
-    fn prune_state_commitment_infos_pointers(
-        self,
-        prune_below: BlockNumber,
-        max_deletions: usize,
-    ) -> StorageResult<(Self, Option<PrunedStateCommitmentInfosPointers>)> {
-        let state_commitment_infos_table =
-            self.open_table(&self.tables().state_commitment_infos)?;
-        let mut cursor = state_commitment_infos_table.cursor(self.txn())?;
-        let mut entries_to_delete = Vec::new();
-        // Deletion starts at the first pointer that still exists, i.e. the entry of the lowest
-        // block number that was not pruned yet.
-        let mut entry = cursor.lower_bound(&BlockNumber(0))?;
-        while let Some((block_number, location)) = entry {
-            if block_number >= prune_below || entries_to_delete.len() >= max_deletions {
-                break;
-            }
-            entries_to_delete.push((block_number, location));
-            entry = cursor.next()?;
-        }
-        for (block_number, _location) in &entries_to_delete {
-            state_commitment_infos_table.delete(self.txn(), block_number)?;
-        }
-        Ok((
-            self,
-            entries_to_delete.last().map(|(block_number, location)| {
-                PrunedStateCommitmentInfosPointers {
-                    new_lower_bound: block_number.unchecked_next(),
-                    data_end_offset: location.next_offset(),
-                }
-            }),
-        ))
-    }
-}
-
-impl StorageWriter {
-    /// Releases the disk blocks of the commitment infos data file below `end`, which no pointer
-    /// may point into (see [`PrunedStateCommitmentInfosPointers::data_end_offset`]). Offsets are
-    /// unchanged and the range reads as zeros; repeating the call is a no-op.
-    pub fn prune_state_commitment_infos_data(&self, end: usize) -> StorageResult<()> {
-        self.file_writers.punch_state_commitment_infos_hole_up_to(end)
     }
 }

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -147,30 +147,6 @@ fn prune_state_commitment_infos_pointers_advances_lower_bound() {
     assert_eq!(stored_heights(&reader, 1..=6), Vec::<u64>::new());
 }
 
-fn state_commitment_infos_lower_bound(reader: &StorageReader) -> Option<BlockNumber> {
-    reader.begin_ro_txn().unwrap().state_commitment_infos_lower_bound().unwrap()
-}
-
-#[test]
-fn state_commitment_infos_lower_bound_is_the_lowest_stored_height() {
-    let (reader, mut writer) = get_test_storage().0;
-
-    // Nothing is stored yet, so there is no bound to report.
-    assert_eq!(state_commitment_infos_lower_bound(&reader), None);
-
-    store_state_commitment_infos(&mut writer, 3..=6, &dummy_state_commitment_infos());
-    assert_eq!(state_commitment_infos_lower_bound(&reader), Some(BlockNumber(3)));
-
-    // Pruning advances the bound to the lowest surviving height, which is what it reports.
-    let pruned = prune_state_commitment_infos_pointers(&mut writer, 5, 10).unwrap();
-    assert_eq!(pruned.new_lower_bound, BlockNumber(5));
-    assert_eq!(state_commitment_infos_lower_bound(&reader), Some(pruned.new_lower_bound));
-
-    // Pruning the rest leaves no bound again.
-    prune_state_commitment_infos_pointers(&mut writer, 100, 10).unwrap();
-    assert_eq!(state_commitment_infos_lower_bound(&reader), None);
-}
-
 fn allocated_bytes(path: &Path) -> usize {
     usize::try_from(std::fs::metadata(path).unwrap().blocks() * 512).unwrap()
 }

--- a/crates/apollo_storage/src/state_commitment_infos_test.rs
+++ b/crates/apollo_storage/src/state_commitment_infos_test.rs
@@ -1,18 +1,13 @@
-use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
-
 use starknet_api::block::BlockNumber;
 
 use crate::state_commitment_infos::{
     CompressedPayload,
     CompressedStateCommitmentInfos,
-    PrunedStateCommitmentInfosPointers,
     StateCommitmentInfosStorageReader,
     StateCommitmentInfosStorageWriter,
     STATE_COMMITMENT_INFOS_VERSION,
 };
 use crate::test_utils::get_test_storage;
-use crate::{StorageReader, StorageWriter};
 
 /// Non-default version, so the round-trip proves the field is stored rather than assumed.
 fn dummy_state_commitment_infos() -> CompressedStateCommitmentInfos {
@@ -78,136 +73,4 @@ fn revert_state_commitment_infos() {
         .unwrap()
         .commit()
         .unwrap();
-}
-
-fn store_state_commitment_infos(
-    writer: &mut StorageWriter,
-    heights: impl IntoIterator<Item = u64>,
-    state_commitment_infos: &CompressedStateCommitmentInfos,
-) {
-    for height in heights {
-        writer
-            .begin_rw_txn()
-            .unwrap()
-            .append_state_commitment_infos(BlockNumber(height), state_commitment_infos)
-            .unwrap()
-            .commit()
-            .unwrap();
-    }
-}
-
-fn prune_state_commitment_infos_pointers(
-    writer: &mut StorageWriter,
-    prune_below: u64,
-    max_deletions: usize,
-) -> Option<PrunedStateCommitmentInfosPointers> {
-    let (txn, pruned) = writer
-        .begin_rw_txn()
-        .unwrap()
-        .prune_state_commitment_infos_pointers(BlockNumber(prune_below), max_deletions)
-        .unwrap();
-    txn.commit().unwrap();
-    pruned
-}
-
-fn stored_heights(reader: &StorageReader, heights: impl IntoIterator<Item = u64>) -> Vec<u64> {
-    let txn = reader.begin_ro_txn().unwrap();
-    heights
-        .into_iter()
-        .filter(|height| txn.has_state_commitment_infos(BlockNumber(*height)).unwrap())
-        .collect()
-}
-
-#[test]
-fn prune_state_commitment_infos_pointers_advances_lower_bound() {
-    let (reader, mut writer) = get_test_storage().0;
-    store_state_commitment_infos(&mut writer, 1..=6, &dummy_state_commitment_infos());
-
-    // Capped by `max_deletions`, lowest heights first; the bound is one past the last removed.
-    let pruned = prune_state_commitment_infos_pointers(&mut writer, 5, 2).unwrap();
-    assert_eq!(pruned.new_lower_bound, BlockNumber(3));
-    let entry_size = pruned.data_end_offset / 2;
-    assert!(entry_size > 0);
-    assert_eq!(stored_heights(&reader, 1..=6), vec![3, 4, 5, 6]);
-
-    // Stops at `prune_below`; the removed infos end where the next stored ones begin.
-    let pruned = prune_state_commitment_infos_pointers(&mut writer, 5, 10).unwrap();
-    assert_eq!(pruned.new_lower_bound, BlockNumber(5));
-    assert_eq!(pruned.data_end_offset, 4 * entry_size);
-    assert_eq!(stored_heights(&reader, 1..=6), vec![5, 6]);
-
-    // Nothing to remove.
-    assert_eq!(prune_state_commitment_infos_pointers(&mut writer, 5, 10), None);
-    assert_eq!(stored_heights(&reader, 1..=6), vec![5, 6]);
-
-    // Heights that were never stored are skipped and don't count as deletions.
-    let pruned = prune_state_commitment_infos_pointers(&mut writer, 100, 10).unwrap();
-    assert_eq!(pruned.new_lower_bound, BlockNumber(7));
-    assert_eq!(pruned.data_end_offset, 6 * entry_size);
-    assert_eq!(stored_heights(&reader, 1..=6), Vec::<u64>::new());
-}
-
-fn allocated_bytes(path: &Path) -> usize {
-    usize::try_from(std::fs::metadata(path).unwrap().blocks() * 512).unwrap()
-}
-
-#[test]
-fn prune_state_commitment_infos_data_releases_disk_blocks() {
-    let ((reader, mut writer), temp_dir) = get_test_storage();
-    const ENTRY_SIZE: usize = 32 * 1024;
-    let state_commitment_infos = CompressedStateCommitmentInfos {
-        version: STATE_COMMITMENT_INFOS_VERSION,
-        payload: CompressedPayload(vec![7; ENTRY_SIZE]),
-    };
-    store_state_commitment_infos(&mut writer, 1..=4, &state_commitment_infos);
-
-    let file_path = find_file(temp_dir.path(), "state_commitment_infos.dat").unwrap();
-    let before = allocated_bytes(&file_path);
-    assert!(before >= 4 * ENTRY_SIZE);
-
-    let pruned = prune_state_commitment_infos_pointers(&mut writer, 3, 10).unwrap();
-    writer.prune_state_commitment_infos_data(pruned.data_end_offset).unwrap();
-
-    let released = before - allocated_bytes(&file_path);
-    assert!(released >= 2 * ENTRY_SIZE - 2 * page_size::get(), "released only {released} bytes");
-
-    // The surviving infos are intact.
-    let txn = reader.begin_ro_txn().unwrap();
-    assert_eq!(txn.get_state_commitment_infos(BlockNumber(1)).unwrap(), None);
-    assert_eq!(
-        txn.get_state_commitment_infos(BlockNumber(3)).unwrap(),
-        Some(state_commitment_infos.clone())
-    );
-    assert_eq!(
-        txn.get_state_commitment_infos(BlockNumber(4)).unwrap(),
-        Some(state_commitment_infos.clone())
-    );
-    drop(txn);
-
-    // Punching the same range again changes nothing.
-    let after = allocated_bytes(&file_path);
-    writer.prune_state_commitment_infos_data(pruned.data_end_offset).unwrap();
-    assert_eq!(allocated_bytes(&file_path), after);
-
-    // Appending after the punch works as before.
-    store_state_commitment_infos(&mut writer, [5], &state_commitment_infos);
-    assert_eq!(
-        reader.begin_ro_txn().unwrap().get_state_commitment_infos(BlockNumber(5)).unwrap(),
-        Some(state_commitment_infos)
-    );
-
-    // Removing everything releases everything written.
-    let pruned = prune_state_commitment_infos_pointers(&mut writer, 100, 10).unwrap();
-    writer.prune_state_commitment_infos_data(pruned.data_end_offset).unwrap();
-    assert!(allocated_bytes(&file_path) < ENTRY_SIZE);
-}
-
-fn find_file(dir: &Path, file_name: &str) -> Option<PathBuf> {
-    std::fs::read_dir(dir).unwrap().map(|entry| entry.unwrap().path()).find_map(|path| {
-        if path.is_dir() {
-            find_file(&path, file_name)
-        } else {
-            (path.file_name()? == file_name).then_some(path)
-        }
-    })
 }


### PR DESCRIPTION
Revert "apollo_dashboard: panel for pruned state commitment infos (#15046)"

Revert "apollo_consensus_orchestrator: prune state commitment infos the cende recorder holds (#15045)"

Revert "apollo_storage,apollo_batcher,apollo_batcher_types: prune state commitment infos on request (#15044)"

Revert "apollo_batcher_config: add state commitment infos pruning config (#15043)"

Revert "apollo_storage: prune state commitment infos and release their disk space (#15042)"