### PR TITLE
apollo_dashboard: add no-data fallbacks outside the observer guard for stuck alerts

### DIFF
--- a/crates/apollo_dashboard/resources/dev_grafana_alerts.json
+++ b/crates/apollo_dashboard/resources/dev_grafana_alerts.json
@@ -18,7 +18,7 @@
       "name": "batched_transactions_stuck",
       "title": "Batched Transactions Stuck",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck-sampling_window_secs-expression$$$s])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck-sampling_window_secs-expression$$$s]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -44,7 +44,7 @@
       "name": "batched_transactions_stuck_long_time",
       "title": "Batched Transactions Stuck Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck_long_time-sampling_window_secs-expression$$$s])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(changes(batcher_batched_transactions{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$batched_transactions_stuck_long_time-sampling_window_secs-expression$$$s]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -408,7 +408,7 @@
       "name": "consensus_block_number_stuck",
       "title": "Consensus Block Number Stuck",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck-sampling_window_secs-expression$$$s]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -434,7 +434,7 @@
       "name": "consensus_block_number_stuck_long_time",
       "title": "Consensus Block Number Stuck Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(consensus_block_number{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$consensus_block_number_stuck_long_time-sampling_window_secs-expression$$$s]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -720,7 +720,7 @@
       "name": "consensus_p2p_not_enough_peers_for_quorum",
       "title": "Consensus P2P Not Enough Peers For Quorum",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[120s])",
+      "expr": "(min(max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[120s]))) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -746,7 +746,7 @@
       "name": "consensus_p2p_not_enough_peers_for_quorum_long_time",
       "title": "Consensus P2P Not Enough Peers For Quorum Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s])",
+      "expr": "(min(max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s]))) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -772,7 +772,7 @@
       "name": "consensus_p2p_peer_down",
       "title": "Consensus p2p peer down",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])",
