### PR TITLE
blockifier: revert instead of reject on blocked storage key access

### DIFF
--- a/crates/blockifier/src/context.rs
+++ b/crates/blockifier/src/context.rs
@@ -130,7 +130,9 @@ pub struct BlockContext {
     pub(crate) versioned_constants: VersionedConstants,
     pub bouncer_config: BouncerConfig,
     /// Storage keys that transactions must not access, in any contract. A transaction that reads
-    /// or writes any of them fails with `blocked_storage_keys_error_message`.
+    /// or writes any of them during its execute stage reverts with
+    /// `blocked_storage_keys_error_message`; one that does so in a stage that cannot be reverted
+    /// fails.
     pub(crate) blocked_storage_keys: HashSet<StorageKey>,
     pub(crate) blocked_storage_keys_error_message: String,
     /// Cached on first access; derived from `chain_info`. Fixed for the lifetime of a block
@@ -182,6 +184,28 @@ impl BlockContext {
         self.blocked_storage_keys = blocked_storage_keys;
         self.blocked_storage_keys_error_message = blocked_storage_keys_error_message;
         self
+    }
+
+    /// Returns the configured error message if any call in `call_infos`, or in their inner calls,
+    /// read or wrote a blocked storage key. Returns `None` when no key is blocked.
+    pub fn blocked_storage_key_access_error<'a>(
+        &self,
+        call_infos: impl Iterator<Item = &'a CallInfo>,
+    ) -> Option<&str> {
+        if self.blocked_storage_keys.is_empty() {
+            return None;
+        }
+        // `CallInfo::iter` walks the whole call tree, so inner calls are covered.
+        call_infos
+            .flat_map(CallInfo::iter)
+            .any(|call_info| {
+                call_info
+                    .storage_access_tracker
+                    .accessed_storage_keys
+                    .iter()
+                    .any(|storage_key| self.blocked_storage_keys.contains(storage_key))
+            })
+            .then_some(self.blocked_storage_keys_error_message.as_str())
     }
 
     pub fn block_info(&self) -> &BlockInfo {

--- a/crates/blockifier/src/transaction/account_transaction.rs
+++ b/crates/blockifier/src/transaction/account_transaction.rs
@@ -40,6 +40,8 @@ use crate::execution::stack_trace::{
     extract_trailing_cairo1_revert_trace,
     gen_tx_execution_error_trace,
     Cairo1RevertHeader,
+    ErrorStack,
+    ErrorStackSegment,
 };
 use crate::fee::fee_checks::{FeeCheckReportFields, PostExecutionReport};
 use crate::fee::fee_utils::{
@@ -765,6 +767,31 @@ impl AccountTransaction {
 
         match execution_result {
             Ok(execute_call_info) => {
+                // A blocked storage key accessed during execution reverts the transaction, so the
+                // sender still pays for the work done. Checked before the fee computation below,
+                // since the reverted receipt is the one that applies.
+                if let Some(message) = tx_context
+                    .block_context
+                    .blocked_storage_key_access_error(execute_call_info.iter())
+                {
+                    let revert_error = blocked_storage_key_revert_error(message);
+                    execution_state.abort();
+                    let revert_receipt = get_revert_receipt();
+                    let post_execution_report = PostExecutionReport::new(
+                        state,
+                        &tx_context,
+                        &revert_receipt,
+                        self.execution_flags.charge_fee,
+                    )?;
+                    return Ok(ValidateExecuteCallInfo::new_reverted(
+                        validate_call_info,
+                        revert_error,
+                        TransactionReceipt {
+                            fee: post_execution_report.recommended_fee(),
+                            ..revert_receipt
+                        },
+                    ));
+                }
                 // When execution succeeded, calculate the actual required fee before committing the
                 // transactional state. If max_fee is insufficient, revert the `run_execute` part.
                 let tx_receipt = TransactionReceipt::from_account_tx(
@@ -956,6 +983,14 @@ impl TransactionInfoCreator for AccountTransaction {
     fn create_tx_info(&self) -> TransactionInfo {
         self.tx.create_tx_info(self.execution_flags.only_query)
     }
+}
+
+/// Builds the revert error for a transaction that accessed a blocked storage key. The message is
+/// operator-configured, so it is carried as a plain frame rather than a structured error.
+fn blocked_storage_key_revert_error(message: &str) -> RevertError {
+    let mut error_stack = ErrorStack::default();
+    error_stack.push(ErrorStackSegment::StringFrame(message.to_string()));
+    RevertError::Execution(error_stack)
 }
 
 /// Represents a bundle of validate-execute stage execution effects.

--- a/crates/blockifier/src/transaction/transaction_execution.rs
+++ b/crates/blockifier/src/transaction/transaction_execution.rs
@@ -17,7 +17,6 @@ use starknet_api::transaction::{
 
 use crate::bouncer::verify_tx_weights_within_max_capacity;
 use crate::context::BlockContext;
-use crate::execution::call_info::CallInfo;
 use crate::state::cached_state::TransactionalState;
 use crate::state::state_api::UpdatableState;
 use crate::transaction::account_transaction::{
@@ -183,25 +182,23 @@ impl<U: UpdatableState> ExecutableTransaction<U> for Transaction {
     }
 }
 
+/// Fails a transaction that accessed a blocked storage key in a stage that cannot be reverted.
+///
+/// A revertible account transaction that touches a blocked key while executing is reverted instead,
+/// in `AccountTransaction::run_revertible`, which charges the sender and drops the execute-stage
+/// call info. What reaches here is therefore only what reverting cannot undo: the validate stage,
+/// the fee transfer, non-revertible transaction types (declare, deploy account, invoke v0) and L1
+/// handlers.
 fn verify_no_blocked_storage_key_accessed(
     tx_execution_info: &TransactionExecutionInfo,
     block_context: &BlockContext,
 ) -> TransactionExecutionResult<()> {
-    if block_context.blocked_storage_keys.is_empty() {
-        return Ok(());
+    match block_context
+        .blocked_storage_key_access_error(tx_execution_info.non_optional_call_infos())
+    {
+        Some(message) => Err(TransactionExecutionError::BlockedStorageKeyAccessed {
+            message: message.to_string(),
+        }),
+        None => Ok(()),
     }
-    // `CallInfo::iter` walks the whole call tree, so inner calls are covered.
-    for call_info in tx_execution_info.non_optional_call_infos().flat_map(CallInfo::iter) {
-        if call_info
-            .storage_access_tracker
-            .accessed_storage_keys
-            .iter()
-            .any(|storage_key| block_context.blocked_storage_keys.contains(storage_key))
-        {
-            return Err(TransactionExecutionError::BlockedStorageKeyAccessed {
-                message: block_context.blocked_storage_keys_error_message.clone(),
-            });
-        }
-    }
-    Ok(())
 }

--- a/crates/blockifier/src/transaction/transaction_execution_test.rs
+++ b/crates/blockifier/src/transaction/transaction_execution_test.rs
@@ -11,9 +11,13 @@ use starknet_api::{felt, invoke_tx_args, storage_key};
 use starknet_types_core::felt::Felt;
 
 use crate::context::{parse_blocked_storage_keys, BlockContext};
+use crate::state::state_api::StateReader;
 use crate::transaction::account_transaction::AccountTransaction;
-use crate::transaction::errors::TransactionExecutionError;
-use crate::transaction::objects::{TransactionExecutionInfo, TransactionExecutionResult};
+use crate::transaction::objects::{
+    RevertError,
+    TransactionExecutionInfo,
+    TransactionExecutionResult,
+};
 use crate::transaction::test_utils::{
     create_test_init_data,
     default_all_resource_bounds,
@@ -69,14 +73,23 @@ fn execute_storage_write_tx(
         .execute(&mut state, &block_context)
 }
 
-fn assert_blocked(result: TransactionExecutionResult<TransactionExecutionInfo>) {
-    let error = result.expect_err("Access to a blocked storage key should fail the tx.");
-    assert_matches!(
-        &error,
-        TransactionExecutionError::BlockedStorageKeyAccessed { message }
-            if message == BLOCKED_STORAGE_KEY_ERROR_MESSAGE
+/// Asserts the tx was included and reverted, carrying the configured message, and that the sender
+/// was still charged.
+fn assert_reverted(result: TransactionExecutionResult<TransactionExecutionInfo>) {
+    let tx_execution_info =
+        result.expect("A blocked storage key should revert the tx, not fail it.");
+    assert!(tx_execution_info.is_reverted());
+    let revert_error =
+        tx_execution_info.revert_error.as_ref().expect("A reverted tx must carry a revert error.");
+    assert_matches!(revert_error, RevertError::Execution(_));
+    assert!(
+        revert_error.to_string().contains(BLOCKED_STORAGE_KEY_ERROR_MESSAGE),
+        "revert error {revert_error} should carry the configured message"
     );
-    assert_eq!(error.to_string(), BLOCKED_STORAGE_KEY_ERROR_MESSAGE);
+    // The execute stage is rolled back, so its call info is dropped.
+    assert!(tx_execution_info.execute_call_info.is_none());
+    // Reverting still charges the sender, which is the point of reverting rather than rejecting.
+    assert!(tx_execution_info.receipt.fee.0 > 0);
 }
 
 fn assert_executed(result: TransactionExecutionResult<TransactionExecutionInfo>) {
@@ -118,12 +131,46 @@ fn test_blocked_storage_keys_do_not_affect_other_keys(
     "0x0000000000000000000000000000000000000000000000000000000000000010",
     felt!(0x10_u8)
 )]
-fn test_blocked_storage_key_access_fails_tx(
+fn test_blocked_storage_key_access_reverts_tx(
     #[case] blocked_storage_keys: &str,
     #[case] accessed_storage_key: Felt,
     #[values(false, true)] nested: bool,
 ) {
-    assert_blocked(execute_storage_write_tx(blocked_storage_keys, accessed_storage_key, nested));
+    assert_reverted(execute_storage_write_tx(blocked_storage_keys, accessed_storage_key, nested));
+}
+
+/// A reverted transaction must leave no trace of the blocked write in the state.
+#[rstest]
+fn test_blocked_storage_key_write_is_rolled_back() {
+    let blocked_storage_key = felt!(0x10_u8);
+    let block_context = BlockContext::create_for_account_testing().with_blocked_storage_keys(
+        parse_blocked_storage_keys("0x10").unwrap(),
+        BLOCKED_STORAGE_KEY_ERROR_MESSAGE.to_string(),
+    );
+    let TestInitData { mut state, account_address, contract_address, mut nonce_manager } =
+        create_test_init_data(
+            &block_context.chain_info,
+            CairoVersion::Cairo1(RunnableCairo1::Casm),
+        );
+    let tx = executable_invoke_tx(invoke_tx_args! {
+        sender_address: account_address,
+        calldata: create_calldata(
+            contract_address,
+            "test_storage_read_write",
+            &[blocked_storage_key, felt!(7_u8)],
+        ),
+        resource_bounds: default_all_resource_bounds(),
+        nonce: nonce_manager.next(account_address),
+    });
+    let tx_execution_info = Transaction::Account(AccountTransaction::new_for_sequencing(tx))
+        .execute(&mut state, &block_context)
+        .expect("A blocked storage key should revert the tx, not fail it.");
+    assert!(tx_execution_info.is_reverted());
+
+    let stored_value = state
+        .get_storage_at(contract_address, storage_key!(0x10_u8))
+        .expect("Reading the blocked key from the state should succeed.");
+    assert_eq!(stored_value, Felt::ZERO, "The reverted write must not persist.");
 }
 
 #[test]


### PR DESCRIPTION
Based on branch `yoni/storage-keys-base-fix2`, pinned at commit `7ba8517adc` = tag `APOLLO-0.14.3-RC.17-fix-storage-keys-2`, so this diff is exactly the delta over that tag: one commit, four files.

## What changes

A revertible account transaction that reads or writes a blocked storage key **during its execute stage** is now **reverted** rather than failed. It is included in the block, the execute-stage state changes are rolled back, the sender is charged the revert fee, and the configured message is surfaced as the revert error.

Implemented in `AccountTransaction::run_revertible`, reusing the existing revert path that a post-execution fee failure takes: abort the execution state, compute the revert receipt, return `ValidateExecuteCallInfo::new_reverted`.

## What still rejects, deliberately

Reverting only unwinds the execute stage, so access in a stage that cannot be reverted still fails the transaction:

- the validate stage,
- the fee transfer,
- non-revertible transaction types (declare, deploy account, invoke v0),
- L1 handlers.

Silently permitting those would defeat the feature, so the outer check in `Transaction::execute_raw` is kept for exactly that residue. It no longer fires for the execute stage, because a revert drops `execute_call_info`. Worth a reviewer's opinion: if you would rather these also be permitted, say so and I will narrow it.

## Tests

- Blocked access asserts included-and-reverted: the message rides on the revert error, `execute_call_info` is dropped, and a non-zero fee is charged.
- New test proves the rollback is real: it reads the blocked key from state after the revert and finds zero.
- Unblocked cases, parsing cases and the nested inner-call variants carry over unchanged.

## Verification

```
cargo test -p blockifier --lib                              # 1011 passed
cargo test -p blockifier --lib transaction_execution_test   # 28 passed
cargo clippy -p blockifier -p apollo_batcher -p apollo_batcher_config --tests -- -D warnings   # clean
```

Note on merging: the base is a pinned branch, not `main-v0.14.3`. Retarget it to `main-v0.14.3` before merging, or merge the base first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
