### PR TITLE
ci: pin GitHub Actions to commit SHA (backport #14872 to main-v0.14.3)

### DIFF
--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: moonrepo/setup-rust@v1
+    - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1
       name: Install Rust toolchain and binaries
       with:
         cache: false
@@ -23,6 +23,6 @@ runs:
 
     # This installation is _not_ cached, but takes a couple seconds: it's downloading prepackaged binaries.
     - name: Install Anvil
-      uses: foundry-rs/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
       with:
         version: v1.5.1

--- a/.github/actions/namespace_cache/action.yaml
+++ b/.github/actions/namespace_cache/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Mount namespace cache volume for rust
-      uses: namespacelabs/nscloud-cache-action@v1
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
       with:
         path: |
           /home/runner/.cargo
@@ -21,6 +21,6 @@ runs:
         echo "SCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE}" >> "$GITHUB_ENV"
 
     - name: Mount namespace cache volume for python
-      uses: namespacelabs/nscloud-cache-action@v1
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
       with:
         cache: python

--- a/.github/workflows/apollo_storage_os_input_ci.yml
+++ b/.github/workflows/apollo_storage_os_input_ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -53,7 +53,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/blockifier_ci.yml
+++ b/.github/workflows/blockifier_ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -56,7 +56,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +124,7 @@ jobs:
       # Use base.sha (a concrete commit hash from the webhook payload) instead of
       # base_ref (a branch name) to avoid failures when Graphite's temporary refs
       # are deleted before the runner reaches this step.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
@@ -139,7 +139,7 @@ jobs:
       # Checkout the PR branch into a unique subdirectory to avoid overwriting
       # the base branch's composite action files at the workspace root, and to
       # avoid colliding with any repo folder (e.g. one named "pr").
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           path: pr-${{ github.run_id }}
 

--- a/.github/workflows/blockifier_compiled_cairo.yml
+++ b/.github/workflows/blockifier_compiled_cairo.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -47,13 +47,13 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"

--- a/.github/workflows/blockifier_reexecution_ci.yml
+++ b/.github/workflows/blockifier_reexecution_ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -50,16 +50,16 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       # Download the blockifier re-execution test data.
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           credentials_json: ${{ secrets.SA_REEXECUTION_ARTIFACTS_READ_ACCESS_KEY }}
-      - uses: "google-github-actions/setup-gcloud@v2"
+      - uses: "google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f" # v2
       - run: echo "REEXECUTION_INPUT_FILES_PREFIX=$(cat ./crates/blockifier_reexecution/resources/offline_reexecution_files_prefix)" >> $GITHUB_ENV
       - run: gcloud storage cp -r gs://reexecution_artifacts/$REEXECUTION_INPUT_FILES_PREFIX/resources/* ./crates/blockifier_reexecution/resources/
       # Run blockifier re-execution tests.

--- a/.github/workflows/blockifier_reexecution_docker_publish.yml
+++ b/.github/workflows/blockifier_reexecution_docker_publish.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Login to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -46,7 +46,7 @@ jobs:
             type=raw,value={{branch}}{{tag}}-{{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
           context: .
           file: crates/blockifier_reexecution/replay/Dockerfile

--- a/.github/workflows/clean_stale_prs.yml
+++ b/.github/workflows/clean_stale_prs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: namespace-profile-small-ubuntu-24-04-amd64
     steps:
       - name: 🚀 Run stale
-        uses: actions/stale@v3
+        uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30

--- a/.github/workflows/committer_and_os_cli_push.yml
+++ b/.github/workflows/committer_and_os_cli_push.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -61,7 +61,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
       # Python + requirements are needed to compile the OS.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -96,13 +96,13 @@ jobs:
         run: ./build_native_in_docker.sh cargo build -p starknet_committer_and_os_cli -r --bin starknet_committer_and_os_cli --target-dir CLI_TARGET
 
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           credentials_json: ${{ secrets.COMMITER_PRODUCTS_EXT_WRITER_JSON }}
 
       - name: Upload binary to GCP
         id: upload_file
-        uses: "google-github-actions/upload-cloud-storage@v2"
+        uses: "google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23" # v2
         with:
           path: "CLI_TARGET/release/starknet_committer_and_os_cli"
           destination: "committer-products-external/${{ env.SHORT_HASH }}/release/"

--- a/.github/workflows/committer_ci.yml
+++ b/.github/workflows/committer_ci.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -69,7 +69,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && needs.optimize_ci.outputs.skip == 'false' }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - uses: ./.github/actions/bootstrap
         with:
@@ -77,7 +77,7 @@ jobs:
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
       # Python + requirements are needed to compile the OS.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -88,10 +88,10 @@ jobs:
       - run: pip install -r scripts/requirements.txt
 
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           credentials_json: ${{ secrets.COMMITER_PRODUCTS_EXT_WRITER_JSON }}
-      - uses: "google-github-actions/setup-gcloud@v2"
+      - uses: "google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f" # v2
       - run: echo "BENCH_INPUT_FILES_PREFIX=$(cat ./crates/starknet_committer_and_os_cli/src/committer_cli/tests/flow_test_files_prefix)" >> $GITHUB_ENV
       - run: gcloud storage cp -r gs://committer-testing-artifacts/$BENCH_INPUT_FILES_PREFIX/* ./crates/starknet_committer_and_os_cli/test_inputs
       - run: cargo test -p starknet_committer_and_os_cli --release -- --include-ignored test_regression
@@ -131,14 +131,14 @@ jobs:
       # are deleted before the runner reaches this step.
       - name: Checkout base branch (PR only)
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       # Push/dispatch: Checkout the specified or current branch.
       - name: Checkout repository (push/dispatch)
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ inputs.branch || github.ref }}
 
