### PR TITLE
apollo_starknet_os_program,starknet_os: add the Cairo0 proof-fact fold tree

### DIFF
--- a/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/proof_fact_fold.cairo
+++ b/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/proof_fact_fold.cairo
@@ -4,9 +4,46 @@
 
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_blake2s.blake2s import blake_with_opcode, encode_felt252s_to_u32s
+from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.registers import get_label_location
 
 const BLAKE2S_DIGEST_N_WORDS = 8;
+// A fold-tree entry: a circuit hash (8 words) followed by an output digest (8 words).
+const FOLD_ENTRY_N_WORDS = 2 * BLAKE2S_DIGEST_N_WORDS;
+
+// A reference to one transaction's proof facts, recorded during transaction execution.
+struct ProofFactsReference {
+    proof_facts_size: felt,
+    proof_facts: felt*,
+}
+
+// Folds the proof facts of a block's privacy transactions into the block's root entry:
+// [multiverifier circuit hash, root output digest].
+// Preconditions: `n_transactions` is at least 1 and every referenced proof facts size is
+// at least 3; transactions with empty proof facts must not be included.
+func fold_block_proof_facts{range_check_ptr}(
+    n_transactions: felt, proof_facts_references: ProofFactsReference*
+) -> (root_entry: felt*) {
+    alloc_locals;
+    assert_not_zero(n_transactions);
+    let (local leaf_entries: felt*) = alloc();
+    build_leaf_entries(
+        n_transactions=n_transactions,
+        proof_facts_references=proof_facts_references,
+        leaf_entries=leaf_entries,
+    );
+    return fold_entries_to_root(n_entries=n_transactions, entries=leaf_entries);
+}
+
+// The digest the circuit verifier outputs for the proof whose facts fold to `entry`:
+// blake2s over the entry's 16 words (proving side: `get_verification_output`).
+func compute_fold_digest{range_check_ptr}(entry: felt*) -> (fold_digest: felt*) {
+    alloc_locals;
+    let (local fold_digest: felt*) = alloc();
+    blake_with_opcode(len=FOLD_ENTRY_N_WORDS, data=entry, out=fold_digest);
+    return (fold_digest=fold_digest);
+}
 
 // Computes one transaction's leaf output digest, as 8 little-endian u32 words:
 // blake2s(encode_felt252s_to_u32s(proof_facts[2:])). The preimage drops the two version
