### PR TITLE
ci,scripts: bootstrap the Rust toolchain in check-system-test-trigger

### DIFF
--- a/.github/workflows/hybrid_system_test.yaml
+++ b/.github/workflows/hybrid_system_test.yaml
@@ -55,14 +55,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      # check_test_trigger.py shells out to `cargo tree`, so the pinned toolchain must be installed
+      # rather than left to whatever the runner image carries. Bootstrap also mounts the Namespace
+      # cache volumes, including the python one used by the pip install below.
+      - uses: ./.github/actions/bootstrap
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "pypy3.9"
-
-      - name: Set up pip dependency caching
-        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
-        with:
-          cache: python
 
       - name: Install Python Dependencies
         run: pip install -r scripts/requirements.txt

--- a/scripts/tests_utils.py
+++ b/scripts/tests_utils.py
@@ -22,15 +22,7 @@ DEPENDENCY_PATTERN = r"([a-zA-Z0-9_]+) [^(]* \(([^)]+)\)"
 
 def get_workspace_tree() -> Dict[str, str]:
     tree = dict()
-    # Temporarily disable rustc-wrapper for cargo tree to avoid requiring sccache.
-    # TODO(Yoav): Remove this once hybrid_system_test uses bootstrap.
-    env = os.environ.copy()
-    env["RUSTC_WRAPPER"] = ""
-    res = (
-        subprocess.check_output("cargo tree --depth 0".split(), env=env)
-        .decode("utf-8")
-        .splitlines()
-    )
+    res = subprocess.check_output("cargo tree --depth 0".split()).decode("utf-8").splitlines()
     for l in res:
         m = re.match(PATTERN, l)
         if m is not None:
@@ -65,11 +57,8 @@ def get_modified_packages(files: List[str]) -> Set[str]:
 
 
 def get_package_dependencies(package_name: str) -> Set[str]:
-    # TODO(Yoav): Remove the env override once hybrid_system_test uses bootstrap.
-    env = os.environ.copy()
-    env["RUSTC_WRAPPER"] = ""
     res = (
-        subprocess.check_output(f"cargo tree -i {package_name} --prefix none".split(), env=env)
+        subprocess.check_output(f"cargo tree -i {package_name} --prefix none".split())
         .decode("utf-8")
         .splitlines()
     )


### PR DESCRIPTION
## Problem

`check-system-test-trigger` in `hybrid_system_test.yaml` runs `scripts/check_test_trigger.py`, which calls `cargo tree --depth 0` via `scripts/tests_utils.py::get_workspace_tree()`. The job installs Python but never a Rust toolchain, so `cargo` resolves to whatever rustup state the runner image happens to carry.

On PR #15026 that state was broken, deterministically. Three attempts of run [34341989783](https://github.com/starkware-libs/sequencer/actions/runs/34341989783) on three different runners (`nsc-runner-ksra8te9v8m3i`, `-u4nb253qddbkm`, `-92iapg1b1s7bo`) all failed the same way:

```
info: syncing channel updates for 1.96-x86_64-unknown-linux-gnu
info: downloading component rust-std
error: 'cargo' is not installed for the toolchain '1.96-x86_64-unknown-linux-gnu'.
```

A passing run of the same job on another branch ([34336680140](https://github.com/starkware-libs/sequencer/actions/runs/34336680140)) shows `syncing channel updates` and then ~50 s of work; the failing runs spend ~7 s and only fetch `rust-std`. rustup is finding a 1.96 toolchain it considers already installed and topping up the target, but the install has no `cargo` component.

## Fix

Use `./.github/actions/bootstrap` in the job, the same way `main.yml`, `merge_queue_ci.yml` and `main_nightly.yml` already do for every other job that runs these scripts. That installs the toolchain pinned by `rust-toolchain.toml` explicitly instead of relying on ambient runner state.

Bootstrap's `namespace_cache` step already mounts the python cache volume, so the job's own `nscloud-cache-action` step is dropped rather than mounting it twice.

`tests_utils.py` carried two `RUSTC_WRAPPER=""` overrides with `TODO(Yoav): Remove this once hybrid_system_test uses bootstrap.` This PR is that condition, so both overrides are removed. Bootstrap installs sccache (via `install_cargo_tools.sh`) and `.cargo/config.toml` already sets `rustc-wrapper = "sccache"` for every other cargo invocation, so no new requirement is introduced.

## Verification

- `python -c 'import yaml; ...'` parses the workflow; the job's steps are now: checkout → bootstrap → setup-python → pip install → check.
- `black -l 100 -t py37 --check` and `isort -c` (the `py_code_style.py` flags) pass on `scripts/tests_utils.py`.
- Locally, `get_workspace_tree()` and `get_package_dependencies()` run without the override (115 workspace packages resolved).
- This PR edits `.github/workflows/hybrid_system_test.yaml`, which is in the job's `path_triggers`, so `check-system-test-trigger` runs for real here (no optimizer skip) and should return `should_run=true`, exercising the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
