### PR TITLE
apollo_infra: delete dead code

### DIFF
--- a/crates/apollo_infra/src/metrics.rs
+++ b/crates/apollo_infra/src/metrics.rs
@@ -105,10 +105,6 @@ impl LocalClientMetrics {
         self.response_times.record(duration_secs, &[(LABEL_NAME_REQUEST_VARIANT, request_label)]);
     }
 
-    pub fn get_response_time_metric(&self) -> &'static LabeledMetricHistogram {
-        self.response_times
-    }
-
     pub fn get_all_labeled_metrics(&self) -> Vec<&'static LabeledMetricHistogram> {
         vec![self.response_times]
     }
@@ -149,14 +145,6 @@ impl RemoteClientMetrics {
     pub fn record_communication_failure(&self, duration_secs: f64, request_label: &'static str) {
         self.communication_failure_times
             .record(duration_secs, &[(LABEL_NAME_REQUEST_VARIANT, request_label)]);
-    }
-
-    pub fn get_response_time_metric(&self) -> &'static LabeledMetricHistogram {
-        self.response_times
-    }
-
-    pub fn get_communication_failure_time_metric(&self) -> &'static LabeledMetricHistogram {
-        self.communication_failure_times
     }
 
     pub fn get_all_labeled_metrics(&self) -> Vec<&'static LabeledMetricHistogram> {
@@ -253,14 +241,6 @@ impl LocalServerMetrics {
 
     pub fn record_queueing_time(&self, duration_secs: f64, request_label: &'static str) {
         self.queueing_times.record(duration_secs, &[(LABEL_NAME_REQUEST_VARIANT, request_label)]);
-    }
-
-    pub fn get_processing_time_metric(&self) -> &'static LabeledMetricHistogram {
-        self.processing_times
-    }
-
-    pub fn get_queueing_time_metric(&self) -> &'static LabeledMetricHistogram {
-        self.queueing_times
     }
 
     pub fn get_received_metric(&self) -> &'static MetricCounter {


### PR DESCRIPTION
## What

Deletes 5 unused public getter methods that return `&'static` metric handles in `crates/apollo_infra/src/metrics.rs`:

- `LocalClientMetrics::get_response_time_metric`
- `RemoteClientMetrics::get_response_time_metric`
- `RemoteClientMetrics::get_communication_failure_time_metric`
- `LocalServerMetrics::get_processing_time_metric`
- `LocalServerMetrics::get_queueing_time_metric`

## Why they're dead

Each of these methods is never called anywhere:

- Zero callers in the workspace (all crates, including `*_test.rs`, `tests/`, and `benches/`).
- Zero references in the sibling repos `starkware-industries/sequencer-devops` and `starkware-industries/starkware` (searched identifier names across code, scripts, and config).

Removing them does not orphan any struct field: each underlying field (`response_times`, `communication_failure_times`, `processing_times`, `queueing_times`) remains used by that struct's `register`, `record_*`, and `get_all_labeled_metrics` methods, which access the fields directly rather than through these getters.

`apollo_infra` is an internal infrastructure crate (not a published SDK); these getters are not part of an externally consumed API surface.

## Precedent

This is the same cleanup as #12559 ("apollo_infra: remove unused metric getter methods"), which removed other unused metric-handle getters from these same structs. The getters removed here were left in place at that time but have since become unused.

Note: the unrelated `// TODO(Tsabary): add the getter fns for tests.` comment in `LocalServerMetrics` refers to `get_*_value` test accessors (which parse a metric string, gated by `#[cfg(any(feature = "testing", test))]`), not to these `get_*_metric` handle getters; it is intentionally left untouched.

## Verification (`RUSTC_WRAPPER` unset, `CARGO_INCREMENTAL=0`)

- `scripts/rust_fmt.sh` — clean (no reformatting).
- `cargo build -p apollo_infra` — zero warnings.
- `cargo build -p apollo_infra --tests` — zero warnings.
- `cargo clippy -p apollo_infra --all-targets` — clean (exit 0).
- `SEED=0 cargo test -p apollo_infra` — 43 passed, 0 failed (+ doc-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qk1V7PE8s7D9ZDoMrBnhV

---
_Generated by [Claude Code](https://claude.ai/code/session_017qk1V7PE8s7D9ZDoMrBnhV)_