@@ -64,4 +101,90 @@ func get_multiverifier_circuit_hash() -> (circuit_hash: felt*) {
     dw 0xfd73c261;
     dw 0x9078e728;
     dw 0x973f680f;
+}
+
+// Builds the layer-0 fold entries, one per transaction, consecutively at `leaf_entries`.
+func build_leaf_entries{range_check_ptr}(
+    n_transactions: felt, proof_facts_references: ProofFactsReference*, leaf_entries: felt*
+) {
+    alloc_locals;
+    if (n_transactions == 0) {
+        return ();
+    }
+    let (leaf_verifier_circuit_hash) = get_leaf_verifier_circuit_hash();
+    memcpy(dst=leaf_entries, src=leaf_verifier_circuit_hash, len=BLAKE2S_DIGEST_N_WORDS);
+    let (output_digest) = compute_leaf_output_digest(
+        proof_facts_size=proof_facts_references.proof_facts_size,
+        proof_facts=proof_facts_references.proof_facts,
+    );
+    memcpy(
+        dst=leaf_entries + BLAKE2S_DIGEST_N_WORDS, src=output_digest, len=BLAKE2S_DIGEST_N_WORDS
+    );
+    return build_leaf_entries(
+        n_transactions=n_transactions - 1,
+        proof_facts_references=&proof_facts_references[1],
+        leaf_entries=leaf_entries + FOLD_ENTRY_N_WORDS,
+    );
+}
+
+// Folds `n_entries` consecutive entries at `entries` into the single root entry. A
+// single entry self-folds (the multiverifier verifies the same proof in both slots).
+// Precondition: `n_entries` is at least 1.
+func fold_entries_to_root{range_check_ptr}(n_entries: felt, entries: felt*) -> (root_entry: felt*) {
+    alloc_locals;
+    if (n_entries == 1) {
+        let (local self_fold_preimage: felt*) = alloc();
+        memcpy(dst=self_fold_preimage, src=entries, len=FOLD_ENTRY_N_WORDS);
+        memcpy(dst=self_fold_preimage + FOLD_ENTRY_N_WORDS, src=entries, len=FOLD_ENTRY_N_WORDS);
+        let (local root_entry: felt*) = alloc();
+        fold_pair(children=self_fold_preimage, parent_entry=root_entry);
+        return (root_entry=root_entry);
+    }
+    return fold_layers_to_root(n_entries=n_entries, entries=entries);
+}
+
+// Folds layers of adjacent pairs until a single entry remains and returns it.
+// Precondition: `n_entries` is at least 2.
+func fold_layers_to_root{range_check_ptr}(n_entries: felt, entries: felt*) -> (root_entry: felt*) {
+    alloc_locals;
+    let (local next_layer_entries: felt*) = alloc();
+    let (n_next_layer_entries) = fold_layer(
+        n_entries=n_entries, entries=entries, next_layer_entries=next_layer_entries
+    );
+    if (n_next_layer_entries == 1) {
+        return (root_entry=next_layer_entries);
+    }
+    return fold_layers_to_root(n_entries=n_next_layer_entries, entries=next_layer_entries);
+}
+
+// Folds one layer of adjacent pairs left to right into `next_layer_entries`, carrying a
+// trailing unpaired entry unchanged; returns the next layer's entry count.
+func fold_layer{range_check_ptr}(n_entries: felt, entries: felt*, next_layer_entries: felt*) -> (
+    n_next_layer_entries: felt
+) {
+    if (n_entries == 0) {
+        return (n_next_layer_entries=0);
+    }
+    if (n_entries == 1) {
+        memcpy(dst=next_layer_entries, src=entries, len=FOLD_ENTRY_N_WORDS);
+        return (n_next_layer_entries=1);
+    }
+    fold_pair(children=entries, parent_entry=next_layer_entries);
+    let (n_rest_entries) = fold_layer(
+        n_entries=n_entries - 2,
+        entries=entries + 2 * FOLD_ENTRY_N_WORDS,
+        next_layer_entries=next_layer_entries + FOLD_ENTRY_N_WORDS,
+    );
+    return (n_next_layer_entries=n_rest_entries + 1);
+}
+
+// Folds the two consecutive entries at `children` into `parent_entry`: the
+// multiverifier's circuit hash, then blake2s over the children's 32 raw u32 words.
+func fold_pair{range_check_ptr}(children: felt*, parent_entry: felt*) {
+    let (multiverifier_circuit_hash) = get_multiverifier_circuit_hash();
+    memcpy(dst=parent_entry, src=multiverifier_circuit_hash, len=BLAKE2S_DIGEST_N_WORDS);
+    blake_with_opcode(
+        len=2 * FOLD_ENTRY_N_WORDS, data=children, out=parent_entry + BLAKE2S_DIGEST_N_WORDS
+    );
+    return ();
 }

