### PR TITLE
starknet_os_flow_tests,starknet_os,starknet_transaction_prover: test the fold against the verifier

### DIFF
--- a/crates/starknet_os/Cargo.toml
+++ b/crates/starknet_os/Cargo.toml
@@ -15,6 +15,7 @@ deserialize = [
 ]
 include_program_output = []
 testing = [
+  "apollo_starknet_os_program/test_programs",
   "blockifier/testing",
   "expect-test",
   "itertools",

--- a/crates/starknet_os/src/proof_fact_fold_test.rs
+++ b/crates/starknet_os/src/proof_fact_fold_test.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 
 use apollo_starknet_os_program::test_programs::PROOF_FACT_FOLD_BYTES;
 use cairo_vm::types::builtin_name::BuiltinName;
-use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::relocatable::MaybeRelocatable;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use expect_test::expect;
 use rstest::rstest;
 use starknet_types_core::felt::Felt;
@@ -25,123 +23,19 @@ use super::{
 use crate::test_utils::cairo_runner::{
     initialize_and_run_cairo_0_entry_point,
     EndpointArg,
-    EntryPointRunnerConfig,
     ImplicitArg,
     PointerArg,
     ValueArg,
 };
-
-const FOLD_ENTRY_N_WORDS: usize = 2 * BLAKE2S_DIGEST_N_WORDS;
-
-fn entrypoint_runner_config() -> EntryPointRunnerConfig {
-    EntryPointRunnerConfig {
-        layout: LayoutName::all_cairo,
-        trace_enabled: false,
-        verify_secure: false,
-        proof_mode: false,
-        add_main_prefix_to_entrypoint: true,
-        validate_builtins_offset: true,
-    }
-}
-
-fn felt_array_arg(felts: &[Felt]) -> EndpointArg {
-    EndpointArg::Pointer(PointerArg::Array(
-        felts.iter().map(|felt| MaybeRelocatable::Int(*felt)).collect(),
-    ))
-}
-
-/// Runs a function of `proof_fact_fold.cairo` that returns a single pointer to
-/// `n_returned_words` u32 words, and returns those words.
-fn run_cairo_function_returning_words(
-    function_name: &str,
-    explicit_args: &[EndpointArg],
-    implicit_args: &[ImplicitArg],
-    n_returned_words: usize,
-) -> Vec<u32> {
-    let expected_return_values = vec![EndpointArg::Pointer(PointerArg::Array(vec![
-        MaybeRelocatable::from(Felt::ZERO);
-        n_returned_words
-    ]))];
-    let (_, explicit_return_values, _) = initialize_and_run_cairo_0_entry_point(
-        &entrypoint_runner_config(),
-        PROOF_FACT_FOLD_BYTES,
-        function_name,
-        explicit_args,
-        implicit_args,
-        &expected_return_values,
-        HashMap::new(),
-        None,
-    )
-    .unwrap_or_else(|error| panic!("Failed to run Cairo function {function_name}: {error:?}"));
-    let [EndpointArg::Pointer(PointerArg::Array(returned_words))] =
-        explicit_return_values.as_slice()
-    else {
-        panic!("Expected {function_name} to return a single words-array pointer.");
-    };
-    returned_words
-        .iter()
-        .map(|returned_word| {
-            let MaybeRelocatable::Int(word_felt) = returned_word else {
-                panic!("Expected a felt digest word, got {returned_word:?}.");
-            };
-            u32::try_from(word_felt.to_biguint()).expect("A digest word must fit in a u32.")
-        })
-        .collect()
-}
-
-fn fold_entry_from_words(entry_words: &[u32]) -> FoldEntry {
-    FoldEntry {
-        circuit_hash: entry_words[..BLAKE2S_DIGEST_N_WORDS].try_into().unwrap(),
-        output_digest: entry_words[BLAKE2S_DIGEST_N_WORDS..].try_into().unwrap(),
-    }
-}
-
-/// Runs the Cairo `fold_block_proof_facts` and returns the root entry.
-fn run_cairo_fold_block_proof_facts(per_transaction_proof_facts: &[&[Felt]]) -> FoldEntry {
-    let root_entry_words = run_cairo_function_returning_words(
-        "fold_block_proof_facts",
-        &fold_block_proof_facts_args(per_transaction_proof_facts),
-        &[ImplicitArg::Builtin(BuiltinName::range_check)],
-        FOLD_ENTRY_N_WORDS,
-    );
-    fold_entry_from_words(&root_entry_words)
-}
-
-/// Runs the Cairo `fold_block_proof_facts` and returns the run's execution resources.
-fn run_cairo_fold_execution_resources(
-    per_transaction_proof_facts: &[&[Felt]],
-) -> ExecutionResources {
-    let expected_return_values = vec![EndpointArg::Pointer(PointerArg::Array(vec![
-            MaybeRelocatable::from(Felt::ZERO);
-            FOLD_ENTRY_N_WORDS
-        ]))];
-    let (_, _, cairo_runner) = initialize_and_run_cairo_0_entry_point(
-        &entrypoint_runner_config(),
-        PROOF_FACT_FOLD_BYTES,
-        "fold_block_proof_facts",
-        &fold_block_proof_facts_args(per_transaction_proof_facts),
-        &[ImplicitArg::Builtin(BuiltinName::range_check)],
-        &expected_return_values,
-        HashMap::new(),
-        None,
-    )
-    .unwrap_or_else(|error| panic!("Failed to run fold_block_proof_facts: {error:?}"));
-    cairo_runner.get_execution_resources().unwrap().filter_unused_builtins()
-}
-
-/// The Cairo arguments: `n_transactions`, then an array of `ProofFactsReference`s - a
-/// (size, pointer) pair per transaction.
-fn fold_block_proof_facts_args(per_transaction_proof_facts: &[&[Felt]]) -> Vec<EndpointArg> {
-    let proof_facts_references = EndpointArg::Pointer(PointerArg::Composed(
-        per_transaction_proof_facts
-            .iter()
-            .flat_map(|proof_facts| {
-                [EndpointArg::from(Felt::from(proof_facts.len())), felt_array_arg(proof_facts)]
-            })
-            .collect(),
-    ));
-    vec![EndpointArg::from(Felt::from(per_transaction_proof_facts.len())), proof_facts_references]
-}
+use crate::test_utils::proof_fact_fold_runner::{
+    entrypoint_runner_config,
+    felt_array_arg,
+    fold_entry_from_words,
+    run_cairo_fold_block_proof_facts,
+    run_cairo_fold_execution_resources,
+    run_cairo_function_returning_words,
+    FOLD_ENTRY_N_WORDS,
+};
 
 /// Proof facts shaped like a real transaction's, with values derived from
 /// `transaction_index` so different transactions get different digests.

--- a/crates/starknet_os/src/test_utils.rs
+++ b/crates/starknet_os/src/test_utils.rs
@@ -10,6 +10,7 @@ pub mod cairo_dict;
 pub mod cairo_runner;
 pub mod coverage;
 pub mod errors;
+pub mod proof_fact_fold_runner;
 #[cfg(test)]
 pub mod utils;
 pub mod validations;

--- a/crates/starknet_os/src/test_utils/proof_fact_fold_runner.rs
+++ b/crates/starknet_os/src/test_utils/proof_fact_fold_runner.rs
@@ -1,0 +1,132 @@
+//! Runs functions of the OS's `proof_fact_fold.cairo` as standalone Cairo0 entry points,
+//! for tests comparing them against the Rust mirror and against the circuit verifier.
+
+use std::collections::HashMap;
+
+use apollo_starknet_os_program::test_programs::PROOF_FACT_FOLD_BYTES;
+use cairo_vm::types::builtin_name::BuiltinName;
+use cairo_vm::types::layout_name::LayoutName;
+use cairo_vm::types::relocatable::MaybeRelocatable;
+use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
+use starknet_types_core::felt::Felt;
+
+use crate::proof_fact_fold::{FoldEntry, BLAKE2S_DIGEST_N_WORDS};
+use crate::test_utils::cairo_runner::{
+    initialize_and_run_cairo_0_entry_point,
+    EndpointArg,
+    EntryPointRunnerConfig,
+    ImplicitArg,
+    PointerArg,
+};
+
+pub const FOLD_ENTRY_N_WORDS: usize = 2 * BLAKE2S_DIGEST_N_WORDS;
+
+pub fn entrypoint_runner_config() -> EntryPointRunnerConfig {
+    EntryPointRunnerConfig {
+        layout: LayoutName::all_cairo,
+        trace_enabled: false,
+        verify_secure: false,
+        proof_mode: false,
+        add_main_prefix_to_entrypoint: true,
+        validate_builtins_offset: true,
+    }
+}
+
+pub fn felt_array_arg(felts: &[Felt]) -> EndpointArg {
+    EndpointArg::Pointer(PointerArg::Array(
+        felts.iter().map(|felt| MaybeRelocatable::Int(*felt)).collect(),
+    ))
+}
+
+/// Runs a function of `proof_fact_fold.cairo` that returns a single pointer to
+/// `n_returned_words` u32 words, and returns those words.
+pub fn run_cairo_function_returning_words(
+    function_name: &str,
+    explicit_args: &[EndpointArg],
+    implicit_args: &[ImplicitArg],
+    n_returned_words: usize,
+) -> Vec<u32> {
+    let expected_return_values = vec![EndpointArg::Pointer(PointerArg::Array(vec![
+        MaybeRelocatable::from(Felt::ZERO);
+        n_returned_words
+    ]))];
+    let (_, explicit_return_values, _) = initialize_and_run_cairo_0_entry_point(
+        &entrypoint_runner_config(),
+        PROOF_FACT_FOLD_BYTES,
+        function_name,
+        explicit_args,
+        implicit_args,
+        &expected_return_values,
+        HashMap::new(),
+        None,
+    )
+    .unwrap_or_else(|error| panic!("Failed to run Cairo function {function_name}: {error:?}"));
+    let [EndpointArg::Pointer(PointerArg::Array(returned_words))] =
+        explicit_return_values.as_slice()
+    else {
+        panic!("Expected {function_name} to return a single words-array pointer.");
+    };
+    returned_words
+        .iter()
+        .map(|returned_word| {
+            let MaybeRelocatable::Int(word_felt) = returned_word else {
+                panic!("Expected a felt digest word, got {returned_word:?}.");
+            };
+            u32::try_from(word_felt.to_biguint()).expect("A digest word must fit in a u32.")
+        })
+        .collect()
+}
+
+pub fn fold_entry_from_words(entry_words: &[u32]) -> FoldEntry {
+    FoldEntry {
+        circuit_hash: entry_words[..BLAKE2S_DIGEST_N_WORDS].try_into().unwrap(),
+        output_digest: entry_words[BLAKE2S_DIGEST_N_WORDS..].try_into().unwrap(),
+    }
+}
+
+/// Runs the Cairo `fold_block_proof_facts` and returns the root entry.
+pub fn run_cairo_fold_block_proof_facts(per_transaction_proof_facts: &[&[Felt]]) -> FoldEntry {
+    let root_entry_words = run_cairo_function_returning_words(
+        "fold_block_proof_facts",
+        &fold_block_proof_facts_args(per_transaction_proof_facts),
+        &[ImplicitArg::Builtin(BuiltinName::range_check)],
+        FOLD_ENTRY_N_WORDS,
+    );
+    fold_entry_from_words(&root_entry_words)
+}
+
+/// Runs the Cairo `fold_block_proof_facts` and returns the run's execution resources.
+pub fn run_cairo_fold_execution_resources(
+    per_transaction_proof_facts: &[&[Felt]],
+) -> ExecutionResources {
+    let expected_return_values = vec![EndpointArg::Pointer(PointerArg::Array(vec![
+            MaybeRelocatable::from(Felt::ZERO);
+            FOLD_ENTRY_N_WORDS
+        ]))];
+    let (_, _, cairo_runner) = initialize_and_run_cairo_0_entry_point(
+        &entrypoint_runner_config(),
+        PROOF_FACT_FOLD_BYTES,
+        "fold_block_proof_facts",
+        &fold_block_proof_facts_args(per_transaction_proof_facts),
+        &[ImplicitArg::Builtin(BuiltinName::range_check)],
+        &expected_return_values,
+        HashMap::new(),
+        None,
+    )
+    .unwrap_or_else(|error| panic!("Failed to run fold_block_proof_facts: {error:?}"));
+    cairo_runner.get_execution_resources().unwrap().filter_unused_builtins()
+}
+
+/// The Cairo arguments: `n_transactions`, then an array of `ProofFactsReference`s - a
+/// (size, pointer) pair per transaction.
+pub fn fold_block_proof_facts_args(per_transaction_proof_facts: &[&[Felt]]) -> Vec<EndpointArg> {
+    let proof_facts_references = EndpointArg::Pointer(PointerArg::Composed(
+        per_transaction_proof_facts
+            .iter()
+            .flat_map(|proof_facts| {
+                [EndpointArg::from(Felt::from(proof_facts.len())), felt_array_arg(proof_facts)]
+            })
+            .collect(),
+    ));
+    vec![EndpointArg::from(Felt::from(per_transaction_proof_facts.len())), proof_facts_references]
+}

--- a/crates/starknet_os_flow_tests/Cargo.toml
+++ b/crates/starknet_os_flow_tests/Cargo.toml
@@ -36,7 +36,7 @@ starknet_committer = { workspace = true, features = ["testing"] }
 starknet_os = { workspace = true, features = ["include_program_output", "testing"] }
 starknet_patricia_storage = { workspace = true, features = ["testing"] }
 starknet_proof_verifier.workspace = true
-starknet_transaction_prover.workspace = true
+starknet_transaction_prover = { workspace = true, features = ["testing"] }
 strum.workspace = true
 tokio.workspace = true
 

--- a/crates/starknet_os_flow_tests/src/lib.rs
+++ b/crates/starknet_os_flow_tests/src/lib.rs
@@ -3,6 +3,7 @@
 pub(crate) mod fuzz_tests;
 pub(crate) mod initial_state;
 pub(crate) mod os_resources_test;
+pub(crate) mod proof_fact_verifier_test;
 pub(crate) mod special_contracts;
 pub(crate) mod test_manager;
 pub(crate) mod tests;

--- a/crates/starknet_os_flow_tests/src/proof_fact_verifier_test.rs
+++ b/crates/starknet_os_flow_tests/src/proof_fact_verifier_test.rs
@@ -1,0 +1,91 @@
+//! Combined tests of the OS-side proof-fact fold against a real simple-bootloader run
+//! of the circuit verifier on the `four_leaves` fixture (see
+//! `starknet_transaction_prover::verifier_task`).
+
+use blockifier::test_utils::get_valid_virtual_os_program_hash;
+use blockifier_test_utils::cairo_versions::{CairoVersion, RunnableCairo1};
+use blockifier_test_utils::calldata::create_calldata;
+use blockifier_test_utils::contracts::FeatureContract;
+use starknet_api::transaction::fields::ProofFacts;
+use starknet_api::{calldata, invoke_tx_args};
+use starknet_os::proof_fact_fold::pack_output_digest;
+use starknet_os::test_utils::proof_fact_fold_runner::run_cairo_fold_block_proof_facts;
+use starknet_transaction_prover::verifier_task::test_utils::{
+    four_leaves_proof_facts,
+    run_four_leaves_verifier_task,
+    FIXTURE_VERIFIER_PROGRAM_HASH,
+};
+use starknet_transaction_prover::verifier_task::{
+    verify_circuit_verifier_task_output,
+    VerifierTaskError,
+};
+use starknet_types_core::felt::Felt;
+
+use crate::test_manager::TestBuilder;
+
+/// The OS's fold code against the real verifier: the Cairo0 `fold_block_proof_facts`
+/// over the `four_leaves` transactions' proof facts, packed the way the OS output packs
+/// the root output digest, matches the digest the circuit verifier outputs for the
+/// fixture's root proof.
+#[test]
+fn test_cairo_fold_matches_circuit_verifier_output() {
+    let task_output = run_four_leaves_verifier_task().unwrap();
+    let proof_facts = four_leaves_proof_facts();
+    let cairo_root_entry = run_cairo_fold_block_proof_facts(&[proof_facts.as_slice(); 4]);
+    let (root_output_low, root_output_high) = pack_output_digest(&cairo_root_entry.output_digest);
+    verify_circuit_verifier_task_output(
+        &task_output,
+        FIXTURE_VERIFIER_PROGRAM_HASH,
+        root_output_low,
+        root_output_high,
+    )
+    .unwrap();
+}
+
+/// A real OS run's emitted packed root output digest plugs into the verifier-task
+/// comparison: against a verifier run over different proof facts, it is cleanly unpacked
+/// and rejected as a fold-digest mismatch (not as a malformed packed digest).
+///
+/// The matching-digest path cannot include the OS program yet: the OS only accepts proof
+/// facts whose program hash is an allowed virtual-OS hash, while the `four_leaves`
+/// fixture's leaves carry the proving side's test-task hash, and the proofs the OS does
+/// accept are single-leaf recursion-circuit proofs of the pinned proving stack
+/// (proving-utils v0.14.3), whose circuit differs from the fold's `canonical_small`
+/// registry. Until a recursive-tree fixture over OS-valid proof facts exists, the
+/// matching path is covered by `test_cairo_fold_matches_circuit_verifier_output`, and
+/// the OS output wiring by the fold assertions of every flow test.
+#[tokio::test]
+async fn test_os_emitted_fold_output_feeds_verifier_task_comparison() {
+    let test_contract = FeatureContract::TestContract(CairoVersion::Cairo1(RunnableCairo1::Casm));
+    let (mut test_builder, [test_contract_address]) =
+        TestBuilder::create_standard([(test_contract, calldata![Felt::ZERO, Felt::ZERO])]).await;
+    let proof_facts = ProofFacts::custom_proof_facts_for_testing(
+        get_valid_virtual_os_program_hash(),
+        test_builder.compute_virtual_os_config_hash(),
+    );
+    let calldata = create_calldata(test_contract_address, "empty_function", &[]);
+    for _ in 0..4 {
+        test_builder.add_funded_account_invoke(
+            invoke_tx_args! { calldata: calldata.clone(), proof_facts: proof_facts.clone() },
+        );
+    }
+
+    let test_output = test_builder.build_and_run().await;
+    test_output.perform_default_validations();
+    let os_output = test_output
+        .runner_output
+        .get_os_output(test_output.private_keys.as_ref())
+        .expect("Getting OsOutput from raw OS output should not fail.");
+    assert_eq!(os_output.common_os_output.n_proof_facts_transactions, 4);
+
+    let task_output = run_four_leaves_verifier_task().unwrap();
+    assert!(matches!(
+        verify_circuit_verifier_task_output(
+            &task_output,
+            FIXTURE_VERIFIER_PROGRAM_HASH,
+            os_output.common_os_output.proof_facts_root_output_low,
+            os_output.common_os_output.proof_facts_root_output_high,
+        ),
+        Err(VerifierTaskError::FoldDigestMismatch { .. })
+    ));
+}

--- a/crates/starknet_transaction_prover/Cargo.toml
+++ b/crates/starknet_transaction_prover/Cargo.toml
@@ -11,6 +11,7 @@ cairo_native = ["blockifier/cairo_native"]
 # Enables in-memory stwo proving.  Requires a nightly Rust toolchain because the
 # stwo prover crate uses unstable features (array_chunks, portable_simd, …).
 stwo_proving = ["dep:privacy-prove"]
+testing = ["dep:flate2"]
 
 [dependencies]
 anyhow.workspace = true
@@ -24,6 +25,7 @@ cairo-program-runner-lib.workspace = true
 cairo-lang-utils.workspace = true
 cairo-vm.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+flate2 = { workspace = true, optional = true }
 futures.workspace = true
 http.workspace = true
 http-body-util.workspace = true

--- a/crates/starknet_transaction_prover/src/verifier_task.rs
+++ b/crates/starknet_transaction_prover/src/verifier_task.rs
@@ -32,6 +32,9 @@ use starknet_os::proof_fact_fold::{
 };
 use starknet_types_core::felt::Felt;
 
+#[cfg(any(test, feature = "testing"))]
+pub mod test_utils;
+
 #[cfg(test)]
 #[path = "verifier_task_test.rs"]
 mod verifier_task_test;

--- a/crates/starknet_transaction_prover/src/verifier_task/test_utils.rs
+++ b/crates/starknet_transaction_prover/src/verifier_task/test_utils.rs
@@ -1,0 +1,70 @@
+//! The vendored verifier-task fixtures - the simple bootloader, the circuit verifier
+//! executable, and the `four_leaves` golden root proof - with helpers to run them.
+
+use std::io::Read;
+
+use flate2::read::GzDecoder;
+use starknet_types_core::felt::Felt;
+
+use super::{run_circuit_verifier_task, CircuitVerifierTaskOutput, VerifierTaskError};
+
+/// The simple bootloader compiled program, from cairo-program-runner-lib at
+/// proving-utils tag v0.14.3-rust-bump (the pinned workspace dependency),
+/// resources/compiled_programs/bootloaders/simple_bootloader_compiled.json.
+pub const SIMPLE_BOOTLOADER_PROGRAM_GZ: &[u8] =
+    include_bytes!("../../resources/simple_bootloader_compiled.json.gz");
+
+/// The circuit verifier executable, built with scarb 2.19.4 from proving-dev commit
+/// b75d21f91fe846401e002ad169dbcbe57f289ebf: `scarb build --package
+/// stwo_circuit_verifier` (dev profile, default features). Its multiverifier constants
+/// match the `canonical_small` registry the fold's circuit hash constants are pinned to.
+pub const VERIFIER_EXECUTABLE_GZ: &[u8] =
+    include_bytes!("../../resources/stwo_circuit_verifier_canonical_small.executable.json.gz");
+
+/// The `four_leaves` golden root proof (proving-dev commit b75d21f9,
+/// crates/stwo_run_and_prove_recursive_tree/test_data/goldens/four_leaves/root.proof):
+/// the recursive tree over four identical leaves, as the verifier's felt252 argument
+/// stream (a JSON array of hex strings).
+pub const ROOT_PROOF_GZ: &[u8] = include_bytes!("../../resources/four_leaves_root_proof.json.gz");
+
+/// The fixture verifier executable's hash under the Blake program hash function, as the
+/// simple bootloader outputs it.
+pub const FIXTURE_VERIFIER_PROGRAM_HASH: Felt =
+    Felt::from_hex_unchecked("0x764dc214c7f45a6899b05d42ba4d23d5849e0bf0383ec951f000b1742107fdd");
+
+pub fn gunzip(compressed_bytes: &[u8]) -> Vec<u8> {
+    let mut decompressed_bytes = Vec::new();
+    GzDecoder::new(compressed_bytes).read_to_end(&mut decompressed_bytes).unwrap();
+    decompressed_bytes
+}
+
+pub fn root_proof_felts() -> Vec<Felt> {
+    let root_proof_hex: Vec<String> = serde_json::from_slice(&gunzip(ROOT_PROOF_GZ)).unwrap();
+    root_proof_hex.iter().map(|proof_felt_hex| Felt::from_hex(proof_felt_hex).unwrap()).collect()
+}
+
+/// The proof facts of each of the `four_leaves` fixture's transactions: the fixture's
+/// leaf output preimage (see `test_four_leaf_fold_matches_proving_side_golden` in
+/// starknet_os), with the two version markers the OS leaf preimage drops prepended.
+pub fn four_leaves_proof_facts() -> Vec<Felt> {
+    [
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::from_hex("0x32b88272d54b83880ebebd9c4292a650bee27d1575e82123391b6df2932e843")
+            .unwrap(),
+        Felt::from_hex("0xb").unwrap(),
+        Felt::from_hex("0xd").unwrap(),
+        Felt::from_hex("0x11").unwrap(),
+    ]
+    .to_vec()
+}
+
+/// Runs the circuit verifier on the `four_leaves` root proof as a single
+/// simple-bootloader task and returns the parsed output page.
+pub fn run_four_leaves_verifier_task() -> Result<CircuitVerifierTaskOutput, VerifierTaskError> {
+    run_circuit_verifier_task(
+        &gunzip(SIMPLE_BOOTLOADER_PROGRAM_GZ),
+        &gunzip(VERIFIER_EXECUTABLE_GZ),
+        &root_proof_felts(),
+    )
+}

--- a/crates/starknet_transaction_prover/src/verifier_task_test.rs
+++ b/crates/starknet_transaction_prover/src/verifier_task_test.rs
@@ -1,75 +1,23 @@
-use std::io::Read;
-
-use flate2::read::GzDecoder;
 use starknet_os::proof_fact_fold::{fold_block_proof_facts, pack_output_digest};
 use starknet_types_core::felt::Felt;
 
+use super::test_utils::{
+    four_leaves_proof_facts,
+    gunzip,
+    root_proof_felts,
+    run_four_leaves_verifier_task,
+    FIXTURE_VERIFIER_PROGRAM_HASH,
+    SIMPLE_BOOTLOADER_PROGRAM_GZ,
+    VERIFIER_EXECUTABLE_GZ,
+};
 use super::{run_circuit_verifier_task, verify_circuit_verifier_task_output, VerifierTaskError};
-
-/// The simple bootloader compiled program, from cairo-program-runner-lib at
-/// proving-utils tag v0.14.3-rust-bump (the pinned workspace dependency),
-/// resources/compiled_programs/bootloaders/simple_bootloader_compiled.json.
-const SIMPLE_BOOTLOADER_PROGRAM_GZ: &[u8] =
-    include_bytes!("../resources/simple_bootloader_compiled.json.gz");
-
-/// The circuit verifier executable, built with scarb 2.19.4 from proving-dev commit
-/// b75d21f91fe846401e002ad169dbcbe57f289ebf: `scarb build --package
-/// stwo_circuit_verifier` (dev profile, default features). Its multiverifier constants
-/// match the `canonical_small` registry the fold's circuit hash constants are pinned to.
-const VERIFIER_EXECUTABLE_GZ: &[u8] =
-    include_bytes!("../resources/stwo_circuit_verifier_canonical_small.executable.json.gz");
-
-/// The `four_leaves` golden root proof (proving-dev commit b75d21f9,
-/// crates/stwo_run_and_prove_recursive_tree/test_data/goldens/four_leaves/root.proof):
-/// the recursive tree over four identical leaves, as the verifier's felt252 argument
-/// stream (a JSON array of hex strings).
-const ROOT_PROOF_GZ: &[u8] = include_bytes!("../resources/four_leaves_root_proof.json.gz");
-
-/// The fixture verifier executable's hash under the Blake program hash function, as the
-/// simple bootloader outputs it.
-const FIXTURE_VERIFIER_PROGRAM_HASH: Felt =
-    Felt::from_hex_unchecked("0x764dc214c7f45a6899b05d42ba4d23d5849e0bf0383ec951f000b1742107fdd");
-
-fn gunzip(compressed_bytes: &[u8]) -> Vec<u8> {
-    let mut decompressed_bytes = Vec::new();
-    GzDecoder::new(compressed_bytes).read_to_end(&mut decompressed_bytes).unwrap();
-    decompressed_bytes
-}
-
-fn root_proof_felts() -> Vec<Felt> {
-    let root_proof_hex: Vec<String> = serde_json::from_slice(&gunzip(ROOT_PROOF_GZ)).unwrap();
-    root_proof_hex.iter().map(|proof_felt_hex| Felt::from_hex(proof_felt_hex).unwrap()).collect()
-}
-
-/// The proof facts of each of the `four_leaves` fixture's transactions: the fixture's
-/// leaf output preimage (see `test_four_leaf_fold_matches_proving_side_golden` in
-/// starknet_os), with the two version markers the OS leaf preimage drops prepended.
-fn four_leaves_proof_facts() -> Vec<Felt> {
-    [
-        Felt::ZERO,
-        Felt::ZERO,
-        Felt::from_hex("0x32b88272d54b83880ebebd9c4292a650bee27d1575e82123391b6df2932e843")
-            .unwrap(),
-        Felt::from_hex("0xb").unwrap(),
-        Felt::from_hex("0xd").unwrap(),
-        Felt::from_hex("0x11").unwrap(),
-    ]
-    .to_vec()
-}
 
 /// The whole chain on real data: the simple bootloader runs the circuit verifier on the
 /// `four_leaves` root proof, and the verifier's output digest matches the digest
 /// expected from the OS-side fold of the same four transactions' proof facts.
 #[test]
 fn test_run_and_verify_circuit_verifier_task() {
-    let simple_bootloader_program = gunzip(SIMPLE_BOOTLOADER_PROGRAM_GZ);
-    let verifier_executable = gunzip(VERIFIER_EXECUTABLE_GZ);
-    let task_output = run_circuit_verifier_task(
-        &simple_bootloader_program,
-        &verifier_executable,
-        &root_proof_felts(),
-    )
-    .unwrap();
+    let task_output = run_four_leaves_verifier_task().unwrap();
     assert_eq!(task_output.verifier_program_hash, FIXTURE_VERIFIER_PROGRAM_HASH);
 
     // The OS side of the comparison: fold the four transactions' proof facts to the
@@ -110,14 +58,12 @@ fn test_run_and_verify_circuit_verifier_task() {
 /// turns into an unsatisfiable assertion: the run fails and there is no output.
 #[test]
 fn test_corrupted_root_proof_fails_the_run() {
-    let simple_bootloader_program = gunzip(SIMPLE_BOOTLOADER_PROGRAM_GZ);
-    let verifier_executable = gunzip(VERIFIER_EXECUTABLE_GZ);
     let mut corrupted_root_proof_felts = root_proof_felts();
     corrupted_root_proof_felts[100] += Felt::ONE;
     assert!(matches!(
         run_circuit_verifier_task(
-            &simple_bootloader_program,
-            &verifier_executable,
+            &gunzip(SIMPLE_BOOTLOADER_PROGRAM_GZ),
+            &gunzip(VERIFIER_EXECUTABLE_GZ),
             &corrupted_root_proof_felts,
         ),
         Err(VerifierTaskError::VerifierRun(_))


### PR DESCRIPTION
Part 8 of the privacy proof-fact fold stack, on top of #15088. Test-only: combined tests connecting the OS side of the fold to a real simple-bootloader run of the circuit verifier.

**New tests** (`starknet_os_flow_tests::proof_fact_verifier_test`):
- `test_cairo_fold_matches_circuit_verifier_output` — the positive loop on real artifacts: the **Cairo0** `fold_block_proof_facts` (the exact code the OS runs) over the `four_leaves` transactions' proof facts, packed the way the OS output packs the root output digest, matches the digest the circuit verifier outputs when the simple bootloader runs it on the fixture's root proof. Previously the verifier was only compared against the Rust fold; this closes bootloader+verifier ⟷ Cairo OS fold directly, through the production comparison function (`verify_circuit_verifier_task_output`).
- `test_os_emitted_fold_output_feeds_verifier_task_comparison` — the OS program in the loop: a real OS run over a block of 4 proof-facts invokes, whose emitted `proof_facts_root_output_low/high` are fed into `verify_circuit_verifier_task_output` against the real verifier run. Asserts the OS-emitted packed digest is cleanly unpacked and rejected as `FoldDigestMismatch` (the facts differ from the fixture's), i.e. the packing seam is well-formed and mismatched fact sets are caught.

**Why the OS-program run can't be on the matching-digest path yet** (documented on the test): the OS only accepts proof facts whose program hash is an allowed virtual-OS hash, while the `four_leaves` fixture's leaves carry the proving side's test-task program hash; and the transaction proofs the OS does accept are verified against the privacy recursion circuits or the production (`large_proofs`) registry — not the `canonical_small` registry the fold's circuit hashes are pinned to. Closing that gap needs the fold's production-registry swap (see the leaf-verifier question in #15086) plus a recursive-tree fixture over OS-valid proof facts; until then the matching path is covered by the Cairo-fold test above, and the OS output wiring by the fold assertions every flow test already makes.

**Plumbing** (no production-code changes): the Cairo fold entry-point runner moved from `proof_fact_fold_test` to `starknet_os::test_utils::proof_fact_fold_runner` (exposed under `testing`, which now also enables `apollo_starknet_os_program/test_programs`); the verifier-task fixtures and helpers moved from `verifier_task_test` to `starknet_transaction_prover::verifier_task::test_utils` (new `testing` feature); both test files now import from there.

Verified: the 2 new flow tests pass; 24/24 starknet_os fold tests and 2/2 verifier-task tests pass after the refactor (against `cairo-program-runner-lib` 1.1.0 from the 0.14.4 merge); rustfmt clean.

Stack: leaf digest (#15090) ← rust tree fold (#15091) ← cairo leaf digest (#15092) ← cairo tree fold (#15093) ← OS output wiring (#15064) ← registry pin (#15086) ← verifier task (#15088) ← **this PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmPJM3Wph4QLmFmhcxVsh4