### PR TITLE
apollo_network: delete dead code

### DIFF
--- a/crates/apollo_network/src/peer_whitelist_test.rs
+++ b/crates/apollo_network/src/peer_whitelist_test.rs
@@ -1,9 +1,8 @@
 use std::collections::HashSet;
 use std::task::{Context, Poll};
 
-use libp2p::core::{ConnectedPoint, Endpoint};
-use libp2p::swarm::behaviour::ConnectionEstablished;
-use libp2p::swarm::{ConnectionId, FromSwarm, NetworkBehaviour, ToSwarm};
+use libp2p::core::Endpoint;
+use libp2p::swarm::{ConnectionId, NetworkBehaviour, ToSwarm};
 use libp2p::{Multiaddr, PeerId};
 
 use super::peer_whitelist::Behaviour;
@@ -134,23 +133,4 @@ fn expect_all_events_are_close_connections(behaviour: &mut Behaviour) -> Vec<Pee
         disconnected.push(peer_id);
     }
     disconnected
-}
-
-#[allow(dead_code)]
-fn simulate_connection_established(
-    behaviour: &mut Behaviour,
-    peer_id: PeerId,
-    connection_id: usize,
-) {
-    let address = Multiaddr::empty();
-    behaviour.on_swarm_event(FromSwarm::ConnectionEstablished(ConnectionEstablished {
-        peer_id,
-        connection_id: ConnectionId::new_unchecked(connection_id),
-        endpoint: &ConnectedPoint::Listener {
-            local_addr: address.clone(),
-            send_back_addr: address,
-        },
-        failed_addresses: &[],
-        other_established: 0,
-    }));
 }


### PR DESCRIPTION
## What

Deletes the unused `simulate_connection_established` test helper in `peer_whitelist_test.rs`, along with the `#[allow(dead_code)]` that masked it and the imports (`ConnectedPoint`, `ConnectionEstablished`, `FromSwarm`) that become unused once it is gone.

The helper has no callers anywhere in the file. (It is a distinct function from the identically named, still-live helper in `peer_manager/test.rs`, which is untouched.) Removing its `#[allow(dead_code)]` makes the compiler report it as never used in both the default and `--tests` configurations; after deletion the crate builds with zero dead-code/unused warnings in both.

## Scope change from the first revision

An earlier revision also removed `PeerManager::report_session` + `PeerManagerError::NoSuchSession`. Per @matanl-starkware's review, that code is intentionally kept for upcoming peer-reporting / decentralization work, so it has been fully restored (including its `#[allow(dead_code)]`). Only the unrelated dead test helper remains in this PR.

## Verification (`RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)

- `scripts/rust_fmt.sh` — clean
- `cargo build -p apollo_network` — zero warnings
- `cargo build -p apollo_network --tests` — zero warnings
- `cargo clippy -p apollo_network --all-targets` — clean
- `SEED=0 cargo test -p apollo_network` — 126 + 25 passed, 0 failed