### PR TITLE
apollo_consensus_orchestrator: retry transient feeder errors for the retrospective block hash

### DIFF
--- a/crates/apollo_consensus_orchestrator/src/utils.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils.rs
@@ -438,12 +438,12 @@ pub(crate) async fn wait_for_retrospective_block_hash(
         )
         .await;
 
-        // If the block is not found, try again after the retry interval. In any other case, return
-        // the result.
+        // Retry while a client cannot answer yet: the block is not found, or state sync's feeder
+        // fallback failed transiently. In any other case, return the result.
         let state_sync_not_ready = matches!(
             result,
             Err(RetrospectiveBlockHashError::StateSyncError(StateSyncClientError::StateSyncError(
-                StateSyncError::BlockNotFound(_)
+                StateSyncError::BlockNotFound(_) | StateSyncError::ReaderClientError(_)
             )))
         );
         let batcher_not_ready = matches!(

--- a/crates/apollo_consensus_orchestrator/src/utils_test.rs
+++ b/crates/apollo_consensus_orchestrator/src/utils_test.rs
@@ -284,6 +284,61 @@ async fn wait_for_retrospective_block_hash_state_sync_ready_after_a_while() {
 }
 
 #[tokio::test]
+async fn wait_for_retrospective_block_hash_state_sync_transient_feeder_error() {
+    let (mut test_proposal_args, _proposal_receiver) = create_proposal_build_arguments();
+    test_proposal_args.build_param.height = CURRENT_BLOCK_NUMBER;
+    test_proposal_args
+        .deps
+        .batcher
+        .expect_get_block_hash()
+        .withf(|block_number| *block_number == MUST_HAVE_BLOCK_HASH_FOR)
+        .times(2)
+        .returning(|_| Ok(RETRO_BLOCK_HASH));
+    test_proposal_args
+        .deps
+        .batcher
+        .expect_get_block_hash()
+        .withf(|block_number| *block_number == RETRO_BLOCK_NUMBER)
+        .returning(|_| Ok(RETRO_BLOCK_HASH));
+    // State sync falls back to the feeder gateway for blocks it has not synced yet; the feeder
+    // fails transiently (e.g. a 500) in the first attempt.
+    test_proposal_args
+        .deps
+        .state_sync_client
+        .expect_get_block_hash()
+        .withf(|block_number| *block_number == RETRO_BLOCK_NUMBER)
+        .times(1)
+        .returning(|_| {
+            Err(StateSyncError::ReaderClientError("Internal server error".to_string()).into())
+        });
+    test_proposal_args
+        .deps
+        .state_sync_client
+        .expect_get_block_hash()
+        .withf(|block_number| *block_number == RETRO_BLOCK_NUMBER)
+        .times(1)
+        .returning(|_| Ok(RETRO_BLOCK_HASH));
+
+    let proposal_args: ProposalBuildArguments = test_proposal_args.into();
+    let init = get_proposal_init(&proposal_args).await;
+    let res = wait_for_retrospective_block_hash(
+        proposal_args.deps.batcher,
+        proposal_args.deps.state_sync_client,
+        &init,
+        proposal_args.deps.clock.as_ref(),
+        proposal_args.retrospective_block_hash_deadline,
+        proposal_args.retrospective_block_hash_retry_interval_millis,
+        proposal_args.compare_retrospective_block_hash,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        res,
+        Some(BlockHashAndNumber { number: RETRO_BLOCK_NUMBER, hash: RETRO_BLOCK_HASH })
+    );
+}
+
+#[tokio::test]
 async fn wait_for_retrospective_block_hash_batcher_ready_after_a_while() {
     let (mut test_proposal_args, _proposal_receiver) = create_proposal_build_arguments();
     test_proposal_args.build_param.height = CURRENT_BLOCK_NUMBER;


### PR DESCRIPTION
## Problem

Consensus fetches the retrospective block hash (height − 10) through the state sync client. When state sync has not synced that block yet, `StateSync::get_block_hash` falls back to the feeder gateway (`apollo_state_sync/src/lib.rs`). A transient feeder failure (e.g. HTTP 500) surfaces as `StateSyncError::ReaderClientError`, which `wait_for_retrospective_block_hash` did not treat as retryable — only `BlockNotFound` was. The proposal failed on the first attempt.

Observed on mainnet 2026-09-09 ~01:22–01:30 UTC: a feeder-gateway degradation produced 16 `PROPOSAL_FAILED … RetrospectiveBlockHashError(StateSyncError(StateSyncError(ReaderClientError(… 500 …))))` across the validators with zero retry warnings, round churn up to round 4, and block cadence dropping from ~35/min to 2/min.

## Fix

Treat `ReaderClientError` as "state sync cannot answer yet", the same as `BlockNotFound`, so the existing deadline-bounded retry loop absorbs it. The loop already caps retries at `retrospective_block_hash_deadline`, so this cannot push a proposal past its deadline.

## Test

`wait_for_retrospective_block_hash_state_sync_transient_feeder_error`: state sync returns `ReaderClientError` on the first attempt and the hash on the second; expects `Ok(Some(hash))`. Fails before the fix (the loop returns the error after one attempt), passes after.

## Verification

- `SEED=0 cargo test -p apollo_consensus_orchestrator` — 243 passed, 0 failed
- `scripts/rust_fmt.sh` — clean
- `cargo clippy -p apollo_consensus_orchestrator --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
