### PR TITLE
starknet_os: pin the fold circuit hashes to a vendored registry and pin fold costs

### DIFF
--- a/crates/starknet_os/resources/circuit_registry_canonical_small.json
+++ b/crates/starknet_os/resources/circuit_registry_canonical_small.json
@@ -1,0 +1,71 @@
+{
+  "cairo_prover_params": {
+    "channel_hash": "blake2s",
+    "channel_salt": 0,
+    "fri_config": {
+      "pow_bits": 16,
+      "log_blowup_factor": 1,
+      "log_last_layer_degree_bound": 0,
+      "n_queries": 70,
+      "fold_step": 1
+    },
+    "preprocessed_trace": "canonical_small",
+    "store_polynomials_coefficients": false,
+    "include_all_preprocessed_columns": true,
+    "opt_n_id_to_big_components": 16,
+    "lifting_size_policy": "at_least_preprocessed"
+  },
+  "circuit_proof_configs": {
+    "default": {
+      "fri_config": {
+        "pow_bits": 26,
+        "log_blowup_factor": 1,
+        "log_last_layer_degree_bound": 0,
+        "n_queries": 70,
+        "fold_step": 4
+      },
+      "component_log_sizes": {
+        "eq": 20,
+        "qm31_ops": 23,
+        "m31_to_u32": 21,
+        "triple_xor": 20,
+        "blake_g_gate": 23
+      }
+    }
+  },
+  "leaf_verifiers": [
+    {
+      "config": "default",
+      "trace_log_size": 20,
+      "circuit_hash": [
+        "0xd2d85a42",
+        "0x79697b22",
+        "0x3a41a061",
+        "0x011cb393",
+        "0x7a040ec9",
+        "0x4508f4ca",
+        "0x42239409",
+        "0x60f3baea"
+      ]
+    }
+  ],
+  "multiverifiers": [
+    {
+      "config": "default",
+      "input_configs": [
+        "default",
+        "default"
+      ],
+      "circuit_hash": [
+        "0xa5989715",
+        "0x2377c07a",
+        "0xc6d1e844",
+        "0x54f0a04d",
+        "0x8be65a7d",
+        "0xfd73c261",
+        "0x9078e728",
+        "0x973f680f"
+      ]
+    }
+  ]
+}

--- a/crates/starknet_os/src/proof_fact_fold.rs
+++ b/crates/starknet_os/src/proof_fact_fold.rs
@@ -17,8 +17,9 @@ pub type Blake2sDigestWords = [u32; BLAKE2S_DIGEST_N_WORDS];
 /// The leaf cairo-verifier circuit's hash, from the proving side's circuit registry:
 /// blake2s(log_blowup_factor || component_log_sizes || preprocessed_root).
 ///
-/// NOTE: `canonical_small` test-registry value; to be replaced with the production
-/// registry's before production use.
+/// NOTE: `canonical_small` test-registry value, pinned against the vendored
+/// `resources/circuit_registry_canonical_small.json`; to be replaced - together with the
+/// registry - with the production value before production use.
 pub const LEAF_VERIFIER_CIRCUIT_HASH: Blake2sDigestWords = [
     0xd2d85a42, 0x79697b22, 0x3a41a061, 0x011cb393, 0x7a040ec9, 0x4508f4ca, 0x42239409, 0x60f3baea,
 ];

--- a/crates/starknet_os/src/proof_fact_fold_test.rs
+++ b/crates/starknet_os/src/proof_fact_fold_test.rs
@@ -4,6 +4,8 @@ use apollo_starknet_os_program::test_programs::PROOF_FACT_FOLD_BYTES;
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::relocatable::MaybeRelocatable;
+use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use expect_test::expect;
 use rstest::rstest;
 use starknet_types_core::felt::Felt;
 
@@ -102,6 +104,28 @@ fn run_cairo_fold_block_proof_facts(per_transaction_proof_facts: &[&[Felt]]) -> 
         FOLD_ENTRY_N_WORDS,
     );
     fold_entry_from_words(&root_entry_words)