--- a/crates/starknet_os/src/proof_fact_fold_test.rs
+++ b/crates/starknet_os/src/proof_fact_fold_test.rs
@@ -8,9 +8,11 @@ use rstest::rstest;
 use starknet_types_core::felt::Felt;
 
 use super::{
+    compute_fold_digest,
     compute_leaf_output_digest,
     fold_block_proof_facts,
     Blake2sDigestWords,
+    FoldEntry,
     BLAKE2S_DIGEST_N_WORDS,
     LEAF_VERIFIER_CIRCUIT_HASH,
     MULTIVERIFIER_CIRCUIT_HASH,
@@ -22,6 +24,8 @@ use crate::test_utils::cairo_runner::{
     ImplicitArg,
     PointerArg,
 };
+
+const FOLD_ENTRY_N_WORDS: usize = 2 * BLAKE2S_DIGEST_N_WORDS;
 
 fn entrypoint_runner_config() -> EntryPointRunnerConfig {
     EntryPointRunnerConfig {
@@ -77,6 +81,38 @@ fn run_cairo_function_returning_words(
             u32::try_from(word_felt.to_biguint()).expect("A digest word must fit in a u32.")
         })
         .collect()
+}
+
+fn fold_entry_from_words(entry_words: &[u32]) -> FoldEntry {
+    FoldEntry {
+        circuit_hash: entry_words[..BLAKE2S_DIGEST_N_WORDS].try_into().unwrap(),
+        output_digest: entry_words[BLAKE2S_DIGEST_N_WORDS..].try_into().unwrap(),
+    }
+}
+
+/// Runs the Cairo `fold_block_proof_facts` and returns the root entry.
+fn run_cairo_fold_block_proof_facts(per_transaction_proof_facts: &[&[Felt]]) -> FoldEntry {
+    let root_entry_words = run_cairo_function_returning_words(
+        "fold_block_proof_facts",
+        &fold_block_proof_facts_args(per_transaction_proof_facts),
+        &[ImplicitArg::Builtin(BuiltinName::range_check)],
+        FOLD_ENTRY_N_WORDS,
+    );
+    fold_entry_from_words(&root_entry_words)
+}
+
+/// The Cairo arguments: `n_transactions`, then an array of `ProofFactsReference`s - a
+/// (size, pointer) pair per transaction.
+fn fold_block_proof_facts_args(per_transaction_proof_facts: &[&[Felt]]) -> Vec<EndpointArg> {
+    let proof_facts_references = EndpointArg::Pointer(PointerArg::Composed(
+        per_transaction_proof_facts
+            .iter()
+            .flat_map(|proof_facts| {
+                [EndpointArg::from(Felt::from(proof_facts.len())), felt_array_arg(proof_facts)]
+            })
+            .collect(),
+    ));
+    vec![EndpointArg::from(Felt::from(per_transaction_proof_facts.len())), proof_facts_references]
 }
 
 /// Proof facts shaped like a real transaction's, with values derived from
@@ -154,6 +190,43 @@ fn test_cairo_leaf_output_digest_matches_rust(#[case] proof_facts: Vec<Felt>) {
         BLAKE2S_DIGEST_N_WORDS,
     );
     assert_eq!(cairo_digest_words, compute_leaf_output_digest(&proof_facts));
+}
+
+/// Covers the self-fold (one transaction), a full layer (two, four), the carry rule at
+/// one layer (three) and at two layers (five), and a deeper tree (seven).
+#[rstest]
+#[case::single_transaction_self_fold(1)]
+#[case::two_transactions(2)]
+#[case::three_transactions_carry(3)]
+#[case::four_transactions(4)]
+#[case::five_transactions_double_carry(5)]
+#[case::seven_transactions(7)]
+fn test_cairo_fold_block_proof_facts_matches_rust(#[case] n_transactions: u64) {
+    let per_transaction_proof_facts: Vec<Vec<Felt>> =
+        (0..n_transactions).map(synthetic_proof_facts).collect();
+    let proof_facts_references: Vec<&[Felt]> =
+        per_transaction_proof_facts.iter().map(Vec::as_slice).collect();
+    let cairo_root_entry = run_cairo_fold_block_proof_facts(&proof_facts_references);
+    assert_eq!(cairo_root_entry, fold_block_proof_facts(&proof_facts_references));
+}
+
+#[test]
+fn test_cairo_fold_digest_matches_rust() {
+    let proof_facts = synthetic_proof_facts(0);
+    let root_entry = fold_block_proof_facts(&[&proof_facts, &proof_facts]);
+    let root_entry_words: Vec<Felt> = root_entry
+        .circuit_hash
+        .iter()
+        .chain(root_entry.output_digest.iter())
+        .map(|word| Felt::from(*word))
+        .collect();
+    let cairo_fold_digest_words = run_cairo_function_returning_words(
+        "compute_fold_digest",
+        &[felt_array_arg(&root_entry_words)],
+        &[ImplicitArg::Builtin(BuiltinName::range_check)],
+        BLAKE2S_DIGEST_N_WORDS,
+    );
+    assert_eq!(cairo_fold_digest_words, compute_fold_digest(&root_entry));
 }
 
 #[rstest]


### PR DESCRIPTION
Fourth PR of the privacy proof-fact fold stack. Adds the fold tree above the leaf digest in Cairo0: `fold_block_proof_facts` folds a block's `ProofFactsReference` array into the block's root fold entry (leaf entries, pairwise folding with a carried trailing entry, single-transaction self-fold), and `compute_fold_digest` computes the digest the Cairo circuit verifier outputs for that entry. Still not reachable from the OS program — the OS output wiring lands in #15064.

Tested for bit-exact agreement with the Rust mirror across tree shapes exercising the pairing and carry rules (N = 1, 2, 3, 4, 5, 7).

Stack: leaf digest (#15090) ← rust tree fold (#15091) ← cairo leaf digest (#15092) ← **this PR** ← OS output wiring (#15064) ← registry pin (#15086) ← verifier task (#15088).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmPJM3Wph4QLmFmhcxVsh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmPJM3Wph4QLmFmhcxVsh4)_