### PR TITLE
apollo_consensus_orchestrator: collect recent block hashes before state commitment infos in blob

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
+++ b/crates/apollo_consensus_orchestrator/src/sequencer_consensus_context.rs
@@ -668,6 +668,9 @@ impl SequencerConsensusContext {
             .prev()
             .and_then(|parent_height| self.fee_proposals_window.get(&parent_height).copied())
             .flatten();
+        // Collected first: `get_block_hash` flushes finished committer results to storage,
+        // making this height's state commitment infos readable in the collection below.
+        let recent_block_hashes = self.collect_recent_block_hashes(height).await;
         let recent_state_commitment_infos =
             self.collect_recent_state_commitment_infos(height).await.unwrap_or_else(|e| {
                 // `finalize_decision` must not fail, so continue with an empty vector.
@@ -704,7 +707,7 @@ impl SequencerConsensusContext {
                 parent_proposal_commitment: central_objects
                     .parent_proposal_commitment
                     .map(|c| proposal_commitment_from(c.partial_block_hash, parent_fee_proposal)),
-                recent_block_hashes: self.collect_recent_block_hashes(height).await,
+                recent_block_hashes,
                 recent_state_commitment_infos,
                 initial_reads: central_objects.initial_reads,
                 block_hash_commitments: block_header_commitments,


### PR DESCRIPTION
## Problem
`get_block(latest)` on the feeder gateway (BLOBS mode, blob fallback) returns `Info for block ID N is not ready yet` for the tip block ~100% of the time: blob N carries `hash[N]` but only `info[N-1]`.

## Root cause
In `finalize_decision`, the state commitment infos are collected **before** the recent block hashes. The committer's finished result for the decided height (hash + state commitment infos together) sits un-persisted in the commitment manager's results channel; the first drain that writes it to storage is inside `get_block_hash` — called by the *hashes* collection, a few microseconds after the infos collection already read storage and gave up. Deterministic one-blob lag.

Evidence (stress env, 50 ms storage polling, 4 consecutive blocks): `BlockStateCommitmentInfo[b]` becomes readable at the exact write instant of blob b+1 (±10 ms), while `BlockIdToApolloHash[b]` rides blob b.

## Fix
Collect the recent block hashes first: its `get_block_hash` drain persists this height's commitment infos before the infos collection reads them, so blob N carries both `hash[N]` and `info[N]`. If the commit hasn't finished at decision time (heavy load), both windows end at the same height — the Apollo-hash anchor never advances past the infos it needs.

## Testing
- `cargo test -p apollo_consensus_orchestrator`: 242/242 pass.
- `scripts/rust_fmt.sh --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)