+}
+
+/// Runs the Cairo `fold_block_proof_facts` and returns the run's execution resources.
+fn run_cairo_fold_execution_resources(
+    per_transaction_proof_facts: &[&[Felt]],
+) -> ExecutionResources {
+    let expected_return_values = vec![EndpointArg::Pointer(PointerArg::Array(vec![
+            MaybeRelocatable::from(Felt::ZERO);
+            FOLD_ENTRY_N_WORDS
+        ]))];
+    let (_, _, cairo_runner) = initialize_and_run_cairo_0_entry_point(
+        &entrypoint_runner_config(),
+        PROOF_FACT_FOLD_BYTES,
+        "fold_block_proof_facts",
+        &fold_block_proof_facts_args(per_transaction_proof_facts),
+        &[ImplicitArg::Builtin(BuiltinName::range_check)],
+        &expected_return_values,
+        HashMap::new(),
+        None,
+    )
+    .unwrap_or_else(|error| panic!("Failed to run fold_block_proof_facts: {error:?}"));
+    cairo_runner.get_execution_resources().unwrap().filter_unused_builtins()
 }
 
 /// The Cairo arguments: `n_transactions`, then an array of `ProofFactsReference`s - a
@@ -327,4 +351,82 @@ fn test_cairo_pack_and_unpack_output_digest_match_rust() {
         FOLD_ENTRY_N_WORDS,
     );
     assert_eq!(fold_entry_from_words(&unpacked_entry_words), root_entry);
+}
+
+/// One circuit hash of the vendored registry as digest words.
+fn registry_circuit_hash(
+    registry: &serde_json::Value,
+    verifier_list_key: &str,
+) -> Blake2sDigestWords {
+    let verifier_entries = registry[verifier_list_key]
+        .as_array()
+        .unwrap_or_else(|| panic!("The registry must list {verifier_list_key}."));
+    // The fold hardcodes a single circuit hash per role. The production registry lists
+    // one leaf verifier per trace size, each with its own circuit hash; whether all
+    // production leaves are proven at one canonical trace size, or the OS must allow
+    // several leaf circuit hashes, must be settled before swapping the production
+    // registry in - this assertion failing on such a registry forces that decision.
+    assert_eq!(
+        verifier_entries.len(),
+        1,
+        "The fold hardcodes a single circuit hash, but the registry lists {} {verifier_list_key}.",
+        verifier_entries.len()
+    );
+    let circuit_hash_words: Vec<u32> = verifier_entries[0]["circuit_hash"]
+        .as_array()
+        .expect("A circuit hash must be an array of words.")
+        .iter()
+        .map(|circuit_hash_word| {
+            let word_hex =
+                circuit_hash_word.as_str().expect("A circuit hash word must be a string.");
+            u32::from_str_radix(word_hex.trim_start_matches("0x"), 16)
+                .expect("A circuit hash word must be a hex u32.")
+        })
+        .collect();
+    circuit_hash_words.try_into().expect("A circuit hash must have exactly 8 words.")
+}
+
+/// Pins the circuit hash constants to the vendored circuit registry
+/// (`resources/circuit_registry_canonical_small.json`): the `canonical_small` registry,
+/// taken verbatim from proving-dev commit b75d21f91fe846401e002ad169dbcbe57f289ebf at
+/// crates/stwo_run_and_prove_recursive_tree/test_data/circuit_registry.json. Together
+/// with `test_cairo_circuit_hash_constants_match_rust` this pins the Cairo constants to
+/// the registry, so swapping in the production registry is a one-file change whose
+/// omissions or drift are caught here.
+#[test]
+fn test_circuit_hash_constants_match_vendored_registry() {
+    let registry: serde_json::Value =
+        serde_json::from_str(include_str!("../resources/circuit_registry_canonical_small.json"))
+            .expect("The vendored circuit registry must be valid JSON.");
+    assert_eq!(registry_circuit_hash(&registry, "leaf_verifiers"), LEAF_VERIFIER_CIRCUIT_HASH);
+    assert_eq!(registry_circuit_hash(&registry, "multiverifiers"), MULTIVERIFIER_CIRCUIT_HASH);
+}
+
+/// Pins the Cairo fold's execution cost, answering the design's per-block budget
+/// question: `fold_block_proof_facts` over `n_transactions` realistic transactions
+/// (9-felt proof facts with three large felts) costs `n_transactions` leaf digests
+/// (felt encoding + blake) plus the fold hashes - one self-fold for a single
+/// transaction, `n_transactions - 1` pair folds otherwise. A change here means the
+/// fold's cost profile changed; rerun with `UPDATE_EXPECT=1` after verifying the cause.
+#[test]
+fn test_fold_block_proof_facts_execution_resources() {
+    let fold_resources_summary = |n_transactions: u64| {
+        let per_transaction_proof_facts: Vec<Vec<Felt>> =
+            (0..n_transactions).map(synthetic_proof_facts).collect();
+        let proof_facts_references: Vec<&[Felt]> =
+            per_transaction_proof_facts.iter().map(Vec::as_slice).collect();
+        let execution_resources = run_cairo_fold_execution_resources(&proof_facts_references);
+        format!(
+            "{} steps, {} range checks",
+            execution_resources.n_steps,
+            execution_resources
+                .builtin_instance_counter
+                .get(&BuiltinName::range_check)
+                .copied()
+                .unwrap_or(0)
+        )
+    };
+    expect!["943 steps, 13 range checks"].assert_eq(&fold_resources_summary(1));
+    expect!["1281 steps, 23 range checks"].assert_eq(&fold_resources_summary(2));
+    expect!["5763 steps, 101 range checks"].assert_eq(&fold_resources_summary(8));
 }