@@ -148,7 +148,7 @@ jobs:
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
       # Python + requirements are needed to compile the OS.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -160,10 +160,10 @@ jobs:
 
       # Auth with GCS for bench_tools to download inputs.
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           credentials_json: ${{ secrets.COMMITER_PRODUCTS_EXT_WRITER_JSON }}
-      - uses: "google-github-actions/setup-gcloud@v2"
+      - uses: "google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f" # v2
 
       # PR-only: Benchmark the base branch code.
       - name: Benchmark base branch (PR only)
@@ -179,7 +179,7 @@ jobs:
       # the base branch's composite action files at the workspace root.
       - name: Checkout current branch (PR only)
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           path: pr-${{ github.run_id }}
 
@@ -239,7 +239,7 @@ jobs:
       # Push/dispatch: Store benchmark results to GitHub Pages.
       - name: Store benchmark results (push/dispatch)
         if: github.event_name != 'pull_request'
-        uses: starkware-libs/github-action-benchmark@v1
+        uses: starkware-libs/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1
         with:
           tool: "customSmallerIsBetter"
           output-file-path: benchmark_output.json
@@ -257,7 +257,7 @@ jobs:
       # always() ensures artifacts are uploaded even if benchmarks fail, to help diagnose issues.
       - name: Upload benchmark artifacts (push/dispatch)
         if: github.event_name != 'pull_request' && always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-results-${{ steps.branch.outputs.name }}-${{ github.sha }}
           path: target/criterion/*/new/estimates.json

--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -51,16 +51,16 @@ jobs:
     outputs:
       should_run: ${{ steps.system_check.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "pypy3.9"
 
       - name: Set up pip dependency caching
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
         with:
           cache: python
 
@@ -102,10 +102,10 @@ jobs:
           - svc: dummy_exchange_rate_oracle
             dockerfile: dummy_exchange_rate_oracle.Dockerfile
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Build ${{ matrix.svc }} image remotely
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ${{ env.dockerfile_base_path }}/${{ matrix.dockerfile }}
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create registries.yaml for nscr.io
         run: |
@@ -145,7 +145,7 @@ jobs:
         run: cargo build --bin sequencer_node_setup --bin sequencer_simulator
 
       - name: Create k3d cluster (Local k8s)
-        uses: AbsaOSS/k3d-action@v2.4.0
+        uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 # v2.4.0
         with:
           # Pin k3d explicitly: the action's default (v5.4.6) predates the checksums.txt release
           # asset that the current k3d install.sh fetches (with --fail), so its install 404s. v5.5.0
@@ -197,7 +197,7 @@ jobs:
           kubectl get storageclass
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
           cache: pipenv
@@ -286,7 +286,7 @@ jobs:
           echo "RECEIVER_ADDRESS=$RECEIVER_ADDRESS" >> "$GITHUB_ENV"
 
       - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
         with:
           version: v1.5.1
 

--- a/.github/workflows/lock_closed_prs.yml
+++ b/.github/workflows/lock_closed_prs.yml
@@ -11,7 +11,7 @@ jobs:
     name: 🔒 Lock closed issues and PRs
     runs-on: namespace-profile-small-ubuntu-24-04-amd64
     steps:
-      - uses: dessant/lock-threads@v2.0.3
+      - uses: dessant/lock-threads@486f7380c15596f92b724e4260e4981c68d6bde6 # v2.0.3
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: "30"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Optimize CI
         id: check_skip
         if: github.event_name == 'pull_request'
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
       - name: Don't skip for manual runs
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 30
     steps:
       # Environment setup.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Fetch the entire history. Required to checkout the merge target commit, so the diff can
           # be computed.
@@ -57,7 +57,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -96,7 +96,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -108,7 +108,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Fetch the entire history.
           fetch-depth: 0
@@ -117,7 +117,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -129,10 +129,10 @@ jobs:
 
       # Auth with GCS for tests to download artifacts.
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           credentials_json: ${{ secrets.SYSTEST_BLOBS_READ_ACCESS_KEY }}
-      - uses: "google-github-actions/setup-gcloud@v2"
+      - uses: "google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f" # v2
 
       - name: Clone starknet-specs for spec tests
         run: scripts/prepare_starknet_specs.sh /tmp/starknet-specs
@@ -151,7 +151,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Fetch the entire history.
           fetch-depth: 0
@@ -160,7 +160,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -183,7 +183,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main_nightly.yml
+++ b/.github/workflows/main_nightly.yml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.define_branches.outputs.branches) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ matrix.branch }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -56,7 +56,7 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.define_branches.outputs.branches) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ matrix.branch }}
 
@@ -65,7 +65,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Run merge-gatekeeper-new on pull request
         if: github.event_name == 'pull_request'
-        uses: starkware-libs/merge-gatekeeper@v1
+        uses: starkware-libs/merge-gatekeeper@c0535e7c50a3fc70a0f4857afd37ccd6cfcc59de # v1
         with:
           self: merge-gatekeeper-new
           timeout: 3600
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run merge-gatekeeper-new on Merge Queue || push
         if: github.event_name == 'merge_group' || github.event_name == 'push'
-        uses: starkware-libs/merge-gatekeeper@v1
+        uses: starkware-libs/merge-gatekeeper@c0535e7c50a3fc70a0f4857afd37ccd6cfcc59de # v1
         with:
           self: merge-gatekeeper-new
           ref: ${{github.ref}}

--- a/.github/workflows/main_pr.yml
+++ b/.github/workflows/main_pr.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - name: Run Merge Gatekeeper on pull request
         if: github.event_name == 'pull_request'
-        uses: upsidr/merge-gatekeeper@v1
+        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           timeout: 3600
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run Merge Gatekeeper on Merge Queue || push
         if: github.event_name == 'merge_group' || github.event_name == 'push'
-        uses: upsidr/merge-gatekeeper@v1
+        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{github.ref}}

--- a/.github/workflows/merge_queue_ci.yml
+++ b/.github/workflows/merge_queue_ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: namespace-profile-medium-ubuntu-24-04-amd64
     steps:
       # Environment setup.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # Install rust components + lld.
       - uses: ./.github/actions/bootstrap
@@ -22,7 +22,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"

--- a/.github/workflows/papyrus_ci.yml
+++ b/.github/workflows/papyrus_ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: namespace-profile-medium-ubuntu-24-04-amd64
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -47,9 +47,9 @@ jobs:
     runs-on: namespace-profile-medium-ubuntu-24-04-amd64
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # run this job only if the path 'crates/apollo_storage/src/db/**' is changed, because it takes around 2 minutes.
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: changes
         with:
           # The 'base' and 'ref' parameters are set to be able to run the job in a 'merge_group' event. in a 'pull_request' event

--- a/.github/workflows/papyrus_nightly-tests-call.yml
+++ b/.github/workflows/papyrus_nightly-tests-call.yml
@@ -23,7 +23,7 @@ jobs:
   GW-integration-test-call:
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
       - name: In case of a failure - post to a Slack channel.
         id: slack
         if: ${{ steps.run_test.outputs.retVal != 0 }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_ALERT_CHANNEL }}
           slack-message: >

--- a/.github/workflows/papyrus_nightly-tests.yml
+++ b/.github/workflows/papyrus_nightly-tests.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-latest
     if: github.event.schedule == '30 0 * * *'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
   random-table-test:
     runs-on: namespace-profile-medium-ubuntu-24-04-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sequencer_cdk8s-test.yml
+++ b/.github/workflows/sequencer_cdk8s-test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -67,16 +67,16 @@ jobs:
 
     steps:
       - name: Checkout sequencer
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"
 
       - name: Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 22
 
@@ -102,7 +102,7 @@ jobs:
           cdk8s synth --app "pipenv run python -m main --namespace ${{ env.namespace }} -l ${{ env.layout }} -o ${{ env.overlay2 }} --monitoring-dashboard-file ${{ env.monitoring_dashboard_file }} --cluster ${{ env.cluster }}" --output dist2
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cdk8s-artifacts
           path: |
@@ -121,7 +121,7 @@ jobs:
       crds_path: ./cdk8s-artifacts/resources/crds
     steps:
       - name: Setup go lang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "stable"
 
@@ -129,7 +129,7 @@ jobs:
         run: go install sigs.k8s.io/kubectl-validate@latest
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: cdk8s-artifacts
           path: cdk8s-artifacts
@@ -195,16 +195,16 @@ jobs:
       service_path: ${{ github.workspace }}/deployments/${{ matrix.service }}
     steps:
       - name: Checkout sequencer
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"
 
       - name: Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 22
 
@@ -225,7 +225,7 @@ jobs:
           cdk8s synth --app "pipenv run python -m main --namespace ${{ env.namespace }}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cdk8s-${{ matrix.service }}-artifacts
           path: ${{ env.service_path }}/dist
@@ -240,7 +240,7 @@ jobs:
         service: [anvil, dummy_eth2strk_oracle, dummy_recorder]
     steps:
       - name: Setup go lang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "stable"
 
@@ -248,7 +248,7 @@ jobs:
         run: go install sigs.k8s.io/kubectl-validate@latest
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: cdk8s-${{ matrix.service }}-artifacts
           path: dist

--- a/.github/workflows/sequencer_cdk8s-test.yml
+++ b/.github/workflows/sequencer_cdk8s-test.yml
@@ -37,10 +37,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout sequencer
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"
@@ -153,16 +153,16 @@ jobs:
 
     steps:
       - name: Checkout sequencer
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"
 
       - name: Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 22
 

--- a/.github/workflows/sequencer_docker-publish.yml
+++ b/.github/workflows/sequencer_docker-publish.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # Login to a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Login to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -48,7 +48,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # v4.1.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}/sequencer
           tags: |
@@ -63,7 +63,7 @@ jobs:
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
           context: .
           file: deployments/images/sequencer/Dockerfile

--- a/.github/workflows/starknet_transaction_prover_ci.yml
+++ b/.github/workflows/starknet_transaction_prover_ci.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -60,14 +60,14 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup pypy and link to the location expected by .cargo/config.toml.
       # Python + requirements are needed to compile the OS (apollo_starknet_os_program).
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: setup-pypy
         with:
           python-version: "pypy3.9"
@@ -79,7 +79,7 @@ jobs:
 
       # Cache the rustup directory so the nightly toolchain isn't re-downloaded every run.
       - name: Cache rustup toolchains
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
         with:
           path: /home/runner/.rustup
 
@@ -106,10 +106,10 @@ jobs:
 
       # Download RPC record fixtures from GCS for ignored integration tests.
       - id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           credentials_json: ${{ secrets.SA_STARKNET_OS_RUNNER_ARTIFACTS }}
-      - uses: "google-github-actions/setup-gcloud@v2"
+      - uses: "google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f" # v2
       - run: mkdir -p ./crates/starknet_transaction_prover/resources/rpc_records
       - run: gcloud storage cp -r gs://starknet-os-runner-artifacts/rpc_records/* ./crates/starknet_transaction_prover/resources/rpc_records/
 
@@ -129,13 +129,13 @@ jobs:
     if: needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build starknet_transaction_prover Docker image
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
           context: .
           file: crates/starknet_transaction_prover/Dockerfile

--- a/.github/workflows/starknet_transaction_prover_docker_publish.yml
+++ b/.github/workflows/starknet_transaction_prover_docker_publish.yml
@@ -31,16 +31,16 @@ jobs:
             runner: namespace-profile-small-ubuntu-24-04-arm64
             target_cpu: neoverse-v2
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -50,7 +50,7 @@ jobs:
             # Testing: for workflow dispatch debugging
             type=raw,value=test-{{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         id: build
         with:
           context: .
@@ -67,7 +67,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
         shell: bash
 
-      - uses: namespace-actions/upload-artifact@v1
+      - uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1
         with:
           name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
@@ -80,16 +80,16 @@ jobs:
     needs: build
     timeout-minutes: 10
     steps:
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -99,7 +99,7 @@ jobs:
             # Testing: for workflow dispatch debugging
             type=raw,value=test-{{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - uses: namespace-actions/download-artifact@v2
+      - uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2
         with:
           path: /tmp/digests
           pattern: digest-*

--- a/.github/workflows/upload_artifacts_workflow.yml
+++ b/.github/workflows/upload_artifacts_workflow.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Optimize CI
         id: check_skip
-        uses: withgraphite/graphite-ci-action@v0.0.9
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689 # v0.0.9
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
@@ -66,7 +66,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.optimize_ci.outputs.skip == 'false'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # Commit hash on pull request event would be the head commit of the branch.
       - name: Get commit hash prefix for PR update
@@ -92,7 +92,7 @@ jobs:
       # Comment with a link to the workflow (or update existing comment on rerun).
       - name: Find Comment
         if: github.event_name == 'pull_request'
-        uses: starkware-libs/find-comment@v3
+        uses: starkware-libs/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find-comment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
       - name: Create comment
         # If the PR number is found and the comment is not found, create a new comment.
         if: github.event_name == 'pull_request' && steps.find-comment.outputs.comment-id == ''
-        uses: starkware-libs/create-or-update-comment@v4
+        uses: starkware-libs/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -114,7 +114,7 @@ jobs:
       - name: Update comment
         # If the PR number is found and the comment exists, update it.
         if: github.event_name == 'pull_request' && steps.find-comment.outputs.comment-id != ''
-        uses: starkware-libs/create-or-update-comment@v4
+        uses: starkware-libs/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -135,20 +135,20 @@ jobs:
             target/release/native_blockifier.pypy39-pp73-x86_64-linux-gnu.so
 
       - name: Authenticate with GCS
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed" # v2
         with:
           credentials_json: ${{ secrets.SA_NATIVE_BLOCKIFIER_ARTIFACTS_BUCKET_WRITER_ACCESS_KEY }}
 
       - name: Upload native blockifier shared object to GCP
         id: upload_nb_file
-        uses: "google-github-actions/upload-cloud-storage@v2"
+        uses: "google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23" # v2
         with:
           path: "target/release/native_blockifier.pypy39-pp73-x86_64-linux-gnu.so"
           destination: "native_blockifier_artifacts/${{ env.SHORT_HASH }}/release/"
 
       - name: Upload starknet-native-compile to GCP
         id: upload_snc_file
-        uses: "google-github-actions/upload-cloud-storage@v2"
+        uses: "google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23" # v2
         with:
           path: "target/release/shared_executables/starknet-native-compile"
           destination: "native_blockifier_artifacts/${{ env.SHORT_HASH }}/release/"

--- a/.github/workflows/verify-deps.yml
+++ b/.github/workflows/verify-deps.yml
@@ -12,7 +12,7 @@ jobs:
     name: Latest Dependencies
     runs-on: namespace-profile-medium-ubuntu-24-04-amd64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/bootstrap
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Clean cherry-pick of #14872 onto \`main-v0.14.3\`.

The org now rejects workflows whose actions are not pinned to a full-length commit SHA. All three Docker publish workflows for tag \`APOLLO-0.14.3-RC.17-fix-storage-keys-1\` failed at "Set up job" with:

> The actions actions/checkout@v6, docker/login-action@v2.1.0, docker/metadata-action@v4.1.1, and docker/build-push-action@v6.13.0 are not allowed in starkware-libs/sequencer because all actions must be pinned to a full-length commit SHA.

\`APOLLO-0.14.3-RC.17\` itself published successfully on 2026-08-26, before the policy took effect. Without this backport no tag cut from \`main-v0.14.3\` can publish images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)