+      "expr": "(min(max_over_time(apollo_consensus_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m]))) or vector(2)",
       "conditions": [
         {
           "evaluator": {
@@ -1058,7 +1058,7 @@
       "name": "gateway_add_tx_idle_p2p_rpc",
       "title": "Gateway add_tx idle (p2p+rpc)",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(gateway_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$gateway_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -1318,7 +1318,7 @@
       "name": "http_server_no_successful_transactions",
       "title": "http server no successful transactions",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(http_server_added_transactions_success{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$http_server_no_successful_transactions-sampling_window_secs-expression$$$s]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -1630,7 +1630,7 @@
       "name": "mempool_add_tx_idle_p2p_rpc",
       "title": "Mempool add_tx idle (p2p+rpc)",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s])) or vector(1)) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(mempool_transactions_received{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$$$mempool_add_tx_idle_p2p_rpc-sampling_window_secs-expression$$$s]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -1708,7 +1708,7 @@
       "name": "mempool_p2p_peer_down",
       "title": "Mempool p2p peer down",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(max_over_time(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((min(max_over_time(apollo_mempool_p2p_num_connected_peers{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(2)",
       "conditions": [
         {
           "evaluator": {
@@ -1994,7 +1994,7 @@
       "name": "preconfirmed_block_not_written",
       "title": "Preconfirmed block not written",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "(increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m])) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)",
+      "expr": "((sum(increase(batcher_preconfirmed_block_written{cluster=~\"$cluster\", namespace=~\"$namespace\"}[2m]))) and on() (is_observer{cluster=~\"$cluster\", namespace=~\"$namespace\"} == 0)) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -2228,7 +2228,7 @@
       "name": "state_sync_stuck",
       "title": "State Sync Stuck",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "increase(apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}[120s])",
+      "expr": "(sum(increase(apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}[120s]))) or vector(1)",
       "conditions": [
         {
           "evaluator": {
@@ -2254,7 +2254,7 @@
       "name": "state_sync_stuck_long_time",
       "title": "State Sync Stuck Long Time",
       "ruleGroup": "evaluation_rate_default",
-      "expr": "increase(apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s])",
+      "expr": "(sum(increase(apollo_state_sync_class_manager_marker{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1800s]))) or vector(1)",
       "conditions": [
         {
           "evaluator": {

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_delay.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_delay.rs
@@ -79,7 +79,7 @@ pub(crate) fn get_consensus_p2p_peer_down() -> Alert {
         ALERT_NAME,
         "Consensus p2p peer down",
         EvaluationRate::Default,
-        format!("max_over_time({}[2m])", CONSENSUS_NUM_CONNECTED_PEERS.get_name_with_filter()),
+        format!("min(max_over_time({}[2m]))", CONSENSUS_NUM_CONNECTED_PEERS.get_name_with_filter()),
         vec![AlertCondition::new(
             AlertComparisonOp::LessThan,
             // TODO(shahak): find a way to make this depend on num_validators
@@ -90,6 +90,7 @@ pub(crate) fn get_consensus_p2p_peer_down() -> Alert {
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::Applicable,
     )
+    .with_no_data_fallback(2.0)
 }
 
 pub(crate) fn get_cende_write_blob_failure_once_alert() -> Alert {

--- a/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/block_production_halt.rs
@@ -30,15 +30,10 @@ fn get_consensus_block_number_stuck(
     alert_severity: impl Into<SeverityValueOrPlaceholder>,
 ) -> Alert {
     let name = title.to_lowercase().replace(' ', "_");
-    // Fall back to `vector(1)`, not `vector(0)`, when the metric has no samples: an absent/late
-    // series (e.g. transient query-time gaps for a remote-region node) must not read as a halt.
     // A real halt keeps the gauge present, so `increase` yields a present `0` and still fires;
     // a dead pod is caught by the `pod_state_not_ready` / `pod_state_crashloopbackoff` alerts.
-    // The fallback must stay `>=` the stuck threshold (`< 1`).
-    let expr_template_string = format!(
-        "sum(increase({}[{{}}s])) or vector(1)",
-        CONSENSUS_BLOCK_NUMBER.get_name_with_filter()
-    );
+    let expr_template_string =
+        format!("sum(increase({}[{{}}s]))", CONSENSUS_BLOCK_NUMBER.get_name_with_filter());
     Alert::new(
         &name,
         title,
@@ -52,6 +47,7 @@ fn get_consensus_block_number_stuck(
         alert_severity,
         ObserverApplicability::NotApplicable,
     )
+    .with_no_data_fallback(1.0)
 }
 
 pub(crate) fn get_consensus_block_number_stuck_vec() -> Vec<Alert> {
@@ -71,7 +67,7 @@ pub(crate) fn get_consensus_block_number_stuck_vec() -> Vec<Alert> {
 fn get_batched_transactions_stuck(title: &'static str) -> Alert {
     let name = title.to_lowercase().replace(' ', "_");
     let expr_template_string =
-        format!("changes({}[{{}}s])", BATCHED_TRANSACTIONS.get_name_with_filter());
+        format!("sum(changes({}[{{}}s]))", BATCHED_TRANSACTIONS.get_name_with_filter());
     Alert::new(
         &name,
         title,
@@ -85,6 +81,7 @@ fn get_batched_transactions_stuck(title: &'static str) -> Alert {
         SeverityValueOrPlaceholder::Placeholder(name.clone()),
         ObserverApplicability::NotApplicable,
     )
+    .with_no_data_fallback(1.0)
 }
 
 pub(crate) fn get_batched_transactions_stuck_vec() -> Vec<Alert> {
@@ -104,7 +101,7 @@ fn get_consensus_p2p_not_enough_peers_for_quorum(
         title,
         EvaluationRate::Default,
         format!(
-            "max_over_time({}[{}s])",
+            "min(max_over_time({}[{}s]))",
             CONSENSUS_NUM_CONNECTED_PEERS.get_name_with_filter(),
             duration.as_secs()
         ),
@@ -119,6 +116,7 @@ fn get_consensus_p2p_not_enough_peers_for_quorum(
         alert_severity,
         ObserverApplicability::Applicable,
     )
+    .with_no_data_fallback(1.0)
 }
 
 pub(crate) fn get_consensus_p2p_not_enough_peers_for_quorum_vec() -> Vec<Alert> {

--- a/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/preconfirmed.rs
@@ -19,10 +19,11 @@ pub(crate) fn get_preconfirmed_block_not_written() -> Alert {
         ALERT_NAME,
         "Preconfirmed block not written",
         EvaluationRate::Default,
-        format!("increase({}[2m])", PRECONFIRMED_BLOCK_WRITTEN.get_name_with_filter()),
+        format!("sum(increase({}[2m]))", PRECONFIRMED_BLOCK_WRITTEN.get_name_with_filter()),
         vec![AlertCondition::new(AlertComparisonOp::LessThan, 1.0, AlertLogicalOp::And)],
         PENDING_DURATION_DEFAULT,
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
+    .with_no_data_fallback(1.0)
 }

--- a/crates/apollo_dashboard/src/alert_scenarios/sync_halt.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/sync_halt.rs
@@ -47,7 +47,7 @@ fn get_state_sync_stuck(
         alert_name,
         EvaluationRate::Default,
         format!(
-            "increase({}[{}s])",
+            "sum(increase({}[{}s]))",
             STATE_SYNC_CLASS_MANAGER_MARKER.get_name_with_filter(),
             duration.as_secs()
         ), // Alert is triggered when the class manager marker is not updated for {duration}s
@@ -56,6 +56,7 @@ fn get_state_sync_stuck(
         alert_severity,
         ObserverApplicability::Applicable,
     )
+    .with_no_data_fallback(1.0)
 }
 
 pub(crate) fn get_state_sync_stuck_vec() -> Vec<Alert> {

--- a/crates/apollo_dashboard/src/alert_scenarios/tps.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/tps.rs
@@ -30,13 +30,9 @@ fn build_idle_alert(
     metric_name_with_filter: &str,
     alert_severity: AlertSeverity,
 ) -> Alert {
-    // Fall back to `vector(1)`, not `vector(0)`, when the metric has no samples: a transient
-    // scrape/ingestion gap makes `increase` return empty, and `or vector(0)` would turn that into a
-    // hard `0` that trips `< 0.1` and false-pages even while tx ingestion is healthy. A real idle
-    // keeps the counter present, so `increase` yields a present `0` and still fires; a dead pod is
-    // caught by the `pod_state_*` alerts. The fallback must stay `>=` the idle threshold (`< 0.1`).
-    let expr_template_string =
-        format!("sum(increase({}[{{}}s])) or vector(1)", metric_name_with_filter);
+    // A real idle keeps the counter present, so `increase` yields a present `0` and still fires;
+    // a dead pod is caught by the `pod_state_*` alerts.
+    let expr_template_string = format!("sum(increase({}[{{}}s]))", metric_name_with_filter);
     Alert::new(
         alert_name,
         alert_title,
@@ -50,6 +46,7 @@ fn build_idle_alert(
         alert_severity,
         ObserverApplicability::NotApplicable,
     )
+    .with_no_data_fallback(1.0)
 }
 
 pub(crate) fn get_http_server_no_successful_transactions() -> Alert {

--- a/crates/apollo_dashboard/src/alert_scenarios/transaction_delays.rs
+++ b/crates/apollo_dashboard/src/alert_scenarios/transaction_delays.rs
@@ -29,7 +29,10 @@ pub(crate) fn get_mempool_p2p_peer_down() -> Alert {
         ALERT_NAME,
         "Mempool p2p peer down",
         EvaluationRate::Default,
-        format!("max_over_time({}[2m])", MEMPOOL_P2P_NUM_CONNECTED_PEERS.get_name_with_filter()),
+        format!(
+            "min(max_over_time({}[2m]))",
+            MEMPOOL_P2P_NUM_CONNECTED_PEERS.get_name_with_filter()
+        ),
         vec![AlertCondition::new(
             AlertComparisonOp::LessThan,
             // TODO(shahak): find a way to make this depend on num_validators
@@ -40,6 +43,7 @@ pub(crate) fn get_mempool_p2p_peer_down() -> Alert {
         SeverityValueOrPlaceholder::Placeholder(ALERT_NAME.to_string()),
         ObserverApplicability::NotApplicable,
     )
+    .with_no_data_fallback(2.0)
 }
 
 /// Triggers if the average latency of `add_tx` calls, across all HTTP servers, exceeds 15 seconds

--- a/crates/apollo_dashboard/src/alerts.rs
+++ b/crates/apollo_dashboard/src/alerts.rs
@@ -295,6 +295,21 @@ impl Alert {
         }
     }
 
+    /// Keeps the rule defined when its series are absent, so a scrape gap leaves the alert in
+    /// `Normal` instead of raising a notifying `DatasourceNoData`. The fallback is appended after
+    /// the observer guard, which would otherwise erase it once `is_observer` goes stale in the
+    /// same gap. `value` must be `>=` the alert threshold, or the rule fires permanently. The
+    /// expression must aggregate away its labels, or `or` cannot suppress the fallback while data
+    /// is present.
+    pub(crate) fn with_no_data_fallback(mut self, value: f64) -> Self {
+        self.expr = ExpressionOrExpressionWithPlaceholder::ConcreteValue(format!(
+            "({}) or vector({})",
+            self.expr.to_alert_promql(),
+            value
+        ));
+        self
+    }
+
     pub(crate) fn get_placeholder_names(&self) -> &HashSet<String> {
         &self.placeholder_names
     }


### PR DESCRIPTION
## Problem

Grafana rules are generated with `noDataState: NoData` (`deployments/monitoring/src/common/grafana10_objects.py:207`). That is **not silent** — per Grafana's docs an absent series raises a `DatasourceNoData` alert instance that routes to notification policies and contact points.

Eleven `LessThan` stuck-detectors could reach that state from a scrape gap alone, notifying on a perfectly healthy node.

## Evidence

Mainnet node-3, 2026-08-27. Scrapes for the whole `starknet-mainnet-apollo-3` cluster thinned from 6/min to 0 between 12:38:30 and 12:45:30 UTC — all 8 pods, 5 nodes, 3 node pools; the five sibling clusters were unaffected. The node itself was healthy throughout: 285 blocks added, 284 precommits broadcast, zero round changes fleet-wide.

`increase(apollo_state_sync_class_manager_marker[120s])` over that window:

```
12:41:00  50.107
   ...     (no data — fewer than 2 samples in every 120s window)
12:45:00  21.893
```

## Fix

`Alert::with_no_data_fallback` keeps the rule defined at a non-firing value. Two constraints make the placement non-obvious, and the helper enforces both:

**1. The fallback goes after the observer guard.** `Alert::new` wraps `NotApplicable` alerts as `(expr) and on() (is_observer == 0)`. A fallback appended by the caller lands inside that, and `is_observer` is scraped from the same pod as the metric it guards — so past the 5m staleness lookback the `and` has an empty right side and discards the fallback:

```promql
((sum(increase(…)) or vector(1)) and on() (absent == 0))   -- 0 series
((sum(increase(…))) and on() (absent == 0)) or vector(1)   -- 1
```

**2. The expression must aggregate away its labels.** `or` only suppresses a right-hand element whose label set already exists on the left, and `vector(N)` is labelless:

```promql
increase(m{ns}[2m]) or vector(1)        -- 2 series (real + constant 1, always)
sum(increase(m{ns}[2m])) or vector(1)   -- 1 series
```

Aggregation is safe because `alert_builder.py:168` substitutes an exact `namespace=`/`cluster=`, so it collapses pods within one namespace rather than across nodes. `sum` for the counters, matching the existing idiom; `min` for the peer gauges so a pod below the threshold still alerts.

Detection is unaffected: a real stall keeps the gauge present, so `increase` yields a present `0` and still fires. The fallback must stay `>=` the threshold, hence `vector(2)` for the two `peer_down` alerts.

## Scope

Six alerts that had no fallback (nine generated rules):

| Alert | Threshold | Fallback |
|---|---|---|
| `state_sync_stuck` (+`_long_time`) | < 1 | `vector(1)` |
| `preconfirmed_block_not_written` | < 1 | `vector(1)` |
| `batched_transactions_stuck` (+`_long_time`) | < 1 | `vector(1)` |
| `consensus_p2p_not_enough_peers_for_quorum` (+`_long_time`) | < 1 | `vector(1)` |
| `consensus_p2p_peer_down` | < 2 | `vector(2)` |
| `mempool_p2p_peer_down` | < 2 | `vector(2)` |

Plus the five existing fallbacks from #14705 and #14876, moved outside the guard — placed inside, those only ever worked for gaps shorter than the staleness lookback.

## Not in this PR

- Four alerts still pair `or vector(0)` with `LessThan`, which turns no-data into a hard `0` and a **false page**: `consensus_block_number_progress_is_slow`, `consensus_decisions_reached_by_consensus_ratio`, `consensus_votes_num_sent_messages`, `gateway_low_successful_transaction_rate`. During this same incident `consensus_block_number_progress_is_slow` held `0.000` for seven consecutive evaluations on the healthy node. Higher severity than this PR; worth a follow-up.
- Long-window blind alerts (15m–1h) are left alone — a gap of this size still leaves samples at the window edges.
- `pod_state_not_ready` is deliberately unchanged: the series vanishing *is* the signal, and a labelless fallback would not join with its `sum by (service_name)`.

## Testing

- `cargo test -p apollo_dashboard` — 22 passed
- `cargo clippy -p apollo_dashboard --all-targets -- -D warnings` — clean
- `cargo run --bin sequencer_dashboard_generator` re-run
- Each generated rule verified to end in a trailing fallback `>=` its threshold
- Behaviour checked against live GMP: data present → real value only; guard absent → fallback survives; metric absent → fallback; validator → real value, single series

No placeholders added or removed, so no per-env override changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)