### PR TITLE
apollo_committer,starknet_committer: avoid cloning compressed commitment infos on every block commit

### DIFF
--- a/crates/apollo_committer/src/committer.rs
+++ b/crates/apollo_committer/src/committer.rs
@@ -662,7 +662,7 @@ where
                 commitment_infos_updates.push(CommitmentInfosUpdate::Write(CommitmentInfosWrite {
                     block_number: height,
                     keys_digest: digest,
-                    commitment_infos: compressed_commitment_infos.clone(),
+                    commitment_infos_bytes: compressed_commitment_infos.to_bytes(),
                 }));
 
                 info!(

--- a/crates/starknet_committer/src/db/forest_trait_witnesses.rs
+++ b/crates/starknet_committer/src/db/forest_trait_witnesses.rs
@@ -21,12 +21,15 @@ use crate::forest::forest_errors::ForestResult;
 use crate::patricia_merkle_tree::tree::SortedLeafIndices;
 use crate::patricia_merkle_tree::types::{CompressedStateCommitmentInfos, StarknetForestProofs};
 
-/// The information required to write the OS-input commitment infos to the database. The payload
-/// is stored as given, so the caller compresses it (once) before handing it over.
+/// The information required to write the OS-input commitment infos to the database.
+/// `commitment_infos_bytes` must be [`CompressedStateCommitmentInfos::to_bytes`] output; readers
+/// parse it back via [`CompressedStateCommitmentInfos::from_bytes`]. Pre-serialized so the caller
+/// can keep its own owned [`CompressedStateCommitmentInfos`] (e.g. to return to its own caller)
+/// without cloning the payload just to satisfy this struct.
 pub struct CommitmentInfosWrite {
     pub block_number: BlockNumber,
     pub keys_digest: [u8; 32],
-    pub commitment_infos: CompressedStateCommitmentInfos,
+    pub commitment_infos_bytes: Vec<u8>,
 }
 
 /// Commitment-infos DB operation, which can be either delete or write.

--- a/crates/starknet_committer/src/db/index_db/db.rs
+++ b/crates/starknet_committer/src/db/index_db/db.rs
@@ -450,7 +450,7 @@ impl<S: Storage> IndexDb<S> {
             CommitmentInfosUpdate::Write(CommitmentInfosWrite {
                 block_number,
                 keys_digest,
-                commitment_infos,
+                commitment_infos_bytes,
             }) => {
                 operations.insert(
                     Self::metadata_key(ForestMetadataType::AccessedKeysDigest(DbBlockNumber(
@@ -463,7 +463,7 @@ impl<S: Storage> IndexDb<S> {
                         &PATRICIA_PATHS_PREFIX,
                         DbBlockNumber(block_number),
                     )),
-                    DbOperation::Set(DbValue(commitment_infos.to_bytes())),
+                    DbOperation::Set(DbValue(commitment_infos_bytes)),
                 );
             }
         }


### PR DESCRIPTION
## Summary

Follow-up performance optimization to #15070, which forwarded the stored `CompressedStateCommitmentInfos` as-is in the *historical replay* branch of `read_paths_and_commit_block` to skip a decompress/re-compress round trip.

This PR targets the other branch of the same function — the normal `CommitTip` path that runs on **every produced block** — where `CommitmentInfosWrite.commitment_infos` was typed as an owned `CompressedStateCommitmentInfos`. That forced `committer.rs` to `.clone()` the whole compressed payload (a full deep copy of the `Vec<u8>` byte buffer) purely so it could still return the original, un-cloned value from `read_paths_and_commit_block`. The DB-write side only ever needed a borrow: `commitment_infos.to_bytes()` takes `&self` and produces its own fresh `Vec<u8>` for storage.

Changes:
- `CommitmentInfosWrite.commitment_infos` → `commitment_infos_bytes: Vec<u8>`, holding the already-serialized bytes (`CompressedStateCommitmentInfos::to_bytes()` output).
- `committer.rs` now calls `compressed_commitment_infos.to_bytes()` (borrow) instead of `.clone()` (deep copy) when building the DB write, keeping its own owned value to return in the response.
- `append_commitment_infos_update` in `index_db/db.rs` writes the bytes directly instead of calling `.to_bytes()` on a typed value.

Net effect: one full O(payload_size) copy of the compressed commitment-infos payload removed from the per-block commit-tip hot path (the `to_bytes()` copy that remains was already happening downstream regardless). On-disk format is unchanged — bytes written are byte-identical to before.

## Test plan
- `cargo build -p apollo_committer -p starknet_committer` — clean.
- `SEED=0 cargo test -p apollo_committer -p starknet_committer` — 158/158 tests pass (25 + 133).
- `cargo clippy -p apollo_committer -p starknet_committer --all-targets` — clean, no warnings.
- Reviewed by an independent Opus pass for correctness/style; addressed its one doc-comment suggestion, no blocking findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172sao8Geft9LtLhSQhJs2T)_