### PR TITLE
ci: pin remaining GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/install_rust/action.yml
+++ b/.github/actions/install_rust/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: moonrepo/setup-rust@v1
+    - uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1
       name: Install Rust toolchain and binaries
       with:
         cache: false
@@ -23,6 +23,6 @@ runs:
 
     # This installation is _not_ cached, but takes a couple seconds: it's downloading prepackaged binaries.
     - name: Install Anvil
-      uses: foundry-rs/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
       with:
         version: v1.5.1

--- a/.github/actions/namespace_cache/action.yaml
+++ b/.github/actions/namespace_cache/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Mount namespace cache volume for rust
-      uses: namespacelabs/nscloud-cache-action@v1
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
       with:
         path: |
           /home/runner/.cargo
@@ -21,6 +21,6 @@ runs:
         echo "SCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE}" >> "$GITHUB_ENV"
 
     - name: Mount namespace cache volume for python
-      uses: namespacelabs/nscloud-cache-action@v1
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
       with:
         cache: python

--- a/.github/workflows/sequencer_cdk8s-test.yml
+++ b/.github/workflows/sequencer_cdk8s-test.yml
@@ -37,10 +37,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout sequencer
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"
@@ -153,16 +153,16 @@ jobs:
 
     steps:
       - name: Checkout sequencer
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"
 
       - name: Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 22
 


### PR DESCRIPTION
Backport of #15097 (`0e243b36`) to `main-v0.14.4`. Cherry-picked cleanly, no conflicts, no manual edits.

Pins the 8 remaining unpinned external action references so a moved tag can't silently change what CI runs:

- `actions/install_rust`: `moonrepo/setup-rust@v1`, `foundry-rs/foundry-toolchain@v1`
- `actions/namespace_cache`: `namespacelabs/nscloud-cache-action@v1` (x2)
- `sequencer_cdk8s-test`: `actions/checkout@v6` (x2), `actions/setup-python@v5.4.0` (x2), `actions/setup-node@v4.2.0`

Verified on this branch: no unpinned external `uses:` references remain, and all three files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)