### PR DESCRIPTION
Part 6 of the privacy proof-fact fold stack, on top of #15064. Test-only: converts the "placeholder circuit hash constants" caveat into a CI-enforced pin, and answers the design's per-block cost question with measured numbers.

**Registry drift test:**
- Vendors the `canonical_small` circuit registry verbatim (proving-dev commit `b75d21f9`, `crates/stwo_run_and_prove_recursive_tree/test_data/circuit_registry.json`) into `crates/starknet_os/resources/`.
- `test_circuit_hash_constants_match_vendored_registry` pins `LEAF_VERIFIER_CIRCUIT_HASH` / `MULTIVERIFIER_CIRCUIT_HASH` to the registry's values; chained with the existing Cairo-vs-Rust hash tests, the Cairo values are now pinned to the registry end to end. Swapping in the production registry becomes a one-file change whose omissions or later drift fail CI.
- The test asserts the registry lists **exactly one leaf verifier**. This is deliberate: the production registry lists one leaf verifier per trace size (25–29), each with its own circuit hash, while the fold hardcodes a single `ch_leaf`. The assertion failing on a production registry is the forcing function for the open contract question — are all production leaves (re-)proven at one canonical trace size, or must the OS accept a set of leaf circuit hashes? This needs settling with the proving side before the production swap (it would change the fold's leaf-entry construction if the answer is a set).

**Fold cost pins** (design open question 4):
- `test_fold_block_proof_facts_execution_resources` pins the Cairo fold's measured resources over realistic 9-felt proof facts: **943 steps (1 tx), 1281 (2 txs), 5763 (8 txs)** — ~747 steps and ~13 range checks marginal per transaction, plus the +14 steps/invoke recording cost already measured in #15064. A 100-tx privacy block folds for under ~75K steps: comfortably within the OS budget, so the design's Cairo0-cost concern is closed.

Verified: 23/23 fold tests pass clean; rustfmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmPJM3Wph4QLmFmhcxVsh4